### PR TITLE
For issue #21.

### DIFF
--- a/Documentation/Doxyfile
+++ b/Documentation/Doxyfile
@@ -762,7 +762,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = NO
+WARN_AS_ERROR          = YES
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -421,6 +421,7 @@ namespace playrho
         PointArray m_points; ///< Points of contact (at least 40-bytes). @sa pointCount.
     };
     
+    /// @brief Configuration data for manifold calculation.
     struct Manifold::Conf
     {
         Length linearSlop = DefaultLinearSlop;

--- a/PlayRho/Collision/Shapes/ChainShape.hpp
+++ b/PlayRho/Collision/Shapes/ChainShape.hpp
@@ -46,6 +46,7 @@ public:
         return DefaultLinearSlop * Real{2};
     }
     
+    /// @brief Configuration data for chain shapes.
     struct Conf: public Builder<Conf>
     {
         Conf(): Builder<Conf>{Builder<Conf>{}.UseVertexRadius(GetDefaultVertexRadius())}

--- a/PlayRho/Collision/Shapes/DiskShape.hpp
+++ b/PlayRho/Collision/Shapes/DiskShape.hpp
@@ -42,6 +42,7 @@ public:
         return DefaultLinearSlop * Real{2};
     }
 
+    /// @brief Configuration data for disk shapes.
     struct Conf: public Builder<Conf>
     {
         constexpr Conf(): Builder<Conf>{Builder<Conf>{}.UseVertexRadius(GetDefaultRadius())}
@@ -49,15 +50,16 @@ public:
             // Intentionally empty.
         }
         
-        constexpr Conf& UseLocation(Length2D value) noexcept;
+        constexpr Conf& UseLocation(Length2D value) noexcept
+        {
+            location = value;
+            return *this;
+        }
 
         Length2D location = Length2D{};
     };
 
-    static constexpr Conf GetDefaultConf() noexcept
-    {
-        return Conf{};
-    }
+    static constexpr Conf GetDefaultConf() noexcept;
 
     /// Initializing constructor.
     explicit DiskShape(const Conf& conf = GetDefaultConf()) noexcept:
@@ -113,10 +115,9 @@ private:
     Length2D m_location = Length2D{};
 };
 
-constexpr DiskShape::Conf& DiskShape::Conf::UseLocation(Length2D value) noexcept
+constexpr DiskShape::Conf DiskShape::GetDefaultConf() noexcept
 {
-    location = value;
-    return *this;
+    return Conf{};
 }
 
 inline ChildCounter DiskShape::GetChildCount() const noexcept

--- a/PlayRho/Collision/Shapes/EdgeShape.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShape.hpp
@@ -40,6 +40,7 @@ public:
         return DefaultLinearSlop * Real{2};
     }
 
