### PR TITLE
For issue #150.

### DIFF
--- a/PlayRho/Dynamics/Contacts/Contact.cpp
+++ b/PlayRho/Dynamics/Contacts/Contact.cpp
@@ -56,16 +56,16 @@ Contact::UpdateConf Contact::GetUpdateConf(const StepConf& conf) noexcept
     return UpdateConf{GetDistanceConf(conf), GetManifoldConf(conf)};
 }
 
-Contact::Contact(Fixture* fA, ChildCounter iA, Fixture* fB, ChildCounter iB):
-    m_fixtureA{fA}, m_fixtureB{fB}, m_indexA{iA}, m_indexB{iB},
-    m_friction{MixFriction(fA->GetFriction(), fB->GetFriction())},
-    m_restitution{MixRestitution(fA->GetRestitution(), fB->GetRestitution())}
+Contact::Contact(const FixtureProxy* fpA, const FixtureProxy* fpB):
+    m_fixtureProxyA{fpA}, m_fixtureProxyB{fpB},
+    m_friction{MixFriction(fpA->fixture->GetFriction(), fpB->fixture->GetFriction())},
+    m_restitution{MixRestitution(fpA->fixture->GetRestitution(), fpB->fixture->GetRestitution())}
 {
-    assert(fA && fB);
-    assert(fA != fB);
-    assert(fA->GetShape());
-    assert(fB->GetShape());
-    assert(fA->GetBody() != fB->GetBody());
+    assert(fpA != fpB);
+    assert(fpA->fixture != fpB->fixture);
+    assert(fpA->fixture->GetShape());
+    assert(fpB->fixture->GetShape());
+    assert(fpA->fixture->GetBody() != fpB->fixture->GetBody());
 }
 
 void Contact::Update(const UpdateConf& conf, ContactListener* listener)

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -27,6 +27,7 @@
 #include <PlayRho/Collision/Distance.hpp>
 #include <PlayRho/Collision/TimeOfImpact.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
+#include <PlayRho/Dynamics/FixtureProxy.hpp>
 
 namespace playrho {
 
@@ -89,21 +90,22 @@ public:
 
     /// @brief Initializing constructor.
     ///
-    /// @param fA Fixture A. A non-null pointer to fixture A that must have a shape
-    ///   and may not be the same fixture or have the same body as the other fixture.
-    /// @param iA Index of child A (from fixture A).
-    /// @param fB Fixture B. A non-null pointer to fixture B that must have a shape
-    ///   and may not be the same fixture or have the same body as the other fixture.
-    /// @param iB Index of child B (from fixture B).
+    /// @param fpA Non-null pointer to fixture proxy A whose fixture must have a shape
+    ///   and may not be the same or have the same body as the other fixture proxy.
+    /// @param fpB Non-null pointer to fixture proxy B whose fixture must have a shape
+    ///   and may not be the same or have the same body as the other fixture proxy.
     ///
-    /// @warning Behavior is undefined if <code>fixtureA</code> is null.
-    /// @warning Behavior is undefined if <code>fixtureB</code> is null.
-    /// @warning Behavior is undefined if <code>fixtureA == fixtureB</code>.
-    /// @warning Behavior is undefined if <code>fixtureA</code> has no associated shape.
-    /// @warning Behavior is undefined if <code>fixtureB</code> has no associated shape.
-    /// @warning Behavior is undefined if both fixtures have the same body.
+    /// @warning Behavior is undefined if <code>fpA</code> is null.
+    /// @warning Behavior is undefined if <code>fpA->fixture</code> is null.
+    /// @warning Behavior is undefined if <code>fpB</code> is null.
+    /// @warning Behavior is undefined if <code>fpB->fixture</code> is null.
+    /// @warning Behavior is undefined if <code>fpA == fpB</code>.
+    /// @warning Behavior is undefined if <code>fpA->fixture == fpB->fixture</code>.
+    /// @warning Behavior is undefined if <code>fpA->fixture</code> has no associated shape.
+    /// @warning Behavior is undefined if <code>fpB->fixture</code> has no associated shape.
+    /// @warning Behavior is undefined if both fixture proxy's fixture's have the same body.
     ///
-    Contact(Fixture* fA, ChildCounter iA, Fixture* fB, ChildCounter iB);
+    Contact(const FixtureProxy* fpA, const FixtureProxy* fpB);
     
     /// @brief Default construction not allowed.
     Contact() = delete;
@@ -286,13 +288,9 @@ private:
     void UnsetIslanded() noexcept;
 
     // Member variables...
-
-    Fixture* const m_fixtureA; ///< Fixture A. @details Non-null pointer to fixture A.
-    Fixture* const m_fixtureB; ///< Fixture B. @details Non-null pointer to fixture B.
-
-    ChildCounter const m_indexA;
-    ChildCounter const m_indexB;
-
+    const FixtureProxy* const m_fixtureProxyA;
+    const FixtureProxy* const m_fixtureProxyB;
+    
     Manifold mutable m_manifold; ///< Manifold of the contact. 60-bytes. @sa Update.
 
     substep_type m_toiCount = 0; ///< Count of TOI calculations contact has gone through since last reset.
@@ -369,22 +367,22 @@ inline void Contact::UnsetTouching() noexcept
 
 inline Fixture* Contact::GetFixtureA() const noexcept
 {
-    return m_fixtureA;
+    return m_fixtureProxyA->fixture;
 }
 
 inline ChildCounter Contact::GetChildIndexA() const noexcept
 {
-    return m_indexA;
+    return m_fixtureProxyA->childIndex;
 }
 
 inline Fixture* Contact::GetFixtureB() const noexcept
 {
-    return m_fixtureB;
+    return m_fixtureProxyB->fixture;
 }
 
 inline ChildCounter Contact::GetChildIndexB() const noexcept
 {
-    return m_indexB;
+    return m_fixtureProxyB->childIndex;
 }
 
 inline void Contact::FlagForFiltering() noexcept

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -657,7 +657,9 @@ void World::CopyContacts(const std::map<const Body*, Body*>& bodyMap,
         const auto newBodyA = bodyMap.at(otherFixtureA->GetBody());
         const auto newBodyB = bodyMap.at(otherFixtureB->GetBody());
         
-        const auto newContact = new Contact{newFixtureA, childIndexA, newFixtureB, childIndexB};
+        const auto fpA = newFixtureA->GetProxy(childIndexA);
+        const auto fpB = newFixtureB->GetProxy(childIndexB);
+        const auto newContact = new Contact{fpA, fpB};
         assert(newContact);
         if (newContact != nullptr)
         {
@@ -2474,7 +2476,7 @@ bool World::Add(const FixtureProxy& proxyA, const FixtureProxy& proxyB)
         return false;
     }
 
-    const auto contact = new Contact{fixtureA, proxyA.childIndex, fixtureB, proxyB.childIndex};
+    const auto contact = new Contact{&proxyA, &proxyB};
     
     // Insert into the contacts container.
     //

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
+#include <PlayRho/Dynamics/FixtureProxy.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/FixtureDef.hpp>
@@ -32,9 +33,9 @@ TEST(Contact, ByteSize)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(Contact), std::size_t(104)); break;
-        case  8: EXPECT_EQ(sizeof(Contact), std::size_t(184)); break;
-        case 16: EXPECT_EQ(sizeof(Contact), std::size_t(352)); break;
+        case  4: EXPECT_EQ(sizeof(Contact), std::size_t(96)); break;
+        case  8: EXPECT_EQ(sizeof(Contact), std::size_t(176)); break;
+        case 16: EXPECT_EQ(sizeof(Contact), std::size_t(336)); break;
         default: FAIL(); break;
     }
 }
