### PR TITLE
Adds more unit test code.

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		472724231E310BB400C64921 /* Real.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 472724221E310BB400C64921 /* Real.cpp */; };
 		472724251E310C7600C64921 /* float.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 472724241E310C7600C64921 /* float.cpp */; };
 		472724301E315E1A00C64921 /* Fixed.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4727242D1E315E1A00C64921 /* Fixed.hpp */; };
+		472D35381F98C56200574B73 /* Intervals.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 472D35361F98C56200574B73 /* Intervals.hpp */; };
 		472E24661F82C4EA0051E192 /* Interval.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 472E24651F82C4EA0051E192 /* Interval.cpp */; };
 		472E301B1DBA925500DA821D /* VertexSet.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 472E30181DBA925500DA821D /* VertexSet.hpp */; };
 		472E301E1DBA98BC00DA821D /* VertexSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 472E301D1DBA98BC00DA821D /* VertexSet.cpp */; };
@@ -404,6 +405,7 @@
 		472724241E310C7600C64921 /* float.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = float.cpp; sourceTree = "<group>"; };
 		4727242D1E315E1A00C64921 /* Fixed.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Fixed.hpp; sourceTree = "<group>"; };
 		472D35331F968FB100574B73 /* UiState.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = UiState.hpp; sourceTree = "<group>"; };
+		472D35361F98C56200574B73 /* Intervals.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Intervals.hpp; sourceTree = "<group>"; };
 		472E24651F82C4EA0051E192 /* Interval.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Interval.cpp; sourceTree = "<group>"; };
 		472E24681F83301D0051E192 /* BreakableTwo.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BreakableTwo.hpp; sourceTree = "<group>"; };
 		472E30181DBA925500DA821D /* VertexSet.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VertexSet.hpp; sourceTree = "<group>"; };
@@ -951,6 +953,7 @@
 				47B58F5C1F5B314400354C34 /* FlagGuard.hpp */,
 				80BB8943141C3E5900F1753A /* GrowableStack.hpp */,
 				47D28D9F1F72B9340094C032 /* Interval.hpp */,
+				472D35361F98C56200574B73 /* Intervals.hpp */,
 				470F9B3A1EE63515007EF7B6 /* InvalidArgument.hpp */,
 				4787D6E91F2FA0CA008C115E /* LengthError.hpp */,
 				471E7EA81F32668E00DFF626 /* Matrix.hpp */,
@@ -1271,6 +1274,7 @@
 				4787D6BF1F2E968E008C115E /* JointDef.hpp in Headers */,
 				80BB8996141C3E5900F1753A /* ChainShape.hpp in Headers */,
 				470F94BA1EC4D4F800AA3C82 /* FixtureAtty.hpp in Headers */,
+				472D35381F98C56200574B73 /* Intervals.hpp in Headers */,
 				470F94AE1EC4CAE600AA3C82 /* FixtureDef.hpp in Headers */,
 				4734B2211DC1340500F15E29 /* Span.hpp in Headers */,
 				80BB8998141C3E5900F1753A /* DiskShape.hpp in Headers */,

--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -34,7 +34,7 @@ int main()
     // Construct a world object, which will hold and simulate bodies.
     auto world = World{};
 
-    // Call the body factory which allocates memory for the ground body.
+    // Call world's body creation method which allocates memory for ground body.
     // The body is also added to the world.
     const auto ground = world.CreateBody(BodyDef{}
                                          .UseLocation(Length2D{0 * Meter, -10 * Meter}));
@@ -46,7 +46,7 @@ int main()
     // Add the box shape to the ground body.
     ground->CreateFixture(box);
 
-    // Define a location above the ground for a "dynamic" body and call the body factory.
+    // Define location above ground for a "dynamic" body & call world's body creation method.
     const auto ball = world.CreateBody(BodyDef{}
                                        .UseLocation(Length2D{0 * Meter, 4 * Meter})
                                        .UseType(BodyType::Dynamic));

--- a/PlayRho/Common/Intervals.hpp
+++ b/PlayRho/Common/Intervals.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+
+#ifndef PLAYRHO_COMMON_INTERVALS_HPP
+#define PLAYRHO_COMMON_INTERVALS_HPP
+
+#include <PlayRho/Common/Interval.hpp>
+#include <PlayRho/Common/Units.hpp>
+
+namespace playrho {
+    
+    /// @brief Length Interval alias.
+    /// @relatedalso Interval
+    using LengthInterval = Interval<Length>;
+
+} // namespace playrho
+
+#endif // PLAYRHO_COMMON_INTERVALS_HPP

