### PR TITLE
Refactors DynamicTree

### DIFF
--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -60,7 +60,7 @@ namespace playrho {
         
         /// @brief Initializing constructor.
         constexpr AABB(ValueRange<Length>&& x, ValueRange<Length>&& y) noexcept:
-            rangeX{std::move(x)}, rangeY{std::move(y)}
+            rangeX{x}, rangeY{y}
         {
             // Intentionally empty.
         }

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -615,7 +615,7 @@ inline DynamicTree::TreeNode& SetParent(DynamicTree::TreeNode& node,
 
 /// @brief Gets the height of the binary tree.
 /// @return Height of the tree (as stored in the root node) or 0 if the root node is not valid.
-constexpr inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
+inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
 {
     const auto index = tree.GetRootIndex();
     return (index != DynamicTree::GetInvalidSize())? tree.GetHeight(index): DynamicTree::Height{0};

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -51,7 +51,7 @@ public:
     /// @brief Size type.
     using Size = ContactCounter;
 
-    struct TreeNode;
+    class TreeNode;
     struct UnusedNode;
     struct LeafNode;
     struct BranchNode;
@@ -376,19 +376,19 @@ union DynamicTree::VariantData
 /// @brief Is unused.
 /// @details Determines whether the given DynamicTree node is an unused node.
 /// @relatedalso DynamicTree::TreeNode
-bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
+constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is leaf.
 /// @details Determines whether the given DynamicTree node is a leaf node.
 ///   Leaf nodes have a pointer to user data.
 /// @relatedalso DynamicTree::TreeNode
-bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
+constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is branch.
 /// @details Determines whether the given DynamicTree node is a branch node.
 ///   Branch nodes have 2 indices to child nodes.
 /// @relatedalso DynamicTree::TreeNode
-bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
+constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief A node in the dynamic tree.
 /// @note Users do not interact with this directly.
@@ -403,10 +403,10 @@ public:
     ~TreeNode() = default;
     
     /// @brief Copy constructor.
-    TreeNode(const TreeNode& other) noexcept = default;
+    constexpr TreeNode(const TreeNode& other) noexcept = default;
 
     /// @brief Move constructor.
-    TreeNode(TreeNode&& other) = default;
+    constexpr TreeNode(TreeNode&& other) = default;
 
     /// @brief Initializing constructor.
     constexpr TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
@@ -438,88 +438,88 @@ public:
     TreeNode& operator= (TreeNode&& other) noexcept = default;
     
     /// @brief Gets the node "height".
-    Height GetHeight() const noexcept
+    constexpr Height GetHeight() const noexcept
     {
         return m_height;
     }
     
     /// @brief Sets the node "height" to the given value.
-    TreeNode& SetHeight(Height value) noexcept
+    constexpr TreeNode& SetHeight(Height value) noexcept
     {
         m_height = value;
         return *this;
     }
     
     /// @brief Gets the node's "other" index.
-    Size GetOther() const noexcept
+    constexpr Size GetOther() const noexcept
     {
         return m_other;
     }
                 
     /// @brief Sets the node's "other" index to the given value.
-    TreeNode& SetOther(Size other) noexcept
+    constexpr TreeNode& SetOther(Size other) noexcept
     {
         m_other = other;
         return *this;
     }
 
     /// @brief Gets the node's AABB.
-    AABB GetAABB() const noexcept
+    constexpr AABB GetAABB() const noexcept
     {
         return m_aabb;
     }
 
     /// @brief Sets the node's AABB.
-    TreeNode& SetAABB(AABB value) noexcept
+    constexpr TreeNode& SetAABB(AABB value) noexcept
     {
         m_aabb = value;
         return *this;
     }
     
     /// @brief Gets the node as an "unused" value.
-    UnusedNode AsUnused() const noexcept
+    constexpr UnusedNode AsUnused() const noexcept
     {
         assert(IsUnused(*this));
         return m_variant.unused;
     }
     
     /// @brief Gets the node as a "leaf" value.
-    LeafNode AsLeaf() const noexcept
+    constexpr LeafNode AsLeaf() const noexcept
     {
         assert(IsLeaf(*this));
         return m_variant.leaf;
     }
     
     /// @brief Gets the node as a "branch" value.
-    BranchNode AsBranch() const noexcept
+    constexpr BranchNode AsBranch() const noexcept
     {
         assert(IsBranch(*this));
         return m_variant.branch;
     }
 
     /// @brief Gets the node as an "unused" value.
-    UnusedNode& AsUnused() noexcept
+    constexpr UnusedNode& AsUnused() noexcept
     {
         assert(IsUnused(*this));
         return m_variant.unused;
     }
     
     /// @brief Gets the node as a "leaf" value.
-    LeafNode& AsLeaf() noexcept
+    constexpr LeafNode& AsLeaf() noexcept
     {
         assert(IsLeaf(*this));
         return m_variant.leaf;
     }
     
     /// @brief Gets the node as a "branch" value.
-    BranchNode& AsBranch() noexcept
+    constexpr BranchNode& AsBranch() noexcept
     {
         assert(IsBranch(*this));
         return m_variant.branch;
     }
 
     /// @brief Assign's the node's value.
-    TreeNode& Assign(Size height, const UnusedNode& value) noexcept
+    constexpr TreeNode& Assign(Size height, const UnusedNode& value) noexcept
     {
         assert(height == DynamicTree::GetInvalidHeight());
         m_height = height;
@@ -528,7 +528,7 @@ public:
     }
     
     /// @brief Assign's the node's value.
-    TreeNode& Assign(Size height, const LeafNode& value) noexcept
+    constexpr TreeNode& Assign(Size height, const LeafNode& value) noexcept
     {
         assert(height == 0);
         m_height = height;
@@ -537,7 +537,7 @@ public:
     }
     
     /// @brief Assign's the node's value.
-    TreeNode& Assign(Size height, const BranchNode& value) noexcept
+    constexpr TreeNode& Assign(Size height, const BranchNode& value) noexcept
     {
         assert(height > 0);
         m_height = height;
@@ -564,7 +564,7 @@ private:
 
 /// @brief Whether this node is free (or allocated).
 /// @relatedalso DynamicTree::TreeNode
-inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
+constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
 {
     return node.GetHeight() == DynamicTree::GetInvalidHeight();
 }
@@ -573,7 +573,7 @@ inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
 /// @note This has constant complexity.
 /// @return <code>true</code> if this is a leaf node, <code>false</code> otherwise.
 /// @relatedalso DynamicTree::TreeNode
-inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
+constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 {
     return node.GetHeight() == 0;
 }
@@ -581,14 +581,14 @@ inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 /// @brief Is branch.
 /// @details Determines whether the given node is a "branch" node.
 /// @relatedalso DynamicTree::TreeNode
-inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
+constexpr inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
 {
     return (node.GetHeight() != DynamicTree::GetInvalidSize()) && (node.GetHeight() > 0);
 }
 
 /// @brief Gets the AABB of the given DynamicTree node.
 /// @relatedalso DynamicTree::TreeNode
-inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
+constexpr inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
 {
     assert(!IsUnused(node));
     return node.GetAABB();
@@ -597,7 +597,7 @@ inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
 /// @brief Gets the next index of the given node.
 /// @warning Behavior is undefined if the given node is not an "unused" node.
 /// @relatedalso DynamicTree::TreeNode
-inline DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
+constexpr inline DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
 {
     assert(IsUnused(node));
     return node.GetOther();
@@ -615,7 +615,7 @@ inline DynamicTree::TreeNode& SetParent(DynamicTree::TreeNode& node,
 
 /// @brief Gets the height of the binary tree.
 /// @return Height of the tree (as stored in the root node) or 0 if the root node is not valid.
-inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
+constexpr inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
 {
     const auto index = tree.GetRootIndex();
     return (index != DynamicTree::GetInvalidSize())? tree.GetHeight(index): DynamicTree::Height{0};
@@ -624,7 +624,7 @@ inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
 /// @brief Tests for overlap of the elements identified in the given dynamic tree.
 /// @relatedalso DynamicTree
 inline bool TestOverlap(const DynamicTree& tree,
-                        DynamicTree::Size proxyIdA, DynamicTree::Size proxyIdB)
+                        DynamicTree::Size proxyIdA, DynamicTree::Size proxyIdB) noexcept
 {
     return TestOverlap(tree.GetAABB(proxyIdA), tree.GetAABB(proxyIdB));
 }
@@ -632,7 +632,7 @@ inline bool TestOverlap(const DynamicTree& tree,
 /// @brief Gets the ratio of the sum of the perimeters of nodes to the root perimeter.
 /// @note Zero is returned if no proxies exist at the time of the call.
 /// @return Value of zero or more.
-inline Real ComputePerimeterRatio(const DynamicTree& tree)
+inline Real ComputePerimeterRatio(const DynamicTree& tree) noexcept
 {
     const auto root = tree.GetRootIndex();
     if (root != DynamicTree::GetInvalidSize())

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2048,7 +2048,7 @@ StepStats World::Step(const StepConf& conf)
 
 void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
 {
-    m_tree.Query(aabb, [&](DynamicTree::size_type proxyId) {
+    m_tree.Query(aabb, [&](DynamicTree::Size proxyId) {
         const auto proxy = static_cast<FixtureProxy*>(m_tree.GetUserData(proxyId));
         return callback(proxy->fixture, proxy->childIndex);
     });
@@ -2057,7 +2057,7 @@ void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
 void World::RayCast(Length2D point1, Length2D point2, RayCastCallback callback) const
 {
     m_tree.RayCast(RayCastInput{point1, point2, Real{1}},
-                   [&](const RayCastInput& input, DynamicTree::size_type proxyId)
+                   [&](const RayCastInput& input, DynamicTree::Size proxyId)
     {
         const auto userData = m_tree.GetUserData(proxyId);
         const auto proxy = static_cast<FixtureProxy*>(userData);
@@ -2337,7 +2337,7 @@ World::UpdateContactsStats World::UpdateContacts(Contacts& contacts, const StepC
 
 void World::RegisterForProcessing(ProxyId pid) noexcept
 {
-    assert(pid != DynamicTree::InvalidIndex);
+    assert(pid != DynamicTree::GetInvalidSize());
     m_proxies.push_back(pid);
 }
 
@@ -2347,7 +2347,7 @@ void World::UnregisterForProcessing(ProxyId pid) noexcept
     auto it = find(/*execution::par_unseq,*/ begin(m_proxies), itEnd, pid);
     if (it != itEnd)
     {
-        *it = DynamicTree::InvalidIndex;
+        *it = DynamicTree::GetInvalidSize();
     }
 }
 
@@ -2357,7 +2357,7 @@ ContactCounter World::FindNewContacts()
 
     for_each(cbegin(m_proxies), cend(m_proxies), [&](ProxyId pid) {
         const auto aabb = m_tree.GetAABB(pid);
-        m_tree.ForEach(aabb, [&](DynamicTree::size_type nodeId) {
+        m_tree.ForEach(aabb, [&](DynamicTree::Size nodeId) {
             // A proxy cannot form a pair with itself.
             if (nodeId != pid)
             {

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -338,7 +338,7 @@ private:
     /// @brief Flags type data type.
     using FlagsType = std::uint32_t;
 
-    using ProxyId = DynamicTree::size_type;
+    using ProxyId = DynamicTree::Size;
     using ContactKeyQueue = std::vector<ContactKey>;
     using ProxyQueue = std::vector<ProxyId>;
     using FixtureQueue = std::vector<Fixture*>;

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -745,7 +745,7 @@ void Test::DrawStats(Drawer& drawer, const StepConf& stepConf)
 
     const auto proxyCount = m_world->GetTree().GetProxyCount();
     const auto nodeCount = m_world->GetTree().GetNodeCount();
-    const auto height = m_world->GetTree().GetHeight();
+    const auto height = GetHeight(m_world->GetTree());
     const auto balance = m_world->GetTree().GetMaxBalance();
     const auto quality = ComputePerimeterRatio(m_world->GetTree());
     const auto capacity = m_world->GetTree().GetNodeCapacity();

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -85,7 +85,7 @@ public:
         for (auto i = 0; i < e_actorCount; ++i)
         {
             const auto actor = m_actors + i;
-            if (actor->proxyId == DynamicTree::InvalidIndex)
+            if (actor->proxyId == DynamicTree::GetInvalidSize())
                 continue;
 
             Color c(0.9f, 0.9f, 0.9f);
@@ -151,7 +151,7 @@ public:
         }
 
         {
-            DynamicTree::size_type height = m_tree.GetHeight();
+            const auto height = GetHeight(m_tree);
             drawer.DrawString(5, m_textLine, "dynamic tree height = %d", height);
             m_textLine += DRAW_STRING_NEW_LINE;
         }
@@ -184,14 +184,14 @@ public:
         }
     }
 
-    bool QueryCallback(DynamicTree::size_type proxyId)
+    bool QueryCallback(DynamicTree::Size proxyId)
     {
         Actor* actor = (Actor*)m_tree.GetUserData(proxyId);
         actor->overlap = TestOverlap(m_queryAABB, actor->aabb);
         return true;
     }
 
-    Real RayCastCallback(const RayCastInput& input, DynamicTree::size_type proxyId)
+    Real RayCastCallback(const RayCastInput& input, DynamicTree::Size proxyId)
     {
         auto actor = static_cast<Actor*>(m_tree.GetUserData(proxyId));
 
@@ -215,7 +215,7 @@ private:
         AABB aabb;
         Real fraction;
         bool overlap;
-        DynamicTree::size_type proxyId;
+        DynamicTree::Size proxyId;
     };
 
     AABB GetRandomAABB()
@@ -225,7 +225,7 @@ private:
         //aabb->lowerBound.y = -m_proxyExtent + m_worldExtent;
         const auto lowerBound = Vec2(RandomFloat(-m_worldExtent, m_worldExtent), RandomFloat(0.0f, 2.0f * m_worldExtent)) * Meter;
         const auto upperBound = lowerBound + w;
-        return AABB(lowerBound, upperBound);
+        return AABB{lowerBound, upperBound};
     }
 
     void MoveAABB(AABB* aabb)
@@ -252,7 +252,7 @@ private:
         {
             const auto j = rand() % e_actorCount;
             const auto actor = m_actors + j;
-            if (actor->proxyId == DynamicTree::InvalidIndex)
+            if (actor->proxyId == DynamicTree::GetInvalidSize())
             {
                 actor->aabb = GetRandomAABB();
                 actor->proxyId = m_tree.CreateProxy(GetFattenedAABB(actor->aabb, extension), actor);
@@ -267,10 +267,10 @@ private:
         {
             const auto j = rand() % e_actorCount;
             const auto actor = m_actors + j;
-            if (actor->proxyId != DynamicTree::InvalidIndex)
+            if (actor->proxyId != DynamicTree::GetInvalidSize())
             {
                 m_tree.DestroyProxy(actor->proxyId);
-                actor->proxyId = DynamicTree::InvalidIndex;
+                actor->proxyId = DynamicTree::GetInvalidSize();
                 return;
             }
         }
@@ -284,7 +284,7 @@ private:
         {
             const auto j = rand() % e_actorCount;
             const auto actor = m_actors + j;
-            if (actor->proxyId == DynamicTree::InvalidIndex)
+            if (actor->proxyId == DynamicTree::GetInvalidSize())
             {
                 continue;
             }
@@ -322,11 +322,11 @@ private:
 
     void Query()
     {
-        m_tree.Query(m_queryAABB, [&](DynamicTree::size_type nodeId){ return QueryCallback(nodeId); });
+        m_tree.Query(m_queryAABB, [&](DynamicTree::Size nodeId){ return QueryCallback(nodeId); });
 
         for (auto i = decltype(e_actorCount){0}; i < e_actorCount; ++i)
         {
-            if (m_actors[i].proxyId == DynamicTree::InvalidIndex)
+            if (m_actors[i].proxyId == DynamicTree::GetInvalidSize())
             {
                 continue;
             }
@@ -344,7 +344,7 @@ private:
         auto input = m_rayCastInput;
 
         // Ray cast against the dynamic tree.
-        m_tree.RayCast(input, [&](const RayCastInput& rci, DynamicTree::size_type proxyId) {
+        m_tree.RayCast(input, [&](const RayCastInput& rci, DynamicTree::Size proxyId) {
             return RayCastCallback(rci, proxyId);
         });
 
@@ -353,7 +353,7 @@ private:
         RayCastHit bruteOutput;
         for (auto i = decltype(e_actorCount){0}; i < e_actorCount; ++i)
         {
-            if (m_actors[i].proxyId == DynamicTree::InvalidIndex)
+            if (m_actors[i].proxyId == DynamicTree::GetInvalidSize())
             {
                 continue;
             }

--- a/Testbed/Tests/Tiles.hpp
+++ b/Testbed/Tests/Tiles.hpp
@@ -101,7 +101,7 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        const auto height = m_world->GetTree().GetHeight();
+        const auto height = GetHeight(m_world->GetTree());
         const auto leafCount = m_world->GetTree().GetProxyCount();
         if (leafCount > 0)
         {

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -30,8 +30,13 @@ TEST(DynamicTree, ByteSize)
 }
 
 TEST(DynamicTree, TreeNodeByteSize)
-{
-    EXPECT_EQ(sizeof(DynamicTree::TreeNode), std::size_t(32));
+{    
+    switch (sizeof(Real))
+    {
+        case  4: EXPECT_EQ(sizeof(DynamicTree::TreeNode), std::size_t(32)); break;
+        case  8: EXPECT_EQ(sizeof(DynamicTree::TreeNode), std::size_t(48)); break;
+        default: FAIL(); break;
+    }
 }
 
 TEST(DynamicTree, Traits)

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -29,6 +29,11 @@ TEST(DynamicTree, ByteSize)
     EXPECT_EQ(sizeof(DynamicTree), std::size_t(32));
 }
 
+TEST(DynamicTree, TreeNodeByteSize)
+{
+    EXPECT_EQ(sizeof(DynamicTree::TreeNode), std::size_t(32));
+}
+
 TEST(DynamicTree, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible<DynamicTree>::value);
@@ -56,9 +61,9 @@ TEST(DynamicTree, DefaultConstruction)
 {
     DynamicTree foo;
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(0));
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(0));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(0));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(0));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(0));
     EXPECT_TRUE(foo.Validate());
 }
@@ -68,7 +73,7 @@ TEST(DynamicTree, InitializingConstruction)
     constexpr auto initCapacity = DynamicTree::GetDefaultInitialNodeCapacity() * 2;
     DynamicTree foo{initCapacity};
     EXPECT_EQ(foo.GetNodeCapacity(), initCapacity);
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(0));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
     EXPECT_TRUE(foo.Validate());
 }
 
@@ -79,7 +84,7 @@ TEST(DynamicTree, CopyConstruction)
         DynamicTree copy{orig};
         EXPECT_EQ(copy.GetRootIndex(), orig.GetRootIndex());
         EXPECT_EQ(copy.GetNodeCapacity(), orig.GetNodeCapacity());
-        EXPECT_EQ(copy.GetHeight(), orig.GetHeight());
+        EXPECT_EQ(GetHeight(copy), GetHeight(orig));
         EXPECT_EQ(ComputePerimeterRatio(copy), ComputePerimeterRatio(orig));
         EXPECT_EQ(copy.GetNodeCount(), orig.GetNodeCount());
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
@@ -90,7 +95,7 @@ TEST(DynamicTree, CopyConstruction)
         DynamicTree copy{orig};
         EXPECT_EQ(copy.GetRootIndex(), orig.GetRootIndex());
         EXPECT_EQ(copy.GetNodeCapacity(), orig.GetNodeCapacity());
-        EXPECT_EQ(copy.GetHeight(), orig.GetHeight());
+        EXPECT_EQ(GetHeight(copy), GetHeight(orig));
         EXPECT_EQ(ComputePerimeterRatio(copy), ComputePerimeterRatio(orig));
         EXPECT_EQ(copy.GetNodeCount(), orig.GetNodeCount());
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
@@ -106,7 +111,7 @@ TEST(DynamicTree, CopyAssignment)
         copy = orig;
         EXPECT_EQ(copy.GetRootIndex(), orig.GetRootIndex());
         EXPECT_EQ(copy.GetNodeCapacity(), orig.GetNodeCapacity());
-        EXPECT_EQ(copy.GetHeight(), orig.GetHeight());
+        EXPECT_EQ(GetHeight(copy), GetHeight(orig));
         EXPECT_EQ(ComputePerimeterRatio(copy), ComputePerimeterRatio(orig));
         EXPECT_EQ(copy.GetNodeCount(), orig.GetNodeCount());
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
@@ -118,7 +123,7 @@ TEST(DynamicTree, CopyAssignment)
         copy = orig;
         EXPECT_EQ(copy.GetRootIndex(), orig.GetRootIndex());
         EXPECT_EQ(copy.GetNodeCapacity(), orig.GetNodeCapacity());
-        EXPECT_EQ(copy.GetHeight(), orig.GetHeight());
+        EXPECT_EQ(GetHeight(copy), GetHeight(orig));
         EXPECT_EQ(ComputePerimeterRatio(copy), ComputePerimeterRatio(orig));
         EXPECT_EQ(copy.GetNodeCount(), orig.GetNodeCount());
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
@@ -131,7 +136,7 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     DynamicTree foo;
 
     ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    ASSERT_EQ(foo.GetNodeCount(), DynamicTree::size_type(0));
+    ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
         Length2D{Real(3) * Meter, Real(1) * Meter},
@@ -140,21 +145,21 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     const auto userdata = nullptr;
 
     const auto pid = foo.CreateProxy(aabb, userdata);
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(1));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(1));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
     EXPECT_EQ(foo.GetAABB(pid), aabb);
     EXPECT_EQ(foo.GetUserData(pid), userdata);
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(0));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(0));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(0));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(1));
 
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::size_type(0));
+    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(0));
 
     foo.DestroyProxy(pid);
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(0));
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(0));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(0));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(0));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(0));
 }
 
@@ -163,7 +168,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     DynamicTree foo;
     
     ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    ASSERT_EQ(foo.GetNodeCount(), DynamicTree::size_type(0));
+    ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
         Length2D{Real(3) * Meter, Real(1) * Meter},
@@ -177,12 +182,12 @@ TEST(DynamicTree, FourIdenticalProxies)
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }
 
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(1));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(1));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(0));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(0));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(0));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(1));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::size_type(0));
+    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(0));
 
     {
         const auto pid = foo.CreateProxy(aabb, userdata);
@@ -190,12 +195,12 @@ TEST(DynamicTree, FourIdenticalProxies)
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }
 
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(3));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(3));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(1));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(0));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(1));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(3));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::size_type(1));
+    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(1));
     
     {
         const auto pid = foo.CreateProxy(aabb, userdata);
@@ -203,12 +208,12 @@ TEST(DynamicTree, FourIdenticalProxies)
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }
     
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(5));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(5));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(2));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(1));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(2));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(1));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(5));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::size_type(2));
+    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(2));
     
     {
         const auto pid = foo.CreateProxy(aabb, userdata);
@@ -216,19 +221,19 @@ TEST(DynamicTree, FourIdenticalProxies)
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }
     
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(7));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(7));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(2));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(0));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(2));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(7));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::size_type(2));
+    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(2));
     
     foo.RebuildBottomUp();
     
