### PR TITLE
For issue #133, issue #132, and issue #128.

### DIFF
--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -344,10 +344,6 @@ bool Body::Insert(Joint* joint)
     const auto bodyB = joint->GetBodyB();
     
     const auto other = (this == bodyA)? bodyB: (this == bodyB)? bodyA: nullptr;
-    if (other == nullptr)
-    {
-        return false;
-    }
     m_joints.push_back(std::make_pair(other, joint));
     return true;
 }

--- a/PlayRho/Dynamics/Joints/MouseJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.cpp
@@ -180,7 +180,10 @@ bool MouseJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
     const auto incImpulse = (m_impulse - oldImpulse);
     const auto angImpulseB = AngularMomentum{Cross(m_rB, incImpulse) / Radian};
 
-    velB += Velocity{bodyConstraintB->GetInvMass() * incImpulse, bodyConstraintB->GetInvRotInertia() * angImpulseB};
+    velB += Velocity{
+        bodyConstraintB->GetInvMass() * incImpulse,
+        bodyConstraintB->GetInvRotInertia() * angImpulseB
+    };
 
     bodyConstraintB->SetVelocity(velB);
     

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -1151,12 +1151,12 @@ void World::AddJointsToIsland(Island& island, std::vector<Body*>& stack, const B
         // Use data of ji before dereferencing its pointers.
         const auto other = ji.first;
         const auto joint = ji.second;
-        assert(other->IsEnabled() || !other->IsAwake());
-        if (!IsIslanded(joint) && other->IsEnabled())
+        assert(other == nullptr || other->IsEnabled() || !other->IsAwake());
+        if (!IsIslanded(joint) && ((other == nullptr) || other->IsEnabled()))
         {
             island.m_joints.push_back(joint);
             SetIslanded(joint);
-            if (!IsIslanded(other))
+            if ((other != nullptr) && !IsIslanded(other))
             {
                 // Only now dereference ji's pointers.
                 const auto bodyA = joint->GetBodyA();

--- a/Testbed/Framework/DebugDraw.hpp
+++ b/Testbed/Framework/DebugDraw.hpp
@@ -107,9 +107,9 @@ public:
 
     void DrawPoint(const Length2D& p, float size, const Color& color) override;
 
-    void DrawString(int x, int y, const char* string, ...) override; 
+    void DrawString(int x, int y, TextAlign align, const char* string, ...) override;
 
-    void DrawString(const Length2D& p, const char* string, ...) override;
+    void DrawString(const Length2D& p, TextAlign align, const char* string, ...) override;
 
     void Flush() override;
     

--- a/Testbed/Framework/Drawer.hpp
+++ b/Testbed/Framework/Drawer.hpp
@@ -59,6 +59,13 @@ public:
     /// @brief Size type.
     using size_type = std::size_t;
 
+    enum TextAlign
+    {
+        Left,
+        Center,
+        Right,
+    };
+
     Drawer() = default;
 
     virtual ~Drawer() noexcept = 0;
@@ -81,10 +88,10 @@ public:
     virtual void DrawPoint(const Length2D& p, float size, const Color& color) = 0;
     
     /// Draws a string at the given screen coordinates.
-    virtual void DrawString(int x, int y, const char* string, ...) = 0; 
+    virtual void DrawString(int x, int y, TextAlign align, const char* string, ...) = 0;
     
     /// Draws a string at the given world coordinates.
-    virtual void DrawString(const Length2D& p, const char* string, ...) = 0;
+    virtual void DrawString(const Length2D& p, TextAlign align, const char* string, ...) = 0;
         
     virtual void Flush() = 0;
     

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -680,6 +680,8 @@ static bool UserInterface(int mousex, int mousey, unsigned char mousebutton, int
             settings.drawSkins = !settings.drawSkins;
         if (imguiCheck("AABBs", settings.drawAABBs, true))
             settings.drawAABBs = !settings.drawAABBs;
+        if (imguiCheck("Labels", settings.drawLabels, true))
+            settings.drawLabels = !settings.drawLabels;
         if (imguiCheck("Contact Points", settings.drawContactPoints, true))
             settings.drawContactPoints = !settings.drawContactPoints;
         if (imguiCheck("Contact Normals", settings.drawContactNormals, true))
@@ -773,7 +775,7 @@ int main()
 #endif
 
     camera.m_width = 1280; // 1152;
-    camera.m_height = 960; // 864;
+    camera.m_height = 980; // 864;
     menuX = camera.m_width - menuWidth - 10;
     menuHeight = camera.m_height - 20;
 

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -62,6 +62,7 @@ struct Settings
     int maxSubSteps = DefaultMaxSubSteps;
     bool drawShapes = true;
     bool drawSkins = false;
+    bool drawLabels = false;
     bool drawJoints = true;
     bool drawAABBs = false;
     bool drawContactPoints = false;
@@ -215,13 +216,11 @@ protected:
 
     const Body* GetBomb() const noexcept { return m_bomb; }
     void SetBomb(Body* body) noexcept { m_bomb = body; }
-    void SetGroundBody(Body* body) noexcept { m_groundBody = body; }
     
     World* const m_world;
     TextLinePos m_textLine = TextLinePos{30};
     
 private:
-    Body* m_groundBody;
     Fixtures m_selectedFixtures;
     AABB m_worldAABB;
     ContactPoints m_points;

--- a/Testbed/Tests/BagOfDisks.hpp
+++ b/Testbed/Tests/BagOfDisks.hpp
@@ -129,7 +129,7 @@ namespace playrho {
         
         void PostStep(const Settings&, Drawer& drawer) override
         {
-            drawer.DrawString(5, m_textLine,
+            drawer.DrawString(5, m_textLine, Drawer::Left,
                               "Press 'A' or 'D' to increase angular velocity counter-clockwise or clockwise respectively.");
             m_textLine += DRAW_STRING_NEW_LINE;
         }

--- a/Testbed/Tests/BodyTypes.hpp
+++ b/Testbed/Tests/BodyTypes.hpp
@@ -131,7 +131,8 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Keys: (d) dynamic, (s) static, (k) kinematic");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Keys: (d) dynamic, (s) static, (k) kinematic");
         m_textLine += DRAW_STRING_NEW_LINE;
     }
 

--- a/Testbed/Tests/BulletTest.hpp
+++ b/Testbed/Tests/BulletTest.hpp
@@ -95,7 +95,8 @@ public:
 
         if (gjkCalls > 0)
         {
-            drawer.DrawString(5, m_textLine, "gjk calls = %d, ave gjk iters = %3.1f, max gjk iters = %d",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "gjk calls = %d, ave gjk iters = %3.1f, max gjk iters = %d",
                 gjkCalls, float(gjkIters) / gjkCalls, gjkMaxIters);
             m_textLine += DRAW_STRING_NEW_LINE;
         }
@@ -110,11 +111,13 @@ public:
 #endif
         if (toiCalls > 0)
         {
-            drawer.DrawString(5, m_textLine, "toi calls = %d, ave toi iters = %3.1f, max toi iters = %d",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "toi calls = %d, ave toi iters = %3.1f, max toi iters = %d",
                 toiCalls, float(toiIters) / toiCalls, toiMaxRootIters);
             m_textLine += DRAW_STRING_NEW_LINE;
 
-            drawer.DrawString(5, m_textLine, "ave toi root iters = %3.1f, max toi root iters = %d",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "ave toi root iters = %3.1f, max toi root iters = %d",
                 float(toiRootIters) / toiCalls, toiMaxRootIters);
             m_textLine += DRAW_STRING_NEW_LINE;
         }

--- a/Testbed/Tests/Car.hpp
+++ b/Testbed/Tests/Car.hpp
@@ -259,10 +259,11 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Keys: left = a, brake = s, right = d, hz down = q, hz up = e");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "frequency = %g hz, damping ratio = %g",
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "frequency = %g hz, damping ratio = %g",
                           static_cast<double>(Real{m_hz / Hertz}), m_zeta);
         m_textLine += DRAW_STRING_NEW_LINE;
     }

--- a/Testbed/Tests/CharacterCollision.hpp
+++ b/Testbed/Tests/CharacterCollision.hpp
@@ -260,7 +260,8 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "This tests various character collision shapes for snag-free smooth sliding.");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "This tests various character collision shapes for snag-free smooth sliding.");
         m_textLine += DRAW_STRING_NEW_LINE;
     }
 

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -27,7 +27,7 @@ namespace playrho {
 class Confined : public Test
 {
 public:
-    const Length wall_length = Real(0.15f) * Meter; // DefaultLinearSlop * 1000
+    const Length wall_length = DefaultLinearSlop * 80;
     const Length vertexRadiusIncrement = wall_length / Real{40};
     
     enum
@@ -98,7 +98,6 @@ public:
         bd.bullet = m_bullet_mode;
         const auto wl = StripUnit(wall_length);
         bd.position = Vec2(RandomFloat(-wl / Real{2}, +wl / Real{2}), RandomFloat(0, wl)) * Meter;
-        bd.userData = reinterpret_cast<void*>(m_sequence);
         //bd.allowSleep = false;
 
         const auto body = m_world->CreateBody(bd);
@@ -108,8 +107,6 @@ public:
         conf.restitution = 0.8f;
         conf.vertexRadius = radius;
         body->CreateFixture(std::make_shared<DiskShape>(conf));
-
-        ++m_sequence;
     }
 
     void CreateBox()
@@ -125,11 +122,8 @@ public:
         bd.bullet = m_bullet_mode;
         const auto wl = StripUnit(wall_length);
         bd.position = Vec2(RandomFloat(-wl / Real{2}, +wl / Real{2}), RandomFloat(0, wl)) * Meter;
-        bd.userData = reinterpret_cast<void*>(m_sequence);
         const auto body = m_world->CreateBody(bd);
         body->CreateFixture(std::make_shared<PolygonShape>(side_length/Real{2}, side_length/Real{2}, conf));
-
-        ++m_sequence;
     }
 
     void ToggleBulletMode()