+    /// @brief Configuration data for edge shapes.
     struct Conf: public Builder<Conf>
     {
         constexpr Conf(): Builder<Conf>{Builder<Conf>{}.UseVertexRadius(GetDefaultVertexRadius())}

--- a/PlayRho/Collision/Shapes/MultiShape.hpp
+++ b/PlayRho/Collision/Shapes/MultiShape.hpp
@@ -28,12 +28,12 @@ namespace playrho {
     
     class VertexSet;
     
-    /// Concave shape.
+    /// @brief Concave shape.
     class MultiShape: public Shape
     {
     public:
         
-        /// Vertex count type.
+        /// @brief Vertex count type.
         ///
         /// @note This type must not support more than 255 vertices as that would conflict
         ///   with the <code>ContactFeature::Index</code> type.
@@ -47,6 +47,7 @@ namespace playrho {
             return DefaultLinearSlop * Real{2};
         }
         
+        /// @brief Configuration data for multi-shape shapes.
         struct Conf: public Builder<Conf>
         {
             constexpr Conf(): Builder<Conf>{Builder<Conf>{}.UseVertexRadius(GetDefaultVertexRadius())}
@@ -60,7 +61,7 @@ namespace playrho {
             return Conf{};
         }
         
-        /// Default constructor.
+        /// @brief Default constructor.
         /// @details Constructs a polygon shape with a 0,0 centroid and vertex count of 0.
         /// @note Polygons with a vertex count less than 1 are "degenerate" and should be
         ///   treated as invalid.
@@ -72,7 +73,7 @@ namespace playrho {
         
         MultiShape(const MultiShape&) = default;
         
-        /// Gets the number of child primitives.
+        /// @brief Gets the number of child primitives.
         /// @return Positive non-zero count.
         ChildCounter GetChildCount() const noexcept override;
         
@@ -80,6 +81,7 @@ namespace playrho {
         /// @throws InvalidArgument if the index is out of range.
         DistanceProxy GetChild(ChildCounter index) const override;
         
+        /// @brief Gets mass data.
         /// Computes the mass properties of this shape using its dimensions and density.
         /// The inertia tensor is computed about the local origin.
         /// @return Mass data for this shape.

--- a/PlayRho/Collision/Shapes/PolygonShape.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.hpp
@@ -52,6 +52,7 @@ public:
         return DefaultLinearSlop * Real{2};
     }
 
+    /// @brief Configuration data for polygon shapes.
     struct Conf: public Builder<Conf>
     {
         constexpr Conf(): Builder<Conf>{Builder<Conf>{}.UseVertexRadius(GetDefaultVertexRadius())}

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -104,12 +104,6 @@ public:
         constexpr ConcreteConf& UseDensity(NonNegative<Density> value) noexcept;
     };
 
-    /// @brief Visitor interface.
-    ///
-    /// @details Interface to inerit from for objects wishing to "visit" shapes.
-    ///   This uses the vistor design pattern.
-    /// @sa https://en.wikipedia.org/wiki/Visitor_pattern .
-    ///
     class Visitor;
 
     /// @brief Default constructor is deleted.
@@ -236,6 +230,12 @@ Shape::Builder<ConcreteConf>::UseDensity(NonNegative<Density> value) noexcept
     return static_cast<ConcreteConf&>(*this);
 }
 
+/// @brief Visitor interface.
+///
+/// @details Interface to inerit from for objects wishing to "visit" shapes.
+///   This uses the vistor design pattern.
+/// @sa https://en.wikipedia.org/wiki/Visitor_pattern .
+///
 class Shape::Visitor
 {
 public:

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -133,6 +133,7 @@ namespace playrho {
         using dist_sum_type = Wider<dist_iter_type>::type;
         using root_sum_type = Wider<root_iter_type>::type;
 
+        /// @brief Time of impact statistics.
         struct Stats
         {
             // 3-bytes

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -55,6 +55,7 @@ namespace playrho
 
     public:
         
+        /// @brief Point data for world manifold.
         struct PointData
         {
             Length2D location; ///< Location of point.

--- a/PlayRho/Common/BlockAllocator.cpp
+++ b/PlayRho/Common/BlockAllocator.cpp
@@ -69,6 +69,7 @@ static constexpr std::uint8_t s_blockSizeLookup[BlockAllocator::MaxBlockSize + 1
     13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // 608-640
 };
 
+/// @brief Chunk.
 struct BlockAllocator::Chunk
 {
     using size_type = std::size_t;
@@ -77,6 +78,7 @@ struct BlockAllocator::Chunk
     Block* blocks;
 };
 
+/// @brief Block.
 struct BlockAllocator::Block
 {
     Block* next;

--- a/PlayRho/Common/BoundedValue.hpp
+++ b/PlayRho/Common/BoundedValue.hpp
@@ -47,6 +47,7 @@ namespace playrho {
         BelowPosInf
     };
 
+    /// @brief Value check helper.
     template <typename T, class Enable = void>
     struct ValueCheckHelper
     {
@@ -54,6 +55,7 @@ namespace playrho {
         static constexpr T one() noexcept { return T(0); }
     };
     
+    /// @brief Specialization of the value check helper.
     template <typename T>
     struct ValueCheckHelper<T, typename std::enable_if<std::is_arithmetic<T>::value>::type>
     {
@@ -79,6 +81,7 @@ namespace playrho {
         // Intentionally empty.
     }
 
+    /// @brief Bounded value.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
     class BoundedValue
     {

--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -742,6 +742,7 @@ namespace playrho
         return result == Fixed64::CmpResult::GreaterThan;
     }
 
+    /// @brief Specialization of the Wider trait for Fixed32 type.
     template<> struct Wider<Fixed32> { using type = Fixed64; };
 
     template <>
@@ -776,6 +777,7 @@ namespace std
     
     // Fixed32
 
+    /// @brief Template specialization of numeric limits for Fixed32.
     template <>
     class numeric_limits<playrho::Fixed32>
     {
@@ -896,6 +898,7 @@ namespace std
 
 #ifndef _WIN32
 
+    /// @brief Template specialization of numeric limits for Fixed64.
     template <>
     class numeric_limits<playrho::Fixed64>
     {

--- a/PlayRho/Common/LengthError.hpp
+++ b/PlayRho/Common/LengthError.hpp
@@ -26,7 +26,7 @@
 namespace playrho {
     
     /// @brief Length based logic error.
-    /// @detail The exception used to indicate that an operation would produce a
+    /// @details The exception used to indicate that an operation would produce a
     ///   result that exceeded an object's maximum size.
     class LengthError: public std::length_error
     {

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -494,6 +494,7 @@ constexpr inline Mat33 GetSymInverse33(const Mat33& value) noexcept
     };
 }
 
+/// @brief Contact impulses data.
 struct ContactImpulses
 {
     Momentum m_normal; ///< Normal impulse. This is the non-penetration impulse (4-bytes).

--- a/PlayRho/Common/Range.hpp
+++ b/PlayRho/Common/Range.hpp
@@ -25,6 +25,8 @@
 
 namespace playrho
 {
+    
+    /// @brief Template range value class.
     template <typename IT>
     class Range
     {
@@ -57,6 +59,7 @@ namespace playrho
         iterator_type m_end;
     };
 
+    /// @brief Template sized range value class.
     template <typename IT>
     class SizedRange: public Range<IT>
     {

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -49,6 +49,8 @@ namespace playrho
 
 namespace details
 {
+
+/// @brief Defaults object for real types.
 template <typename T>
 struct Defaults
 {
@@ -66,6 +68,7 @@ struct Defaults
     }
 };
 
+/// @brief Specialization of defaults object for fixed point types.
 template <unsigned int FRACTION_BITS>
 struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
 {

--- a/PlayRho/Common/StackAllocator.hpp
+++ b/PlayRho/Common/StackAllocator.hpp
@@ -36,6 +36,7 @@ class StackAllocator
 public:
     using size_type = std::size_t;
 
+    /// @brief Stack allocator configuration data.
     struct Configuration
     {
         size_type preallocation_size = 100 * 1024;

--- a/PlayRho/Common/Wider.hpp
+++ b/PlayRho/Common/Wider.hpp
@@ -35,19 +35,39 @@ namespace playrho
 ///
 template <typename T> struct Wider {};
 
+/// @brief Specialization of the Wider trait for signed 8-bit integers.
 template <> struct Wider<std::int8_t> { using type = std::int16_t; };
+
+/// @brief Specialization of the Wider trait for unsigned 8-bit integers.
 template <> struct Wider<std::uint8_t> { using type = std::uint16_t; };
+
+/// @brief Specialization of the Wider trait for signed 16-bit integers.
 template <> struct Wider<std::int16_t> { using type = std::int32_t; };
+
+/// @brief Specialization of the Wider trait for unsigned 16-bit integers.
 template <> struct Wider<std::uint16_t> { using type = std::uint32_t; };
+
+/// @brief Specialization of the Wider trait for signed 32-bit integers.
 template <> struct Wider<std::int32_t> { using type = std::int64_t; };
+
+/// @brief Specialization of the Wider trait for unsigned 32-bit integers.
 template <> struct Wider<std::uint32_t> { using type = std::uint64_t; };
+
+/// @brief Specialization of the Wider trait for float.
 template <> struct Wider<float> { using type = double; };
+
+/// @brief Specialization of the Wider trait for double.
 template <> struct Wider<double> { using type = long double; };
 
 #ifndef _WIN32
 // Note: __int128_t not defined for Windows!
+    
+/// @brief Specialization of the Wider trait for signed 64-bit integers.
 template <> struct Wider<std::int64_t> { using type = __int128_t; };
+
+/// @brief Specialization of the Wider trait for unsigned 64-bit integers.
 template <> struct Wider<std::uint64_t> { using type = __uint128_t; };
+
 #endif
 
 } // namespace playrho
@@ -57,6 +77,8 @@ namespace std {
 #ifndef _WIN32
 // This might already be defined by the standard library header, but
 // define it here explicitly in case it's not.
+
+/// @brief Make unsigned specialization for the __int128_t type.
 template <> struct make_unsigned<__int128_t> { typedef __uint128_t type; };
 #endif
 

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -73,6 +73,7 @@ class Contact
 public:
     using substep_type = ts_iters_t;
 
+    /// @brief Update configuration.
     struct UpdateConf
     {
         DistanceConf distance;

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -114,6 +114,7 @@ namespace playrho
 
 namespace std
 {
+    /// @brief Hash function object specialization for ContactKey.
     template <>
     struct hash<playrho::ContactKey>
     {

--- a/PlayRho/Dynamics/Contacts/ContactSolver.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.hpp
@@ -28,6 +28,7 @@ namespace playrho {
     class PositionConstraint;
     class BodyConstraint;
     
+    /// @brief Solution for position constraint.
     struct PositionSolution
     {
         Position pos_a;

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -44,6 +44,7 @@ namespace playrho {
         using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
         using index_type = std::size_t;
         
+        /// @brief Configuration data for velocity constraints.
         struct Conf
         {
             Real dtRatio = Real(1);

--- a/PlayRho/Dynamics/Joints/JointKey.hpp
+++ b/PlayRho/Dynamics/Joints/JointKey.hpp
@@ -33,6 +33,7 @@ namespace playrho
     class Joint;
     class Body;
 
+    /// @brief Joint key.
     class JointKey
     {
     public:
@@ -94,6 +95,7 @@ namespace playrho
 
 namespace std
 {
+    /// @brief Function object for performaing less-than comparisons between two joint keys.
     template <>
     struct less<playrho::JointKey>
     {
@@ -104,6 +106,7 @@ namespace std
         }
     };
     
+    /// @brief Function object for performaing equal-to comparisons between two joint keys.
     template <>
     struct equal_to<playrho::JointKey>
     {

--- a/PlayRho/Dynamics/MovementConf.hpp
+++ b/PlayRho/Dynamics/MovementConf.hpp
@@ -27,6 +27,7 @@ namespace playrho
 {
     class StepConf;
     
+    /// @brief Movement configuration.
     struct MovementConf
     {
         Length maxTranslation;

--- a/PlayRho/Rope/Rope.hpp
+++ b/PlayRho/Rope/Rope.hpp
@@ -24,7 +24,7 @@
 
 namespace playrho {
 
-/// 
+/// @brief Rope definition.
 struct RopeDef
 {
     using size_type = std::size_t;
@@ -53,7 +53,7 @@ struct RopeDef
     Real k3 = Real{1} / Real(10);
 };
 
-/// 
+/// @brief Rope.
 class Rope
 {
 public:


### PR DESCRIPTION
#### Description - What's this PR do?
Changes to fix doxygen warnings.
Changes the doxygen configuration to treat warnings as errors and exit with non-zero exit status on any warnings.
Comment documentation changes to deal with some "compound" classes that aren't documented.

#### Impacts/Risks of These Changes?
Should only improve documentation.

#### Related Issues
Issue #21.