--- a/PlayRho/Common/Transformation.hpp
+++ b/PlayRho/Common/Transformation.hpp
@@ -33,14 +33,15 @@ namespace playrho
 {
     
     /// @brief Describes a geometric transformation.
-    /// @details
-    /// A transform contains translation and rotation. It is used to represent
-    /// the position and orientation of rigid frames.
+    /// @details A transform contains translation and rotation. It is used to represent
+    ///   the position and orientation of rigid frames.
+    /// @note The default transformation is the identity transformation - the transformation
+    ///   which neither translates nor rotates a location.
     /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
     struct Transformation
     {
-        Length2D p; ///< Translational portion of the transformation. 8-bytes.
-        UnitVec2 q; ///< Rotational portion of the transformation. 8-bytes.
+        Length2D p = Length2D{}; ///< Translational portion of the transformation. 8-bytes.
+        UnitVec2 q = UnitVec2::GetRight(); ///< Rotational portion of the transformation. 8-bytes.
     };
     
     /// @brief Identity transformation value.

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -155,8 +155,14 @@ public:
     /// @note This function should not be called if the world is locked.
     /// @warning This function is locked during callbacks.
     ///
-    /// @return <code>nullptr</code> if the world is locked or a parameter is dissallowed.
-    ///   A pointer to the created fixture otherwise.
+    /// @return Pointer to the created fixture.
+    ///
+    /// @throws WrongState if called while the world is "locked".
+    /// @throws InvalidArgument if called without a shape.
+    /// @throws InvalidArgument if called for a shape with a vertex radius less than the
+    ///    minimum vertex radius.
+    /// @throws InvalidArgument if called for a shape with a vertex radius greater than the
+    ///    maximum vertex radius.
     ///
     Fixture* CreateFixture(const std::shared_ptr<const Shape>& shape,
                            const FixtureDef& def = GetDefaultFixtureDef(),

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -68,6 +68,8 @@ inline Real MixRestitution(Real restitution1, Real restitution2) noexcept
 ///   AABB in the broad-phase (except if filtered). Therefore a contact object may exist
 ///   that has no actual contact points.
 ///
+/// @note These are created by World instances. Users have no need to instantiate these
+///   themselves.
 /// @note This data structure is 104-bytes large (on at least one 64-bit platform).
 ///
 class Contact
@@ -96,6 +98,7 @@ public:
     ///   and may not be the same or have the same body as the other fixture.
     /// @param iB Child index B.
     ///
+    /// @note This need never be called directly by a user.
     /// @warning Behavior is undefined if <code>fA</code> is null.
     /// @warning Behavior is undefined if <code>fB</code> is null.
     /// @warning Behavior is undefined if <code>fA == fB</code>.

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -48,7 +48,7 @@ class Shape;
 /// such as collision filters, etc.
 ///
 /// @warning you cannot reuse fixtures.
-/// @note Fixtures are created via Body::CreateFixture.
+/// @note Fixtures should be created using the Body::CreateFixture method.
 /// @note This structure is 56-bytes large (using a 4-byte Real on at least one 64-bit
 ///   architecture/build).
 ///

--- a/PlayRho/Dynamics/FixtureProxy.hpp
+++ b/PlayRho/Dynamics/FixtureProxy.hpp
@@ -42,6 +42,20 @@ struct FixtureProxy
     size_type treeId;
 };
 
+/// @brief Equality operator
+/// @relatedalso FixtureProxy
+constexpr bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+{
+    return lhs.treeId == rhs.treeId;
+}
+
+/// @brief Inequality operator
+/// @relatedalso FixtureProxy
+constexpr bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+{
+    return !(lhs.treeId == rhs.treeId);
+}
+
 } // namespace playrho
 
 #endif // PLAYRHO_DYNAMICS_FIXTUREPROXY_HPP

--- a/PlayRho/Dynamics/Joints/GearJoint.hpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.hpp
@@ -112,9 +112,9 @@ private:
     Momentum m_impulse = Momentum{0};
 
     // Solver temp