@@ -227,33 +221,21 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        for (auto& body: m_world->GetBodies())
-        {
-            auto& b = GetRef(body);
-            if (b.GetType() != BodyType::Dynamic)
-            {
-                continue;
-            }
-            
-            const auto location = b.GetLocation();
-            const auto userData = b.GetUserData();
-            drawer.DrawString(location, "B%d", reinterpret_cast<decltype(m_sequence)>(userData));
-        }
-        
-        drawer.DrawString(5, m_textLine, "Press 'c' to create a circle.");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Press 'c' to create a circle.");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "Press 'b' to create a box.");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Press 'b' to create a box.");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "Press '.' to toggle bullet mode (currently %s).", m_bullet_mode? "on": "off");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press '.' to toggle bullet mode (currently %s).", m_bullet_mode? "on": "off");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "Press 'i' to impart impulses.");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press 'i' to impart impulses.");
         m_textLine += DRAW_STRING_NEW_LINE;
     }
     
     bool m_bullet_mode = false;
     Length m_enclosureVertexRadius = vertexRadiusIncrement;
     Body* m_enclosure = nullptr;
-    std::size_t m_sequence = 0;
 };
 
 } // namespace playrho

--- a/Testbed/Tests/ContinuousTest.hpp
+++ b/Testbed/Tests/ContinuousTest.hpp
@@ -77,7 +77,8 @@ public:
 
         if (gjkCalls > 0)
         {
-            drawer.DrawString(5, m_textLine, "gjk calls = %d, ave gjk iters = %3.1f, max gjk iters = %d",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "gjk calls = %d, ave gjk iters = %3.1f, max gjk iters = %d",
                 gjkCalls, float(gjkIters) / gjkCalls, gjkMaxIters);
             m_textLine += DRAW_STRING_NEW_LINE;
         }
