### PR TITLE
For issue #20 and issue #21.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,7 +11,7 @@ WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
-CheckOptions:    
+CheckOptions:
   - key:             cert-dcl59-cpp.HeaderFileExtensions
     value:           ',h,hh,hpp,hxx'
   - key:             cert-err09-cpp.CheckThrowTemporaries
@@ -185,7 +185,7 @@ CheckOptions:
   - key:             modernize-replace-random-shuffle.IncludeStyle
     value:           llvm
   - key:             modernize-use-auto.RemoveStars
-    value:           '0'
+    value:           '1'
   - key:             modernize-use-default-member-init.IgnoreMacros
     value:           '1'
   - key:             modernize-use-default-member-init.UseAssignment
@@ -225,15 +225,15 @@ CheckOptions:
   - key:             readability-braces-around-statements.ShortStatementLines
     value:           '0'
   - key:             readability-function-size.BranchThreshold
-    value:           '4294967295'
+    value:           '13'
   - key:             readability-function-size.LineThreshold
-    value:           '4294967295'
+    value:           '200'
   - key:             readability-function-size.NestingThreshold
-    value:           '4294967295'
+    value:           '5'
   - key:             readability-function-size.ParameterThreshold
-    value:           '4294967295'
+    value:           '6'
   - key:             readability-function-size.StatementThreshold
-    value:           '800'
+    value:           '100'
   - key:             readability-identifier-naming.IgnoreFailedSplit
     value:           '0'
   - key:             readability-implicit-bool-conversion.AllowIntegerConditions
@@ -247,4 +247,3 @@ CheckOptions:
   - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
     value:           '3'
 ...
-

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -192,6 +192,12 @@
 		47CF984B1DF9C4A30077F5F2 /* ShapeSeparation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47CF98491DF9C4A30077F5F2 /* ShapeSeparation.cpp */; };
 		47CF984D1DF9C4A30077F5F2 /* ShapeSeparation.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47CF984A1DF9C4A30077F5F2 /* ShapeSeparation.hpp */; };
 		47CF98501E0088ED0077F5F2 /* Angle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47CF984F1E0088ED0077F5F2 /* Angle.cpp */; };
+		47D28D871F6DD9540094C032 /* ShapeVisitor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47D28D851F6DD9540094C032 /* ShapeVisitor.hpp */; };
+		47D28D8B1F6DEABF0094C032 /* JointVisitor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47D28D891F6DEABF0094C032 /* JointVisitor.hpp */; };
+		47D28D8E1F6E2C7C0094C032 /* JointType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D28D8C1F6E2C7C0094C032 /* JointType.cpp */; };
+		47D28D8F1F6E2C7C0094C032 /* JointType.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47D28D8D1F6E2C7C0094C032 /* JointType.hpp */; };
+		47D28D931F6E2D8A0094C032 /* TypeJointVisitor.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47D28D911F6E2D8A0094C032 /* TypeJointVisitor.hpp */; };
+		47D28D951F6E32720094C032 /* PulleyJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D28D941F6E32720094C032 /* PulleyJoint.cpp */; };
 		47D61F741F1F148500E702BD /* SilkscreenTtfData.h in Headers */ = {isa = PBXBuildFile; fileRef = 47D61F731F1F148500E702BD /* SilkscreenTtfData.h */; };
 		47D61F761F1F1F2500E702BD /* DroidSansTtfData.h in Headers */ = {isa = PBXBuildFile; fileRef = 47D61F751F1F1F2500E702BD /* DroidSansTtfData.h */; };
 		47D61F781F1FE3B700E702BD /* EdgeShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D61F771F1FE3B700E702BD /* EdgeShape.cpp */; };
@@ -546,6 +552,12 @@
 		47CF98491DF9C4A30077F5F2 /* ShapeSeparation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ShapeSeparation.cpp; sourceTree = "<group>"; };
 		47CF984A1DF9C4A30077F5F2 /* ShapeSeparation.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ShapeSeparation.hpp; sourceTree = "<group>"; };
 		47CF984F1E0088ED0077F5F2 /* Angle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Angle.cpp; sourceTree = "<group>"; };
+		47D28D851F6DD9540094C032 /* ShapeVisitor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ShapeVisitor.hpp; sourceTree = "<group>"; };
+		47D28D891F6DEABF0094C032 /* JointVisitor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = JointVisitor.hpp; sourceTree = "<group>"; };
+		47D28D8C1F6E2C7C0094C032 /* JointType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JointType.cpp; sourceTree = "<group>"; };
+		47D28D8D1F6E2C7C0094C032 /* JointType.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = JointType.hpp; sourceTree = "<group>"; };
+		47D28D911F6E2D8A0094C032 /* TypeJointVisitor.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TypeJointVisitor.hpp; sourceTree = "<group>"; };
+		47D28D941F6E32720094C032 /* PulleyJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PulleyJoint.cpp; sourceTree = "<group>"; };
 		47D61F731F1F148500E702BD /* SilkscreenTtfData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SilkscreenTtfData.h; sourceTree = "<group>"; };
 		47D61F751F1F1F2500E702BD /* DroidSansTtfData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DroidSansTtfData.h; sourceTree = "<group>"; };
 		47D61F771F1FE3B700E702BD /* EdgeShape.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EdgeShape.cpp; sourceTree = "<group>"; };
@@ -790,6 +802,7 @@
 				47FFD0FC1DAC6235000D6D0E /* PositionConstraint.cpp */,
 				47AFC3041DAEBC120023E9D1 /* PositionSolverManifold.cpp */,
 				4768D3F71E3E895A00574143 /* PrismaticJoint.cpp */,
+				47D28D941F6E32720094C032 /* PulleyJoint.cpp */,
 				470F9B511EF8E2C5007EF7B6 /* RayCastOutput.cpp */,
 				472724221E310BB400C64921 /* Real.cpp */,
 				47315E031E28A66100DDA856 /* RevoluteJoint.cpp */,
@@ -895,6 +908,7 @@
 				80BB893C141C3E5900F1753A /* PolygonShape.hpp */,
 				470F9B051EDB8F62007EF7B6 /* Shape.cpp */,
 				80BB893D141C3E5900F1753A /* Shape.hpp */,
+				47D28D851F6DD9540094C032 /* ShapeVisitor.hpp */,
 			);
 			path = Shapes;
 			sourceTree = "<group>";
@@ -1018,10 +1032,13 @@
 				4787D6C91F2EA3A1008C115E /* GearJointDef.hpp */,
 				80BB8974141C3E5900F1753A /* Joint.cpp */,
 				80BB8975141C3E5900F1753A /* Joint.hpp */,
+				47D28D891F6DEABF0094C032 /* JointVisitor.hpp */,
 				4787D6BC1F2E968E008C115E /* JointDef.cpp */,
 				4787D6BD1F2E968E008C115E /* JointDef.hpp */,
 				470F94D71EC8C37500AA3C82 /* JointKey.cpp */,
 				470F94D81EC8C37500AA3C82 /* JointKey.hpp */,
+				47D28D8C1F6E2C7C0094C032 /* JointType.cpp */,
+				47D28D8D1F6E2C7C0094C032 /* JointType.hpp */,
 				80620F8D168B934600D46C8D /* MotorJoint.cpp */,
 				80620F8E168B934600D46C8D /* MotorJoint.hpp */,
 				4787D6CC1F2EC902008C115E /* MotorJointDef.cpp */,
@@ -1046,6 +1063,7 @@
 				80BB897F141C3E5900F1753A /* RopeJoint.hpp */,
 				4787D6DC1F2ED2D6008C115E /* RopeJointDef.cpp */,
 				4787D6DD1F2ED2D6008C115E /* RopeJointDef.hpp */,
+				47D28D911F6E2D8A0094C032 /* TypeJointVisitor.hpp */,
 				80BB8980141C3E5900F1753A /* WeldJoint.cpp */,
 				80BB8981141C3E5900F1753A /* WeldJoint.hpp */,
 				4787D6E01F2ED461008C115E /* WeldJointDef.cpp */,
@@ -1266,9 +1284,11 @@
 				478869101D78BF7200AEC7F1 /* VelocityConstraint.hpp in Headers */,
 				80BB89B7141C3E5900F1753A /* WorldCallbacks.hpp in Headers */,
 				47B58F661F64D2B500354C34 /* Real.hpp in Headers */,
+				47D28D871F6DD9540094C032 /* ShapeVisitor.hpp in Headers */,
 				4768D3F51E3A7ACA00574143 /* Wider.hpp in Headers */,
 				4787D6E71F2ED62C008C115E /* WheelJointDef.hpp in Headers */,
 				470F94E31ECBB3A100AA3C82 /* Range.hpp in Headers */,
+				47D28D931F6E2D8A0094C032 /* TypeJointVisitor.hpp in Headers */,
 				470F94B41EC4CB6C00AA3C82 /* Filter.hpp in Headers */,
 				4787D6CF1F2EC902008C115E /* MotorJointDef.hpp in Headers */,
 				479B63C01ED8B64300D49BC7 /* BoundedValue.hpp in Headers */,
@@ -1283,6 +1303,7 @@
 				80BB89BF141C3E5900F1753A /* Contact.hpp in Headers */,
 				4787D6C31F2E9DC0008C115E /* DistanceJointDef.hpp in Headers */,
 				80BB89C1141C3E5900F1753A /* ContactSolver.hpp in Headers */,
+				47D28D8F1F6E2C7C0094C032 /* JointType.hpp in Headers */,
 				47CF984D1DF9C4A30077F5F2 /* ShapeSeparation.hpp in Headers */,
 				80BB89CB141C3E5900F1753A /* DistanceJoint.hpp in Headers */,
 				470F9B121EDF2890007EF7B6 /* Position.hpp in Headers */,
@@ -1306,6 +1327,7 @@
 				80BB89DF141C3E5900F1753A /* WheelJoint.hpp in Headers */,
 				4787D6DB1F2ECFFB008C115E /* RevoluteJointDef.hpp in Headers */,
 				4751EE2E1CEDD7A300D459CB /* MotorJoint.hpp in Headers */,
+				47D28D8B1F6DEABF0094C032 /* JointVisitor.hpp in Headers */,
 				470F94C61EC4D78300AA3C82 /* JointAtty.hpp in Headers */,
 				470F94D21EC6376F00AA3C82 /* ContactKey.hpp in Headers */,
 				47578BE11D8869110078CD40 /* WorldManifold.hpp in Headers */,
@@ -1467,6 +1489,7 @@
 				474BC4301D413DC200447DCD /* DistanceProxy.cpp in Sources */,
 				47C85D0A1EFA251B00F70C56 /* WheelJoint.cpp in Sources */,
 				475A945D1D959537000CA9A8 /* Joint.cpp in Sources */,
+				47D28D951F6E32720094C032 /* PulleyJoint.cpp in Sources */,
 				47D61F7C1F21112000E702BD /* MultiShape.cpp in Sources */,
 				474BC4311D413DC200447DCD /* Epsilon.cpp in Sources */,
 				470F9B521EF8E2C5007EF7B6 /* RayCastOutput.cpp in Sources */,
@@ -1575,6 +1598,7 @@
 				80BB898F141C3E5900F1753A /* Distance.cpp in Sources */,
 				4787D6D61F2ECD87008C115E /* PulleyJointDef.cpp in Sources */,
 				80BB8991141C3E5900F1753A /* DynamicTree.cpp in Sources */,
