### PR TITLE
For issue 66

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		47B58F591F57218400354C34 /* Version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47B58F571F57218400354C34 /* Version.cpp */; };
 		47B58F5A1F57218400354C34 /* Version.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47B58F581F57218400354C34 /* Version.hpp */; };
 		47B58F5E1F5B314400354C34 /* FlagGuard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47B58F5C1F5B314400354C34 /* FlagGuard.hpp */; };
+		47B58F601F5B791500354C34 /* FlagGuard.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47B58F5F1F5B791500354C34 /* FlagGuard.cpp */; };
 		47C85D0A1EFA251B00F70C56 /* WheelJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47C85D091EFA251B00F70C56 /* WheelJoint.cpp */; };
 		47C85D0C1EFA2C1C00F70C56 /* Version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47C85D0B1EFA2C1C00F70C56 /* Version.cpp */; };
 		47C85D0E1EFAE03700F70C56 /* WeldJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47C85D0D1EFAE03700F70C56 /* WeldJoint.cpp */; };
@@ -533,6 +534,7 @@
 		47B58F571F57218400354C34 /* Version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Version.cpp; sourceTree = "<group>"; };
 		47B58F581F57218400354C34 /* Version.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Version.hpp; sourceTree = "<group>"; };
 		47B58F5C1F5B314400354C34 /* FlagGuard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = FlagGuard.hpp; sourceTree = "<group>"; };
+		47B58F5F1F5B791500354C34 /* FlagGuard.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FlagGuard.cpp; sourceTree = "<group>"; };
 		47C85D091EFA251B00F70C56 /* WheelJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WheelJoint.cpp; sourceTree = "<group>"; };
 		47C85D0B1EFA2C1C00F70C56 /* Version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Version.cpp; sourceTree = "<group>"; };
 		47C85D0D1EFAE03700F70C56 /* WeldJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeldJoint.cpp; sourceTree = "<group>"; };
@@ -769,6 +771,7 @@
 				477D20051E32B6E80069D610 /* Fixed.cpp */,
 				475A94551D930E6C000CA9A8 /* Fixture.cpp */,
 				4731DE151DDCD00100E7F931 /* FixtureProxy.cpp */,
+				47B58F5F1F5B791500354C34 /* FlagGuard.cpp */,
 				472724241E310C7600C64921 /* float.cpp */,
 				474FDB521E72643D00F401AF /* forward_list.cpp */,
 				474B67211E80466D00B6D126 /* functional.cpp */,
@@ -1493,6 +1496,7 @@
 				474FDB531E72643D00F401AF /* forward_list.cpp in Sources */,
 				473971AA1D9F0E4E00F7137F /* ContactSolver.cpp in Sources */,
 				475A94541D930503000CA9A8 /* BlockAllocator.cpp in Sources */,
+				47B58F601F5B791500354C34 /* FlagGuard.cpp in Sources */,
 				4731DDFC1DC8FBEE00E7F931 /* Island.cpp in Sources */,
 				473273271F47760D00E22AE2 /* OptionalValue.cpp in Sources */,
 				474BC4341D413DC200447DCD /* Manifold.cpp in Sources */,

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		47B58F561F570E2C00354C34 /* DynamicMemory.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47B58F541F570E2C00354C34 /* DynamicMemory.hpp */; };
 		47B58F591F57218400354C34 /* Version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47B58F571F57218400354C34 /* Version.cpp */; };
 		47B58F5A1F57218400354C34 /* Version.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47B58F581F57218400354C34 /* Version.hpp */; };
+		47B58F5E1F5B314400354C34 /* FlagGuard.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47B58F5C1F5B314400354C34 /* FlagGuard.hpp */; };
 		47C85D0A1EFA251B00F70C56 /* WheelJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47C85D091EFA251B00F70C56 /* WheelJoint.cpp */; };
 		47C85D0C1EFA2C1C00F70C56 /* Version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47C85D0B1EFA2C1C00F70C56 /* Version.cpp */; };
 		47C85D0E1EFAE03700F70C56 /* WeldJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47C85D0D1EFAE03700F70C56 /* WeldJoint.cpp */; };
@@ -531,6 +532,7 @@
 		47B58F541F570E2C00354C34 /* DynamicMemory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = DynamicMemory.hpp; sourceTree = "<group>"; };
 		47B58F571F57218400354C34 /* Version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Version.cpp; sourceTree = "<group>"; };
 		47B58F581F57218400354C34 /* Version.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Version.hpp; sourceTree = "<group>"; };
+		47B58F5C1F5B314400354C34 /* FlagGuard.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = FlagGuard.hpp; sourceTree = "<group>"; };
 		47C85D091EFA251B00F70C56 /* WheelJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WheelJoint.cpp; sourceTree = "<group>"; };
 		47C85D0B1EFA2C1C00F70C56 /* Version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Version.cpp; sourceTree = "<group>"; };
 		47C85D0D1EFAE03700F70C56 /* WeldJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WeldJoint.cpp; sourceTree = "<group>"; };
@@ -913,6 +915,7 @@
 				47B58F531F570E2C00354C34 /* DynamicMemory.cpp */,
 				47B58F541F570E2C00354C34 /* DynamicMemory.hpp */,
 				4727242D1E315E1A00C64921 /* Fixed.hpp */,
+				47B58F5C1F5B314400354C34 /* FlagGuard.hpp */,
 				80BB8943141C3E5900F1753A /* GrowableStack.hpp */,
 				470F9B3A1EE63515007EF7B6 /* InvalidArgument.hpp */,
 				4787D6E91F2FA0CA008C115E /* LengthError.hpp */,