@@ -87,11 +88,13 @@ public:
 
         if (toiCalls > 0)
         {
-            drawer.DrawString(5, m_textLine, "toi calls = %d, ave [max] toi iters = %3.1f [%d]",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "toi calls = %d, ave [max] toi iters = %3.1f [%d]",
                                 toiCalls, float(toiIters) / toiCalls, toiMaxRootIters);
             m_textLine += DRAW_STRING_NEW_LINE;
             
-            drawer.DrawString(5, m_textLine, "ave [max] toi root iters = %3.1f [%d]",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "ave [max] toi root iters = %3.1f [%d]",
                 float(toiRootIters) / toiCalls, toiMaxRootIters);
             m_textLine += DRAW_STRING_NEW_LINE;
 

--- a/Testbed/Tests/ConvexHull.hpp
+++ b/Testbed/Tests/ConvexHull.hpp
@@ -82,7 +82,8 @@ public:
         const auto conf = PolygonShape::Conf{};
         const auto shape = PolygonShape{Span<const Length2D>{&m_points[0], m_points.size()}, conf};
 
-        drawer.DrawString(5, m_textLine, "Press g to generate a new random convex hull");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press g to generate a new random convex hull");
         m_textLine += DRAW_STRING_NEW_LINE;
 
         drawer.DrawPolygon(shape.GetVertices().begin(), shape.GetVertexCount(), Color(0.9f, 0.9f, 0.9f));
@@ -90,12 +91,13 @@ public:
         for (auto i = std::size_t{0}; i < m_points.size(); ++i)
         {
             drawer.DrawPoint(m_points[i], 3.0f, Color(0.3f, 0.9f, 0.3f));
-            drawer.DrawString(m_points[i] + Vec2(0.05f, 0.05f) * Meter, "%d", i);
+            drawer.DrawString(m_points[i] + Vec2(0.05f, 0.05f) * Meter, Drawer::Left,
+                              "%d", i);
         }
 
         if (!Validate(shape))
         {
-            drawer.DrawString(5, m_textLine, "Note: Invalid convex hull");
+            drawer.DrawString(5, m_textLine, Drawer::Left, "Note: Invalid convex hull");
             m_textLine += DRAW_STRING_NEW_LINE;
         }
 

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -94,7 +94,8 @@ public:
         switch (manifold.GetType())
         {
             case Manifold::e_circles:
-                drawer.DrawString(5, m_textLine, "%s %s: lp={%g,%g}, #=%d%s",
+                drawer.DrawString(5, m_textLine, Drawer::Left,
+                                  "%s %s: lp={%g,%g}, #=%d%s",
                                   GetName(manifold.GetType()),
                                   name,
                                   static_cast<double>(Real{GetX(manifold.GetLocalPoint()) / Meter}),
@@ -104,7 +105,8 @@ public:
                 break;
             case Manifold::e_faceA:
             case Manifold::e_faceB:
-                drawer.DrawString(5, m_textLine, "%s %s: lp={%g,%g}, ln={%g,%g}, #=%d%s",
+                drawer.DrawString(5, m_textLine, Drawer::Left,
+                                  "%s %s: lp={%g,%g}, ln={%g,%g}, #=%d%s",
                                   GetName(manifold.GetType()),
                                   name,
                                   static_cast<double>(Real{GetX(manifold.GetLocalPoint()) / Meter}),
@@ -168,26 +170,26 @@ public:
             adjustedDistance = 0;
         }
         
-        drawer.DrawString(xfmA.p, "Shape A");
-        drawer.DrawString(xfmB.p, "Shape B");
+        drawer.DrawString(xfmA.p, Drawer::Left, "Shape A");
+        drawer.DrawString(xfmB.p, Drawer::Left, "Shape B");
 
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press 'A', 'D', 'W', 'S', 'Q', 'E' to move selected shape left, right, up, down, counter-clockwise, or clockwise.");
         m_textLine += DRAW_STRING_NEW_LINE;
 
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press num-pad '+'/'-' to increase/decrease vertex radius of selected shape (%g & %g).",
                           static_cast<double>(Real{rA / Meter}),
                           static_cast<double>(Real{rB / Meter}));
         m_textLine += DRAW_STRING_NEW_LINE;
         
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press '=', or '-' to toggle drawing simplex, or manifold info (%s, %s).",
                           m_drawSimplexInfo? "on": "off",
                           m_drawManifoldInfo? "on": "off");
         m_textLine += DRAW_STRING_NEW_LINE;
 
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Max separation: %g for a-face[%i] b-vert[%i]; %g for b-face[%i] a-vert[%i]",
                           static_cast<double>(Real{maxIndicesAB.separation / Meter}),
                           maxIndicesAB.index1,
@@ -233,7 +235,8 @@ public:
             // Circles or Face-B manifold type.
         }
 
-        drawer.DrawString(5, m_textLine, "distance = %g (from %g), iterations = %d",
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "distance = %g (from %g), iterations = %d",
                           static_cast<double>(Real{adjustedDistance / Meter}),
                           static_cast<double>(Real{outputDistance / Meter}),
                           output.iterations);
@@ -241,7 +244,8 @@ public:
         
         {
             const auto size = output.simplex.GetSize();
-            drawer.DrawString(5, m_textLine, "Simplex info: size=%d, wpt-a={%g,%g}, wpt-b={%g,%g})",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "Simplex info: size=%d, wpt-a={%g,%g}, wpt-b={%g,%g})",
                               size,
                               static_cast<double>(Real{GetX(witnessPoints.a) / Meter}),
                               static_cast<double>(Real{GetY(witnessPoints.a) / Meter}),
@@ -253,7 +257,8 @@ public:
                 const auto& edge = output.simplex.GetSimplexEdge(i);
                 const auto coef = output.simplex.GetCoefficient(i);
                 
-                drawer.DrawString(5, m_textLine, "  a[%d]={%g,%g} b[%d]={%g,%g} coef=%g",
+                drawer.DrawString(5, m_textLine, Drawer::Left,
+                                  "  a[%d]={%g,%g} b[%d]={%g,%g} coef=%g",
                                   edge.GetIndexA(),
                                   static_cast<double>(Real{GetX(edge.GetPointA()) / Meter}),
                                   static_cast<double>(Real{GetY(edge.GetPointA()) / Meter}),
@@ -356,8 +361,8 @@ public:
             {
                 drawer.DrawPoint(edge.GetPointA(), 6.0f, simplexPointColor);
                 drawer.DrawPoint(edge.GetPointB(), 6.0f, simplexPointColor);
-                drawer.DrawString(edge.GetPointA(), "%d", edge.GetIndexA());
-                drawer.DrawString(edge.GetPointB(), "%d", edge.GetIndexB());
+                drawer.DrawString(edge.GetPointA(), Drawer::Left, "%d", edge.GetIndexA());
+                drawer.DrawString(edge.GetPointB(), Drawer::Left, "%d", edge.GetIndexB());
             }
         }
     }

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -152,7 +152,8 @@ public:
 
         {
             const auto height = GetHeight(m_tree);
-            drawer.DrawString(5, m_textLine, "dynamic tree height = %d", height);
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "dynamic tree height = %d", height);
             m_textLine += DRAW_STRING_NEW_LINE;
         }
 

--- a/Testbed/Tests/EdgeShapes.hpp
+++ b/Testbed/Tests/EdgeShapes.hpp
@@ -169,7 +169,7 @@ public:
 
     void PostStep(const Settings& settings, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Press 1-5 to drop stuff");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Press 1-5 to drop stuff");
         m_textLine += DRAW_STRING_NEW_LINE;
 
         const auto L = Real(25);

--- a/Testbed/Tests/Gears.hpp
+++ b/Testbed/Tests/Gears.hpp
@@ -118,14 +118,16 @@ public:
             const auto ratio = m_joint4->GetRatio();
             const auto angle = GetJointAngle(*m_joint1) + ratio * GetJointAngle(*m_joint2);
             const auto value = static_cast<double>(Real{angle / Radian});
-            drawer.DrawString(5, m_textLine, "theta1 + %4.2f * theta2 = %4.2f", (float) ratio, value);
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "theta1 + %4.2f * theta2 = %4.2f", (float) ratio, value);
             m_textLine += DRAW_STRING_NEW_LINE;
         }
 
         {
             const auto ratio = m_joint5->GetRatio();
             const auto value = ratio * GetJointTranslation(*m_joint3);
-            drawer.DrawString(5, m_textLine, "theta2 + %4.2f * delta = %4.2f",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "theta2 + %4.2f * delta = %4.2f",
                               static_cast<double>(ratio),
                               static_cast<double>(Real{value / Meter}));
             m_textLine += DRAW_STRING_NEW_LINE;

--- a/Testbed/Tests/HeavyOnLight.hpp
+++ b/Testbed/Tests/HeavyOnLight.hpp
@@ -92,7 +92,7 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press '+'/'-' to increase/decrease density of top shape (%f kg/m^2)",
                           double(Real{m_top->GetShape()->GetDensity() / KilogramPerSquareMeter}));
         m_textLine += DRAW_STRING_NEW_LINE;

--- a/Testbed/Tests/MotorJoint.hpp
+++ b/Testbed/Tests/MotorJoint.hpp
@@ -84,7 +84,7 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Keys: (s) pause");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Keys: (s) pause");
         m_textLine += 15;
     }
 