+				47D28D8E1F6E2C7C0094C032 /* JointType.cpp in Sources */,
 				80BB8993141C3E5900F1753A /* TimeOfImpact.cpp in Sources */,
 				470F9B4C1EEF20B6007EF7B6 /* BodyDef.cpp in Sources */,
 				80BB8995141C3E5900F1753A /* ChainShape.cpp in Sources */,

--- a/PlayRho/Collision/Shapes/ChainShape.cpp
+++ b/PlayRho/Collision/Shapes/ChainShape.cpp
@@ -20,6 +20,7 @@
  */
 
 #include <PlayRho/Collision/Shapes/ChainShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 
 namespace playrho {
 
@@ -130,6 +131,11 @@ DistanceProxy ChainShape::GetChild(ChildCounter index) const
         return DistanceProxy{GetVertexRadius(), 2, &m_vertices[index], &m_normals[index * 2]};
     }
     return DistanceProxy{GetVertexRadius(), 1, &m_vertices[0], nullptr};
+}
+
+void ChainShape::Accept(ShapeVisitor &visitor) const
+{
+    visitor.Visit(*this);
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/ChainShape.hpp
+++ b/PlayRho/Collision/Shapes/ChainShape.hpp
@@ -86,7 +86,7 @@ public:
     /// @return Mass data for this shape.
     MassData GetMassData() const noexcept override;
     
-    void Accept(Visitor& visitor) const override;
+    void Accept(ShapeVisitor& visitor) const override;
 
     /// Get the vertex count.
     ChildCounter GetVertexCount() const noexcept;
@@ -105,11 +105,6 @@ private:
 inline ChildCounter ChainShape::GetVertexCount() const noexcept
 {
     return static_cast<ChildCounter>(m_vertices.size());
-}
-
-inline void ChainShape::Accept(playrho::Shape::Visitor &visitor) const
-{
-    visitor.Visit(*this);
 }
 
 inline Length2D ChainShape::GetVertex(ChildCounter index) const

--- a/PlayRho/Collision/Shapes/DiskShape.cpp
+++ b/PlayRho/Collision/Shapes/DiskShape.cpp
@@ -18,12 +18,18 @@
  */
 
 #include <PlayRho/Collision/Shapes/DiskShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 
 namespace playrho {
 
 MassData DiskShape::GetMassData() const noexcept
 {
     return playrho::GetMassData(GetVertexRadius(), GetDensity(), GetLocation());
+}
+
+void DiskShape::Accept(ShapeVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/DiskShape.hpp
+++ b/PlayRho/Collision/Shapes/DiskShape.hpp
@@ -97,7 +97,7 @@ public:
     MassData GetMassData() const noexcept override;
     
     /// @brief Accepts the given visitor.
-    void Accept(Visitor& visitor) const override;
+    void Accept(ShapeVisitor& visitor) const override;
 
     /// Gets the "radius" of the shape.
     /// @return Non-negative distance.
@@ -140,11 +140,6 @@ inline DistanceProxy DiskShape::GetChild(ChildCounter index) const
         throw InvalidArgument("only index of 0 is supported");
     }
     return DistanceProxy{GetVertexRadius(), 1, &m_location, nullptr};
-}
-
-inline void DiskShape::Accept(Visitor& visitor) const
-{
-    visitor.Visit(*this);
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/EdgeShape.cpp
+++ b/PlayRho/Collision/Shapes/EdgeShape.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <PlayRho/Collision/Shapes/EdgeShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 
 namespace playrho {
 
@@ -33,6 +34,11 @@ void EdgeShape::Set(Length2D v1, Length2D v2)
 
     m_normals[0] = GetUnitVector(GetFwdPerpendicular(v2 - v1));
     m_normals[1] = -m_normals[0];
+}
+
+void EdgeShape::Accept(ShapeVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/EdgeShape.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShape.hpp
@@ -105,7 +105,7 @@ public:
     /// @return Mass data for this shape.
     MassData GetMassData() const noexcept override;
     
-    void Accept(Visitor& visitor) const override;
+    void Accept(ShapeVisitor& visitor) const override;
 
     /// @brief Sets this as an isolated edge.
     void Set(Length2D v1, Length2D v2);
@@ -140,11 +140,6 @@ inline DistanceProxy EdgeShape::GetChild(ChildCounter index) const
         throw InvalidArgument("only index of 0 is supported");
     }
     return DistanceProxy{GetVertexRadius(), 2, m_vertices, m_normals};
-}
-
-inline void EdgeShape::Accept(Visitor& visitor) const
-{
-    visitor.Visit(*this);
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/MultiShape.cpp
+++ b/PlayRho/Collision/Shapes/MultiShape.cpp
@@ -19,6 +19,7 @@
  */
 
 #include <PlayRho/Collision/Shapes/MultiShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 #include <algorithm>
 
@@ -70,6 +71,11 @@ void MultiShape::AddConvexHull(const VertexSet& pointSet) noexcept
     }
     
     m_children.push_back(ConvexHull{vertices, normals});
+}
+
+void MultiShape::Accept(ShapeVisitor &visitor) const
+{
+    visitor.Visit(*this);
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/MultiShape.hpp
+++ b/PlayRho/Collision/Shapes/MultiShape.hpp
@@ -93,7 +93,7 @@ namespace playrho {
         /// @return Mass data for this shape.
         MassData GetMassData() const noexcept override;
                 
-        void Accept(Visitor& visitor) const override;
+        void Accept(ShapeVisitor& visitor) const override;
         
         /// Creates a convex hull from the given set of local points.
         /// The size of the set must be in the range [1, MaxShapeVertices].
@@ -135,11 +135,6 @@ namespace playrho {
             GetVertexRadius(), static_cast<DistanceProxy::size_type>(child.vertices.size()),
             child.vertices.data(), child.normals.data()
         };
-    }
-    
-    inline void MultiShape::Accept(playrho::Shape::Visitor &visitor) const
-    {
-        visitor.Visit(*this);
     }
 
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/PolygonShape.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <PlayRho/Collision/Shapes/PolygonShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 
 namespace playrho {
@@ -130,6 +131,11 @@ void PolygonShape::Set(const VertexSet& points) noexcept
             m_centroid = ComputeCentroid(GetVertices());
             break;
     }
+}
+
+void PolygonShape::Accept(ShapeVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 Length2D GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index)

--- a/PlayRho/Collision/Shapes/PolygonShape.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.hpp
@@ -107,7 +107,7 @@ public:
     /// @return Mass data for this shape.
     MassData GetMassData() const noexcept override;
     
-    void Accept(Visitor& visitor) const override;
+    void Accept(ShapeVisitor& visitor) const override;
 
     /// Creates a convex hull from the given array of local points.
     /// The size of the span must be in the range [1, MaxShapeVertices].
@@ -193,11 +193,6 @@ inline DistanceProxy PolygonShape::GetChild(ChildCounter index) const
     return DistanceProxy{GetVertexRadius(),
         static_cast<DistanceProxy::size_type>(m_vertices.size()), m_vertices.data(),
         m_normals.data()};
-}
-
-inline void PolygonShape::Accept(Visitor& visitor) const
-{
-    visitor.Visit(*this);
 }
 
 inline PolygonShape::VertexCounter PolygonShape::GetVertexCount() const noexcept

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -27,11 +27,7 @@
 
 namespace playrho {
 
-class DiskShape;
-class EdgeShape;
-class PolygonShape;
-class ChainShape;
-class MultiShape;
+class ShapeVisitor;
 
 /// @brief A base abstract class for describing a type of shape.
 ///
@@ -113,26 +109,6 @@ public:
         constexpr ConcreteConf& UseDensity(NonNegative<Density> value) noexcept;
     };
 
-    class Visitor;
-
-    /// @brief Default constructor is deleted.
-    /// @details This is a base class that shouldn't ever be directly instantiated.
-    Shape() = delete;
-
-    /// @brief Initializing constructor.
-    ///
-    explicit Shape(const Conf& conf) noexcept:
-        m_vertexRadius{conf.vertexRadius},
-        m_density{conf.density},
-        m_friction{conf.friction},
-        m_restitution{conf.restitution}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Copy constructor.
-    Shape(const Shape&) = default;
-
     virtual ~Shape() = default;
 
     /// @brief Gets the number of child primitives of the shape.
@@ -149,7 +125,7 @@ public:
     virtual MassData GetMassData() const noexcept = 0;
 
     /// @brief Accepts a visitor.
-    virtual void Accept(Visitor& visitor) const = 0;
+    virtual void Accept(ShapeVisitor& visitor) const = 0;
     
     /// @brief Gets the vertex radius.
     NonNegative<Length> GetVertexRadius() const noexcept;
@@ -192,6 +168,35 @@ public:
     /// @brief Sets the coefficient of restitution.
     /// @note This will _not_ change the restitution of existing contacts.
     void SetRestitution(Finite<Real> restitution) noexcept;
+
+protected:
+
+    /// @brief Default constructor.
+    /// @details This is a base class that shouldn't ever be directly instantiated.
+    Shape() = default;
+    
+    /// @brief Initializing constructor.
+    ///
+    explicit Shape(const Conf& conf) noexcept:
+        m_vertexRadius{conf.vertexRadius},
+        m_density{conf.density},
+        m_friction{conf.friction},
+        m_restitution{conf.restitution}
+    {
+        // Intentionally empty.
+    }
+    
+    /// @brief Copy constructor.
+    Shape(const Shape& other) = default;
+    
+    /// @brief Move constructor.
+    Shape(Shape&& other) = default;
+
+    /// @brief Copy assignment operator.
+    Shape& operator= (const Shape& other) = default;
+    
+    /// @brief Move assignment operator.
+    Shape& operator= (Shape&& other) = default;
 
 private:
     
@@ -239,57 +244,6 @@ Shape::Builder<ConcreteConf>::UseDensity(NonNegative<Density> value) noexcept
     density = value;
     return static_cast<ConcreteConf&>(*this);
 }