@@ -61,7 +62,9 @@ TEST(Contact, SetAwake)
     auto bB = Body{nullptr, BodyDef{}.UseType(BodyType::Dynamic)};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    const auto c = Contact{&fA, 0, &fB, 0};
+    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
+    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    const auto c = Contact{&fpA, &fpB};
     
     bA.UnsetAwake();
     ASSERT_FALSE(bA.IsAwake());
@@ -82,8 +85,10 @@ TEST(Contact, ResetFriction)
     auto bB = Body{nullptr, BodyDef{}.UseType(BodyType::Dynamic)};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    auto c = Contact{&fA, 0, &fB, 0};
-    
+    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
+    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    auto c = Contact{&fpA, &fpB};
+
     ASSERT_GT(shape->GetFriction(), Real(0));
     ASSERT_EQ(c.GetFriction(), shape->GetFriction());
     c.SetFriction(shape->GetFriction() * Real(2));
@@ -99,8 +104,10 @@ TEST(Contact, ResetRestitution)
     auto bB = Body{nullptr, BodyDef{}.UseType(BodyType::Dynamic)};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    auto c = Contact{&fA, 0, &fB, 0};
-    
+    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
+    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    auto c = Contact{&fpA, &fpB};
+
     ASSERT_EQ(shape->GetRestitution(), Real(0));
     ASSERT_EQ(c.GetRestitution(), shape->GetRestitution());
     c.SetRestitution(Real(2));

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -35,7 +35,7 @@ TEST(DynamicTree, TreeNodeByteSize)
     {
         case  4: EXPECT_EQ(sizeof(DynamicTree::TreeNode), std::size_t(32)); break;
         case  8: EXPECT_EQ(sizeof(DynamicTree::TreeNode), std::size_t(48)); break;
-        default: FAIL(); break;
+        case 16: EXPECT_EQ(sizeof(DynamicTree::TreeNode), std::size_t(96)); break;
     }
 }
 

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -157,8 +157,10 @@ TEST(WorldManifold, GetForContact)
     auto bB = Body{nullptr, BodyDef{}};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    const auto c = Contact{&fA, 0, &fB, 0};
-    
+    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
+    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    const auto c = Contact{&fpA, &fpB};
+
     const auto wm = GetWorldManifold(c);
     
     EXPECT_EQ(wm.GetPointCount(), decltype(wm.GetPointCount()){0});


### PR DESCRIPTION
#### Description - What's this PR do?
Stores FixtureProxy* in Contact instead of Fixture* + child index, thereby saving 8-bytes per Contact.