--- a/Testbed/Tests/NewtonsCradle.hpp
+++ b/Testbed/Tests/NewtonsCradle.hpp
@@ -252,15 +252,23 @@ namespace playrho {
         
         void PostStep(const Settings&, Drawer& drawer) override
         {
-            drawer.DrawString(5, m_textLine, "Drag a circle with mouse, then let go to see how the physics is simulated");
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "Drag a circle with mouse, then let go to see how the physics is simulated");
             m_textLine += DRAW_STRING_NEW_LINE;
-            drawer.DrawString(5, m_textLine, "Press '.' to toggle bullet mode (currently %s).", m_bullet_mode? "on": "off");
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "Press '.' to toggle bullet mode (currently %s).",
+                              m_bullet_mode? "on": "off");
             m_textLine += DRAW_STRING_NEW_LINE;
-            drawer.DrawString(5, m_textLine, "Press 'A' to toggle left side wall (currently %s).", m_left_side_wall? "on": "off");
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "Press 'A' to toggle left side wall (currently %s).",
+                              m_left_side_wall? "on": "off");
             m_textLine += DRAW_STRING_NEW_LINE;
-            drawer.DrawString(5, m_textLine, "Press 'D' to toggle right side wall (currently %s).", m_right_side_wall? "on": "off");
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "Press 'D' to toggle right side wall (currently %s).",
+                              m_right_side_wall? "on": "off");
             m_textLine += DRAW_STRING_NEW_LINE;