-
-/// @brief Visitor interface.
-///
-/// @details Interface to inerit from for objects wishing to "visit" shapes.
-///   This uses the vistor design pattern.
-/// @sa https://en.wikipedia.org/wiki/Visitor_pattern .
-///
-class Shape::Visitor
-{
-public:
-    virtual ~Visitor() = default;
-    
-    /// @brief Visits a DiskShape.
-    virtual void Visit(const DiskShape& /*shape*/)
-    {
-        visited = true;
-    }
-    
-    /// @brief Visits an EdgeShape.
-    virtual void Visit(const EdgeShape& /*shape*/)
-    {
-        visited = true;
-    }
-    
-    /// @brief Visits a PolygonShape.
-    virtual void Visit(const PolygonShape& /*shape*/)
-    {
-        visited = true;
-    }
-    
-    /// @brief Visits a ChainShape.
-    virtual void Visit(const ChainShape& /*shape*/)
-    {
-        visited = true;
-    }
-    
-    /// @brief Visits a MultiShape.
-    virtual void Visit(const MultiShape& /*shape*/)
-    {
-        visited = true;
-    }
-    
-    /// @brief Is base visited.
-    bool IsBaseVisited() const noexcept
-    {
-        return visited;
-    }
-    
-private:
-    bool visited = false;
-};
 
 inline NonNegative<Length> Shape::GetVertexRadius() const noexcept
 {

--- a/PlayRho/Collision/Shapes/ShapeVisitor.hpp
+++ b/PlayRho/Collision/Shapes/ShapeVisitor.hpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_COLLISION_SHAPES_SHAPEVISITOR_HPP
+#define PLAYRHO_COLLISION_SHAPES_SHAPEVISITOR_HPP
+
+namespace playrho {
+
+class DiskShape;
+class EdgeShape;
+class PolygonShape;
+class ChainShape;
+class MultiShape;
+
+/// @brief Vistor interface for Shape instances.
+///
+/// @details Interface to inherit from for objects wishing to "visit" shapes.
+///   This uses the visitor design pattern.
+/// @sa https://en.wikipedia.org/wiki/Visitor_pattern .
+///
+class ShapeVisitor
+{
+public:
+    virtual ~ShapeVisitor() = default;
+    
+    /// @brief Visits a DiskShape.
+    virtual void Visit(const DiskShape& /*shape*/) = 0;
+    
+    /// @brief Visits an EdgeShape.
+    virtual void Visit(const EdgeShape& /*shape*/) = 0;
+    
+    /// @brief Visits a PolygonShape.
+    virtual void Visit(const PolygonShape& /*shape*/) = 0;
+    
+    /// @brief Visits a ChainShape.
+    virtual void Visit(const ChainShape& /*shape*/) = 0;
+    
+    /// @brief Visits a MultiShape.
+    virtual void Visit(const MultiShape& /*shape*/) = 0;
+    
+protected:
+    ShapeVisitor() = default;
+
+    /// @brief Copy constructor.
+    ShapeVisitor(const ShapeVisitor& other) = default;
+
+    /// @brief Move constructor.
+    ShapeVisitor(ShapeVisitor&& other) = default;
+    
+    /// @brief Copy assignment operator.
+    ShapeVisitor& operator= (const ShapeVisitor& other) = default;
+
+    /// @brief Move assignment operator.
+    ShapeVisitor& operator= (ShapeVisitor&& other) = default;
+};
+
+/// @brief A ShapeVisitor implementation that reports whether it's been visited.
+/// @sa ShapeVisitor
+class IsVisitedShapeVisitor: public ShapeVisitor
+{
+public:
+    
+    IsVisitedShapeVisitor() = default;
+    
+    /// @brief Copy constructor.
+    IsVisitedShapeVisitor(const IsVisitedShapeVisitor& other) = default;
+
+    /// @brief Move constructor.
+    IsVisitedShapeVisitor(IsVisitedShapeVisitor&& other) = default;
+
+    ~IsVisitedShapeVisitor() override = default;
+    
+    /// @brief Copy assignment operator.
+    IsVisitedShapeVisitor& operator= (const IsVisitedShapeVisitor& other) = default;
+    
+    /// @brief Move assignment operator.
+    IsVisitedShapeVisitor& operator= (IsVisitedShapeVisitor&& other) = default;
+
+    /// @brief Visits a DiskShape.
+    void Visit(const DiskShape& /*shape*/) override
+    {
+        visited = true;
+    }
+    
+    /// @brief Visits an EdgeShape.
+    void Visit(const EdgeShape& /*shape*/) override
+    {
+        visited = true;
+    }
+    
+    /// @brief Visits a PolygonShape.
+    void Visit(const PolygonShape& /*shape*/) override
+    {
+        visited = true;
+    }
+    
+    /// @brief Visits a ChainShape.
+    void Visit(const ChainShape& /*shape*/) override
+    {
+        visited = true;
+    }
+    
+    /// @brief Visits a MultiShape.
+    void Visit(const MultiShape& /*shape*/) override
+    {
+        visited = true;
+    }
+    
+    /// @brief Whether this visitor has been visited.
+    bool IsVisited() const noexcept
+    {
+        return visited;
+    }
+    
+private:
+    bool visited = false;
+};
+
+} // namespace playrho
+
+#endif // PLAYRHO_COLLISION_SHAPES_SHAPEVISITOR_HPP

--- a/PlayRho/Common/CodeDumper.cpp
+++ b/PlayRho/Common/CodeDumper.cpp
@@ -41,6 +41,7 @@
 #include <PlayRho/Collision/Shapes/PolygonShape.hpp>
 #include <PlayRho/Collision/Shapes/ChainShape.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 
 #include <cstdarg>
 
@@ -57,7 +58,7 @@ namespace
         va_end(args);
     }
     