-    Vec2 m_JvAC;
+    Vec2 m_JvAC = Vec2_zero;
     Vec2 m_JvBD;
-    Length m_JwA;
+    Length m_JwA = Length{0};
     Length m_JwB;
     Length m_JwC;
     Length m_JwD;

--- a/PlayRho/Dynamics/Joints/MotorJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.cpp
@@ -232,25 +232,10 @@ Length2D MotorJoint::GetAnchorB() const
     return GetBodyB()->GetLocation();
 }
 
-Momentum2D MotorJoint::GetLinearReaction() const
-{
-    return m_linearImpulse;
-}
-
-AngularMomentum MotorJoint::GetAngularReaction() const
-{
-    return m_angularImpulse;
-}
-
 void MotorJoint::SetCorrectionFactor(Real factor)
 {
     assert(IsValid(factor) && (0 <= factor) && (factor <= Real{1}));
     m_correctionFactor = factor;
-}
-
-Real MotorJoint::GetCorrectionFactor() const
-{
-    return m_correctionFactor;
 }
 
 void MotorJoint::SetLinearOffset(const Length2D linearOffset)
@@ -264,11 +249,6 @@ void MotorJoint::SetLinearOffset(const Length2D linearOffset)
     }
 }
 
-const Length2D MotorJoint::GetLinearOffset() const
-{
-    return m_linearOffset;
-}
-
 void MotorJoint::SetAngularOffset(Angle angularOffset)
 {
     if (angularOffset != m_angularOffset)
@@ -278,11 +258,6 @@ void MotorJoint::SetAngularOffset(Angle angularOffset)
         GetBodyA()->SetAwake();
         GetBodyB()->SetAwake();
     }
-}
-
-Angle MotorJoint::GetAngularOffset() const
-{
-    return m_angularOffset;
 }
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/MotorJoint.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.hpp
@@ -49,35 +49,35 @@ public:
     Momentum2D GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
+    /// @brief Gets the target linear offset, in frame A.
+    Length2D GetLinearOffset() const noexcept;
+
     /// @brief Sets the target linear offset, in frame A.
     void SetLinearOffset(const Length2D linearOffset);
 
-    /// @brief Gets the target linear offset, in frame A.
-    const Length2D GetLinearOffset() const;
+    /// @brief Gets the target angular offset.
+    Angle GetAngularOffset() const noexcept;
 
     /// @brief Sets the target angular offset.
     void SetAngularOffset(Angle angularOffset);
 
-    /// @brief Gets the target angular offset.
-    Angle GetAngularOffset() const;
+    /// @brief Gets the maximum friction force.
+    NonNegative<Force> GetMaxForce() const noexcept;
 
     /// @brief Sets the maximum friction force.
     void SetMaxForce(NonNegative<Force> force);
 
-    /// @brief Gets the maximum friction force.
-    NonNegative<Force> GetMaxForce() const;
+    /// @brief Gets the maximum friction torque.
+    NonNegative<Torque> GetMaxTorque() const noexcept;
 
-    /// Set the maximum friction torque.
+    /// @brief Sets the maximum friction torque.
     void SetMaxTorque(NonNegative<Torque> torque);
 
-    /// Get the maximum friction torque.
-    NonNegative<Torque> GetMaxTorque() const;
+    /// @brief Gets the position correction factor in the range [0,1].
+    Real GetCorrectionFactor() const noexcept;
 
-    /// Set the position correction factor in the range [0,1].
+    /// @brief Sets the position correction factor in the range [0,1].
     void SetCorrectionFactor(Real factor);
-
-    /// Get the position correction factor in the range [0,1].
-    Real GetCorrectionFactor() const;
 
 private:
 
@@ -105,14 +105,19 @@ private:
     RotInertia m_angularMass;
 };
 
+inline NonNegative<Force> MotorJoint::GetMaxForce() const noexcept
+{
+    return m_maxForce;
+}
+
 inline void MotorJoint::SetMaxForce(NonNegative<Force> force)
 {
     m_maxForce = force;
 }
 
-inline NonNegative<Force> MotorJoint::GetMaxForce() const
+inline NonNegative<Torque> MotorJoint::GetMaxTorque() const noexcept
 {
-    return m_maxForce;
+    return m_maxTorque;
 }
 
 inline void MotorJoint::SetMaxTorque(NonNegative<Torque> torque)
