### PR TITLE
Changes DynamicTree nomenclature from using the term "proxy" to using "leaf"

### DIFF
--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -268,7 +268,7 @@ DynamicTree::Size DynamicTree::FindReference(Size index) const noexcept
     return (it != m_nodes + m_nodeCapacity)? static_cast<Size>(it - m_nodes): GetInvalidSize();
 }
 
-DynamicTree::Size DynamicTree::CreateProxy(const AABB& aabb, void* userData)
+DynamicTree::Size DynamicTree::CreateLeaf(const AABB& aabb, void* userData)
 {
     assert(IsValid(aabb));
     const auto index = AllocateNode(LeafNode{userData}, aabb);
@@ -277,7 +277,7 @@ DynamicTree::Size DynamicTree::CreateProxy(const AABB& aabb, void* userData)
     return index;
 }
 
-void DynamicTree::DestroyProxy(Size index)
+void DynamicTree::DestroyLeaf(Size index)
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
@@ -289,7 +289,7 @@ void DynamicTree::DestroyProxy(Size index)
     FreeNode(index);
 }
 
-void DynamicTree::UpdateProxy(Size index, const AABB& aabb)
+void DynamicTree::UpdateLeaf(Size index, const AABB& aabb)
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -103,23 +103,23 @@ public:
     /// @brief Move assignment operator.
     DynamicTree& operator= (DynamicTree&& other) noexcept;
 
-    /// @brief Creates a new proxy.
-    /// @details Creates a proxy for a tight fitting AABB and a userData pointer.
-    /// @note The indices of proxies that have been destroyed get reused for new proxies.
+    /// @brief Creates a new leaf node.
+    /// @details Creates a leaf node for a tight fitting AABB and a userData pointer.
+    /// @note The indices of leaf nodes that have been destroyed get reused for new nodes.
     /// @post If the root index had been the GetInvalidSize(), then it will be set to the index
     ///   returned from this method.
-    /// @return Index of the created proxy.
-    Size CreateProxy(const AABB& aabb, void* userData);
+    /// @return Index of the created leaf node.
+    Size CreateLeaf(const AABB& aabb, void* userData);
 
-    /// @brief Destroys a proxy.
+    /// @brief Destroys a leaf node.
     /// @warning Behavior is undefined if the given index is not valid.
-    void DestroyProxy(Size index);
+    void DestroyLeaf(Size index);
 
-    /// @brief Updates a proxy with a new AABB value.
+    /// @brief Updates a leaf node with a new AABB value.
     /// @warning Behavior is undefined if the given index is not valid.
-    /// @param index Proxy ID. Behavior is undefined if this is not a valid ID.
-    /// @param aabb New axis aligned bounding box of the proxy.
-    void UpdateProxy(Size index, const AABB& aabb);
+    /// @param index Leaf node's ID. Behavior is undefined if this is not a valid ID.
+    /// @param aabb New axis aligned bounding box for the leaf node.
+    void UpdateLeaf(Size index, const AABB& aabb);
 
     /// @brief Gets the user data for the node identified by the given identifier.
     /// @warning Behavior is undefined if the given index is not valid.
@@ -130,13 +130,13 @@ public:
     /// @brief Sets the user data for the element at the given index to the given value.
     void SetUserData(Size index, void* value) noexcept;
 
-    /// @brief Gets the AABB for a proxy.
+    /// @brief Gets the AABB for a leaf.
     /// @warning Behavior is undefined if the given index is not valid.
-    /// @param index Proxy ID. Must be a valid ID.
+    /// @param index Leaf node's ID. Must be a valid ID.
     AABB GetAABB(Size index) const noexcept;
 
     /// @brief Query an AABB for overlapping proxies.
-    /// @note The callback instance is called for each proxy that overlaps the supplied AABB.
+    /// @note The callback instance is called for each leaf node that overlaps the supplied AABB.
     void Query(const AABB& aabb, const QueryCallback& callback) const;
 
     /// @brief Calls the given callback for each of the entries overlapping the given AABB.
