### PR TITLE
Various changes around adding iforce2d's Trajectories demo to the Testbed

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -501,6 +501,7 @@
 		4768D3FA1E414A0100574143 /* Vector2D.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Vector2D.hpp; sourceTree = "<group>"; };
 		4768D3FF1E54E7CB00574143 /* StepConf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StepConf.cpp; sourceTree = "<group>"; };
 		4775A9371E05B032001C2332 /* StepConf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StepConf.cpp; sourceTree = "<group>"; };
+		47791F761F901B8700E257AF /* iforce2d_Trajectories.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = iforce2d_Trajectories.hpp; sourceTree = "<group>"; };
 		477D20051E32B6E80069D610 /* Fixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Fixed.cpp; sourceTree = "<group>"; };
 		477DB2AA1D1C4BE800846ED6 /* PositionSolverManifold.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PositionSolverManifold.cpp; sourceTree = "<group>"; };
 		477DB2AB1D1C4BE800846ED6 /* PositionSolverManifold.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PositionSolverManifold.hpp; sourceTree = "<group>"; };
@@ -1171,6 +1172,7 @@
 				809BC10118B855CB00F5D9F0 /* HeavyOnLight.hpp */,
 				809BC10218B85A4900F5D9F0 /* HeavyOnLightTwo.hpp */,
 				4745273F1E8AC88F002E28FB /* iforce2d_TopdownCar.hpp */,
+				47791F761F901B8700E257AF /* iforce2d_Trajectories.hpp */,
 				4751EE281CEDD78F00D459CB /* Mobile.hpp */,
 				4751EE2D1CEDD7A300D459CB /* MobileBalanced.hpp */,
 				4751EE2C1CEDD7A300D459CB /* MotorJoint.hpp */,

--- a/PlayRho/Collision/Shapes/PolygonShape.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.hpp
@@ -218,14 +218,18 @@ inline UnitVec2 PolygonShape::GetNormal(VertexCounter index) const
     return m_normals[index];
 }
 
+// Free functions...
+
 /// Gets the identified edge of the given polygon shape.
 /// @note This must not be called for shapes with less than 2 vertices.
 /// @warning Behavior is undefined if called for a shape with less than 2 vertices.
+/// @relatedalso PolygonShape
 Length2D GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index);
 
 /// Validate convexity of the given shape.
 /// @note This is a time consuming operation.
 /// @returns true if valid
+/// @relatedalso PolygonShape
 bool Validate(const PolygonShape& shape);
 
 /// Build vertices to represent an oriented box.
@@ -234,9 +238,11 @@ bool Validate(const PolygonShape& shape);
 /// @param hy the half-height.
 /// @param center the center of the box in local coordinates.
 /// @param angle the rotation of the box in local coordinates.
+/// @relatedalso PolygonShape
 void SetAsBox(PolygonShape& shape, Length hx, Length hy, Length2D center, Angle angle) noexcept;
 
 /// @brief Transforms the given shape by the given transformation.
+/// @relatedalso PolygonShape
 inline PolygonShape Transform(PolygonShape value, Transformation xfm) noexcept
 {
     return value.Transform(xfm);

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -79,8 +79,8 @@ Body::FlagsType Body::GetFlags(const BodyDef& bd) noexcept
 }
 
 Body::Body(World* world, const BodyDef& bd):
-    m_xf{bd.position, UnitVec2::Get(bd.angle)},
-    m_sweep{Position{bd.position, bd.angle}},
+    m_xf{bd.location, UnitVec2::Get(bd.angle)},
+    m_sweep{Position{bd.location, bd.angle}},
     m_flags{GetFlags(bd)},
     m_world{world},
     m_invMass{(bd.type == BodyType::Dynamic)? InvMass{Real{1} / Kilogram}: InvMass{0}},
