### PR TITLE
Dynamic tree updates

### DIFF
--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -834,7 +834,7 @@ bool DynamicTree::Validate() const
         ++freeCount;
     }
 
-    if ((m_root != GetInvalidSize()) && (playrho::GetHeight(*this) != ComputeHeight()))
+    if ((m_root != GetInvalidSize()) && (playrho::GetHeight(*this) != playrho::ComputeHeight(*this)))
     {
         return false;
     }

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -113,40 +113,6 @@ DynamicTree::Size DynamicTree::GetParent(Size index) const noexcept
     return m_nodes[index].GetOther();
 }
 
-void DynamicTree::SetParent(Size index, Size newParent) noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(!IsUnused(m_nodes[index]));
-    assert(newParent == GetInvalidSize() || !IsUnused(m_nodes[newParent]));
-    m_nodes[index].SetOther(newParent);
-}
-
-DynamicTree::Size DynamicTree::GetChild1(Size index) const noexcept
-{
-    assert(IsBranch(m_nodes[index]));
-    return m_nodes[index].AsBranch().child1;
-}
-
-void DynamicTree::SetChild1(Size index, Size value) noexcept
-{
-    assert(IsBranch(m_nodes[index]));
-    assert(!IsUnused(m_nodes[value]));
-    m_nodes[index].AsBranch().child1 = value;
-}
-
-DynamicTree::Size DynamicTree::GetChild2(Size index) const noexcept
-{
-    assert(IsBranch(m_nodes[index]));
-    return m_nodes[index].AsBranch().child2;
-}
-
-void DynamicTree::SetChild2(Size index, Size value) noexcept
-{
-    assert(IsBranch(m_nodes[index]));
-    assert(!IsUnused(m_nodes[value]));
-    m_nodes[index].AsBranch().child2 = value;
-}
-
 void DynamicTree::SwapChild(Size index, Size oldChild, Size newChild) noexcept
 {
     if (index == GetInvalidSize())
@@ -192,7 +158,7 @@ void DynamicTree::SetNodeCapacity(Size value) noexcept
 }
 
 // Allocate a node from the pool. Grow the pool if necessary.
-DynamicTree::Size DynamicTree::AllocateNode(const LeafNode& node, AABB aabb) noexcept
+DynamicTree::Size DynamicTree::AllocateNode(const LeafData& node, AABB aabb) noexcept
 {
     // Expand the node pool as needed.
     if (m_freeListIndex == GetInvalidSize())
@@ -211,7 +177,7 @@ DynamicTree::Size DynamicTree::AllocateNode(const LeafNode& node, AABB aabb) noe
     return index;
 }
 
-DynamicTree::Size DynamicTree::AllocateNode(const BranchNode& node, AABB aabb, Height height,
+DynamicTree::Size DynamicTree::AllocateNode(const BranchData& node, AABB aabb, Height height,
                                             Size other) noexcept
 {
     assert(height > 0);
@@ -239,7 +205,7 @@ void DynamicTree::FreeNode(Size index) noexcept
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
     assert(m_nodeCount > 0); // index is not ncessarily less than m_nodeCount.
-    assert(!IsUnused(m_nodes[index]));
+    assert(!IsUnused(m_nodes[index].GetHeight()));
     //assert(GetParent(index) == GetInvalidSize());
     assert(index != m_freeListIndex);
     //const auto found = FindReference(index);
@@ -256,7 +222,7 @@ DynamicTree::Size DynamicTree::FindReference(Size index) const noexcept
         {
             return true;
         }
-        if (IsBranch(node))
+        if (IsBranch(node.GetHeight()))
         {
             if (node.AsBranch().child1 == index || node.AsBranch().child2 == index)
             {
@@ -268,10 +234,10 @@ DynamicTree::Size DynamicTree::FindReference(Size index) const noexcept
     return (it != m_nodes + m_nodeCapacity)? static_cast<Size>(it - m_nodes): GetInvalidSize();
 }
 
-DynamicTree::Size DynamicTree::CreateLeaf(const AABB& aabb, void* userData)
+DynamicTree::Size DynamicTree::CreateLeaf(const AABB& aabb, LeafData leafData)
 {
     assert(IsValid(aabb));
-    const auto index = AllocateNode(LeafNode{userData}, aabb);
+    const auto index = AllocateNode(leafData, aabb);
     InsertLeaf(index);
     m_proxyCount++;
     return index;
@@ -281,7 +247,7 @@ void DynamicTree::DestroyLeaf(Size index)
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index]));
+    assert(IsLeaf(m_nodes[index].GetHeight()));
     assert(m_proxyCount > 0);
 
     m_proxyCount--;
@@ -293,7 +259,7 @@ void DynamicTree::UpdateLeaf(Size index, const AABB& aabb)
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index]));
+    assert(IsLeaf(m_nodes[index].GetHeight()));
 
     RemoveLeaf(index);
     m_nodes[index].SetAABB(aabb);
@@ -306,7 +272,7 @@ DynamicTree::Size DynamicTree::FindLowestCostNode(AABB leafAABB) const noexcept
     assert(IsValid(leafAABB));
 
     auto index = m_root;