@@ -144,14 +144,14 @@ public:
 
     /// @brief Ray-cast against the proxies in the tree.
     ///
-    /// @note This relies on the callback to perform an exact ray-cast in the case were the
-    ///    proxy contains a shape.
-    /// @note The callback also performs the any collision filtering.
+    /// @note This relies on the callback to perform an exact ray-cast in the case where the
+    ///    leaf node contains a shape.
+    /// @note The callback also performs collision filtering.
     /// @note Performance is roughly k * log(n), where k is the number of collisions and n is the
-    ///   number of proxies in the tree.
+    ///   number of leaf nodes in the tree.
     ///
     /// @param input the ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
-    /// @param callback A callback instance function that's called for each proxy that is hit
+    /// @param callback A callback instance function that's called for each leaf that is hit
     ///   by the ray. The callback should return 0 to terminate raycasting, or greater than 0
     ///   to update the segment bounding box. Values less than zero are ignored.
     ///
@@ -215,8 +215,8 @@ public:
     /// @return Count of existing proxies (count of nodes currently allocated).
     Size GetNodeCount() const noexcept;
     
-    /// @brief Gets the current proxy count.
-    /// @details Gets the current proxy count which is also the current leaf node count.
+    /// @brief Gets the current leaf node count.
+    /// @details Gets the current leaf node count.
     Size GetProxyCount() const noexcept;
 
     /// @brief Finds the lowest cost node.
@@ -636,9 +636,9 @@ inline AABB GetAABB(const DynamicTree& tree) noexcept
 /// @brief Tests for overlap of the elements identified in the given dynamic tree.
 /// @relatedalso DynamicTree
 inline bool TestOverlap(const DynamicTree& tree,
-                        DynamicTree::Size proxyIdA, DynamicTree::Size proxyIdB) noexcept
+                        DynamicTree::Size leafIdA, DynamicTree::Size leafIdB) noexcept
 {
-    return TestOverlap(tree.GetAABB(proxyIdA), tree.GetAABB(proxyIdB));
+    return TestOverlap(tree.GetAABB(leafIdA), tree.GetAABB(leafIdB));
 }
 
 /// @brief Gets the ratio of the sum of the perimeters of nodes to the root perimeter.

--- a/PlayRho/Dynamics/Contacts/ContactKey.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.cpp
@@ -27,7 +27,7 @@ namespace playrho {
 
 ContactKey GetContactKey(const FixtureProxy& fpA, const FixtureProxy& fpB) noexcept
 {
-    return ContactKey{fpA.proxyId, fpB.proxyId};
+    return ContactKey{fpA.treeId, fpB.treeId};
 }
 
 ContactKey GetContactKey(const Fixture* fixtureA, ChildCounter childIndexA,

--- a/PlayRho/Dynamics/FixtureProxy.hpp
+++ b/PlayRho/Dynamics/FixtureProxy.hpp
@@ -46,18 +46,35 @@ struct FixtureProxy
 
     /// @brief Initializing constructor.
     FixtureProxy(const AABB& bb, size_type pid, Fixture* f, ChildCounter ci):
-        aabb{bb}, fixture{f}, proxyId{pid}, childIndex{ci} {}
+        aabb{bb}, fixture{f}, treeId{pid}, childIndex{ci} {}
     
     ~FixtureProxy() = default;
     
+    // Deleted because some fields are marked <code>const</code>.
     FixtureProxy& operator= (const FixtureProxy& other) = delete;
 
-    FixtureProxy& operator= (FixtureProxy&& other) noexcept = delete;
+    // Deleted because some fields are marked <code>const</code>.
+    FixtureProxy& operator= (FixtureProxy&& other) = delete;
 
     AABB aabb; ///< Axis Aligned Bounding Box. 16-bytes.
-    Fixture* const fixture; ///< Fixture. 8-bytes.
-    const size_type proxyId; ///< Proxy ID. 4-bytes.
-    const ChildCounter childIndex; ///< Child index. 4-bytes.
+    
+    /// @brief Fixture that this proxy is for.
+    /// @note 8-bytes.
+    Fixture* const fixture;
+
+    /// @brief Tree ID.
+    /// @details This is the ID of the leaf node in the dynamic tree for this "proxy".
+    /// @note 4-bytes.
+    const size_type treeId;
+ 
+    /// @brief Child index of the fixture's shape that this proxy is for.
+    /// @note This could potentially be calculated via pointer arithmetic - i.e.
+    ///    this - array, where "this" is the address of this class and "array" is the
+    ///    address of the array that this class is within. While that would shrink
+    ///    this structure's size, it may also cause some fixture proxies to straddle
+    ///    any 64-byte wide cache lines (which would presumably not help performance).
+    /// @note 4-bytes.
+    const ChildCounter childIndex;
 };
 
 } // namespace playrho

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -346,7 +346,7 @@ static bool Draw(Drawer& drawer, const World& world, const Settings& settings,
                 for (auto i = decltype(proxy_count){0}; i < proxy_count; ++i)
                 {
                     const auto proxy = f.GetProxy(i);
-                    Draw(drawer, world.GetTree().GetAABB(proxy->proxyId), color);
+                    Draw(drawer, world.GetTree().GetAABB(proxy->treeId), color);
                 }
             }
         }

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -100,7 +100,7 @@ TEST(DynamicTree, CopyConstruction)
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
     }
 
