### PR TITLE
For issue #76.

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -213,6 +213,26 @@ static void UnitVecFromAngle(benchmark::State& state)
     }
 }
 
+static void DifferentSignsViaSignbit(benchmark::State& state)
+{
+    const auto a = static_cast<float>(rand() - (RAND_MAX / 2));
+    const auto b = static_cast<float>(rand() - (RAND_MAX / 2));
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(std::signbit(a) != std::signbit(b));
+    }
+}
+
+static void DifferentSignsViaMultiplication(benchmark::State& state)
+{
+    const auto a = static_cast<float>(rand() - (RAND_MAX / 2));
+    const auto b = static_cast<float>(rand() - (RAND_MAX / 2));
+    while (state.KeepRunning())
+    {
+        benchmark::DoNotOptimize(a * b < 0.0f);
+    }
+}
+
 // ----
 
 static void FloatAddTwoRand(benchmark::State& state)
@@ -1070,6 +1090,9 @@ BENCHMARK(FloatDiv);
 
 BENCHMARK(FloatAlmostEqual1);
 BENCHMARK(FloatAlmostEqual2);
+
+BENCHMARK(DifferentSignsViaSignbit);
+BENCHMARK(DifferentSignsViaMultiplication);
 
 BENCHMARK(FloatSqrt);
 BENCHMARK(FloatSin);


### PR DESCRIPTION
#### Description - What's this PR do?
Adds trivial benchmarks of detecting differing signs via std::signbit vs. multiplication. I'm seeing that `std::signbit` is slightly faster by virtue of more runs getting done than with alt method.

#### Impacts/Risks of These Changes?
Isolated to running the Benchmark application.

#### Related Issues
Related to issue #76 .