-    class ShapeDumper: public Shape::Visitor
+    class ShapeDumper: public ShapeVisitor
     {
     public:
         void Visit(const DiskShape& shape) override;
@@ -192,7 +193,7 @@ void playrho::Dump(const Body& body, std::size_t bodyIndex)
 
 void playrho::Dump(const Joint& joint, std::size_t index)
 {
-    switch (joint.GetType())
+    switch (GetType(joint))
     {
         case JointType::Pulley:
             Dump(static_cast<const PulleyJoint&>(joint), index);

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -79,7 +79,7 @@ public:
     using Joints = std::vector<KeyedJointPtr>;
     
     /// @brief Container type for contacts.
-    using Contacts = std::vector<std::pair<ContactKey,Contact*>>;
+    using Contacts = std::vector<KeyedContactPtr>;
 
     /// @brief Invalid island index.
     static constexpr auto InvalidIslandIndex = static_cast<BodyCounter>(-1);

--- a/PlayRho/Dynamics/Joints/DistanceJoint.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.cpp
@@ -20,12 +20,13 @@
  */
 
 #include <PlayRho/Dynamics/Joints/DistanceJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // 1-D constrained system
 // m (v2 - v1) = lambda
@@ -60,6 +61,11 @@ DistanceJoint::DistanceJoint(const DistanceJointDef& def):
     m_dampingRatio(def.dampingRatio)
 {
     // Intentionally empty.
+}
+
+void DistanceJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void DistanceJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
@@ -249,3 +255,5 @@ AngularMomentum DistanceJoint::GetAngularReaction() const
 {
     return AngularMomentum{0};
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/DistanceJoint.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_DISTANCE_JOINT_HPP
-#define PLAYRHO_DISTANCE_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/DistanceJointDef.hpp>
@@ -41,6 +41,8 @@ public:
 
     /// @brief Initializing constructor.
     DistanceJoint(const DistanceJointDef& data);
+
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
 
@@ -136,4 +138,4 @@ inline Real DistanceJoint::GetDampingRatio() const noexcept
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINT_HPP

--- a/PlayRho/Dynamics/Joints/DistanceJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointDef.cpp
@@ -23,7 +23,7 @@
 #include <PlayRho/Dynamics/Joints/DistanceJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 DistanceJointDef::DistanceJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
                                    Length2D anchor1, Length2D anchor2) noexcept :
@@ -35,7 +35,7 @@ DistanceJointDef::DistanceJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
     // Intentionally empty.
 }
 
-DistanceJointDef playrho::GetDistanceJointDef(const DistanceJoint& joint) noexcept
+DistanceJointDef GetDistanceJointDef(const DistanceJoint& joint) noexcept
 {
     auto def = DistanceJointDef{};
     
@@ -49,3 +49,5 @@ DistanceJointDef playrho::GetDistanceJointDef(const DistanceJoint& joint) noexce
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/DistanceJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_DISTANCE_JOINT_DEF_HPP
-#define PLAYRHO_DISTANCE_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -104,4 +104,4 @@ DistanceJointDef GetDistanceJointDef(const DistanceJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_DISTANCE_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/FrictionJoint.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.cpp
@@ -20,11 +20,12 @@
  */
 
 #include <PlayRho/Dynamics/Joints/FrictionJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Point-to-point constraint
 // Cdot = v2 - v1
@@ -46,6 +47,11 @@ FrictionJoint::FrictionJoint(const FrictionJointDef& def):
     m_maxTorque(def.maxTorque)
 {
     // Intentionally empty.
+}
+
+void FrictionJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void FrictionJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step,
@@ -223,3 +229,5 @@ AngularMomentum FrictionJoint::GetAngularReaction() const
 {
     return m_angularImpulse;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/FrictionJoint.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_FRICTION_JOINT_HPP
-#define PLAYRHO_FRICTION_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/FrictionJointDef.hpp>
@@ -37,6 +37,8 @@ public:
     
     /// @brief Initializing constructor.
     FrictionJoint(const FrictionJointDef& def);
+
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
@@ -106,4 +108,4 @@ inline NonNegative<Torque> FrictionJoint::GetMaxTorque() const
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINT_HPP

--- a/PlayRho/Dynamics/Joints/FrictionJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointDef.cpp
@@ -22,7 +22,7 @@
 #include <PlayRho/Dynamics/Joints/FrictionJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 FrictionJointDef::FrictionJointDef(Body* bA, Body* bB, const Length2D anchor) noexcept:
     super{super{JointType::Friction}.UseBodyA(bA).UseBodyB(bB)},
@@ -32,7 +32,7 @@ FrictionJointDef::FrictionJointDef(Body* bA, Body* bB, const Length2D anchor) no
     // Intentionally empty.
 }
 
-FrictionJointDef playrho::GetFrictionJointDef(const FrictionJoint& joint) noexcept
+FrictionJointDef GetFrictionJointDef(const FrictionJoint& joint) noexcept
 {
     auto def = FrictionJointDef{};
     
@@ -45,3 +45,5 @@ FrictionJointDef playrho::GetFrictionJointDef(const FrictionJoint& joint) noexce
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/FrictionJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_FRICTION_JOINT_DEF_HPP
-#define PLAYRHO_FRICTION_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -81,4 +81,4 @@ FrictionJointDef GetFrictionJointDef(const FrictionJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_FRICTION_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/GearJoint.cpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.cpp
@@ -22,12 +22,13 @@
 #include <PlayRho/Dynamics/Joints/GearJoint.hpp>
 #include <PlayRho/Dynamics/Joints/RevoluteJoint.hpp>
 #include <PlayRho/Dynamics/Joints/PrismaticJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Gear Joint:
 // C0 = (coordinate1 + ratio * coordinate2)_initial
@@ -52,8 +53,8 @@ GearJoint::GearJoint(const GearJointDef& def):
     Joint(def),
     m_joint1(def.joint1),
     m_joint2(def.joint2),
-    m_typeA(def.joint1->GetType()),
-    m_typeB(def.joint2->GetType()),
+    m_typeA(GetType(*def.joint1)),
+    m_typeB(GetType(*def.joint2)),
     m_ratio(def.ratio)
 {
     assert(m_typeA == JointType::Revolute || m_typeA == JointType::Prismatic);
@@ -124,6 +125,11 @@ GearJoint::GearJoint(const GearJointDef& def):
     }
 
     m_constant = coordinateA + m_ratio * coordinateB;
+}
+
+void GearJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void GearJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step,
@@ -414,3 +420,5 @@ void GearJoint::SetRatio(Real ratio)
     assert(IsValid(ratio));
     m_ratio = ratio;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/GearJoint.hpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_GEAR_JOINT_HPP
-#define PLAYRHO_GEAR_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_GEARJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_GEARJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/GearJointDef.hpp>
@@ -45,6 +45,8 @@ public:
     /// @brief Initializing constructor.
     GearJoint(const GearJointDef& data);
     
+    void Accept(JointVisitor& visitor) const override;
+
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
 
@@ -120,4 +122,4 @@ inline Real GearJoint::GetRatio() const noexcept
     
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_GEARJOINT_HPP

--- a/PlayRho/Dynamics/Joints/GearJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/GearJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_GEAR_JOINT_DEF_HPP
-#define PLAYRHO_GEAR_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_GEARJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_GEARJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -67,4 +67,4 @@ GearJointDef GetGearJointDef(const GearJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_GEAR_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_GEARJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -33,11 +33,11 @@
 namespace playrho {
 
 class Body;
-class Joint;
 class StepConf;
 struct Velocity;
 struct ConstraintSolverConf;
 class BodyConstraint;
+class JointVisitor;
 
 /// @brief A body constraint pointer alias.
 using BodyConstraintPtr = BodyConstraint*;
@@ -78,8 +78,7 @@ public:
     /// @brief Is the given definition okay.
     static bool IsOkay(const JointDef& def) noexcept;
 
-    /// @brief Gets the type of the concrete joint.
-    JointType GetType() const noexcept;
+    virtual ~Joint() = default;
 
     /// @brief Gets the first body attached to this joint.
     Body* GetBodyA() const noexcept;
@@ -98,6 +97,9 @@ public:
 
     /// Get the angular reaction on bodyB.
     virtual AngularMomentum GetAngularReaction() const = 0;
+    
+    /// @brief Accepts a visitor.
+    virtual void Accept(JointVisitor& visitor) const = 0;
 
     /// Get the user data pointer.
     void* GetUserData() const noexcept;
@@ -112,8 +114,6 @@ public:
 
     /// @brief Shifts the origin for any points stored in world coordinates.
     virtual void ShiftOrigin(const Length2D newOrigin) { NOT_USED(newOrigin);  }
-
-    virtual ~Joint() = default;
 
 protected:
     
@@ -178,7 +178,6 @@ private:
     Body* const m_bodyA;
     Body* const m_bodyB;
     void* m_userData;
-    const JointType m_type;
     FlagsType m_flags = 0u; ///< Flags. 1-byte.
 };
 
@@ -193,15 +192,10 @@ constexpr inline Joint::FlagsType Joint::GetFlags(const JointDef& def) noexcept
 }
 
 inline Joint::Joint(const JointDef& def):
-    m_type{def.type}, m_bodyA{def.bodyA}, m_bodyB{def.bodyB},
+    m_bodyA{def.bodyA}, m_bodyB{def.bodyB},
     m_flags{GetFlags(def)}, m_userData{def.userData}
 {
     // Intentionally empty.
-}
-
-inline JointType Joint::GetType() const noexcept
-{
-    return m_type;
 }
 
 inline Body* Joint::GetBodyA() const noexcept

--- a/PlayRho/Dynamics/Joints/JointDef.cpp
+++ b/PlayRho/Dynamics/Joints/JointDef.cpp
@@ -22,15 +22,14 @@
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 
-namespace playrho
+namespace playrho {
+
+void Set(JointDef& def, const Joint& joint) noexcept
 {
-    
-    void Set(JointDef& def, const Joint& joint) noexcept
-    {
-        def.bodyA = joint.GetBodyA();
-        def.bodyB = joint.GetBodyB();
-        def.userData = joint.GetUserData();
-        def.collideConnected = joint.GetCollideConnected();
-    }
+    def.bodyA = joint.GetBodyA();
+    def.bodyB = joint.GetBodyB();
+    def.userData = joint.GetUserData();
+    def.collideConnected = joint.GetCollideConnected();
+}
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/JointDef.hpp
+++ b/PlayRho/Dynamics/Joints/JointDef.hpp
@@ -22,29 +22,13 @@
 #ifndef PLAYRHO_DYNAMICS_JOINTS_JOINTDEF_HPP
 #define PLAYRHO_DYNAMICS_JOINTS_JOINTDEF_HPP
 
+#include <PlayRho/Dynamics/Joints/JointType.hpp>
 #include <cstdint>
 
 namespace playrho {
 
 class Body;
 class Joint;
-
-/// @brief Enumeration of joint types.
-enum class JointType : std::uint8_t
-{
-    Unknown,
-    Revolute,
-    Prismatic,
-    Distance,
-    Pulley,
-    Mouse,
-    Gear,
-    Wheel,
-    Weld,
-    Friction,
-    Rope,
-    Motor
-};
 
 /// @brief Abstract base Joint definition class.
 /// @details Joint definitions are used to construct joints.

--- a/PlayRho/Dynamics/Joints/JointType.cpp
+++ b/PlayRho/Dynamics/Joints/JointType.cpp
@@ -1,5 +1,5 @@
 /*
- * Original work Copyright (c) 2007-2011 Erin Catto http://www.box2d.org
+ * Original work Copyright (c) 2006-2007 Erin Catto http://www.box2d.org
  * Modified work Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
@@ -19,26 +19,16 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/Joints/GearJointDef.hpp>
-#include <PlayRho/Dynamics/Joints/GearJoint.hpp>
+#include <PlayRho/Dynamics/Joints/Joint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 
 namespace playrho {
 
-GearJointDef::GearJointDef(NonNull<Joint*> j1, NonNull<Joint*> j2) noexcept:
-    super{super{JointType::Gear}.UseBodyA(j1->GetBodyB()).UseBodyB(j2->GetBodyB())},
-    joint1{j1}, joint2{j2}
+JointType GetType(const Joint& joint) noexcept
 {
-    // Intentionally empty.
-}
-
-GearJointDef GetGearJointDef(const GearJoint& joint) noexcept
-{
-    auto def = GearJointDef{joint.GetJoint1(), joint.GetJoint2()};
-    
-    Set(def, joint);
-    def.ratio = joint.GetRatio();
-    
-    return def;
+    auto visitor = TypeJointVisitor{};
+    joint.Accept(visitor);
+    return visitor.GetType().value_or(JointType::Unknown);
 }
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/JointType.hpp
+++ b/PlayRho/Dynamics/Joints/JointType.hpp
@@ -1,5 +1,5 @@
 /*
- * Original work Copyright (c) 2007-2011 Erin Catto http://www.box2d.org
+ * Original work Copyright (c) 2006-2007 Erin Catto http://www.box2d.org
  * Modified work Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
@@ -19,26 +19,35 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/Joints/GearJointDef.hpp>
-#include <PlayRho/Dynamics/Joints/GearJoint.hpp>
+#ifndef PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP
+
+#include <cstdint>
 
 namespace playrho {
 
-GearJointDef::GearJointDef(NonNull<Joint*> j1, NonNull<Joint*> j2) noexcept:
-    super{super{JointType::Gear}.UseBodyA(j1->GetBodyB()).UseBodyB(j2->GetBodyB())},
-    joint1{j1}, joint2{j2}
+/// @brief Enumeration of joint types.
+enum class JointType : std::uint8_t
 {
-    // Intentionally empty.
-}
+    Unknown,
+    Revolute,
+    Prismatic,
+    Distance,
+    Pulley,
+    Mouse,
+    Gear,
+    Wheel,
+    Weld,
+    Friction,
+    Rope,
+    Motor
+};
 
-GearJointDef GetGearJointDef(const GearJoint& joint) noexcept
-{
-    auto def = GearJointDef{joint.GetJoint1(), joint.GetJoint2()};
-    
-    Set(def, joint);
-    def.ratio = joint.GetRatio();
-    
-    return def;
-}
+class Joint;
+
+/// @brief Gets the type of the given joint.
+JointType GetType(const Joint& joint) noexcept;
 
 } // namespace playrho
+
+#endif // PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP

--- a/PlayRho/Dynamics/Joints/JointVisitor.hpp
+++ b/PlayRho/Dynamics/Joints/JointVisitor.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_DYNAMICS_JOINTS_JOINTVISITOR_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_JOINTVISITOR_HPP
+
+namespace playrho {
+
+class RevoluteJoint;
+class PrismaticJoint;
+class DistanceJoint;
+class PulleyJoint;
+class MouseJoint;
+class GearJoint;
+class WheelJoint;
+class WeldJoint;
+class FrictionJoint;
+class RopeJoint;
+class MotorJoint;
+
+/// @brief Vistor interface for Joint instances.
+///
+/// @details Interface to inherit from for objects wishing to "visit" joints.
+///   This uses the visitor design pattern.
+/// @sa https://en.wikipedia.org/wiki/Visitor_pattern .
+///
+class JointVisitor
+{
+public:
+    virtual ~JointVisitor() = default;
+    
+    /// @brief Visits a RevoluteJoint.
+    virtual void Visit(const RevoluteJoint& joint) = 0;
+    
+    /// @brief Visits a PrismaticJoint.
+    virtual void Visit(const PrismaticJoint& joint) = 0;
+    
+    /// @brief Visits a DistanceJoint.
+    virtual void Visit(const DistanceJoint& joint) = 0;
+    
+    /// @brief Visits a PulleyJoint.
+    virtual void Visit(const PulleyJoint& joint) = 0;
+    
+    /// @brief Visits a MouseJoint.
+    virtual void Visit(const MouseJoint& joint) = 0;
+    
+    /// @brief Visits a GearJoint.
+    virtual void Visit(const GearJoint& joint) = 0;
+    
+    /// @brief Visits a WheelJoint.
+    virtual void Visit(const WheelJoint& joint) = 0;
+    
+    /// @brief Visits a WeldJoint.
+    virtual void Visit(const WeldJoint& joint) = 0;
+    
+    /// @brief Visits a FrictionJoint.
+    virtual void Visit(const FrictionJoint& joint) = 0;
+    
+    /// @brief Visits a RopeJoint.
+    virtual void Visit(const RopeJoint& joint) = 0;
+    
+    /// @brief Visits a MotorJoint.
+    virtual void Visit(const MotorJoint& joint) = 0;
+    
+protected:
+    JointVisitor() = default;
+    
+    /// @brief Copy constructor.
+    JointVisitor(const JointVisitor& other) = default;
+    
+    /// @brief Move constructor.
+    JointVisitor(JointVisitor&& other) = default;
+    
+    /// @brief Copy assignment operator.
+    JointVisitor& operator= (const JointVisitor& other) = default;
+    
+    /// @brief Move assignment operator.
+    JointVisitor& operator= (JointVisitor&& other) = default;
+};
+
+} // namespace playrho
+
+#endif // PLAYRHO_DYNAMICS_JOINTS_JOINTVISITOR_HPP

--- a/PlayRho/Dynamics/Joints/MotorJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.cpp
@@ -20,11 +20,12 @@
  */
 
 #include <PlayRho/Dynamics/Joints/MotorJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Point-to-point constraint
 // Cdot = v2 - v1
@@ -47,6 +48,11 @@ MotorJoint::MotorJoint(const MotorJointDef& def):
     m_correctionFactor(def.correctionFactor)
 {
     // Intentionally empty.
+}
+
+void MotorJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void MotorJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step, const ConstraintSolverConf&)
@@ -278,3 +284,5 @@ Angle MotorJoint::GetAngularOffset() const
 {
     return m_angularOffset;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/MotorJoint.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_MOTOR_JOINT_HPP
-#define PLAYRHO_MOTOR_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_MOTORJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_MOTORJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/MotorJointDef.hpp>
@@ -37,6 +37,8 @@ public:
     
     /// @brief Initializing constructor.
     MotorJoint(const MotorJointDef& def);
+    
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
@@ -120,4 +122,4 @@ inline NonNegative<Torque> MotorJoint::GetMaxTorque() const
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_MOTORJOINT_HPP

--- a/PlayRho/Dynamics/Joints/MotorJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJointDef.cpp
@@ -23,7 +23,7 @@
 #include <PlayRho/Dynamics/Joints/MotorJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 MotorJointDef::MotorJointDef(NonNull<Body*> bA, NonNull<Body*> bB) noexcept:
     super{super{JointType::Motor}.UseBodyA(bA).UseBodyB(bB)},
@@ -33,7 +33,7 @@ MotorJointDef::MotorJointDef(NonNull<Body*> bA, NonNull<Body*> bB) noexcept:
     // Intentionally empty.
 }
 
-MotorJointDef playrho::GetMotorJointDef(const MotorJoint& joint) noexcept
+MotorJointDef GetMotorJointDef(const MotorJoint& joint) noexcept
 {
     auto def = MotorJointDef{};
     
@@ -47,3 +47,5 @@ MotorJointDef playrho::GetMotorJointDef(const MotorJoint& joint) noexcept
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/MotorJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_MOTOR_JOINT_DEF_HPP
-#define PLAYRHO_MOTOR_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_MOTORJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_MOTORJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -90,4 +90,4 @@ MotorJointDef GetMotorJointDef(const MotorJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_MOTOR_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_MOTORJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/MouseJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.cpp
@@ -20,11 +20,12 @@
  */
 
 #include <PlayRho/Dynamics/Joints/MouseJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // p = attached point, m = mouse point
 // C = p - m
@@ -60,6 +61,11 @@ MouseJoint::MouseJoint(const MouseJointDef& def):
 {
     assert(IsValid(def.target));
     assert(IsValid(def.dampingRatio));
+}
+
+void MouseJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void MouseJoint::SetTarget(const Length2D target) noexcept
@@ -212,3 +218,5 @@ void MouseJoint::ShiftOrigin(const Length2D newOrigin)
 {
     m_targetA -= newOrigin;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/MouseJoint.hpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_MOUSE_JOINT_HPP
-#define PLAYRHO_MOUSE_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/MouseJointDef.hpp>
@@ -48,6 +48,8 @@ public:
 
     /// @brief Initializing constructor.
     MouseJoint(const MouseJointDef& def);
+    
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
 
@@ -152,4 +154,4 @@ inline NonNegative<Real> MouseJoint::GetDampingRatio() const noexcept
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINT_HPP

--- a/PlayRho/Dynamics/Joints/MouseJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/MouseJointDef.cpp
@@ -22,9 +22,9 @@
 #include <PlayRho/Dynamics/Joints/MouseJointDef.hpp>
 #include <PlayRho/Dynamics/Joints/MouseJoint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
-MouseJointDef playrho::GetMouseJointDef(const MouseJoint& joint) noexcept
+MouseJointDef GetMouseJointDef(const MouseJoint& joint) noexcept
 {
     auto def = MouseJointDef{};
     
@@ -37,3 +37,5 @@ MouseJointDef playrho::GetMouseJointDef(const MouseJoint& joint) noexcept
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/MouseJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/MouseJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_MOUSE_JOINT_DEF_HPP
-#define PLAYRHO_MOUSE_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -108,4 +108,4 @@ MouseJointDef GetMouseJointDef(const MouseJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_MOUSE_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_PRISMATIC_JOINT_HPP
-#define PLAYRHO_PRISMATIC_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/PrismaticJointDef.hpp>
@@ -42,6 +42,8 @@ public:
     
     /// @brief Copy constructor.
     PrismaticJoint(const PrismaticJointDef& def);
+    
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
@@ -174,4 +176,4 @@ LinearVelocity GetLinearVelocity(const PrismaticJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINT_HPP

--- a/PlayRho/Dynamics/Joints/PrismaticJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointDef.cpp
@@ -21,10 +21,22 @@
 
 #include <PlayRho/Dynamics/Joints/PrismaticJointDef.hpp>
 #include <PlayRho/Dynamics/Joints/PrismaticJoint.hpp>
+#include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
-PrismaticJointDef playrho::GetPrismaticJointDef(const PrismaticJoint& joint) noexcept
+PrismaticJointDef::PrismaticJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2D anchor,
+                                     const UnitVec2 axis) noexcept:
+    super{super{JointType::Prismatic}.UseBodyA(bA).UseBodyB(bB)},
+    localAnchorA{GetLocalPoint(*bA, anchor)},
+    localAnchorB{GetLocalPoint(*bB, anchor)},
+    localAxisA{GetLocalVector(*bA, axis)},
+    referenceAngle{bB->GetAngle() - bA->GetAngle()}
+{
+    // Intentionally empty.
+}
+
+PrismaticJointDef GetPrismaticJointDef(const PrismaticJoint& joint) noexcept
 {
     auto def = PrismaticJointDef{};
     
@@ -43,3 +55,5 @@ PrismaticJointDef playrho::GetPrismaticJointDef(const PrismaticJoint& joint) noe
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/PrismaticJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_PRISMATIC_JOINT_DEF_HPP
-#define PLAYRHO_PRISMATIC_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -125,4 +125,4 @@ PrismaticJointDef GetPrismaticJointDef(const PrismaticJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_PRISMATIC_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/PulleyJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.cpp
@@ -20,12 +20,13 @@
  */
 
 #include <PlayRho/Dynamics/Joints/PulleyJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Pulley:
 // length1 = norm(p1 - s1)
@@ -51,6 +52,11 @@ PulleyJoint::PulleyJoint(const PulleyJointDef& def):
     m_constant(def.lengthA + def.ratio * def.lengthB)
 {
     assert(!AlmostZero(def.ratio));
+}
+
+void PulleyJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void PulleyJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
@@ -221,20 +227,22 @@ AngularMomentum PulleyJoint::GetAngularReaction() const
     return AngularMomentum{0};
 }
 
-Length playrho::GetCurrentLengthA(const PulleyJoint& joint)
-{
-    return GetLength(GetWorldPoint(*joint.GetBodyA(),
-                                   joint.GetLocalAnchorA()) - joint.GetGroundAnchorA());
-}
-
-Length playrho::GetCurrentLengthB(const PulleyJoint& joint)
-{
-    return GetLength(GetWorldPoint(*joint.GetBodyB(),
-                                   joint.GetLocalAnchorB()) - joint.GetGroundAnchorB());
-}
-
 void PulleyJoint::ShiftOrigin(const Length2D newOrigin)
 {
     m_groundAnchorA -= newOrigin;
     m_groundAnchorB -= newOrigin;
 }
+
+Length GetCurrentLengthA(const PulleyJoint& joint)
+{
+    return GetLength(GetWorldPoint(*joint.GetBodyA(),
+                                   joint.GetLocalAnchorA()) - joint.GetGroundAnchorA());
+}
+
+Length GetCurrentLengthB(const PulleyJoint& joint)
+{
+    return GetLength(GetWorldPoint(*joint.GetBodyB(),
+                                   joint.GetLocalAnchorB()) - joint.GetGroundAnchorB());
+}
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/PulleyJoint.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_PULLEY_JOINT_HPP
-#define PLAYRHO_PULLEY_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/PulleyJointDef.hpp>
@@ -41,6 +41,8 @@ public:
     
     /// @brief Initializing constructor.
     PulleyJoint(const PulleyJointDef& data);
+    
+    void Accept(JointVisitor& visitor) const override;
 
     /// @brief Gets the local anchor A.
     Length2D GetLocalAnchorA() const noexcept;
@@ -143,4 +145,4 @@ Length GetCurrentLengthB(const PulleyJoint& joint);
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINT_HPP

--- a/PlayRho/Dynamics/Joints/PulleyJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointDef.cpp
@@ -23,7 +23,7 @@
 #include <PlayRho/Dynamics/Joints/PulleyJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 PulleyJointDef::PulleyJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
                                const Length2D groundA, const Length2D groundB,
@@ -39,7 +39,7 @@ PulleyJointDef::PulleyJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
     // Intentionally empty.
 }
 
-PulleyJointDef playrho::GetPulleyJointDef(const PulleyJoint& joint) noexcept
+PulleyJointDef GetPulleyJointDef(const PulleyJoint& joint) noexcept
 {
     auto def = PulleyJointDef{};
     
@@ -55,3 +55,5 @@ PulleyJointDef playrho::GetPulleyJointDef(const PulleyJoint& joint) noexcept
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/PulleyJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_PULLEY_JOINT_DEF_HPP
-#define PLAYRHO_PULLEY_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -60,7 +60,7 @@ struct PulleyJointDef : public JointBuilder<PulleyJointDef>
     Length2D localAnchorA = Length2D{Real(-1) * Meter, Real(0) * Meter};
     
     /// The local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{Real(1) * Meter, Real(0) * Meter};
+    Length2D localAnchorB = Length2D{Real(+1) * Meter, Real(0) * Meter};
     
     /// The a reference length for the segment attached to bodyA.
     Length lengthA = Length{0};
@@ -83,4 +83,4 @@ PulleyJointDef GetPulleyJointDef(const PulleyJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_PULLEY_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -20,12 +20,13 @@
  */
 
 #include <PlayRho/Dynamics/Joints/RevoluteJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Point-to-point constraint
 // C = p2 - p1
@@ -53,6 +54,11 @@ RevoluteJoint::RevoluteJoint(const RevoluteJointDef& def):
     m_upperAngle{def.upperAngle}
 {
     // Intentionally empty.
+}
+
+void RevoluteJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void RevoluteJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
@@ -511,12 +517,14 @@ void RevoluteJoint::SetLimits(Angle lower, Angle upper)
     }
 }
 
-Angle playrho::GetJointAngle(const RevoluteJoint& joint)
+Angle GetJointAngle(const RevoluteJoint& joint)
 {
     return joint.GetBodyB()->GetAngle() - joint.GetBodyA()->GetAngle() - joint.GetReferenceAngle();
 }
 
-AngularVelocity playrho::GetAngularVelocity(const RevoluteJoint& joint)
+AngularVelocity GetAngularVelocity(const RevoluteJoint& joint)
 {
     return joint.GetBodyB()->GetVelocity().angular - joint.GetBodyA()->GetVelocity().angular;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_REVOLUTE_JOINT_HPP
-#define PLAYRHO_REVOLUTE_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/RevoluteJointDef.hpp>
@@ -44,6 +44,8 @@ public:
     
     /// @brief Initializing constructor.
     RevoluteJoint(const RevoluteJointDef& def);
+    
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
@@ -177,4 +179,4 @@ AngularVelocity GetAngularVelocity(const RevoluteJoint& joint);
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINT_HPP

--- a/PlayRho/Dynamics/Joints/RevoluteJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointDef.cpp
@@ -23,7 +23,7 @@
 #include <PlayRho/Dynamics/Joints/RevoluteJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 RevoluteJointDef::RevoluteJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
                                    const Length2D anchor) noexcept:
@@ -35,7 +35,7 @@ RevoluteJointDef::RevoluteJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
     // Intentionally empty.
 }
 
-RevoluteJointDef playrho::GetRevoluteJointDef(const RevoluteJoint& joint) noexcept
+RevoluteJointDef GetRevoluteJointDef(const RevoluteJoint& joint) noexcept
 {
     auto def = RevoluteJointDef{};
     
@@ -53,3 +53,5 @@ RevoluteJointDef playrho::GetRevoluteJointDef(const RevoluteJoint& joint) noexce
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/RevoluteJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_REVOLUTE_JOINT_DEF_HPP
-#define PLAYRHO_REVOLUTE_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -122,4 +122,4 @@ RevoluteJointDef GetRevoluteJointDef(const RevoluteJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_REVOLUTE_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/RopeJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.cpp
@@ -20,12 +20,13 @@
  */
 
 #include <PlayRho/Dynamics/Joints/RopeJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Limit:
 // C = norm(pB - pA) - L
@@ -41,6 +42,11 @@ RopeJoint::RopeJoint(const RopeJointDef& def):
     m_localAnchorB(def.localAnchorB),
     m_maxLength(def.maxLength)
 {
+}
+
+void RopeJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void RopeJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
@@ -218,3 +224,5 @@ Joint::LimitState RopeJoint::GetLimitState() const
 {
     return m_state;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/RopeJoint.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_ROPE_JOINT_HPP
-#define PLAYRHO_ROPE_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_ROPEJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_ROPEJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/RopeJointDef.hpp>
@@ -42,6 +42,8 @@ public:
     
     /// @brief Initializing constructor.
     RopeJoint(const RopeJointDef& data);
+    
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
@@ -89,4 +91,4 @@ private:
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_ROPEJOINT_HPP

--- a/PlayRho/Dynamics/Joints/RopeJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJointDef.cpp
@@ -23,9 +23,9 @@
 #include <PlayRho/Dynamics/Joints/RopeJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
-RopeJointDef playrho::GetRopeJointDef(const RopeJoint& joint) noexcept
+RopeJointDef GetRopeJointDef(const RopeJoint& joint) noexcept
 {
     auto def = RopeJointDef{};
     
@@ -37,3 +37,5 @@ RopeJointDef playrho::GetRopeJointDef(const RopeJoint& joint) noexcept
     
     return def;
 }
+    
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/RopeJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_ROPE_JOINT_DEF_HPP
-#define PLAYRHO_ROPE_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_ROPEJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_ROPEJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -72,5 +72,4 @@ RopeJointDef GetRopeJointDef(const RopeJoint& joint) noexcept;
 
 } // namespace playrho
 
-
-#endif /* PLAYRHO_ROPE_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_ROPEJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/TypeJointVisitor.hpp
+++ b/PlayRho/Dynamics/Joints/TypeJointVisitor.hpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_DYNAMICS_JOINTS_TYPEJOINTVISITOR_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_TYPEJOINTVISITOR_HPP
+
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
+#include <PlayRho/Dynamics/Joints/JointType.hpp>
+#include <PlayRho/Common/OptionalValue.hpp>
+
+namespace playrho {
+
+/// @brief Typing JointVisitor.
+/// @details Records the type of joint that gets visited.
+class TypeJointVisitor: public JointVisitor
+{
+public:
+    
+    void Visit(const RevoluteJoint& /*joint*/) override
+    {
+        m_type = JointType::Revolute;
+    }
+    
+    void Visit(const PrismaticJoint& /*joint*/) override
+    {
+        m_type = JointType::Prismatic;
+    }
+    
+    void Visit(const DistanceJoint& /*joint*/) override
+    {
+        m_type = JointType::Distance;
+    }
+    
+    void Visit(const PulleyJoint& /*joint*/) override
+    {
+        m_type = JointType::Pulley;
+    }
+    
+    /// @brief Visits a MouseJoint.
+    void Visit(const MouseJoint& /*joint*/) override
+    {
+        m_type = JointType::Mouse;
+    }
+    
+    /// @brief Visits a GearJoint.
+    void Visit(const GearJoint& /*joint*/) override
+    {
+        m_type = JointType::Gear;
+    }
+    
+    /// @brief Visits a WheelJoint.
+    void Visit(const WheelJoint& /*joint*/) override
+    {
+        m_type = JointType::Wheel;
+    }
+    
+    /// @brief Visits a WeldJoint.
+    void Visit(const WeldJoint& /*joint*/) override
+    {
+        m_type = JointType::Weld;
+    }
+    
+    /// @brief Visits a FrictionJoint.
+    void Visit(const FrictionJoint& /*joint*/) override
+    {
+        m_type = JointType::Friction;
+    }
+    
+    /// @brief Visits a RopeJoint.
+    void Visit(const RopeJoint& /*joint*/) override
+    {
+        m_type = JointType::Rope;
+    }
+    
+    /// @brief Visits a MotorJoint.
+    void Visit(const MotorJoint& /*joint*/) override
+    {
+        m_type = JointType::Motor;
+    }
+    
+    /// @brief Gets the type of joint that had been visited.
+    Optional<JointType> GetType() const noexcept
+    {
+        return m_type;
+    }
+    
+private:
+    Optional<JointType> m_type;
+};
+
+} // namespace playrho
+
+#endif // PLAYRHO_DYNAMICS_JOINTS_TYPEJOINTVISITOR_HPP

--- a/PlayRho/Dynamics/Joints/WeldJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.cpp
@@ -20,12 +20,13 @@
  */
 
 #include <PlayRho/Dynamics/Joints/WeldJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Point-to-point constraint
 // C = p2 - p1
@@ -50,6 +51,11 @@ WeldJoint::WeldJoint(const WeldJointDef& def):
     m_dampingRatio(def.dampingRatio)
 {
     // Intentionally empty.
+}
+
+void WeldJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void WeldJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step,
@@ -394,3 +400,5 @@ AngularMomentum WeldJoint::GetAngularReaction() const
     // AngularMomentum is L^2 M T^-1 QP^-1
     return AngularMomentum{GetZ(m_impulse) * SquareMeter * Kilogram / (Second * Radian)};
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/WeldJoint.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_WELD_JOINT_HPP
-#define PLAYRHO_WELD_JOINT_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_WELDJOINT_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_WELDJOINT_HPP
 
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/WeldJointDef.hpp>
@@ -36,6 +36,8 @@ public:
     
     /// @brief Initializing constructor.
     WeldJoint(const WeldJointDef& def);
+    
+    void Accept(JointVisitor& visitor) const override;
 
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
@@ -91,4 +93,4 @@ private:
 
 } // namespace playrho
 
-#endif
+#endif // PLAYRHO_DYNAMICS_JOINTS_WELDJOINT_HPP

--- a/PlayRho/Dynamics/Joints/WeldJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJointDef.cpp
@@ -23,7 +23,7 @@
 #include <PlayRho/Dynamics/Joints/WeldJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 WeldJointDef::WeldJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2D anchor) noexcept:
     super{super{JointType::Weld}.UseBodyA(bA).UseBodyB(bB)},
@@ -34,7 +34,7 @@ WeldJointDef::WeldJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2D 
     // Intentionally empty.
 }
 
-WeldJointDef playrho::GetWeldJointDef(const WeldJoint& joint) noexcept
+WeldJointDef GetWeldJointDef(const WeldJoint& joint) noexcept
 {
     auto def = WeldJointDef{};
     
@@ -48,3 +48,5 @@ WeldJointDef playrho::GetWeldJointDef(const WeldJoint& joint) noexcept
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/WeldJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_WELD_JOINT_DEF_HPP
-#define PLAYRHO_WELD_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_WELDJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_WELDJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -87,4 +87,4 @@ WeldJointDef GetWeldJointDef(const WeldJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_WELD_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_WELDJOINTDEF_HPP

--- a/PlayRho/Dynamics/Joints/WheelJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.cpp
@@ -20,12 +20,13 @@
  */
 
 #include <PlayRho/Dynamics/Joints/WheelJoint.hpp>
+#include <PlayRho/Dynamics/Joints/JointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 // Linear constraint (point-to-line)
 // d = pB - pA = xB + rB - xA - rA
@@ -56,6 +57,11 @@ WheelJoint::WheelJoint(const WheelJointDef& def):
     m_dampingRatio(def.dampingRatio)
 {
     // Intentionally empty.
+}
+
+void WheelJoint::Accept(JointVisitor& visitor) const
+{
+    visitor.Visit(*this);
 }
 
 void WheelJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step, const ConstraintSolverConf&)
@@ -360,7 +366,7 @@ Torque WheelJoint::GetMotorTorque(Frequency inv_dt) const
     return inv_dt * m_motorImpulse;
 }
 
-Length playrho::GetJointTranslation(const WheelJoint& joint) noexcept
+Length GetJointTranslation(const WheelJoint& joint) noexcept
 {
     const auto pA = GetWorldPoint(*joint.GetBodyA(), joint.GetLocalAnchorA());
     const auto pB = GetWorldPoint(*joint.GetBodyB(), joint.GetLocalAnchorB());
@@ -369,7 +375,9 @@ Length playrho::GetJointTranslation(const WheelJoint& joint) noexcept
     return Length{Dot(d, axis)};
 }
 
-AngularVelocity playrho::GetAngularVelocity(const WheelJoint& joint) noexcept
+AngularVelocity GetAngularVelocity(const WheelJoint& joint) noexcept
 {
     return joint.GetBodyB()->GetVelocity().angular - joint.GetBodyA()->GetVelocity().angular;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/WheelJoint.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.hpp
@@ -39,6 +39,8 @@ public:
     /// @brief Initializing constructor.
     WheelJoint(const WheelJointDef& def);
     
+    void Accept(JointVisitor& visitor) const override;
+
     Length2D GetAnchorA() const override;
     Length2D GetAnchorB() const override;
 

--- a/PlayRho/Dynamics/Joints/WheelJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJointDef.cpp
@@ -23,7 +23,7 @@
 #include <PlayRho/Dynamics/Joints/WheelJoint.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 
-using namespace playrho;
+namespace playrho {
 
 WheelJointDef::WheelJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2D anchor,
                              const UnitVec2 axis) noexcept:
@@ -35,7 +35,7 @@ WheelJointDef::WheelJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2
     // Intentionally empty.
 }
 
-WheelJointDef playrho::GetWheelJointDef(const WheelJoint& joint) noexcept
+WheelJointDef GetWheelJointDef(const WheelJoint& joint) noexcept
 {
     auto def = WheelJointDef{};
     
@@ -52,3 +52,5 @@ WheelJointDef playrho::GetWheelJointDef(const WheelJoint& joint) noexcept
     
     return def;
 }
+
+} // namespace playrho

--- a/PlayRho/Dynamics/Joints/WheelJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointDef.hpp
@@ -19,8 +19,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#ifndef PLAYRHO_WHEEL_JOINT_DEF_HPP
-#define PLAYRHO_WHEEL_JOINT_DEF_HPP
+#ifndef PLAYRHO_DYNAMICS_JOINTS_WHEELJOINTDEF_HPP
+#define PLAYRHO_DYNAMICS_JOINTS_WHEELJOINTDEF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointDef.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
@@ -124,4 +124,4 @@ WheelJointDef GetWheelJointDef(const WheelJoint& joint) noexcept;
 
 } // namespace playrho
 
