### PR TITLE
Optimizes the World body synchronization code...

### DIFF
--- a/PlayRho/Collision/AABB.cpp
+++ b/PlayRho/Collision/AABB.cpp
@@ -41,6 +41,22 @@ AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept
     return GetFattenedAABB(result, proxy.GetVertexRadius());
 }
 
+AABB ComputeAABB(const DistanceProxy& proxy,
+                 const Transformation& xfm0, const Transformation& xfm1) noexcept
+{
+    assert(IsValid(xfm0));
+    assert(IsValid(xfm1));
+    auto result = AABB{};
+    const auto count = proxy.GetVertexCount();
+    for (auto i = decltype(count){0}; i < count; ++i)
+    {
+        const auto vertex = proxy.GetVertex(i);
+        Include(result, Transform(vertex, xfm0));
+        Include(result, Transform(vertex, xfm1));
+    }
+    return GetFattenedAABB(result, proxy.GetVertexRadius());
+}
+
 AABB ComputeAABB(const Shape& shape, const Transformation& xf)
 {
     auto sum = AABB{};

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -299,7 +299,19 @@ namespace playrho {
     /// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
     /// @relatedalso DistanceProxy
     AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept;
-    
+
+    /// @brief Computes the AABB.
+    /// @details Computes the Axis Aligned Bounding Box (AABB) for the given child shape
+    ///   at the given transforms.
+    /// @warning Behavior is undefined if a given transformation is invalid.
+    /// @param proxy Distance proxy for the child shape.
+    /// @param xfm0 World transform 0 of the shape.
+    /// @param xfm1 World transform 1 of the shape.
+    /// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
+    /// @relatedalso DistanceProxy
+    AABB ComputeAABB(const DistanceProxy& proxy,
+                     const Transformation& xfm0, const Transformation& xfm1) noexcept;
+
     /// @brief Computes the AABB for the given shape with the given transformation.
     /// @relatedalso Shape
     AABB ComputeAABB(const Shape& shape, const Transformation& xf);

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -623,14 +623,10 @@ private:
     /// @brief Touches each proxy of the given fixture.
     /// @note This sets things up so that pairs may be created for potentially new contacts.
     void InternalTouchProxies(Fixture& fixture) noexcept;
-
-    ChildCounter Synchronize(Fixture& fixture,
-                             Transformation xfm1, Transformation xfm2,
-                             Real multiplier, Length extension);
-
+    
     ContactCounter Synchronize(Body& body,
                                Transformation xfm1, Transformation xfm2,
-                               Real multiplier, Length aabbExtension);
+                               Real multiplier, Length extension);
     
     void CreateAndDestroyProxies(const StepConf& conf);
     void CreateAndDestroyProxies(Fixture& fixture, const StepConf& conf);
@@ -892,6 +888,12 @@ inline void World::UnsetIslanded(Contact* contact) noexcept
 inline void World::UnsetIslanded(Joint* joint) noexcept
 {
     JointAtty::UnsetIslanded(*joint);
+}
+
+inline void World::RegisterForProcessing(ProxyId pid) noexcept
+{
+    assert(pid != DynamicTree::GetInvalidSize());
+    m_proxies.push_back(pid);
 }
 
 // Free functions.


### PR DESCRIPTION
#### Description - What's this PR do?
- Adds an AABB computing method that computes the AABB for a given distance proxy at two transformations at once.
- Folds the World fixture synchronization code into the body synchronization code.
- Moves the trivial World RegisterForProcessing method into the header to promote its in-lining.