@@ -1297,6 +1300,7 @@
 				470F9B121EDF2890007EF7B6 /* Position.hpp in Headers */,
 				4726DD2C1D31B4090012A882 /* AABB.hpp in Headers */,
 				478E67CD1E777A43009B9AD5 /* StepStats.hpp in Headers */,
+				47B58F5E1F5B314400354C34 /* FlagGuard.hpp in Headers */,
 				80BB89CD141C3E5900F1753A /* FrictionJoint.hpp in Headers */,
 				80BB89CF141C3E5900F1753A /* GearJoint.hpp in Headers */,
 				80BB89D1141C3E5900F1753A /* Joint.hpp in Headers */,

--- a/PlayRho/Common/FlagGuard.hpp
+++ b/PlayRho/Common/FlagGuard.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef FlagGuard_hpp
+#define FlagGuard_hpp
+
+#include <type_traits>
+
+namespace playrho {
+    
+    /// @brief Flag guard type.
+    template <typename T>
+    class FlagGuard
+    {
+    public:
+        FlagGuard(T& flag, T value) : m_flag(flag), m_value(value)
+        {
+            static_assert(std::is_unsigned<T>::value, "Unsigned type required");
+            m_flag |= m_value;
+        }
+        
+        ~FlagGuard() noexcept
+        {
+            m_flag &= ~m_value;
+        }
+        
+        FlagGuard() = delete;
+        
+    private:
+        T& m_flag;
+        T m_value;
+    };
+
+} // namespace playrho
+
+#endif /* FlagGuard_hpp */

--- a/PlayRho/Common/FlagGuard.hpp
+++ b/PlayRho/Common/FlagGuard.hpp
@@ -30,12 +30,19 @@ namespace playrho {
     class FlagGuard
     {
     public:
+        /// @brief Initializing constructor.
+        /// @details Sets the given flag variable to the bitwise or of it with the
+        ///   given value and then unsets those bits on destruction of this instance.
+        /// @param flag Flag variable to set until the destruction of this instance.
+        /// @param value Bit value to or with the flag variable on construction.
         FlagGuard(T& flag, T value) : m_flag(flag), m_value(value)
         {
             static_assert(std::is_unsigned<T>::value, "Unsigned type required");
             m_flag |= m_value;
         }
         
+        /// @brief Destructor.
+        /// @details Unsets the bits that were set on construction.
         ~FlagGuard() noexcept
         {
             m_flag &= ~m_value;

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -57,6 +57,7 @@
 
 #include <PlayRho/Common/LengthError.hpp>
 #include <PlayRho/Common/DynamicMemory.hpp>
+#include <PlayRho/Common/FlagGuard.hpp>
 
 #include <new>
 #include <functional>
@@ -88,48 +89,7 @@ using BodyConstraints = vector<BodyConstraint>;
 using PositionConstraints = vector<PositionConstraint>;
 using VelocityConstraints = vector<VelocityConstraint>;
 
-template <typename T>
-class FlagGuard
-{
-public:
-    FlagGuard(T& flag, T value) : m_flag(flag), m_value(value)
-    {
-        static_assert(is_unsigned<T>::value, "Unsigned integer required");
-        m_flag |= m_value;
-    }
-
-    ~FlagGuard() noexcept
-    {
-        m_flag &= ~m_value;
-    }
-
-    FlagGuard() = delete;
-
-private:
-    T& m_flag;
-    T m_value;
-};
-
-template <class T>
-class RaiiWrapper
-{
-public:
-    RaiiWrapper() = delete;
-    explicit RaiiWrapper(function<void(T&)> on_destruction): m_on_destruction(on_destruction) {}
-    ~RaiiWrapper() { m_on_destruction(m_wrapped); }
-    T m_wrapped;
-
-private:
-    function<void(T&)> m_on_destruction;
-};
-
 namespace {
-    
-    struct PositionAndVelocity
-    {
-        Position position;
-        Velocity velocity;
-    };
 
     inline ConstraintSolverConf GetRegConstraintSolverConf(const StepConf& conf)
     {

--- a/UnitTests/FlagGuard.cpp
+++ b/UnitTests/FlagGuard.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "gtest/gtest.h"
+#include <cstdint>
+#include <cstddef>
+#include <PlayRho/Common/FlagGuard.hpp>
+
+using namespace playrho;
+
+TEST(FlagGuard, ByteSizeOverhead)
+{
+    EXPECT_EQ(sizeof(FlagGuard<std::uint8_t>), sizeof(std::uint8_t*) * 2);
+    EXPECT_EQ(sizeof(FlagGuard<std::uint16_t>), sizeof(std::uint16_t*) * 2);
+    EXPECT_EQ(sizeof(FlagGuard<std::uint32_t>), sizeof(std::uint32_t*) * 2);
+}
+
+TEST(FlagGuard, uint8_t)
+{
+    std::uint8_t foo = 0;
+    ASSERT_EQ(foo, 0);
+    {
+        FlagGuard<decltype(foo)> guard(foo, 0x1u);
+        EXPECT_EQ(foo, 0x1u);
+    }
+    EXPECT_EQ(foo, 0x0u);
+    foo = 0x44u;
+    ASSERT_EQ(foo, 0x44u);
+    {
+        FlagGuard<decltype(foo)> guard(foo, 0x11u);
+        EXPECT_EQ(foo, (0x11u | 0x44u));
+    }
+    EXPECT_EQ(foo, 0x44u);
+}


### PR DESCRIPTION
#### Description - What's this PR do?
Moves `FlagGuard` out from World.cpp and up to general usability. Add associated unit test code. Also removes some stuff no longer used.

#### Impacts/Risks of These Changes?
Potential reuse now of the `FlagGuard` type. Reduces the size of the `World.cpp` file. Adds to the unit test code coverage amount.

#### Related Issues
For issue #66.