@@ -88,7 +88,7 @@ Body::Body(World* world, const BodyDef& bd):
     m_angularDamping{bd.angularDamping},
     m_userData{bd.userData}
 {
-    assert(IsValid(bd.position));
+    assert(IsValid(bd.location));
     assert(IsValid(bd.angle));
     assert(IsValid(bd.linearVelocity));
     assert(IsValid(bd.angularVelocity));

--- a/PlayRho/Dynamics/BodyDef.cpp
+++ b/PlayRho/Dynamics/BodyDef.cpp
@@ -29,7 +29,7 @@ namespace playrho
     {
         auto def = BodyDef{};
         def.type = body.GetType();
-        def.position = body.GetLocation();
+        def.location = body.GetLocation();
         def.angle = body.GetAngle();
         def.linearVelocity = GetLinearVelocity(body);
         def.angularVelocity = GetAngularVelocity(body);

--- a/PlayRho/Dynamics/BodyDef.hpp
+++ b/PlayRho/Dynamics/BodyDef.hpp
@@ -101,9 +101,9 @@ namespace playrho {
         /// @note If a dynamic body would have zero mass, the mass is set to one.
         BodyType type = BodyType::Static;
         
-        /// The world position of the body. Avoid creating bodies at the origin
+        /// The world location of the body. Avoid creating bodies at the origin
         /// since this can lead to many overlapping shapes.
-        Length2D position = Length2D{};
+        Length2D location = Length2D{};
         
         /// The world angle of the body.
         Angle angle = Angle{0};
@@ -167,7 +167,7 @@ namespace playrho {
     
     constexpr inline BodyDef& BodyDef::UseLocation(Length2D l) noexcept
     {
-        position = l;
+        location = l;
         return *this;
     }
     

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -639,6 +639,15 @@ void DebugDraw::DrawSegment(const Length2D& p1, const Length2D& p2, const Color&
     m_lines->Vertex(m_camera, c2, color);
 }
 
+void DebugDraw::DrawSegment(const Length2D& p1, const Color& c1,
+                 const Length2D& p2, const Color& c2)
+{
+    const auto coord1 = Coord2D{static_cast<float>(StripUnit(GetX(p1))), static_cast<float>(StripUnit(GetY(p1)))};
+    const auto coord2 = Coord2D{static_cast<float>(StripUnit(GetX(p2))), static_cast<float>(StripUnit(GetY(p2)))};
+    m_lines->Vertex(m_camera, coord1, c1);
+    m_lines->Vertex(m_camera, coord2, c2);
+}
+
 void DebugDraw::DrawPoint(const Length2D& p, float size, const Color& color)
 {
     const auto c = Coord2D{static_cast<float>(StripUnit(GetX(p))), static_cast<float>(StripUnit(GetY(p)))};

--- a/Testbed/Framework/DebugDraw.hpp
+++ b/Testbed/Framework/DebugDraw.hpp
@@ -105,6 +105,9 @@ public:
 
     void DrawSegment(const Length2D& p1, const Length2D& p2, const Color& color) override;
 
+    void DrawSegment(const Length2D& p1, const Color& c1,
+                     const Length2D& p2, const Color& c2) override;
+
     void DrawPoint(const Length2D& p, float size, const Color& color) override;
 
     void DrawString(int x, int y, TextAlign align, const char* string, ...) override;

--- a/Testbed/Framework/Drawer.hpp
+++ b/Testbed/Framework/Drawer.hpp
@@ -81,9 +81,13 @@ public:
     
     /// Draw a solid circle.
     virtual void DrawSolidCircle(const Length2D& center, Length radius, const Color& color) = 0;
-    
-    /// Draw a line segment.
-    virtual void DrawSegment(const Length2D& p1, const Length2D& p2, const Color& color) = 0;
+ 
+    /// Draws a line segment from point 1 to point 2.
+    virtual void DrawSegment(const Length2D& p1, const Length2D& p2, const Color& c) = 0;
+
+    /// Draws a line segment from point 1 to point 2 in color 1 to color 2.
+    virtual void DrawSegment(const Length2D& p1, const Color& c1,
+                             const Length2D& p2, const Color& c2) = 0;
 
     virtual void DrawPoint(const Length2D& p, float size, const Color& color) = 0;
     
@@ -99,6 +103,13 @@ public:
 
     virtual Length2D GetTranslation() const = 0;
 };
+
+/// @brief Draws segment with a single constant color.
+inline void DrawSegment(Drawer& drawer, const Length2D& p1, const Length2D& p2,
+                        const Color& color)
+{
+    drawer.DrawSegment(p1, p2, color);
+}
 
 } // namespace playrho
 

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -215,7 +215,12 @@ protected:
     }
 
     const Body* GetBomb() const noexcept { return m_bomb; }
+    
     void SetBomb(Body* body) noexcept { m_bomb = body; }
+    
+    Length2D GetMouseWorld() const noexcept { return m_mouseWorld; }
+
+    void SetMouseWorld(Length2D value) noexcept { m_mouseWorld = value; }
     
     World* const m_world;
     TextLinePos m_textLine = TextLinePos{30};

--- a/Testbed/Framework/TestEntry.cpp
+++ b/Testbed/Framework/TestEntry.cpp
@@ -79,6 +79,7 @@
 #include "../Tests/Orbiter.hpp"
 #include "../Tests/NewtonsCradle.hpp"
 #include "../Tests/iforce2d_TopdownCar.hpp"
+#include "../Tests/iforce2d_Trajectories.hpp"
 
 namespace playrho {
 
@@ -149,6 +150,7 @@ static const TestEntry testEntries[] =
     {"Add Pair Stress Test", MakeUniqueTest<AddPair>},
     {"Newton's Cradle", MakeUniqueTest<NewtonsCradle>},
     {"Top-down Car", MakeUniqueTest<iforce2d_TopdownCar>},
+    {"Trajectories", MakeUniqueTest<iforce2d_Trajectories>},
 };
 
 static const std::size_t numTestEntries = sizeof(testEntries) / sizeof(TestEntry);

--- a/Testbed/Tests/ApplyForce.hpp
+++ b/Testbed/Tests/ApplyForce.hpp
@@ -36,7 +36,7 @@ public:
         Body* ground;
         {
             BodyDef bd;
-            bd.position = Length2D(Real(0) * Meter, Real(20) * Meter);
+            bd.location = Length2D(Real(0) * Meter, Real(20) * Meter);
             ground = m_world->CreateBody(bd);
 
             auto conf = EdgeShape::Conf{};
@@ -92,7 +92,7 @@ public:
             bd.angularDamping = Real(2) * Hertz;
             bd.linearDamping = Real(0.5f) * Hertz;
 
-            bd.position = Vec2(0, 2) * Meter;
+            bd.location = Vec2(0, 2) * Meter;
             bd.angle = Pi * Radian;
             bd.allowSleep = false;
             m_body = m_world->CreateBody(bd);
@@ -112,7 +112,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(Real{0}, 5.0f + 1.54f * i) * Meter;
+                bd.location = Vec2(Real{0}, 5.0f + 1.54f * i) * Meter;
                 const auto body = m_world->CreateBody(bd);
 
                 body->CreateFixture(shape);

--- a/Testbed/Tests/BasicSliderCrank.hpp
+++ b/Testbed/Tests/BasicSliderCrank.hpp
@@ -33,7 +33,7 @@ public:
         const auto ground = [&]()
         {
             BodyDef bd;
-            bd.position = Vec2(0.0f, 17.0f) * Meter;
+            bd.location = Vec2(0.0f, 17.0f) * Meter;
             return m_world->CreateBody(bd);
         }();
         
@@ -44,7 +44,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(-8.0f, 20.0f) * Meter;
+                bd.location = Vec2(-8.0f, 20.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 auto conf = PolygonShape::Conf{};
                 conf.density = Real{2} * KilogramPerSquareMeter;
@@ -59,7 +59,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(4.0f, 20.0f) * Meter;
+                bd.location = Vec2(4.0f, 20.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 auto conf = PolygonShape::Conf{};
                 conf.density = Real{2} * KilogramPerSquareMeter;
@@ -75,7 +75,7 @@ public:
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
                 bd.fixedRotation = true;
-                bd.position = Vec2(12.0f, 20.0f) * Meter;
+                bd.location = Vec2(12.0f, 20.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 auto conf = PolygonShape::Conf{};
                 conf.density = Real{2} * KilogramPerSquareMeter;

--- a/Testbed/Tests/BodyTypes.hpp
+++ b/Testbed/Tests/BodyTypes.hpp
@@ -36,7 +36,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(0.0f, 3.0f) * Meter;
+            bd.location = Vec2(0.0f, 3.0f) * Meter;
             m_attachment = m_world->CreateBody(bd);
             auto conf = PolygonShape::Conf{};
             conf.density = Real{2} * KilogramPerSquareMeter;
@@ -47,7 +47,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-4.0f, 5.0f) * Meter;
+            bd.location = Vec2(-4.0f, 5.0f) * Meter;
             m_platform = m_world->CreateBody(bd);
 
             auto conf = PolygonShape::Conf{};
@@ -78,7 +78,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(0.0f, 8.0f) * Meter;
+            bd.location = Vec2(0.0f, 8.0f) * Meter;
             Body* body = m_world->CreateBody(bd);
 
             auto conf = PolygonShape::Conf{};

--- a/Testbed/Tests/Breakable.hpp
+++ b/Testbed/Tests/Breakable.hpp
@@ -49,7 +49,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(0.0f, 40.0f) * Meter;
+            bd.location = Vec2(0.0f, 40.0f) * Meter;
             bd.angle = 0.25f * Pi * Radian;
             m_body1 = m_world->CreateBody(bd);
 
@@ -100,7 +100,7 @@ public:
 
         BodyDef bd;
         bd.type = BodyType::Dynamic;
-        bd.position = body1->GetLocation();
+        bd.location = body1->GetLocation();
         bd.angle = body1->GetAngle();
 
         const auto body2 = m_world->CreateBody(bd);

--- a/Testbed/Tests/BulletTest.hpp
+++ b/Testbed/Tests/BulletTest.hpp
@@ -32,7 +32,7 @@ public:
     {
         {
             BodyDef bd;
-            bd.position = Vec2(0.0f, 0.0f) * Meter;
+            bd.location = Vec2(0.0f, 0.0f) * Meter;
             Body* body = m_world->CreateBody(bd);
 
             body->CreateFixture(std::make_shared<EdgeShape>(Vec2(-10.0f, 0.0f) * Meter, Vec2(10.0f, 0.0f) * Meter));
@@ -45,7 +45,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(0.0f, 4.0f) * Meter;
+            bd.location = Vec2(0.0f, 4.0f) * Meter;
 
             PolygonShape box;
             box.SetAsBox(Real{2.0f} * Meter, Real{0.1f} * Meter);
@@ -59,7 +59,7 @@ public:
 
             //m_x = RandomFloat(-1.0f, 1.0f);
             m_x = 0.20352793f;
-            bd.position = Vec2(m_x, 10.0f) * Meter;
+            bd.location = Vec2(m_x, 10.0f) * Meter;
             bd.bullet = true;
 
             m_bullet = m_world->CreateBody(bd);

--- a/Testbed/Tests/Cantilever.hpp
+++ b/Testbed/Tests/Cantilever.hpp
@@ -55,7 +55,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(-14.5f + 1.0f * i, 5.0f) * Meter;
+                bd.location = Vec2(-14.5f + 1.0f * i, 5.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
 
@@ -78,7 +78,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(-14.0f + 2.0f * i, 15.0f) * Meter;
+                bd.location = Vec2(-14.0f + 2.0f * i, 15.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
 
@@ -102,7 +102,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(-4.5f + 1.0f * i, 5.0f) * Meter;
+                bd.location = Vec2(-4.5f + 1.0f * i, 5.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
 
@@ -128,7 +128,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(5.5f + 1.0f * i, 10.0f) * Meter;
+                bd.location = Vec2(5.5f + 1.0f * i, 10.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
 
@@ -152,7 +152,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-8.0f + 8.0f * i, 12.0f) * Meter;
+            bd.location = Vec2(-8.0f + 8.0f * i, 12.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(polyshape);
         }
@@ -164,7 +164,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-6.0f + 6.0f * i, 10.0f) * Meter;
+            bd.location = Vec2(-6.0f + 6.0f * i, 10.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(circleshape);
         }

--- a/Testbed/Tests/Car.hpp
+++ b/Testbed/Tests/Car.hpp
@@ -90,7 +90,7 @@ public:
         // Teeter
         {
             BodyDef bd;
-            bd.position = Vec2(140.0f, 1.0f) * Meter;
+            bd.location = Vec2(140.0f, 1.0f) * Meter;
             bd.type = BodyType::Dynamic;
             const auto body = m_world->CreateBody(bd);
 
@@ -120,7 +120,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(161.0f + 2.0f * i, -0.125f) * Meter;
+                bd.location = Vec2(161.0f + 2.0f * i, -0.125f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
 
@@ -144,23 +144,23 @@ public:
             BodyDef bd;
             bd.type = BodyType::Dynamic;
 
-            bd.position = Vec2(230.0f, 0.5f) * Meter;
+            bd.location = Vec2(230.0f, 0.5f) * Meter;
             body = m_world->CreateBody(bd);
             body->CreateFixture(box);
 
-            bd.position = Vec2(230.0f, 1.5f) * Meter;
+            bd.location = Vec2(230.0f, 1.5f) * Meter;
             body = m_world->CreateBody(bd);
             body->CreateFixture(box);
 
-            bd.position = Vec2(230.0f, 2.5f) * Meter;
+            bd.location = Vec2(230.0f, 2.5f) * Meter;
             body = m_world->CreateBody(bd);
             body->CreateFixture(box);
 
-            bd.position = Vec2(230.0f, 3.5f) * Meter;
+            bd.location = Vec2(230.0f, 3.5f) * Meter;
             body = m_world->CreateBody(bd);
             body->CreateFixture(box);
 
-            bd.position = Vec2(230.0f, 4.5f) * Meter;
+            bd.location = Vec2(230.0f, 4.5f) * Meter;
             body = m_world->CreateBody(bd);
             body->CreateFixture(box);
         }
@@ -184,15 +184,15 @@ public:
 
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(0.0f, 1.0f) * Meter;
+            bd.location = Vec2(0.0f, 1.0f) * Meter;
             m_car = m_world->CreateBody(bd);
             m_car->CreateFixture(chassis);
 
-            bd.position = Vec2(-1.0f, 0.35f) * Meter;
+            bd.location = Vec2(-1.0f, 0.35f) * Meter;
             m_wheel1 = m_world->CreateBody(bd);
             m_wheel1->CreateFixture(circle);
 
-            bd.position = Vec2(1.0f, 0.4f) * Meter;
+            bd.location = Vec2(1.0f, 0.4f) * Meter;
             m_wheel2 = m_world->CreateBody(bd);
             m_wheel2->CreateFixture(circle);
 

--- a/Testbed/Tests/Chain.hpp
+++ b/Testbed/Tests/Chain.hpp
@@ -43,7 +43,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(0.5f + i, y) * Meter;
+                bd.location = Vec2(0.5f + i, y) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
 

--- a/Testbed/Tests/CharacterCollision.hpp
+++ b/Testbed/Tests/CharacterCollision.hpp
@@ -160,7 +160,7 @@ public:
         // Square character 1
         {
             BodyDef bd;
-            bd.position = Vec2(-3.0f, 8.0f) * Meter;
+            bd.location = Vec2(-3.0f, 8.0f) * Meter;
             bd.type = BodyType::Dynamic;
             bd.fixedRotation = false;
             bd.allowSleep = false;
@@ -173,7 +173,7 @@ public:
             const auto square = std::make_shared<PolygonShape>(Real{0.5f} * Meter, Real{0.5f} * Meter, conf);
             body->CreateFixture(square);
             
-            bd.position = Vec2(19.0f, 7.0f) * Meter;
+            bd.location = Vec2(19.0f, 7.0f) * Meter;
             const auto body2 = m_world->CreateBody(bd);
             body2->CreateFixture(square);
         }
@@ -181,7 +181,7 @@ public:
         // Square character 2
         {
             BodyDef bd;
-            bd.position = Vec2(-5.0f, 5.0f) * Meter;
+            bd.location = Vec2(-5.0f, 5.0f) * Meter;
             bd.type = BodyType::Dynamic;
             bd.fixedRotation = true;
             bd.allowSleep = false;
@@ -196,7 +196,7 @@ public:
         // Hexagon character
         {
             BodyDef bd;
-            bd.position = Vec2(-5.0f, 8.0f) * Meter;
+            bd.location = Vec2(-5.0f, 8.0f) * Meter;
             bd.type = BodyType::Dynamic;
             bd.fixedRotation = true;
             bd.allowSleep = false;
@@ -222,7 +222,7 @@ public:
         // Disk character
         {
             BodyDef bd;
-            bd.position = Vec2(3.0f, 5.0f) * Meter;
+            bd.location = Vec2(3.0f, 5.0f) * Meter;
             bd.type = BodyType::Dynamic;
             bd.fixedRotation = true;
             bd.allowSleep = false;
@@ -237,7 +237,7 @@ public:
         // Disk character
         {
             BodyDef bd;
-            bd.position = Vec2(-7.0f, 6.0f) * Meter;
+            bd.location = Vec2(-7.0f, 6.0f) * Meter;
             bd.type = BodyType::Dynamic;
             bd.allowSleep = false;
 

--- a/Testbed/Tests/CollisionFiltering.hpp
+++ b/Testbed/Tests/CollisionFiltering.hpp
@@ -74,7 +74,7 @@ public:
 
         BodyDef triangleBodyDef;
         triangleBodyDef.type = BodyType::Dynamic;
-        triangleBodyDef.position = Vec2(-5.0f, 2.0f) * Meter;
+        triangleBodyDef.location = Vec2(-5.0f, 2.0f) * Meter;
 
         const auto body1 = m_world->CreateBody(triangleBodyDef);
         body1->CreateFixture(std::make_shared<PolygonShape>(polygon), triangleShapeDef);
@@ -85,7 +85,7 @@ public:
         vertices[2] *= 2.0f;
         polygon.Set(Span<const Length2D>{vertices, 3});
         triangleShapeDef.filter.groupIndex = k_largeGroup;
-        triangleBodyDef.position = Vec2(-5.0f, 6.0f) * Meter;
+        triangleBodyDef.location = Vec2(-5.0f, 6.0f) * Meter;
         triangleBodyDef.fixedRotation = true; // look at me!
 
         const auto body2 = m_world->CreateBody(triangleBodyDef);
@@ -94,7 +94,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-5.0f, 10.0f) * Meter;
+            bd.location = Vec2(-5.0f, 10.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             auto conf = PolygonShape::Conf{};
             conf.density = Real{1} * KilogramPerSquareMeter;
@@ -126,7 +126,7 @@ public:
 
         BodyDef boxBodyDef;
         boxBodyDef.type = BodyType::Dynamic;
-        boxBodyDef.position = Vec2(0.0f, 2.0f) * Meter;
+        boxBodyDef.location = Vec2(0.0f, 2.0f) * Meter;
 
         const auto body3 = m_world->CreateBody(boxBodyDef);
         body3->CreateFixture(std::make_shared<PolygonShape>(polygon), boxShapeDef);
@@ -134,7 +134,7 @@ public:
         // Large box (recycle definitions)
         polygon.SetAsBox(Real{2.0f} * Meter, Real{1.0f} * Meter);
         boxShapeDef.filter.groupIndex = k_largeGroup;
-        boxBodyDef.position = Vec2(0.0f, 6.0f) * Meter;
+        boxBodyDef.location = Vec2(0.0f, 6.0f) * Meter;
 
         const auto body4 = m_world->CreateBody(boxBodyDef);
         body4->CreateFixture(std::make_shared<PolygonShape>(polygon), boxShapeDef);
@@ -153,7 +153,7 @@ public:
 
         BodyDef circleBodyDef;
         circleBodyDef.type = BodyType::Dynamic;
-        circleBodyDef.position = Vec2(5.0f, 2.0f) * Meter;
+        circleBodyDef.location = Vec2(5.0f, 2.0f) * Meter;
         
         const auto body5 = m_world->CreateBody(circleBodyDef);
         body5->CreateFixture(std::make_shared<DiskShape>(circle), circleShapeDef);
@@ -161,7 +161,7 @@ public:
         // Large circle
         circle.SetRadius(circle.GetRadius() * Real{2});
         circleShapeDef.filter.groupIndex = k_largeGroup;
-        circleBodyDef.position = Vec2(5.0f, 6.0f) * Meter;
+        circleBodyDef.location = Vec2(5.0f, 6.0f) * Meter;
 
         const auto body6 = m_world->CreateBody(circleBodyDef);
         body6->CreateFixture(std::make_shared<DiskShape>(circle), circleShapeDef);

--- a/Testbed/Tests/CollisionProcessing.hpp
+++ b/Testbed/Tests/CollisionProcessing.hpp
@@ -53,7 +53,7 @@ public:
 
         BodyDef triangleBodyDef;
         triangleBodyDef.type = BodyType::Dynamic;
-        triangleBodyDef.position = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
+        triangleBodyDef.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
 
         const auto body1 = m_world->CreateBody(triangleBodyDef);
         body1->CreateFixture(std::make_shared<PolygonShape>(polygon));
@@ -64,7 +64,7 @@ public:
         vertices[2] *= 2.0f;
         polygon.Set(Span<const Length2D>{vertices, 3});
 
-        triangleBodyDef.position = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
+        triangleBodyDef.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
 
         const auto body2 = m_world->CreateBody(triangleBodyDef);
         body2->CreateFixture(std::make_shared<PolygonShape>(polygon));
@@ -74,14 +74,14 @@ public:
 
         BodyDef boxBodyDef;
         boxBodyDef.type = BodyType::Dynamic;
-        boxBodyDef.position = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
+        boxBodyDef.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
 
         const auto body3 = m_world->CreateBody(boxBodyDef);
         body3->CreateFixture(std::make_shared<PolygonShape>(polygon));
 
         // Large box (recycle definitions)
         polygon.SetAsBox(Real{2.0f} * Meter, Real{1.0f} * Meter);
-        boxBodyDef.position = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
+        boxBodyDef.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
         
         const auto body4 = m_world->CreateBody(boxBodyDef);
         body4->CreateFixture(std::make_shared<PolygonShape>(polygon));
@@ -93,14 +93,14 @@ public:
 
         BodyDef circleBodyDef;
         circleBodyDef.type = BodyType::Dynamic;
-        circleBodyDef.position = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
+        circleBodyDef.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
 
         const auto body5 = m_world->CreateBody(circleBodyDef);
         body5->CreateFixture(std::make_shared<DiskShape>(circle));
 
         // Large circle
         circle.SetRadius(circle.GetRadius() * Real{2});
-        circleBodyDef.position = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
+        circleBodyDef.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * Meter;
 
         const auto body6 = m_world->CreateBody(circleBodyDef);
         body6->CreateFixture(std::make_shared<DiskShape>(circle));

--- a/Testbed/Tests/CompoundShapes.hpp
+++ b/Testbed/Tests/CompoundShapes.hpp
@@ -32,7 +32,7 @@ public:
     {
         {
             BodyDef bd;
-            bd.position = Vec2(0.0f, 0.0f) * Meter;
+            bd.location = Vec2(0.0f, 0.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(std::make_shared<EdgeShape>(Vec2(50.0f, 0.0f) * Meter, Vec2(-50.0f, 0.0f) * Meter));
         }
@@ -51,7 +51,7 @@ public:
                 const auto x = RandomFloat(-0.1f, 0.1f);
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(x + 5.0f, 1.05f + 2.5f * i) * Meter;
+                bd.location = Vec2(x + 5.0f, 1.05f + 2.5f * i) * Meter;
                 bd.angle = Radian * RandomFloat(-Pi, Pi);
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(circle1);
@@ -70,7 +70,7 @@ public:
                 const auto x = RandomFloat(-0.1f, 0.1f);
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(x - 5.0f, 1.05f + 2.5f * i) * Meter;
+                bd.location = Vec2(x - 5.0f, 1.05f + 2.5f * i) * Meter;
                 bd.angle = Radian * RandomFloat(-Pi, Pi);
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(polygon1);
@@ -108,7 +108,7 @@ public:
                 const auto x = RandomFloat(-0.1f, 0.1f);
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(x, 2.05f + 2.5f * i) * Meter;
+                bd.location = Vec2(x, 2.05f + 2.5f * i) * Meter;
                 bd.angle = Real{0.0f} * Radian;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(triangle1);
@@ -130,7 +130,7 @@ public:
 
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2( 0.0f, 2.0f ) * Meter;
+            bd.location = Vec2( 0.0f, 2.0f ) * Meter;
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(bottom);
             body->CreateFixture(left);

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -53,7 +53,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2{
+                bd.location = Vec2{
                     -10.0f + (2.1f * j + 1.0f + 0.01f * i) * (radius / Meter),
                     (2.0f * i + 1.0f) * (radius/ Meter)
                 } * Meter;
@@ -86,7 +86,7 @@ public:
         BodyDef bd;
         bd.type = BodyType::Dynamic;
         bd.bullet = m_bullet_mode;
-        bd.position = Vec2{0, 20} * Meter + GetRandomOffset();
+        bd.location = Vec2{0, 20} * Meter + GetRandomOffset();
         //bd.allowSleep = false;
 
         const auto body = m_world->CreateBody(bd);
@@ -109,7 +109,7 @@ public:
         BodyDef bd;
         bd.type = BodyType::Dynamic;
         bd.bullet = m_bullet_mode;
-        bd.position = Vec2{0, 20} * Meter + GetRandomOffset();
+        bd.location = Vec2{0, 20} * Meter + GetRandomOffset();
         const auto body = m_world->CreateBody(bd);
         body->CreateFixture(std::make_shared<PolygonShape>(side_length/Real{2}, side_length/Real{2}, conf));
     }

--- a/Testbed/Tests/ContinuousTest.hpp
+++ b/Testbed/Tests/ContinuousTest.hpp
@@ -32,7 +32,7 @@ public:
     {
         {
             BodyDef bd;
-            bd.position = Vec2(0.0f, 0.0f) * Meter;
+            bd.location = Vec2(0.0f, 0.0f) * Meter;
             Body* body = m_world->CreateBody(bd);
 
             body->CreateFixture(std::make_shared<EdgeShape>(Vec2(-10.0f, 0.0f) * Meter, Vec2(10.0f, 0.0f) * Meter));
@@ -45,7 +45,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(0.0f, 20.0f) * Meter;
+            bd.location = Vec2(0.0f, 20.0f) * Meter;
             //bd.angle = 0.1f;
 
             const auto shape = std::make_shared<PolygonShape>(Real{2.0f} * Meter, Real{0.1f} * Meter);

--- a/Testbed/Tests/ConveyorBelt.hpp
+++ b/Testbed/Tests/ConveyorBelt.hpp
@@ -39,7 +39,7 @@ public:
         // Platform
         {
             BodyDef bd;
-            bd.position = Vec2(-5.0f, 5.0f) * Meter;
+            bd.location = Vec2(-5.0f, 5.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
 
             auto conf = PolygonShape::Conf{};
@@ -54,7 +54,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-10.0f + 2.0f * i, 7.0f) * Meter;
+            bd.location = Vec2(-10.0f + 2.0f * i, 7.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(boxshape);
         }

--- a/Testbed/Tests/Dominos.hpp
+++ b/Testbed/Tests/Dominos.hpp
@@ -35,7 +35,7 @@ public:
 
         {
             BodyDef bd;
-            bd.position = Vec2(-1.5f, 10.0f) * Meter;
+            bd.location = Vec2(-1.5f, 10.0f) * Meter;
             const auto ground = m_world->CreateBody(bd);
             ground->CreateFixture(std::make_shared<PolygonShape>(PolygonShape{Real{6.0f} * Meter, Real{0.25f} * Meter}));
         }
@@ -59,7 +59,7 @@ public:
             SetAsBox(shape, Real{7.2f} * Meter, Real{0.25f} * Meter, Vec2_zero * Meter, Real{0.3f} * Radian);
 
             BodyDef bd;
-            bd.position = Vec2(1.2f, 6.0f) * Meter;
+            bd.location = Vec2(1.2f, 6.0f) * Meter;
             const auto ground = m_world->CreateBody(bd);
             ground->CreateFixture(std::make_shared<PolygonShape>(shape));
         }
@@ -71,7 +71,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-0.9f, 1.0f) * Meter;
+            bd.location = Vec2(-0.9f, 1.0f) * Meter;
             bd.angle = Real{-0.15f} * Radian;
 
             b3 = m_world->CreateBody(bd);
@@ -88,7 +88,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-10.0f, 15.0f) * Meter;
+            bd.location = Vec2(-10.0f, 15.0f) * Meter;
             b4 = m_world->CreateBody(bd);
             auto conf = PolygonShape::Conf{};
             conf.density = Real{10} * KilogramPerSquareMeter;
@@ -103,7 +103,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(6.5f, 3.0f) * Meter;
+            bd.location = Vec2(6.5f, 3.0f) * Meter;
             b5 = m_world->CreateBody(bd);
 
             auto conf = PolygonShape::Conf{};
@@ -132,7 +132,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(6.5f, 4.1f) * Meter;
+            bd.location = Vec2(6.5f, 4.1f) * Meter;
             b6 = m_world->CreateBody(bd);
             auto conf = PolygonShape::Conf{};
             conf.density = Real{30} * KilogramPerSquareMeter;
@@ -147,7 +147,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(7.4f, 1.0f) * Meter;
+            bd.location = Vec2(7.4f, 1.0f) * Meter;
 
             b7 = m_world->CreateBody(bd);
             auto conf = PolygonShape::Conf{};
@@ -175,7 +175,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Length2D{
+                bd.location = Length2D{
                     Real{5.9f} * Meter + Real{2.0f} * radius * static_cast<Real>(i),
                     Real{2.4f} * Meter
                 };

--- a/Testbed/Tests/DumpShell.hpp
+++ b/Testbed/Tests/DumpShell.hpp
@@ -49,7 +49,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType(0);
-            bd.position = Vec2(2.587699890136719e-02f, 5.515012264251709e+00f) * Meter;
+            bd.location = Vec2(2.587699890136719e-02f, 5.515012264251709e+00f) * Meter;
             bd.angle = Real{0.0f} * Radian;
             bd.linearVelocity = Vec2(0.000000000000000e+00f, 0.000000000000000e+00f) * MeterPerSecond;
             bd.angularVelocity = Real{0.0f} * RadianPerSecond;
@@ -85,7 +85,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType(2);
-            bd.position = Vec2(-3.122138977050781e-02f, 7.535382270812988e+00f) * Meter;
+            bd.location = Vec2(-3.122138977050781e-02f, 7.535382270812988e+00f) * Meter;
             bd.angle = Real{-1.313644275069237e-02f} * Radian;
             bd.linearVelocity = Vec2(8.230687379837036e-01f, 7.775862514972687e-02f) * MeterPerSecond;
             bd.angularVelocity = Real{3.705333173274994e-02f} * RadianPerSecond;
@@ -122,7 +122,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType(2);
-            bd.position = Vec2(-7.438077926635742e-01f, 6.626811981201172e+00f) * Meter;
+            bd.location = Vec2(-7.438077926635742e-01f, 6.626811981201172e+00f) * Meter;
             bd.angle = Real{-1.884713363647461e+01f} * Radian;
             bd.linearVelocity = Vec2(1.785794943571091e-01f, 3.799796104431152e-07f) * MeterPerSecond;
             bd.angularVelocity = Real{-5.908820639888290e-06f} * RadianPerSecond;

--- a/Testbed/Tests/EdgeShapes.hpp
+++ b/Testbed/Tests/EdgeShapes.hpp
@@ -110,7 +110,7 @@ public:
 
         const auto x = RandomFloat(-10.0f, 10.0f);
         const auto y = RandomFloat(10.0f, 20.0f);
-        bd.position = Vec2(x, y) * Meter;
+        bd.location = Vec2(x, y) * Meter;
         bd.angle = Radian * RandomFloat(-Pi, Pi);
         bd.type = BodyType::Dynamic;
 

--- a/Testbed/Tests/EdgeTest.hpp
+++ b/Testbed/Tests/EdgeTest.hpp
@@ -65,7 +65,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-0.5f, 0.6f) * Meter;
+            bd.location = Vec2(-0.5f, 0.6f) * Meter;
             bd.allowSleep = false;
             const auto body = m_world->CreateBody(bd);
 
@@ -78,7 +78,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(1.0f, 0.6f) * Meter;
+            bd.location = Vec2(1.0f, 0.6f) * Meter;
             bd.allowSleep = false;
             const auto body = m_world->CreateBody(bd);
 

--- a/Testbed/Tests/FifteenPuzzle.hpp
+++ b/Testbed/Tests/FifteenPuzzle.hpp
@@ -71,7 +71,7 @@ namespace playrho {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
             bd.bullet = true;
-            bd.position = GetCenter() + relPos + Length2D{sideLength / 2, sideLength / 2};
+            bd.location = GetCenter() + relPos + Length2D{sideLength / 2, sideLength / 2};
             bd.linearDamping = 20.0f * Hertz;
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(std::make_shared<PolygonShape>(halfSide, halfSide, conf));

--- a/Testbed/Tests/Gears.hpp
+++ b/Testbed/Tests/Gears.hpp
@@ -42,23 +42,23 @@ public:
         {
             auto bd1 = BodyDef{};
             bd1.type = BodyType::Static;
-            bd1.position = Vec2(10.0f, 9.0f) * Meter;
+            bd1.location = Vec2(10.0f, 9.0f) * Meter;
             const auto body1 = m_world->CreateBody(bd1);
 
             auto bd2 = BodyDef{};
             bd2.type = BodyType::Dynamic;
-            bd2.position = Vec2(10.0f, 8.0f) * Meter;
+            bd2.location = Vec2(10.0f, 8.0f) * Meter;
             const auto body2 = m_world->CreateBody(bd2);
             body2->CreateFixture(box);
 
             auto bd3 = BodyDef{};
             bd3.type = BodyType::Dynamic;
-            bd3.position = Vec2(10.0f, 6.0f) * Meter;
+            bd3.location = Vec2(10.0f, 6.0f) * Meter;
             const auto body3 = m_world->CreateBody(bd3);
             body3->CreateFixture(circle2);
 
-            auto joint1 = m_world->CreateJoint(RevoluteJointDef{body2, body1, bd1.position});
-            auto joint2 = m_world->CreateJoint(RevoluteJointDef{body2, body3, bd3.position});
+            auto joint1 = m_world->CreateJoint(RevoluteJointDef{body2, body1, bd1.location});
+            auto joint2 = m_world->CreateJoint(RevoluteJointDef{body2, body3, bd3.location});
 
             auto jd4 = GearJointDef{joint1, joint2};
             jd4.ratio = circle2->GetRadius() / circle1->GetRadius();
@@ -68,34 +68,34 @@ public:
         {
             auto bd1 = BodyDef{};
             bd1.type = BodyType::Dynamic;
-            bd1.position = Vec2(-3.0f, 12.0f) * Meter;
+            bd1.location = Vec2(-3.0f, 12.0f) * Meter;
             const auto body1 = m_world->CreateBody(bd1);
             body1->CreateFixture(circle1);
 
             auto jd1 = RevoluteJointDef{};
             jd1.bodyA = ground;
             jd1.bodyB = body1;
-            jd1.localAnchorA = GetLocalPoint(*ground, bd1.position);
-            jd1.localAnchorB = GetLocalPoint(*body1, bd1.position);
+            jd1.localAnchorA = GetLocalPoint(*ground, bd1.location);
+            jd1.localAnchorB = GetLocalPoint(*body1, bd1.location);
             jd1.referenceAngle = body1->GetAngle() - ground->GetAngle();
             m_joint1 = static_cast<RevoluteJoint*>(m_world->CreateJoint(jd1));
 
             auto bd2 = BodyDef{};
             bd2.type = BodyType::Dynamic;
-            bd2.position = Vec2(0.0f, 12.0f) * Meter;
+            bd2.location = Vec2(0.0f, 12.0f) * Meter;
             const auto body2 = m_world->CreateBody(bd2);
             body2->CreateFixture(circle2);
 
-            auto jd2 = RevoluteJointDef{ground, body2, bd2.position};
+            auto jd2 = RevoluteJointDef{ground, body2, bd2.location};
             m_joint2 = static_cast<RevoluteJoint*>(m_world->CreateJoint(jd2));
 
             auto bd3 = BodyDef{};
             bd3.type = BodyType::Dynamic;
-            bd3.position = Vec2(2.5f, 12.0f) * Meter;
+            bd3.location = Vec2(2.5f, 12.0f) * Meter;
             const auto body3 = m_world->CreateBody(bd3);
             body3->CreateFixture(box);
 
-            auto jd3 = PrismaticJointDef{ground, body3, bd3.position, UnitVec2::GetTop()};
+            auto jd3 = PrismaticJointDef{ground, body3, bd3.location, UnitVec2::GetTop()};
             jd3.lowerTranslation = Real{-5.0f} * Meter;
             jd3.upperTranslation = Real{5.0f} * Meter;
             jd3.enableLimit = true;

--- a/Testbed/Tests/Mobile.hpp
+++ b/Testbed/Tests/Mobile.hpp
@@ -57,7 +57,7 @@ public:
 
         BodyDef bodyDef;
         bodyDef.type = BodyType::Dynamic;
-        bodyDef.position = parent->GetLocation() + localAnchor - h;
+        bodyDef.location = parent->GetLocation() + localAnchor - h;
         const auto body = m_world->CreateBody(bodyDef);
         body->CreateFixture(shape);
 

--- a/Testbed/Tests/MobileBalanced.hpp
+++ b/Testbed/Tests/MobileBalanced.hpp
@@ -64,7 +64,7 @@ public:
 
         BodyDef bodyDef;
         bodyDef.type = BodyType::Dynamic;
-        bodyDef.position = p;
+        bodyDef.location = p;
         const auto body = m_world->CreateBody(bodyDef);
 
         body->CreateFixture(shape);

--- a/Testbed/Tests/MotorJoint.hpp
+++ b/Testbed/Tests/MotorJoint.hpp
@@ -38,7 +38,7 @@ public:
         // Define motorized body
         BodyDef bd;
         bd.type = BodyType::Dynamic;
-        bd.position = Vec2(0.0f, 8.0f) * Meter;
+        bd.location = Vec2(0.0f, 8.0f) * Meter;
         const auto body = m_world->CreateBody(bd);
 
         auto conf = PolygonShape::Conf{};

--- a/Testbed/Tests/NewtonsCradle.hpp
+++ b/Testbed/Tests/NewtonsCradle.hpp
@@ -57,7 +57,7 @@ namespace playrho {
             m_frame = [&]() {
                 BodyDef bd;
                 bd.type = BodyType::Static;
-                bd.position = Length2D{0, frame_height};
+                bd.location = Length2D{0, frame_height};
                 const auto body = m_world->CreateBody(bd);
                 
                 const auto frame_width = frame_width_per_arm * static_cast<Real>(m_num_arms);
@@ -74,7 +74,7 @@ namespace playrho {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
                 bd.bullet = m_bullet_mode;
-                bd.position = Length2D{x, frame_height - (arm_length / Real{2})};
+                bd.location = Length2D{x, frame_height - (arm_length / Real{2})};
                 
                 m_swings[i] = m_world->CreateBody(bd);
                 CreateArm(m_swings[i], arm_length);
@@ -110,7 +110,7 @@ namespace playrho {
 
                 BodyDef def;
                 def.type = BodyType::Static;
-                def.position = Length2D{frame_width / Real{2} + frame_width / Real{24}, frame_height - (arm_length / Real{2})};
+                def.location = Length2D{frame_width / Real{2} + frame_width / Real{24}, frame_height - (arm_length / Real{2})};
                 const auto body = m_world->CreateBody(def);
                 
                 auto shape = PolygonShape((frame_width/Real{24}), (arm_length / Real{2} + frame_width / Real{24}));
@@ -128,7 +128,7 @@ namespace playrho {
 
                 BodyDef def;
                 def.type = BodyType::Static;
-                def.position = Length2D{
+                def.location = Length2D{
                     -(frame_width / Real{2} + frame_width / Real{24}),
                     frame_height - (arm_length / Real{2})
                 };

--- a/Testbed/Tests/OneSidedPlatform.hpp
+++ b/Testbed/Tests/OneSidedPlatform.hpp
@@ -46,7 +46,7 @@ public:
         // Platform
         {
             BodyDef bd;
-            bd.position = Vec2(0.0f, 10.0f) * Meter;
+            bd.location = Vec2(0.0f, 10.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             m_platform = body->CreateFixture(std::make_shared<PolygonShape>(Real{3.0f} * Meter, Real{0.5f} * Meter));
             m_bottom = Real(10.0f - 0.5f) * Meter;
@@ -57,7 +57,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(0.0f, 12.0f) * Meter;
+            bd.location = Vec2(0.0f, 12.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             auto conf = DiskShape::Conf{};
             conf.vertexRadius = m_radius;

--- a/Testbed/Tests/Orbiter.hpp
+++ b/Testbed/Tests/Orbiter.hpp
@@ -35,14 +35,14 @@ namespace playrho {
             const auto radius = Real{12.0f};
 
             bd.type = BodyType::Static;
-            bd.position = m_center;
+            bd.location = m_center;
             const auto ctrBody = m_world->CreateBody(bd);
             const auto ctrShape = std::make_shared<DiskShape>();
             ctrShape->SetRadius(Real{3} * Meter);
             ctrBody->CreateFixture(ctrShape);
 
             bd.type = BodyType::Dynamic;
-            bd.position = Length2D{GetX(m_center), GetY(m_center) + radius * Meter};
+            bd.location = Length2D{GetX(m_center), GetY(m_center) + radius * Meter};
             m_orbiter = m_world->CreateBody(bd);
             const auto ballShape = std::make_shared<DiskShape>();
             ballShape->SetRadius(Real{0.5f} * Meter);
@@ -62,7 +62,7 @@ namespace playrho {
             const auto outerCicle = std::make_shared<ChainShape>(conf);
 
             bd.type = BodyType::Dynamic;
-            bd.position = m_center;
+            bd.location = m_center;
             bd.bullet = true;
             const auto dysonSphere = m_world->CreateBody(bd);
             dysonSphere->CreateFixture(outerCicle);

--- a/Testbed/Tests/Pinball.hpp
+++ b/Testbed/Tests/Pinball.hpp
@@ -53,10 +53,10 @@ public:
             BodyDef bd;
             bd.type = BodyType::Dynamic;
 
-            bd.position = p1;
+            bd.location = p1;
             const auto leftFlipper = m_world->CreateBody(bd);
 
-            bd.position = p2;
+            bd.location = p2;
             const auto rightFlipper = m_world->CreateBody(bd);
 
             const auto box = std::make_shared<PolygonShape>(Real{1.75f} * Meter, Real{0.1f} * Meter);
@@ -90,7 +90,7 @@ public:
         // Disk character
         {
             BodyDef bd;
-            bd.position = Vec2(1.0f, 15.0f) * Meter;
+            bd.location = Vec2(1.0f, 15.0f) * Meter;
             bd.type = BodyType::Dynamic;
             bd.bullet = true;
 

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -126,7 +126,7 @@ public:
         bd.type = BodyType::Dynamic;
 
         const auto x = RandomFloat(-2.0f, 2.0f);
-        bd.position = Vec2(x, 10.0f) * Meter;
+        bd.location = Vec2(x, 10.0f) * Meter;
         bd.angle = Radian * RandomFloat(-Pi, Pi);
 
         if (index == 4)

--- a/Testbed/Tests/Prismatic.hpp
+++ b/Testbed/Tests/Prismatic.hpp
@@ -36,7 +36,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-10.0f, 10.0f) * Meter;
+            bd.location = Vec2(-10.0f, 10.0f) * Meter;
             bd.angle = Real{0.5f} * Radian * Pi;
             bd.allowSleep = false;
             const auto body = m_world->CreateBody(bd);

--- a/Testbed/Tests/Pulleys.hpp
+++ b/Testbed/Tests/Pulleys.hpp
@@ -54,11 +54,11 @@ public:
             bd.type = BodyType::Dynamic;
 
             //bd.fixedRotation = true;
-            bd.position = Vec2(-10.0f, y) * Meter;
+            bd.location = Vec2(-10.0f, y) * Meter;
             const auto body1 = m_world->CreateBody(bd);
             body1->CreateFixture(shape);
 
-            bd.position = Vec2(10.0f, y) * Meter;
+            bd.location = Vec2(10.0f, y) * Meter;
             const auto body2 = m_world->CreateBody(bd);
             body2->CreateFixture(shape);
 

--- a/Testbed/Tests/Pyramid.hpp
+++ b/Testbed/Tests/Pyramid.hpp
@@ -54,7 +54,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = y * Meter;
+                bd.location = y * Meter;
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
 

--- a/Testbed/Tests/RayCast.hpp
+++ b/Testbed/Tests/RayCast.hpp
@@ -105,7 +105,7 @@ public:
 
         const auto x = RandomFloat(-10.0f, 10.0f);
         const auto y = RandomFloat(0.0f, 20.0f);
-        bd.position = Vec2(x, y) * Meter;
+        bd.location = Vec2(x, y) * Meter;
         bd.angle = Radian * RandomFloat(-Pi, Pi);
 
         m_userData[m_bodyIndex] = index;

--- a/Testbed/Tests/Revolute.hpp
+++ b/Testbed/Tests/Revolute.hpp
@@ -36,7 +36,7 @@ public:
             BodyDef bd;
             bd.type = BodyType::Dynamic;
 
-            bd.position = Vec2(-10.0f, 20.0f) * Meter;
+            bd.location = Vec2(-10.0f, 20.0f) * Meter;
             const auto body = m_world->CreateBody(bd);
             auto circleConf = DiskShape::Conf{};
             circleConf.vertexRadius = Real{0.5f} * Meter;
@@ -61,7 +61,7 @@ public:
         {
             BodyDef circle_bd;
             circle_bd.type = BodyType::Dynamic;
-            circle_bd.position = Vec2(5.0f, 30.0f) * Meter;
+            circle_bd.location = Vec2(5.0f, 30.0f) * Meter;
 
             FixtureDef fd;
             fd.filter.maskBits = 1;
@@ -77,7 +77,7 @@ public:
             polygon_shape.SetDensity(Real{2} * KilogramPerSquareMeter);
 
             BodyDef polygon_bd;
-            polygon_bd.position = Vec2(20.0f, 10.0f) * Meter;
+            polygon_bd.location = Vec2(20.0f, 10.0f) * Meter;
             polygon_bd.type = BodyType::Dynamic;
             polygon_bd.bullet = true;
             const auto polygon_body = m_world->CreateBody(polygon_bd);

--- a/Testbed/Tests/RopeJoint.hpp
+++ b/Testbed/Tests/RopeJoint.hpp
@@ -63,12 +63,12 @@ public:
                 auto shape = rectangle;
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(0.5f + 1.0f * i, y) * Meter;
+                bd.location = Vec2(0.5f + 1.0f * i, y) * Meter;
                 if (i == N - 1)
                 {
                     shape = square;
                     fd.filter.categoryBits = 0x0002;
-                    bd.position = Vec2(1.0f * i, y) * Meter;
+                    bd.location = Vec2(1.0f * i, y) * Meter;
                     bd.angularDamping = Real(0.4f) * Hertz;
                 }
 

--- a/Testbed/Tests/SensorTest.hpp
+++ b/Testbed/Tests/SensorTest.hpp
@@ -65,7 +65,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-10.0f + 3.0f * i, 20.0f) * Meter;
+            bd.location = Vec2(-10.0f + 3.0f * i, 20.0f) * Meter;
             bd.userData = m_touching + i;
 
             m_touching[i] = false;

--- a/Testbed/Tests/ShapeEditing.hpp
+++ b/Testbed/Tests/ShapeEditing.hpp
@@ -35,7 +35,7 @@ public:
         
         BodyDef bd;
         bd.type = BodyType::Dynamic;
-        bd.position = Vec2(0.0f, 10.0f) * Meter;
+        bd.location = Vec2(0.0f, 10.0f) * Meter;
         m_body = m_world->CreateBody(bd);
 
         PolygonShape shape;

--- a/Testbed/Tests/SliderCrank.hpp
+++ b/Testbed/Tests/SliderCrank.hpp
@@ -40,7 +40,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(0.0f, 7.0f) * Meter;
+                bd.location = Vec2(0.0f, 7.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 auto shapeConf = PolygonShape::Conf{};
                 shapeConf.density = Real{2} * KilogramPerSquareMeter;
@@ -59,7 +59,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(0.0f, 13.0f) * Meter;
+                bd.location = Vec2(0.0f, 13.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 auto shapeConf = PolygonShape::Conf{};
                 shapeConf.density = Real{2} * KilogramPerSquareMeter;
@@ -77,7 +77,7 @@ public:
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
                 bd.fixedRotation = true;
-                bd.position = Vec2(0.0f, 17.0f) * Meter;
+                bd.location = Vec2(0.0f, 17.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 auto shapeConf = PolygonShape::Conf{};
                 shapeConf.density = Real{2} * KilogramPerSquareMeter;
@@ -97,7 +97,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(0.0f, 23.0f) * Meter;
+                bd.location = Vec2(0.0f, 23.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
                 auto shapeConf = PolygonShape::Conf{};
                 shapeConf.density = Real{2} * KilogramPerSquareMeter;

--- a/Testbed/Tests/SphereStack.hpp
+++ b/Testbed/Tests/SphereStack.hpp
@@ -48,7 +48,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(0, 4.0f + 3.0f * i) * Meter;
+                bd.location = Vec2(0, 4.0f + 3.0f * i) * Meter;
 
                 m_bodies[i] = m_world->CreateBody(bd);
                 m_bodies[i]->CreateFixture(shape);

--- a/Testbed/Tests/SpinningCircle.hpp
+++ b/Testbed/Tests/SpinningCircle.hpp
@@ -43,9 +43,9 @@ namespace playrho {
             bodyDef.linearDamping = Real(0.8f) * Hertz;
             bodyDef.bullet = true;
 
-            bodyDef.position = Vec2{0, 26} * Meter;
+            bodyDef.location = Vec2{0, 26} * Meter;
             const auto body1 = m_world->CreateBody(bodyDef);
-            bodyDef.position = Vec2{0, 14} * Meter;
+            bodyDef.location = Vec2{0, 14} * Meter;
             const auto body2 = m_world->CreateBody(bodyDef);
             
             auto shapeConf = DiskShape::Conf{};

--- a/Testbed/Tests/TheoJansen.hpp
+++ b/Testbed/Tests/TheoJansen.hpp
@@ -61,8 +61,8 @@ public:
         BodyDef bd1, bd2;
         bd1.type = BodyType::Dynamic;
         bd2.type = BodyType::Dynamic;
-        bd1.position = m_offset;
-        bd2.position = p4 + m_offset;
+        bd1.location = m_offset;
+        bd2.location = p4 + m_offset;
 
         bd1.angularDamping = Real(10) * Hertz;
         bd2.angularDamping = Real(10) * Hertz;
@@ -120,7 +120,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-40.0f + 2.0f * i, 0.5f) * Meter;
+            bd.location = Vec2(-40.0f + 2.0f * i, 0.5f) * Meter;
 
             const auto body = m_world->CreateBody(bd);
             body->CreateFixture(circle);
@@ -132,7 +132,7 @@ public:
             sd.filter.groupIndex = -1;
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = pivot + m_offset;
+            bd.location = pivot + m_offset;
             m_chassis = m_world->CreateBody(bd);
             auto polygonConf = PolygonShape::Conf{};
             polygonConf.density = Real{1} * KilogramPerSquareMeter;
@@ -144,7 +144,7 @@ public:
             sd.filter.groupIndex = -1;
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = pivot + m_offset;
+            bd.location = pivot + m_offset;
             m_wheel = m_world->CreateBody(bd);
             auto conf = DiskShape::Conf{};
             conf.vertexRadius = Real{1.6f} * Meter;

--- a/Testbed/Tests/Tiles.hpp
+++ b/Testbed/Tests/Tiles.hpp
@@ -42,7 +42,7 @@ public:
         {
             const auto a = Real{0.5f};
             BodyDef bd;
-            GetY(bd.position) = -a * Meter;
+            GetY(bd.location) = -a * Meter;
             const auto ground = m_world->CreateBody(bd);
 
             const auto N = 200;
@@ -82,7 +82,7 @@ public:
                 {
                     BodyDef bd;
                     bd.type = BodyType::Dynamic;
-                    bd.position = y * Meter;
+                    bd.location = y * Meter;
 
                     const auto body = m_world->CreateBody(bd);
                     body->CreateFixture(shape);

--- a/Testbed/Tests/VaryingFriction.hpp
+++ b/Testbed/Tests/VaryingFriction.hpp
@@ -40,7 +40,7 @@ public:
         
         {
             BodyDef bd;
-            bd.position = Vec2(-4.0f, 22.0f) * Meter;
+            bd.location = Vec2(-4.0f, 22.0f) * Meter;
             bd.angle = Real{-0.25f} * Radian;
 
             const auto ground = m_world->CreateBody(bd);
@@ -49,7 +49,7 @@ public:
 
         {
             BodyDef bd;
-            bd.position = Vec2(10.5f, 19.0f) * Meter;
+            bd.location = Vec2(10.5f, 19.0f) * Meter;
 
             const auto ground = m_world->CreateBody(bd);
             ground->CreateFixture(sliderWall);
@@ -57,7 +57,7 @@ public:
 
         {
             BodyDef bd;
-            bd.position = Vec2(4.0f, 14.0f) * Meter;
+            bd.location = Vec2(4.0f, 14.0f) * Meter;
             bd.angle = Real{0.25f} * Radian;
 
             const auto ground = m_world->CreateBody(bd);
@@ -66,7 +66,7 @@ public:
 
         {
             BodyDef bd;
-            bd.position = Vec2(-10.5f, 11.0f) * Meter;
+            bd.location = Vec2(-10.5f, 11.0f) * Meter;
 
             const auto ground = m_world->CreateBody(bd);
             ground->CreateFixture(sliderWall);
@@ -74,7 +74,7 @@ public:
 
         {
             BodyDef bd;
-            bd.position = Vec2(-4.0f, 6.0f) * Meter;
+            bd.location = Vec2(-4.0f, 6.0f) * Meter;
             bd.angle = Real{-0.25f} * Radian;
 
             const auto ground = m_world->CreateBody(bd);
@@ -90,7 +90,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.position = Vec2(-15.0f + 4.0f * i, 28.0f) * Meter;
+                bd.location = Vec2(-15.0f + 4.0f * i, 28.0f) * Meter;
                 const auto body = m_world->CreateBody(bd);
 
                 shape.SetFriction(Real(friction[i]));

--- a/Testbed/Tests/VaryingRestitution.hpp
+++ b/Testbed/Tests/VaryingRestitution.hpp
@@ -46,7 +46,7 @@ public:
         {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
-            bd.position = Vec2(-10.0f + 3.0f * i, 20.0f) * Meter;
+            bd.location = Vec2(-10.0f + 3.0f * i, 20.0f) * Meter;
 
             auto body = m_world->CreateBody(bd);
 

--- a/Testbed/Tests/VerticalStack.hpp
+++ b/Testbed/Tests/VerticalStack.hpp
@@ -67,7 +67,7 @@ public:
                 //const auto x = RandomFloat(-0.02f, 0.02f);
                 //const auto x = i % 2 == 0 ? -0.01f : 0.01f;
                 //bd.position = Vec2(xs[j] + x, (hdim - hdim/20) + (hdim * 2 - hdim / 20) * i);
-                bd.position = Vec2(xs[j] + x, (i + 1) * hdim * 4) * Meter;
+                bd.location = Vec2(xs[j] + x, (i + 1) * hdim * 4) * Meter;
                 
                 const auto body = m_world->CreateBody(bd);
                 body->CreateFixture(shape);
@@ -92,7 +92,7 @@ public:
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
                 bd.bullet = true;
-                bd.position = Vec2(-31.0f, 5.0f) * Meter;
+                bd.location = Vec2(-31.0f, 5.0f) * Meter;
 
                 m_bullet = m_world->CreateBody(bd);
                 m_bullet->CreateFixture(m_bulletshape);

--- a/Testbed/Tests/Web.hpp
+++ b/Testbed/Tests/Web.hpp
@@ -40,19 +40,19 @@ public:
             BodyDef bd;
             bd.type = BodyType::Dynamic;
 
-            bd.position = Vec2(-5.0f, 5.0f) * Meter;
+            bd.location = Vec2(-5.0f, 5.0f) * Meter;
             m_bodies[0] = m_world->CreateBody(bd);
             m_bodies[0]->CreateFixture(shape);
 
-            bd.position = Vec2(5.0f, 5.0f) * Meter;
+            bd.location = Vec2(5.0f, 5.0f) * Meter;
             m_bodies[1] = m_world->CreateBody(bd);
             m_bodies[1]->CreateFixture(shape);
 
-            bd.position = Vec2(5.0f, 15.0f) * Meter;
+            bd.location = Vec2(5.0f, 15.0f) * Meter;
             m_bodies[2] = m_world->CreateBody(bd);
             m_bodies[2]->CreateFixture(shape);
 
-            bd.position = Vec2(-5.0f, 15.0f) * Meter;
+            bd.location = Vec2(-5.0f, 15.0f) * Meter;
             m_bodies[3] = m_world->CreateBody(bd);
             m_bodies[3]->CreateFixture(shape);
 

--- a/Testbed/Tests/iforce2d_Trajectories.hpp
+++ b/Testbed/Tests/iforce2d_Trajectories.hpp
@@ -1,0 +1,369 @@
+/*
+ * Original work Copyright (c) Chris Campbell - www.iforce2d.net
+ * Modified work Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef IFORCE2D_TRAJECTORIES_HPP
+#define IFORCE2D_TRAJECTORIES_HPP
+
+#if defined(__APPLE_CC__)
+#include <OpenGL/gl3.h>
+#else
+#include <GL/glew.h>
+#endif
+
+namespace playrho {
+
+/// @brief iforce2d's Trajectories demo.
+/// @details This is a port of iforce2d's Trajectories demo to the PlayRho Testbed.
+/// @sa http://www.iforce2d.net/b2dtut/projected-trajectory
+class iforce2d_Trajectories : public Test
+{
+public:
+    iforce2d_Trajectories(): m_groundBody{m_world->CreateBody()}
+    {
+        //add four walls to the ground body
+        FixtureDef myFixtureDef;
+        PolygonShape polygonShape;
+        polygonShape.SetAsBox(20 * Meter, 1 * Meter); //ground
+        m_groundBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        SetAsBox(polygonShape, 20 * Meter,  1 * Meter, Vec2(0, 40) * Meter, 0 * Radian); //ceiling
+        m_groundBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        SetAsBox(polygonShape,  1 * Meter, 20 * Meter, Vec2(-20, 20) * Meter, 0 * Radian); //left wall
+        m_groundBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        SetAsBox(polygonShape,  1 * Meter, 20 * Meter, Vec2(20, 20) * Meter, 0 * Radian); //right wall
+        m_groundBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        
+        //small ledges for target practice
+        polygonShape.SetFriction(0.95f);
+        SetAsBox(polygonShape, 1.5f * Meter, 0.25f * Meter, Vec2(3, 35) * Meter, 0 * Radian);
+        m_groundBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        SetAsBox(polygonShape, 1.5f * Meter, 0.25f * Meter, Vec2(13, 30) * Meter, 0 * Radian);
+        m_groundBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        
+        //another ledge which we can move with the mouse
+        BodyDef kinematicBody;
+        kinematicBody.type = BodyType::Kinematic;
+        kinematicBody.location = Length2D{11 * Meter, 22 * Meter};
+        m_targetBody = m_world->CreateBody(kinematicBody);
+        const auto w = BallSize * Meter;
+        Length2D verts[3];
+        verts[0] = Length2D(  0 * Meter, -2*w);
+        verts[1] = Length2D(  w,    0 * Meter);
+        verts[2] = Length2D(  0 * Meter,   -w);
+        polygonShape.Set(Span<const Length2D>(verts, 3));
+        m_targetBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        verts[0] = Length2D(  0 * Meter, -2*w);
+        verts[2] = Length2D(  0 * Meter,   -w);
+        verts[1] = Length2D( -w,    0 * Meter);
+        polygonShape.Set(Span<const Length2D>(verts, 3));
+        m_targetBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        
+        //create dynamic circle body
+        BodyDef myBodyDef;
+        myBodyDef.type = BodyType::Dynamic;
+        myBodyDef.location = Vec2(-15, 5) * Meter;
+        m_launcherBody = m_world->CreateBody(myBodyDef);
+        DiskShape circleShape{DiskShape::Conf{}
+            .UseVertexRadius(2 * Meter)
+            .UseFriction(0.95f)
+            .UseDensity(1 * KilogramPerSquareMeter)};
+        m_launcherBody->CreateFixture(std::make_shared<DiskShape>(circleShape), myFixtureDef);
+        
+        //pin the circle in place
+        RevoluteJointDef revoluteJointDef;
+        revoluteJointDef.bodyA = m_groundBody;
+        revoluteJointDef.bodyB = m_launcherBody;
+        revoluteJointDef.localAnchorA = Length2D(-15 * Meter, 5 * Meter);
+        revoluteJointDef.localAnchorB = Length2D(0 * Meter, 0 * Meter);
+        revoluteJointDef.enableMotor = true;
+        revoluteJointDef.maxMotorTorque = 250 * NewtonMeter;
+        revoluteJointDef.motorSpeed = 0;
+        m_world->CreateJoint( revoluteJointDef );
+        
+        //create dynamic box body to fire
+        myBodyDef.location = Length2D(0 * Meter, -5 * Meter);//will be positioned later
+        m_littleBox = m_world->CreateBody(myBodyDef);
+        polygonShape.SetAsBox( 0.5f * Meter, 0.5f * Meter );
+        polygonShape.SetDensity(1 * KilogramPerSquareMeter);
+        m_littleBox->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
+        
+        //ball for computer 'player' to fire
+        m_littleBox2 = m_world->CreateBody(myBodyDef);
+        circleShape.SetRadius(BallSize * Meter);
+        m_littleBox2->CreateFixture(std::make_shared<DiskShape>(circleShape), myFixtureDef);
+        
+        m_firing = false;
+        m_littleBox->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+        m_launchSpeed = 10 * MeterPerSecond;
+        
+        m_firing2 = false;
+        m_littleBox2->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+        m_littleBox2->SetVelocity(Velocity{});
+
+        SetMouseWorld(Vec2(11,22) * Meter);//sometimes is not set
+    }
+    
+    //this just returns the current top edge of the golf-tee thingy
+    Length2D getComputerTargetPosition()
+    {
+        return GetLocation(*m_targetBody) + Vec2(0, BallSize + 0.01f ) * Meter;
+    }
+    
+    //basic trajectory 'point at timestep n' formula
+    Length2D getTrajectoryPoint(Length2D startingPosition, LinearVelocity2D startingVelocity,
+                                float n /*time steps*/ )
+    {
+        const auto t = Second / 60.0f;
+        const auto stepVelocity = t * startingVelocity; // m/s
+        const auto stepGravity = t * t * m_world->GetGravity(); // m/s/s
+        
+        return startingPosition + n * stepVelocity + 0.5f * (n*n+n) * stepGravity;
+    }
+    
+    //find out how many timesteps it will take for projectile to reach maximum height
+    float getTimestepsToTop(LinearVelocity2D startingVelocity)
+    {
+        const auto t = Second / 60.0f;
+        const auto stepVelocity = t * startingVelocity; // m/s
+        const auto stepGravity = t * t * m_world->GetGravity(); // m/s/s
+        return -GetY(stepVelocity) / GetY(stepGravity) - 1;
+    }
+    
+    //find out the maximum height for this parabola
+    Length getMaxHeight(Length2D startingPosition, LinearVelocity2D startingVelocity)
+    {
+        if ( GetY(startingVelocity) < 0 * MeterPerSecond)
+            return GetY(startingPosition);
+        
+        const auto t = Second / 60.0f;
+        const auto stepVelocity = t * startingVelocity; // m/s
+        const auto stepGravity = t * t * m_world->GetGravity(); // m/s/s
+        
+        const auto n = -GetY(stepVelocity) / GetY(stepGravity) - 1;
+        
+        return GetY(startingPosition) + n * GetY(stepVelocity) + 0.5f * (n*n+n) * GetY(stepGravity);
+    }
+    
+    //find the initial velocity necessary to reach a specified maximum height
+    LinearVelocity calculateVerticalVelocityForHeight(Length desiredHeight)
+    {
+        if ( desiredHeight <= 0 * Meter)
+            return 0 * MeterPerSecond;
+        
+        const auto t = Second / 60.0f;
+        const auto stepGravity = t * t * m_world->GetGravity(); // m/s/s
+        
+        //quadratic equation setup
+        const auto a = 0.5f / GetY(stepGravity);
+        const auto b = 0.5f;
+        const auto c = desiredHeight;
+        
+        const auto quadraticSolution1 = ( -b - Sqrt( b*b - 4*a*c ) ) / (2*a);
+        const auto quadraticSolution2 = ( -b + Sqrt( b*b - 4*a*c ) ) / (2*a);
+        
+        auto v = quadraticSolution1;
+        if ( v < decltype(v){} )
+            v = quadraticSolution2;
+        
+        return v * 60.0f / Second;
+    }
+    
+    //calculate how the computer should launch the ball with the current target location
+    LinearVelocity2D getComputerLaunchVelocity()
+    {
+        const auto targetLocation = getComputerTargetPosition();
+        const auto verticalVelocity = calculateVerticalVelocityForHeight(GetY(targetLocation) - 5 * Meter);//computer projectile starts at y = 5
+        const auto startingVelocity = LinearVelocity2D(0,verticalVelocity);//only interested in vertical here
+        const auto timestepsToTop = getTimestepsToTop(startingVelocity);
+        auto targetEdgePos = GetX(GetLocation(*m_targetBody));
+        if ( targetEdgePos > 15 * Meter )
+            targetEdgePos -= BallSize * Meter;
+        else
+            targetEdgePos += BallSize * Meter;
+        const auto distanceToTargetEdge = targetEdgePos - 15 * Meter;
+        const auto horizontalVelocity = 60 * distanceToTargetEdge / timestepsToTop / Second;
+        return LinearVelocity2D(horizontalVelocity, verticalVelocity);
+    }
+    
+    void KeyboardDown(Key key) override
+    {
+        switch (key) {
+            case Key_Q:
+            {
+                const auto launchSpeed = LinearVelocity2D(m_launchSpeed, 0 * MeterPerSecond);
+                m_littleBox->SetAwake();
+                m_littleBox->SetAcceleration(Gravity, AngularAcceleration{});
+                m_littleBox->SetVelocity(Velocity{});
+                m_littleBox->SetTransform(GetWorldPoint(*m_launcherBody, Vec2(3,0) * Meter),
+                                          m_launcherBody->GetAngle());
+                const auto rotVec = GetWorldVector(*m_launcherBody, UnitVec2::GetRight());
+                const auto speed = Rotate(launchSpeed, rotVec);
+                SetLinearVelocity(*m_littleBox, speed);
+                m_firing = true;
+                break;
+            }
+            case Key_W:
+                m_littleBox->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+                m_littleBox->SetVelocity(Velocity{});
+                m_firing = false;
+                break;
+            case Key_A:
+                m_launchSpeed *= 1.02f;
+                break;
+            case Key_S:
+                m_launchSpeed *= 0.98f;
+                break;
+                
+            case Key_D:
+            {
+                m_littleBox2->SetAwake();
+                m_littleBox2->SetAcceleration(Gravity, AngularAcceleration{});
+                m_littleBox2->SetVelocity(Velocity{});
+                const auto launchVel = getComputerLaunchVelocity();
+                const auto computerStartingPosition = Vec2(15,5) * Meter;
+                m_littleBox2->SetTransform(computerStartingPosition, 0 * Radian);
+                SetLinearVelocity(*m_littleBox2, launchVel );
+                m_firing2 = true;
+                break;
+            }
+            case Key_F:
+                m_littleBox2->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+                m_littleBox2->SetVelocity(Velocity{});
+                m_firing2 = false;
+                break;
+                
+            case Key_M:
+                m_targetBody->SetTransform(GetMouseWorld(), 0 * Radian); //m_mouseWorld is from Test class
+                break;
+                
+            default:
+                break;
+        }
+    }
+    
+    void PreStep(const Settings&, Drawer& drawer) override
+    {
+        const auto startingPosition = GetWorldPoint(*m_launcherBody, Vec2(3,0) * Meter);
+        const auto rotVec = GetWorldVector(*m_launcherBody, UnitVec2::GetRight());
+        const auto startingVelocity = Rotate(LinearVelocity2D(m_launchSpeed, 0 * MeterPerSecond), rotVec);
+        
+        if ( !m_firing )
+            m_littleBox->SetTransform( startingPosition, m_launcherBody->GetAngle() );
+
+        auto hit = false;
+        auto point = Length2D{};
+
+        //draw predicted trajectory
+        auto lastTP = startingPosition;
+        for (auto i = 0; i < 300; ++i) { //5 seconds, should be long enough to hit something
+            const auto trajectoryPosition = getTrajectoryPoint(startingPosition, startingVelocity, i);
+            
+            if (i > 0) {
+                m_world->RayCast(lastTP, trajectoryPosition, [&](Fixture* f, ChildCounter,
+                                                                 Length2D p, UnitVec2) {
+                    if (f->GetBody() == m_littleBox)
+                    {
+                        return World::RayCastOpcode::IgnoreFixture;
+                    }
+                    hit = true;
+                    point = p;
+                    return World::RayCastOpcode::Terminate;
+                });
+                if (hit) {
+                    if (i % 2 == 0)
+                    {
+                        drawer.DrawSegment(trajectoryPosition, point, Color(1, 1, 0));
+                    }
+                    break;
+                }
+            }
+            
+            if (i % 2 == 0)
+            {
+                drawer.DrawSegment(lastTP, trajectoryPosition, Color(1, 1, 0));
+            }
+            lastTP = trajectoryPosition;
+        }
+        
+        if (hit) {
+            //draw raycast intersect location
+            drawer.DrawPoint(point, 5, Color(0, 1, 1));
+        }
+        
+        //draw dot in center of fired box
+        const auto littleBoxPos = GetLocation(*m_littleBox);
+        drawer.DrawPoint(littleBoxPos, 5, Color(0, 1, 0));
+        
+        //draw maximum height line
+        const auto maxHeight = getMaxHeight( startingPosition, startingVelocity );
+        drawer.DrawSegment(Length2D(-20 * Meter, maxHeight), Length2D(+20 * Meter, maxHeight),
+                           Color(1, 1, 1, 0.5f));
+        
+        //draw line to indicate velocity computer player will fire at
+        const auto launchVel = getComputerLaunchVelocity();
+        const auto computerStartingPosition = Vec2(15,5) * Meter;
+        const auto displayVelEndPoint = computerStartingPosition + 0.1f * launchVel * Second;
+        drawer.DrawSegment(computerStartingPosition, Color(1, 0, 0),
+                           displayVelEndPoint, Color(0, 1, 0));
+        
+        if (!m_firing2)
+            m_littleBox2->SetTransform(computerStartingPosition, 0 * Radian);
+    }
+    
+    void PostStep(const Settings&, Drawer& drawer) override
+    {
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Rotate the circle on the left to change launch direction");
+        m_textLine += 15;
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Use a/s to change the launch speed");
+        m_textLine += 15;
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Use q/w to launch and reset the projectile");
+        m_textLine += 15;
+        m_textLine += 15;
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Use d/f to launch and reset the computer controlled projectile");
+        m_textLine += 15;
+        drawer.DrawString(5, m_textLine, Drawer::Left,
+                          "Hold down m and use the left mouse button to move the computer's target");
+        m_textLine += 15;
+    }
+    
+    static Test* Create()
+    {
+        return new iforce2d_Trajectories;
+    }
+    
+    Body* m_groundBody;
+    Body* m_launcherBody;
+    Body* m_littleBox;
+    Body* m_littleBox2;
+    Body* m_targetBody;
+    bool m_firing;
+    bool m_firing2;
+    LinearVelocity m_launchSpeed;
+    const LinearAcceleration2D Gravity{0 * MeterPerSquareSecond, -10 * MeterPerSquareSecond};
+    const Real BallSize = 0.25f;
+};
+
+} // namespace playrho
+
+#endif // IFORCE2D_TRAJECTORIES_HPP

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -795,12 +795,12 @@ TEST(World, StepZeroTimeDoesNothing)
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.position = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
+    def.location = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
     ASSERT_NE(body, nullptr);
-    EXPECT_EQ(body->GetLocation(), def.position);
+    EXPECT_EQ(body->GetLocation(), def.location);
     EXPECT_EQ(GetX(GetLinearVelocity(*body)), Real(0) * MeterPerSecond);
     EXPECT_EQ(GetY(GetLinearVelocity(*body)), Real(0) * MeterPerSecond);
     EXPECT_EQ(GetX(body->GetLinearAcceleration()), Real{0.0f} * MeterPerSquareSecond);
@@ -816,7 +816,7 @@ TEST(World, StepZeroTimeDoesNothing)
         
         EXPECT_EQ(GetY(body->GetLinearAcceleration()), GetY(gravity));
         
-        EXPECT_EQ(GetX(body->GetLocation()), GetX(def.position));
+        EXPECT_EQ(GetX(body->GetLocation()), GetX(def.location));
         EXPECT_EQ(GetY(body->GetLocation()), GetY(pos));
         pos = body->GetLocation();
         
@@ -832,7 +832,7 @@ TEST(World, GravitationalBodyMovement)
 
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
-    body_def.position = p0;
+    body_def.location = p0;
 
     const auto a = Real(-10);
     const auto gravity = LinearAcceleration2D{0, a * MeterPerSquareSecond};
@@ -877,12 +877,12 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.position = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
+    def.location = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
     ASSERT_NE(body, nullptr);
-    EXPECT_EQ(body->GetLocation(), def.position);
+    EXPECT_EQ(body->GetLocation(), def.location);
     EXPECT_EQ(GetX(GetLinearVelocity(*body)), Real(0) * MeterPerSecond);
     EXPECT_EQ(GetY(GetLinearVelocity(*body)), Real(0) * MeterPerSecond);
     EXPECT_EQ(GetX(body->GetLinearAcceleration()), Real{0.0f} * MeterPerSquareSecond);
@@ -898,7 +898,7 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
         
         EXPECT_EQ(GetY(body->GetLinearAcceleration()), GetY(gravity));
         
-        EXPECT_EQ(GetX(body->GetLocation()), GetX(def.position));
+        EXPECT_EQ(GetX(body->GetLocation()), GetX(def.location));
         EXPECT_LT(GetY(body->GetLocation()), GetY(pos));
         EXPECT_EQ(GetY(body->GetLocation()), GetY(pos) + ((GetY(vel) + GetY(gravity) * time_inc) * time_inc));
         pos = body->GetLocation();
@@ -918,13 +918,13 @@ TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.position = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
+    def.location = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
     def.linearVelocity = LinearVelocity2D{0, Real(-9.8) * MeterPerSecond};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
     ASSERT_NE(body, nullptr);
-    EXPECT_EQ(body->GetLocation(), def.position);
+    EXPECT_EQ(body->GetLocation(), def.location);
     EXPECT_EQ(GetX(GetLinearVelocity(*body)), Real(0) * MeterPerSecond);
     EXPECT_EQ(GetY(GetLinearVelocity(*body)), Real(-9.8) * MeterPerSecond);
     EXPECT_EQ(GetX(body->GetLinearAcceleration()), Real{0.0f} * MeterPerSquareSecond);
@@ -947,7 +947,7 @@ TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
         
         EXPECT_EQ(GetY(body->GetLinearAcceleration()), GetY(gravity));
         
-        EXPECT_EQ(GetX(body->GetLocation()), GetX(def.position));
+        EXPECT_EQ(GetX(body->GetLocation()), GetX(def.location));
         EXPECT_GT(GetY(body->GetLocation()), GetY(pos));
         EXPECT_EQ(GetY(body->GetLocation()), GetY(pos) + ((GetY(vel) + GetY(gravity) * time_inc) * time_inc));
         pos = body->GetLocation();
@@ -1047,7 +1047,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     shape->SetDensity(Real{1} * KilogramPerSquareMeter);
     shape->SetRestitution(Real(1));
     
-    body_def.position = Length2D{-x * Meter, Real(0) * Meter};
+    body_def.location = Length2D{-x * Meter, Real(0) * Meter};
     body_def.linearVelocity = LinearVelocity2D{+x * MeterPerSecond, Real(0) * MeterPerSecond};
     const auto body_a = world.CreateBody(body_def);
     ASSERT_NE(body_a, nullptr);
@@ -1057,7 +1057,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     const auto fixture1 = body_a->CreateFixture(shape);
     ASSERT_NE(fixture1, nullptr);
     
-    body_def.position = Length2D{+x * Meter, Real(0) * Meter};
+    body_def.location = Length2D{+x * Meter, Real(0) * Meter};
     body_def.linearVelocity = LinearVelocity2D{-x * MeterPerSecond, Real(0) * MeterPerSecond};
     const auto body_b = world.CreateBody(body_def);
     ASSERT_NE(body_b, nullptr);
@@ -1309,28 +1309,28 @@ TEST(World, PerfectlyOverlappedSameCirclesStayPut)
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.position = Length2D{Real(0) * Meter, Real(0) * Meter};
+    body_def.location = Length2D{Real(0) * Meter, Real(0) * Meter};
 
     const auto body1 = world.CreateBody(body_def);
     {
         const auto fixture = body1->CreateFixture(shape);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body1->GetLocation(), body_def.position);
+    ASSERT_EQ(body1->GetLocation(), body_def.location);
     
     const auto body2 = world.CreateBody(body_def);
     {
         const auto fixture = body2->CreateFixture(shape);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body2->GetLocation(), body_def.position);
+    ASSERT_EQ(body2->GetLocation(), body_def.location);
     
     const auto time_inc = Real(.01);
     for (auto i = 0; i < 100; ++i)
     {
         Step(world, Time{Second * time_inc});
-        EXPECT_EQ(body1->GetLocation(), body_def.position);
-        EXPECT_EQ(body2->GetLocation(), body_def.position);
+        EXPECT_EQ(body1->GetLocation(), body_def.location);
+        EXPECT_EQ(body2->GetLocation(), body_def.location);
     }
 }
 
@@ -1354,28 +1354,28 @@ TEST(World, PerfectlyOverlappedConcentricCirclesStayPut)
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.position = Length2D{};
+    body_def.location = Length2D{};
     
     const auto body1 = world.CreateBody(body_def);
     {
         const auto fixture = body1->CreateFixture(shape1);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body1->GetLocation(), body_def.position);
+    ASSERT_EQ(body1->GetLocation(), body_def.location);
     
     const auto body2 = world.CreateBody(body_def);
     {
         const auto fixture = body2->CreateFixture(shape2);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body2->GetLocation(), body_def.position);
+    ASSERT_EQ(body2->GetLocation(), body_def.location);
     
     const auto time_inc = Real(.01);
     for (auto i = 0; i < 100; ++i)
     {
         Step(world, Time{Second * time_inc});
-        EXPECT_EQ(body1->GetLocation(), body_def.position);
-        EXPECT_EQ(body2->GetLocation(), body_def.position);
+        EXPECT_EQ(body1->GetLocation(), body_def.location);
+        EXPECT_EQ(body2->GetLocation(), body_def.location);
     }
 }
 
@@ -1391,7 +1391,7 @@ TEST(World, ListenerCalledForCircleBodyWithinCircleBody)
 
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
-    body_def.position = Length2D{};
+    body_def.location = Length2D{};
     const auto shape = std::make_shared<DiskShape>(Real{1} * Meter);
     shape->SetDensity(Real{1} * KilogramPerSquareMeter);
     shape->SetRestitution(Real(1));
@@ -1427,7 +1427,7 @@ TEST(World, ListenerCalledForSquareBodyWithinSquareBody)
     
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
-    body_def.position = Length2D{};
+    body_def.location = Length2D{};
     auto shape = std::make_shared<PolygonShape>();
     shape->SetVertexRadius(Real{1} * Meter);
     shape->SetAsBox(Real{2} * Meter, Real{2} * Meter);
@@ -1469,22 +1469,22 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
     
     const auto body1pos = Length2D{-radius/Real(4) * Meter, Real(0) * Meter};
-    body_def.position = body1pos;
+    body_def.location = body1pos;
     const auto body1 = world.CreateBody(body_def);
     {
         const auto fixture = body1->CreateFixture(shape);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body1->GetLocation(), body_def.position);
+    ASSERT_EQ(body1->GetLocation(), body_def.location);
     
     const auto body2pos = Length2D{+radius/Real(4) * Meter, Real(0) * Meter};
-    body_def.position = body2pos;
+    body_def.location = body2pos;
     const auto body2 = world.CreateBody(body_def);
     {
         const auto fixture = body2->CreateFixture(shape);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body2->GetLocation(), body_def.position);
+    ASSERT_EQ(body2->GetLocation(), body_def.location);
     
     auto position_diff = body2pos - body1pos;
     auto distance = GetLength(position_diff);
@@ -1566,21 +1566,21 @@ TEST(World, PerfectlyOverlappedSameSquaresSeparateHorizontally)
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.position = Length2D{};
+    body_def.location = Length2D{};
     
     const auto body1 = world.CreateBody(body_def);
     {
         const auto fixture = body1->CreateFixture(shape);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body1->GetLocation(), body_def.position);
+    ASSERT_EQ(body1->GetLocation(), body_def.location);
     
     const auto body2 = world.CreateBody(body_def);
     {
         const auto fixture = body2->CreateFixture(shape);
         ASSERT_NE(fixture, nullptr);
     }
-    ASSERT_EQ(body2->GetLocation(), body_def.position);
+    ASSERT_EQ(body2->GetLocation(), body_def.location);
     
     auto lastpos1 = body1->GetLocation();
     auto lastpos2 = body2->GetLocation();
@@ -1633,7 +1633,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
     
     const auto body1pos = Length2D{Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
-    body_def.position = body1pos;
+    body_def.location = body1pos;
     const auto body1 = world.CreateBody(body_def);
     {
         const auto fixture = body1->CreateFixture(shape);
@@ -1642,7 +1642,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     ASSERT_EQ(body1->GetLocation(), body1pos);
     
     const auto body2pos = Length2D{-Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
-    body_def.position = body2pos;
+    body_def.location = body2pos;
     const auto body2 = world.CreateBody(body_def);
     {
         const auto fixture = body2->CreateFixture(shape);
@@ -1790,7 +1790,7 @@ TEST(World, CollidingDynamicBodies)
     shape->SetDensity(Real{1} * KilogramPerSquareMeter);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
 
-    body_def.position = Length2D{-(x + 1) * Meter, Real(0) * Meter};
+    body_def.location = Length2D{-(x + 1) * Meter, Real(0) * Meter};
     body_def.linearVelocity = LinearVelocity2D{+x * MeterPerSecond, Real(0) * MeterPerSecond};
     const auto body_a = world.CreateBody(body_def);
     ASSERT_NE(body_a, nullptr);
@@ -1800,7 +1800,7 @@ TEST(World, CollidingDynamicBodies)
     const auto fixture1 = body_a->CreateFixture(shape);
     ASSERT_NE(fixture1, nullptr);
 
-    body_def.position = Length2D{+(x + 1) * Meter, Real(0) * Meter};
+    body_def.location = Length2D{+(x + 1) * Meter, Real(0) * Meter};
     body_def.linearVelocity = LinearVelocity2D{-x * MeterPerSecond, Real(0) * MeterPerSecond};
     const auto body_b = world.CreateBody(body_def);
     ASSERT_NE(body_b, nullptr);
@@ -2259,7 +2259,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     BodyDef body_def;
     body_def.type = BodyType::Static;
 
-    body_def.position = Length2D{left_edge_x, Real{0} * Meter};
+    body_def.location = Length2D{left_edge_x, Real{0} * Meter};
     const auto left_wall_body = world.CreateBody(body_def);
     ASSERT_NE(left_wall_body, nullptr);
     {
@@ -2267,7 +2267,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
         ASSERT_NE(wall_fixture, nullptr);
     }
 
-    body_def.position = Length2D{right_edge_x, Real{0} * Meter};
+    body_def.location = Length2D{right_edge_x, Real{0} * Meter};
     const auto right_wall_body = world.CreateBody(body_def);
     ASSERT_NE(right_wall_body, nullptr);
     {
@@ -2278,7 +2278,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto begin_x = Real(0);
 
     body_def.type = BodyType::Dynamic;
-    body_def.position = Length2D{begin_x * Meter, Real(0) * Meter};
+    body_def.location = Length2D{begin_x * Meter, Real(0) * Meter};
     body_def.bullet = false;
     const auto ball_body = world.CreateBody(body_def);
     ASSERT_NE(ball_body, nullptr);
@@ -2438,7 +2438,7 @@ TEST(World, MouseJointWontCauseTunnelling)
     edge_shape.Set(Length2D{0, +half_box_height * Real(2) * Meter},
                    Length2D{0, -half_box_height * Real(2) * Meter});
 
-    body_def.position = Length2D{left_edge_x * Meter, Real(0) * Meter};
+    body_def.location = Length2D{left_edge_x * Meter, Real(0) * Meter};
     {
         const auto left_wall_body = world.CreateBody(body_def);
         ASSERT_NE(left_wall_body, nullptr);
@@ -2449,7 +2449,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         Include(container_aabb, ComputeAABB(*left_wall_body));
     }
     
-    body_def.position = Length2D{right_edge_x * Meter, Real(0) * Meter};
+    body_def.location = Length2D{right_edge_x * Meter, Real(0) * Meter};
     {
         const auto right_wall_body = world.CreateBody(body_def);
         ASSERT_NE(right_wall_body, nullptr);
@@ -2464,7 +2464,7 @@ TEST(World, MouseJointWontCauseTunnelling)
     edge_shape.Set(Length2D{-half_box_width * Real(2) * Meter, Real(0) * Meter},
                    Length2D{+half_box_width * Real(2) * Meter, Real(0) * Meter});
     
-    body_def.position = Length2D{0, btm_edge_y * Meter};
+    body_def.location = Length2D{0, btm_edge_y * Meter};
     {
         const auto btm_wall_body = world.CreateBody(body_def);
         ASSERT_NE(btm_wall_body, nullptr);
@@ -2475,7 +2475,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         Include(container_aabb, ComputeAABB(*btm_wall_body));
     }
     
-    body_def.position = Length2D{0, top_edge_y * Meter};
+    body_def.location = Length2D{0, top_edge_y * Meter};
     {
         const auto top_wall_body = world.CreateBody(body_def);
         ASSERT_NE(top_wall_body, nullptr);
@@ -2487,7 +2487,7 @@ TEST(World, MouseJointWontCauseTunnelling)
     }
 
     body_def.type = BodyType::Dynamic;
-    body_def.position = Length2D{};
+    body_def.location = Length2D{};
     body_def.bullet = true;
     
     const auto ball_body = world.CreateBody(body_def);
@@ -2511,7 +2511,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         const auto angle = i * 2 * Pi / numBodies;
         const auto x = ball_radius * Real(2.1) * Real(std::cos(angle));
         const auto y = ball_radius * Real(2.1) * Real(std::sin(angle));
-        body_def.position = Length2D{x, y};
+        body_def.location = Length2D{x, y};
         bodies[i] = world.CreateBody(body_def);
         ASSERT_NE(bodies[i], nullptr);
         ASSERT_EQ(GetX(bodies[i]->GetLocation()), x);


### PR DESCRIPTION
#### Description - What's this PR do?
- Adds iforce2d's Trajectories demo to Testbed.
- Renames BodyDef::position to location to avoid confusion with the Position data structure that includes the angular orientation.
- Adds a segment drawing method that takes two colors.
- Adds Test::GetMouseWorld and Test::SetMouseWorld methods.