-            drawer.DrawString(5, m_textLine, "Press '1-5' to set # of balls (currently %d).", m_num_arms);
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "Press '1-5' to set # of balls (currently %d).", m_num_arms);
             m_textLine += DRAW_STRING_NEW_LINE;
         }
     

--- a/Testbed/Tests/OneSidedPlatform.hpp
+++ b/Testbed/Tests/OneSidedPlatform.hpp
@@ -102,11 +102,13 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Press: (c) create a shape, (d) destroy a shape.");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press: (c) create a shape, (d) destroy a shape.");
         m_textLine += DRAW_STRING_NEW_LINE;
 
         const auto v = GetLinearVelocity(*(m_character->GetBody()));
-        drawer.DrawString(5, m_textLine, "Character Linear Velocity: %f",
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Character Linear Velocity: %f",
                           static_cast<double>(Real{GetY(v) / MeterPerSecond}));
         m_textLine += DRAW_STRING_NEW_LINE;
     }

--- a/Testbed/Tests/Pinball.hpp
+++ b/Testbed/Tests/Pinball.hpp
@@ -119,7 +119,7 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Press 'a' to control the flippers");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Press 'a' to control the flippers");
         m_textLine += DRAW_STRING_NEW_LINE;
     }
     

--- a/Testbed/Tests/PolyCollision.hpp
+++ b/Testbed/Tests/PolyCollision.hpp
@@ -53,7 +53,7 @@ public:
         const auto manifold = CollideShapes(proxyA, m_transformA, proxyB, m_transformB);
         const auto pointCount = manifold.GetPointCount();
 
