### PR TITLE
For issue #84.

### DIFF
--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -63,11 +63,11 @@ namespace playrho
         /// @brief Size type.
         using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
 
-        /// Shape index type.
-        using sidx_t = std::remove_const<decltype(MaxShapeVertices)>::type;
+        /// Contact feature index.
+        using CfIndex = ContactFeature::Index;
         
         /// @brief Contact feature type.
-        using cf_t = ContactFeature::Type;
+        using CfType = ContactFeature::Type;
 
         struct Conf;
 
@@ -157,7 +157,7 @@ namespace playrho
         /// @param iA Index of vertex from shape A representing the local center of "circle" A.
         /// @param vB Local center of "circle" B.
         /// @param iB Index of vertex from shape B representing the local center of "circle" B.
-        static inline Manifold GetForCircles(Length2D vA, sidx_t iA, Length2D vB, sidx_t iB) noexcept
+        static inline Manifold GetForCircles(Length2D vA, CfIndex iA, Length2D vB, CfIndex iB) noexcept
         {
             return Manifold{e_circles, GetInvalid<UnitVec2>(), vA, 1, {{
                 Point{vB, GetVertexVertexContactFeature(iA, iB)}
@@ -235,7 +235,7 @@ namespace playrho
         }
         
         /// @brief Gets the face A manifold for the given data.
-        static inline Manifold GetForFaceA(UnitVec2 na, sidx_t ia, Length2D pa) noexcept
+        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2D pa) noexcept
         {
             return Manifold{e_faceA, na, pa, 0, {{
                 Point{GetInvalid<Length2D>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}},
@@ -244,7 +244,7 @@ namespace playrho
         }
         
         /// @brief Gets the face B manifold for the given data.
-        static inline Manifold GetForFaceB(UnitVec2 nb, sidx_t ib, Length2D pb) noexcept
+        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2D pb) noexcept
         {
             return Manifold{e_faceB, nb, pb, 0, {{
                 Point{GetInvalid<Length2D>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}},
@@ -253,8 +253,8 @@ namespace playrho
         }
 
         /// @brief Gets the face A manifold for the given data.
-        static inline Manifold GetForFaceA(UnitVec2 na, sidx_t ia, Length2D pa,
-                                              cf_t tb0, sidx_t ib0, Length2D pb0) noexcept
+        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2D pa,
+                                              CfType tb0, CfIndex ib0, Length2D pb0) noexcept
         {
             return Manifold{e_faceA, na, pa, 1, {{
                 Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}},
@@ -263,8 +263,8 @@ namespace playrho
         }
         
         /// @brief Gets the face B manifold for the given data.
-        static inline Manifold GetForFaceB(UnitVec2 nb, sidx_t ib, Length2D pb,
-                                              cf_t ta0, sidx_t ia0, Length2D pa0) noexcept
+        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2D pb,
+                                              CfType ta0, CfIndex ia0, Length2D pa0) noexcept
         {
             return Manifold{e_faceB, nb, pb, 1, {{
                 Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}},
@@ -273,9 +273,9 @@ namespace playrho
         }
         
         /// @brief Gets the face A manifold for the given data.
-        static inline Manifold GetForFaceA(UnitVec2 na, sidx_t ia, Length2D pa,
-                                              cf_t tb0, sidx_t ib0, Length2D pb0,
-                                              cf_t tb1, sidx_t ib1, Length2D pb1) noexcept
+        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2D pa,
+                                              CfType tb0, CfIndex ib0, Length2D pb0,
+                                              CfType tb1, CfIndex ib1, Length2D pb1) noexcept
         {
             return Manifold{e_faceA, na, pa, 2, {{
                 Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}},
@@ -284,9 +284,9 @@ namespace playrho
         }
 
         /// @brief Gets the face B manifold for the given data.
-        static inline Manifold GetForFaceB(UnitVec2 nb, sidx_t ib, Length2D pb,
-                                              cf_t ta0, sidx_t ia0, Length2D pa0,
-                                              cf_t ta1, sidx_t ia1, Length2D pa1) noexcept
+        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2D pb,
+                                              CfType ta0, CfIndex ia0, Length2D pa0,
+                                              CfType ta1, CfIndex ia1, Length2D pa1) noexcept
         {
             return Manifold{e_faceB, nb, pb, 2, {{
                 Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}},
@@ -371,7 +371,7 @@ namespace playrho
         void AddPoint(const Point& mp) noexcept;
 
         /// @brief Adds a new point with the given data.
-        void AddPoint(cf_t type, sidx_t index, Length2D point) noexcept;
+        void AddPoint(CfType type, CfIndex index, Length2D point) noexcept;
 
         /// @brief Gets the local normal for a face-type manifold.
         /// @note Only valid for face-A or face-B type manifolds.
@@ -503,7 +503,7 @@ namespace playrho
         ++m_pointCount;
     }
 
-    inline void Manifold::AddPoint(cf_t type, sidx_t index, Length2D point) noexcept
+    inline void Manifold::AddPoint(CfType type, CfIndex index, Length2D point) noexcept
     {
         assert(m_pointCount < MaxManifoldPoints);
         switch (m_type)

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -107,7 +107,7 @@ using ChildCounter = std::remove_const<decltype(MaxChildCount)>::type;
 
 /// Time step iterations type.
 /// @details A type for countining iterations per time-step.
-using ts_iters_t = std::uint8_t;
+using TimestepIters = std::uint8_t;
 
 /// @brief Maximum float value.
 constexpr auto MaxFloat = std::numeric_limits<Real>::max(); // FLT_MAX

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -73,7 +73,7 @@ class Contact
 public:
     
     /// @brief Substep type.
-    using substep_type = ts_iters_t;
+    using substep_type = TimestepIters;
 
     /// @brief Update configuration.
     struct UpdateConf

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -42,7 +42,7 @@ public:
     /// @brief Step iterations type.
     /// @details A type for countining iterations per-step.
     /// @note The special value of -1 is reserved for signifying an invalid iteration value.
-    using iteration_type = ts_iters_t;
+    using iteration_type = TimestepIters;
 
     /// @brief Invalid iteration value.
     static constexpr auto InvalidIteration = static_cast<iteration_type>(-1);

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -76,7 +76,7 @@ public:
     using proxy_size_type = std::remove_const<decltype(MaxContacts)>::type;
 
     /// @brief Time step iteration type.
-    using ts_iters_type = ts_iters_t;
+    using ts_iters_type = TimestepIters;
     
     /// @brief Bodies container type.
     using Bodies = std::vector<Body*>;
@@ -365,8 +365,8 @@ private:
         ContactCounter contactsUpdated = 0;
         ContactCounter contactsSkipped = 0;
         bool solved = false; ///< Solved. <code>true</code> if position constraints solved, <code>false</code> otherwise.
-        ts_iters_t positionIterations = 0; ///< Position iterations actually performed.
-        ts_iters_t velocityIterations = 0; ///< Velocity iterations actually performed.
+        TimestepIters positionIterations = 0; ///< Position iterations actually performed.
+        TimestepIters velocityIterations = 0; ///< Velocity iterations actually performed.
     };
     
     void CopyBodies(std::map<const Body*, Body*>& bodyMap,

--- a/PlayRho/Dynamics/WorldCallbacks.hpp
+++ b/PlayRho/Dynamics/WorldCallbacks.hpp
@@ -73,17 +73,17 @@ class ContactImpulsesList
 {
 public:
     
-    /// @brief Count type.
-    using count_t = std::remove_const<decltype(MaxManifoldPoints)>::type;
+    /// @brief Counter type.
+    using Counter = std::remove_const<decltype(MaxManifoldPoints)>::type;
 
     /// @brief Gets the count.
-    count_t GetCount() const noexcept { return count; }
+    Counter GetCount() const noexcept { return count; }
 
     /// @brief Gets the given indexed entry normal.
-    Momentum GetEntryNormal(count_t index) const noexcept { return normalImpulses[index]; }
+    Momentum GetEntryNormal(Counter index) const noexcept { return normalImpulses[index]; }
 
     /// @brief Gets the given indexed entry tangent.
-    Momentum GetEntryTanget(count_t index) const noexcept { return tangentImpulses[index]; }
+    Momentum GetEntryTanget(Counter index) const noexcept { return tangentImpulses[index]; }
     
     /// @brief Adds an entry of the given data.
     void AddEntry(Momentum normal, Momentum tangent) noexcept
@@ -97,7 +97,7 @@ public:
 private:
     Momentum normalImpulses[MaxManifoldPoints];
     Momentum tangentImpulses[MaxManifoldPoints];
-    count_t count = 0;
+    Counter count = 0;
 };
 
 /// @brief A pure-virtual interface for "listeners" for contacts.

--- a/UnitTests/ContactImpulsesList.cpp
+++ b/UnitTests/ContactImpulsesList.cpp
@@ -37,24 +37,24 @@ TEST(ContactImpulsesList, ByteSize)
 TEST(ContactImpulsesList, DefaultConstruction)
 {
     const auto v = ContactImpulsesList{};
-    EXPECT_EQ(v.GetCount(), ContactImpulsesList::count_t(0));
+    EXPECT_EQ(v.GetCount(), ContactImpulsesList::Counter(0));
 }
 
 TEST(ContactImpulsesList, AddEntry)
 {
     auto v = ContactImpulsesList{};
-    EXPECT_EQ(v.GetCount(), ContactImpulsesList::count_t(0));
+    EXPECT_EQ(v.GetCount(), ContactImpulsesList::Counter(0));
     
     const auto normalMomentum = Momentum{Real(3) * Kilogram * MeterPerSecond};
     const auto tangentMomentum = Momentum{Real(1) * Kilogram * MeterPerSecond};
 
     v.AddEntry(normalMomentum, tangentMomentum);
-    EXPECT_EQ(v.GetCount(), ContactImpulsesList::count_t(1));
+    EXPECT_EQ(v.GetCount(), ContactImpulsesList::Counter(1));
     EXPECT_EQ(v.GetEntryNormal(0), normalMomentum);
     EXPECT_EQ(v.GetEntryTanget(0), tangentMomentum);
     
     v.AddEntry(normalMomentum * Real(2), tangentMomentum * Real(2));
-    EXPECT_EQ(v.GetCount(), ContactImpulsesList::count_t(2));
+    EXPECT_EQ(v.GetCount(), ContactImpulsesList::Counter(2));
     EXPECT_EQ(v.GetEntryNormal(0), normalMomentum);
     EXPECT_EQ(v.GetEntryTanget(0), tangentMomentum);
     EXPECT_EQ(v.GetEntryNormal(1), normalMomentum * Real(2));


### PR DESCRIPTION
#### Description - What's this PR do?
Renames PlayRho *_t types to get rid of their _t suffix.

#### Impacts/Risks of These Changes?
Shouldn't be any impacts/risks.

#### How should this be tested?
Do a search for ending with `_t = `. No matches means resolved.

#### Related Issues
Issue #84.