-    while (IsBranch(m_nodes[index]))
+    while (IsBranch(m_nodes[index].GetHeight()))
     {
         const auto child1 = m_nodes[index].AsBranch().child1;
         const auto child2 = m_nodes[index].AsBranch().child2;
@@ -331,7 +297,7 @@ DynamicTree::Size DynamicTree::FindLowestCostNode(AABB leafAABB) const noexcept
             const auto childAabb = playrho::GetAABB(m_nodes[child]);
             const auto leafCost = GetPerimeter(GetEnclosingAABB(leafAABB, childAabb))
                 + inheritanceCost;
-            return (IsLeaf(m_nodes[child]))? leafCost: leafCost - GetPerimeter(childAabb);
+            return (IsLeaf(m_nodes[child].GetHeight()))? leafCost: leafCost - GetPerimeter(childAabb);
         };
 
         const auto cost1 = costFunc(child1);
@@ -353,8 +319,8 @@ void DynamicTree::InsertLeaf(Size index)
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
-    assert(!IsUnused(m_nodes[index]));
-    assert(IsLeaf(m_nodes[index]));
+    assert(!IsUnused(m_nodes[index].GetHeight()));
+    assert(IsLeaf(m_nodes[index].GetHeight()));
 
     if (m_root == GetInvalidSize())
     {
@@ -373,7 +339,7 @@ void DynamicTree::InsertLeaf(Size index)
 
     // Warning: the following may change value of m_nodes!
     // std::max of leaf height and sibling height + 1 = sibling height + 1
-    const auto newParent = AllocateNode(BranchNode{sibling, index},
+    const auto newParent = AllocateNode(BranchData{sibling, index},
                                         GetEnclosingAABB(leafAABB, GetAABB(sibling)),
                                         1 + GetHeight(sibling),
                                         oldParent);
@@ -437,7 +403,7 @@ void DynamicTree::Rebalance(Size index)
     {
         assert(index != GetInvalidSize());
         assert(index < m_nodeCapacity);
-        assert(!IsUnused(m_nodes[index]));
+        assert(!IsUnused(m_nodes[index].GetHeight()));
         
         do
         {
@@ -538,7 +504,7 @@ Length DynamicTree::ComputeTotalPerimeter() const noexcept
     {
         for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)
         {
-            if (!IsUnused(m_nodes[i]))
+            if (!IsUnused(m_nodes[i].GetHeight()))
             {
                 totalPerimeter += GetPerimeter(m_nodes[i].GetAABB());
             }
@@ -551,7 +517,7 @@ Length DynamicTree::ComputeTotalPerimeter() const noexcept
 DynamicTree::Height DynamicTree::ComputeHeight(Size index) const noexcept
 {
     assert(index < m_nodeCapacity);
-    if (IsBranch(m_nodes[index]))
+    if (IsBranch(m_nodes[index].GetHeight()))
     {
         const auto height1 = ComputeHeight(m_nodes[index].AsBranch().child1);
         const auto height2 = ComputeHeight(m_nodes[index].AsBranch().child2);
@@ -573,7 +539,7 @@ void DynamicTree::ForEach(const AABB& aabb, const ForEachCallback& callback) con
         {
             if (TestOverlap(m_nodes[index].GetAABB(), aabb))
             {
-                if (IsLeaf(m_nodes[index]))
+                if (IsLeaf(m_nodes[index].GetHeight()))
                 {
                     callback(index);
                 }
@@ -590,7 +556,7 @@ void DynamicTree::ForEach(const AABB& aabb, const ForEachCallback& callback) con
 void DynamicTree::Query(const AABB& aabb, const QueryCallback& callback) const
 {
     GrowableStack<Size, 256> stack;
-    stack.push(m_root);
+    stack.push(GetRootIndex());
     
     while (!stack.empty())
     {
@@ -598,9 +564,9 @@ void DynamicTree::Query(const AABB& aabb, const QueryCallback& callback) const
         stack.pop();
         if (index != GetInvalidSize())
         {
-            if (TestOverlap(m_nodes[index].GetAABB(), aabb))
+            if (TestOverlap(GetAABB(index), aabb))
             {
-                if (IsLeaf(m_nodes[index]))
+                if (IsLeaf(GetHeight(index)))
                 {
                     if (!callback(index))
                     {
@@ -662,7 +628,7 @@ void DynamicTree::RayCast(const RayCastInput& input, const RayCastCallback& call
             continue;
         }
         
-        if (IsLeaf(m_nodes[index]))
+        if (IsLeaf(m_nodes[index].GetHeight()))
         {
             const auto subInput = RayCastInput{input.p1, input.p2, maxFraction};
             
@@ -709,7 +675,7 @@ bool DynamicTree::ValidateStructure(Size index) const noexcept
         return false;
     }
     
-    if (IsLeaf(m_nodes[index]))
+    if (IsLeaf(m_nodes[index].GetHeight()))
     {
         return true;
     }
@@ -759,7 +725,7 @@ bool DynamicTree::ValidateMetrics(Size index) const noexcept
         return false;
     }
 
-    if (IsUnused(m_nodes[index]) || IsLeaf(m_nodes[index]))
+    if (!IsBranch(m_nodes[index].GetHeight()))
     {
         return true;
     }
@@ -849,17 +815,10 @@ DynamicTree::Height DynamicTree::GetMaxBalance() const noexcept
     auto maxBalance = Height{0};
     for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)
     {
-        if (IsUnused(m_nodes[i]))
+        if (!IsBranch(m_nodes[i].GetHeight()))
         {
             continue;
         }
-
-        if (m_nodes[i].GetHeight() <= 1)
-        {
-            continue;
-        }
-
-        assert(!IsLeaf(m_nodes[i]));
 
         const auto child1 = m_nodes[i].AsBranch().child1;
         assert(child1 != GetInvalidSize());
@@ -886,13 +845,14 @@ void DynamicTree::RebuildBottomUp()
     // Build array of leaves. Free the rest.
     for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)
     {
-        if (IsLeaf(m_nodes[i]))
+        const auto height = m_nodes[i].GetHeight();
+        if (IsLeaf(height))
         {
             m_nodes[i].SetOther(GetInvalidSize());
             nodes[count] = i;
             ++count;
         }
-        else if (IsBranch(m_nodes[i]))
+        else if (IsBranch(height))
         {
             FreeNode(i);
         }
@@ -925,14 +885,14 @@ void DynamicTree::RebuildBottomUp()
 
         const auto index1 = nodes[iMin];
         const auto index2 = nodes[jMin];
-        assert(!IsUnused(m_nodes[index1]));
-        assert(!IsUnused(m_nodes[index2]));
+        assert(!IsUnused(m_nodes[index1].GetHeight()));
+        assert(!IsUnused(m_nodes[index2].GetHeight()));
 
         const auto aabb = GetEnclosingAABB(m_nodes[index1].GetAABB(), m_nodes[index2].GetAABB());
         const auto height = 1 + std::max(m_nodes[index1].GetHeight(), m_nodes[index2].GetHeight());
         
         // Warning: the following may change value of m_nodes!
-        const auto parent = AllocateNode(BranchNode{index1, index2}, aabb, height);
+        const auto parent = AllocateNode(BranchData{index1, index2}, aabb, height);
         m_nodes[index1].SetOther(parent);
         m_nodes[index2].SetOther(parent);
 
@@ -954,52 +914,6 @@ void DynamicTree::ShiftOrigin(Length2D newOrigin)
     {
         m_nodes[i].SetAABB(GetMovedAABB(m_nodes[i].GetAABB(), -newOrigin));
     }
-}
-
-void* DynamicTree::GetUserData(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index]));
-    return m_nodes[index].AsLeaf().userData;
-}
-
-void DynamicTree::SetUserData(Size index, void* value) noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index]));
-    m_nodes[index].AsLeaf().userData = value;
-}
-
-AABB DynamicTree::GetAABB(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(!IsUnused(m_nodes[index]));
-    return m_nodes[index].GetAABB();
-}
-
-void DynamicTree::SetAABB(Size index, AABB value) noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(!IsUnused(m_nodes[index]));
-    m_nodes[index].SetAABB(value);
-}
-
-DynamicTree::Height DynamicTree::GetHeight(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    return m_nodes[index].GetHeight();
-}
-
-void DynamicTree::SetHeight(Size index, Height value) noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    m_nodes[index].SetHeight(value);
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -551,15 +551,13 @@ Length DynamicTree::ComputeTotalPerimeter() const noexcept
 DynamicTree::Height DynamicTree::ComputeHeight(Size index) const noexcept
 {
     assert(index < m_nodeCapacity);
-
-    if (IsLeaf(m_nodes[index]))
+    if (IsBranch(m_nodes[index]))
     {
-        return 0;
+        const auto height1 = ComputeHeight(m_nodes[index].AsBranch().child1);
+        const auto height2 = ComputeHeight(m_nodes[index].AsBranch().child2);
+        return 1 + std::max(height1, height2);
     }
-
-    const auto height1 = ComputeHeight(m_nodes[index].AsBranch().child1);
-    const auto height2 = ComputeHeight(m_nodes[index].AsBranch().child2);
-    return 1 + std::max(height1, height2);
+    return 0;
 }
 
 void DynamicTree::ForEach(const AABB& aabb, const ForEachCallback& callback) const

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -805,7 +805,7 @@ void Query(const DynamicTree& tree, const AABB& aabb, const DynamicTree::QueryCa
                 }
                 else
                 {
-                    assert(IsLeaf(height));
+                    assert(DynamicTree::IsLeaf(height));
                     if (!callback(index))
                     {
                         return;

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -204,10 +204,6 @@ public:
     /// @param index ID of node to compute height from.
     Height ComputeHeight(Size index) const noexcept;
 
-    /// @brief Computes the height of the tree from its root.
-    /// @warning Behavior is undefined if the tree doesn't have a valid root.
-    Height ComputeHeight() const noexcept;
-
     /// @brief Gets the current node capacity of this tree.
     Size GetNodeCapacity() const noexcept;
 
@@ -320,11 +316,6 @@ inline DynamicTree::Size DynamicTree::GetNodeCount() const noexcept
 inline DynamicTree::Size DynamicTree::GetProxyCount() const noexcept
 {
     return m_proxyCount;
-}
-
-inline DynamicTree::Height DynamicTree::ComputeHeight() const noexcept
-{
-    return ComputeHeight(GetRootIndex());
 }
 
 /// @brief Unused node of a TreeNode.
@@ -611,6 +602,12 @@ inline DynamicTree::TreeNode& SetParent(DynamicTree::TreeNode& node,
 {
     assert(IsBranch(node));
     return node.SetOther(other);
+}
+
+/// @brief Computes the height of the given dynamic tree.
+inline DynamicTree::Height ComputeHeight(const DynamicTree& tree) noexcept
+{
+    return tree.ComputeHeight(tree.GetRootIndex());
 }
 
 /// @brief Gets the height of the binary tree.

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -166,21 +166,6 @@ public:
     /// @brief Calls the given callback for each of the entries overlapping the given AABB.
     void ForEach(const AABB& aabb, const ForEachCallback& callback) const;
 
-    /// @brief Ray-cast against the proxies in the tree.
-    ///
-    /// @note This relies on the callback to perform an exact ray-cast in the case where the
-    ///    leaf node contains a shape.
-    /// @note The callback also performs collision filtering.
-    /// @note Performance is roughly k * log(n), where k is the number of collisions and n is the
-    ///   number of leaf nodes in the tree.
-    ///
-    /// @param input the ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
-    /// @param callback A callback instance function that's called for each leaf that is hit
-    ///   by the ray. The callback should return 0 to terminate raycasting, or greater than 0
-    ///   to update the segment bounding box. Values less than zero are ignored.
-    ///
-    void RayCast(const RayCastInput& input, const RayCastCallback& callback) const;
-
     /// @brief Validates this tree.
     /// @note Meant for testing.
     /// @return <code>true</code> if valid, <code>false</code> otherwise.
@@ -391,7 +376,7 @@ public:
     constexpr TreeNode(TreeNode&& other) = default;
 
     /// @brief Initializing constructor.
-    constexpr TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
+    constexpr explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_other{other}, m_variant{UnusedData{}}
     {
         assert(IsUnused(m_height));
@@ -764,7 +749,25 @@ inline Real ComputePerimeterRatio(const DynamicTree& tree) noexcept
 
 /// @brief Query the given dynamic tree and find nodes overlapping the given AABB.
 /// @note The callback instance is called for each leaf node that overlaps the supplied AABB.
-void Query(const DynamicTree& tree, const AABB& aabb, const DynamicTree::QueryCallback& callback);
+void Query(const DynamicTree& tree, const AABB& aabb,
+           const DynamicTree::QueryCallback& callback);
+
+/// @brief Ray-cast against the leafs in the given tree.
+///
+/// @note This relies on the callback to perform an exact ray-cast in the case where the
+///    leaf node contains a shape.
+/// @note The callback also performs collision filtering.
+/// @note Performance is roughly k * log(n), where k is the number of collisions and n is the
+///   number of leaf nodes in the tree.
+///
+/// @param tree Dynamic tree to raycast.
+/// @param input the ray-cast input data. The ray extends from p1 to p1 + maxFraction * (p2 - p1).
+/// @param callback A callback instance function that's called for each leaf that is hit
+///   by the ray. The callback should return 0 to terminate raycasting, or greater than 0
+///   to update the segment bounding box. Values less than zero are ignored.
+///
+void RayCast(const DynamicTree& tree, const RayCastInput& input,
+             const DynamicTree::RayCastCallback& callback);
 
 } // namespace playrho
 

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -163,9 +163,6 @@ public:
     /// @warning Behavior is undefined if the given index in not a valid branch node.
     BranchData GetBranchData(Size index) const noexcept;
 
-    /// @brief Calls the given callback for each of the entries overlapping the given AABB.
-    void ForEach(const AABB& aabb, const ForEachCallback& callback) const;
-
     /// @brief Validates this tree.
     /// @note Meant for testing.
     /// @return <code>true</code> if valid, <code>false</code> otherwise.
@@ -768,6 +765,10 @@ void Query(const DynamicTree& tree, const AABB& aabb,
 ///
 void RayCast(const DynamicTree& tree, const RayCastInput& input,
              const DynamicTree::RayCastCallback& callback);
+
+/// @brief Calls the given callback for each of the entries overlapping the given AABB.
+void ForEach(const DynamicTree& tree, const AABB& aabb,
+             const DynamicTree::ForEachCallback& callback);
 
 } // namespace playrho
 

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -163,10 +163,6 @@ public:
     /// @warning Behavior is undefined if the given index in not a valid branch node.
     BranchData GetBranchData(Size index) const noexcept;
 
-    /// @brief Query an AABB for overlapping proxies.
-    /// @note The callback instance is called for each leaf node that overlaps the supplied AABB.
-    void Query(const AABB& aabb, const QueryCallback& callback) const;
-
     /// @brief Calls the given callback for each of the entries overlapping the given AABB.
     void ForEach(const AABB& aabb, const ForEachCallback& callback) const;
 
@@ -625,6 +621,13 @@ inline void DynamicTree::SetLeafData(Size index, LeafData value) noexcept
     m_nodes[index].AsLeaf() = value;
 }
 
+inline DynamicTree::Size DynamicTree::GetParent(Size index) const noexcept
+{
+    assert(index != GetInvalidSize());
+    assert(!IsUnused(m_nodes[index].GetHeight()));
+    return m_nodes[index].GetOther();
+}
+
 inline void DynamicTree::SetParent(Size index, Size newParent) noexcept
 {
     assert(index != GetInvalidSize());
@@ -758,6 +761,10 @@ inline Real ComputePerimeterRatio(const DynamicTree& tree) noexcept
     }
     return 0;
 }
+
+/// @brief Query the given dynamic tree and find nodes overlapping the given AABB.
+/// @note The callback instance is called for each leaf node that overlaps the supplied AABB.
+void Query(const DynamicTree& tree, const AABB& aabb, const DynamicTree::QueryCallback& callback);
 
 } // namespace playrho
 

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -202,6 +202,7 @@ public:
     /// @brief Computes the height of the tree from a given node.
     /// @warning Behavior is undefined if the given index is not valid.
     /// @param index ID of node to compute height from.
+    /// @return 0 unless the given index is to a branch node.
     Height ComputeHeight(Size index) const noexcept;
 
     /// @brief Gets the current node capacity of this tree.

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -217,7 +217,7 @@ public:
     
     /// @brief Gets the current leaf node count.
     /// @details Gets the current leaf node count.
-    Size GetProxyCount() const noexcept;
+    Size GetLeafCount() const noexcept;
 
     /// @brief Finds the lowest cost node.
     /// @warning Behavior is undefined if the tree doesn't have a valid root.
@@ -292,7 +292,7 @@ private:
     Size m_nodeCount = Size{0}; ///< Node count. @details Count of currently allocated nodes.
     Size m_nodeCapacity; ///< Node capacity. @details Size of buffer allocated for nodes.
 
-    Size m_proxyCount = 0; ///< Proxy count. @details Count of currently allocated leaf nodes.
+    Size m_leafCount = 0; ///< Leaf count. @details Count of currently allocated leaf nodes.
 
     Size m_freeListIndex = Size{0}; ///< Free list. @details Index to free nodes.
 };
@@ -544,9 +544,9 @@ inline DynamicTree::Size DynamicTree::GetNodeCount() const noexcept
     return m_nodeCount;
 }
 
-inline DynamicTree::Size DynamicTree::GetProxyCount() const noexcept
+inline DynamicTree::Size DynamicTree::GetLeafCount() const noexcept
 {
-    return m_proxyCount;
+    return m_leafCount;
 }
 
 inline DynamicTree::Height DynamicTree::GetHeight(Size index) const noexcept

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -632,7 +632,7 @@ void World::CopyBodies(std::map<const Body*, Body*>& bodyMap,
                 const auto proxyPtr = proxies + childIndex;
                 const auto fp = otherFixture.GetProxy(childIndex);
                 new (proxyPtr) FixtureProxy{fp->aabb, fp->treeId, newFixture, childIndex};
-                m_tree.SetUserData(fp->treeId, proxyPtr);
+                m_tree.SetLeafData(fp->treeId, proxyPtr);
             }
             FixtureAtty::SetProxies(*newFixture, Span<FixtureProxy>(proxies, childCount));
         }
@@ -2051,7 +2051,7 @@ StepStats World::Step(const StepConf& conf)
 void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
 {
     m_tree.Query(aabb, [&](DynamicTree::Size treeId) {
-        const auto proxy = static_cast<FixtureProxy*>(m_tree.GetUserData(treeId));
+        const auto proxy = static_cast<FixtureProxy*>(m_tree.GetLeafData(treeId));
         return callback(proxy->fixture, proxy->childIndex);
     });
 }
@@ -2061,8 +2061,8 @@ void World::RayCast(Length2D point1, Length2D point2, RayCastCallback callback) 
     m_tree.RayCast(RayCastInput{point1, point2, Real{1}},
                    [&](const RayCastInput& input, DynamicTree::Size treeId)
     {
-        const auto userData = m_tree.GetUserData(treeId);
-        const auto proxy = static_cast<FixtureProxy*>(userData);
+        const auto leafData = m_tree.GetLeafData(treeId);
+        const auto proxy = static_cast<FixtureProxy*>(leafData);
         const auto fixture = proxy->fixture;
         const auto index = proxy->childIndex;
         const auto shape = fixture->GetShape();
@@ -2377,8 +2377,8 @@ ContactCounter World::FindNewContacts()
     {
         if (key != lastKey)
         {
-            const auto& proxyA = *static_cast<FixtureProxy*>(m_tree.GetUserData(key.GetMin()));
-            const auto& proxyB = *static_cast<FixtureProxy*>(m_tree.GetUserData(key.GetMax()));
+            const auto& proxyA = *static_cast<FixtureProxy*>(m_tree.GetLeafData(key.GetMin()));
+            const auto& proxyB = *static_cast<FixtureProxy*>(m_tree.GetLeafData(key.GetMax()));
             
             if (Add(proxyA, proxyB))
             {

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2359,7 +2359,7 @@ ContactCounter World::FindNewContacts()
 
     for_each(cbegin(m_proxies), cend(m_proxies), [&](ProxyId pid) {
         const auto aabb = m_tree.GetAABB(pid);
-        m_tree.ForEach(aabb, [&](DynamicTree::Size nodeId) {
+        ForEach(m_tree, aabb, [&](DynamicTree::Size nodeId) {
             // A proxy cannot form a pair with itself.
             if (nodeId != pid)
             {

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2050,7 +2050,7 @@ StepStats World::Step(const StepConf& conf)
 
 void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
 {
-    m_tree.Query(aabb, [&](DynamicTree::Size treeId) {
+    Query(m_tree, aabb, [&](DynamicTree::Size treeId) {
         const auto proxy = static_cast<FixtureProxy*>(m_tree.GetLeafData(treeId));
         return callback(proxy->fixture, proxy->childIndex);
     });

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2058,7 +2058,7 @@ void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
 
 void World::RayCast(Length2D point1, Length2D point2, RayCastCallback callback) const
 {
-    m_tree.RayCast(RayCastInput{point1, point2, Real{1}},
+    playrho::RayCast(m_tree, RayCastInput{point1, point2, Real{1}},
                    [&](const RayCastInput& input, DynamicTree::Size treeId)
     {
         const auto leafData = m_tree.GetLeafData(treeId);

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -745,7 +745,7 @@ void Test::DrawStats(Drawer& drawer, const StepConf& stepConf)
     drawer.DrawString(5, m_textLine, Drawer::Left, stream.str().c_str());
     m_textLine += DRAW_STRING_NEW_LINE;
 
-    const auto proxyCount = m_world->GetTree().GetProxyCount();
+    const auto proxyCount = m_world->GetTree().GetLeafCount();
     const auto nodeCount = m_world->GetTree().GetNodeCount();
     const auto height = GetHeight(m_world->GetTree());
     const auto balance = m_world->GetTree().GetMaxBalance();

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -187,14 +187,14 @@ public:
 
     bool QueryCallback(DynamicTree::Size treeId)
     {
-        Actor* actor = (Actor*)m_tree.GetUserData(treeId);
+        Actor* actor = (Actor*)m_tree.GetLeafData(treeId);
         actor->overlap = TestOverlap(m_queryAABB, actor->aabb);
         return true;
     }
 
     Real RayCastCallback(const RayCastInput& input, DynamicTree::Size treeId)
     {
-        auto actor = static_cast<Actor*>(m_tree.GetUserData(treeId));
+        auto actor = static_cast<Actor*>(m_tree.GetLeafData(treeId));
 
         const auto output = playrho::RayCast(actor->aabb, input);
 

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -323,7 +323,7 @@ private:
 
     void Query()
     {
-        m_tree.Query(m_queryAABB, [&](DynamicTree::Size nodeId){ return QueryCallback(nodeId); });
+        playrho::Query(m_tree, m_queryAABB, [&](DynamicTree::Size nodeId){ return QueryCallback(nodeId); });
 
         for (auto i = decltype(e_actorCount){0}; i < e_actorCount; ++i)
         {

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -345,7 +345,7 @@ private:
         auto input = m_rayCastInput;
 
         // Ray cast against the dynamic tree.
-        m_tree.RayCast(input, [&](const RayCastInput& rci, DynamicTree::Size treeId) {
+        playrho::RayCast(m_tree, input, [&](const RayCastInput& rci, DynamicTree::Size treeId) {
             return RayCastCallback(rci, treeId);
         });
 

--- a/Testbed/Tests/Tiles.hpp
+++ b/Testbed/Tests/Tiles.hpp
@@ -102,7 +102,7 @@ public:
     void PostStep(const Settings&, Drawer& drawer) override
     {
         const auto height = GetHeight(m_world->GetTree());
-        const auto leafCount = m_world->GetTree().GetProxyCount();
+        const auto leafCount = m_world->GetTree().GetLeafCount();
         if (leafCount > 0)
         {
             const auto minimumNodeCount = 2 * leafCount - 1;

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -163,7 +163,7 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(1));
 
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(0));
+    EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(0));
 
     foo.DestroyLeaf(pid);
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
@@ -197,7 +197,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(GetHeight(foo), DynamicTree::Height(0));
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(1));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(0));
+    EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(0));
 
     {
         const auto pid = foo.CreateLeaf(aabb, userdata);
@@ -210,7 +210,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(GetHeight(foo), DynamicTree::Height(1));
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(3));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(1));
+    EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(1));
     
     {
         const auto pid = foo.CreateLeaf(aabb, userdata);
@@ -223,7 +223,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(GetHeight(foo), DynamicTree::Height(2));
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(1));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(5));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(2));
+    EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(2));
     
     {
         const auto pid = foo.CreateLeaf(aabb, userdata);
@@ -236,7 +236,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(GetHeight(foo), DynamicTree::Height(2));
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(7));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(2));
+    EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(2));
     
     foo.RebuildBottomUp();
     
@@ -245,5 +245,5 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(GetHeight(foo), DynamicTree::Height(3));
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(2));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(7));
-    EXPECT_EQ(foo.ComputeHeight(), DynamicTree::Height(3));
+    EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(3));
 }

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -109,7 +109,7 @@ TEST(DynamicTree, CopyConstruction)
         EXPECT_EQ(ComputePerimeterRatio(copy), ComputePerimeterRatio(orig));
         EXPECT_EQ(copy.GetNodeCount(), orig.GetNodeCount());
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
-        EXPECT_EQ(copy.GetUserData(pid), orig.GetUserData(pid));
+        EXPECT_EQ(copy.GetLeafData(pid), orig.GetLeafData(pid));
     }
 }
 
@@ -137,7 +137,7 @@ TEST(DynamicTree, CopyAssignment)
         EXPECT_EQ(ComputePerimeterRatio(copy), ComputePerimeterRatio(orig));
         EXPECT_EQ(copy.GetNodeCount(), orig.GetNodeCount());
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
-        EXPECT_EQ(copy.GetUserData(pid), orig.GetUserData(pid));
+        EXPECT_EQ(copy.GetLeafData(pid), orig.GetLeafData(pid));
     }
 }
 
@@ -158,7 +158,7 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(1));
     EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
     EXPECT_EQ(foo.GetAABB(pid), aabb);
-    EXPECT_EQ(foo.GetUserData(pid), userdata);
+    EXPECT_EQ(foo.GetLeafData(pid), userdata);
     EXPECT_EQ(GetHeight(foo), DynamicTree::Height(0));
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(0));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(1));
@@ -184,12 +184,12 @@ TEST(DynamicTree, FourIdenticalProxies)
         Length2D{Real(3) * Meter, Real(1) * Meter},
         Length2D{-Real(5) * Meter, -Real(2) * Meter}
     };
-    const auto userdata = nullptr;
+    const auto leafData = nullptr;
     
     {
-        const auto pid = foo.CreateLeaf(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, leafData);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
-        EXPECT_EQ(foo.GetUserData(pid), userdata);
+        EXPECT_EQ(foo.GetLeafData(pid), leafData);
     }
 
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(1));
@@ -200,9 +200,9 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(0));
 
     {
-        const auto pid = foo.CreateLeaf(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, leafData);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
-        EXPECT_EQ(foo.GetUserData(pid), userdata);
+        EXPECT_EQ(foo.GetLeafData(pid), leafData);
     }
 
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(3));
@@ -213,9 +213,9 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(1));
     
     {
-        const auto pid = foo.CreateLeaf(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, leafData);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
-        EXPECT_EQ(foo.GetUserData(pid), userdata);
+        EXPECT_EQ(foo.GetLeafData(pid), leafData);
     }
     
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(5));
@@ -226,9 +226,9 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(2));
     
     {
-        const auto pid = foo.CreateLeaf(aabb, userdata);
+        const auto pid = foo.CreateLeaf(aabb, leafData);
         EXPECT_EQ(foo.GetAABB(pid), aabb);
-        EXPECT_EQ(foo.GetUserData(pid), userdata);
+        EXPECT_EQ(foo.GetLeafData(pid), leafData);
     }
     
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(7));

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -100,7 +100,11 @@ TEST(DynamicTree, CopyConstruction)
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
     }
 
