### PR TITLE
For issue #70.

### DIFF
--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -23,6 +23,7 @@
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/Collision.hpp>
 #include <PlayRho/Collision/ShapeSeparation.hpp>
+#include <PlayRho/Defines.hpp>
 
 #include <array>
 #include <bitset>

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -20,8 +20,6 @@
 #ifndef ArrayList_hpp
 #define ArrayList_hpp
 
-#include <PlayRho/Defines.hpp>
-
 #include <type_traits>
 #include <initializer_list>
 #include <cassert>

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -34,7 +34,6 @@
 #include <cstdint>
 #include <algorithm>
 
-#include <PlayRho/Defines.hpp>
 #include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Common/RealNum.hpp>
 #include <PlayRho/Common/Units.hpp>

--- a/PlayRho/Defines.hpp
+++ b/PlayRho/Defines.hpp
@@ -2,28 +2,24 @@
  * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
 #ifndef Defines_hpp
 #define Defines_hpp
-
-#ifdef __clang__
-#define PLAYRHO_CONSTEXPR constexpr
-#else
-#define PLAYRHO_CONSTEXPR
-#endif
 
 // Setup a define for unreachable code.
 //

--- a/PlayRho/Dynamics/Joints/Joint.cpp
+++ b/PlayRho/Dynamics/Joints/Joint.cpp
@@ -34,6 +34,7 @@
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
+#include <PlayRho/Defines.hpp>
 
 #include <new>
 #include <algorithm>


### PR DESCRIPTION
#### Description - What's this PR do?
Avoids polluting user code with PlayRho macros (other than header include guards).

#### Impacts/Risks of These Changes?
Live up to documentation in terms of avoiding name space pollution. Risk should be minimal.

#### Related Issues
Issue #70.