@@ -120,9 +125,29 @@ inline void MotorJoint::SetMaxTorque(NonNegative<Torque> torque)
     m_maxTorque = torque;
 }
 
-inline NonNegative<Torque> MotorJoint::GetMaxTorque() const
+inline Length2D MotorJoint::GetLinearOffset() const noexcept
 {
-    return m_maxTorque;
+    return m_linearOffset;
+}
+
+inline Angle MotorJoint::GetAngularOffset() const noexcept
+{
+    return m_angularOffset;
+}
+
+inline Momentum2D MotorJoint::GetLinearReaction() const
+{
+    return m_linearImpulse;
+}
+
+inline AngularMomentum MotorJoint::GetAngularReaction() const
+{
+    return m_angularImpulse;
+}
+
+inline Real MotorJoint::GetCorrectionFactor() const noexcept
+{
+    return m_correctionFactor;
 }
 
 } // namespace playrho

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -86,7 +86,9 @@ TEST(DistanceJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
+
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
     EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);
     EXPECT_EQ(joint.GetLength(), def.length);

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -20,6 +20,7 @@
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/World.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Collision/Shapes/DiskShape.hpp>
 
 using namespace playrho;
@@ -58,12 +59,12 @@ TEST(Fixture, CreateMatchesDef)
     
     EXPECT_EQ(fixture->GetBody(), body);
     EXPECT_EQ(fixture->GetShape(), shapeA);
-
     EXPECT_EQ(fixture->GetDensity(), density);
     EXPECT_EQ(fixture->GetFriction(), friction);
     EXPECT_EQ(fixture->GetUserData(), userData);
     EXPECT_EQ(fixture->GetRestitution(), restitution);
     EXPECT_EQ(fixture->IsSensor(), isSensor);
+    EXPECT_EQ(fixture->GetProxyCount(), 0);
 }
 
 TEST(Fixture, SetSensor)
@@ -105,4 +106,55 @@ TEST(Fixture, SetAwakeFreeFunction)
     const auto fixture = body->CreateFixture(shapeA);
     SetAwake(*fixture);
     EXPECT_TRUE(body->IsAwake());