-    const auto pid = orig.CreateLeaf(AABB{Length2D{Real(0) * Meter, Real(0) * Meter}, Length2D(Real(1) * Meter, Real(1) * Meter)}, &orig);
+    const auto aabb = AABB{
+        Length2D{Real(0) * Meter, Real(0) * Meter},
+        Length2D(Real(1) * Meter, Real(1) * Meter)
+    };
+    const auto pid = orig.CreateLeaf(aabb, &orig);
     {
         DynamicTree copy{orig};
         EXPECT_EQ(copy.GetRootIndex(), orig.GetRootIndex());
@@ -127,7 +131,11 @@ TEST(DynamicTree, CopyAssignment)
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
     }
     
-    const auto pid = orig.CreateLeaf(AABB{Length2D{Real(0) * Meter, Real(0) * Meter}, Length2D(Real(1) * Meter, Real(1) * Meter)}, &orig);
+    const auto aabb = AABB{
+        Length2D{Real(0) * Meter, Real(0) * Meter},
+        Length2D{Real(1) * Meter, Real(1) * Meter}
+    };
+    const auto pid = orig.CreateLeaf(aabb, &orig);
     {
         DynamicTree copy;
         copy = orig;
@@ -246,4 +254,118 @@ TEST(DynamicTree, FourIdenticalProxies)
     EXPECT_EQ(foo.GetMaxBalance(), DynamicTree::Height(2));
     EXPECT_EQ(ComputePerimeterRatio(foo), Real(7));
     EXPECT_EQ(ComputeHeight(foo), DynamicTree::Height(3));
+}
+
+TEST(DynamicTree, MoveConstruction)
+{
+    DynamicTree foo;
+    
+    const auto aabb = AABB{
+        Length2D{Real(3) * Meter, Real(1) * Meter},
+        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+    };
+
+    const auto leafData = nullptr;
+
+    const auto leaf0 = foo.CreateLeaf(aabb, leafData);
+    const auto leaf1 = foo.CreateLeaf(aabb, leafData);
+    const auto leaf2 = foo.CreateLeaf(aabb, leafData);
+    const auto leaf3 = foo.CreateLeaf(aabb, leafData);
+
+    ASSERT_EQ(foo.GetRootIndex(), DynamicTree::Size(4));
+    ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(7));
+    ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
+    ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(4));
+
+    DynamicTree roo{std::move(foo)};
+
+    EXPECT_EQ(foo.GetRootIndex(), DynamicTree::GetInvalidSize());
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
+    EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(0));
+    EXPECT_EQ(foo.GetLeafCount(), DynamicTree::Size(0));
+    
+    EXPECT_EQ(roo.GetRootIndex(), DynamicTree::Size(4));
+    EXPECT_EQ(roo.GetNodeCount(), DynamicTree::Size(7));
+    EXPECT_EQ(roo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
+    EXPECT_EQ(roo.GetLeafCount(), DynamicTree::Size(4));
+    
+    EXPECT_EQ(roo.GetAABB(leaf0), aabb);
+    EXPECT_EQ(roo.GetAABB(leaf1), aabb);
+    EXPECT_EQ(roo.GetAABB(leaf2), aabb);
+    EXPECT_EQ(roo.GetAABB(leaf3), aabb);
+}
+
+TEST(DynamicTree, MoveAssignment)
+{
+    DynamicTree foo;
+    
+    const auto aabb = AABB{
+        Length2D{Real(3) * Meter, Real(1) * Meter},
+        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+    };
+    
+    const auto leafData = nullptr;
+    
+    const auto leaf0 = foo.CreateLeaf(aabb, leafData);
+    const auto leaf1 = foo.CreateLeaf(aabb, leafData);
+    const auto leaf2 = foo.CreateLeaf(aabb, leafData);
+    const auto leaf3 = foo.CreateLeaf(aabb, leafData);
+    
+    ASSERT_EQ(foo.GetRootIndex(), DynamicTree::Size(4));
+    ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(7));
+    ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
+    ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(4));
+    
+    DynamicTree roo;
+    
+    roo = std::move(foo);
+    
+    EXPECT_EQ(foo.GetRootIndex(), DynamicTree::GetInvalidSize());
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
+    EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(0));
+    EXPECT_EQ(foo.GetLeafCount(), DynamicTree::Size(0));
+    
+    EXPECT_EQ(roo.GetRootIndex(), DynamicTree::Size(4));
+    EXPECT_EQ(roo.GetNodeCount(), DynamicTree::Size(7));
+    EXPECT_EQ(roo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
+    EXPECT_EQ(roo.GetLeafCount(), DynamicTree::Size(4));
+    
+    EXPECT_EQ(roo.GetAABB(leaf0), aabb);
+    EXPECT_EQ(roo.GetAABB(leaf1), aabb);
+    EXPECT_EQ(roo.GetAABB(leaf2), aabb);
+    EXPECT_EQ(roo.GetAABB(leaf3), aabb);
+}
+
+TEST(DynamicTree, CapacityIncreases)
+{
+    DynamicTree foo{DynamicTree::Size{1}};
+    ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
+    ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(1));
+    ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(0));
+
+    const auto aabb = AABB{
+        Length2D{Real(3) * Meter, Real(1) * Meter},
+        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+    };
+    const auto leafData = nullptr;
+
+    foo.CreateLeaf(aabb, leafData);
+    ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(1));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(1));
+    EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(1));
+    
+    foo.CreateLeaf(aabb, leafData);
+    ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(2));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(3));
+    EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(4));
+
+    foo.CreateLeaf(aabb, leafData);
+    ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(3));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(5));
+    EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(8));
+
+    foo.CreateLeaf(aabb, leafData);
+    ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(4));
+    EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(7));
+    EXPECT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(8));
 }

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -126,7 +126,7 @@ TEST(World, DefaultInit)
     World world;
 
     EXPECT_EQ(GetBodyCount(world), BodyCounter(0));