-        drawer.DrawString(5, m_textLine, "point count = %d", pointCount);
+        drawer.DrawString(5, m_textLine, Drawer::Left, "point count = %d", pointCount);
         m_textLine += DRAW_STRING_NEW_LINE;
 
         {

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -230,11 +230,11 @@ public:
         const auto color = Color(0.4f, 0.7f, 0.8f);
         drawer.DrawCircle(circle.GetLocation(), circle.GetRadius(), color);
 
-        drawer.DrawString(5, m_textLine, "Press 1-5 to drop stuff");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Press 1-5 to drop stuff");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "Press 'a' to (de)activate some bodies");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Press 'a' to (de)activate some bodies");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "Press 'd' to destroy a body");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Press 'd' to destroy a body");
         m_textLine += DRAW_STRING_NEW_LINE;
     }
 

--- a/Testbed/Tests/Prismatic.hpp
+++ b/Testbed/Tests/Prismatic.hpp
@@ -86,10 +86,10 @@ public:
 
     void PostStep(const Settings& settings, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Keys: (l) limits, (m) motors, (s) speed");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Keys: (l) limits, (m) motors, (s) speed");
         m_textLine += DRAW_STRING_NEW_LINE;
         const auto force = m_joint->GetMotorForce(Real{settings.hz} * Hertz);