-    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::size_type(7));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(7));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
-    EXPECT_EQ(foo.GetHeight(), DynamicTree::size_type(3));
-    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::size_type(2));
+    EXPECT_EQ(GetHeight(foo), DynamicTree::Height(3));
+    EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(2));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(7));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::size_type(3));
+    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(3));
 }

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -129,7 +129,7 @@ TEST(World, DefaultInit)
     EXPECT_EQ(world.GetTree().GetProxyCount(), World::proxy_size_type(0));
     EXPECT_EQ(GetJointCount(world), JointCounter(0));
     EXPECT_EQ(GetContactCount(world), ContactCounter(0));
-    EXPECT_EQ(world.GetTree().GetHeight(), World::proxy_size_type(0));
+    EXPECT_EQ(GetHeight(world.GetTree()), World::proxy_size_type(0));
     EXPECT_EQ(ComputePerimeterRatio(world.GetTree()), Real(0));
 
     EXPECT_EQ(world.GetGravity(), EarthlyGravity);
@@ -230,7 +230,7 @@ TEST(World, CopyConstruction)
         EXPECT_EQ(world.GetJoints().size(), copy.GetJoints().size());
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
-        EXPECT_EQ(world.GetTree().GetHeight(), copy.GetTree().GetHeight());
+        EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
         EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }
@@ -269,7 +269,7 @@ TEST(World, CopyConstruction)
         }
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
-        EXPECT_EQ(world.GetTree().GetHeight(), copy.GetTree().GetHeight());
+        EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
         EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }
@@ -288,7 +288,7 @@ TEST(World, CopyAssignment)
         EXPECT_EQ(world.GetJoints().size(), copy.GetJoints().size());
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
-        EXPECT_EQ(world.GetTree().GetHeight(), copy.GetTree().GetHeight());
+        EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
         EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }
@@ -328,7 +328,7 @@ TEST(World, CopyAssignment)
         }
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
-        EXPECT_EQ(world.GetTree().GetHeight(), copy.GetTree().GetHeight());
+        EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
         EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }


### PR DESCRIPTION
#### Description - What's this PR do?
Basically refactors the `DynamicTree` class and related code.

More specifically...
- Changes `Dynamic::TreeNode` structure definition to use a union and… recognize its variant like uses more shaving off 8-bytes from its size.
- Changes DynamicTree's use of its TreeNode to include using placement new on it.
- Renames DynamicTree::size_type to DynamicTree::Size.
- Renames DynamicTree::next to DynamicTree::other.
- Adds DynamicTree::Height alias for Height related code.
- Refactors DynamicTree::InvalidIndex to being DynamicTree::GetInvalidSize() instead.
- Refactors DynamicTree::GetHeight() to being a free function instead.
- Refactors loops out from calling sites and moves it into called function.
- Cleanups and rebased to latest master code.
- Removes unnecessary std::move calls.

#### Impacts/Risks of These Changes?
Could change performance if there was a bug but mostly I just changed code around to shrink function code and be more readable (at least for me).