-    EXPECT_EQ(world.GetTree().GetProxyCount(), World::proxy_size_type(0));
+    EXPECT_EQ(world.GetTree().GetLeafCount(), World::proxy_size_type(0));
     EXPECT_EQ(GetJointCount(world), JointCounter(0));
     EXPECT_EQ(GetContactCount(world), ContactCounter(0));
     EXPECT_EQ(GetHeight(world.GetTree()), World::proxy_size_type(0));
@@ -231,7 +231,7 @@ TEST(World, CopyConstruction)
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
         EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
-        EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
+        EXPECT_EQ(world.GetTree().GetLeafCount(), copy.GetTree().GetLeafCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }
     
@@ -270,7 +270,7 @@ TEST(World, CopyConstruction)
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
         EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
-        EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
+        EXPECT_EQ(world.GetTree().GetLeafCount(), copy.GetTree().GetLeafCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }
 }
@@ -289,7 +289,7 @@ TEST(World, CopyAssignment)
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
         EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
-        EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
+        EXPECT_EQ(world.GetTree().GetLeafCount(), copy.GetTree().GetLeafCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }
     
@@ -329,7 +329,7 @@ TEST(World, CopyAssignment)
         EXPECT_EQ(world.GetBodies().size(), copy.GetBodies().size());
         EXPECT_EQ(world.GetContacts().size(), copy.GetContacts().size());
         EXPECT_EQ(GetHeight(world.GetTree()), GetHeight(copy.GetTree()));
-        EXPECT_EQ(world.GetTree().GetProxyCount(), copy.GetTree().GetProxyCount());
+        EXPECT_EQ(world.GetTree().GetLeafCount(), copy.GetTree().GetLeafCount());
         EXPECT_EQ(world.GetTree().GetMaxBalance(), copy.GetTree().GetMaxBalance());
     }
 }


### PR DESCRIPTION
#### Description - What's this PR do?
- Refactors DynamicTree::ForEach into being a free function.
- Refactors DynamicTree::RayCast into being a free function.
- Refactors DynamicTree::Query into being a free function.
- Renames DynamicTree::GetUserData and SetUserData to GetLeafData and SetLeafData respectively.
- Replaces DynamicTree::LeafNode containing pointer to "user data" with a LeafData type alias.
- Move trivial method definitions from their .cpp file to the .hpp file for DynamicTree.
- Refactors implementation of DynamicTree::ComputeHeight(Size index) to be more robust.
- Refactors DynamicTree::ComputeHeight() into a free function.