-    const auto pid = orig.CreateProxy(AABB{Length2D{Real(0) * Meter, Real(0) * Meter}, Length2D(Real(1) * Meter, Real(1) * Meter)}, &orig);
+    const auto pid = orig.CreateLeaf(AABB{Length2D{Real(0) * Meter, Real(0) * Meter}, Length2D(Real(1) * Meter, Real(1) * Meter)}, &orig);
     {
         DynamicTree copy{orig};
         EXPECT_EQ(copy.GetRootIndex(), orig.GetRootIndex());
@@ -127,7 +127,7 @@ TEST(DynamicTree, CopyAssignment)
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
     }
     
-    const auto pid = orig.CreateProxy(AABB{Length2D{Real(0) * Meter, Real(0) * Meter}, Length2D(Real(1) * Meter, Real(1) * Meter)}, &orig);
+    const auto pid = orig.CreateLeaf(AABB{Length2D{Real(0) * Meter, Real(0) * Meter}, Length2D(Real(1) * Meter, Real(1) * Meter)}, &orig);
     {
         DynamicTree copy;
         copy = orig;
@@ -154,7 +154,7 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     };
     const auto userdata = nullptr;
 
-    const auto pid = foo.CreateProxy(aabb, userdata);
+    const auto pid = foo.CreateLeaf(aabb, userdata);
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(1));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
     EXPECT_EQ(foo.GetAABB(pid), aabb);
@@ -165,7 +165,7 @@ TEST(DynamicTree, CreateAndDestroyProxy)
 
     EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(0));
 
-    foo.DestroyProxy(pid);
+    foo.DestroyLeaf(pid);
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
     EXPECT_EQ(GetHeight(foo), DynamicTree::Height(0));
@@ -187,7 +187,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     const auto userdata = nullptr;
     
     {
-        const auto pid = foo.CreateProxy(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, userdata);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }
@@ -200,7 +200,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(0));
 
     {
-        const auto pid = foo.CreateProxy(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, userdata);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }
@@ -213,7 +213,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(1));
     
     {
-        const auto pid = foo.CreateProxy(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, userdata);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }
@@ -226,7 +226,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(2));
     
     {
-        const auto pid = foo.CreateProxy(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, userdata);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
         EXPECT_EQ(foo.GetUserData(pid), userdata);
     }


### PR DESCRIPTION
#### Description - What's this PR do?

Switches to nomenclature that makes more sense to me.

If the `DynamicTree` class is supposed to be usage agnostic, then calling things from it's perspective "leaf" makes more sense to me than calling things "proxy". "proxy" relates directly to the `FixtureProxy` class and while that's actually what the dynamic tree leafs are associating with in their user data, that's making the association in a way that contradicts calling it *user data*.