+}
+
+TEST(Fixture, CopyConstructor)
+{
+    const auto density = Real{2} * KilogramPerSquareMeter;
+    int variable;
+    const auto userData = &variable;
+    const auto friction = Real(0.5);
+    const auto restitution = Real(0.4);
+    const auto isSensor = true;
+    const auto shapeA = std::make_shared<DiskShape>();
+    shapeA->SetFriction(friction);
+    shapeA->SetRestitution(restitution);
+    shapeA->SetDensity(density);
+    
+    auto def = FixtureDef{};
+    def.userData = userData;
+    def.isSensor = isSensor;
+    
+    World world;
+    const auto body = world.CreateBody();
+    const auto fixture = body->CreateFixture(shapeA, def);
+    
+    ASSERT_EQ(fixture->GetBody(), body);
+    ASSERT_EQ(fixture->GetShape(), shapeA);
+    ASSERT_EQ(fixture->GetDensity(), density);
+    ASSERT_EQ(fixture->GetFriction(), friction);
+    ASSERT_EQ(fixture->GetUserData(), userData);
+    ASSERT_EQ(fixture->GetRestitution(), restitution);
+    ASSERT_EQ(fixture->IsSensor(), isSensor);
+    ASSERT_EQ(fixture->GetProxyCount(), 0);
+
+    const auto stepConf = StepConf{};
+    world.Step(stepConf);
+    ASSERT_EQ(fixture->GetProxyCount(), 1);
+    ASSERT_EQ(fixture->GetProxy(0), FixtureProxy{0});
+
+    Fixture copy{*fixture};
+    
+    EXPECT_EQ(copy.GetBody(), body);
+    EXPECT_EQ(copy.GetShape(), shapeA);
+    EXPECT_EQ(copy.GetDensity(), density);
+    EXPECT_EQ(copy.GetFriction(), friction);
+    EXPECT_EQ(copy.GetUserData(), userData);
+    EXPECT_EQ(copy.GetRestitution(), restitution);
+    EXPECT_EQ(copy.IsSensor(), isSensor);
+    EXPECT_EQ(copy.GetProxyCount(), fixture->GetProxyCount());
+    if (copy.GetProxyCount() == fixture->GetProxyCount())
+    {
+        EXPECT_EQ(copy.GetProxy(0), fixture->GetProxy(0));
+    }
 }

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -80,6 +80,8 @@ TEST(FrictionJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
     
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
     EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -95,6 +95,8 @@ TEST(GearJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.joint2->GetBodyB());
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
     
     EXPECT_EQ(joint.GetLocalAnchorA(), revJoint1.GetLocalAnchorB());
     EXPECT_EQ(joint.GetLocalAnchorB(), revJoint2.GetLocalAnchorB());

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -77,7 +77,9 @@ TEST(MotorJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
+
     EXPECT_EQ(joint.GetLinearOffset(), def.linearOffset);
     EXPECT_EQ(joint.GetAngularOffset(), def.angularOffset);
     EXPECT_EQ(joint.GetMaxForce(), def.maxForce);
@@ -152,4 +154,28 @@ TEST(MotorJoint, WithDynamicCircles)
     EXPECT_NEAR(double(Real{GetY(b2->GetLocation()) / Meter}), 0.0, 0.01);
     EXPECT_EQ(b1->GetAngle(), Angle{0});
     EXPECT_EQ(b2->GetAngle(), Angle{0});
+}
+
+TEST(MotorJoint, SetLinearOffset)
+{
+    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    b1->CreateFixture(circle);
+    b2->CreateFixture(circle);
+    //const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    const auto jd = MotorJointDef{b1, b2};
+    const auto joint = static_cast<MotorJoint*>(world.CreateJoint(jd));
+    ASSERT_NE(joint, nullptr);
+    EXPECT_EQ(joint->GetAnchorA(), p1);
+    EXPECT_EQ(joint->GetAnchorB(), p2);
+    
+    const auto linearOffset = Length2D{2 * Meter, 1 * Meter};
+    ASSERT_EQ(joint->GetLinearOffset(), jd.linearOffset);
+    ASSERT_NE(jd.linearOffset, linearOffset);
+    joint->SetLinearOffset(linearOffset);
+    EXPECT_EQ(joint->GetLinearOffset(), linearOffset);
 }

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -69,7 +69,9 @@ TEST(PulleyJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
+
     EXPECT_EQ(joint.GetGroundAnchorA(), def.groundAnchorA);
     EXPECT_EQ(joint.GetGroundAnchorB(), def.groundAnchorB);
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -71,7 +71,9 @@ TEST(RevoluteJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), jd.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), jd.collideConnected);
     EXPECT_EQ(joint.GetUserData(), jd.userData);
-    
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
+
     EXPECT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
     EXPECT_EQ(joint.GetLocalAnchorB(), jd.localAnchorB);
     EXPECT_EQ(joint.GetLowerLimit(), jd.lowerAngle);

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -75,7 +75,9 @@ TEST(RopeJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
+
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
     EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);
     EXPECT_EQ(joint.GetMaxLength(), def.maxLength);

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -32,6 +32,13 @@ TEST(Transformation, ByteSizeIs_16_32_or_64)
     }
 }
 
+TEST(Transformation, DefaultConstruct)
+{
+    const Transformation xfm;
+    EXPECT_EQ(xfm.p, Length2D{});
+    EXPECT_EQ(xfm.q, UnitVec2::GetRight());
+}
+
 TEST(Transformation, Initialize)
 {
     const auto translation = Length2D{Real(2) * Meter, Real(4) * Meter};

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -77,7 +77,9 @@ TEST(WeldJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
+
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
     EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);
     EXPECT_EQ(joint.GetReferenceAngle(), def.referenceAngle);

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -80,7 +80,9 @@ TEST(WheelJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
+
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
     EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);
     EXPECT_EQ(joint.GetLocalAxisA(), def.localAxisA);


### PR DESCRIPTION
#### Description - What's this PR do?
Adds more unit test code. Also refactors AABB's use of `Interval<Length>` out to its own type alias.

Some previous changes had introduced new library code without adding corresponding unit test code. This rectifies that. Also adds unit test code for some formerly untested aspects of joints.