### PR TITLE
CMake Build fixes for CMake-generated MSVC projects.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,14 +14,19 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
-# Tell C++ compiler to optimize release builds for speed.
-# In clang++, the optimize for speed flag is '-Ot'. This option isn't supported on g++
-# however and it'd be nice to use an option that works for both compilers. So use '-O3'.
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
-
 # Set name for entire project.
 # Details at: https://cmake.org/cmake/help/v3.1/command/project.html
 project(PlayRho)
+
+# Tell C++ compiler to optimize release builds for speed.
+# In clang++, the optimize for speed flag is '-Ot'. This option isn't supported on g++
+# however and it'd be nice to use an option that works for both compilers. So use '-O3'.
+# For Visual Studio Compilers, the speed optimization flag is /O2, which is the default setting for release builds
+if(MSVC)
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
+else()
+	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+endif()
 
 # Provide options that user can optionally select.
 # Details at: https://cmake.org/cmake/help/v3.1/command/option.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,11 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+# Semicolon separated list of supported configuration types, only
+# supports Debug, Release, MinSizeRel, and RelWithDebInfo, anything
+# else will be ignored. PlayRho only supports Debug and Release
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release;" CACHE STRING "Semicolon separated list of supported configuration types. PlayRho only supports Debug and Release configurations.")
+
 # Set name for entire project.
 # Details at: https://cmake.org/cmake/help/v3.1/command/project.html
 project(PlayRho)

--- a/Testbed/CMakeLists.txt
+++ b/Testbed/CMakeLists.txt
@@ -37,7 +37,7 @@ include_directories (
 )
 
 link_directories (
-  ${GLFW_LIBRARY_DIRS}
+	${GLFW_LIBRARY_DIRS}
 )
 
 if(APPLE)
@@ -53,6 +53,11 @@ add_executable(Testbed
 	${Testbed_Framework_SRCS}
 	${Testbed_Tests_SRCS}
 )
+
+#Resolve Linker error LNK4098; make sure default libcmt doesn't clash with other libraries
+if(MSVC)
+	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:libcmt.lib")
+endif()
 
 target_link_libraries (
 	Testbed


### PR DESCRIPTION
#### Description - What's this PR do?
This PR:
 - solves issue #29,
 - resolves another linker error in the Testbed on MSVC from the CMake generated project, and 
 - sets the PlayRho default configurations for multi-configuration projects to `Debug` and `Release` only.

#### Impacts/Risks of These Changes?
- Building using VS 2017 from CMake is improved.
- The last commit specifying default build configurations will also affect XCode projects. I am unable to test this on XCode, but I don't believe it will have a negative impact.
- These changes do not resolve issue #16

#### Where should a reviewer start?
Look through commits

#### How should this be tested?
Generate project with CMake for VS. Build the Testbed.

#### Any background context you want to provide?
This pr moves towards the goal of build automation on major platforms.

#### Related Issues
#29