-#endif /* PLAYRHO_WHEEL_JOINT_DEF_HPP */
+#endif // PLAYRHO_DYNAMICS_JOINTS_WHEELJOINTDEF_HPP

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -381,7 +381,7 @@ private:
     void CopyContacts(const std::map<const Body*, Body*>& bodyMap,
                       const std::map<const Fixture*, Fixture*>& fixtureMap,
                       SizedRange<World::Contacts::const_iterator> range);
-
+    
     /// @brief Internal destroy.
     /// @warning Behavior is undefined if passed a null pointer for the joint.
     void InternalDestroy(Joint* joint);
@@ -418,10 +418,18 @@ private:
     /// @post Contacts are listed in the island in the order that bodies provide those contacts.
     /// @post Joints are listed the island in the order that bodies provide those joints.
     void AddToIsland(Island& island, Body& seed,
-                       Bodies::size_type& remNumBodies,
-                       Contacts::size_type& remNumContacts,
-                       Joints::size_type& remNumJoints);
+                     Bodies::size_type& remNumBodies,
+                     Contacts::size_type& remNumContacts,
+                     Joints::size_type& remNumJoints);
 
+    void AddToIsland(Island& island, std::vector<Body*>& stack,
+                     Bodies::size_type& remNumBodies,
+                     Contacts::size_type& remNumContacts,
+                     Joints::size_type& remNumJoints);
+    
+    void AddContactsToIsland(Island& island, std::vector<Body*>& stack, const Body* b);
+    void AddJointsToIsland(Island& island, std::vector<Body*>& stack, const Body* b);
+    
     Bodies::size_type RemoveUnspeedablesFromIslanded(const std::vector<Body*>& bodies);
 
     /// @brief Solves the step using successive time of impact (TOI) events.
