### PR TITLE
Removes the AABB from the FixtureProxy.

### DIFF
--- a/PlayRho/Collision/AABB.cpp
+++ b/PlayRho/Collision/AABB.cpp
@@ -63,10 +63,4 @@ AABB ComputeAABB(const Body& body)
     return sum;
 }
 
-AABB GetAABB(const Fixture& fixture, ChildCounter childIndex) noexcept
-{
-    const auto proxy = fixture.GetProxy(childIndex);
-    return proxy? proxy->aabb: AABB{};
-}
-
 } // namespace playrho

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -308,14 +308,6 @@ namespace playrho {
     /// @relatedalso Body
     AABB ComputeAABB(const Body& body);
 
-    /// @brief Gets the fixture's AABB.
-    /// @note This AABB may be enlarged and/or stale. If you need a more accurate AABB,
-    ///   compute it using the shape and the body transform.
-    /// @warning Behavior is undefined is child index is not a valid proxy index.
-    /// @sa Fixture::GetProxy.
-    /// @relatedalso Fixture
-    AABB GetAABB(const Fixture& fixture, ChildCounter childIndex) noexcept;
-
     /// @brief Output stream operator.
     inline ::std::ostream& operator<< (::std::ostream& os, const AABB& value)
     {

--- a/PlayRho/Dynamics/FixtureProxy.hpp
+++ b/PlayRho/Dynamics/FixtureProxy.hpp
@@ -45,8 +45,8 @@ struct FixtureProxy
     FixtureProxy(FixtureProxy&& copy) = default;
 
     /// @brief Initializing constructor.
-    FixtureProxy(const AABB& bb, size_type pid, Fixture* f, ChildCounter ci):
-        aabb{bb}, fixture{f}, treeId{pid}, childIndex{ci} {}
+    FixtureProxy(size_type pid, Fixture* f, ChildCounter ci):
+        fixture{f}, treeId{pid}, childIndex{ci} {}
     
     ~FixtureProxy() = default;
     
@@ -55,8 +55,6 @@ struct FixtureProxy
 
     // Deleted because some fields are marked <code>const</code>.
     FixtureProxy& operator= (FixtureProxy&& other) = delete;
-
-    AABB aabb; ///< Axis Aligned Bounding Box. 16-bytes.
     
     /// @brief Fixture that this proxy is for.
     /// @note 8-bytes.

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -631,7 +631,7 @@ void World::CopyBodies(std::map<const Body*, Body*>& bodyMap,
             {
                 const auto proxyPtr = proxies + childIndex;
                 const auto fp = otherFixture.GetProxy(childIndex);
-                new (proxyPtr) FixtureProxy{fp->aabb, fp->treeId, newFixture, childIndex};
+                new (proxyPtr) FixtureProxy{fp->treeId, newFixture, childIndex};
                 m_tree.SetLeafData(fp->treeId, proxyPtr);
             }
             FixtureAtty::SetProxies(*newFixture, Span<FixtureProxy>(proxies, childCount));
@@ -2766,7 +2766,7 @@ void World::CreateProxies(Fixture& fixture, Length aabbExtension)
         const auto fattenedAABB = GetFattenedAABB(aabb, aabbExtension);
         const auto treeId = m_tree.CreateLeaf(fattenedAABB, proxyPtr);
         RegisterForProcessing(treeId);
-        new (proxyPtr) FixtureProxy{aabb, treeId, &fixture, childIndex};
+        new (proxyPtr) FixtureProxy{treeId, &fixture, childIndex};
     }
 
     FixtureAtty::SetProxies(fixture, Span<FixtureProxy>(proxies, childCount));
@@ -2835,11 +2835,11 @@ ChildCounter World::Synchronize(Fixture& fixture,
         // Compute an AABB that covers the swept shape (may miss some rotation effect).
         const auto aabb1 = ComputeAABB(dp, xfm1);
         const auto aabb2 = ComputeAABB(dp, xfm2);
-        proxy.aabb = GetEnclosingAABB(aabb1, aabb2);
+        const auto aabb = GetEnclosingAABB(aabb1, aabb2);
         
-        if (!Contains(m_tree.GetAABB(proxy.treeId), proxy.aabb))
+        if (!Contains(m_tree.GetAABB(proxy.treeId), aabb))
         {
-            const auto newAabb = GetDisplacedAABB(GetFattenedAABB(proxy.aabb, extension),
+            const auto newAabb = GetDisplacedAABB(GetFattenedAABB(aabb, extension),
                                                   expandedDisplacement);
             m_tree.UpdateLeaf(proxy.treeId, newAabb);
             RegisterForProcessing(proxy.treeId);

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -389,34 +389,6 @@ TEST(AABB, Move)
     }
 }
 
-TEST(AABB, GetAABBForFixtureChild)
-{
-    const auto shapeA = std::make_shared<DiskShape>(1 * Meter);
-    const auto bodyCtrPos = Length2D(3 * Meter, 2 * Meter);
-    
-    World world;
-
-    const auto body = world.CreateBody(BodyDef{}.UseLocation(bodyCtrPos));
-    ASSERT_NE(body, nullptr);
-    
-    const auto fixture = body->CreateFixture(shapeA);
-    ASSERT_NE(fixture, nullptr);
-    
-    auto aabb = GetAABB(*fixture, ChildCounter{0});
-    ASSERT_EQ(aabb, AABB{});
-    
-    const auto stepConf = StepConf{};
-    world.Step(stepConf);
-
-    aabb = GetAABB(*fixture, ChildCounter{0});
-    ASSERT_NE(aabb, AABB{});
-
-    EXPECT_EQ(aabb.rangeX.GetMin(), 2 * Meter);
-    EXPECT_EQ(aabb.rangeX.GetMax(), 4 * Meter);
-    EXPECT_EQ(aabb.rangeY.GetMin(), 1 * Meter);
-    EXPECT_EQ(aabb.rangeY.GetMax(), 3 * Meter);
-}
-
 TEST(AABB, ComparisonOperators)
 {
     EXPECT_TRUE(AABB{} == AABB{});

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -62,8 +62,8 @@ TEST(Contact, SetAwake)
     auto bB = Body{nullptr, BodyDef{}.UseType(BodyType::Dynamic)};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
-    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    const auto fpA = FixtureProxy{0u, &fA, 0u};
+    const auto fpB = FixtureProxy{0u, &fB, 0u};
     const auto c = Contact{&fpA, &fpB};
     
     bA.UnsetAwake();
@@ -85,8 +85,8 @@ TEST(Contact, ResetFriction)
     auto bB = Body{nullptr, BodyDef{}.UseType(BodyType::Dynamic)};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
-    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    const auto fpA = FixtureProxy{0u, &fA, 0u};
+    const auto fpB = FixtureProxy{0u, &fB, 0u};
     auto c = Contact{&fpA, &fpB};
 
     ASSERT_GT(shape->GetFriction(), Real(0));
@@ -104,8 +104,8 @@ TEST(Contact, ResetRestitution)
     auto bB = Body{nullptr, BodyDef{}.UseType(BodyType::Dynamic)};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
-    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    const auto fpA = FixtureProxy{0u, &fA, 0u};
+    const auto fpB = FixtureProxy{0u, &fB, 0u};
     auto c = Contact{&fpA, &fpB};
 
     ASSERT_EQ(shape->GetRestitution(), Real(0));

--- a/UnitTests/FixtureProxy.cpp
+++ b/UnitTests/FixtureProxy.cpp
@@ -25,9 +25,9 @@ TEST(FixtureProxy, ByteSizeIs_32_48_or_80)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(FixtureProxy), std::size_t(32)); break;
-        case  8: EXPECT_EQ(sizeof(FixtureProxy), std::size_t(48)); break;
-        case 16: EXPECT_EQ(sizeof(FixtureProxy), std::size_t(80)); break;
+        case  4: EXPECT_EQ(sizeof(FixtureProxy), std::size_t(16)); break;
+        case  8: EXPECT_EQ(sizeof(FixtureProxy), std::size_t(16)); break;
+        case 16: EXPECT_EQ(sizeof(FixtureProxy), std::size_t(16)); break;
         default: FAIL(); break;
     }
 }

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -157,8 +157,8 @@ TEST(WorldManifold, GetForContact)
     auto bB = Body{nullptr, BodyDef{}};
     auto fA = Fixture{&bA, FixtureDef{}, shape};
     auto fB = Fixture{&bB, FixtureDef{}, shape};
-    const auto fpA = FixtureProxy{AABB{}, 0u, &fA, 0u};
-    const auto fpB = FixtureProxy{AABB{}, 0u, &fB, 0u};
+    const auto fpA = FixtureProxy{0u, &fA, 0u};
+    const auto fpB = FixtureProxy{0u, &fB, 0u};
     const auto c = Contact{&fpA, &fpB};
 
     const auto wm = GetWorldManifold(c);


### PR DESCRIPTION
#### Description - What's this PR do?
Removes the AABB from the FixtureProxy. The AABB isn't necessary. This shaves off 16-bytes from each FixtureProxy.
