### PR TITLE
For issue #103.

### DIFF
--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -35,13 +35,13 @@ int main(int, char**)
     // from a pool and creates the ground box shape (also from a pool).
     // The body is also added to the world.
     const auto groundBody = world.CreateBody(playrho::BodyDef{}.UseLocation(playrho::Length2D{
-        playrho::Real(0) * playrho::Meter, playrho::Real(-10) * playrho::Meter
+        0 * playrho::Meter, -10 * playrho::Meter
     }));
 
     // Define the ground box shape.
     // The extents are the half-widths of the box.
     const auto groundBox = std::make_shared<playrho::PolygonShape>(
-        playrho::Real(50) * playrho::Meter, playrho::Real(10) * playrho::Meter);
+        50 * playrho::Meter, 10 * playrho::Meter);
 
     // Add the ground fixture to the ground body.
     groundBody->CreateFixture(groundBox);
@@ -50,18 +50,18 @@ int main(int, char**)
     const auto body = world.CreateBody(playrho::BodyDef{}
                                        .UseType(playrho::BodyType::Dynamic)
                                        .UseLocation(playrho::Length2D{
-        playrho::Real(0) * playrho::Meter, playrho::Real(4) * playrho::Meter
+        0 * playrho::Meter, 4 * playrho::Meter
     }));
 
     // Define another box shape for our dynamic body.
     const auto dynamicBox = std::make_shared<playrho::PolygonShape>(
-        playrho::Real(1) * playrho::Meter, playrho::Real(1) * playrho::Meter);
+        1 * playrho::Meter, 1 * playrho::Meter);
 
     // Set the box density to be non-zero, so it will be dynamic.
-    dynamicBox->SetDensity(playrho::Real(1) * playrho::KilogramPerSquareMeter);
+    dynamicBox->SetDensity(1 * playrho::KilogramPerSquareMeter);
 
     // Override the default friction.
-    dynamicBox->SetFriction(playrho::Real(0.3f));
+    dynamicBox->SetFriction(0.3f);
 
     // Add the shape to the body.
     body->CreateFixture(dynamicBox);

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -28,6 +28,7 @@
 
 #include <PlayRho/Common/RealConstants.hpp>
 #include <PlayRho/Common/Templates.hpp>
+#include <type_traits>
 
 // #define USE_BOOST_UNITS
 #ifdef USE_BOOST_UNITS
@@ -294,6 +295,81 @@ namespace playrho
 #endif
 
 } // namespace playrho
+
+#if defined(USE_BOOST_UNITS)
+namespace boost {
+namespace units {
+
+// Define division and multiplication templated operators in boost::units namespace since
+//   boost::units is the consistent namespace of operands for these and this aids with
+//   argument dependent lookup (ADL).
+//
+// Note that while boost::units already defines division and multiplication operator support,
+//   that's only for division or multiplication with the same type that the quantity is based
+//   on. For example when Real is float, Length{0.0f} * 2.0f is already supported but
+//   Length{0.0f} * 2 is not.
+
+/// @brief Division operator.
+///
+/// @details Supports the division of a playrho::Real based boost::units::quantity
+///   by any arithmetic type except playrho::Real.
+/// @note This intentionally excludes the playrho::Real type since the playrho::Real
+///   type is already supported and supporting it again in this template causes
+///   ambiguous overload support.
+///
+template <class Dimension, typename X, typename = std::enable_if_t<
+    std::is_arithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
+    std::is_same<decltype(playrho::Real{} / X{}), playrho::Real>::value >
+>
+auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
+{
+    return lhs / playrho::Real(rhs);
+}
+
+template <class Dimension, typename X, typename = std::enable_if_t<
+    std::is_arithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
+    std::is_same<decltype(X{} / playrho::Real{}), playrho::Real>::value >
+>
+auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
+{
+    return playrho::Real(lhs) / rhs;
+}
+
+/// @brief Multiplication operator.
+///
+/// @details Supports the multiplication of a playrho::Real based boost::units::quantity
+///   by any arithmetic type except playrho::Real.
+/// @note This intentionally excludes the playrho::Real type since the playrho::Real
+///   type is already supported and supporting it again in this template causes
+///   ambiguous overload support.
+///
+template <class Dimension, typename X, typename = std::enable_if_t<
+    std::is_arithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
+    std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
+auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
+{
+    return lhs * playrho::Real(rhs);
+}
+
+/// @brief Multiplication operator.
+///
+/// @details Supports the multiplication of a playrho::Real based boost::units::quantity
+///   by any arithmetic type except playrho::Real.
+/// @note This intentionally excludes the playrho::Real type since the playrho::Real
+///   type is already supported and supporting it again in this template causes
+///   ambiguous overload support.
+///
+template <class Dimension, typename X, typename = std::enable_if_t<
+    std::is_arithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
+    std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
+auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
+{
+    return playrho::Real(lhs) * rhs;
+}
+
+} // namespace units
+} // namespace boost
+#endif // defined(USE_BOOST_UNITS)
 
 #undef PLAYRHO_QUANTITY
 #undef PLAYRHO_UNIT


### PR DESCRIPTION
#### Description - What's this PR do?
Defines additional multiplication and division operator support beyond what boost::units already provides.

#### Impacts/Risks of These Changes?
While this should have no impact at all when boost unit support isn't enabled, it should simplify documentation and make things easier for library users wishing to write code that's also compatible with enabling of boost units.

#### Related Issues
Issue #103.