-        drawer.DrawString(5, m_textLine, "Motor Force = %4.0f",
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Motor Force = %4.0f",
                           static_cast<double>(Real{force / Newton}));
         m_textLine += DRAW_STRING_NEW_LINE;
     }

--- a/Testbed/Tests/Pulleys.hpp
+++ b/Testbed/Tests/Pulleys.hpp
@@ -77,7 +77,9 @@ public:
     {
         const auto ratio = m_joint1->GetRatio();
         const auto L = GetCurrentLengthA(*m_joint1) + ratio * GetCurrentLengthB(*m_joint1);
-        drawer.DrawString(5, m_textLine, "L1 + %4.2f * L2 = %4.2f", (float) ratio,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "L1 + %4.2f * L2 = %4.2f",
+                          (float) ratio,
                           static_cast<double>(Real{L / Meter}));
         m_textLine += DRAW_STRING_NEW_LINE;
     }

--- a/Testbed/Tests/RayCast.hpp
+++ b/Testbed/Tests/RayCast.hpp
@@ -197,14 +197,14 @@ public:
 
     void PostStep(const Settings& settings, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press '1' to drop triangles that should be ignored by the ray.");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press '2'-'6' to drop shapes that should not be ignored by the ray.");
         m_textLine += DRAW_STRING_NEW_LINE;
 
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press 'm' to change the mode of the raycast test (currently: %s).",
                           GetModeName(m_mode));
         m_textLine += DRAW_STRING_NEW_LINE;

--- a/Testbed/Tests/Revolute.hpp
+++ b/Testbed/Tests/Revolute.hpp
@@ -127,7 +127,7 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Keys: (l) limits, (m) motor");
+        drawer.DrawString(5, m_textLine, Drawer::Left, "Keys: (l) limits, (m) motor");
         m_textLine += DRAW_STRING_NEW_LINE;
 
         //if (GetStepCount() == 360)

--- a/Testbed/Tests/RopeJoint.hpp
+++ b/Testbed/Tests/RopeJoint.hpp
@@ -115,15 +115,16 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Press (j) to toggle the rope joint.");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press (j) to toggle the rope joint.");
         m_textLine += DRAW_STRING_NEW_LINE;
         if (m_rope)
         {
-            drawer.DrawString(5, m_textLine, "Rope ON");
+            drawer.DrawString(5, m_textLine, Drawer::Left, "Rope ON");
         }
         else
         {
-            drawer.DrawString(5, m_textLine, "Rope OFF");
+            drawer.DrawString(5, m_textLine, Drawer::Left, "Rope OFF");
         }
         m_textLine += DRAW_STRING_NEW_LINE;
     }

--- a/Testbed/Tests/ShapeEditing.hpp
+++ b/Testbed/Tests/ShapeEditing.hpp
@@ -88,9 +88,11 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Press: (c) create a shape, (d) destroy a shape.");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press: (c) create a shape, (d) destroy a shape.");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "sensor = %d", m_sensor);
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "sensor = %d", m_sensor);
         m_textLine += DRAW_STRING_NEW_LINE;
     }
 

--- a/Testbed/Tests/SliderCrank.hpp
+++ b/Testbed/Tests/SliderCrank.hpp
@@ -127,10 +127,12 @@ public:
 
     void PostStep(const Settings& settings, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Keys: (f) toggle friction, (m) toggle motor");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Keys: (f) toggle friction, (m) toggle motor");
         m_textLine += DRAW_STRING_NEW_LINE;
         const auto torque = m_joint1->GetMotorTorque(Real{settings.hz} * Hertz);
-        drawer.DrawString(5, m_textLine, "Motor Torque = %5.0f",
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Motor Torque = %5.0f",
                           static_cast<double>(Real{torque / NewtonMeter}));
         m_textLine += DRAW_STRING_NEW_LINE;
     }

--- a/Testbed/Tests/TheoJansen.hpp
+++ b/Testbed/Tests/TheoJansen.hpp
@@ -177,7 +177,8 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Keys: left = a, brake = s, right = d, toggle motor = m");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Keys: left = a, brake = s, right = d, toggle motor = m");
         m_textLine += DRAW_STRING_NEW_LINE;
     }
 