@@ -492,7 +500,7 @@ private:
     /// @param[in] toi Time of impact (TOI). Value between 0 and 1.
     ProcessContactsOutput ProcessContactsForTOI(Island& island, Body& body, Real toi,
                                                 const StepConf& conf);
-    
+
     bool Add(Joint* j, Body* bodyA, Body* bodyB);
 
     bool Remove(const Body& b);

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -48,7 +48,7 @@ static void DrawCorner(Drawer& drawer, Length2D p, Length r, Angle a0, Angle a1,
     }
 }
 
-class ShapeDrawer: public Shape::Visitor
+class ShapeDrawer: public ShapeVisitor
 {
 public:
     ShapeDrawer(Drawer& d, Color c, bool s, Transformation t):
@@ -259,7 +259,7 @@ static void Draw(Drawer& drawer, const Joint& joint)
 
     const Color color{0.5f, 0.8f, 0.8f};
 
-    switch (joint.GetType())
+    switch (GetType(joint))
     {
         case JointType::Distance:
             drawer.DrawSegment(p1, p2, color);

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -23,6 +23,7 @@
 #include <PlayRho/PlayRho.hpp>
 #include <PlayRho/Collision/RayCastOutput.hpp>
 #include <PlayRho/Collision/ShapeSeparation.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 #include <PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp>
 #include <PlayRho/Common/Range.hpp>
 #include "Drawer.hpp"

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -32,7 +32,7 @@ namespace playrho {
 /// This callback is called by World::QueryAABB. We find all the fixtures
 /// that overlap an AABB. Of those, we use TestOverlap to determine which fixtures
 /// overlap a circle. Up to 4 overlapped fixtures will be highlighted with a yellow border.
-class ShapeDrawer: public Shape::Visitor
+class ShapeDrawer: public IsVisitedShapeVisitor
 {
 public:
 

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Collision/Shapes/ChainShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 #include <array>
 
 using namespace playrho;
@@ -63,7 +64,7 @@ TEST(ChainShape, GetInvalidChildThrows)
 
 TEST(ChainShape, Accept)
 {
-    class Visitor: public Shape::Visitor
+    class Visitor: public IsVisitedShapeVisitor
     {
     public:
         void Visit(const ChainShape&) override
@@ -76,19 +77,19 @@ TEST(ChainShape, Accept)
     ChainShape foo{};
     Visitor v;
     ASSERT_FALSE(v.visited);
-    ASSERT_FALSE(v.IsBaseVisited());
+    ASSERT_FALSE(v.IsVisited());
     foo.Accept(v);
     EXPECT_TRUE(v.visited);
-    EXPECT_FALSE(v.IsBaseVisited());
+    EXPECT_FALSE(v.IsVisited());
 }
 
 TEST(ChainShape, BaseVisitorForDiskShape)
 {
     const auto shape = ChainShape{};
-    auto visitor = Shape::Visitor{};
-    ASSERT_FALSE(visitor.IsBaseVisited());
+    auto visitor = IsVisitedShapeVisitor{};
+    ASSERT_FALSE(visitor.IsVisited());
     shape.Accept(visitor);
-    EXPECT_TRUE(visitor.IsBaseVisited());
+    EXPECT_TRUE(visitor.IsVisited());
 }
 
 TEST(ChainShape, OneVertexLikeDisk)

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Collision/Shapes/DiskShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 #include <PlayRho/Collision/AABB.hpp>
 
 using namespace playrho;
@@ -73,7 +74,7 @@ TEST(DiskShape, GetInvalidChildThrows)
 
 TEST(DiskShape, Accept)
 {
-    class Visitor: public Shape::Visitor
+    class Visitor: public IsVisitedShapeVisitor
     {
     public:
         void Visit(const DiskShape&) override
@@ -86,19 +87,19 @@ TEST(DiskShape, Accept)
     DiskShape foo{};
     Visitor v;
     ASSERT_FALSE(v.visited);
-    ASSERT_FALSE(v.IsBaseVisited());
+    ASSERT_FALSE(v.IsVisited());
     foo.Accept(v);
     EXPECT_TRUE(v.visited);
-    EXPECT_FALSE(v.IsBaseVisited());
+    EXPECT_FALSE(v.IsVisited());
 }
 
 TEST(DiskShape, BaseVisitorForDiskShape)
 {
     const auto shape = DiskShape{Real{2} * Meter};
-    auto visitor = Shape::Visitor{};
-    ASSERT_FALSE(visitor.IsBaseVisited());
+    auto visitor = IsVisitedShapeVisitor{};
+    ASSERT_FALSE(visitor.IsVisited());
     shape.Accept(visitor);
-    EXPECT_TRUE(visitor.IsBaseVisited());
+    EXPECT_TRUE(visitor.IsVisited());
 }
 
 TEST(DiskShape, TestPoint)

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -81,7 +81,7 @@ TEST(DistanceJoint, Construction)
     DistanceJointDef def;
     DistanceJoint joint{def};
     
-    EXPECT_EQ(joint.GetType(), def.type);
+    EXPECT_EQ(GetType(joint), def.type);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Collision/Shapes/EdgeShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 
 using namespace playrho;
 
@@ -45,7 +46,7 @@ TEST(EdgeShape, GetInvalidChildThrows)
 
 TEST(EdgeShape, Accept)
 {
-    class Visitor: public Shape::Visitor
+    class Visitor: public IsVisitedShapeVisitor
     {
     public:
         void Visit(const EdgeShape&) override
@@ -58,17 +59,17 @@ TEST(EdgeShape, Accept)
     EdgeShape foo{};
     Visitor v;
     ASSERT_FALSE(v.visited);
-    ASSERT_FALSE(v.IsBaseVisited());
+    ASSERT_FALSE(v.IsVisited());
     foo.Accept(v);
     EXPECT_TRUE(v.visited);
-    EXPECT_FALSE(v.IsBaseVisited());
+    EXPECT_FALSE(v.IsVisited());
 }
 
 TEST(EdgeShape, BaseVisitorForDiskShape)
 {
     const auto shape = EdgeShape{};
-    auto visitor = Shape::Visitor{};
-    ASSERT_FALSE(visitor.IsBaseVisited());
+    auto visitor = IsVisitedShapeVisitor{};
+    ASSERT_FALSE(visitor.IsVisited());
     shape.Accept(visitor);
-    EXPECT_TRUE(visitor.IsBaseVisited());
+    EXPECT_TRUE(visitor.IsVisited());
 }

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -75,7 +75,7 @@ TEST(FrictionJoint, Construction)
     FrictionJointDef def;
     FrictionJoint joint{def};
     
-    EXPECT_EQ(joint.GetType(), def.type);
+    EXPECT_EQ(GetType(joint), def.type);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
@@ -92,7 +92,7 @@ TEST(FrictionJoint, GetFrictionJointDef)
     FrictionJointDef def;
     FrictionJoint joint{def};
     
-    ASSERT_EQ(joint.GetType(), def.type);
+    ASSERT_EQ(GetType(joint), def.type);
     ASSERT_EQ(joint.GetBodyA(), def.bodyA);
     ASSERT_EQ(joint.GetBodyB(), def.bodyB);
     ASSERT_EQ(joint.GetCollideConnected(), def.collideConnected);

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -90,7 +90,7 @@ TEST(GearJoint, Construction)
     GearJointDef def{&revJoint1, &revJoint2};
     GearJoint joint{def};
     
-    EXPECT_EQ(joint.GetType(), def.type);
+    EXPECT_EQ(GetType(joint), def.type);
     EXPECT_EQ(joint.GetBodyA(), def.joint1->GetBodyB());
     EXPECT_EQ(joint.GetBodyB(), def.joint2->GetBodyB());
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
@@ -125,7 +125,7 @@ TEST(GearJoint, GetGearJointDef)
     GearJointDef def{&revJoint1, &revJoint2};
     GearJoint joint{def};
     
-    ASSERT_EQ(joint.GetType(), def.type);
+    ASSERT_EQ(GetType(joint), def.type);
     ASSERT_EQ(joint.GetBodyA(), def.joint1->GetBodyB());
     ASSERT_EQ(joint.GetBodyB(), def.joint2->GetBodyB());
     ASSERT_EQ(joint.GetCollideConnected(), def.collideConnected);

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -72,7 +72,7 @@ TEST(MotorJoint, Construction)
     MotorJointDef def;
     MotorJoint joint{def};
     
-    EXPECT_EQ(joint.GetType(), def.type);
+    EXPECT_EQ(GetType(joint), def.type);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
@@ -102,7 +102,7 @@ TEST(MotorJoint, GetMotorJointDef)
     MotorJointDef def;
     MotorJoint joint{def};
     
-    ASSERT_EQ(joint.GetType(), def.type);
+    ASSERT_EQ(GetType(joint), def.type);
     ASSERT_EQ(joint.GetBodyA(), def.bodyA);
     ASSERT_EQ(joint.GetBodyB(), def.bodyB);
     ASSERT_EQ(joint.GetCollideConnected(), def.collideConnected);

--- a/UnitTests/MouseJoint.cpp
+++ b/UnitTests/MouseJoint.cpp
@@ -66,7 +66,7 @@ TEST(MouseJoint, DefaultInitialized)
     const auto def = MouseJointDef{};
     const auto joint = MouseJoint{def};
     
-    EXPECT_EQ(joint.GetType(), JointType::Mouse);
+    EXPECT_EQ(GetType(joint), JointType::Mouse);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetAnchorA(), def.target);

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Collision/Shapes/MultiShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 #include <array>
 
@@ -63,7 +64,7 @@ TEST(MultiShape, GetInvalidChildThrows)
 
 TEST(MultiShape, Accept)
 {
-    class Visitor: public Shape::Visitor
+    class Visitor: public IsVisitedShapeVisitor
     {
     public:
         void Visit(const MultiShape&) override
@@ -76,19 +77,19 @@ TEST(MultiShape, Accept)
     MultiShape foo{};
     Visitor v;
     ASSERT_FALSE(v.visited);
-    ASSERT_FALSE(v.IsBaseVisited());
+    ASSERT_FALSE(v.IsVisited());
     foo.Accept(v);
     EXPECT_TRUE(v.visited);
-    EXPECT_FALSE(v.IsBaseVisited());
+    EXPECT_FALSE(v.IsVisited());
 }
 
 TEST(MultiShape, BaseVisitorForDiskShape)
 {
     const auto shape = MultiShape{};
-    auto visitor = Shape::Visitor{};
-    ASSERT_FALSE(visitor.IsBaseVisited());
+    auto visitor = IsVisitedShapeVisitor{};
+    ASSERT_FALSE(visitor.IsVisited());
     shape.Accept(visitor);
-    EXPECT_TRUE(visitor.IsBaseVisited());
+    EXPECT_TRUE(visitor.IsVisited());
 }
 
 TEST(MultiShape, AddConvexHullWithOnePointSameAsDisk)

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Collision/Shapes/PolygonShape.hpp>
+#include <PlayRho/Collision/Shapes/ShapeVisitor.hpp>
 
 using namespace playrho;
 
@@ -54,7 +55,7 @@ TEST(PolygonShape, GetInvalidChildThrows)
 
 TEST(PolygonShape, Accept)
 {
-    class Visitor: public Shape::Visitor
+    class Visitor: public IsVisitedShapeVisitor
     {
     public:
         void Visit(const PolygonShape&) override
@@ -67,19 +68,19 @@ TEST(PolygonShape, Accept)
     PolygonShape foo{};
     Visitor v;
     ASSERT_FALSE(v.visited);
-    ASSERT_FALSE(v.IsBaseVisited());
+    ASSERT_FALSE(v.IsVisited());
     foo.Accept(v);
     EXPECT_TRUE(v.visited);
-    EXPECT_FALSE(v.IsBaseVisited());
+    EXPECT_FALSE(v.IsVisited());
 }
 
 TEST(PolygonShape, BaseVisitorForDiskShape)
 {
     const auto shape = PolygonShape{};
-    auto visitor = Shape::Visitor{};
-    ASSERT_FALSE(visitor.IsBaseVisited());
+    auto visitor = IsVisitedShapeVisitor{};
+    ASSERT_FALSE(visitor.IsVisited());
     shape.Accept(visitor);
-    EXPECT_TRUE(visitor.IsBaseVisited());
+    EXPECT_TRUE(visitor.IsVisited());
 }
 
 TEST(PolygonShape, FindLowestRightMostVertex)

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "gtest/gtest.h"
+#include <PlayRho/Dynamics/Joints/PulleyJoint.hpp>
+#include <PlayRho/Dynamics/World.hpp>
+
+using namespace playrho;
+
+TEST(PulleyJointDef, DefaultConstruction)
+{
+    PulleyJointDef def;
+    
+    EXPECT_EQ(def.type, JointType::Pulley);
+    EXPECT_EQ(def.bodyA, nullptr);
+    EXPECT_EQ(def.bodyB, nullptr);
+    EXPECT_EQ(def.collideConnected, true);
+    EXPECT_EQ(def.userData, nullptr);
+    
+    EXPECT_EQ(def.localAnchorA, (Length2D{-1 * Meter, 0 * Meter}));
+    EXPECT_EQ(def.localAnchorB, (Length2D{+1 * Meter, 0 * Meter}));
+    EXPECT_EQ(def.lengthA, Real(0) * Meter);
+    EXPECT_EQ(def.lengthB, Real(0) * Meter);
+    EXPECT_EQ(def.ratio, Real(1));
+}
+
+TEST(PulleyJointDef, UseRatio)
+{
+    const auto value = Real(31);
+    EXPECT_NE(PulleyJointDef{}.ratio, value);
+    EXPECT_EQ(PulleyJointDef{}.UseRatio(value).ratio, value);
+}
+
+TEST(PulleyJoint, ByteSize)
+{
+    switch (sizeof(Real))
+    {
+        case  4: EXPECT_EQ(sizeof(PulleyJoint), std::size_t(128)); break;
+        case  8: EXPECT_EQ(sizeof(PulleyJoint), std::size_t(216)); break;
+        case 16: EXPECT_EQ(sizeof(PulleyJoint), std::size_t(400)); break;
+        default: FAIL(); break;
+    }
+}
+
+TEST(PulleyJoint, Construction)
+{
+    PulleyJointDef def;
+    PulleyJoint joint{def};
+    
+    EXPECT_EQ(GetType(joint), def.type);
+    EXPECT_EQ(joint.GetBodyA(), def.bodyA);
+    EXPECT_EQ(joint.GetBodyB(), def.bodyB);
+    EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
+    EXPECT_EQ(joint.GetUserData(), def.userData);
+    
+    EXPECT_EQ(joint.GetGroundAnchorA(), def.groundAnchorA);
+    EXPECT_EQ(joint.GetGroundAnchorB(), def.groundAnchorB);
+    EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
+    EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);
+    EXPECT_EQ(joint.GetLengthA(), def.lengthA);
+    EXPECT_EQ(joint.GetLengthB(), def.lengthB);
+    EXPECT_EQ(joint.GetRatio(), def.ratio);
+}
+
+TEST(PulleyJoint, GetAnchorAandB)
+{
+    World world;
+    
+    const auto loc0 = Length2D{Real(+1) * Meter, Real(-3) * Meter};
+    const auto loc1 = Length2D{Real(-2) * Meter, Real(+1.2f) * Meter};
+    
+    const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
+    const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
+    
+    auto jd = PulleyJointDef{};
+    jd.bodyA = b0;
+    jd.bodyB = b1;
+    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    
+    auto joint = PulleyJoint{jd};
+    ASSERT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
+    ASSERT_EQ(joint.GetLocalAnchorB(), jd.localAnchorB);
+    EXPECT_EQ(joint.GetAnchorA(), loc0 + jd.localAnchorA);
+    EXPECT_EQ(joint.GetAnchorB(), loc1 + jd.localAnchorB);
+}
+
+TEST(PulleyJoint, ShiftOrigin)
+{
+    PulleyJointDef def;
+    PulleyJoint joint{def};
+    
+    ASSERT_EQ(joint.GetGroundAnchorA(), def.groundAnchorA);
+    ASSERT_EQ(joint.GetGroundAnchorB(), def.groundAnchorB);
+    
+    const auto newOrigin = Length2D{1 * Meter, 1 * Meter};
+
+    joint.ShiftOrigin(newOrigin);
+
+    EXPECT_EQ(joint.GetGroundAnchorA(), def.groundAnchorA - newOrigin);
+    EXPECT_EQ(joint.GetGroundAnchorB(), def.groundAnchorB - newOrigin);
+}

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -66,7 +66,7 @@ TEST(RevoluteJoint, Construction)
     
     const auto joint = RevoluteJoint{jd};
 
-    EXPECT_EQ(joint.GetType(), jd.type);
+    EXPECT_EQ(GetType(joint), jd.type);
     EXPECT_EQ(joint.GetBodyA(), jd.bodyA);
     EXPECT_EQ(joint.GetBodyB(), jd.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), jd.collideConnected);

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -70,7 +70,7 @@ TEST(RopeJoint, Construction)
     RopeJointDef def;
     RopeJoint joint{def};
     
-    EXPECT_EQ(joint.GetType(), def.type);
+    EXPECT_EQ(GetType(joint), def.type);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
@@ -92,7 +92,7 @@ TEST(RopeJoint, GetRopeJointDef)
     def.localAnchorB = localAnchorB;
     RopeJoint joint{def};
     
-    ASSERT_EQ(joint.GetType(), def.type);
+    ASSERT_EQ(GetType(joint), def.type);
     ASSERT_EQ(joint.GetBodyA(), def.bodyA);
     ASSERT_EQ(joint.GetBodyB(), def.bodyB);
     ASSERT_EQ(joint.GetCollideConnected(), def.collideConnected);

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -72,7 +72,7 @@ TEST(WeldJoint, Construction)
     WeldJointDef def;
     WeldJoint joint{def};
     
-    EXPECT_EQ(joint.GetType(), def.type);
+    EXPECT_EQ(GetType(joint), def.type);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
@@ -93,7 +93,7 @@ TEST(WeldJoint, GetWeldJointDef)
     WeldJointDef def{&bodyA, &bodyB, anchor};
     WeldJoint joint{def};
     
-    ASSERT_EQ(joint.GetType(), def.type);
+    ASSERT_EQ(GetType(joint), def.type);
     ASSERT_EQ(joint.GetBodyA(), def.bodyA);
     ASSERT_EQ(joint.GetBodyB(), def.bodyB);
     ASSERT_EQ(joint.GetCollideConnected(), def.collideConnected);

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -75,7 +75,7 @@ TEST(WheelJoint, Construction)
     WheelJointDef def;
     WheelJoint joint{def};
     
-    EXPECT_EQ(joint.GetType(), def.type);
+    EXPECT_EQ(GetType(joint), def.type);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
@@ -199,7 +199,7 @@ TEST(WheelJoint, GetWheelJointDef)
     WheelJointDef def;
     WheelJoint joint{def};
     
-    ASSERT_EQ(joint.GetType(), def.type);
+    ASSERT_EQ(GetType(joint), def.type);
     ASSERT_EQ(joint.GetBodyA(), def.bodyA);
     ASSERT_EQ(joint.GetBodyB(), def.bodyB);
     ASSERT_EQ(joint.GetCollideConnected(), def.collideConnected);

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -262,7 +262,7 @@ TEST(World, CopyConstruction)
         auto copyJointIter = copy.GetJoints().begin();
         for (auto i = decltype(minJoints){0}; i < minJoints; ++i)
         {
-            EXPECT_EQ((*worldJointIter)->GetType(), (*copyJointIter)->GetType());
+            EXPECT_EQ(GetType(*(*worldJointIter)), GetType(*(*copyJointIter)));
             ++worldJointIter;
             ++copyJointIter;
         }
@@ -321,7 +321,7 @@ TEST(World, CopyAssignment)
         auto copyJointIter = copy.GetJoints().begin();
         for (auto i = decltype(minJoints){0}; i < minJoints; ++i)
         {
-            EXPECT_EQ((*worldJointIter)->GetType(), (*copyJointIter)->GetType());
+            EXPECT_EQ(GetType(*(*worldJointIter)), GetType(*(*copyJointIter)));
             ++worldJointIter;
             ++copyJointIter;
         }
@@ -694,7 +694,7 @@ TEST(World, CreateAndDestroyJoint)
     EXPECT_NE(world.GetJoints().begin(), world.GetJoints().end());
     const auto first = *world.GetJoints().begin();
     EXPECT_EQ(joint, first);
-    EXPECT_EQ(joint->GetType(), JointType::Distance);
+    EXPECT_EQ(GetType(*joint), JointType::Distance);
     EXPECT_EQ(joint->GetBodyA(), body1);
     EXPECT_EQ(joint->GetBodyB(), body2);
     EXPECT_EQ(joint->GetAnchorA(), anchorA);


### PR DESCRIPTION
#### Description - What's this PR do?
Tweaks the clang tidy configuration and updates code to address those changes.
Moves JointType off to its own file. Refactors Joint::GetType() into a free function. Adds more unit test code. More clang-tidy related changes.

#### Impacts/Risks of These Changes?
More consistent use of visitor pattern. Improved header guard macros.

#### Related Issues
- Issue #20.
- Issue #21.
