### PR TITLE
For issue #136.

### DIFF
--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -58,7 +58,14 @@ namespace playrho {
         /// @note If an unset AABB is added to another AABB, the result will be the other AABB.
         constexpr AABB() = default;
         
-        /// @brief Initializing constructor.
+        /// @brief Initializing copy constructor.
+        constexpr AABB(const ValueRange<Length>& x, const ValueRange<Length>& y) noexcept:
+            rangeX{x}, rangeY{y}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing move constructor.
         constexpr AABB(ValueRange<Length>&& x, ValueRange<Length>&& y) noexcept:
             rangeX{x}, rangeY{y}
         {
@@ -89,13 +96,13 @@ namespace playrho {
         /// @brief Gets the lower bound.
         constexpr Length2D GetLowerBound() const noexcept
         {
-            return {rangeX.GetMin(), rangeY.GetMin()};
+            return Length2D{rangeX.GetMin(), rangeY.GetMin()};
         }
         
         /// @brief Gets the upper bound.
         constexpr Length2D GetUpperBound() const noexcept
         {
-            return {rangeX.GetMax(), rangeY.GetMax()};
+            return Length2D{rangeX.GetMax(), rangeY.GetMax()};
         }
 
         /// @brief Checks whether this AABB fully contains the given AABB.
@@ -182,14 +189,14 @@ namespace playrho {
     /// @relatedalso AABB
     constexpr Length2D GetCenter(const AABB& aabb) noexcept
     {
-        return {GetCenter(aabb.rangeX), GetCenter(aabb.rangeY)};
+        return Length2D{GetCenter(aabb.rangeX), GetCenter(aabb.rangeY)};
     }
     
     /// @brief Gets dimensions of the given AABB.
     /// @relatedalso AABB
     constexpr Length2D GetDimensions(const AABB& aabb) noexcept
     {
-        return {GetSize(aabb.rangeX), GetSize(aabb.rangeY)};
+        return Length2D{GetSize(aabb.rangeX), GetSize(aabb.rangeY)};
     }
     
     /// @brief Gets the extents of the AABB (half-widths).
@@ -280,14 +287,14 @@ namespace playrho {
     /// @relatedalso AABB
     constexpr Length2D GetLowerBound(const AABB& aabb) noexcept
     {
-        return {aabb.rangeX.GetMin(), aabb.rangeY.GetMin()};
+        return Length2D{aabb.rangeX.GetMin(), aabb.rangeY.GetMin()};
     }
     
     /// @brief Gets the upper bound.
     /// @relatedalso AABB
     constexpr Length2D GetUpperBound(const AABB& aabb) noexcept
     {
-        return {aabb.rangeX.GetMax(), aabb.rangeY.GetMax()};
+        return Length2D{aabb.rangeX.GetMax(), aabb.rangeY.GetMax()};
     }
     
     /// @brief Computes the AABB.
@@ -315,6 +322,17 @@ namespace playrho {
     /// @sa Fixture::GetProxy.
     /// @relatedalso Fixture
     AABB GetAABB(const Fixture& fixture, ChildCounter childIndex) noexcept;
+
+    /// @brief Output stream operator.
+    inline ::std::ostream& operator<< (::std::ostream& os, const AABB& value)
+    {
+        os << "{";
+        os << value.rangeX;
+        os << ',';
+        os << value.rangeY;
+        os << "}";
+        return os;
+    }
 
 } // namespace playrho
 

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -531,7 +531,7 @@ void DynamicTree::Rebalance(Size index)
     }
 }
 
-Real DynamicTree::ComputeTotalPerimeter() const noexcept
+Length DynamicTree::ComputeTotalPerimeter() const noexcept
 {
     auto totalPerimeter = Length{0};
     if (m_root != GetInvalidSize())

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -183,7 +183,7 @@ public:
     /// @brief Gets the ratio of the sum of the perimeters of nodes to the root perimeter.
     /// @note Zero is returned if no proxies exist at the time of the call.
     /// @return Value of zero or more.
-    Real ComputeTotalPerimeter() const noexcept;
+    Length ComputeTotalPerimeter() const noexcept;
 
     /// @brief Builds an optimal tree.
     /// @note This operation is very expensive.
@@ -403,7 +403,7 @@ public:
     ~TreeNode() = default;
     
     /// @brief Copy constructor.
-    constexpr TreeNode(const TreeNode& other) noexcept = default;
+    constexpr TreeNode(const TreeNode& other) = default;
 
     /// @brief Move constructor.
     constexpr TreeNode(TreeNode&& other) = default;
@@ -432,10 +432,10 @@ public:
     }
     
     /// @brief Copy assignment operator.
-    TreeNode& operator= (const TreeNode& other) noexcept = default;
+    TreeNode& operator= (const TreeNode& other) = default;
     
     /// @brief Move assignment operator.
-    TreeNode& operator= (TreeNode&& other) noexcept = default;
+    TreeNode& operator= (TreeNode&& other) = default;
     
     /// @brief Gets the node "height".
     constexpr Height GetHeight() const noexcept
@@ -615,10 +615,22 @@ inline DynamicTree::TreeNode& SetParent(DynamicTree::TreeNode& node,
 
 /// @brief Gets the height of the binary tree.
 /// @return Height of the tree (as stored in the root node) or 0 if the root node is not valid.
+/// @relatedalso DynamicTree
 inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
 {
     const auto index = tree.GetRootIndex();
     return (index != DynamicTree::GetInvalidSize())? tree.GetHeight(index): DynamicTree::Height{0};
+}
+
+/// @brief Gets the AABB for the given DynamicTree.
+/// @details Gets the AABB that encloses all other AABB instances that are within the
+///   given DynamicTree.
+/// @return Enclosing AABB or the "unset" AABB.
+/// @relatedalso DynamicTree
+inline AABB GetAABB(const DynamicTree& tree) noexcept
+{
+    const auto index = tree.GetRootIndex();
+    return (index != DynamicTree::GetInvalidSize())? tree.GetAABB(index): AABB{};
 }
 
 /// @brief Tests for overlap of the elements identified in the given dynamic tree.

--- a/PlayRho/Common/ValueRange.hpp
+++ b/PlayRho/Common/ValueRange.hpp
@@ -24,6 +24,7 @@
 #include <PlayRho/Common/BoundedValue.hpp>
 #include <algorithm>
 #include <limits>
+#include <iostream>
 
 namespace playrho {
     
@@ -236,6 +237,13 @@ namespace playrho {
     constexpr bool IsWithin(const ValueRange<T>& a, const ValueRange<T>& b)
     {
         return b.GetMin() >= a.GetMin() && b.GetMax() <= a.GetMax();
+    }
+
+    /// @brief Output stream operator.
+    template <typename T>
+    ::std::ostream& operator<< (::std::ostream& os, const ValueRange<T>& value)
+    {
+        return os << '{' << value.GetMin() << "..." << value.GetMax() << '}';
     }
 
 } // namespace playrho

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -28,6 +28,7 @@
 #include <iterator>
 #include <algorithm>
 #include <functional>
+#include <iostream>
 #include <PlayRho/Common/InvalidArgument.hpp>
 
 namespace playrho
@@ -83,7 +84,7 @@ struct Vector
     
     /// @brief Initializing constructor.
     template<typename... Tail>
-    constexpr Vector(typename std::enable_if<sizeof...(Tail)+1 == N, T>::type
+    constexpr explicit Vector(typename std::enable_if<sizeof...(Tail)+1 == N, T>::type
                      head, Tail... tail) noexcept: elements{head, T(tail)...}
     {
         //static_assert(sizeof...(args) == N, "Invalid number of arguments");
@@ -274,6 +275,24 @@ constexpr auto Get(const Vector<N, T>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::Get<> (playrho::Vector)");
     return v[I];
+}
+
+/// @brief Output stream operator.
+/// @relatedalso Vector
+template <std::size_t N, typename T>
+::std::ostream& operator<< (::std::ostream& os, const Vector<N, T>& value)
+{
+    os << "{";
+    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    {
+        if (i > static_cast<size_t>(0))
+        {
+            os << ',';
+        }
+        os << value[i];
+    }
+    os << "}";
+    return os;
 }
 
 } // namespace playrho

--- a/PlayRho/Common/Vector2D.hpp
+++ b/PlayRho/Common/Vector2D.hpp
@@ -25,7 +25,6 @@
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/InvalidArgument.hpp>
 #include <PlayRho/Common/Vector.hpp>
-#include <iostream>
 
 namespace playrho
 {
@@ -69,13 +68,6 @@ namespace playrho
         Real{0} * MeterPerSquareSecond,
         Real{-9.8f} * MeterPerSquareSecond
     };
-    
-    /// @brief Output stream operator.
-    template <typename T>
-    inline ::std::ostream& operator<<(::std::ostream& os, const Vector2D<T>& value)
-    {
-        return os << "{" << Get<0>(value) << "," << Get<1>(value) << "}";
-    }
 
     /// @brief Gets the given value as a Vec2.
     constexpr inline Vec2 GetVec2(const Vector2D<Real> value)

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -222,7 +222,7 @@ protected:
     
 private:
     Fixtures m_selectedFixtures;
-    AABB m_worldAABB;
+    AABB m_maxAABB;
     ContactPoints m_points;
     DestructionListenerImpl m_destructionListener;
     Body* m_bomb = nullptr;

--- a/Testbed/Tests/BodyTypes.hpp
+++ b/Testbed/Tests/BodyTypes.hpp
@@ -123,7 +123,8 @@ public:
                 (GetX(p) > Real{10.0f} * Meter && GetX(velocity.linear) > Real{0.0f} * MeterPerSecond))
             {
                 m_platform->SetVelocity(Velocity{
-                    {-GetX(velocity.linear), GetY(velocity.linear)}, velocity.angular
+                    LinearVelocity2D{-GetX(velocity.linear), GetY(velocity.linear)},
+                    velocity.angular
                 });
             }
         }

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -76,7 +76,7 @@ public:
     Length2D GetRandomOffset() const
     {
         const auto halfWL = StripUnit(wall_length) / Real{2};
-        return Vec2{RandomFloat(-halfWL, +halfWL), RandomFloat(-halfWL, +halfWL)};
+        return Vec2{RandomFloat(-halfWL, +halfWL), RandomFloat(-halfWL, +halfWL)} * Meter;
     }
     
     void CreateCircle()
@@ -86,7 +86,7 @@ public:
         BodyDef bd;
         bd.type = BodyType::Dynamic;
         bd.bullet = m_bullet_mode;
-        bd.position = (Vec2{0, 20} + GetRandomOffset()) * Meter;
+        bd.position = Vec2{0, 20} * Meter + GetRandomOffset();
         //bd.allowSleep = false;
 
         const auto body = m_world->CreateBody(bd);
@@ -109,7 +109,7 @@ public:
         BodyDef bd;
         bd.type = BodyType::Dynamic;
         bd.bullet = m_bullet_mode;
-        bd.position = (Vec2{0, 20} + GetRandomOffset()) * Meter;
+        bd.position = Vec2{0, 20} * Meter + GetRandomOffset();
         const auto body = m_world->CreateBody(bd);
         body->CreateFixture(std::make_shared<PolygonShape>(side_length/Real{2}, side_length/Real{2}, conf));
     }

--- a/Testbed/Tests/FifteenPuzzle.hpp
+++ b/Testbed/Tests/FifteenPuzzle.hpp
@@ -72,7 +72,7 @@ namespace playrho {
             bd.type = BodyType::Dynamic;
             bd.bullet = true;
             bd.position = GetCenter() + relPos + Length2D{sideLength / 2, sideLength / 2};
-            bd.linearDamping = 20.0f;
+            bd.linearDamping = 20.0f * Hertz;
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(std::make_shared<PolygonShape>(halfSide, halfSide, conf));
             

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -191,6 +191,13 @@ TEST(AABB, InitializingConstruction)
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
+    {
+        const auto rangeX = ValueRange<Length>{-2 * Meter, +3 * Meter};
+        const auto rangeY = ValueRange<Length>{-8 * Meter, -4 * Meter};
+        AABB foo{rangeX, rangeY};
+        EXPECT_EQ(foo.rangeX, rangeX);
+        EXPECT_EQ(foo.rangeY, rangeY);
+    }
 }
 
 TEST(AABB, Swappable)

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -24,6 +24,7 @@
 #include <type_traits>
 #include <algorithm>
 #include <utility>
+#include <string>
 
 using namespace playrho;
 
@@ -381,4 +382,32 @@ TEST(AABB, Move)
         const auto moveby = Length2D{Real(1) * Meter, Real(1) * Meter};
         EXPECT_EQ(aabb.Move(moveby), AABB(lower + moveby, upper + moveby));
     }
+}
+
+TEST(AABB, StreamOutputOperator)
+{
+    const auto rangeX = ValueRange<Length>{-2 * Meter, +3 * Meter};
+    const auto rangeY = ValueRange<Length>{-8 * Meter, -4 * Meter};
+    AABB foo{rangeX, rangeY};
+    ASSERT_EQ(foo.rangeX, rangeX);
+    ASSERT_EQ(foo.rangeY, rangeY);
+    
+    std::stringstream aabbStream;
+    ASSERT_TRUE(aabbStream.str().empty());
+    aabbStream << foo;
+    ASSERT_FALSE(aabbStream.str().empty());
+    
+    std::stringstream xRangeStream;
+    xRangeStream << foo.rangeX;
+    
+    std::stringstream yRangeStream;
+    yRangeStream << foo.rangeY;
+    
+    std::string comp;
+    comp += '{';
+    comp += xRangeStream.str();
+    comp += ',';
+    comp += yRangeStream.str();
+    comp += '}';
+    EXPECT_STREQ(aabbStream.str().c_str(), comp.c_str());
 }

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -2352,7 +2352,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
             {
                 ++increments;
                 ball_body->SetVelocity(Velocity{
-                    {
+                    LinearVelocity2D{
                         static_cast<Real>(increments) * GetX(velocity),
                         GetY(ball_body->GetVelocity().linear)
                     }, ball_body->GetVelocity().angular});
@@ -2394,7 +2394,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
             {
                 ++increments;
                 ball_body->SetVelocity(Velocity{
-                    {
+                    LinearVelocity2D{
                         -static_cast<Real>(increments) * GetX(velocity),
                         GetY(ball_body->GetVelocity().linear)
                     }, ball_body->GetVelocity().angular});
@@ -2408,7 +2408,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
         
         ++increments;
         ball_body->SetVelocity(Velocity{
-            {
+            LinearVelocity2D{
                 static_cast<Real>(increments) * GetX(velocity),
                 GetY(ball_body->GetVelocity().linear)
             }, ball_body->GetVelocity().angular});


### PR DESCRIPTION
#### Description - What's this PR do?
Adds a Tumbler like benchmark test.
Adds ValueRange based initializing copy constructor to AABB.
Fixes some unit mistakes.
Adds stream output operator support for ValueRange and Vector.
Adds drawing of DynamicTree's root AABB to Testbed when draw AABB is toggled on.
Adds max AABB stat collection to Testbed statistics output.

#### Related Issues
- Issue #136.