--- a/Testbed/Tests/Tiles.hpp
+++ b/Testbed/Tests/Tiles.hpp
@@ -107,12 +107,14 @@ public:
         {
             const auto minimumNodeCount = 2 * leafCount - 1;
             const auto minimumHeight = ceilf(logf(float(minimumNodeCount)) / logf(2.0f));
-            drawer.DrawString(5, m_textLine, "dynamic tree height = %d, min = %d",
+            drawer.DrawString(5, m_textLine, Drawer::Left,
+                              "dynamic tree height = %d, min = %d",
                               height, int(minimumHeight));
             m_textLine += DRAW_STRING_NEW_LINE;
         }
 
-        drawer.DrawString(5, m_textLine, "create time = %6.2f ms, fixture count = %d",
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "create time = %6.2f ms, fixture count = %d",
             m_createTime * 1000, m_fixtureCount);
         m_textLine += DRAW_STRING_NEW_LINE;
 

--- a/Testbed/Tests/TimeOfImpact.hpp
+++ b/Testbed/Tests/TimeOfImpact.hpp
@@ -62,10 +62,13 @@ public:
         const auto output = GetToiViaSat(m_shapeA.GetChild(0), sweepA,
                                          m_shapeB.GetChild(0), sweepB);
 
-        drawer.DrawString(5, m_textLine, "at toi=%g, state=%s", static_cast<float>(output.get_t()), GetName(output.get_state()));
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "at toi=%g, state=%s",
+                          static_cast<float>(output.get_t()), GetName(output.get_state()));
         m_textLine += DRAW_STRING_NEW_LINE;
 
-        drawer.DrawString(5, m_textLine, "TOI iters = %d, max root iters = %d",
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "TOI iters = %d, max root iters = %d",
                           output.get_toi_iters(), output.get_max_root_iters());
         m_textLine += DRAW_STRING_NEW_LINE;
 

--- a/Testbed/Tests/Tumbler.hpp
+++ b/Testbed/Tests/Tumbler.hpp
@@ -71,11 +71,11 @@ public:
 
     void PostStep(const Settings& settings, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press C to clear and re-emit shapes. "
                           "Press 0 or 1 for remaining emitted shapes to be disks or squares.");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine,
+        drawer.DrawString(5, m_textLine, Drawer::Left,
                           "Press '+' or '-' to speed up or slow down rotation. '=' to stop it.");
         m_textLine += DRAW_STRING_NEW_LINE;
 

--- a/Testbed/Tests/VerticalStack.hpp
+++ b/Testbed/Tests/VerticalStack.hpp
@@ -111,9 +111,11 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "Press: (,) to launch a bullet.");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press: (,) to launch a bullet.");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "Blocksolve = %d", g_blockSolve);
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Blocksolve = %d", g_blockSolve);
         m_textLine += DRAW_STRING_NEW_LINE;
 
         //if (GetStepCount() == 300)

--- a/Testbed/Tests/Web.hpp
+++ b/Testbed/Tests/Web.hpp
@@ -179,9 +179,11 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        drawer.DrawString(5, m_textLine, "This demonstrates a soft distance joint.");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "This demonstrates a soft distance joint.");
         m_textLine += DRAW_STRING_NEW_LINE;
-        drawer.DrawString(5, m_textLine, "Press: (b) to delete a body, (j) to delete a joint");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press: (b) to delete a body, (j) to delete a joint");
         m_textLine += DRAW_STRING_NEW_LINE;
     }
 

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -469,7 +469,8 @@ public:
     void PostStep(const Settings&, Drawer& drawer) override
     {
         //show some useful info
-        drawer.DrawString(5, m_textLine, "Press w/a/s/d to control the car");
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Press w/a/s/d to control the car");
         m_textLine += 15;
         
         //drawer.DrawString(5, m_textLine, "Tire traction: %.2f", m_tire->m_currentTraction);


### PR DESCRIPTION
#### Description - What's this PR do?
Summary of changes:
- Removes the need of a dummy body A for MouseJoint.
- Removes the creation and use of a dummy body in the Testbed.
- Adds a "Labels" toggle and functionality for showing labels on bodies.
- Adds the ability to pass text alignment to the Drawer draw text methods.

#### Impacts/Risks of These Changes?
Statistics in Testbed should no longer show 1 more body than is visible. MouseJoint no longer needs a body A.

#### Related Issues
- Issue #128.
- Issue #132.
- Issue #133.
