### PR TITLE
Rename 2 element types

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -1074,7 +1074,7 @@ static void DefaultWorldStep(benchmark::State& state)
 
 static void DropDisks(benchmark::State& state)
 {
-    auto world = playrho::World{playrho::WorldDef{}.UseGravity(playrho::EarthlyGravity)};
+    auto world = playrho::World{playrho::WorldDef{}.UseGravity(playrho::EarthlyGravity2)};
 
     const auto diskDef = playrho::DiskShape::Conf{}.UseVertexRadius(0.5f * playrho::Meter);
     const auto shape = std::make_shared<playrho::DiskShape>(diskDef);

--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -208,10 +208,10 @@ static void AABB(benchmark::State& state)
     const auto pui1 = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     const auto pui2 = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     const auto pui3 = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
-    const auto p0 = playrho::Length2D{pui0 * playrho::Meter, 1.0f * playrho::Meter};
-    const auto p1 = playrho::Length2D{pui1 * playrho::Meter, 2.0f * playrho::Meter};
-    const auto p2 = playrho::Length2D{pui2 * playrho::Meter, 1.0f * playrho::Meter};
-    const auto p3 = playrho::Length2D{pui3 * playrho::Meter, 2.0f * playrho::Meter};
+    const auto p0 = playrho::Length2{pui0 * playrho::Meter, 1.0f * playrho::Meter};
+    const auto p1 = playrho::Length2{pui1 * playrho::Meter, 2.0f * playrho::Meter};
+    const auto p2 = playrho::Length2{pui2 * playrho::Meter, 1.0f * playrho::Meter};
+    const auto p3 = playrho::Length2{pui3 * playrho::Meter, 2.0f * playrho::Meter};
     
     while (state.KeepRunning())
     {
@@ -952,23 +952,23 @@ static void ConstructAndAssignVC(benchmark::State& state)
     const auto invMass = playrho::Real(1) / playrho::Kilogram;
     const auto invRotI = playrho::Real(1) / ((playrho::SquareMeter * playrho::Kilogram) / playrho::SquareRadian);
     const auto normal = playrho::UnitVec2::GetRight();
-    const auto location = playrho::Length2D{playrho::Real(0) * playrho::Meter, playrho::Real(0) * playrho::Meter};
-    const auto impulse = playrho::Momentum2D{playrho::Momentum{0}, playrho::Momentum{0}};
+    const auto location = playrho::Length2{playrho::Real(0) * playrho::Meter, playrho::Real(0) * playrho::Meter};
+    const auto impulse = playrho::Momentum2{playrho::Momentum{0}, playrho::Momentum{0}};
     const auto separation = playrho::Length{playrho::Real(-0.001) * playrho::Meter};
     const auto ps0 = playrho::WorldManifold::PointData{location, impulse, separation};
     const auto worldManifold = playrho::WorldManifold{normal, ps0};
     
-    const auto locA = playrho::Length2D{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
+    const auto locA = playrho::Length2{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posA = playrho::Position{locA, playrho::Angle(0)};
     const auto velA = playrho::Velocity{
-        playrho::LinearVelocity2D{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
+        playrho::LinearVelocity2{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
     
-    const auto locB = playrho::Length2D{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
+    const auto locB = playrho::Length2{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posB = playrho::Position{locB, playrho::Angle(0)};
     const auto velB = playrho::Velocity{
-        playrho::LinearVelocity2D{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
+        playrho::LinearVelocity2{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
     
@@ -1031,23 +1031,23 @@ static void SolveVC(benchmark::State& state)
     const auto invMass = playrho::Real(1) / playrho::Kilogram;
     const auto invRotI = playrho::Real(1) / ((playrho::SquareMeter * playrho::Kilogram) / playrho::SquareRadian);
     const auto normal = playrho::UnitVec2::GetRight();
-    const auto location = playrho::Length2D{playrho::Real(0) * playrho::Meter, playrho::Real(0) * playrho::Meter};
-    const auto impulse = playrho::Momentum2D{playrho::Momentum{0}, playrho::Momentum{0}};
+    const auto location = playrho::Length2{playrho::Real(0) * playrho::Meter, playrho::Real(0) * playrho::Meter};
+    const auto impulse = playrho::Momentum2{playrho::Momentum{0}, playrho::Momentum{0}};
     const auto separation = playrho::Length{playrho::Real(-0.001) * playrho::Meter};
     const auto ps0 = playrho::WorldManifold::PointData{location, impulse, separation};
     const auto worldManifold = playrho::WorldManifold{normal, ps0};
     
-    const auto locA = playrho::Length2D{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
+    const auto locA = playrho::Length2{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posA = playrho::Position{locA, playrho::Angle(0)};
     const auto velA = playrho::Velocity{
-        playrho::LinearVelocity2D{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
+        playrho::LinearVelocity2{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
 
-    const auto locB = playrho::Length2D{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
+    const auto locB = playrho::Length2{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posB = playrho::Position{locB, playrho::Angle(0)};
     const auto velB = playrho::Velocity{
-        playrho::LinearVelocity2D{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
+        playrho::LinearVelocity2{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
 
@@ -1074,14 +1074,14 @@ static void DefaultWorldStep(benchmark::State& state)
 
 static void DropDisks(benchmark::State& state)
 {
-    auto world = playrho::World{playrho::WorldDef{}.UseGravity(playrho::EarthlyGravity2)};
+    auto world = playrho::World{playrho::WorldDef{}.UseGravity(playrho::EarthlyGravity2D)};
 
     const auto diskDef = playrho::DiskShape::Conf{}.UseVertexRadius(0.5f * playrho::Meter);
     const auto shape = std::make_shared<playrho::DiskShape>(diskDef);
     for (auto i = 0; i < state.range(); ++i)
     {
         const auto x = i * 2 * playrho::Meter;
-        const auto location = playrho::Length2D{x, 0 * playrho::Meter};
+        const auto location = playrho::Length2{x, 0 * playrho::Meter};
         const auto body = world.CreateBody(playrho::BodyDef{}
                                            .UseType(playrho::BodyType::Dynamic)
                                            .UseLocation(location));
@@ -1108,10 +1108,10 @@ static void AddPairStressTest(benchmark::State& state, int count)
     const auto rectBodyDef = playrho::BodyDef{}
         .UseType(playrho::BodyType::Dynamic)
         .UseBullet(true)
-        .UseLocation(playrho::Length2D{-40.0f * playrho::Meter, 5.0f * playrho::Meter})
-        .UseLinearVelocity(playrho::LinearVelocity2D{playrho::Vec2(150.0f, 0.0f) * playrho::MeterPerSecond});
+        .UseLocation(playrho::Length2{-40.0f * playrho::Meter, 5.0f * playrho::Meter})
+        .UseLinearVelocity(playrho::LinearVelocity2{playrho::Vec2(150.0f, 0.0f) * playrho::MeterPerSecond});
 
-    const auto worldDef = playrho::WorldDef{}.UseGravity(playrho::LinearAcceleration2D{}).UseInitialTreeSize(8192);
+    const auto worldDef = playrho::WorldDef{}.UseGravity(playrho::LinearAcceleration2{}).UseInitialTreeSize(8192);
     const auto stepConf = playrho::StepConf{};
     const auto minX = -6.0f;
     const auto maxX = 0.0f;
@@ -1158,11 +1158,11 @@ static void DropTiles(int count)
     
     {
         const auto a = playrho::Real{0.5f};
-        const auto ground = m_world.CreateBody(playrho::BodyDef{}.UseLocation(playrho::Length2D{0, -a * playrho::Meter}));
+        const auto ground = m_world.CreateBody(playrho::BodyDef{}.UseLocation(playrho::Length2{0, -a * playrho::Meter}));
         
         const auto N = 200;
         const auto M = 10;
-        playrho::Length2D position;
+        playrho::Length2 position;
         GetY(position) = playrho::Real(0.0f) * playrho::Meter;
         for (auto j = 0; j < M; ++j)
         {
@@ -1183,10 +1183,10 @@ static void DropTiles(int count)
         const auto shape = std::make_shared<playrho::PolygonShape>(a * playrho::Meter, a * playrho::Meter, conf);
         shape->SetDensity(playrho::Real{5} * playrho::KilogramPerSquareMeter);
         
-        playrho::Length2D x(playrho::Real(-7.0f) * playrho::Meter, playrho::Real(0.75f) * playrho::Meter);
-        playrho::Length2D y;
-        const auto deltaX = playrho::Length2D(playrho::Real(0.5625f) * playrho::Meter, playrho::Real(1.25f) * playrho::Meter);
-        const auto deltaY = playrho::Length2D(playrho::Real(1.125f) * playrho::Meter, playrho::Real(0.0f) * playrho::Meter);
+        playrho::Length2 x(playrho::Real(-7.0f) * playrho::Meter, playrho::Real(0.75f) * playrho::Meter);
+        playrho::Length2 y;
+        const auto deltaX = playrho::Length2(playrho::Real(0.5625f) * playrho::Meter, playrho::Real(1.25f) * playrho::Meter);
+        const auto deltaY = playrho::Length2(playrho::Real(1.125f) * playrho::Meter, playrho::Real(0.0f) * playrho::Meter);
         
         for (auto i = 0; i < count; ++i)
         {
@@ -1286,7 +1286,7 @@ playrho::RevoluteJoint* Tumbler::CreateRevoluteJoint(playrho::World& world,
     jd.bodyA = stable;
     jd.bodyB = turn;
     jd.localAnchorA = playrho::Vec2(0.0f, 10.0f) * playrho::Meter;
-    jd.localAnchorB = playrho::Vec2(0.0f, 0.0f) * playrho::Meter;
+    jd.localAnchorB = playrho::Length2{};
     jd.referenceAngle = playrho::Angle{0};
     
     // Make it turn 4 times faster than Testbed Tumbler demo

--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -36,7 +36,7 @@ int main()
 
     // Call world's body creation method which allocates memory for ground body.
     // The body is also added to the world.
-    const auto ground = world.CreateBody(BodyDef{}.UseLocation(Length2D{0_m, -10_m}));
+    const auto ground = world.CreateBody(BodyDef{}.UseLocation(Length2{0_m, -10_m}));
 
     // Define the ground shape. Use a polygon configured as a box for this.
     // The extents are the half-width and half-height of the box.
@@ -47,7 +47,7 @@ int main()
 
     // Define location above ground for a "dynamic" body & call world's body creation method.
     const auto ball = world.CreateBody(BodyDef{}
-                                       .UseLocation(Length2D{0_m, 4_m})
+                                       .UseLocation(Length2{0_m, 4_m})
                                        .UseType(BodyType::Dynamic));
 
     // Define a disk shape for the ball body.

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -81,7 +81,7 @@ namespace playrho {
         ///   given point's X value.
         /// @post <code>rangeY</code> will have its min and max values both set to the
         ///   given point's Y value.
-        constexpr explicit AABB(const Length2D p) noexcept:
+        constexpr explicit AABB(const Length2 p) noexcept:
             rangeX{Get<0>(p)}, rangeY{Get<1>(p)}
         {
             // Intentionally empty.
@@ -90,7 +90,7 @@ namespace playrho {
         /// @brief Initializing constructor for two points.
         /// @param a Point location "A" to initialize this AABB with.
         /// @param b Point location "B" to initialize this AABB with.
-        constexpr AABB(const Length2D a, const Length2D b) noexcept:
+        constexpr AABB(const Length2 a, const Length2 b) noexcept:
             rangeX{Get<0>(a), Get<0>(b)}, rangeY{Get<1>(a), Get<1>(b)}
         {
             // Intentionally empty.
@@ -169,21 +169,21 @@ namespace playrho {
     
     /// @brief Gets the center of the AABB.
     /// @relatedalso AABB
-    constexpr Length2D GetCenter(const AABB& aabb) noexcept
+    constexpr Length2 GetCenter(const AABB& aabb) noexcept
     {
-        return Length2D{GetCenter(aabb.rangeX), GetCenter(aabb.rangeY)};
+        return Length2{GetCenter(aabb.rangeX), GetCenter(aabb.rangeY)};
     }
     
     /// @brief Gets dimensions of the given AABB.
     /// @relatedalso AABB
-    constexpr Length2D GetDimensions(const AABB& aabb) noexcept
+    constexpr Length2 GetDimensions(const AABB& aabb) noexcept
     {
-        return Length2D{GetSize(aabb.rangeX), GetSize(aabb.rangeY)};
+        return Length2{GetSize(aabb.rangeX), GetSize(aabb.rangeY)};
     }
     
     /// @brief Gets the extents of the AABB (half-widths).
     /// @relatedalso AABB
-    constexpr Length2D GetExtents(const AABB& aabb) noexcept
+    constexpr Length2 GetExtents(const AABB& aabb) noexcept
     {
         return GetDimensions(aabb) / Real{2};
     }
@@ -220,7 +220,7 @@ namespace playrho {
 
     /// @brief Includes the given location into the given AABB.
     /// @relatedalso AABB
-    constexpr AABB& Include(AABB& var, const Length2D& value) noexcept
+    constexpr AABB& Include(AABB& var, const Length2& value) noexcept
     {
         var.rangeX.Include(Get<0>(value));
         var.rangeY.Include(Get<1>(value));
@@ -240,7 +240,7 @@ namespace playrho {
     }
     
     /// @brief Moves the given AABB by the given value.
-    constexpr AABB& Move(AABB& var, const Length2D value) noexcept
+    constexpr AABB& Move(AABB& var, const Length2 value) noexcept
     {
         var.rangeX.Move(Get<0>(value));
         var.rangeY.Move(Get<1>(value));
@@ -259,7 +259,7 @@ namespace playrho {
     /// @brief Gets the AABB that the result of displacing the given AABB by the given
     ///   displacement amount.
     /// @relatedalso AABB
-    constexpr AABB GetDisplacedAABB(AABB aabb, const Length2D displacement)
+    constexpr AABB GetDisplacedAABB(AABB aabb, const Length2 displacement)
     {
         aabb.rangeX.Expand(Get<0>(displacement));
         aabb.rangeY.Expand(Get<1>(displacement));
@@ -275,7 +275,7 @@ namespace playrho {
 
     /// @brief Gets the result of moving the given AABB by the given value.
     /// @relatedalso AABB
-    constexpr AABB GetMovedAABB(AABB aabb, const Length2D value) noexcept
+    constexpr AABB GetMovedAABB(AABB aabb, const Length2 value) noexcept
     {
         return Move(aabb, value);
     }
@@ -289,16 +289,16 @@ namespace playrho {
 
     /// @brief Gets the lower bound.
     /// @relatedalso AABB
-    constexpr Length2D GetLowerBound(const AABB& aabb) noexcept
+    constexpr Length2 GetLowerBound(const AABB& aabb) noexcept
     {
-        return Length2D{aabb.rangeX.GetMin(), aabb.rangeY.GetMin()};
+        return Length2{aabb.rangeX.GetMin(), aabb.rangeY.GetMin()};
     }
     
     /// @brief Gets the upper bound.
     /// @relatedalso AABB
-    constexpr Length2D GetUpperBound(const AABB& aabb) noexcept
+    constexpr Length2 GetUpperBound(const AABB& aabb) noexcept
     {
-        return Length2D{aabb.rangeX.GetMax(), aabb.rangeY.GetMax()};
+        return Length2{aabb.rangeX.GetMax(), aabb.rangeY.GetMax()};
     }
     
     /// @brief Computes the AABB.

--- a/PlayRho/Collision/Collision.hpp
+++ b/PlayRho/Collision/Collision.hpp
@@ -65,7 +65,7 @@ PointStates GetPointStates(const Manifold& manifold1, const Manifold& manifold2)
 /// @note This data structure is 12-bytes large (on at least one 64-bit platform).
 struct ClipVertex
 {
-    Length2D v; ///< Vertex of edge or polygon. 8-bytes.
+    Length2 v; ///< Vertex of edge or polygon. 8-bytes.
     ContactFeature cf; ///< Contact feature information. 4-bytes.
 };
 

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -74,8 +74,8 @@ namespace {
 
 WitnessPoints GetWitnessPoints(const Simplex& simplex) noexcept
 {
-    auto pointA = Length2D{};
-    auto pointB = Length2D{};
+    auto pointA = Length2{};
+    auto pointB = Length2{};
 
     const auto size = simplex.GetSize();
     for (auto i = decltype(size){0}; i < size; ++i)

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -30,8 +30,8 @@ namespace playrho {
     /// @brief Witness Points.
     struct WitnessPoints
     {
-        Length2D a; ///< Point A.
-        Length2D b; ///< Point B.
+        Length2 a; ///< Point A.
+        Length2 b; ///< Point B.
     };
     
     /// @brief Gets the witness points of the given simplex.

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -70,7 +70,7 @@ DistanceProxy::size_type GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noe
     return index;
 }
 
-std::size_t FindLowestRightMostVertex(Span<const Length2D> vertices)
+std::size_t FindLowestRightMostVertex(Span<const Length2> vertices)
 {
     const auto size = vertices.size();
     if (size > 0)
@@ -91,9 +91,9 @@ std::size_t FindLowestRightMostVertex(Span<const Length2D> vertices)
     return static_cast<std::size_t>(-1);
 }
 
-std::vector<Length2D> GetConvexHullAsVector(Span<const Length2D> vertices)
+std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices)
 {
-    std::vector<Length2D> result;
+    std::vector<Length2> result;
     
     // Create the convex hull using the Gift wrapping algorithm
     // http://en.wikipedia.org/wiki/Gift_wrapping_algorithm
@@ -144,7 +144,7 @@ std::vector<Length2D> GetConvexHullAsVector(Span<const Length2D> vertices)
     return result;
 }
 
-bool TestPoint(const DistanceProxy& proxy, Length2D point) noexcept
+bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept
 {
     const auto count = proxy.GetVertexCount();
     const auto vr = proxy.GetVertexRadius();

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -76,7 +76,7 @@ namespace playrho
         ///   more than <code>MaxShapeVertices</code> elements.
         ///
         constexpr DistanceProxy(const NonNegative<Length> vertexRadius, const size_type count,
-                                const Length2D* vertices, const UnitVec2* normals) noexcept:
+                                const Length2* vertices, const UnitVec2* normals) noexcept:
             m_vertices{vertices},
             m_normals{normals},
             m_count{count},
@@ -106,7 +106,7 @@ namespace playrho
         ///   represented by this proxy.
         /// @warning Behavior is undefined if InvalidIndex is given as the index value.
         ///
-        /// @return 2D vector position (relative to the shape's origin) at the given index.
+        /// @return Vertex linear position (relative to the shape's origin) at the given index.
         ///
         /// @sa Distance.
         ///
@@ -127,7 +127,7 @@ namespace playrho
 
     private:
     
-        const Length2D* m_vertices = nullptr; ///< Vertices.
+        const Length2* m_vertices = nullptr; ///< Vertices.
         const UnitVec2* m_normals = nullptr; ///< Normals.
         size_type m_count = 0; ///< Count of valid elements of m_vertices.
         NonNegative<Length> m_vertexRadius = Length{0}; ///< Radius of the vertices of the associated shape.
@@ -157,10 +157,10 @@ namespace playrho
     DistanceProxy::size_type GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept;
 
     /// @brief Finds the lowest right most vertex in the given collection.
-    std::size_t FindLowestRightMostVertex(Span<const Length2D> vertices);
+    std::size_t FindLowestRightMostVertex(Span<const Length2> vertices);
     
     /// @brief Gets the convex hull for the given collection of vertices as a vector.
-    std::vector<Length2D> GetConvexHullAsVector(Span<const Length2D> vertices);
+    std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices);
 
     /// @brief Tests a point for containment in the given distance proxy.
     /// @param proxy Distance proxy to check if point is within.
@@ -168,7 +168,7 @@ namespace playrho
     /// @return <code>true</code> if point is contained in the proxy, <code>false</code> otherwise.
     /// @relatedalso DistanceProxy
     /// @ingroup TestPointGroup
-    bool TestPoint(const DistanceProxy& proxy, Length2D point) noexcept;
+    bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept;
     
 } // namespace playrho
 

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -769,7 +769,7 @@ void DynamicTree::RebuildBottomUp()
     Validate();
 }
 
-void DynamicTree::ShiftOrigin(Length2D newOrigin)
+void DynamicTree::ShiftOrigin(Length2 newOrigin)
 {
     // Build array of leaves. Free the rest.
     for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -196,7 +196,7 @@ public:
     /// @note Useful for large worlds.
     /// @note The shift formula is: position -= newOrigin
     /// @param newOrigin the new origin with respect to the old origin
-    void ShiftOrigin(Length2D newOrigin);
+    void ShiftOrigin(Length2 newOrigin);
     
     /// @brief Computes the height of the tree from a given node.
     /// @warning Behavior is undefined if the given index is not valid.

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -279,7 +279,7 @@ Manifold GetFaceManifold(const Manifold::Type type,
 
 Manifold CollideShapes(Manifold::Type type, Length totalRadius,
                        const DistanceProxy& shape, const Transformation& sxf,
-                       Length2D point, const Transformation& xfm)
+                       Length2 point, const Transformation& xfm)
 {
     // Computes the center of the circle in the frame of the polygon.
     const auto cLocal = InverseTransform(Transform(point, xfm), sxf); ///< Center of circle in frame of polygon.
@@ -390,8 +390,8 @@ Manifold CollideShapes(Manifold::Type type, Length totalRadius,
     return Manifold{};
 }
 
-inline Manifold CollideShapes(Length2D locationA, const Transformation& xfA,
-                              Length2D locationB, const Transformation& xfB,
+inline Manifold CollideShapes(Length2 locationA, const Transformation& xfA,
+                              Length2 locationB, const Transformation& xfB,
                               Length totalRadius) noexcept
 {
     const auto pA = Transform(locationA, xfA);
@@ -505,8 +505,8 @@ Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
 
     if (vertexCountShapeA == 4 && vertexCountShapeB == 4)
     {
-        Length2D verticesA[4];
-        Length2D verticesB[4];
+        Length2 verticesA[4];
+        Length2 verticesB[4];
         UnitVec2 normalsA[4];
         UnitVec2 normalsB[4];
         
@@ -782,7 +782,7 @@ Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transfor
             case 3:
             {
                 const auto ln = UnitVec2::GetLeft();
-                const auto lp = Length2D{};
+                const auto lp = Length2{};
                 return Manifold::GetForFaceA(ln, lp);
             }
             default:
@@ -915,7 +915,7 @@ bool operator!=(const Manifold& lhs, const Manifold& rhs) noexcept
 }
 
 #if 0
-Length2D GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
+Length2 GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
                                 ContactFeature::Index index)
 {
     switch (type)
@@ -927,7 +927,7 @@ Length2D GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
             return proxy.GetVertex(index);
         }
     }
-    return GetInvalid<Length2D>();
+    return GetInvalid<Length2>();
 }
 #endif
 

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -129,7 +129,7 @@ namespace playrho {
             /// point of shape A. It is also the point at which impulse forces should be relatively
             /// applied for position resolution.
             /// @note 8-bytes.
-            Length2D localPoint;
+            Length2 localPoint;
 
             /// @brief Contact feature.
             /// @details Uniquely identifies a contact point between two shapes - A and B.
@@ -157,7 +157,7 @@ namespace playrho {
         /// @param iA Index of vertex from shape A representing the local center of "circle" A.
         /// @param vB Local center of "circle" B.
         /// @param iB Index of vertex from shape B representing the local center of "circle" B.
-        static inline Manifold GetForCircles(Length2D vA, CfIndex iA, Length2D vB, CfIndex iB) noexcept
+        static inline Manifold GetForCircles(Length2 vA, CfIndex iA, Length2 vB, CfIndex iB) noexcept
         {
             return Manifold{e_circles, GetInvalid<UnitVec2>(), vA, 1, {{
                 Point{vB, GetVertexVertexContactFeature(iA, iB)}
@@ -169,7 +169,7 @@ namespace playrho {
         /// Gets a face A typed manifold.
         /// @param normalA Local normal of the face from polygon A.
         /// @param faceA Any point in local coordinates on the face whose normal was provided.
-        static inline Manifold GetForFaceA(UnitVec2 normalA, Length2D faceA) noexcept
+        static inline Manifold GetForFaceA(UnitVec2 normalA, Length2 faceA) noexcept
         {
             return Manifold{e_faceA, normalA, faceA, 0, {{}}};
         }
@@ -178,7 +178,7 @@ namespace playrho {
         /// @param ln Normal on polygon A.
         /// @param lp Center of face A.
         /// @param mp1 Manifold point 1 (of 1).
-        static inline Manifold GetForFaceA(UnitVec2 ln, Length2D lp,
+        static inline Manifold GetForFaceA(UnitVec2 ln, Length2 lp,
                                            const Point& mp1) noexcept
         {
             //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
@@ -190,7 +190,7 @@ namespace playrho {
         /// @param lp Center of face A.
         /// @param mp1 Manifold point 1 (of 2).
         /// @param mp2 Manifold point 2 (of 2).
-        static inline Manifold GetForFaceA(UnitVec2 ln, Length2D lp,
+        static inline Manifold GetForFaceA(UnitVec2 ln, Length2 lp,
                                            const Point& mp1, const Point& mp2) noexcept
         {
             //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
@@ -204,7 +204,7 @@ namespace playrho {
         /// Gets a face B typed manifold.
         /// @param ln Normal on polygon B.
         /// @param lp Center of face B.
-        static inline Manifold GetForFaceB(UnitVec2 ln, Length2D lp) noexcept
+        static inline Manifold GetForFaceB(UnitVec2 ln, Length2 lp) noexcept
         {
             return Manifold{e_faceB, ln, lp, 0, {{}}};
         }
@@ -213,7 +213,7 @@ namespace playrho {
         /// @param ln Normal on polygon B.
         /// @param lp Center of face B.
         /// @param mp1 Manifold point 1.
-        static inline Manifold GetForFaceB(UnitVec2 ln, Length2D lp,
+        static inline Manifold GetForFaceB(UnitVec2 ln, Length2 lp,
                                            const Point& mp1) noexcept
         {
             //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
@@ -225,7 +225,7 @@ namespace playrho {
         /// @param lp Center of face B.
         /// @param mp1 Manifold point 1 (of 2).
         /// @param mp2 Manifold point 2 (of 2).
-        static inline Manifold GetForFaceB(UnitVec2 ln, Length2D lp,
+        static inline Manifold GetForFaceB(UnitVec2 ln, Length2 lp,
                                            const Point& mp1, const Point& mp2) noexcept
         {
             //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
@@ -235,26 +235,26 @@ namespace playrho {
         }
         
         /// @brief Gets the face A manifold for the given data.
-        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2D pa) noexcept
+        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2 pa) noexcept
         {
             return Manifold{e_faceA, na, pa, 0, {{
-                Point{GetInvalid<Length2D>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}},
-                Point{GetInvalid<Length2D>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}}
+                Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}},
+                Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}}
             }}};
         }
         
         /// @brief Gets the face B manifold for the given data.
-        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2D pb) noexcept
+        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2 pb) noexcept
         {
             return Manifold{e_faceB, nb, pb, 0, {{
-                Point{GetInvalid<Length2D>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}},
-                Point{GetInvalid<Length2D>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}}
+                Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}},
+                Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}}
             }}};
         }
 
         /// @brief Gets the face A manifold for the given data.
-        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2D pa,
-                                              CfType tb0, CfIndex ib0, Length2D pb0) noexcept
+        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2 pa,
+                                              CfType tb0, CfIndex ib0, Length2 pb0) noexcept
         {
             return Manifold{e_faceA, na, pa, 1, {{
                 Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}},
@@ -263,8 +263,8 @@ namespace playrho {
         }
         
         /// @brief Gets the face B manifold for the given data.
-        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2D pb,
-                                              CfType ta0, CfIndex ia0, Length2D pa0) noexcept
+        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2 pb,
+                                              CfType ta0, CfIndex ia0, Length2 pa0) noexcept
         {
             return Manifold{e_faceB, nb, pb, 1, {{
                 Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}},
@@ -273,9 +273,9 @@ namespace playrho {
         }
         
         /// @brief Gets the face A manifold for the given data.
-        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2D pa,
-                                              CfType tb0, CfIndex ib0, Length2D pb0,
-                                              CfType tb1, CfIndex ib1, Length2D pb1) noexcept
+        static inline Manifold GetForFaceA(UnitVec2 na, CfIndex ia, Length2 pa,
+                                              CfType tb0, CfIndex ib0, Length2 pb0,
+                                              CfType tb1, CfIndex ib1, Length2 pb1) noexcept
         {
             return Manifold{e_faceA, na, pa, 2, {{
                 Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}},
@@ -284,9 +284,9 @@ namespace playrho {
         }
 
         /// @brief Gets the face B manifold for the given data.
-        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2D pb,
-                                              CfType ta0, CfIndex ia0, Length2D pa0,
-                                              CfType ta1, CfIndex ia1, Length2D pa1) noexcept
+        static inline Manifold GetForFaceB(UnitVec2 nb, CfIndex ib, Length2 pb,
+                                              CfType ta0, CfIndex ia0, Length2 pa0,
+                                              CfType ta1, CfIndex ia1, Length2 pa1) noexcept
         {
             return Manifold{e_faceB, nb, pb, 2, {{
                 Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}},
@@ -335,16 +335,16 @@ namespace playrho {
         /// @brief Gets the contact impulses for the given index.
         /// @return Pair of impulses where the first impulse is the "normal impulse"
         ///   and the second impulse is the "tangent impulse".
-        constexpr Momentum2D GetContactImpulses(size_type index) const noexcept
+        constexpr Momentum2 GetContactImpulses(size_type index) const noexcept
         {
             assert(index < m_pointCount);
-            return Momentum2D{m_points[index].normalImpulse, m_points[index].tangentImpulse};
+            return Momentum2{m_points[index].normalImpulse, m_points[index].tangentImpulse};
         }
 
         /// @brief Sets the contact impulses for the given index.
         /// @details Sets the contact impulses for the given index where the first impulse
         ///   is the "normal impulse" and the second impulse is the "tangent impulse".
-        void SetContactImpulses(size_type index, Momentum2D value) noexcept
+        void SetContactImpulses(size_type index, Momentum2 value) noexcept
         {
             assert(index < m_pointCount);
             m_points[index].normalImpulse = Get<0>(value);
@@ -375,7 +375,7 @@ namespace playrho {
         void AddPoint(const Point& mp) noexcept;
 
         /// @brief Adds a new point with the given data.
-        void AddPoint(CfType type, CfIndex index, Length2D point) noexcept;
+        void AddPoint(CfType type, CfIndex index, Length2 point) noexcept;
 
         /// @brief Gets the local normal for a face-type manifold.
         /// @note Only valid for face-A or face-B type manifolds.
@@ -397,14 +397,14 @@ namespace playrho {
         /// @note Only valid for circle, face-A, or face-B type manifolds.
         /// @warning Behavior is undefined for unset (e_unset) type manifolds.
         /// @return Local point.
-        constexpr Length2D GetLocalPoint() const noexcept
+        constexpr Length2 GetLocalPoint() const noexcept
         {
             assert(m_type != e_unset);
             return m_localPoint;
         }
         
         /// @brief Gets the opposing point.
-        constexpr Length2D GetOpposingPoint(size_type index) const noexcept
+        constexpr Length2 GetOpposingPoint(size_type index) const noexcept
         {
             assert((0 <= index) && (index < m_pointCount));
             return m_points[index].localPoint;
@@ -430,7 +430,7 @@ namespace playrho {
         /// @param lp Local point.
         /// @param n number of points defined in arary.
         /// @param mpa Manifold point array.
-        constexpr Manifold(Type t, UnitVec2 ln, Length2D lp, size_type n, const PointArray& mpa) noexcept;
+        constexpr Manifold(Type t, UnitVec2 ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
         
         Type m_type = e_unset; ///< Type of collision this manifold is associated with (1-byte).
         size_type m_pointCount = 0; ///< Number of defined manifold points (1-byte).
@@ -443,7 +443,7 @@ namespace playrho {
         /// Local point.
         /// @details Exact usage depends on manifold type (8-bytes).
         /// @note Invalid for the unset manifold type.
-        Length2D m_localPoint = GetInvalid<Length2D>();
+        Length2 m_localPoint = GetInvalid<Length2>();
         
         PointArray m_points; ///< Points of contact (at least 40-bytes). @sa pointCount.
     };
@@ -494,7 +494,7 @@ namespace playrho {
     /// @relatedalso Manifold
     bool operator!=(const Manifold& lhs, const Manifold& rhs) noexcept;
 
-    constexpr inline Manifold::Manifold(Type t, UnitVec2 ln, Length2D lp, size_type n,
+    constexpr inline Manifold::Manifold(Type t, UnitVec2 ln, Length2 lp, size_type n,
                                               const PointArray& mpa) noexcept:
         m_type{t}, m_localNormal{ln}, m_localPoint{lp}, m_pointCount{n}, m_points{mpa}
     {
@@ -518,7 +518,7 @@ namespace playrho {
         ++m_pointCount;
     }
 
-    inline void Manifold::AddPoint(CfType type, CfIndex index, Length2D point) noexcept
+    inline void Manifold::AddPoint(CfType type, CfIndex index, Length2 point) noexcept
     {
         assert(m_pointCount < MaxManifoldPoints);
         switch (m_type)
@@ -573,7 +573,7 @@ namespace playrho {
 #endif
 
 #if 0
-    Length2D GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
+    Length2 GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
                            ContactFeature::Index index);
 #endif
     

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -29,7 +29,7 @@
 
 namespace playrho {
 
-MassData GetMassData(Length r, NonNegative<Density> density, Length2D location)
+MassData GetMassData(Length r, NonNegative<Density> density, Length2 location)
 {
     // Uses parallel axis theorem, perpendicular axis theorem, and the second moment of area.
     // See: https://en.wikipedia.org/wiki/Second_moment_of_area
@@ -52,7 +52,7 @@ MassData GetMassData(Length r, NonNegative<Density> density, Length2D location)
     return MassData{location, mass, I};
 }
 
-MassData GetMassData(Length r, NonNegative<Density> density, Length2D v0, Length2D v1)
+MassData GetMassData(Length r, NonNegative<Density> density, Length2 v0, Length2 v1)
 {
     const auto r_squared = Area{r * r};
     const auto circle_area = r_squared * Pi;
@@ -70,11 +70,11 @@ MassData GetMassData(Length r, NonNegative<Density> density, Length2D v0, Length
     const auto halfCircleArea = circle_area / Real{2};
     const auto halfRSquared = r_squared / Real{2};
     
-    const auto vertices = Vector<const Length2D, 4>{
-        Length2D{v0 + offset},
-        Length2D{v0 - offset},
-        Length2D{v1 - offset},
-        Length2D{v1 + offset}
+    const auto vertices = Vector<const Length2, 4>{
+        Length2{v0 + offset},
+        Length2{v0 - offset},
+        Length2{v1 - offset},
+        Length2{v1 + offset}
     };
     const auto I_z = GetPolarMoment(vertices);
     const auto I0 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetLengthSquared(v0))};
@@ -87,7 +87,7 @@ MassData GetMassData(Length r, NonNegative<Density> density, Length2D v0, Length
 }
 
 MassData GetMassData(Length vertexRadius, NonNegative<Density> density,
-                              Span<const Length2D> vertices)
+                              Span<const Length2> vertices)
 {
     // See: https://en.wikipedia.org/wiki/Centroid#Centroid_of_polygon
     
@@ -128,7 +128,7 @@ MassData GetMassData(Length vertexRadius, NonNegative<Density> density,
             break;
     }
     
-    auto center = Length2D{};
+    auto center = Length2{};
     auto area = Area{0};
     auto I = SecondMomentOfArea{0};
     
@@ -185,7 +185,7 @@ MassData ComputeMassData(const Body& body) noexcept
 {
     auto mass = Mass{0};
     auto I = RotInertia{0};
-    auto center = Length2D{};
+    auto center = Length2{};
     for (auto&& f: body.GetFixtures())
     {
         const auto& fixture = GetRef(f);

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -39,7 +39,7 @@ namespace playrho {
     struct MassData
     {
         /// @brief Position of the shape's centroid relative to the shape's origin.
-        Length2D center = Length2D{};
+        Length2 center = Length2{};
         
         /// @brief Mass of the shape in kilograms.
         NonNegative<Mass> mass = NonNegative<Mass>{0};
@@ -74,7 +74,7 @@ namespace playrho {
     ///
     /// @relatedalso MassData
     ///
-    MassData GetMassData(Length r, NonNegative<Density> density, Length2D location);
+    MassData GetMassData(Length r, NonNegative<Density> density, Length2 location);
 
     /// @brief Computes the mass data for a linear shape.
     ///
@@ -85,13 +85,13 @@ namespace playrho {
     ///
     /// @relatedalso MassData
     ///
-    MassData GetMassData(Length r, NonNegative<Density> density, Length2D v0, Length2D v1);
+    MassData GetMassData(Length r, NonNegative<Density> density, Length2 v0, Length2 v1);
 
     /// @brief Gets the mass data for the given collection of vertices with the given
     ///    properties.
     /// @relatedalso MassData
     MassData GetMassData(Length vertexRadius, NonNegative<Density> density,
-                         Span<const Length2D> vertices);
+                         Span<const Length2> vertices);
     
     /// @brief Computes the mass data for the given fixture.
     ///

--- a/PlayRho/Collision/RayCastInput.hpp
+++ b/PlayRho/Collision/RayCastInput.hpp
@@ -34,9 +34,9 @@ namespace playrho {
     /// @details The ray extends from p1 to p1 + maxFraction * (p2 - p1).
     struct RayCastInput
     {
-        Length2D p1; ///< Point 1.
+        Length2 p1; ///< Point 1.
 
-        Length2D p2; ///< Point 2.
+        Length2 p2; ///< Point 2.
 
         /// @brief Max fraction.
         /// @details Unit interval value - a value between 0 and 1 inclusive.

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -27,7 +27,7 @@
 
 namespace playrho {
 
-RayCastOutput RayCast(Length radius, Length2D location, const RayCastInput& input) noexcept
+RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept
 {
     // Collision Detection in Interactive 3D Environments by Gino van den Bergen
     // From Section 3.1.2
@@ -38,7 +38,7 @@ RayCastOutput RayCast(Length radius, Length2D location, const RayCastInput& inpu
     const auto b = GetLengthSquared(s) - Square(radius);
     
     // Solve quadratic equation.
-    const auto raySegment = input.p2 - input.p1; // Length2D
+    const auto raySegment = input.p2 - input.p1; // Length2
     const auto c =  Dot(s, raySegment); // Area
     const auto rr = GetLengthSquared(raySegment); // Area
     const auto sigma = (Square(c) - rr * b) / (SquareMeter * SquareMeter);

--- a/PlayRho/Collision/RayCastOutput.hpp
+++ b/PlayRho/Collision/RayCastOutput.hpp
@@ -60,7 +60,7 @@ namespace playrho
     /// @param radius Radius of the circle.
     /// @param location Location in world coordinates of the circle.
     /// @param input Ray-cast input parameters.
-    RayCastOutput RayCast(Length radius, Length2D location, const RayCastInput& input) noexcept;
+    RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept;
 
     /// @brief Cast a ray against the given AABB.
     /// @param aabb Axis Aligned Bounding Box.

--- a/PlayRho/Collision/SeparationFinder.cpp
+++ b/PlayRho/Collision/SeparationFinder.cpp
@@ -43,7 +43,7 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
             const auto pointA = Transform(localPointA, xfA);
             const auto pointB = Transform(localPointB, xfB);
             const auto axis = GetUnitVector(pointB - pointA, UnitVec2::GetZero());
-            return SeparationFinder{proxyA, proxyB, axis, GetInvalid<Length2D>(), type};
+            return SeparationFinder{proxyA, proxyB, axis, GetInvalid<Length2>(), type};
         }
         case e_faceB:
         {
@@ -102,7 +102,7 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
     }
 
     // Should never be reached
-    return SeparationFinder{proxyA, proxyB, UnitVec2{}, GetInvalid<Length2D>(), type};
+    return SeparationFinder{proxyA, proxyB, UnitVec2{}, GetInvalid<Length2>(), type};
 }
 
 SeparationFinder::Data SeparationFinder::FindMinSeparationForPoints(const Transformation& xfA, const Transformation& xfB) const

--- a/PlayRho/Collision/SeparationFinder.hpp
+++ b/PlayRho/Collision/SeparationFinder.hpp
@@ -118,13 +118,13 @@ namespace playrho {
         constexpr UnitVec2 GetAxis() const noexcept;
         
         /// @brief Gets the local point.
-        constexpr Length2D GetLocalPoint() const noexcept;
+        constexpr Length2 GetLocalPoint() const noexcept;
 
     private:
         
         /// @brief Initializing constructor.
         constexpr SeparationFinder(const DistanceProxy& dpA, const DistanceProxy& dpB,
-                                         const UnitVec2 axis, const Length2D lp, const Type type):
+                                         const UnitVec2 axis, const Length2 lp, const Type type):
             m_proxyA{dpA}, m_proxyB{dpB}, m_axis{axis}, m_localPoint{lp}, m_type{type}
         {
             // Intentionally empty.
@@ -151,7 +151,7 @@ namespace playrho {
         const DistanceProxy& m_proxyA; ///< Distance proxy A.
         const DistanceProxy& m_proxyB; ///< Distance proxy B.
         const UnitVec2 m_axis; ///< Axis. @details Directional vector of the axis of separation.
-        const Length2D m_localPoint; ///< Local point. @note Only used if type is e_faceA or e_faceB.
+        const Length2 m_localPoint; ///< Local point. @note Only used if type is e_faceA or e_faceB.
         const Type m_type; ///< The type of this instance.
     };
 
@@ -165,7 +165,7 @@ namespace playrho {
         return m_axis;
     }
     
-    constexpr inline Length2D SeparationFinder::GetLocalPoint() const noexcept
+    constexpr inline Length2 SeparationFinder::GetLocalPoint() const noexcept
     {
         return m_localPoint;
     }

--- a/PlayRho/Collision/ShapeSeparation.cpp
+++ b/PlayRho/Collision/ShapeSeparation.cpp
@@ -26,7 +26,7 @@ namespace playrho {
 namespace {
 
 inline IndexSeparation GetMinIndexSeparation(const DistanceProxy& proxy,
-                                             UnitVec2 normal, Length2D offset)
+                                             UnitVec2 normal, Length2 offset)
 {
     // Search for the vector that's most anti-parallel to the normal.
     // See: https://en.wikipedia.org/wiki/Antiparallel_(mathematics)#Antiparallel_vectors
@@ -66,7 +66,7 @@ IndexPairSeparation GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformat
     };
     
     const auto xf = MulT(xf1, xf2);
-    const Length2D p2vertices[4] = {
+    const Length2 p2vertices[4] = {
         Transform(proxy2.GetVertex(0), xf),
         Transform(proxy2.GetVertex(1), xf),
         Transform(proxy2.GetVertex(2), xf),

--- a/PlayRho/Collision/Shapes/ChainShape.cpp
+++ b/PlayRho/Collision/Shapes/ChainShape.cpp
@@ -26,7 +26,7 @@ namespace playrho {
 
 namespace {
 #if 0
-    inline bool IsEachVertexFarEnoughApart(Span<const Length2D> vertices)
+    inline bool IsEachVertexFarEnoughApart(Span<const Length2> vertices)
     {
         for (auto i = decltype(vertices.size()){1}; i < vertices.size(); ++i)
         {
@@ -82,7 +82,7 @@ MassData ChainShape::GetMassData() const noexcept
             auto mass = Mass{0};
             auto I = RotInertia{0};
             auto area = Area(0);
-            auto center = Length2D{};
+            auto center = Length2{};
             const auto vertexRadius = GetVertexRadius();
             auto vprev = GetVertex(0);
             const auto circle_area = Square(vertexRadius) * Pi;

--- a/PlayRho/Collision/Shapes/ChainShape.hpp
+++ b/PlayRho/Collision/Shapes/ChainShape.hpp
@@ -62,7 +62,7 @@ public:
         }
         
         /// @brief Vertices that define a chain shape.
-        std::vector<Length2D> vertices;
+        std::vector<Length2> vertices;
     };
 
     /// @brief Gets the default configuration.
@@ -100,13 +100,13 @@ public:
     ChildCounter GetVertexCount() const noexcept;
 
     /// @brief Gets a vertex by index.
-    Length2D GetVertex(ChildCounter index) const;
+    Length2 GetVertex(ChildCounter index) const;
 
     /// @brief Gets the normal at the given index.
     UnitVec2 GetNormal(ChildCounter index) const;
 
 private:
-    std::vector<Length2D> m_vertices; ///< Vertices.
+    std::vector<Length2> m_vertices; ///< Vertices.
     std::vector<UnitVec2> m_normals; ///< Normals.
 };
 
@@ -115,7 +115,7 @@ inline ChildCounter ChainShape::GetVertexCount() const noexcept
     return static_cast<ChildCounter>(m_vertices.size());
 }
 
-inline Length2D ChainShape::GetVertex(ChildCounter index) const
+inline Length2 ChainShape::GetVertex(ChildCounter index) const
 {
     assert((0 <= index) && (index < GetVertexCount()));
     return m_vertices[index];

--- a/PlayRho/Collision/Shapes/DiskShape.hpp
+++ b/PlayRho/Collision/Shapes/DiskShape.hpp
@@ -55,14 +55,14 @@ public:
         }
         
         /// @brief Uses the given value as the location.
-        constexpr Conf& UseLocation(Length2D value) noexcept
+        constexpr Conf& UseLocation(Length2 value) noexcept
         {
             location = value;
             return *this;
         }
 
         /// @brief Location for the disk shape to be centered at.
-        Length2D location = Length2D{};
+        Length2 location = Length2{};
     };
 
     /// @brief Gets the default configuration.
@@ -118,15 +118,15 @@ public:
     /// @return The origin (0, 0) unless explicitly set otherwise on construction or via
     ///   the set location method.
     /// @sa SetPosition.
-    Length2D GetLocation() const noexcept { return m_location; }
+    Length2 GetLocation() const noexcept { return m_location; }
     
     /// @brief Sets the location to the given value.
-    void SetLocation(const Length2D value) noexcept { m_location = value; }
+    void SetLocation(const Length2 value) noexcept { m_location = value; }
 
 private:
     /// Location of the shape as initialized on construction or as assigned using the
     ///   SetPosition method.
-    Length2D m_location = Length2D{};
+    Length2 m_location = Length2{};
 };
 
 constexpr DiskShape::Conf DiskShape::GetDefaultConf() noexcept

--- a/PlayRho/Collision/Shapes/EdgeShape.cpp
+++ b/PlayRho/Collision/Shapes/EdgeShape.cpp
@@ -27,7 +27,7 @@ MassData EdgeShape::GetMassData() const noexcept
     return playrho::GetMassData(GetVertexRadius(), GetDensity(), GetVertex1(), GetVertex2());
 }
 
-void EdgeShape::Set(Length2D v1, Length2D v2)
+void EdgeShape::Set(Length2 v1, Length2 v2)
 {
     m_vertices[0] = v1;
     m_vertices[1] = v2;

--- a/PlayRho/Collision/Shapes/EdgeShape.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShape.hpp
@@ -54,21 +54,21 @@ public:
         }
         
         /// @brief Uses the given value for vertex 1.
-        constexpr Conf& UseVertex1(Length2D value) noexcept
+        constexpr Conf& UseVertex1(Length2 value) noexcept
         {
             vertex1 = value;
             return *this;
         }
 
         /// @brief Uses the given value for vertex 2.
-        constexpr Conf& UseVertex2(Length2D value) noexcept
+        constexpr Conf& UseVertex2(Length2 value) noexcept
         {
             vertex2 = value;
             return *this;
         }
 
-        Length2D vertex1 = Length2D{}; ///< Vertex 1.
-        Length2D vertex2 = Length2D{}; ///< Vertex 2.
+        Length2 vertex1 = Length2{}; ///< Vertex 1.
+        Length2 vertex2 = Length2{}; ///< Vertex 2.
     };
     
     /// @brief Gets the default configuration for an EdgeShape.
@@ -87,7 +87,7 @@ public:
     }
 
     /// @brief Initializing constructor.
-    EdgeShape(Length2D v1, Length2D v2, const Conf& conf = GetDefaultConf()) noexcept:
+    EdgeShape(Length2 v1, Length2 v2, const Conf& conf = GetDefaultConf()) noexcept:
         Shape{conf},
         m_vertices{v1, v2}
     {
@@ -118,13 +118,13 @@ public:
     void Accept(ShapeVisitor& visitor) const override;
 
     /// @brief Sets this as an isolated edge.
-    void Set(Length2D v1, Length2D v2);
+    void Set(Length2 v1, Length2 v2);
 
     /// @brief Gets vertex number 1 (of 2).
-    Length2D GetVertex1() const noexcept { return m_vertices[0]; }
+    Length2 GetVertex1() const noexcept { return m_vertices[0]; }
 
     /// @brief Gets vertex number 2 (of 2).
-    Length2D GetVertex2() const noexcept { return m_vertices[1]; }
+    Length2 GetVertex2() const noexcept { return m_vertices[1]; }
 
     /// @brief Gets normal number 1 (of 2).
     UnitVec2 GetNormal1() const noexcept { return m_normals[0]; }
@@ -133,7 +133,7 @@ public:
     UnitVec2 GetNormal2() const noexcept { return m_normals[1]; }
 
 private:
-    Length2D m_vertices[2]; ///< Vertices
+    Length2 m_vertices[2]; ///< Vertices
     UnitVec2 m_normals[2]; ///< Normals.
 };
 

--- a/PlayRho/Collision/Shapes/MultiShape.cpp
+++ b/PlayRho/Collision/Shapes/MultiShape.cpp
@@ -31,13 +31,13 @@ namespace playrho {
 MassData MultiShape::GetMassData() const noexcept
 {
     auto mass = 0_kg;
-    const auto origin = Length2D{};
+    const auto origin = Length2{};
     auto weightedCenter = origin * Kilogram;
     auto I = RotInertia(0);
 
     std::for_each(std::begin(m_children), std::end(m_children), [&](const ConvexHull& ch) {
         const auto md = playrho::GetMassData(GetVertexRadius(), GetDensity(),
-                                      Span<const Length2D>(ch.vertices.data(), ch.vertices.size()));
+                                      Span<const Length2>(ch.vertices.data(), ch.vertices.size()));
         mass += Mass{md.mass};
         weightedCenter += md.center * Mass{md.mass};
         I += RotInertia{md.I};

--- a/PlayRho/Collision/Shapes/MultiShape.hpp
+++ b/PlayRho/Collision/Shapes/MultiShape.hpp
@@ -104,7 +104,7 @@ namespace playrho {
         {
             /// Array of vertices.
             /// @details Consecutive vertices constitute "edges" of the polygon.
-            std::vector<Length2D> vertices;
+            std::vector<Length2> vertices;
             
             /// Normals of edges.
             /// @details

--- a/PlayRho/Collision/Shapes/PolygonShape.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.cpp
@@ -29,7 +29,7 @@ PolygonShape::PolygonShape(Length hx, Length hy, const Conf& conf) noexcept:
     SetAsBox(hx, hy);
 }
 
-PolygonShape::PolygonShape(Span<const Length2D> points, const Conf& conf) noexcept:
+PolygonShape::PolygonShape(Span<const Length2> points, const Conf& conf) noexcept:
     Shape{conf}
 {
     Set(points);
@@ -38,19 +38,19 @@ PolygonShape::PolygonShape(Span<const Length2D> points, const Conf& conf) noexce
 MassData PolygonShape::GetMassData() const noexcept
 {
     return playrho::GetMassData(GetVertexRadius(), GetDensity(),
-                                Span<const Length2D>(m_vertices.data(), m_vertices.size()));
+                                Span<const Length2>(m_vertices.data(), m_vertices.size()));
 }
 
 void PolygonShape::SetAsBox(Length hx, Length hy) noexcept
 {
-    m_centroid = Length2D{};
+    m_centroid = Length2{};
 
     // vertices must be counter-clockwise
 
-    const auto btm_rgt = Length2D{+hx, -hy};
-    const auto top_rgt = Length2D{ hx,  hy};
-    const auto top_lft = Length2D{-hx, +hy};
-    const auto btm_lft = Length2D{-hx, -hy};
+    const auto btm_rgt = Length2{+hx, -hy};
+    const auto top_rgt = Length2{ hx,  hy};
+    const auto top_lft = Length2{-hx, +hy};
+    const auto btm_lft = Length2{-hx, -hy};
     
     m_vertices.clear();
     m_vertices.emplace_back(btm_rgt);
@@ -65,7 +65,7 @@ void PolygonShape::SetAsBox(Length hx, Length hy) noexcept
     m_normals.emplace_back(UnitVec2::GetBottom());
 }
 
-void SetAsBox(PolygonShape& shape, Length hx, Length hy, Length2D center, Angle angle) noexcept
+void SetAsBox(PolygonShape& shape, Length hx, Length hy, Length2 center, Angle angle) noexcept
 {
     shape.SetAsBox(hx, hy);
     shape.Transform(Transformation{center, UnitVec2::Get(angle)});
@@ -82,7 +82,7 @@ PolygonShape& PolygonShape::Transform(Transformation xfm) noexcept
     return *this;
 }
 
-void PolygonShape::Set(Span<const Length2D> points) noexcept
+void PolygonShape::Set(Span<const Length2> points) noexcept
 {
     // Perform welding and copy vertices into local buffer.
     auto point_set = VertexSet(Square(DefaultLinearSlop));
@@ -119,7 +119,7 @@ void PolygonShape::Set(const VertexSet& points) noexcept
     switch (count)
     {
         case 0:
-            m_centroid = GetInvalid<Length2D>();
+            m_centroid = GetInvalid<Length2>();
             break;
         case 1:
             m_centroid = m_vertices[0];
@@ -138,7 +138,7 @@ void PolygonShape::Accept(ShapeVisitor& visitor) const
     visitor.Visit(*this);
 }
 
-Length2D GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index)
+Length2 GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index)
 {
     assert(shape.GetVertexCount() > 1);
 

--- a/PlayRho/Collision/Shapes/PolygonShape.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.hpp
@@ -97,7 +97,7 @@ public:
     /// @warning the points may be re-ordered, even if they form a convex polygon
     /// @warning collinear points are handled but not removed. Collinear points
     /// may lead to poor stacking behavior.
-    explicit PolygonShape(Span<const Length2D> points, const Conf& conf = GetDefaultConf()) noexcept;
+    explicit PolygonShape(Span<const Length2> points, const Conf& conf = GetDefaultConf()) noexcept;
     
     ~PolygonShape() override = default;
     
@@ -120,7 +120,7 @@ public:
     /// @warning the points may be re-ordered, even if they form a convex polygon
     /// @warning collinear points are handled but not removed. Collinear points
     /// may lead to poor stacking behavior.
-    void Set(Span<const Length2D> points) noexcept;
+    void Set(Span<const Length2> points) noexcept;
 
     /// Creates a convex hull from the given set of local points.
     /// The size of the set must be in the range [1, MaxShapeVertices].
@@ -144,7 +144,7 @@ public:
 
     /// Gets a vertex by index.
     /// @details Vertices go counter-clockwise.
-    Length2D GetVertex(VertexCounter index) const;
+    Length2 GetVertex(VertexCounter index) const;
 
     /// Gets a normal by index.
     /// @details
@@ -156,9 +156,9 @@ public:
 
     /// Gets the span of vertices.
     /// @details Vertices go counter-clockwise.
-    Span<const Length2D> GetVertices() const noexcept
+    Span<const Length2> GetVertices() const noexcept
     {
-        return Span<const Length2D>(&m_vertices[0], GetVertexCount());
+        return Span<const Length2>(&m_vertices[0], GetVertexCount());
     }
 
     /// @brief Gets the span of normals.
@@ -168,12 +168,12 @@ public:
     }
     
     /// @brief Gets the centroid.
-    Length2D GetCentroid() const noexcept { return m_centroid; }
+    Length2 GetCentroid() const noexcept { return m_centroid; }
     
 private:
     /// Array of vertices.
     /// @details Consecutive vertices constitute "edges" of the polygon.
-    std::vector<Length2D> m_vertices;
+    std::vector<Length2> m_vertices;
 
     /// Normals of edges.
     /// @details
@@ -182,7 +182,7 @@ private:
     std::vector<UnitVec2> m_normals;
 
     /// Centroid of this shape.
-    Length2D m_centroid = Length2D{};
+    Length2 m_centroid = Length2{};
 };
 
 inline ChildCounter PolygonShape::GetChildCount() const noexcept
@@ -206,7 +206,7 @@ inline PolygonShape::VertexCounter PolygonShape::GetVertexCount() const noexcept
     return static_cast<VertexCounter>(m_vertices.size());
 }
 
-inline Length2D PolygonShape::GetVertex(VertexCounter index) const
+inline Length2 PolygonShape::GetVertex(VertexCounter index) const
 {
     assert(0 <= index && index < GetVertexCount());
     return m_vertices[index];
@@ -224,7 +224,7 @@ inline UnitVec2 PolygonShape::GetNormal(VertexCounter index) const
 /// @note This must not be called for shapes with less than 2 vertices.
 /// @warning Behavior is undefined if called for a shape with less than 2 vertices.
 /// @relatedalso PolygonShape
-Length2D GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index);
+Length2 GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index);
 
 /// Validate convexity of the given shape.
 /// @note This is a time consuming operation.
@@ -239,7 +239,7 @@ bool Validate(const PolygonShape& shape);
 /// @param center the center of the box in local coordinates.
 /// @param angle the rotation of the box in local coordinates.
 /// @relatedalso PolygonShape
-void SetAsBox(PolygonShape& shape, Length hx, Length hy, Length2D center, Angle angle) noexcept;
+void SetAsBox(PolygonShape& shape, Length hx, Length hy, Length2 center, Angle angle) noexcept;
 
 /// @brief Transforms the given shape by the given transformation.
 /// @relatedalso PolygonShape

--- a/PlayRho/Collision/Shapes/Shape.cpp
+++ b/PlayRho/Collision/Shapes/Shape.cpp
@@ -35,7 +35,7 @@ Shape::Shape(const ShapeDef& conf) noexcept:
 
 // Free functions...
 
-bool TestPoint(const Shape& shape, Length2D point) noexcept
+bool TestPoint(const Shape& shape, Length2 point) noexcept
 {
     const auto childCount = shape.GetChildCount();
     for (auto i = decltype(childCount){0}; i < childCount; ++i)

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -229,7 +229,7 @@ inline NonNegative<Length> GetVertexRadius(const Shape& shape) noexcept
 ///   <code>false</code> otherwise.
 /// @relatedalso Shape
 /// @ingroup TestPointGroup
-bool TestPoint(const Shape& shape, Length2D point) noexcept;
+bool TestPoint(const Shape& shape, Length2 point) noexcept;
 
 } // namespace playrho
 

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -126,7 +126,7 @@ namespace playrho {
         /// @param simplexEdges A one or two edge list.
         /// @warning Behavior is undefined if the given edge list has zero edges.
         /// @return "search direction" vector.
-        static constexpr Length2D CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept;
+        static constexpr Length2 CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept;
         
         /// Gets the given simplex's "metric".
         static inline Real CalcMetric(const SimplexEdges& simplexEdges);
@@ -238,7 +238,7 @@ namespace playrho {
         return list;
     }
 
-    constexpr inline Length2D Simplex::CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept
+    constexpr inline Length2 Simplex::CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept
     {
         assert((simplexEdges.size() == 1) || (simplexEdges.size() == 2));
         switch (simplexEdges.size())
@@ -258,7 +258,7 @@ namespace playrho {
             }
                 
             default:
-                return Length2D{0_m, 0_m};
+                return Length2{0_m, 0_m};
         }
     }
 
@@ -320,20 +320,20 @@ namespace playrho {
     }
 
     /// @brief Gets the scaled delta for the given indexed element of the given simplex.
-    inline Length2D GetScaledDelta(const Simplex& simplex, Simplex::size_type index)
+    inline Length2 GetScaledDelta(const Simplex& simplex, Simplex::size_type index)
     {
         return GetPointDelta(simplex.GetSimplexEdge(index)) * simplex.GetCoefficient(index);
     }
 
     /// Gets the "closest point".
-    constexpr inline Length2D GetClosestPoint(const Simplex& simplex)
+    constexpr inline Length2 GetClosestPoint(const Simplex& simplex)
     {
         switch (simplex.GetSize())
         {
             case 1: return GetScaledDelta(simplex, 0);
             case 2: return GetScaledDelta(simplex, 0) + GetScaledDelta(simplex, 1);
-            case 3: return Length2D{0_m, 0_m};
-            default: return Length2D{0_m, 0_m};
+            case 3: return Length2{0_m, 0_m};
+            default: return Length2{0_m, 0_m};
         }
     }
 

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -50,7 +50,7 @@ namespace playrho {
         /// @param iA Index of point A within the shape that it comes from.
         /// @param pB Point B in world coordinates.
         /// @param iB Index of point B within the shape that it comes from.
-        constexpr SimplexEdge(Length2D pA, index_type iA, Length2D pB, index_type iB) noexcept;
+        constexpr SimplexEdge(Length2 pA, index_type iA, Length2 pB, index_type iB) noexcept;
         
         /// @brief Gets point A (in world coordinates).
         constexpr auto GetPointA() const noexcept { return m_wA; }
@@ -68,13 +68,13 @@ namespace playrho {
         constexpr auto GetIndexPair() const noexcept { return m_indexPair; }
 
     private:
-        Length2D m_wA; ///< Point A in world coordinates. This is the support point in proxy A. 8-bytes.
-        Length2D m_wB; ///< Point B in world coordinates. This is the support point in proxy B. 8-bytes.
+        Length2 m_wA; ///< Point A in world coordinates. This is the support point in proxy A. 8-bytes.
+        Length2 m_wB; ///< Point B in world coordinates. This is the support point in proxy B. 8-bytes.
         IndexPair m_indexPair; ///< Index pair. @details Indices of points A and B. 2-bytes.
     };
     
-    constexpr inline SimplexEdge::SimplexEdge(Length2D pA, index_type iA,
-                                              Length2D pB, index_type iB) noexcept:
+    constexpr inline SimplexEdge::SimplexEdge(Length2 pA, index_type iA,
+                                              Length2 pB, index_type iB) noexcept:
         m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
     {
         // Intentionally empty.
@@ -82,7 +82,7 @@ namespace playrho {
     
     /// @brief Gets "w".
     /// @return 2D vector value of wB minus wA.
-    constexpr inline Length2D GetPointDelta(const SimplexEdge& sv) noexcept
+    constexpr inline Length2 GetPointDelta(const SimplexEdge& sv) noexcept
     {
         return sv.GetPointB() - sv.GetPointA();
     }

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -48,11 +48,11 @@ namespace playrho {
         /// @brief Points.
         /// @details Manifold's contact points in world coordinates (mid-point of intersection)
         /// @note 16-bytes.
-        Length2D m_points[MaxManifoldPoints] = {GetInvalid<Length2D>(), GetInvalid<Length2D>()};
+        Length2 m_points[MaxManifoldPoints] = {GetInvalid<Length2>(), GetInvalid<Length2>()};
 
         /// @brief Impulses.
         /// @note 16-bytes.
-        Momentum2D m_impulses[MaxManifoldPoints] = {Momentum2D{}, Momentum2D{}};
+        Momentum2 m_impulses[MaxManifoldPoints] = {Momentum2{}, Momentum2{}};
         
         /// @brief Separations.
         /// @details A negative value indicates overlap.
@@ -64,8 +64,8 @@ namespace playrho {
         /// @note This data structure is 20-bytes large at least on one 64-bit architecture.
         struct PointData
         {
-            Length2D location; ///< Location of point or the invalid Length2D value.
-            Momentum2D impulse; ///< "Normal" and "tangent" impulses at the point.
+            Length2 location; ///< Location of point or the invalid Length2 value.
+            Momentum2 impulse; ///< "Normal" and "tangent" impulses at the point.
             Length separation; ///< Separation at point or the invalid Length value.
         };
         
@@ -86,8 +86,8 @@ namespace playrho {
         /// @brief Initializing constructor.
         constexpr explicit WorldManifold(UnitVec2 normal, PointData ps0) noexcept:
             m_normal{normal},
-            m_points{ps0.location, GetInvalid<Length2D>()},
-            m_impulses{ps0.impulse, Momentum2D{}},
+            m_points{ps0.location, GetInvalid<Length2>()},
+            m_impulses{ps0.impulse, Momentum2{}},
             m_separations{ps0.separation, GetInvalid<Length>()}
         {
             assert(IsValid(normal));
@@ -132,7 +132,7 @@ namespace playrho {
         ///
         /// @return Point or an invalid value if the given index was invalid.
         ///
-        Length2D GetPoint(size_type index) const noexcept
+        Length2 GetPoint(size_type index) const noexcept
         {
             assert(index < MaxManifoldPoints);
             return m_points[index];
@@ -156,7 +156,7 @@ namespace playrho {
         
         /// @brief Gets the given index contact impulses.
         /// @return "Normal impulse" and "tangent impulse" pair.
-        Momentum2D GetImpulses(size_type index) const noexcept
+        Momentum2 GetImpulses(size_type index) const noexcept
         {
             assert(index < MaxManifoldPoints);
             return m_impulses[index];

--- a/PlayRho/Common/Acceleration.hpp
+++ b/PlayRho/Common/Acceleration.hpp
@@ -31,7 +31,7 @@ namespace playrho
     /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
     struct Acceleration
     {
-        LinearAcceleration2D linear; ///< Linear acceleration.
+        LinearAcceleration2 linear; ///< Linear acceleration.
         AngularAcceleration angular; ///< Angular acceleration.
     };
     

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -21,11 +21,11 @@
 
 namespace playrho {
 
-Length2D ComputeCentroid(const Span<const Length2D>& vertices)
+Length2 ComputeCentroid(const Span<const Length2>& vertices)
 {
     assert(vertices.size() >= 3);
     
-    auto c = Length2D{} * Area{0};
+    auto c = Length2{} * Area{0};
     auto area = Area{0};
     
     // pRef is the reference point for forming triangles.
@@ -55,9 +55,9 @@ Length2D ComputeCentroid(const Span<const Length2D>& vertices)
     return c / area;
 }
 
-std::vector<Length2D> GetCircleVertices(Length radius, unsigned slices, Angle start, Real turns)
+std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle start, Real turns)
 {
-    std::vector<Length2D> vertices;
+    std::vector<Length2> vertices;
     if (slices > 0)
     {
         const auto integralTurns = static_cast<long int>(turns);
@@ -93,7 +93,7 @@ NonNegative<Area> GetAreaOfCircle(Length radius)
     return Area{radius * radius * Pi};
 }
 
-NonNegative<Area> GetAreaOfPolygon(Span<const Length2D> vertices)
+NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices)
 {
     // Uses the "Shoelace formula".
     // See: https://en.wikipedia.org/wiki/Shoelace_formula
@@ -112,7 +112,7 @@ NonNegative<Area> GetAreaOfPolygon(Span<const Length2D> vertices)
     return Abs(sum) / Real{2};
 }
 
-SecondMomentOfArea GetPolarMoment(Span<const Length2D> vertices)
+SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices)
 {
     assert(vertices.size() > 2);
     

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -389,7 +389,7 @@ constexpr auto Dot(const T1 a, const T2 b) noexcept
     return result;
 }
 
-/// @brief Performs the 2D analog of the cross product of two vectors.
+/// @brief Performs the 2-element analog of the cross product of two vectors.
 ///
 /// @details Defined as the result of: <code>(a.x * b.y) - (a.y * b.x)</code>.
 ///
@@ -572,17 +572,17 @@ constexpr inline Vec2 Transform(const Vec2 v, const Mat22& A) noexcept
 }
 
 #ifdef USE_BOOST_UNITS
-constexpr inline auto Transform(const LinearVelocity2D v, const Mass22& A) noexcept
+constexpr inline auto Transform(const LinearVelocity2 v, const Mass22& A) noexcept
 {
-    return Momentum2D{
+    return Momentum2{
         Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
         Get<1>(Get<0>(A)) * Get<0>(v) + Get<1>(Get<1>(A)) * Get<1>(v)
     };
 }
 
-constexpr inline auto Transform(const Momentum2D v, const InvMass22 A) noexcept
+constexpr inline auto Transform(const Momentum2 v, const InvMass22 A) noexcept
 {
-    return LinearVelocity2D{
+    return LinearVelocity2{
         Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
         Get<1>(Get<0>(A)) * Get<0>(v) + Get<1>(Get<1>(A)) * Get<1>(v)
     };
@@ -698,7 +698,7 @@ constexpr inline auto InverseRotate(const Vector2<T> vector, const UnitVec2& ang
 /// @param v 2-D position to transform (to rotate and then translate).
 /// @param xfm Transformation (a translation and rotation) to apply to the given vector.
 /// @return Rotated and translated vector.
-constexpr inline Length2D Transform(const Length2D v, const Transformation xfm) noexcept
+constexpr inline Length2 Transform(const Length2 v, const Transformation xfm) noexcept
 {
     return Rotate(v, xfm.q) + xfm.p;
 }
@@ -713,7 +713,7 @@ constexpr inline Length2D Transform(const Length2D v, const Transformation xfm) 
 /// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
 /// @param T Transformation (a translation and rotation) to inversely apply to the given vector.
 /// @return Inverse transformed vector.
-constexpr inline Length2D InverseTransform(const Length2D v, const Transformation T) noexcept
+constexpr inline Length2 InverseTransform(const Length2 v, const Transformation T) noexcept
 {
     const auto v2 = v - T.p;
     return InverseRotate(v2, T.q);
@@ -785,15 +785,15 @@ inline std::uint64_t NextPowerOfTwo(std::uint64_t x)
 }
 
 /// @brief Gets the transformation for the given values.
-constexpr inline Transformation GetTransformation(const Length2D ctr, const UnitVec2 rot,
-                                                  const Length2D localCtr) noexcept
+constexpr inline Transformation GetTransformation(const Length2 ctr, const UnitVec2 rot,
+                                                  const Length2 localCtr) noexcept
 {
     assert(IsValid(rot));
     return Transformation{ctr - (Rotate(localCtr, rot)), rot};
 }
 
 /// @brief Gets the transformation for the given values.
-inline Transformation GetTransformation(const Position pos, const Length2D local_ctr) noexcept
+inline Transformation GetTransformation(const Position pos, const Length2 local_ctr) noexcept
 {
     assert(IsValid(pos));
     assert(IsValid(local_ctr));
@@ -868,9 +868,9 @@ inline Real Normalize(Vec2& vector)
 /// @brief Gets the contact relative velocity.
 /// @note If relA and relB are the zero vectors, the resulting value is simply
 ///    velB.linear - velA.linear.
-inline LinearVelocity2D
-GetContactRelVelocity(const Velocity velA, const Length2D relA,
-                      const Velocity velB, const Length2D relB) noexcept
+inline LinearVelocity2
+GetContactRelVelocity(const Velocity velA, const Length2 relA,
+                      const Velocity velB, const Length2 relB) noexcept
 {
 #if 0 // Using std::fma appears to be slower!
     const auto revPerpRelB = GetRevPerpendicular(relB);
@@ -905,7 +905,7 @@ GetContactRelVelocity(const Velocity velA, const Length2D relA,
 /// @brief Computes the centroid of a counter-clockwise array of 3 or more vertices.
 /// @note Behavior is undefined if there are less than 3 vertices or the vertices don't
 ///   go counter-clockwise.
-Length2D ComputeCentroid(const Span<const Length2D>& vertices);
+Length2 ComputeCentroid(const Span<const Length2>& vertices);
 
 /// @brief Gets the modulo next value.
 template <typename T>
@@ -996,7 +996,7 @@ inline UnitVec2 GetUnitVector(Vector2<LinearVelocity> value, LinearVelocity& mag
 #endif // USE_BOOST_UNITS
 
 /// @brief Gets the vertices for a circle described by the given parameters.
-std::vector<Length2D> GetCircleVertices(Length radius, unsigned slices,
+std::vector<Length2> GetCircleVertices(Length radius, unsigned slices,
                                         Angle start = Angle{0}, Real turns = Real{1});
 
 /// @brief Gets the area of a cirlce.
@@ -1006,7 +1006,7 @@ NonNegative<Area> GetAreaOfCircle(Length radius);
 /// @note This function is valid for any non-self-intersecting (simple) polygon,
 ///   which can be convex or concave.
 /// @note Winding order doesn't matter.
-NonNegative<Area> GetAreaOfPolygon(Span<const Length2D> vertices);
+NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices);
 
 /// @brief Gets the polar moment of the area enclosed by the given vertices.
 ///
@@ -1014,7 +1014,7 @@ NonNegative<Area> GetAreaOfPolygon(Span<const Length2D> vertices);
 ///
 /// @param vertices Collection of three or more vertices.
 ///
-SecondMomentOfArea GetPolarMoment(Span<const Length2D> vertices);
+SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices);
 
 /// @}
 

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -33,7 +33,7 @@ namespace playrho
     /// @note This structure is likely to be 12-bytes large (at least on 64-bit platforms).
     struct Position
     {
-        Length2D linear; ///< Linear position.
+        Length2 linear; ///< Linear position.
         Angle angular; ///< Angular position.
     };
     

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -50,7 +50,7 @@ namespace playrho
         
         /// @brief Initializing constructor.
         constexpr Sweep(const Position p0, const Position p1,
-                        const Length2D lc = Length2D{0_m, 0_m},
+                        const Length2 lc = Length2{0_m, 0_m},
                         Real a0 = 0) noexcept:
         	pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
         {
@@ -60,7 +60,7 @@ namespace playrho
         
         /// @brief Initializing constructor.
         constexpr explicit Sweep(const Position p,
-                                 const Length2D lc = Length2D{0_m, 0_m}):
+                                 const Length2 lc = Length2{0_m, 0_m}):
         	Sweep{p, p, lc, 0}
         {
             // Intentionally empty.
@@ -69,7 +69,7 @@ namespace playrho
         /// @brief Gets the local center of mass position.
         /// @note This value can only be set via a sweep constructed using an initializing
         ///   constructor.
-        Length2D GetLocalCenter() const noexcept { return localCenter; }
+        Length2 GetLocalCenter() const noexcept { return localCenter; }
         
         /// @brief Gets the alpha0 for this sweep.
         /// @return Value between 0 and less than 1.
@@ -99,7 +99,7 @@ namespace playrho
     private:
         /// @brief Local center of mass position.
         /// @note 8-bytes.
-        Length2D localCenter = Length2D{0_m, 0_m};
+        Length2 localCenter = Length2{0_m, 0_m};
         
         /// @brief Fraction of the current time step in the range [0,1]
         /// @note pos0.linear and pos0.angular are the positions at alpha0.

--- a/PlayRho/Common/Transformation.hpp
+++ b/PlayRho/Common/Transformation.hpp
@@ -40,12 +40,12 @@ namespace playrho
     /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
     struct Transformation
     {
-        Length2D p = Length2D{}; ///< Translational portion of the transformation. 8-bytes.
+        Length2 p = Length2{}; ///< Translational portion of the transformation. 8-bytes.
         UnitVec2 q = UnitVec2::GetRight(); ///< Rotational portion of the transformation. 8-bytes.
     };
     
     /// @brief Identity transformation value.
-    constexpr auto Transform_identity = Transformation{Length2D{0_m, 0_m}, UnitVec2::GetRight()};
+    constexpr auto Transform_identity = Transformation{Length2{0_m, 0_m}, UnitVec2::GetRight()};
     
     /// @brief Determines if the given value is valid.
     /// @relatedalso Transformation

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -298,6 +298,10 @@ namespace playrho
     /// @sa Time.
     constexpr auto Second = PLAYRHO_UNIT(Time, boost::units::si::second);
 
+    /// @brief Square second unit.
+    /// @sa Second
+    constexpr auto SquareSecond = Second * Second;
+
     /// @brief Hertz unit of Frequency.
     /// @details Represents the hertz unit of Frequency (Hz).
     /// @sa Frequency.
@@ -326,6 +330,9 @@ namespace playrho
     /// @brief Square meter unit of Area.
     /// @sa Area.
     constexpr auto SquareMeter = PLAYRHO_UNIT(Area, boost::units::si::square_meter);
+
+    /// @brief Cubic meter unit of Volume.
+    constexpr auto CubicMeter = Meter * Meter * Meter;
 
     /// @brief Kilogram per square meter unit of Density.
     /// @sa Density.
@@ -714,13 +721,32 @@ namespace playrho
     }
 
     /// @}
-
+    
     /// @brief Strips the units off of the given value.
     constexpr inline Real StripUnit(const Real value)
     {
         return value;
     }
     
+    /// @defgroup UnitConstants Physical constants.
+    /// @sa Quantities
+    /// @sa Units
+    /// @{
+
+    /// @brief Earthly gravity.
+    /// @details An approximation of the average acceleration of Earthly objects towards
+    ///   the Earth due to the Earth's gravity.
+    /// @note This constant is only appropriate for use for objects of low mass and close
+    ///   distance relative to the Earth.
+    constexpr auto EarthlyLinearAcceleration = -9.8f * MeterPerSquareSecond;
+    
+    /// @brief Big "G".
+    /// @details Gravitational constant used in calculating the attractive force on a mass
+    ///   to another mass at a given distance due to gravity.
+    constexpr auto BigG = 6.67408e-11f * CubicMeter / (Kilogram * SquareSecond);
+    
+    /// @}
+
 #if defined(USE_BOOST_UNITS)
     
     /// @brief Strips the units off of the given value.

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -61,13 +61,11 @@ namespace playrho
     /// @brief 2-element vector of Momentum quantities.
     /// @note Often used as a 2-dimensional momentum vector.
     using Momentum2D = Vector2<Momentum>;
-        
-    /// @brief Earthly gravity.
-    /// @details An approximation of Earth's average gravity at sea-level in 2-dimensions.
-    constexpr auto EarthlyGravity = LinearAcceleration2D{
-        Real{0} * MeterPerSquareSecond,
-        Real{-9.8f} * MeterPerSquareSecond
-    };
+    
+    /// @brief Earthly gravity in 2-dimensions.
+    /// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
+    /// @sa EarthlyLinearAcceleration
+    constexpr auto EarthlyGravity2 = LinearAcceleration2D{0_mps2, EarthlyLinearAcceleration};
 
     /// @brief Gets the given value as a Vec2.
     constexpr inline Vec2 GetVec2(const Vector2<Real> value)

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -38,34 +38,30 @@ namespace playrho
     ///   (or 8 using Real of float).
     using Vec2 = Vector2<Real>;
     
-    /// @brief An all zero Vec2 value.
-    /// @see Vec2.
-    constexpr auto Vec2_zero = Vec2{0, 0};
-
     /// @brief 2-element vector of Length quanties.
     /// @note Often used as a 2-dimensional distance or location vector.
-    using Length2D = Vector2<Length>;
+    using Length2 = Vector2<Length>;
 
     /// @brief 2-element vector of LinearVelocity quantities.
     /// @note Often used as a 2-dimensional speed vector.
-    using LinearVelocity2D = Vector2<LinearVelocity>;
+    using LinearVelocity2 = Vector2<LinearVelocity>;
     
     /// @brief 2-element vector of LinearAcceleration quantities.
     /// @note Often used as a 2-dimensional linear acceleration vector.
-    using LinearAcceleration2D = Vector2<LinearAcceleration>;
+    using LinearAcceleration2 = Vector2<LinearAcceleration>;
     
     /// @brief 2-element vector of Force quantities.
     /// @note Often used as a 2-dimensional force vector.
-    using Force2D = Vector2<Force>;
+    using Force2 = Vector2<Force>;
     
     /// @brief 2-element vector of Momentum quantities.
     /// @note Often used as a 2-dimensional momentum vector.
-    using Momentum2D = Vector2<Momentum>;
+    using Momentum2 = Vector2<Momentum>;
     
     /// @brief Earthly gravity in 2-dimensions.
     /// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
     /// @sa EarthlyLinearAcceleration
-    constexpr auto EarthlyGravity2 = LinearAcceleration2D{0_mps2, EarthlyLinearAcceleration};
+    constexpr auto EarthlyGravity2D = LinearAcceleration2{0_mps2, EarthlyLinearAcceleration};
 
     /// @brief Gets the given value as a Vec2.
     constexpr inline Vec2 GetVec2(const Vector2<Real> value)
@@ -88,35 +84,35 @@ namespace playrho
     }
     
 #ifdef USE_BOOST_UNITS
-    /// @brief Gets an invalid value for the Length2D type.
+    /// @brief Gets an invalid value for the Length2 type.
     template <>
-    constexpr Length2D GetInvalid() noexcept
+    constexpr Length2 GetInvalid() noexcept
     {
-        return Length2D{GetInvalid<Length>(), GetInvalid<Length>()};
+        return Length2{GetInvalid<Length>(), GetInvalid<Length>()};
     }
     
-    /// @brief Gets an invalid value for the LinearVelocity2D type.
+    /// @brief Gets an invalid value for the LinearVelocity2 type.
     template <>
-    constexpr LinearVelocity2D GetInvalid() noexcept
+    constexpr LinearVelocity2 GetInvalid() noexcept
     {
-        return LinearVelocity2D{GetInvalid<LinearVelocity>(), GetInvalid<LinearVelocity>()};
+        return LinearVelocity2{GetInvalid<LinearVelocity>(), GetInvalid<LinearVelocity>()};
     }
     
-    /// @brief Gets an invalid value for the Force2D type.
+    /// @brief Gets an invalid value for the Force2 type.
     template <>
-    constexpr Force2D GetInvalid() noexcept
+    constexpr Force2 GetInvalid() noexcept
     {
-        return Force2D{GetInvalid<Force>(), GetInvalid<Force>()};
+        return Force2{GetInvalid<Force>(), GetInvalid<Force>()};
     }
     
-    /// @brief Gets an invalid value for the Momentum2D type.
+    /// @brief Gets an invalid value for the Momentum2 type.
     template <>
-    constexpr Momentum2D GetInvalid() noexcept
+    constexpr Momentum2 GetInvalid() noexcept
     {
-        return Momentum2D{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
+        return Momentum2{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
     }
     
-    constexpr inline Vec2 GetVec2(const Length2D value)
+    constexpr inline Vec2 GetVec2(const Length2 value)
     {
         return Vec2{
             Get<0>(value) / Meter,
@@ -124,7 +120,7 @@ namespace playrho
         };
     }
     
-    constexpr inline Vec2 GetVec2(const LinearVelocity2D value)
+    constexpr inline Vec2 GetVec2(const LinearVelocity2 value)
     {
         return Vec2{
             Get<0>(value) / MeterPerSecond,
@@ -132,7 +128,7 @@ namespace playrho
         };
     }
     
-    constexpr inline Vec2 GetVec2(const Momentum2D value)
+    constexpr inline Vec2 GetVec2(const Momentum2 value)
     {
         return Vec2{
             Get<0>(value) / (Kilogram * MeterPerSecond),
@@ -140,7 +136,7 @@ namespace playrho
         };
     }
     
-    constexpr inline Vec2 GetVec2(const Force2D value)
+    constexpr inline Vec2 GetVec2(const Force2 value)
     {
         return Vec2{
             Get<0>(value) / Newton,

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -31,7 +31,7 @@ namespace playrho
     /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
     struct Velocity
     {
-        LinearVelocity2D linear; ///< Linear velocity.
+        LinearVelocity2 linear; ///< Linear velocity.
         AngularVelocity angular; ///< Angular velocity.
     };
     

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -36,7 +36,7 @@ namespace playrho {
     public:
         
         /// @brief Constant pointer type.
-        using const_pointer = const Length2D*;
+        using const_pointer = const Length2*;
 
         /// @brief Gets the default minimum separation squared value.
         static Area GetDefaultMinSeparationSquared()
@@ -55,7 +55,7 @@ namespace playrho {
         Area GetMinSeparationSquared() const noexcept { return m_minSepSquared; }
 
         /// @brief Adds the given vertex into the set if allowed.
-        bool add(Length2D value)
+        bool add(Length2 value)
         {
             if (find(value) != end())
             {
@@ -82,25 +82,25 @@ namespace playrho {
 
         /// Finds contained point whose delta with the given point has a squared length less
         /// than or equal to this set's minimum length squared value.
-        const_pointer find(Length2D value) const
+        const_pointer find(Length2 value) const
         {
             // squaring anything smaller than the sqrt(std::numeric_limits<Vec2::data_type>::min())
             // won't be reversible.
             // i.e. won't obey the property that square(sqrt(a)) == a and sqrt(square(a)) == a.
-            return std::find_if(begin(), end(), [&](Length2D elem) {
+            return std::find_if(begin(), end(), [&](Length2 elem) {
                 // length squared must be large enough to have a reasonable enough unit vector.
                 return GetLengthSquared(value - elem) <= m_minSepSquared;
             });
         }
 
         /// @brief Indexed access.
-        Length2D operator[](std::size_t index) const noexcept
+        Length2 operator[](std::size_t index) const noexcept
         {
             return m_elements[index];
         }
 
     private:
-        std::vector<Length2D> m_elements; ///< Elements.
+        std::vector<Length2> m_elements; ///< Elements.
         const Area m_minSepSquared; ///< Minimum length squared. sizeof(Vec2)/2 or 4-bytes.
     };
 

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -229,7 +229,7 @@ void Body::SetMassData(const MassData& massData)
 
 void Body::SetVelocity(const Velocity& velocity) noexcept
 {
-    if ((velocity.linear != LinearVelocity2D{}) || (velocity.angular != AngularVelocity{0}))
+    if ((velocity.linear != LinearVelocity2{}) || (velocity.angular != AngularVelocity{0}))
     {
         if (!IsSpeedable())
         {
@@ -241,12 +241,12 @@ void Body::SetVelocity(const Velocity& velocity) noexcept
     m_velocity = velocity;
 }
 
-void Body::SetAcceleration(LinearAcceleration2D linear, AngularAcceleration angular) noexcept
+void Body::SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angular) noexcept
 {
     assert(IsValid(linear));
     assert(IsValid(angular));
 
-    if ((linear != LinearAcceleration2D{}) || (angular != AngularAcceleration{0}))
+    if ((linear != LinearAcceleration2{}) || (angular != AngularAcceleration{0}))
     {
         if (!IsAccelerable())
         {
@@ -271,7 +271,7 @@ void Body::SetTransformation(Transformation value) noexcept
     }
 }
 
-void Body::SetTransform(Length2D location, Angle angle)
+void Body::SetTransform(Length2 location, Angle angle)
 {
     assert(IsValid(location));
     assert(IsValid(angle));
@@ -487,7 +487,7 @@ std::size_t GetFixtureCount(const Body& body) noexcept
     return fixtures.size();
 }
 
-void RotateAboutWorldPoint(Body& body, Angle amount, Length2D worldPoint)
+void RotateAboutWorldPoint(Body& body, Angle amount, Length2 worldPoint)
 {
     const auto xfm = body.GetTransformation();
     const auto p = xfm.p - worldPoint;
@@ -495,17 +495,17 @@ void RotateAboutWorldPoint(Body& body, Angle amount, Length2D worldPoint)
     const auto s = Real{std::sin(amount / Radian)};
     const auto x = GetX(p) * c - GetY(p) * s;
     const auto y = GetX(p) * s + GetY(p) * c;
-    const auto pos = Length2D{x, y} + worldPoint;
+    const auto pos = Length2{x, y} + worldPoint;
     const auto angle = GetAngle(xfm.q) + amount;
     body.SetTransform(pos, angle);
 }
 
-void RotateAboutLocalPoint(Body& body, Angle amount, Length2D localPoint)
+void RotateAboutLocalPoint(Body& body, Angle amount, Length2 localPoint)
 {
     RotateAboutWorldPoint(body, amount, GetWorldPoint(body, localPoint));
 }
 
-Force2D GetCentripetalForce(const Body& body, Length2D axis)
+Force2 GetCentripetalForce(const Body& body, Length2 axis)
 {
     // For background on centripetal force, see:
     //   https://en.wikipedia.org/wiki/Centripetal_force
@@ -515,10 +515,10 @@ Force2D GetCentripetalForce(const Body& body, Length2D axis)
     const auto magnitude = GetLength(GetVec2(velocity)) * MeterPerSecond;
     const auto location = body.GetLocation();
     const auto mass = GetMass(body);
-    const auto delta = Length2D{axis - location};
+    const auto delta = Length2{axis - location};
     const auto radius = GetLength(delta);
     const auto dir = delta / radius;
-    return Force2D{dir * mass * Square(magnitude) / radius};
+    return Force2{dir * mass * Square(magnitude) / radius};
 }
 
 Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
@@ -527,7 +527,7 @@ Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
     const auto bodies = world->GetBodies();
     const auto m1 = GetMass(body);
     const auto loc1 = GetLocation(body);
-    auto sumForce = Force2D{};
+    auto sumForce = Force2{};
     for (auto jt = std::begin(bodies); jt != std::end(bodies); jt = std::next(jt))
     {
         const auto& b2 = *(*jt);

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -523,8 +523,6 @@ Force2D GetCentripetalForce(const Body& body, Length2D axis)
 
 Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
 {
-    constexpr auto G = 6.67408e-11f * Meter * Meter * Meter / (Kilogram * Second * Second);
-
     const auto world = body.GetWorld();
     const auto bodies = world->GetBodies();
     const auto m1 = GetMass(body);
@@ -542,7 +540,7 @@ Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
         const auto dir = GetUnitVector(delta);
         const auto rr = GetLengthSquared(delta);
         const auto orderedMass = std::minmax(m1, m2);
-        const auto f = (G * orderedMass.first) * (orderedMass.second / rr);
+        const auto f = (BigG * orderedMass.first) * (orderedMass.second / rr);
         sumForce += f * dir;
     }
     // F = m a... i.e.  a = F / m.

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -193,7 +193,7 @@ public:
     /// @param location Valid world location of the body's local origin. Behavior is undefined
     ///   if value is invalid.
     /// @param angle Valid world rotation. Behavior is undefined if value is invalid.
-    void SetTransform(Length2D location, Angle angle);
+    void SetTransform(Length2 location, Angle angle);
 
     /// @brief Gets the body transform for the body's origin.
     /// @return the world transform of the body's origin.
@@ -211,7 +211,7 @@ public:
     ///   5. Restitution and friction values of the body's fixtures when they experience collisions.
     /// @return World location of the body's origin.
     /// @sa GetTransformation.
-    Length2D GetLocation() const noexcept;
+    Length2 GetLocation() const noexcept;
 
     /// @brief Gets the body's sweep.
     const Sweep& GetSweep() const noexcept;
@@ -221,10 +221,10 @@ public:
     Angle GetAngle() const noexcept;
 
     /// @brief Get the world position of the center of mass.
-    Length2D GetWorldCenter() const noexcept;
+    Length2 GetWorldCenter() const noexcept;
 
     /// @brief Gets the local position of the center of mass.
-    Length2D GetLocalCenter() const noexcept;
+    Length2 GetLocalCenter() const noexcept;
 
     /// @brief Gets the velocity.
     Velocity GetVelocity() const noexcept;
@@ -240,10 +240,10 @@ public:
     /// @note A non-zero acceleration will also awaken the body.
     /// @param linear Linear acceleration.
     /// @param angular Angular acceleration.
-    void SetAcceleration(LinearAcceleration2D linear, AngularAcceleration angular) noexcept;
+    void SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angular) noexcept;
 
     /// @brief Gets this body's linear acceleration.
-    LinearAcceleration2D GetLinearAcceleration() const noexcept;
+    LinearAcceleration2 GetLinearAcceleration() const noexcept;
 
     /// @brief Gets this body's angular acceleration.
     AngularAcceleration GetAngularAcceleration() const noexcept;
@@ -510,7 +510,7 @@ private:
 
     /// @brief Linear acceleration.
     /// @note 8-bytes.
-    LinearAcceleration2D m_linearAcceleration = LinearAcceleration2D{};
+    LinearAcceleration2 m_linearAcceleration = LinearAcceleration2{};
 
     World* const m_world; ///< World to which this body belongs. 8-bytes.
     void* m_userData; ///< User data. 8-bytes.
@@ -572,7 +572,7 @@ inline Transformation Body::GetTransformation() const noexcept
     return m_xf;
 }
 
-inline Length2D Body::GetLocation() const noexcept
+inline Length2 Body::GetLocation() const noexcept
 {
     return GetTransformation().p;
 }
@@ -587,12 +587,12 @@ inline Angle Body::GetAngle() const noexcept
     return GetSweep().pos1.angular;
 }
 
-inline Length2D Body::GetWorldCenter() const noexcept
+inline Length2 Body::GetWorldCenter() const noexcept
 {
     return GetSweep().pos1.linear;
 }
 
-inline Length2D Body::GetLocalCenter() const noexcept
+inline Length2 Body::GetLocalCenter() const noexcept
 {
     return GetSweep().GetLocalCenter();
 }
@@ -680,7 +680,7 @@ inline void Body::UnsetAwake() noexcept
     {
         UnsetAwakeFlag();
         m_underActiveTime = 0;
-        m_velocity = Velocity{LinearVelocity2D{}, AngularVelocity{0}};
+        m_velocity = Velocity{LinearVelocity2{}, AngularVelocity{0}};
     }
 }
 
@@ -781,7 +781,7 @@ inline void* Body::GetUserData() const noexcept
     return m_userData;
 }
 
-inline LinearAcceleration2D Body::GetLinearAcceleration() const noexcept
+inline LinearAcceleration2 Body::GetLinearAcceleration() const noexcept
 {
     return m_linearAcceleration;
 }
@@ -921,23 +921,23 @@ inline Mass GetMass(const Body& body) noexcept
 
 /// @brief Sets the given linear acceleration of the given body.
 /// @relatedalso Body
-inline void SetLinearAcceleration(Body& body, LinearAcceleration2D value)
+inline void SetLinearAcceleration(Body& body, LinearAcceleration2 value)
 {
     body.SetAcceleration(value, body.GetAngularAcceleration());
 }
 
 /// @brief Applies the given linear acceleration to the given body.
 /// @relatedalso Body
-inline void ApplyLinearAcceleration(Body& body, LinearAcceleration2D amount)
+inline void ApplyLinearAcceleration(Body& body, LinearAcceleration2 amount)
 {
     SetLinearAcceleration(body, body.GetLinearAcceleration() + amount);
 }
 
 /// @brief Sets the given amount of force at the given point to the given body.
 /// @relatedalso Body
-inline void SetForce(Body& body, Force2D force, Length2D point) noexcept
+inline void SetForce(Body& body, Force2 force, Length2 point) noexcept
 {
-    const auto linAccel = LinearAcceleration2D{force * body.GetInvMass()};
+    const auto linAccel = LinearAcceleration2{force * body.GetInvMass()};
     const auto invRotI = body.GetInvRotInertia();
     const auto dp = point - body.GetWorldCenter();
     const auto cp = Torque{Cross(dp, force) / Radian};
@@ -953,12 +953,12 @@ inline void SetForce(Body& body, Force2D force, Length2D point) noexcept
 /// @param force World force vector.
 /// @param point World position of the point of application.
 /// @relatedalso Body
-inline void ApplyForce(Body& body, Force2D force, Length2D point) noexcept
+inline void ApplyForce(Body& body, Force2 force, Length2 point) noexcept
 {
     // Torque is L^2 M T^-2 QP^-1.
-    const auto linAccel = LinearAcceleration2D{force * body.GetInvMass()};
+    const auto linAccel = LinearAcceleration2{force * body.GetInvMass()};
     const auto invRotI = body.GetInvRotInertia(); // L^-2 M^-1 QP^2
-    const auto dp = Length2D{point - body.GetWorldCenter()}; // L
+    const auto dp = Length2{point - body.GetWorldCenter()}; // L
     const auto cp = Torque{Cross(dp, force) / Radian}; // L * M L T^-2 is L^2 M T^-2
     // L^2 M T^-2 QP^-1 * L^-2 M^-1 QP^2 = QP T^-2;
     const auto angAccel = AngularAcceleration{cp * invRotI};
@@ -971,7 +971,7 @@ inline void ApplyForce(Body& body, Force2D force, Length2D point) noexcept
 /// @param body Body to apply the force to.
 /// @param force World force vector.
 /// @relatedalso Body
-inline void ApplyForceToCenter(Body& body, Force2D force) noexcept
+inline void ApplyForceToCenter(Body& body, Force2 force) noexcept
 {
     const auto linAccel = body.GetLinearAcceleration() + force * body.GetInvMass();
     const auto angAccel = body.GetAngularAcceleration();
@@ -1012,7 +1012,7 @@ inline void ApplyTorque(Body& body, Torque torque) noexcept
 /// @param impulse the world impulse vector.
 /// @param point the world position of the point of application.
 /// @relatedalso Body
-inline void ApplyLinearImpulse(Body& body, Momentum2D impulse, Length2D point) noexcept
+inline void ApplyLinearImpulse(Body& body, Momentum2 impulse, Length2 point) noexcept
 {
     auto velocity = body.GetVelocity();
     velocity.linear += body.GetInvMass() * impulse;
@@ -1037,7 +1037,7 @@ inline void ApplyAngularImpulse(Body& body, AngularMomentum impulse) noexcept
 /// @brief Gets the centripetal force necessary to put the body into an orbit having
 ///    the given radius.
 /// @relatedalso Body
-Force2D GetCentripetalForce(const Body& body, Length2D axis);
+Force2 GetCentripetalForce(const Body& body, Length2 axis);
 
 /// @brief Gets the rotational inertia of the body.
 /// @param body Body to get the rotational inertia for.
@@ -1061,7 +1061,7 @@ inline RotInertia GetLocalRotInertia(const Body& body) noexcept
 /// @param body Body to get the linear velocity for.
 /// @return the linear velocity of the center of mass.
 /// @relatedalso Body
-inline LinearVelocity2D GetLinearVelocity(const Body& body) noexcept
+inline LinearVelocity2 GetLinearVelocity(const Body& body) noexcept
 {
     return body.GetVelocity().linear;
 }
@@ -1079,7 +1079,7 @@ inline AngularVelocity GetAngularVelocity(const Body& body) noexcept
 /// @param body Body to set the linear velocity of.
 /// @param v the new linear velocity of the center of mass.
 /// @relatedalso Body
-inline void SetLinearVelocity(Body& body, const LinearVelocity2D v) noexcept
+inline void SetLinearVelocity(Body& body, const LinearVelocity2 v) noexcept
 {
     body.SetVelocity(Velocity{v, GetAngularVelocity(body)});
 }
@@ -1098,7 +1098,7 @@ inline void SetAngularVelocity(Body& body, AngularVelocity omega) noexcept
 /// @param localPoint a point measured relative the the body's origin.
 /// @return the same point expressed in world coordinates.
 /// @relatedalso Body
-inline Length2D GetWorldPoint(const Body& body, const Length2D localPoint) noexcept
+inline Length2 GetWorldPoint(const Body& body, const Length2 localPoint) noexcept
 {
     return Transform(localPoint, body.GetTransformation());
 }
@@ -1108,7 +1108,7 @@ inline Length2D GetWorldPoint(const Body& body, const Length2D localPoint) noexc
 /// @param localVector a vector fixed in the body.
 /// @return the same vector expressed in world coordinates.
 /// @relatedalso Body
-inline Length2D GetWorldVector(const Body& body, const Length2D localVector) noexcept
+inline Length2 GetWorldVector(const Body& body, const Length2 localVector) noexcept
 {
     return Rotate(localVector, body.GetTransformation().q);
 }
@@ -1125,7 +1125,7 @@ inline UnitVec2 GetWorldVector(const Body& body, const UnitVec2 localVector) noe
 /// @param worldPoint point in world coordinates.
 /// @return the corresponding local point relative to the body's origin.
 /// @relatedalso Body
-inline Length2D GetLocalPoint(const Body& body, const Length2D worldPoint) noexcept
+inline Length2 GetLocalPoint(const Body& body, const Length2 worldPoint) noexcept
 {
     return InverseTransform(worldPoint, body.GetTransformation());
 }
@@ -1145,13 +1145,13 @@ inline UnitVec2 GetLocalVector(const Body& body, const UnitVec2 uv) noexcept
 /// @param worldPoint point in world coordinates.
 /// @return the world velocity of a point.
 /// @relatedalso Body
-inline LinearVelocity2D GetLinearVelocityFromWorldPoint(const Body& body,
-                                                        const Length2D worldPoint) noexcept
+inline LinearVelocity2 GetLinearVelocityFromWorldPoint(const Body& body,
+                                                        const Length2 worldPoint) noexcept
 {
     const auto velocity = body.GetVelocity();
     const auto worldCtr = body.GetWorldCenter();
-    const auto dp = Length2D{worldPoint - worldCtr};
-    const auto rlv = LinearVelocity2D{GetRevPerpendicular(dp) * (velocity.angular / Radian)};
+    const auto dp = Length2{worldPoint - worldCtr};
+    const auto rlv = LinearVelocity2{GetRevPerpendicular(dp) * (velocity.angular / Radian)};
     return velocity.linear + rlv;
 }
 
@@ -1160,15 +1160,15 @@ inline LinearVelocity2D GetLinearVelocityFromWorldPoint(const Body& body,
 /// @param localPoint point in local coordinates.
 /// @return the world velocity of a point.
 /// @relatedalso Body
-inline LinearVelocity2D GetLinearVelocityFromLocalPoint(const Body& body,
-                                                        const Length2D localPoint) noexcept
+inline LinearVelocity2 GetLinearVelocityFromLocalPoint(const Body& body,
+                                                        const Length2 localPoint) noexcept
 {
     return GetLinearVelocityFromWorldPoint(body, GetWorldPoint(body, localPoint));
 }
 
 /// @brief Gets the net force that the given body is currently experiencing.
 /// @relatedalso Body
-inline Force2D GetForce(const Body& body) noexcept
+inline Force2 GetForce(const Body& body) noexcept
 {
     return body.GetLinearAcceleration() * GetMass(body);
 }
@@ -1204,7 +1204,7 @@ std::size_t GetFixtureCount(const Body& body) noexcept;
 /// @param amount Amount to rotate body by (in counter-clockwise direction).
 /// @param worldPoint Point in world coordinates.
 /// @relatedalso Body
-void RotateAboutWorldPoint(Body& body, Angle amount, Length2D worldPoint);
+void RotateAboutWorldPoint(Body& body, Angle amount, Length2 worldPoint);
 
 /// @brief Rotates a body a given amount around a point in body local coordinates.
 /// @details This changes both the linear and angular positions of the body.
@@ -1215,7 +1215,7 @@ void RotateAboutWorldPoint(Body& body, Angle amount, Length2D worldPoint);
 /// @param amount Amount to rotate body by (in counter-clockwise direction).
 /// @param localPoint Point in local coordinates.
 /// @relatedalso Body
-void RotateAboutLocalPoint(Body& body, Angle amount, Length2D localPoint);
+void RotateAboutLocalPoint(Body& body, Angle amount, Length2 localPoint);
 
 /// @brief Gets the body's origin location.
 /// @details This is the location of the body's origin relative to its world.
@@ -1229,7 +1229,7 @@ void RotateAboutLocalPoint(Body& body, Angle amount, Length2D localPoint);
 /// @return World location of the body's origin.
 /// @sa GetAngle.
 /// @relatedalso Body
-inline Length2D GetLocation(const Body& body) noexcept
+inline Length2 GetLocation(const Body& body) noexcept
 {
     return body.GetTransformation().p;
 }
@@ -1250,7 +1250,7 @@ inline Angle GetAngle(const Body& body) noexcept
 ///   if value is invalid.
 /// @sa Body::SetTransform
 /// @relatedalso Body
-inline void SetLocation(Body& body, Length2D value) noexcept
+inline void SetLocation(Body& body, Length2 value) noexcept
 {
     body.SetTransform(value, GetAngle(body));
 }

--- a/PlayRho/Dynamics/BodyAtty.hpp
+++ b/PlayRho/Dynamics/BodyAtty.hpp
@@ -97,7 +97,7 @@ private:
             case BodyType::Static:
                 b.UnsetAwakeFlag();
                 b.m_underActiveTime = 0;
-                b.m_velocity = Velocity{LinearVelocity2D{}, AngularVelocity{0}};
+                b.m_velocity = Velocity{LinearVelocity2{}, AngularVelocity{0}};
                 b.m_sweep.pos0 = b.m_sweep.pos1;
                 break;
         }

--- a/PlayRho/Dynamics/BodyDef.hpp
+++ b/PlayRho/Dynamics/BodyDef.hpp
@@ -51,19 +51,19 @@ namespace playrho {
         constexpr BodyDef& UseType(BodyType t) noexcept;
 
         /// @brief Use the given location.
-        constexpr BodyDef& UseLocation(Length2D l) noexcept;
+        constexpr BodyDef& UseLocation(Length2 l) noexcept;
         
         /// @brief Use the given angle.
         constexpr BodyDef& UseAngle(Angle a) noexcept;
         
         /// @brief Use the given linear velocity.
-        constexpr BodyDef& UseLinearVelocity(LinearVelocity2D v) noexcept;
+        constexpr BodyDef& UseLinearVelocity(LinearVelocity2 v) noexcept;
         
         /// @brief Use the given angular velocity.
         constexpr BodyDef& UseAngularVelocity(AngularVelocity v) noexcept;
         
         /// @brief Use the given linear acceleration.
-        constexpr BodyDef& UseLinearAcceleration(LinearAcceleration2D v) noexcept;
+        constexpr BodyDef& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
         
         /// @brief Use the given angular acceleration.
         constexpr BodyDef& UseAngularAcceleration(AngularAcceleration v) noexcept;
@@ -103,20 +103,20 @@ namespace playrho {
         
         /// The world location of the body. Avoid creating bodies at the origin
         /// since this can lead to many overlapping shapes.
-        Length2D location = Length2D{};
+        Length2 location = Length2{};
         
         /// The world angle of the body.
         Angle angle = Angle{0};
         
         /// The linear velocity of the body's origin in world co-ordinates (in m/s).
-        LinearVelocity2D linearVelocity = LinearVelocity2D{};
+        LinearVelocity2 linearVelocity = LinearVelocity2{};
         
         /// The angular velocity of the body.
         AngularVelocity angularVelocity = AngularVelocity{0};
         
         /// Initial linear acceleration of the body.
         /// @note Usually this should be 0.
-        LinearAcceleration2D linearAcceleration = LinearAcceleration2D{};
+        LinearAcceleration2 linearAcceleration = LinearAcceleration2{};
         
         /// Initial angular acceleration of the body.
         /// @note Usually this should be 0.
@@ -165,7 +165,7 @@ namespace playrho {
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseLocation(Length2D l) noexcept
+    constexpr inline BodyDef& BodyDef::UseLocation(Length2 l) noexcept
     {
         location = l;
         return *this;
@@ -177,13 +177,13 @@ namespace playrho {
         return *this;
     }
     
-    constexpr BodyDef& BodyDef::UseLinearVelocity(LinearVelocity2D v) noexcept
+    constexpr BodyDef& BodyDef::UseLinearVelocity(LinearVelocity2 v) noexcept
     {
         linearVelocity = v;
         return *this;
     }
     
-    constexpr BodyDef& BodyDef::UseLinearAcceleration(LinearAcceleration2D v) noexcept
+    constexpr BodyDef& BodyDef::UseLinearAcceleration(LinearAcceleration2 v) noexcept
     {
         linearAcceleration = v;
         return *this;

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -42,7 +42,7 @@ namespace playrho {
         BodyConstraint() = default;
         
         /// @brief Initializing constructor.
-        constexpr BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2D localCenter,
+        constexpr BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
                                  Position position, Velocity velocity) noexcept:
             m_position{position},
             m_velocity{velocity},
@@ -66,7 +66,7 @@ namespace playrho {
         InvRotInertia GetInvRotInertia() const noexcept;
         
         /// @brief Gets the location of the body's center of mass in local coordinates.
-        Length2D GetLocalCenter() const noexcept;
+        Length2 GetLocalCenter() const noexcept;
         
         /// @brief Gets the position of the body.
         Position GetPosition() const noexcept;
@@ -87,7 +87,7 @@ namespace playrho {
     private:
         Position m_position; ///< Body position data.
         Velocity m_velocity; ///< Body velocity data.
-        Length2D m_localCenter; ///< Local center of the associated body's sweep.
+        Length2 m_localCenter; ///< Local center of the associated body's sweep.
         InvMass m_invMass; ///< Inverse mass of associated body (a non-negative value).
 
         /// Inverse rotational inertia about the center of mass of the associated body
@@ -105,7 +105,7 @@ namespace playrho {
         return m_invRotI;
     }
     
-    inline Length2D BodyConstraint::GetLocalCenter() const noexcept
+    inline Length2 BodyConstraint::GetLocalCenter() const noexcept
     {
         return m_localCenter;
     }

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -64,7 +64,7 @@ struct ImpulseChange
     UnitVec2 direction; ///< Direction.
 };
 
-VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2D impulses)
+VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impulses)
 {
     assert(IsValid(impulses));
 
@@ -94,7 +94,7 @@ VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2D imp
     };
 }
 
-Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2D newImpulses)
+Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2 newImpulses)
 {
     const auto delta_v = GetVelocityDelta(vc, newImpulses - GetNormalImpulses(vc));
     vc.GetBodyA()->SetVelocity(vc.GetBodyA()->GetVelocity() + delta_v.vel_a);
@@ -104,7 +104,7 @@ Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2D newImpulses)
 }
 
 Optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
-                                         const LinearVelocity2D b_prime)
+                                         const LinearVelocity2 b_prime)
 {
     //
     // Case 1: vn = 0
@@ -143,7 +143,7 @@ Optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
     return Optional<Momentum>{};
 }
 
-Optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc, const LinearVelocity2D b_prime)
+Optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc, const LinearVelocity2 b_prime)
 {
     //
     // Case 2: vn1 = 0 and x2 = 0
@@ -151,7 +151,7 @@ Optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc, const LinearVel
     //   0 = a11 * x1 + a12 * 0 + b1'
     // vn2 = a21 * x1 + a22 * 0 + b2'
     //
-    const auto newImpulses = Momentum2D{
+    const auto newImpulses = Momentum2{
         -GetNormalMassAtPoint(vc, 0) * Get<0>(b_prime), Momentum{0}
     };
     const auto K = vc.GetK();
@@ -178,7 +178,7 @@ Optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc, const LinearVel
     return Optional<Momentum>{};
 }
 
-Optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc, const LinearVelocity2D b_prime)
+Optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc, const LinearVelocity2 b_prime)
 {
     //
     // Case 3: vn2 = 0 and x1 = 0
@@ -186,7 +186,7 @@ Optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc, const LinearVel
     // vn1 = a11 * 0 + a12 * x2 + b1'
     //   0 = a21 * 0 + a22 * x2 + b2'
     //
-    const auto newImpulses = Momentum2D{
+    const auto newImpulses = Momentum2{
         Momentum{0}, -GetNormalMassAtPoint(vc, 1) * Get<1>(b_prime)
     };
     const auto K = vc.GetK();
@@ -213,7 +213,7 @@ Optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc, const LinearVel
     return Optional<Momentum>{};
 }
 
-Optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc, const LinearVelocity2D b_prime)
+Optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc, const LinearVelocity2 b_prime)
 {
     //
     // Case 4: x1 = 0 and x2 = 0
@@ -224,7 +224,7 @@ Optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc, const LinearVel
     const auto vn2 = Get<1>(b_prime);
     if ((vn1 >= LinearVelocity{0}) && (vn2 >= LinearVelocity{0}))
     {
-        return Optional<Momentum>{BlockSolveUpdate(vc, Momentum2D{Momentum(0), Momentum(0)})};
+        return Optional<Momentum>{BlockSolveUpdate(vc, Momentum2{Momentum(0), Momentum(0)})};
     }
     return Optional<Momentum>{};
 }
@@ -284,7 +284,7 @@ inline Momentum BlockSolveNormalConstraint(VelocityConstraint& vc)
         const auto vn1 = Dot(dv1, normal);
         
         // Compute b
-        const auto b = LinearVelocity2D{
+        const auto b = LinearVelocity2{
             vn0 - vc.GetVelocityBiasAtPoint(0),
             vn1 - vc.GetVelocityBiasAtPoint(1)
         };
@@ -499,14 +499,14 @@ PositionSolution SolvePositionConstraint(const PositionConstraint& pc,
     const auto totalRadius = pc.GetRadiusA() + pc.GetRadiusB();
 
     const auto solver_fn = [&](const PositionSolverManifold psm,
-                               const Length2D pA, const Length2D pB) {
+                               const Length2 pA, const Length2 pB) {
         const auto separation = psm.m_separation - totalRadius;
         // Positive separation means shapes not overlapping and not touching.
         // Zero separation means shapes are touching.
         // Negative separation means shapes are overlapping.
 
-        const auto rA = Length2D{psm.m_point - pA};
-        const auto rB = Length2D{psm.m_point - pB};
+        const auto rA = Length2{psm.m_point - pA};
+        const auto rB = Length2{psm.m_point - pB};
 
         // Compute the effective mass.
         const auto K = InvMass{[&]() {
@@ -526,7 +526,7 @@ PositionSolution SolvePositionConstraint(const PositionConstraint& pc,
                               -conf.maxLinearCorrection, Length{0});
 
         // Compute response factors...
-        const auto P = Length2D{psm.m_normal * C} / K; // L M
+        const auto P = Length2{psm.m_normal * C} / K; // L M
         const auto LA = Cross(rA, P) / Radian; // L^2 M QP^-1
         const auto LB = Cross(rB, P) / Radian; // L^2 M QP^-1
 

--- a/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
+++ b/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
@@ -30,8 +30,8 @@ namespace {
 /// @param plp Point's local point. Location of shape B in local coordinates.
 /// @note The returned separation is the magnitude of the positional difference of the two points.
 ///   This is always a non-negative amount.
-inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2D lp,
-                                            const Transformation& xfB, Length2D plp)
+inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2 lp,
+                                            const Transformation& xfB, Length2 plp)
 {
     const auto pointA = Transform(lp, xfA);
     const auto pointB = Transform(plp, xfB);
@@ -51,8 +51,8 @@ inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2D 
 /// @param plp Point's local point. Location for shape B in local coordinates.
 /// @return Separation is the dot-product of the positional difference between the two points in
 ///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2D lp, UnitVec2 ln,
-                                          const Transformation& xfB, Length2D plp)
+inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2 lp, UnitVec2 ln,
+                                          const Transformation& xfB, Length2 plp)
 {
     const auto planePoint = Transform(lp, xfA);
     const auto normal = Rotate(ln, xfA.q);
@@ -70,8 +70,8 @@ inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2D lp
 /// @param plp Point's local point. Location for shape A in local coordinates.
 /// @return Separation is the dot-product of the positional difference between the two points in
 ///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceB(const Transformation& xfB, Length2D lp, UnitVec2 ln,
-                                          const Transformation& xfA, Length2D plp)
+inline PositionSolverManifold GetForFaceB(const Transformation& xfB, Length2 lp, UnitVec2 ln,
+                                          const Transformation& xfA, Length2 plp)
 {
     const auto planePoint = Transform(lp, xfB);
     const auto normal = Rotate(ln, xfB.q);
@@ -105,7 +105,7 @@ PositionSolverManifold GetPSM(const Manifold& manifold, Manifold::size_type inde
     }
 
     // should not be reached
-    return PositionSolverManifold{GetInvalid<UnitVec2>(), GetInvalid<Length2D>(), GetInvalid<Length>()};
+    return PositionSolverManifold{GetInvalid<UnitVec2>(), GetInvalid<Length2>(), GetInvalid<Length>()};
 }
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp
+++ b/PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp
@@ -42,7 +42,7 @@ namespace playrho {
         /// Point.
         /// @details Point at which position resolution should be relatively applied.
         /// @note This field is 8-bytes large.
-        Length2D m_point;
+        Length2 m_point;
         
         /// Separation.
         /// @details Separation between two points (i.e. penetration if negative).

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
@@ -125,7 +125,7 @@ VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
 
 VelocityConstraint::Point
 VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                             Length2D relA, Length2D relB, Conf conf) const noexcept
+                             Length2 relA, Length2 relB, Conf conf) const noexcept
 {
     assert(IsValid(normalImpulse));
     assert(IsValid(tangentImpulse));
@@ -172,7 +172,7 @@ VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
 }
 
 void VelocityConstraint::AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                                  Length2D relA, Length2D relB, Conf conf)
+                                  Length2 relA, Length2 relB, Conf conf)
 {
     assert(m_pointCount < MaxManifoldPoints);
     m_points[m_pointCount] = GetPoint(normalImpulse * conf.dtRatio, tangentImpulse * conf.dtRatio,

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -164,12 +164,12 @@ namespace playrho {
         /// Gets the point relative position of A.
         /// @note The <code>AddPoint</code> method sets this value.
         /// @return Previously set value or an invalid value.
-        Length2D GetPointRelPosA(size_type index) const noexcept;
+        Length2 GetPointRelPosA(size_type index) const noexcept;
         
         /// Gets the point relative position of B.
         /// @note The <code>AddPoint</code> method sets this value.
         /// @return Previously set value or an invalid value.
-        Length2D GetPointRelPosB(size_type index) const noexcept;
+        Length2 GetPointRelPosB(size_type index) const noexcept;
         
         /// @brief Sets the normal impulse at the given point.
         void SetNormalImpulseAtPoint(size_type index, Momentum value);
@@ -189,10 +189,10 @@ namespace playrho {
         struct Point
         {
             /// Position of body A relative to world manifold point.
-            Length2D relA = Length2D{};
+            Length2 relA = Length2{};
             
             /// Position of body B relative to world manifold point.
-            Length2D relB = Length2D{};
+            Length2 relB = Length2{};
             
             /// Normal impulse.
             Momentum normalImpulse = Momentum{0};
@@ -235,14 +235,14 @@ namespace playrho {
         /// @warning Behavior is undefined if an attempt is made to add more than MaxManifoldPoints points.
         /// @sa GetPointCount().
         void AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                      Length2D relA, Length2D relB, Conf conf);
+                      Length2 relA, Length2 relB, Conf conf);
         
         /// Removes the last point added.
         void RemovePoint() noexcept;
         
         /// @brief Gets a point instance for the given parameters.
         Point GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                       Length2D relA, Length2D relB, Conf conf) const noexcept;
+                       Length2 relA, Length2 relB, Conf conf) const noexcept;
         
         /// Accesses the point identified by the given index.
         /// @warning Behavior is undefined if given index is not less than <code>MaxManifoldPoints</code>.
@@ -307,12 +307,12 @@ namespace playrho {
         return m_normalMass;
     }
     
-    inline Length2D VelocityConstraint::GetPointRelPosA(VelocityConstraint::size_type index) const noexcept
+    inline Length2 VelocityConstraint::GetPointRelPosA(VelocityConstraint::size_type index) const noexcept
     {
         return GetPointAt(index).relA;
     }
     
-    inline Length2D VelocityConstraint::GetPointRelPosB(VelocityConstraint::size_type index) const noexcept
+    inline Length2 VelocityConstraint::GetPointRelPosB(VelocityConstraint::size_type index) const noexcept
     {
         return GetPointAt(index).relB;
     }
@@ -376,14 +376,14 @@ namespace playrho {
     }
     
     /// @brief Gets the point relative position A data.
-    inline Length2D GetPointRelPosA(const VelocityConstraint& vc,
+    inline Length2 GetPointRelPosA(const VelocityConstraint& vc,
                                     VelocityConstraint::size_type index)
     {
         return vc.GetPointRelPosA(index);
     }
     
     /// @brief Gets the point relative position B data.
-    inline Length2D GetPointRelPosB(const VelocityConstraint& vc,
+    inline Length2 GetPointRelPosB(const VelocityConstraint& vc,
                                     VelocityConstraint::size_type index)
     {
         return vc.GetPointRelPosB(index);
@@ -424,15 +424,15 @@ namespace playrho {
     }
     
     /// @brief Gets the normal impulses of the given velocity constraint.
-    inline Momentum2D GetNormalImpulses(const VelocityConstraint& vc)
+    inline Momentum2 GetNormalImpulses(const VelocityConstraint& vc)
     {
-        return Momentum2D{GetNormalImpulseAtPoint(vc, 0), GetNormalImpulseAtPoint(vc, 1)};
+        return Momentum2{GetNormalImpulseAtPoint(vc, 0), GetNormalImpulseAtPoint(vc, 1)};
     }
     
     /// @brief Gets the tangent impulses of the given velocity constraint.
-    inline Momentum2D GetTangentImpulses(const VelocityConstraint& vc)
+    inline Momentum2 GetTangentImpulses(const VelocityConstraint& vc)
     {
-        return Momentum2D{GetTangentImpulseAtPoint(vc, 0), GetTangentImpulseAtPoint(vc, 1)};
+        return Momentum2{GetTangentImpulseAtPoint(vc, 0), GetTangentImpulseAtPoint(vc, 1)};
     }
     
     /// @brief Sets the normal impulse at the given point of the given velocity constraint.
@@ -448,14 +448,14 @@ namespace playrho {
     }
     
     /// @brief Sets the normal impulses of the given velocity constraint.
-    inline void SetNormalImpulses(VelocityConstraint& vc, const Momentum2D impulses)
+    inline void SetNormalImpulses(VelocityConstraint& vc, const Momentum2 impulses)
     {
         SetNormalImpulseAtPoint(vc, 0, impulses[0]);
         SetNormalImpulseAtPoint(vc, 1, impulses[1]);
     }
     
     /// @brief Sets the tangent impulses of the given velocity constraint.
-    inline void SetTangentImpulses(VelocityConstraint& vc, const Momentum2D impulses)
+    inline void SetTangentImpulses(VelocityConstraint& vc, const Momentum2 impulses)
     {
         SetTangentImpulseAtPoint(vc, 0, impulses[0]);
         SetTangentImpulseAtPoint(vc, 1, impulses[1]);

--- a/PlayRho/Dynamics/Fixture.cpp
+++ b/PlayRho/Dynamics/Fixture.cpp
@@ -120,7 +120,7 @@ void Fixture::SetSensor(bool sensor) noexcept
     }
 }
 
-bool TestPoint(const Fixture& f, Length2D p) noexcept
+bool TestPoint(const Fixture& f, Length2 p) noexcept
 {
     return TestPoint(*f.GetShape(), InverseTransform(p, GetTransformation(f)));
 }

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -282,7 +282,7 @@ inline void Fixture::ResetProxies() noexcept
 /// @param p Point in world coordinates.
 /// @relatedalso Fixture
 /// @ingroup TestPointGroup
-bool TestPoint(const Fixture& f, Length2D p) noexcept;
+bool TestPoint(const Fixture& f, Length2 p) noexcept;
 
 /// @brief Sets the associated body's sleep status to awake.
 /// @note This is a convenience function that simply looks up the fixture's body and

--- a/PlayRho/Dynamics/Joints/DistanceJoint.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.cpp
@@ -91,7 +91,7 @@ void DistanceJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
 
     m_rA = Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA);
     m_rB = Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB);
-    const auto deltaLocation = Length2D{(posB.linear + m_rB) - (posA.linear + m_rA)};
+    const auto deltaLocation = Length2{(posB.linear + m_rB) - (posA.linear + m_rA)};
 
     // Handle singularity.
     auto length = Length{0};
@@ -142,7 +142,7 @@ void DistanceJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         const auto P = m_impulse * m_u;
 
         // P is M L T^-2
-        // Cross(Length2D, P) is: M L^2 T^-1
+        // Cross(Length2, P) is: M L^2 T^-1
         // inv rotational inertia is: L^-2 M^-1 QP^2
         // Product is: L^-2 M^-1 QP^2 M L^2 T^-1 = QP^2 T^-1
         const auto LA = Cross(m_rA, P) / Radian;
@@ -215,9 +215,9 @@ bool DistanceJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     const auto qA = UnitVec2::Get(posA.angular);
     const auto qB = UnitVec2::Get(posB.angular);
 
-    const auto rA = Length2D{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
-    const auto rB = Length2D{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
-    const auto relLoc = Length2D{(posB.linear + rB) - (posA.linear + rA)};
+    const auto rA = Length2{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
+    const auto rB = Length2{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
+    const auto relLoc = Length2{(posB.linear + rB) - (posA.linear + rA)};
 
     auto length = Length{0};
     const auto u = GetUnitVector(relLoc, length);
@@ -236,17 +236,17 @@ bool DistanceJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     return Abs(C) < conf.linearSlop;
 }
 
-Length2D DistanceJoint::GetAnchorA() const
+Length2 DistanceJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D DistanceJoint::GetAnchorB() const
+Length2 DistanceJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D DistanceJoint::GetLinearReaction() const
+Momentum2 DistanceJoint::GetLinearReaction() const
 {
     return m_impulse * m_u;
 }

--- a/PlayRho/Dynamics/Joints/DistanceJoint.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.hpp
@@ -48,22 +48,22 @@ public:
 
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
+    Length2 GetAnchorA() const override;
 
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorB() const override;
 
     /// @brief Get the linear reaction.
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
 
     /// @brief Gets the angular reaction.
     /// @note This is always zero for a distance joint.
     AngularMomentum GetAngularReaction() const override;
 
     /// @brief Gets the local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const noexcept { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const noexcept { return m_localAnchorA; }
 
     /// @brief Gets the local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const noexcept { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const noexcept { return m_localAnchorB; }
 
     /// @brief Sets the natural length.
     /// @note Manipulating the length can lead to non-physical behavior when the frequency is zero.
@@ -92,8 +92,8 @@ private:
     bool SolvePositionConstraints(BodyConstraintsMap& bodies,
                                   const ConstraintSolverConf& conf) const override;
 
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     Length m_length; ///< Length.
     NonNegative<Frequency> m_frequency = NonNegative<Frequency>{0}; ///< Frequency.
     Real m_dampingRatio; ///< Damping ratio.
@@ -106,8 +106,8 @@ private:
     LinearVelocity m_bias; ///< Bias.
     Mass m_mass; ///< Mass.
     UnitVec2 m_u; ///< "u" directional.
-    Length2D m_rA; ///< Relative A position.
-    Length2D m_rB; ///< Relative B position.
+    Length2 m_rA; ///< Relative A position.
+    Length2 m_rB; ///< Relative B position.
 };
 
 inline void DistanceJoint::SetLength(Length length) noexcept

--- a/PlayRho/Dynamics/Joints/DistanceJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointDef.cpp
@@ -26,7 +26,7 @@
 namespace playrho {
 
 DistanceJointDef::DistanceJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
-                                   Length2D anchor1, Length2D anchor2) noexcept :
+                                   Length2 anchor1, Length2 anchor2) noexcept :
     super{super{JointType::Distance}.UseBodyA(bA).UseBodyB(bB)},
     localAnchorA{GetLocalPoint(*bA, anchor1)},
     localAnchorB{GetLocalPoint(*bB, anchor2)},

--- a/PlayRho/Dynamics/Joints/DistanceJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointDef.hpp
@@ -51,8 +51,8 @@ struct DistanceJointDef : public JointBuilder<DistanceJointDef>
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, and length using the world anchors.
     DistanceJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB,
-                     Length2D anchorA = Length2D{},
-                     Length2D anchorB = Length2D{}) noexcept;
+                     Length2 anchorA = Length2{},
+                     Length2 anchorB = Length2{}) noexcept;
     
     /// @brief Uses the given length.
     constexpr DistanceJointDef& UseLength(Length v) noexcept;
@@ -64,10 +64,10 @@ struct DistanceJointDef : public JointBuilder<DistanceJointDef>
     constexpr DistanceJointDef& UseDampingRatio(Real v) noexcept;
     
     /// @brief Local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{};
+    Length2 localAnchorA = Length2{};
     
     /// @brief Local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{};
+    Length2 localAnchorB = Length2{};
     
     /// @brief Natural length between the anchor points.
     Length length = 1_m;

--- a/PlayRho/Dynamics/Joints/FrictionJoint.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.cpp
@@ -124,7 +124,7 @@ void FrictionJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const St
     }
     else
     {
-        m_linearImpulse = Momentum2D{};
+        m_linearImpulse = Momentum2{};
         m_angularImpulse = AngularMomentum{0};
     }
 
@@ -169,8 +169,8 @@ bool FrictionJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
 
     // Solve linear friction
     {
-        const auto vb = LinearVelocity2D{velB.linear + (GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
-        const auto va = LinearVelocity2D{velA.linear + (GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
+        const auto vb = LinearVelocity2{velB.linear + (GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
+        const auto va = LinearVelocity2{velA.linear + (GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
 
         const auto impulse = -Transform(vb - va, m_linearMass);
         const auto oldImpulse = m_linearImpulse;
@@ -183,11 +183,11 @@ bool FrictionJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
             m_linearImpulse = GetUnitVector(m_linearImpulse, UnitVec2::GetZero()) * maxImpulse;
         }
 
-        const auto incImpulse = Momentum2D{m_linearImpulse - oldImpulse};
+        const auto incImpulse = Momentum2{m_linearImpulse - oldImpulse};
         const auto angImpulseA = AngularMomentum{Cross(m_rA, incImpulse) / Radian};
         const auto angImpulseB = AngularMomentum{Cross(m_rB, incImpulse) / Radian};
 
-        if (incImpulse != Momentum2D{})
+        if (incImpulse != Momentum2{})
         {
             solved = false;
         }
@@ -210,17 +210,17 @@ bool FrictionJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
     return true;
 }
 
-Length2D FrictionJoint::GetAnchorA() const
+Length2 FrictionJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D FrictionJoint::GetAnchorB() const
+Length2 FrictionJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D FrictionJoint::GetLinearReaction() const
+Momentum2 FrictionJoint::GetLinearReaction() const
 {
     return m_linearImpulse;
 }

--- a/PlayRho/Dynamics/Joints/FrictionJoint.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.hpp
@@ -44,17 +44,17 @@ public:
 
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// The local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const { return m_localAnchorA; }
 
     /// The local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const  { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const  { return m_localAnchorB; }
 
     /// Set the maximum friction force in N.
     void SetMaxForce(NonNegative<Force> force);
@@ -76,18 +76,18 @@ private:
     bool SolvePositionConstraints(BodyConstraintsMap& bodies,
                                   const ConstraintSolverConf& conf) const override;
 
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     NonNegative<Force> m_maxForce = NonNegative<Force>{0}; ///< Max force.
     NonNegative<Torque> m_maxTorque = NonNegative<Torque>{0}; ///< Max torque.
 
     // Solver shared data - data saved & updated over multiple InitVelocityConstraints calls.
-    Momentum2D m_linearImpulse = Momentum2D{}; ///< Linear impulse.
+    Momentum2 m_linearImpulse = Momentum2{}; ///< Linear impulse.
     AngularMomentum m_angularImpulse = AngularMomentum{0}; ///< Angular impulse.
 
     // Solver temp
-    Length2D m_rA; ///< Relative A.
-    Length2D m_rB; ///< Relative B.
+    Length2 m_rA; ///< Relative A.
+    Length2 m_rB; ///< Relative B.
     Mass22 m_linearMass; ///< 2x2 linear mass matrix in kilograms.
     RotInertia m_angularMass; ///< Angular mass.
 };

--- a/PlayRho/Dynamics/Joints/FrictionJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointDef.cpp
@@ -24,7 +24,7 @@
 
 namespace playrho {
 
-FrictionJointDef::FrictionJointDef(Body* bA, Body* bB, const Length2D anchor) noexcept:
+FrictionJointDef::FrictionJointDef(Body* bA, Body* bB, const Length2 anchor) noexcept:
     super{super{JointType::Friction}.UseBodyA(bA).UseBodyB(bB)},
     localAnchorA{GetLocalPoint(*bA, anchor)},
     localAnchorB{GetLocalPoint(*bB, anchor)}

--- a/PlayRho/Dynamics/Joints/FrictionJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointDef.hpp
@@ -43,7 +43,7 @@ struct FrictionJointDef : public JointBuilder<FrictionJointDef>
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, axis, and reference angle using the world
     ///   anchor and world axis.
-    FrictionJointDef(Body* bodyA, Body* bodyB, const Length2D anchor) noexcept;
+    FrictionJointDef(Body* bodyA, Body* bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given maximum force value.
     constexpr FrictionJointDef& UseMaxForce(NonNegative<Force> v) noexcept;
@@ -52,10 +52,10 @@ struct FrictionJointDef : public JointBuilder<FrictionJointDef>
     constexpr FrictionJointDef& UseMaxTorque(NonNegative<Torque> v) noexcept;
     
     /// @brief Local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{};
+    Length2 localAnchorA = Length2{};
     
     /// @brief Local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{};
+    Length2 localAnchorB = Length2{};
     
     /// @brief Maximum friction force.
     NonNegative<Force> maxForce = NonNegative<Force>{0};

--- a/PlayRho/Dynamics/Joints/GearJoint.cpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.cpp
@@ -161,7 +161,7 @@ void GearJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepCo
 
     if (m_typeA == JointType::Revolute)
     {
-        m_JvAC = Vec2_zero;
+        m_JvAC = Vec2{};
         m_JwA = 1_m;
         m_JwC = 1_m;
         const auto invAngMass = bodyConstraintA->GetInvRotInertia() + bodyConstraintC->GetInvRotInertia();
@@ -170,8 +170,8 @@ void GearJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepCo
     else
     {
         const auto u = Rotate(m_localAxisC, qC);
-        const auto rC = Length2D{Rotate(m_localAnchorC - bodyConstraintC->GetLocalCenter(), qC)};
-        const auto rA = Length2D{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
+        const auto rC = Length2{Rotate(m_localAnchorC - bodyConstraintC->GetLocalCenter(), qC)};
+        const auto rA = Length2{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
         m_JvAC = Real{1} * u;
         m_JwC = Cross(rC, u);
         m_JwA = Cross(rA, u);
@@ -183,7 +183,7 @@ void GearJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepCo
 
     if (m_typeB == JointType::Revolute)
     {
-        m_JvBD = Vec2_zero;
+        m_JvBD = Vec2{};
         m_JwB = m_ratio * Meter;
         m_JwD = m_ratio * Meter;
         const auto invAngMass = InvRotInertia{Square(m_ratio) * (bodyConstraintB->GetInvRotInertia() + bodyConstraintD->GetInvRotInertia())};
@@ -313,7 +313,7 @@ bool GearJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
 
     if (m_typeA == JointType::Revolute)
     {
-        JvAC = Vec2_zero;
+        JvAC = Vec2{};
         JwA = 1;
         JwC = 1;
         const auto invAngMass = bodyConstraintA->GetInvRotInertia() + bodyConstraintC->GetInvRotInertia();
@@ -339,7 +339,7 @@ bool GearJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
 
     if (m_typeB == JointType::Revolute)
     {
-        JvBD = Vec2_zero;
+        JvBD = Vec2{};
         JwB = m_ratio;
         JwD = m_ratio;
         const auto invAngMass = InvRotInertia{
@@ -395,17 +395,17 @@ bool GearJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     return linearError < conf.linearSlop;
 }
 
-Length2D GearJoint::GetAnchorA() const
+Length2 GearJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D GearJoint::GetAnchorB() const
+Length2 GearJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D GearJoint::GetLinearReaction() const
+Momentum2 GearJoint::GetLinearReaction() const
 {
     return m_impulse * m_JvAC;
 }

--- a/PlayRho/Dynamics/Joints/GearJoint.hpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.hpp
@@ -51,17 +51,17 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// @brief Gets the local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const noexcept { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const noexcept { return m_localAnchorA; }
     
     /// @brief Gets the local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const noexcept { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const noexcept { return m_localAnchorB; }
 
     /// @brief Gets the first joint.
     NonNull<Joint*> GetJoint1() const noexcept { return m_joint1; }
@@ -95,10 +95,10 @@ private:
     Body* m_bodyD; ///< Body D.
 
     // Solver shared
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
-    Length2D m_localAnchorC; ///< Local anchor C.
-    Length2D m_localAnchorD; ///< Local anchor D.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorC; ///< Local anchor C.
+    Length2 m_localAnchorD; ///< Local anchor D.
 
     UnitVec2 m_localAxisC; ///< Local axis C.
     UnitVec2 m_localAxisD; ///< Local axis D.
@@ -112,7 +112,7 @@ private:
     Momentum m_impulse = Momentum{0}; ///< Impulse.
 
     // Solver temp
-    Vec2 m_JvAC = Vec2_zero; ///< AC Jv data.
+    Vec2 m_JvAC = Vec2{}; ///< AC Jv data.
     Vec2 m_JvBD; ///< BD Jv data.
     Length m_JwA = Length{0}; ///< A Jw data.
     Length m_JwB; ///< B Jw data.

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -93,13 +93,13 @@ public:
     Body* GetBodyB() const noexcept;
 
     /// Get the anchor point on bodyA in world coordinates.
-    virtual Length2D GetAnchorA() const = 0;
+    virtual Length2 GetAnchorA() const = 0;
 
     /// Get the anchor point on bodyB in world coordinates.
-    virtual Length2D GetAnchorB() const = 0;
+    virtual Length2 GetAnchorB() const = 0;
 
     /// Get the linear reaction on bodyB at the joint anchor.
-    virtual Momentum2D GetLinearReaction() const = 0;
+    virtual Momentum2 GetLinearReaction() const = 0;
 
     /// Get the angular reaction on bodyB.
     virtual AngularMomentum GetAngularReaction() const = 0;
@@ -119,7 +119,7 @@ public:
     bool GetCollideConnected() const noexcept;
 
     /// @brief Shifts the origin for any points stored in world coordinates.
-    virtual void ShiftOrigin(const Length2D newOrigin) { NOT_USED(newOrigin);  }
+    virtual void ShiftOrigin(const Length2 newOrigin) { NOT_USED(newOrigin);  }
 
 protected:
     

--- a/PlayRho/Dynamics/Joints/MotorJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.cpp
@@ -132,7 +132,7 @@ void MotorJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepC
     }
     else
     {
-        m_linearImpulse = Momentum2D{};
+        m_linearImpulse = Momentum2{};
         m_angularImpulse = AngularMomentum{0};
     }
 
@@ -178,10 +178,10 @@ bool MotorJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
 
     // Solve linear friction
     {
-        const auto vb = LinearVelocity2D{velB.linear + (GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
-        const auto va = LinearVelocity2D{velA.linear - (GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
+        const auto vb = LinearVelocity2{velB.linear + (GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
+        const auto va = LinearVelocity2{velA.linear - (GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
 
-        const auto Cdot = LinearVelocity2D{(vb - va) + inv_h * m_correctionFactor * m_linearError};
+        const auto Cdot = LinearVelocity2{(vb - va) + inv_h * m_correctionFactor * m_linearError};
 
         const auto impulse = -Transform(Cdot, m_linearMass);
         const auto oldImpulse = m_linearImpulse;
@@ -198,7 +198,7 @@ bool MotorJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
         const auto angImpulseA = AngularMomentum{Cross(m_rA, incImpulse) / Radian};
         const auto angImpulseB = AngularMomentum{Cross(m_rB, incImpulse) / Radian};
 
-        if (incImpulse != Momentum2D{})
+        if (incImpulse != Momentum2{})
         {
             solved = false;
         }
@@ -222,12 +222,12 @@ bool MotorJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     return true;
 }
 
-Length2D MotorJoint::GetAnchorA() const
+Length2 MotorJoint::GetAnchorA() const
 {
     return GetBodyA()->GetLocation();
 }
 
-Length2D MotorJoint::GetAnchorB() const
+Length2 MotorJoint::GetAnchorB() const
 {
     return GetBodyB()->GetLocation();
 }
@@ -238,7 +238,7 @@ void MotorJoint::SetCorrectionFactor(Real factor)
     m_correctionFactor = factor;
 }
 
-void MotorJoint::SetLinearOffset(const Length2D linearOffset)
+void MotorJoint::SetLinearOffset(const Length2 linearOffset)
 {
     if (m_linearOffset != linearOffset)
     {

--- a/PlayRho/Dynamics/Joints/MotorJoint.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.hpp
@@ -43,17 +43,17 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// @brief Gets the target linear offset, in frame A.
-    Length2D GetLinearOffset() const noexcept;
+    Length2 GetLinearOffset() const noexcept;
 
     /// @brief Sets the target linear offset, in frame A.
-    void SetLinearOffset(const Length2D linearOffset);
+    void SetLinearOffset(const Length2 linearOffset);
 
     /// @brief Gets the target angular offset.
     Angle GetAngularOffset() const noexcept;
@@ -88,18 +88,18 @@ private:
                                   const ConstraintSolverConf& conf) const override;
 
     // Solver shared
-    Length2D m_linearOffset; ///< Linear offset.
+    Length2 m_linearOffset; ///< Linear offset.
     Angle m_angularOffset; ///< Angular offset.
-    Momentum2D m_linearImpulse = Momentum2D{}; ///< Linear impulse.
+    Momentum2 m_linearImpulse = Momentum2{}; ///< Linear impulse.
     AngularMomentum m_angularImpulse = AngularMomentum{0}; ///< Angular impulse.
     NonNegative<Force> m_maxForce = NonNegative<Force>{0}; ///< Max force.
     NonNegative<Torque> m_maxTorque = NonNegative<Torque>{0}; ///< Max torque.
     Real m_correctionFactor; ///< Correction factor.
 
     // Solver temp
-    Length2D m_rA; ///< Relative A.
-    Length2D m_rB; ///< Relative B.
-    Length2D m_linearError; ///< Linear error.
+    Length2 m_rA; ///< Relative A.
+    Length2 m_rB; ///< Relative B.
+    Length2 m_linearError; ///< Linear error.
     Angle m_angularError; ///< Angular error.
     Mass22 m_linearMass; ///< 2x2 linear mass matrix in kilograms.
     RotInertia m_angularMass; ///< Angular mass.
@@ -125,7 +125,7 @@ inline void MotorJoint::SetMaxTorque(NonNegative<Torque> torque)
     m_maxTorque = torque;
 }
 
-inline Length2D MotorJoint::GetLinearOffset() const noexcept
+inline Length2 MotorJoint::GetLinearOffset() const noexcept
 {
     return m_linearOffset;
 }
@@ -135,7 +135,7 @@ inline Angle MotorJoint::GetAngularOffset() const noexcept
     return m_angularOffset;
 }
 
-inline Momentum2D MotorJoint::GetLinearReaction() const
+inline Momentum2 MotorJoint::GetLinearReaction() const
 {
     return m_linearImpulse;
 }

--- a/PlayRho/Dynamics/Joints/MotorJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointDef.hpp
@@ -43,7 +43,7 @@ struct MotorJointDef : public JointBuilder<MotorJointDef>
     MotorJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB) noexcept;
     
     /// @brief Uses the given linear offset value.
-    MotorJointDef& UseLinearOffset(Length2D v) noexcept;
+    MotorJointDef& UseLinearOffset(Length2 v) noexcept;
 
     /// @brief Uses the given angular offset value.
     MotorJointDef& UseAngularOffset(Angle v) noexcept;
@@ -58,7 +58,7 @@ struct MotorJointDef : public JointBuilder<MotorJointDef>
     MotorJointDef& UseCorrectionFactor(Real v) noexcept;
     
     /// @brief Position of bodyB minus the position of bodyA, in bodyA's frame.
-    Length2D linearOffset = Length2D{};
+    Length2 linearOffset = Length2{};
     
     /// @brief Angle of bodyB minus angle of bodyA.
     Angle angularOffset = Angle{0};
@@ -73,7 +73,7 @@ struct MotorJointDef : public JointBuilder<MotorJointDef>
     Real correctionFactor = Real(0.3);
 };
 
-inline MotorJointDef& MotorJointDef::UseLinearOffset(Length2D v) noexcept
+inline MotorJointDef& MotorJointDef::UseLinearOffset(Length2 v) noexcept
 {
     linearOffset = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/MouseJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.cpp
@@ -68,7 +68,7 @@ void MouseJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
-void MouseJoint::SetTarget(const Length2D target) noexcept
+void MouseJoint::SetTarget(const Length2 target) noexcept
 {
     assert(IsValid(target));
     if (m_targetA != target)
@@ -137,7 +137,7 @@ void MouseJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepC
 
     m_mass = GetEffectiveMassMatrix(*bodyConstraintB);
 
-    m_C = LinearVelocity2D{((posB.linear + m_rB) - m_targetA) * beta};
+    m_C = LinearVelocity2{((posB.linear + m_rB) - m_targetA) * beta};
     assert(IsValid(m_C));
 
     // Cheat with some damping
@@ -152,7 +152,7 @@ void MouseJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepC
     }
     else
     {
-        m_impulse = Momentum2D{};
+        m_impulse = Momentum2{};
     }
 
     bodyConstraintB->SetVelocity(velB);
@@ -165,8 +165,8 @@ bool MouseJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
     auto velB = bodyConstraintB->GetVelocity();
     assert(IsValid(velB));
 
-    const auto Cdot = LinearVelocity2D{velB.linear + (GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
-    const auto ev = Cdot + LinearVelocity2D{m_C + (m_gamma * m_impulse)};
+    const auto Cdot = LinearVelocity2{velB.linear + (GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
+    const auto ev = Cdot + LinearVelocity2{m_C + (m_gamma * m_impulse)};
     const auto oldImpulse = m_impulse;
     const auto addImpulse = Transform(-ev, m_mass);
     assert(IsValid(addImpulse));
@@ -187,7 +187,7 @@ bool MouseJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
 
     bodyConstraintB->SetVelocity(velB);
     
-    return incImpulse == Momentum2D{};
+    return incImpulse == Momentum2{};
 }
 
 bool MouseJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const ConstraintSolverConf& conf) const
@@ -197,17 +197,17 @@ bool MouseJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Cons
     return true;
 }
 
-Length2D MouseJoint::GetAnchorA() const
+Length2 MouseJoint::GetAnchorA() const
 {
     return GetTarget();
 }
 
-Length2D MouseJoint::GetAnchorB() const
+Length2 MouseJoint::GetAnchorB() const
 {
-    return GetBodyB()? GetWorldPoint(*GetBodyB(), GetLocalAnchorB()): GetInvalid<Length2D>();
+    return GetBodyB()? GetWorldPoint(*GetBodyB(), GetLocalAnchorB()): GetInvalid<Length2>();
 }
 
-Momentum2D MouseJoint::GetLinearReaction() const
+Momentum2 MouseJoint::GetLinearReaction() const
 {
     return m_impulse;
 }
@@ -217,7 +217,7 @@ AngularMomentum MouseJoint::GetAngularReaction() const
     return AngularMomentum{0};
 }
 
-void MouseJoint::ShiftOrigin(const Length2D newOrigin)
+void MouseJoint::ShiftOrigin(const Length2 newOrigin)
 {
     m_targetA -= newOrigin;
 }

--- a/PlayRho/Dynamics/Joints/MouseJoint.hpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.hpp
@@ -53,22 +53,22 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
+    Length2 GetAnchorA() const override;
 
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
 
     AngularMomentum GetAngularReaction() const override;
 
     /// @brief Gets the local anchor B.
-    Length2D GetLocalAnchorB() const noexcept;
+    Length2 GetLocalAnchorB() const noexcept;
 
     /// @brief Sets the target point.
-    void SetTarget(const Length2D target) noexcept;
+    void SetTarget(const Length2 target) noexcept;
 
     /// @brief Gets the target point.
-    Length2D GetTarget() const noexcept;
+    Length2 GetTarget() const noexcept;
 
     /// @brief Sets the maximum force.
     void SetMaxForce(NonNegative<Force> force) noexcept;
@@ -89,7 +89,7 @@ public:
     NonNegative<Real> GetDampingRatio() const noexcept;
 
     /// Implement Joint::ShiftOrigin
-    void ShiftOrigin(const Length2D newOrigin) override;
+    void ShiftOrigin(const Length2 newOrigin) override;
 
 private:
     void InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step,
@@ -101,28 +101,28 @@ private:
     /// @brief Gets the effective mass matrix.
     Mass22 GetEffectiveMassMatrix(const BodyConstraint& body) const noexcept;
 
-    Length2D m_targetA; ///< Target location (A).
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_targetA; ///< Target location (A).
+    Length2 m_localAnchorB; ///< Local anchor B.
     NonNegative<Frequency> m_frequency = NonNegative<Frequency>{0}; ///< Frequency.
     NonNegative<Real> m_dampingRatio = NonNegative<Real>{0}; ///< Damping ratio.
     
     // Solver shared
-    Momentum2D m_impulse = Momentum2D{}; ///< Impulse.
+    Momentum2 m_impulse = Momentum2{}; ///< Impulse.
     NonNegative<Force> m_maxForce = NonNegative<Force>{0}; ///< Max force.
     InvMass m_gamma = InvMass{0}; ///< Gamma.
 
     // Solver variables. These are only valid after InitVelocityConstraints called.
-    Length2D m_rB; ///< Relative B.
+    Length2 m_rB; ///< Relative B.
     Mass22 m_mass; ///< 2x2 mass matrix in kilograms.
-    LinearVelocity2D m_C; ///< Velocity constant.
+    LinearVelocity2 m_C; ///< Velocity constant.
 };
 
-inline Length2D MouseJoint::GetLocalAnchorB() const noexcept
+inline Length2 MouseJoint::GetLocalAnchorB() const noexcept
 {
     return m_localAnchorB;
 }
 
-inline Length2D MouseJoint::GetTarget() const noexcept
+inline Length2 MouseJoint::GetTarget() const noexcept
 {
     return m_targetA;
 }

--- a/PlayRho/Dynamics/Joints/MouseJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/MouseJointDef.hpp
@@ -47,7 +47,7 @@ struct MouseJointDef : public JointBuilder<MouseJointDef>
     }
     
     /// @brief Use value for target.
-    constexpr MouseJointDef& UseTarget(Length2D v) noexcept;
+    constexpr MouseJointDef& UseTarget(Length2 v) noexcept;
 
     /// @brief Use value for max force.
     constexpr MouseJointDef& UseMaxForce(NonNegative<Force> v) noexcept;
@@ -60,7 +60,7 @@ struct MouseJointDef : public JointBuilder<MouseJointDef>
 
     /// The initial world target point. This is assumed
     /// to coincide with the body anchor initially.
-    Length2D target = Length2D{};
+    Length2 target = Length2{};
     
     /// Max force.
     /// @details
@@ -79,7 +79,7 @@ struct MouseJointDef : public JointBuilder<MouseJointDef>
     NonNegative<Real> dampingRatio = NonNegative<Real>(0.7f);
 };
 
-constexpr MouseJointDef& MouseJointDef::UseTarget(Length2D v) noexcept
+constexpr MouseJointDef& MouseJointDef::UseTarget(Length2 v) noexcept
 {
     target = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
@@ -137,9 +137,9 @@ void PrismaticJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
     const auto qB = UnitVec2::Get(posB.angular);
 
     // Compute the effective masses.
-    const auto rA = Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA); // Length2D
-    const auto rB = Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB); // Length2D
-    const auto d = (posB.linear - posA.linear) + rB - rA; // Length2D
+    const auto rA = Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA); // Length2
+    const auto rB = Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB); // Length2
+    const auto d = (posB.linear - posA.linear) + rB - rA; // Length2
 
     // Compute motor Jacobian and effective mass.
     m_axis = Rotate(m_localXAxisA, qA);
@@ -224,11 +224,11 @@ void PrismaticJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         m_motorImpulse *= step.dtRatio;
 
         const auto ulImpulseX = GetX(m_impulse) * m_perp;
-        const auto Px = Momentum2D{GetX(ulImpulseX) * NewtonSecond, GetY(ulImpulseX) * NewtonSecond};
+        const auto Px = Momentum2{GetX(ulImpulseX) * NewtonSecond, GetY(ulImpulseX) * NewtonSecond};
         const auto Pxs1 = Momentum{GetX(m_impulse) * m_s1 * Kilogram / Second};
         const auto Pxs2 = Momentum{GetX(m_impulse) * m_s2 * Kilogram / Second};
         const auto PzLength = Momentum{m_motorImpulse + GetZ(m_impulse) * NewtonSecond};
-        const auto Pz = Momentum2D{PzLength * m_axis};
+        const auto Pz = Momentum2{PzLength * m_axis};
         const auto P = Px + Pz;
         
         // AngularMomentum is L^2 M T^-1 QP^-1.
@@ -276,7 +276,7 @@ bool PrismaticJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const 
         m_motorImpulse = Clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse);
         impulse = m_motorImpulse - oldImpulse;
 
-        const auto P = Momentum2D{impulse * m_axis};
+        const auto P = Momentum2{impulse * m_axis};
         
         // Momentum is L^2 M T^-1. AngularMomentum is L^2 M T^-1 QP^-1.
         const auto LA = impulse * m_a1 / Radian;
@@ -322,7 +322,7 @@ bool PrismaticJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const 
         const auto df = m_impulse - f1;
 
         const auto ulP = GetX(df) * m_perp + GetZ(df) * m_axis;
-        const auto P = Momentum2D{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
+        const auto P = Momentum2{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
         const auto LA = AngularMomentum{
             (GetX(df) * m_s1 + GetY(df) * Meter + GetZ(df) * m_a1) * NewtonSecond / Radian
         };
@@ -343,7 +343,7 @@ bool PrismaticJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const 
         GetY(m_impulse) += GetY(df);
 
         const auto ulP = GetX(df) * m_perp;
-        const auto P = Momentum2D{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
+        const auto P = Momentum2{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
         const auto LA = AngularMomentum{
             (GetX(df) * m_s1 + GetY(df) * Meter) * NewtonSecond / Radian
         };
@@ -393,7 +393,7 @@ bool PrismaticJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const 
     // Compute fresh Jacobians
     const auto rA = Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA);
     const auto rB = Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB);
-    const auto d = Length2D{(posB.linear + rB) - (posA.linear + rA)};
+    const auto d = Length2{(posB.linear + rB) - (posA.linear + rA)};
 
     const auto axis = Rotate(m_localXAxisA, qA);
     const auto a1 = Length{Cross(d + rA, axis)};
@@ -504,7 +504,7 @@ bool PrismaticJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const 
     const auto LA = (GetX(impulse) * s1 + GetY(impulse) * Meter + GetZ(impulse) * a1) * Kilogram * Meter / Radian;
     const auto LB = (GetX(impulse) * s2 + GetY(impulse) * Meter + GetZ(impulse) * a2) * Kilogram * Meter / Radian;
 
-    posA -= Position{Length2D{invMassA * P}, invRotInertiaA * LA};
+    posA -= Position{Length2{invMassA * P}, invRotInertiaA * LA};
     posB += Position{invMassB * P, invRotInertiaB * LB};
 
     bodyConstraintA->SetPosition(posA);
@@ -513,21 +513,21 @@ bool PrismaticJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const 
     return (linearError <= conf.linearSlop) && (angularError <= conf.angularSlop);
 }
 
-Length2D PrismaticJoint::GetAnchorA() const
+Length2 PrismaticJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D PrismaticJoint::GetAnchorB() const
+Length2 PrismaticJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D PrismaticJoint::GetLinearReaction() const
+Momentum2 PrismaticJoint::GetLinearReaction() const
 {
     const auto ulImpulse = GetX(m_impulse) * m_perp;
-    const auto impulse = Momentum2D{GetX(ulImpulse) * NewtonSecond, GetY(ulImpulse) * NewtonSecond};
-    return Momentum2D{impulse + (m_motorImpulse + GetZ(m_impulse) * NewtonSecond) * m_axis};
+    const auto impulse = Momentum2{GetX(ulImpulse) * NewtonSecond, GetY(ulImpulse) * NewtonSecond};
+    return Momentum2{impulse + (m_motorImpulse + GetZ(m_impulse) * NewtonSecond) * m_axis};
 }
 
 AngularMomentum PrismaticJoint::GetAngularReaction() const

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.hpp
@@ -49,17 +49,17 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// @brief Gets the local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const { return m_localAnchorA; }
 
     /// @brief Gets the local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const  { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const  { return m_localAnchorB; }
 
     /// @brief Gets local joint axis relative to bodyA.
     UnitVec2 GetLocalAxisA() const { return m_localXAxisA; }
@@ -116,8 +116,8 @@ private:
                                   const ConstraintSolverConf& conf) const override;
 
     // Solver shared
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     UnitVec2 m_localXAxisA; ///< Local X axis A.
     UnitVec2 m_localYAxisA; ///< Local Y axis A.
     Angle m_referenceAngle; ///< Reference angle.

--- a/PlayRho/Dynamics/Joints/PrismaticJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointDef.cpp
@@ -25,7 +25,7 @@
 
 namespace playrho {
 
-PrismaticJointDef::PrismaticJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2D anchor,
+PrismaticJointDef::PrismaticJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2 anchor,
                                      const UnitVec2 axis) noexcept:
     super{super{JointType::Prismatic}.UseBodyA(bA).UseBodyB(bB)},
     localAnchorA{GetLocalPoint(*bA, anchor)},

--- a/PlayRho/Dynamics/Joints/PrismaticJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointDef.hpp
@@ -50,7 +50,7 @@ struct PrismaticJointDef : public JointBuilder<PrismaticJointDef>
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, axis, and reference angle using the world
     ///   anchor and unit world axis.
-    PrismaticJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2D anchor,
+    PrismaticJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor,
                       const UnitVec2 axis) noexcept;
     
     /// @brief Uses the given enable limit state value.
@@ -66,10 +66,10 @@ struct PrismaticJointDef : public JointBuilder<PrismaticJointDef>
     PrismaticJointDef& UseEnableMotor(bool v) noexcept;
     
     /// The local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{};
+    Length2 localAnchorA = Length2{};
     
     /// The local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{};
+    Length2 localAnchorB = Length2{};
     
     /// The local translation unit axis in bodyA.
     UnitVec2 localAxisA = UnitVec2::GetRight();

--- a/PlayRho/Dynamics/Joints/PulleyJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.cpp
@@ -83,8 +83,8 @@ void PulleyJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
     m_rB = Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB);
 
     // Get the pulley axes.
-    const auto pulleyAxisA = Length2D{posA.linear + m_rA - m_groundAnchorA};
-    const auto pulleyAxisB = Length2D{posB.linear + m_rB - m_groundAnchorB};
+    const auto pulleyAxisA = Length2{posA.linear + m_rA - m_groundAnchorA};
+    const auto pulleyAxisB = Length2{posB.linear + m_rB - m_groundAnchorB};
 
     m_uA = GetUnitVector(pulleyAxisA, UnitVec2::GetZero());
     m_uB = GetUnitVector(pulleyAxisB, UnitVec2::GetZero());
@@ -134,8 +134,8 @@ bool PulleyJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Ste
     const auto invRotInertiaB = bodyConstraintB->GetInvRotInertia();
     auto velB = bodyConstraintB->GetVelocity();
 
-    const auto vpA = LinearVelocity2D{velA.linear + GetRevPerpendicular(m_rA) * (velA.angular / Radian)};
-    const auto vpB = LinearVelocity2D{velB.linear + GetRevPerpendicular(m_rB) * (velB.angular / Radian)};
+    const auto vpA = LinearVelocity2{velA.linear + GetRevPerpendicular(m_rA) * (velA.angular / Radian)};
+    const auto vpB = LinearVelocity2{velB.linear + GetRevPerpendicular(m_rB) * (velB.angular / Radian)};
 
     const auto Cdot = LinearVelocity{-Dot(m_uA, vpA) - m_ratio * Dot(m_uB, vpB)};
     const auto impulse = -m_mass * Cdot;
@@ -172,11 +172,11 @@ bool PulleyJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
                            UnitVec2::Get(posB.angular));
 
     // Get the pulley axes.
-    const auto pA = Length2D{posA.linear + rA - m_groundAnchorA};
+    const auto pA = Length2{posA.linear + rA - m_groundAnchorA};
     auto lengthA = Length{0};
     const auto uA = GetUnitVector(pA, lengthA, UnitVec2::GetZero());
 
-    const auto pB = Length2D{posB.linear + rB - m_groundAnchorB};
+    const auto pB = Length2{posB.linear + rB - m_groundAnchorB};
     auto lengthB = Length{0};
     const auto uB = GetUnitVector(pB, lengthB, UnitVec2::GetZero());
 
@@ -207,17 +207,17 @@ bool PulleyJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     return linearError < conf.linearSlop;
 }
 
-Length2D PulleyJoint::GetAnchorA() const
+Length2 PulleyJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D PulleyJoint::GetAnchorB() const
+Length2 PulleyJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D PulleyJoint::GetLinearReaction() const
+Momentum2 PulleyJoint::GetLinearReaction() const
 {
     return m_impulse * m_uB;
 }
@@ -227,7 +227,7 @@ AngularMomentum PulleyJoint::GetAngularReaction() const
     return AngularMomentum{0};
 }
 
-void PulleyJoint::ShiftOrigin(const Length2D newOrigin)
+void PulleyJoint::ShiftOrigin(const Length2 newOrigin)
 {
     m_groundAnchorA -= newOrigin;
     m_groundAnchorB -= newOrigin;

--- a/PlayRho/Dynamics/Joints/PulleyJoint.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.hpp
@@ -53,22 +53,22 @@ public:
     void Accept(JointVisitor& visitor) const override;
 
     /// @brief Gets the local anchor A.
-    Length2D GetLocalAnchorA() const noexcept;
+    Length2 GetLocalAnchorA() const noexcept;
 
     /// @brief Gets the local anchor B.
-    Length2D GetLocalAnchorB() const noexcept;
+    Length2 GetLocalAnchorB() const noexcept;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// Get the first ground anchor.
-    Length2D GetGroundAnchorA() const noexcept;
+    Length2 GetGroundAnchorA() const noexcept;
 
     /// Get the second ground anchor.
-    Length2D GetGroundAnchorB() const noexcept;
+    Length2 GetGroundAnchorB() const noexcept;
 
     /// Get the current length of the segment attached to bodyA.
     Length GetLengthA() const noexcept;
@@ -80,7 +80,7 @@ public:
     Real GetRatio() const noexcept;
 
     /// Implement Joint::ShiftOrigin
-    void ShiftOrigin(const Length2D newOrigin) override;
+    void ShiftOrigin(const Length2 newOrigin) override;
 
 private:
 
@@ -90,12 +90,12 @@ private:
     bool SolvePositionConstraints(BodyConstraintsMap& bodies,
                                   const ConstraintSolverConf& conf) const override;
 
-    Length2D m_groundAnchorA; ///< Ground anchor A.
-    Length2D m_groundAnchorB; ///< Ground anchor B.
+    Length2 m_groundAnchorA; ///< Ground anchor A.
+    Length2 m_groundAnchorB; ///< Ground anchor B.
     Length m_lengthA; ///< Length A.
     Length m_lengthB; ///< Length B.
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     Real m_ratio; ///< Ratio.
     Length m_constant; ///< Constant.
     
@@ -105,27 +105,27 @@ private:
     // Solver temp (recalculated every call to InitVelocityConstraints).
     UnitVec2 m_uA; ///< Unit vector A.
     UnitVec2 m_uB; ///< Unit vector B.
-    Length2D m_rA; ///< Relative A.
-    Length2D m_rB; ///< Relative B.
+    Length2 m_rA; ///< Relative A.
+    Length2 m_rB; ///< Relative B.
     Mass m_mass; ///< Mass.
 };
     
-inline Length2D PulleyJoint::GetLocalAnchorA() const noexcept
+inline Length2 PulleyJoint::GetLocalAnchorA() const noexcept
 {
     return m_localAnchorA;
 }
 
-inline Length2D PulleyJoint::GetLocalAnchorB() const noexcept
+inline Length2 PulleyJoint::GetLocalAnchorB() const noexcept
 {
     return m_localAnchorB;
 }
 
-inline Length2D PulleyJoint::GetGroundAnchorA() const noexcept
+inline Length2 PulleyJoint::GetGroundAnchorA() const noexcept
 {
     return m_groundAnchorA;
 }
 
-inline Length2D PulleyJoint::GetGroundAnchorB() const noexcept
+inline Length2 PulleyJoint::GetGroundAnchorB() const noexcept
 {
     return m_groundAnchorB;
 }

--- a/PlayRho/Dynamics/Joints/PulleyJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointDef.cpp
@@ -26,8 +26,8 @@
 namespace playrho {
 
 PulleyJointDef::PulleyJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
-                               const Length2D groundA, const Length2D groundB,
-                               const Length2D anchorA, const Length2D anchorB):
+                               const Length2 groundA, const Length2 groundB,
+                               const Length2 anchorA, const Length2 anchorB):
     super{super{JointType::Pulley}.UseBodyA(bA).UseBodyB(bB).UseCollideConnected(true)},
     groundAnchorA{groundA},
     groundAnchorB{groundB},

--- a/PlayRho/Dynamics/Joints/PulleyJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointDef.hpp
@@ -44,23 +44,23 @@ struct PulleyJointDef : public JointBuilder<PulleyJointDef>
     
     /// Initialize the bodies, anchors, lengths, max lengths, and ratio using the world anchors.
     PulleyJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB,
-                   const Length2D groundAnchorA, const Length2D groundAnchorB,
-                   const Length2D anchorA, const Length2D anchorB);
+                   const Length2 groundAnchorA, const Length2 groundAnchorB,
+                   const Length2 anchorA, const Length2 anchorB);
     
     /// @brief Uses the given ratio value.
     PulleyJointDef& UseRatio(Real v) noexcept;
     
     /// The first ground anchor in world coordinates. This point never moves.
-    Length2D groundAnchorA = Length2D{-1_m, 1_m};
+    Length2 groundAnchorA = Length2{-1_m, 1_m};
     
     /// The second ground anchor in world coordinates. This point never moves.
-    Length2D groundAnchorB = Length2D{1_m, 1_m};
+    Length2 groundAnchorB = Length2{1_m, 1_m};
     
     /// The local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{-1_m, 0_m};
+    Length2 localAnchorA = Length2{-1_m, 0_m};
     
     /// The local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{+1_m, 0_m};
+    Length2 localAnchorB = Length2{+1_m, 0_m};
     
     /// The a reference length for the segment attached to bodyA.
     Length lengthA = Length{0};

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -174,7 +174,7 @@ void RevoluteJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         m_impulse *= step.dtRatio;
         m_motorImpulse *= step.dtRatio;
 
-        const auto P = Momentum2D{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
+        const auto P = Momentum2{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
         
         // AngularMomentum is L^2 M T^-1 QP^-1.
         const auto L = AngularMomentum{
@@ -283,7 +283,7 @@ bool RevoluteJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
             }
         }
 
-        const auto P = Momentum2D{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
+        const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
         const auto L = AngularMomentum{GetZ(impulse) * SquareMeter * Kilogram / (Second * Radian)};
         const auto LA = AngularMomentum{Cross(m_rA, P) / Radian} + L;
         const auto LB = AngularMomentum{Cross(m_rB, P) / Radian} + L;
@@ -301,7 +301,7 @@ bool RevoluteJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
         GetX(m_impulse) += GetX(impulse);
         GetY(m_impulse) += GetY(impulse);
 
-        const auto P = Momentum2D{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
+        const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
         const auto LA = AngularMomentum{Cross(m_rA, P) / Radian};
         const auto LB = AngularMomentum{Cross(m_rB, P) / Radian};
 
@@ -377,8 +377,8 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
         const auto qA = UnitVec2::Get(posA.angular);
         const auto qB = UnitVec2::Get(posB.angular);
 
-        const auto rA = Length2D{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
-        const auto rB = Length2D{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
+        const auto rA = Length2{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
+        const auto rB = Length2{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
 
         const auto C = (posB.linear + rB) - (posA.linear + rA);
         positionError = GetLengthSquared(C);
@@ -416,19 +416,19 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
     return (positionError <= Square(conf.linearSlop)) && (angularError <= conf.angularSlop);
 }
 
-Length2D RevoluteJoint::GetAnchorA() const
+Length2 RevoluteJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D RevoluteJoint::GetAnchorB() const
+Length2 RevoluteJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D RevoluteJoint::GetLinearReaction() const
+Momentum2 RevoluteJoint::GetLinearReaction() const
 {
-    return Momentum2D{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
+    return Momentum2{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
 }
 
 AngularMomentum RevoluteJoint::GetAngularReaction() const

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.hpp
@@ -51,14 +51,14 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
     /// The local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const noexcept { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const noexcept { return m_localAnchorA; }
 
     /// The local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const noexcept { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const noexcept { return m_localAnchorB; }
 
     /// Get the reference angle.
     Angle GetReferenceAngle() const noexcept { return m_referenceAngle; }
@@ -97,7 +97,7 @@ public:
     Torque GetMaxMotorTorque() const noexcept { return m_maxMotorTorque; }
 
     /// Get the linear reaction.
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
 
     /// Get the angular reaction due to the joint limit.
     AngularMomentum GetAngularReaction() const override;
@@ -121,8 +121,8 @@ private:
                                   const ConstraintSolverConf& conf) const override;
 
     // Solver shared
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     Vec3 m_impulse = Vec3_zero; ///< Impulse. Mofified by: InitVelocityConstraints, SolveVelocityConstraints.
     AngularMomentum m_motorImpulse = 0; ///< Motor impulse. Modified by: InitVelocityConstraints, SolveVelocityConstraints.
 
@@ -137,8 +137,8 @@ private:
 
     // Solver cached temporary data. Values set by by InitVelocityConstraints.
 
-    Length2D m_rA; ///< Rotated delta of body A's local center from local anchor A.
-    Length2D m_rB; ///< Rotated delta of body B's local center from local anchor B.
+    Length2 m_rA; ///< Rotated delta of body A's local center from local anchor A.
+    Length2 m_rB; ///< Rotated delta of body B's local center from local anchor B.
     Mat33 m_mass; ///< Effective mass for point-to-point constraint.
     RotInertia m_motorMass; ///< Effective mass for motor/limit angular constraint.
     LimitState m_limitState = e_inactiveLimit; ///< Limit state.

--- a/PlayRho/Dynamics/Joints/RevoluteJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointDef.cpp
@@ -26,7 +26,7 @@
 namespace playrho {
 
 RevoluteJointDef::RevoluteJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
-                                   const Length2D anchor) noexcept:
+                                   const Length2 anchor) noexcept:
     super{super{JointType::Revolute}.UseBodyA(bA).UseBodyB(bB)},
     localAnchorA{GetLocalPoint(*bA, anchor)},
     localAnchorB{GetLocalPoint(*bB, anchor)},

--- a/PlayRho/Dynamics/Joints/RevoluteJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointDef.hpp
@@ -50,7 +50,7 @@ struct RevoluteJointDef : public JointBuilder<RevoluteJointDef>
     constexpr RevoluteJointDef() noexcept: super{JointType::Revolute} {}
     
     /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
-    RevoluteJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2D anchor) noexcept;
+    RevoluteJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given enable limit state value.
     constexpr RevoluteJointDef& UseEnableLimit(bool v) noexcept;
@@ -65,10 +65,10 @@ struct RevoluteJointDef : public JointBuilder<RevoluteJointDef>
     constexpr RevoluteJointDef& UseEnableMotor(bool v) noexcept;
 
     /// @brief Local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{};
+    Length2 localAnchorA = Length2{};
     
     /// @brief Local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{};
+    Length2 localAnchorB = Length2{};
     
     /// @brief Reference angle.
     /// @details This is the bodyB angle minus bodyA angle in the reference state (radians).

--- a/PlayRho/Dynamics/Joints/RopeJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.cpp
@@ -71,7 +71,7 @@ void RopeJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
 
     m_rA = Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA);
     m_rB = Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB);
-    const auto posDelta = Length2D{(posB.linear + m_rB) - (posA.linear + m_rA)};
+    const auto posDelta = Length2{(posB.linear + m_rB) - (posA.linear + m_rA)};
     
     const auto uv = GetUnitVector(posDelta, m_length);
 
@@ -134,7 +134,7 @@ bool RopeJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
     const auto vpA = velA.linear + GetRevPerpendicular(m_rA) * (velA.angular / Radian);
     const auto vpB = velB.linear + GetRevPerpendicular(m_rB) * (velB.angular / Radian);
     const auto C = m_length - m_maxLength;
-    const auto vpDelta = LinearVelocity2D{vpB - vpA};
+    const auto vpDelta = LinearVelocity2{vpB - vpA};
 
     // Predictive constraint.
     const auto Cdot = LinearVelocity{Dot(m_u, vpDelta)}
@@ -171,8 +171,8 @@ bool RopeJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     const auto qA = UnitVec2::Get(posA.angular);
     const auto qB = UnitVec2::Get(posB.angular);
 
-    const auto rA = Length2D{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
-    const auto rB = Length2D{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
+    const auto rA = Length2{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
+    const auto rB = Length2{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
     const auto posDelta = (posB.linear + rB) - (posA.linear + rA);
     
     auto length = Length{0};
@@ -195,17 +195,17 @@ bool RopeJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     return (length - m_maxLength) < conf.linearSlop;
 }
 
-Length2D RopeJoint::GetAnchorA() const
+Length2 RopeJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D RopeJoint::GetAnchorB() const
+Length2 RopeJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D RopeJoint::GetLinearReaction() const
+Momentum2 RopeJoint::GetLinearReaction() const
 {
     return m_impulse * m_u;
 }

--- a/PlayRho/Dynamics/Joints/RopeJoint.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.hpp
@@ -49,17 +49,17 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// The local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const { return m_localAnchorA; }
 
     /// The local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const  { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const  { return m_localAnchorB; }
 
     /// @brief Sets the maximum length of the rope.
     void SetMaxLength(Length length) { m_maxLength = length; }
@@ -79,16 +79,16 @@ private:
                                   const ConstraintSolverConf& conf) const override;
 
     // Solver shared
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     Length m_maxLength; ///< Max length.
     Length m_length = 0; ///< Length.
     Momentum m_impulse = Momentum{0}; ///< Impulse.
 
     // Solver temp
     UnitVec2 m_u; ///< U direction.
-    Length2D m_rA; ///< Relative A.
-    Length2D m_rB; ///< Relative B.
+    Length2 m_rA; ///< Relative A.
+    Length2 m_rB; ///< Relative B.
     Mass m_mass = Mass{0}; ///< Mass.
     LimitState m_state = e_inactiveLimit; ///< Limit state.
 };

--- a/PlayRho/Dynamics/Joints/RopeJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointDef.hpp
@@ -52,10 +52,10 @@ struct RopeJointDef : public JointBuilder<RopeJointDef>
     constexpr RopeJointDef& UseMaxLength(Length v) noexcept;
     
     /// The local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{-1_m, 0_m};
+    Length2 localAnchorA = Length2{-1_m, 0_m};
     
     /// The local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{1_m, 0_m};
+    Length2 localAnchorB = Length2{1_m, 0_m};
     
     /// The maximum length of the rope.
     Length maxLength = Length{0};

--- a/PlayRho/Dynamics/Joints/WeldJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.cpp
@@ -167,7 +167,7 @@ void WeldJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepCo
         // Scale impulses to support a variable time step.
         m_impulse *= step.dtRatio;
 
-        const auto P = Momentum2D{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
+        const auto P = Momentum2{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
 
         // AngularMomentum is L^2 M T^-1 QP^-1.
         const auto L = AngularMomentum{GetZ(m_impulse) * SquareMeter * Kilogram / (Second * Radian)};
@@ -215,8 +215,8 @@ bool WeldJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         velA.angular -= AngularVelocity{invRotInertiaA * impulse2 * SquareMeter * Kilogram / (Second * Radian)};
         velB.angular += AngularVelocity{invRotInertiaB * impulse2 * SquareMeter * Kilogram / (Second * Radian)};
 
-        const auto vb = velB.linear + LinearVelocity2D{(GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
-        const auto va = velA.linear + LinearVelocity2D{(GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
+        const auto vb = velB.linear + LinearVelocity2{(GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
+        const auto va = velA.linear + LinearVelocity2{(GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
 
         const auto Cdot1 = vb - va;
 
@@ -224,7 +224,7 @@ bool WeldJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         GetX(m_impulse) += GetX(impulse1);
         GetY(m_impulse) += GetY(impulse1);
 
-        const auto P = Momentum2D{GetX(impulse1) * NewtonSecond, GetY(impulse1) * NewtonSecond};
+        const auto P = Momentum2{GetX(impulse1) * NewtonSecond, GetY(impulse1) * NewtonSecond};
         const auto LA = AngularMomentum{Cross(m_rA, P) / Radian};
         const auto LB = AngularMomentum{Cross(m_rB, P) / Radian};
 
@@ -233,8 +233,8 @@ bool WeldJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
     }
     else
     {
-        const auto vb = velB.linear + LinearVelocity2D{(GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
-        const auto va = velA.linear + LinearVelocity2D{(GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
+        const auto vb = velB.linear + LinearVelocity2{(GetRevPerpendicular(m_rB) * (velB.angular / Radian))};
+        const auto va = velA.linear + LinearVelocity2{(GetRevPerpendicular(m_rA) * (velA.angular / Radian))};
 
         const auto Cdot1 = vb - va;
         const auto Cdot2 = Real{(velB.angular - velA.angular) / RadianPerSecond};
@@ -243,7 +243,7 @@ bool WeldJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         const auto impulse = -Transform(Cdot, m_mass);
         m_impulse += impulse;
 
-        const auto P = Momentum2D{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
+        const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
         
         // AngularMomentum is L^2 M T^-1 QP^-1.
         const auto L = AngularMomentum{GetZ(impulse) * SquareMeter * Kilogram / (Second * Radian)};
@@ -320,7 +320,7 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
 
     if (m_frequency > Frequency{0})
     {
-        const auto C1 = Length2D{(posB.linear + rB) - (posA.linear + rA)};
+        const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
 
         positionError = GetLength(C1);
         angularError = Angle{0};
@@ -334,7 +334,7 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     }
     else
     {
-        const auto C1 = Length2D{(posB.linear + rB) - (posA.linear + rA)};
+        const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
         const auto C2 = Angle{posB.angular - posA.angular - m_referenceAngle};
 
         positionError = GetLength(C1);
@@ -353,7 +353,7 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
             impulse = Vec3{GetX(impulse2), GetY(impulse2), 0};
         }
 
-        const auto P = Length2D{GetX(impulse) * Meter, GetY(impulse) * Meter} * Kilogram;
+        const auto P = Length2{GetX(impulse) * Meter, GetY(impulse) * Meter} * Kilogram;
         const auto L = GetZ(impulse) * Kilogram * SquareMeter / Radian;
         const auto LA = L + Cross(rA, P) / Radian;
         const auto LB = L + Cross(rB, P) / Radian;
@@ -368,19 +368,19 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     return (positionError <= conf.linearSlop) && (angularError <= conf.angularSlop);
 }
 
-Length2D WeldJoint::GetAnchorA() const
+Length2 WeldJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D WeldJoint::GetAnchorB() const
+Length2 WeldJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D WeldJoint::GetLinearReaction() const
+Momentum2 WeldJoint::GetLinearReaction() const
 {
-    return Momentum2D{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
+    return Momentum2{GetX(m_impulse) * NewtonSecond, GetY(m_impulse) * NewtonSecond};
 }
 
 AngularMomentum WeldJoint::GetAngularReaction() const

--- a/PlayRho/Dynamics/Joints/WeldJoint.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.hpp
@@ -43,17 +43,17 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// The local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const { return m_localAnchorA; }
 
     /// The local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const  { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const  { return m_localAnchorB; }
 
     /// Get the reference angle.
     Angle GetReferenceAngle() const { return m_referenceAngle; }
@@ -78,8 +78,8 @@ private:
     bool SolvePositionConstraints(BodyConstraintsMap& bodies,
                                   const ConstraintSolverConf& conf) const override;
 
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     Angle m_referenceAngle; ///< Reference angle.
     Frequency m_frequency; ///< Frequency.
     Real m_dampingRatio; ///< Damping ratio.
@@ -90,8 +90,8 @@ private:
     // Solver temp
     InvRotInertia m_gamma; ///< Gamma.
     AngularVelocity m_bias; ///< Bias.
-    Length2D m_rA; ///< Relative A.
-    Length2D m_rB; ///< Relative B.
+    Length2 m_rA; ///< Relative A.
+    Length2 m_rB; ///< Relative B.
     Mat33 m_mass; ///< Mass.
 };
 

--- a/PlayRho/Dynamics/Joints/WeldJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJointDef.cpp
@@ -25,7 +25,7 @@
 
 namespace playrho {
 
-WeldJointDef::WeldJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2D anchor) noexcept:
+WeldJointDef::WeldJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2 anchor) noexcept:
     super{super{JointType::Weld}.UseBodyA(bA).UseBodyB(bB)},
     localAnchorA{GetLocalPoint(*bA, anchor)},
     localAnchorB{GetLocalPoint(*bB, anchor)},

--- a/PlayRho/Dynamics/Joints/WeldJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointDef.hpp
@@ -50,7 +50,7 @@ struct WeldJointDef : public JointBuilder<WeldJointDef>
     /// @param bodyA Body A.
     /// @param bodyB Body B.
     /// @param anchor Anchor location in world coordinates.
-    WeldJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2D anchor) noexcept;
+    WeldJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given frequency value.
     constexpr WeldJointDef& UseFrequency(Frequency v) noexcept;
@@ -59,10 +59,10 @@ struct WeldJointDef : public JointBuilder<WeldJointDef>
     constexpr WeldJointDef& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{};
+    Length2 localAnchorA = Length2{};
     
     /// The local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{};
+    Length2 localAnchorB = Length2{};
     
     /// The bodyB angle minus bodyA angle in the reference state (radians).
     Angle referenceAngle = Angle{0};

--- a/PlayRho/Dynamics/Joints/WheelJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.cpp
@@ -83,9 +83,9 @@ void WheelJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepC
     const auto qB = UnitVec2::Get(posB.angular);
 
     // Compute the effective masses.
-    const auto rA = Length2D{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
-    const auto rB = Length2D{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
-    const auto dd = Length2D{(posB.linear + rB) - (posA.linear + rA)};
+    const auto rA = Length2{Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA)};
+    const auto rB = Length2{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
+    const auto dd = Length2{(posB.linear + rB) - (posA.linear + rA)};
 
     // Point to line constraint
     {
@@ -276,7 +276,7 @@ bool WheelJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Cons
 
     const auto rA = Rotate(m_localAnchorA - bodyConstraintA->GetLocalCenter(), qA);
     const auto rB = Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB);
-    const auto d = Length2D{(posB.linear - posA.linear) + (rB - rA)};
+    const auto d = Length2{(posB.linear - posA.linear) + (rB - rA)};
 
     const auto ay = Rotate(m_localYAxisA, qA);
 
@@ -305,17 +305,17 @@ bool WheelJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Cons
     return Abs(C) <= conf.linearSlop;
 }
 
-Length2D WheelJoint::GetAnchorA() const
+Length2 WheelJoint::GetAnchorA() const
 {
     return GetWorldPoint(*GetBodyA(), GetLocalAnchorA());
 }
 
-Length2D WheelJoint::GetAnchorB() const
+Length2 WheelJoint::GetAnchorB() const
 {
     return GetWorldPoint(*GetBodyB(), GetLocalAnchorB());
 }
 
-Momentum2D WheelJoint::GetLinearReaction() const
+Momentum2 WheelJoint::GetLinearReaction() const
 {
     return m_impulse * m_ay + m_springImpulse * m_ax;
 }

--- a/PlayRho/Dynamics/Joints/WheelJoint.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.hpp
@@ -48,17 +48,17 @@ public:
     
     void Accept(JointVisitor& visitor) const override;
 
-    Length2D GetAnchorA() const override;
-    Length2D GetAnchorB() const override;
+    Length2 GetAnchorA() const override;
+    Length2 GetAnchorB() const override;
 
-    Momentum2D GetLinearReaction() const override;
+    Momentum2 GetLinearReaction() const override;
     AngularMomentum GetAngularReaction() const override;
 
     /// The local anchor point relative to bodyA's origin.
-    Length2D GetLocalAnchorA() const { return m_localAnchorA; }
+    Length2 GetLocalAnchorA() const { return m_localAnchorA; }
 
     /// The local anchor point relative to bodyB's origin.
-    Length2D GetLocalAnchorB() const  { return m_localAnchorB; }
+    Length2 GetLocalAnchorB() const  { return m_localAnchorB; }
 
     /// The local joint axis relative to bodyA.
     UnitVec2 GetLocalAxisA() const { return m_localXAxisA; }
@@ -109,8 +109,8 @@ private:
     Real m_dampingRatio; ///< Damping ratio.
 
     // Solver shared
-    Length2D m_localAnchorA; ///< Local anchor A.
-    Length2D m_localAnchorB; ///< Local anchor B.
+    Length2 m_localAnchorA; ///< Local anchor A.
+    Length2 m_localAnchorB; ///< Local anchor B.
     UnitVec2 m_localXAxisA; ///< Local X axis A.
     UnitVec2 m_localYAxisA; ///< Local Y axis A.
 

--- a/PlayRho/Dynamics/Joints/WheelJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJointDef.cpp
@@ -25,7 +25,7 @@
 
 namespace playrho {
 
-WheelJointDef::WheelJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2D anchor,
+WheelJointDef::WheelJointDef(NonNull<Body*> bA, NonNull<Body*> bB, const Length2 anchor,
                              const UnitVec2 axis) noexcept:
     super{super{JointType::Wheel}.UseBodyA(bA).UseBodyB(bB)},
     localAnchorA{GetLocalPoint(*bA, anchor)},

--- a/PlayRho/Dynamics/Joints/WheelJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointDef.hpp
@@ -46,7 +46,7 @@ struct WheelJointDef : public JointBuilder<WheelJointDef>
     
     /// Initialize the bodies, anchors, axis, and reference angle using the world
     /// anchor and world axis.
-    WheelJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2D anchor,
+    WheelJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor,
                   const UnitVec2 axis) noexcept;
     
     /// @brief Uses the given enable motor state value.
@@ -65,10 +65,10 @@ struct WheelJointDef : public JointBuilder<WheelJointDef>
     constexpr WheelJointDef& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to bodyA's origin.
-    Length2D localAnchorA = Length2D{};
+    Length2 localAnchorA = Length2{};
     
     /// The local anchor point relative to bodyB's origin.
-    Length2D localAnchorB = Length2D{};
+    Length2 localAnchorB = Length2{};
     
     /// The local translation axis in bodyA.
     UnitVec2 localAxisA = UnitVec2::GetRight();

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -210,8 +210,8 @@ namespace {
     inline VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc)
     {
         auto vp = VelocityPair{
-            Velocity{LinearVelocity2D{}, AngularVelocity{0}},
-            Velocity{LinearVelocity2D{}, AngularVelocity{0}}
+            Velocity{LinearVelocity2{}, AngularVelocity{0}},
+            Velocity{LinearVelocity2{}, AngularVelocity{0}}
         };
         
         const auto normal = vc.GetNormal();
@@ -230,8 +230,8 @@ namespace {
         {
             // inverse moment of inertia : L^-2 M^-1 QP^2
             // P is M L T^-2
-            // GetPointRelPosA() is Length2D
-            // Cross(Length2D, P) is: M L^2 T^-2
+            // GetPointRelPosA() is Length2
+            // Cross(Length2, P) is: M L^2 T^-2
             // L^-2 M^-1 QP^2 M L^2 T^-2 is: QP^2 T^-2
             const auto& vcp = vc.GetPointAt(j);
             const auto P = vcp.normalImpulse * normal + vcp.tangentImpulse * tangent;
@@ -856,7 +856,7 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
     }
 }
 
-void World::SetGravity(LinearAcceleration2D gravity) noexcept
+void World::SetGravity(LinearAcceleration2 gravity) noexcept
 {
     if (m_gravity != gravity)
     {
@@ -2053,7 +2053,7 @@ void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
     });
 }
 
-void World::RayCast(Length2D point1, Length2D point2, RayCastCallback callback) const
+void World::RayCast(Length2 point1, Length2 point2, RayCastCallback callback) const
 {
     playrho::RayCast(m_tree, RayCastInput{point1, point2, Real{1}},
                    [&](const RayCastInput& input, DynamicTree::Size treeId)
@@ -2100,7 +2100,7 @@ void World::RayCast(Length2D point1, Length2D point2, RayCastCallback callback) 
     });
 }
 
-void World::ShiftOrigin(Length2D newOrigin)
+void World::ShiftOrigin(Length2 newOrigin)
 {
     if (IsLocked())
     {
@@ -2611,7 +2611,7 @@ void World::SetType(Body& body, BodyType type)
     else
     {
         body.SetAwake();
-        body.SetAcceleration(body.IsAccelerable()? GetGravity(): LinearAcceleration2D{},
+        body.SetAcceleration(body.IsAccelerable()? GetGravity(): LinearAcceleration2{},
                              AngularAcceleration{0});
         const auto fixtures = body.GetFixtures();
         for_each(begin(fixtures), end(fixtures), [&](Body::Fixtures::value_type& f) {
@@ -2814,7 +2814,7 @@ ContactCounter World::Synchronize(Body& body,
 
 ContactCounter World::Synchronize(Fixture& fixture,
                                   Transformation xfm1, Transformation xfm2,
-                                  Length2D displacement, Length extension)
+                                  Length2 displacement, Length extension)
 {
     assert(::playrho::IsValid(xfm1));
     assert(::playrho::IsValid(xfm2));
@@ -2925,7 +2925,7 @@ void SetAccelerations(World& world, Acceleration acceleration) noexcept
     });
 }
 
-Body* CreateRectangularEnclosingBody(World& world, Length2D dimensions, const ShapeDef& baseConf)
+Body* CreateRectangularEnclosingBody(World& world, Length2 dimensions, const ShapeDef& baseConf)
 {
     const auto body = world.CreateBody();
     
@@ -2937,10 +2937,10 @@ Body* CreateRectangularEnclosingBody(World& world, Length2D dimensions, const Sh
     
     const auto halfWidth = GetX(dimensions) / Real{2};
     const auto halfHeight = GetY(dimensions) / Real{2};
-    const auto btmLeft  = Length2D(-halfWidth, -halfHeight);
-    const auto btmRight = Length2D(+halfWidth, -halfHeight);
-    const auto topLeft  = Length2D(-halfWidth, +halfHeight);
-    const auto topRight = Length2D(+halfWidth, +halfHeight);
+    const auto btmLeft  = Length2(-halfWidth, -halfHeight);
+    const auto btmRight = Length2(+halfWidth, -halfHeight);
+    const auto topLeft  = Length2(-halfWidth, +halfHeight);
+    const auto topRight = Length2(+halfWidth, +halfHeight);
     
     conf.vertices.push_back(btmRight);
     conf.vertices.push_back(topRight);
@@ -2953,7 +2953,7 @@ Body* CreateRectangularEnclosingBody(World& world, Length2D dimensions, const Sh
     return body;
 }
 
-Body* FindClosestBody(const World& world, Length2D location) noexcept
+Body* FindClosestBody(const World& world, Length2 location) noexcept
 {
     const auto bodies = world.GetBodies();
     auto found = static_cast<decltype(bodies)::iterator_type::value_type>(nullptr);

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -210,7 +210,7 @@ public:
     /// @brief Ray cast callback function signature.
     using RayCastCallback = std::function<RayCastOpcode(Fixture* fixture,
                                                         ChildCounter child,
-                                                        Length2D point,
+                                                        Length2 point,
                                                         UnitVec2 normal)>;
 
     /// @brief Ray-cast the world for all fixtures in the path of the ray.
@@ -222,7 +222,7 @@ public:
     /// @param point2 Ray ending point.
     /// @param callback A user implemented callback function.
     ///
-    void RayCast(Length2D point1, Length2D point2, RayCastCallback callback) const;
+    void RayCast(Length2 point1, Length2 point2, RayCastCallback callback) const;
 
     /// @brief Gets the world body range for this world.
     /// @return Body range that can be iterated over using its begin and end methods
@@ -259,10 +259,10 @@ public:
     const DynamicTree& GetTree() const noexcept;
     
     /// @brief Changes the global gravity vector.
-    void SetGravity(LinearAcceleration2D gravity) noexcept;
+    void SetGravity(LinearAcceleration2 gravity) noexcept;
     
     /// @brief Gets the global gravity vector.
-    LinearAcceleration2D GetGravity() const noexcept;
+    LinearAcceleration2 GetGravity() const noexcept;
 
     /// @brief Is the world locked (in the middle of a time step).
     bool IsLocked() const noexcept;
@@ -272,7 +272,7 @@ public:
     /// @note The body shift formula is: position -= newOrigin
     /// @param newOrigin the new origin with respect to the old origin
     /// @throws WrongState if this method is called while the world is locked.
-    void ShiftOrigin(Length2D newOrigin);
+    void ShiftOrigin(Length2 newOrigin);
 
     /// @brief Gets the minimum vertex radius that shapes in this world can be.
     Length GetMinVertexRadius() const noexcept;
@@ -690,7 +690,7 @@ private:
     ///   fixture shape's children.
     ContactCounter Synchronize(Fixture& fixture,
                                Transformation xfm1, Transformation xfm2,
-                               Length2D displacement, Length extension);
+                               Length2 displacement, Length extension);
     
     /// @brief Creates and destroys proxies.
     void CreateAndDestroyProxies(const StepConf& conf);
@@ -748,7 +748,7 @@ private:
     ///   during a given time step.
     Contacts m_contacts;
 
-    LinearAcceleration2D m_gravity; ///< Gravity setting. 8-bytes.
+    LinearAcceleration2 m_gravity; ///< Gravity setting. 8-bytes.
 
     DestructionListener* m_destructionListener = nullptr; ///< Destruction listener. 8-bytes.
     
@@ -829,7 +829,7 @@ inline SizedRange<World::Contacts::const_iterator> World::GetContacts() const no
     return {m_contacts.begin(), m_contacts.end(), m_contacts.size()};
 }
 
-inline LinearAcceleration2D World::GetGravity() const noexcept
+inline LinearAcceleration2 World::GetGravity() const noexcept
 {
     return m_gravity;
 }
@@ -1082,19 +1082,19 @@ inline void ClearForces(World& world) noexcept
 
 /// @brief Creates a rectanglular enclosure.
 /// @relatedalso World
-Body* CreateRectangularEnclosingBody(World& world, Length2D dimensions,
+Body* CreateRectangularEnclosingBody(World& world, Length2 dimensions,
                                      const ShapeDef& baseConf);
 
 /// @brief Creates a square enclosure.
 /// @relatedalso World
 inline Body* CreateSquareEnclosingBody(World& world, Length size, const ShapeDef& baseConf)
 {
-    return CreateRectangularEnclosingBody(world, Length2D{size, size}, baseConf);
+    return CreateRectangularEnclosingBody(world, Length2{size, size}, baseConf);
 }
     
 /// @brief Finds body in given world that's closest to the given location.
 /// @relatedalso World
-Body* FindClosestBody(const World& world, Length2D location) noexcept;
+Body* FindClosestBody(const World& world, Length2 location) noexcept;
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/WorldDef.hpp
+++ b/PlayRho/Dynamics/WorldDef.hpp
@@ -45,8 +45,8 @@ namespace playrho {
 
         /// @brief Gravity.
         /// @details The acceleration all dynamic bodies are subject to.
-        /// @note Use Vec2{0, 0} to disable gravity.
-        LinearAcceleration2D gravity = EarthlyGravity;
+        /// @note Use <code>LinearAcceleration2D{}</code> to disable gravity.
+        LinearAcceleration2D gravity = EarthlyGravity2;
         
         /// @brief Minimum vertex radius.
         /// @details This is the minimum vertex radius that this world establishes which bodies

--- a/PlayRho/Dynamics/WorldDef.hpp
+++ b/PlayRho/Dynamics/WorldDef.hpp
@@ -32,7 +32,7 @@ namespace playrho {
     struct WorldDef
     {
         /// @brief Uses the given gravity value.
-        constexpr WorldDef& UseGravity(LinearAcceleration2D value) noexcept;
+        constexpr WorldDef& UseGravity(LinearAcceleration2 value) noexcept;
 
         /// @brief Uses the given min vertex radius value.
         constexpr WorldDef& UseMinVertexRadius(Positive<Length> value) noexcept;
@@ -45,8 +45,8 @@ namespace playrho {
 
         /// @brief Gravity.
         /// @details The acceleration all dynamic bodies are subject to.
-        /// @note Use <code>LinearAcceleration2D{}</code> to disable gravity.
-        LinearAcceleration2D gravity = EarthlyGravity2;
+        /// @note Use <code>LinearAcceleration2{}</code> to disable gravity.
+        LinearAcceleration2 gravity = EarthlyGravity2D;
         
         /// @brief Minimum vertex radius.
         /// @details This is the minimum vertex radius that this world establishes which bodies
@@ -71,7 +71,7 @@ namespace playrho {
         ContactCounter initialTreeSize = 4096;
     };
     
-    constexpr inline WorldDef& WorldDef::UseGravity(LinearAcceleration2D value) noexcept
+    constexpr inline WorldDef& WorldDef::UseGravity(LinearAcceleration2 value) noexcept
     {
         gravity = value;
         return *this;

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -121,7 +121,7 @@ static GLuint sCreateShaderProgram(const char* vs, const char* fs)
 } // namespace
 
 
-Length2D ConvertScreenToWorld(const Camera& camera, const Coord2D ps)
+Length2 ConvertScreenToWorld(const Camera& camera, const Coord2D ps)
 {
     const auto w = float(camera.m_width);
     const auto h = float(camera.m_height);
@@ -136,7 +136,7 @@ Length2D ConvertScreenToWorld(const Camera& camera, const Coord2D ps)
     
     const auto x = Real{((1 - u) * lower.x + u * upper.x)};
     const auto y = Real{((1 - v) * lower.y + v * upper.y)};
-    return Length2D{x * Meter, y * Meter};
+    return Length2{x * Meter, y * Meter};
 }
 
 AABB ConvertScreenToWorld(const Camera& camera)
@@ -151,12 +151,12 @@ AABB ConvertScreenToWorld(const Camera& camera)
     const auto upper = camera.m_center + extents;
     
     return AABB{
-        Length2D{Real{lower.x} * Meter, Real{lower.y} * Meter},
-        Length2D{Real{upper.x} * Meter, Real{upper.y} * Meter}
+        Length2{Real{lower.x} * Meter, Real{lower.y} * Meter},
+        Length2{Real{upper.x} * Meter, Real{upper.y} * Meter}
     };
 }
 
-Coord2D ConvertWorldToScreen(const Camera& camera, const Length2D pw)
+Coord2D ConvertWorldToScreen(const Camera& camera, const Length2 pw)
 {
     const auto w = float(camera.m_width);
     const auto h = float(camera.m_height);
@@ -616,7 +616,7 @@ DebugDraw::~DebugDraw() noexcept
     delete m_points;
 }
 
-void DebugDraw::DrawTriangle(const Length2D& p1, const Length2D& p2, const Length2D& p3, const Color& color)
+void DebugDraw::DrawTriangle(const Length2& p1, const Length2& p2, const Length2& p3, const Color& color)
 {
     const auto c1 = Coord2D{static_cast<float>(StripUnit(GetX(p1))), static_cast<float>(StripUnit(GetY(p1)))};
     const auto c2 = Coord2D{static_cast<float>(StripUnit(GetX(p2))), static_cast<float>(StripUnit(GetY(p2)))};
@@ -626,7 +626,7 @@ void DebugDraw::DrawTriangle(const Length2D& p1, const Length2D& p2, const Lengt
     m_triangles->Vertex(m_camera, c3, color);
 }
 
-void DebugDraw::DrawSegment(const Length2D& p1, const Length2D& p2, const Color& color)
+void DebugDraw::DrawSegment(const Length2& p1, const Length2& p2, const Color& color)
 {
     const auto c1 = Coord2D{static_cast<float>(StripUnit(GetX(p1))), static_cast<float>(StripUnit(GetY(p1)))};
     const auto c2 = Coord2D{static_cast<float>(StripUnit(GetX(p2))), static_cast<float>(StripUnit(GetY(p2)))};
@@ -634,8 +634,8 @@ void DebugDraw::DrawSegment(const Length2D& p1, const Length2D& p2, const Color&
     m_lines->Vertex(m_camera, c2, color);
 }
 
-void DebugDraw::DrawSegment(const Length2D& p1, const Color& c1,
-                 const Length2D& p2, const Color& c2)
+void DebugDraw::DrawSegment(const Length2& p1, const Color& c1,
+                 const Length2& p2, const Color& c2)
 {
     const auto coord1 = Coord2D{static_cast<float>(StripUnit(GetX(p1))), static_cast<float>(StripUnit(GetY(p1)))};
     const auto coord2 = Coord2D{static_cast<float>(StripUnit(GetX(p2))), static_cast<float>(StripUnit(GetY(p2)))};
@@ -643,7 +643,7 @@ void DebugDraw::DrawSegment(const Length2D& p1, const Color& c1,
     m_lines->Vertex(m_camera, coord2, c2);
 }
 
-void DebugDraw::DrawPoint(const Length2D& p, float size, const Color& color)
+void DebugDraw::DrawPoint(const Length2& p, float size, const Color& color)
 {
     const auto c = Coord2D{static_cast<float>(StripUnit(GetX(p))), static_cast<float>(StripUnit(GetY(p)))};
     m_points->Vertex(m_camera, c, color, size);
@@ -656,7 +656,7 @@ void DebugDraw::Flush()
     m_points->Flush(m_camera);
 }
 
-void DebugDraw::DrawPolygon(const Length2D* vertices, size_type vertexCount, const Color& color)
+void DebugDraw::DrawPolygon(const Length2* vertices, size_type vertexCount, const Color& color)
 {
     auto p1 = vertices[vertexCount - 1];
     for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
@@ -667,7 +667,7 @@ void DebugDraw::DrawPolygon(const Length2D* vertices, size_type vertexCount, con
     }
 }
 
-void DebugDraw::DrawCircle(const Length2D& center, Length radius, const Color& color)
+void DebugDraw::DrawCircle(const Length2& center, Length radius, const Color& color)
 {
     auto r1 = Vec2(1, 0);
     auto v1 = center + radius * r1;
@@ -683,7 +683,7 @@ void DebugDraw::DrawCircle(const Length2D& center, Length radius, const Color& c
     }
 }
 
-void DebugDraw::DrawSolidPolygon(const Length2D* vertices, size_type vertexCount, const Color& color)
+void DebugDraw::DrawSolidPolygon(const Length2* vertices, size_type vertexCount, const Color& color)
 {
     for (auto i = decltype(vertexCount){1}; i < vertexCount - 1; ++i)
     {
@@ -691,7 +691,7 @@ void DebugDraw::DrawSolidPolygon(const Length2D* vertices, size_type vertexCount
     }
 }
 
-void DebugDraw::DrawSolidCircle(const Length2D& center, Length radius, const Color& color)
+void DebugDraw::DrawSolidCircle(const Length2& center, Length radius, const Color& color)
 {
     const auto v0 = center;
     auto r1 = Vec2(m_cosInc, m_sinInc);
@@ -709,7 +709,7 @@ void DebugDraw::DrawSolidCircle(const Length2D& center, Length radius, const Col
     }
 }
 
-void DebugDraw::DrawString(const Length2D& pw, TextAlign align, const char *string, ...)
+void DebugDraw::DrawString(const Length2& pw, TextAlign align, const char *string, ...)
 {
     auto ps = ConvertWorldToScreen(m_camera, pw);
 
@@ -742,15 +742,15 @@ void DebugDraw::DrawString(const Length2D& pw, TextAlign align, const char *stri
     ImGui::PopStyleColor();
 }
 
-Length2D DebugDraw::GetTranslation() const
+Length2 DebugDraw::GetTranslation() const
 {
-    return Length2D{
+    return Length2{
         Real(m_camera.m_center.x) * Meter,
         Real(m_camera.m_center.y) * Meter
     };
 }
 
-void DebugDraw::SetTranslation(Length2D value)
+void DebugDraw::SetTranslation(Length2 value)
 {
     m_camera.m_center = Coord2D{
         static_cast<float>(Real{GetX(value) / Meter}),

--- a/Testbed/Framework/DebugDraw.hpp
+++ b/Testbed/Framework/DebugDraw.hpp
@@ -81,9 +81,9 @@ struct Camera
     int m_height = 800;
 };
 
-Length2D ConvertScreenToWorld(const Camera& camera, const Coord2D screenPoint);
+Length2 ConvertScreenToWorld(const Camera& camera, const Coord2D screenPoint);
 AABB ConvertScreenToWorld(const Camera& camera);
-Coord2D ConvertWorldToScreen(const Camera& camera, const Length2D worldPoint);
+Coord2D ConvertWorldToScreen(const Camera& camera, const Length2 worldPoint);
 ProjectionMatrix GetProjectionMatrix(const Camera& camera, float zBias);
 
 class DebugDraw : public Drawer
@@ -93,31 +93,31 @@ public:
 
     virtual ~DebugDraw() noexcept;
     
-    void DrawPolygon(const Length2D* vertices, size_type vertexCount, const Color& color) override;
+    void DrawPolygon(const Length2* vertices, size_type vertexCount, const Color& color) override;
 
-    void DrawSolidPolygon(const Length2D* vertices, size_type vertexCount, const Color& color) override;
+    void DrawSolidPolygon(const Length2* vertices, size_type vertexCount, const Color& color) override;
 
-    void DrawCircle(const Length2D& center, Length radius, const Color& color) override;
+    void DrawCircle(const Length2& center, Length radius, const Color& color) override;
 
-    void DrawSolidCircle(const Length2D& center, Length radius, const Color& color) override;
+    void DrawSolidCircle(const Length2& center, Length radius, const Color& color) override;
 
-    void DrawSegment(const Length2D& p1, const Length2D& p2, const Color& color) override;
+    void DrawSegment(const Length2& p1, const Length2& p2, const Color& color) override;
 
-    void DrawSegment(const Length2D& p1, const Color& c1,
-                     const Length2D& p2, const Color& c2) override;
+    void DrawSegment(const Length2& p1, const Color& c1,
+                     const Length2& p2, const Color& c2) override;
 
-    void DrawPoint(const Length2D& p, float size, const Color& color) override;
+    void DrawPoint(const Length2& p, float size, const Color& color) override;
 
-    void DrawString(const Length2D& p, TextAlign align, const char* string, ...) override;
+    void DrawString(const Length2& p, TextAlign align, const char* string, ...) override;
 
     void Flush() override;
     
-    Length2D GetTranslation() const override;
+    Length2 GetTranslation() const override;
 
-    void SetTranslation(Length2D value) override;
+    void SetTranslation(Length2 value) override;
 
 private:
-    void DrawTriangle(const Length2D& p1, const Length2D& p2, const Length2D& p3, const Color& color);
+    void DrawTriangle(const Length2& p1, const Length2& p2, const Length2& p3, const Color& color);
 
     Camera& m_camera;
     GLRenderPoints* m_points;

--- a/Testbed/Framework/Drawer.hpp
+++ b/Testbed/Framework/Drawer.hpp
@@ -71,38 +71,38 @@ public:
     virtual ~Drawer() noexcept = 0;
 
     /// Draw a closed polygon provided in CCW order.
-    virtual void DrawPolygon(const Length2D* vertices, size_type vertexCount, const Color& color) = 0;
+    virtual void DrawPolygon(const Length2* vertices, size_type vertexCount, const Color& color) = 0;
 
     /// Draw a solid closed polygon provided in CCW order.
-    virtual void DrawSolidPolygon(const Length2D* vertices, size_type vertexCount, const Color& color) = 0;
+    virtual void DrawSolidPolygon(const Length2* vertices, size_type vertexCount, const Color& color) = 0;
 
     /// Draw a circle.
-    virtual void DrawCircle(const Length2D& center, Length radius, const Color& color) = 0;
+    virtual void DrawCircle(const Length2& center, Length radius, const Color& color) = 0;
     
     /// Draw a solid circle.
-    virtual void DrawSolidCircle(const Length2D& center, Length radius, const Color& color) = 0;
+    virtual void DrawSolidCircle(const Length2& center, Length radius, const Color& color) = 0;
  
     /// Draws a line segment from point 1 to point 2.
-    virtual void DrawSegment(const Length2D& p1, const Length2D& p2, const Color& c) = 0;
+    virtual void DrawSegment(const Length2& p1, const Length2& p2, const Color& c) = 0;
 
     /// Draws a line segment from point 1 to point 2 in color 1 to color 2.
-    virtual void DrawSegment(const Length2D& p1, const Color& c1,
-                             const Length2D& p2, const Color& c2) = 0;
+    virtual void DrawSegment(const Length2& p1, const Color& c1,
+                             const Length2& p2, const Color& c2) = 0;
 
-    virtual void DrawPoint(const Length2D& p, float size, const Color& color) = 0;
+    virtual void DrawPoint(const Length2& p, float size, const Color& color) = 0;
     
     /// Draws a string at the given world coordinates.
-    virtual void DrawString(const Length2D& p, TextAlign align, const char* string, ...) = 0;
+    virtual void DrawString(const Length2& p, TextAlign align, const char* string, ...) = 0;
         
     virtual void Flush() = 0;
     
-    virtual void SetTranslation(Length2D value) = 0;
+    virtual void SetTranslation(Length2 value) = 0;
 
-    virtual Length2D GetTranslation() const = 0;
+    virtual Length2 GetTranslation() const = 0;
 };
 
 /// @brief Draws segment with a single constant color.
-inline void DrawSegment(Drawer& drawer, const Length2D& p1, const Length2D& p2,
+inline void DrawSegment(Drawer& drawer, const Length2& p1, const Length2& p2,
                         const Color& color)
 {
     drawer.DrawSegment(p1, p2, color);

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -82,10 +82,10 @@ namespace
     Settings settings; ///< User settings.
     auto rightMouseDown = false;
     auto leftMouseDown = false;
-    Length2D lastp;
+    Length2 lastp;
     
     Coord2D mouseScreen = Coord2D{0.0, 0.0};
-    Length2D mouseWorld = Length2D{};
+    Length2 mouseWorld = Length2{};
     
     const auto menuWidth = 200;
     auto menuX = 0;
@@ -335,7 +335,7 @@ static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, i
             // Pan left
             if (mods == GLFW_MOD_CONTROL)
             {
-                g_testSuite->GetTest()->ShiftOrigin(Length2D(2_m, 0_m));
+                g_testSuite->GetTest()->ShiftOrigin(Length2(2_m, 0_m));
             }
             else
             {
@@ -347,7 +347,7 @@ static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, i
             // Pan right
             if (mods == GLFW_MOD_CONTROL)
             {
-                g_testSuite->GetTest()->ShiftOrigin(Length2D(-2_m, 0_m));
+                g_testSuite->GetTest()->ShiftOrigin(Length2(-2_m, 0_m));
             }
             else
             {
@@ -359,7 +359,7 @@ static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, i
             // Pan down
             if (mods == GLFW_MOD_CONTROL)
             {
-                g_testSuite->GetTest()->ShiftOrigin(Length2D(0_m, 2_m));
+                g_testSuite->GetTest()->ShiftOrigin(Length2(0_m, 2_m));
             }
             else
             {
@@ -371,7 +371,7 @@ static void KeyCallback(GLFWwindow* window, int key, int scancode, int action, i
             // Pan up
             if (mods == GLFW_MOD_CONTROL)
             {
-                g_testSuite->GetTest()->ShiftOrigin(Length2D(0_m, -2_m));
+                g_testSuite->GetTest()->ShiftOrigin(Length2(0_m, -2_m));
             }
             else
             {

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -1296,8 +1296,8 @@ void Test::Step(const Settings& settings, Drawer& drawer, UiState& ui)
     stepConf.angularSlop = Real{settings.angularSlop} * Radian;
     stepConf.regMinSeparation = Real{settings.regMinSeparation} * Meter;
     stepConf.toiMinSeparation = Real{settings.toiMinSeparation} * Meter;
-    stepConf.targetDepth = settings.linearSlop * Real{3} * Meter;
-    stepConf.tolerance = (settings.linearSlop / Real{4}) * Meter;
+    stepConf.targetDepth = 3 * settings.linearSlop * Meter;
+    stepConf.tolerance = (settings.linearSlop / 4) * Meter;
 
     stepConf.maxLinearCorrection = Real{settings.maxLinearCorrection} * Meter;
     stepConf.maxAngularCorrection = Real{settings.maxAngularCorrection} * Degree;

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -227,7 +227,7 @@ static void DrawStats(const std::vector<Fixture*>& selectFixtures)
     }
 }
 
-static void DrawCorner(Drawer& drawer, Length2D p, Length r, Angle a0, Angle a1, Color color)
+static void DrawCorner(Drawer& drawer, Length2 p, Length r, Angle a0, Angle a1, Color color)
 {
     const auto angleDiff = GetRevRotationalAngle(a0, a1);
     auto lastAngle = 0_deg;
@@ -335,7 +335,7 @@ void ShapeDrawer::Visit(const ChainShape& shape)
 void ShapeDrawer::Draw(const DistanceProxy& shape)
 {
     const auto vertexCount = shape.GetVertexCount();
-    auto vertices = std::vector<Length2D>(vertexCount);
+    auto vertices = std::vector<Length2>(vertexCount);
     for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
     {
         vertices[i] = Transform(shape.GetVertex(i), xf);
@@ -486,11 +486,11 @@ static void Draw(Drawer& drawer, const Joint& joint)
 
 static void Draw(Drawer& drawer, const AABB& aabb, const Color& color)
 {
-    Length2D vs[4];
-    vs[0] = Length2D{aabb.rangeX.GetMin(), aabb.rangeY.GetMin()};
-    vs[1] = Length2D{aabb.rangeX.GetMax(), aabb.rangeY.GetMin()};
-    vs[2] = Length2D{aabb.rangeX.GetMax(), aabb.rangeY.GetMax()};
-    vs[3] = Length2D{aabb.rangeX.GetMin(), aabb.rangeY.GetMax()};
+    Length2 vs[4];
+    vs[0] = Length2{aabb.rangeX.GetMin(), aabb.rangeY.GetMin()};
+    vs[1] = Length2{aabb.rangeX.GetMax(), aabb.rangeY.GetMin()};
+    vs[2] = Length2{aabb.rangeX.GetMax(), aabb.rangeY.GetMax()};
+    vs[3] = Length2{aabb.rangeX.GetMin(), aabb.rangeY.GetMax()};
     drawer.DrawPolygon(vs, 4, color);
 }
 
@@ -668,7 +668,7 @@ void Test::PreSolve(Contact& contact, const Manifold& oldManifold)
     }
 }
 
-void Test::MouseDown(const Length2D& p)
+void Test::MouseDown(const Length2& p)
 {
     m_mouseWorld = p;
 
@@ -707,13 +707,13 @@ void Test::MouseDown(const Length2D& p)
     }
 }
 
-void Test::SpawnBomb(const Length2D& worldPt)
+void Test::SpawnBomb(const Length2& worldPt)
 {
     m_bombSpawnPoint = worldPt;
     m_bombSpawning = true;
 }
 
-void Test::CompleteBombSpawn(const Length2D& p)
+void Test::CompleteBombSpawn(const Length2& p)
 {
     if (!m_bombSpawning)
     {
@@ -721,7 +721,7 @@ void Test::CompleteBombSpawn(const Length2D& p)
     }
 
     const auto relP = m_bombSpawnPoint - p;
-    const auto vel = LinearVelocity2D{
+    const auto vel = LinearVelocity2{
         Real{30} * GetX(relP) / Second,
         Real{30} * GetY(relP) / Second
     };
@@ -729,7 +729,7 @@ void Test::CompleteBombSpawn(const Length2D& p)
     m_bombSpawning = false;
 }
 
-void Test::ShiftMouseDown(const Length2D& p)
+void Test::ShiftMouseDown(const Length2& p)
 {
     m_mouseWorld = p;
 
@@ -741,7 +741,7 @@ void Test::ShiftMouseDown(const Length2D& p)
     SpawnBomb(p);
 }
 
-void Test::MouseUp(const Length2D& p)
+void Test::MouseUp(const Length2& p)
 {
     if (m_mouseJoint)
     {
@@ -755,7 +755,7 @@ void Test::MouseUp(const Length2D& p)
     }
 }
 
-void Test::MouseMove(const Length2D& p)
+void Test::MouseMove(const Length2& p)
 {
     m_mouseWorld = p;
 
@@ -767,15 +767,15 @@ void Test::MouseMove(const Length2D& p)
 
 void Test::LaunchBomb()
 {
-    const auto p = Length2D(RandomFloat(-15.0f, 15.0f) * 1_m, 40_m);
-    const auto v = LinearVelocity2D{
+    const auto p = Length2(RandomFloat(-15.0f, 15.0f) * 1_m, 40_m);
+    const auto v = LinearVelocity2{
         Real{-100} * GetX(p) / Second,
         Real{-100} * GetY(p) / Second
     };
     LaunchBomb(p, v);
 }
 
-void Test::LaunchBomb(const Length2D& position, const LinearVelocity2D linearVelocity)
+void Test::LaunchBomb(const Length2& position, const LinearVelocity2 linearVelocity)
 {
     if (m_bomb)
     {
@@ -1427,7 +1427,7 @@ void Test::Step(const Settings& settings, Drawer& drawer, UiState& ui)
     drawer.Flush();
 }
 
-void Test::ShiftOrigin(const Length2D& newOrigin)
+void Test::ShiftOrigin(const Length2& newOrigin)
 {
     m_world.ShiftOrigin(newOrigin);
 }

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -185,11 +185,17 @@ protected:
     
     struct Conf
     {
+        /// @brief World definition/configuration data.
+        /// @note Explicitly uses -10 for gravity here to behave more like
+        ///   Erin Catto's Box2D Testbed (which uses -10 for Earthly gravity).
         WorldDef worldDef = WorldDef{}.UseGravity(LinearAcceleration2D{
             Real(0.0f) * MeterPerSquareSecond, -Real(10.0f) * MeterPerSquareSecond
         }).UseMinVertexRadius(0.0002_m);
+
         Settings settings;
+        
         NeededSettings neededSettings = 0u;
+        
         std::string description;
         std::string seeAlso;
         std::string credits;

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -137,13 +137,13 @@ public:
     /// @sa https://en.wikipedia.org/wiki/Template_method_pattern
     void Step(const Settings& settings, Drawer& drawer, UiState& ui);
     
-    void ShiftMouseDown(const Length2D& p);
-    void MouseMove(const Length2D& p);
+    void ShiftMouseDown(const Length2& p);
+    void MouseMove(const Length2& p);
     void LaunchBomb();
-    void LaunchBomb(const Length2D& position, const LinearVelocity2D velocity);
-    void SpawnBomb(const Length2D& worldPt);
-    void CompleteBombSpawn(const Length2D& p);
-    void ShiftOrigin(const Length2D& newOrigin);
+    void LaunchBomb(const Length2& position, const LinearVelocity2 velocity);
+    void SpawnBomb(const Length2& worldPt);
+    void CompleteBombSpawn(const Length2& p);
+    void ShiftOrigin(const Length2& newOrigin);
     
     void KeyboardHandler(KeyID key, KeyAction action, KeyMods mods);
     
@@ -159,8 +159,8 @@ public:
                                                        m_handledKeys.size());
     }
 
-    void MouseDown(const Length2D& p);
-    void MouseUp(const Length2D& p);
+    void MouseDown(const Length2& p);
+    void MouseUp(const Length2& p);
     
     // Let derived tests know that a joint was destroyed.
     virtual void JointDestroyed(Joint* joint) { NOT_USED(joint); }
@@ -188,7 +188,7 @@ protected:
         /// @brief World definition/configuration data.
         /// @note Explicitly uses -10 for gravity here to behave more like
         ///   Erin Catto's Box2D Testbed (which uses -10 for Earthly gravity).
-        WorldDef worldDef = WorldDef{}.UseGravity(LinearAcceleration2D{
+        WorldDef worldDef = WorldDef{}.UseGravity(LinearAcceleration2{
             Real(0.0f) * MeterPerSquareSecond, -Real(10.0f) * MeterPerSquareSecond
         }).UseMinVertexRadius(0.0002_m);
 
@@ -213,7 +213,7 @@ protected:
         Fixture* fixtureA;
         Fixture* fixtureB;
         UnitVec2 normal;
-        Length2D position;
+        Length2 position;
         PointState state;
         Momentum normalImpulse;
         Momentum tangentImpulse;
@@ -290,9 +290,9 @@ protected:
     
     void SetBomb(Body* body) noexcept { m_bomb = body; }
     
-    Length2D GetMouseWorld() const noexcept { return m_mouseWorld; }
+    Length2 GetMouseWorld() const noexcept { return m_mouseWorld; }
 
-    void SetMouseWorld(Length2D value) noexcept { m_mouseWorld = value; }
+    void SetMouseWorld(Length2 value) noexcept { m_mouseWorld = value; }
     
     KeyHandlerID RegisterKeyHandler(const std::string& info, KeyHandler handler)
     {
@@ -331,9 +331,9 @@ private:
     DestructionListenerImpl m_destructionListener;
     Body* m_bomb = nullptr;
     MouseJoint* m_mouseJoint = nullptr;
-    Length2D m_bombSpawnPoint;
+    Length2 m_bombSpawnPoint;
     bool m_bombSpawning = false;
-    Length2D m_mouseWorld;
+    Length2 m_mouseWorld;
     double m_sumDeltaTime = 0.0;
     int m_stepCount = 0;
     StepStats m_stepStats;

--- a/Testbed/Tests/AddPair.hpp
+++ b/Testbed/Tests/AddPair.hpp
@@ -36,7 +36,7 @@ public:
     
     AddPair(): Test(GetTestConf())
     {
-        m_world.SetGravity(LinearAcceleration2D{});
+        m_world.SetGravity(LinearAcceleration2{});
         {
             const auto conf = DiskShape::Conf{}.UseVertexRadius(1_dm).UseDensity(0.01_kgpm2);
             const auto shape = std::make_shared<DiskShape>(conf);
@@ -59,8 +59,8 @@ public:
             const auto bd = BodyDef{}
                 .UseType(BodyType::Dynamic)
                 .UseBullet(true)
-                .UseLocation(Length2D{-40_m, 5_m})
-                .UseLinearVelocity(LinearVelocity2D{150_mps, 0_mps});
+                .UseLocation(Length2{-40_m, 5_m})
+                .UseLinearVelocity(LinearVelocity2{150_mps, 0_mps});
             const auto body = m_world.CreateBody(bd);
 
             const auto conf = PolygonShape::Conf{}.UseDensity(1.0_kgpm2);

--- a/Testbed/Tests/ApplyForce.hpp
+++ b/Testbed/Tests/ApplyForce.hpp
@@ -30,12 +30,12 @@ public:
     
     ApplyForce()
     {
-        m_world.SetGravity(LinearAcceleration2D{});
+        m_world.SetGravity(LinearAcceleration2{});
 
         RegisterForKey(GLFW_KEY_W, GLFW_PRESS, 0, "Apply Force", [&](KeyActionMods) {
-            const auto lv = Length2D{0_m, -200_m};
-            const auto f = Force2D{GetWorldVector(*m_body, lv) * 1_kg / (1_s * 1_s)};
-            const auto p = GetWorldPoint(*m_body, Length2D{0_m, 2_m});
+            const auto lv = Length2{0_m, -200_m};
+            const auto f = Force2{GetWorldVector(*m_body, lv) * 1_kg / (1_s * 1_s)};
+            const auto p = GetWorldPoint(*m_body, Length2{0_m, 2_m});
             playrho::ApplyForce(*m_body, f, p);
         });
         RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Apply Counter-Clockwise Torque", [&](KeyActionMods) {
@@ -50,7 +50,7 @@ public:
         Body* ground;
         {
             BodyDef bd;
-            bd.location = Length2D(0_m, 20_m);
+            bd.location = Length2(0_m, 20_m);
             ground = m_world.CreateBody(bd);
 
             auto conf = EdgeShape::Conf{};
@@ -59,19 +59,19 @@ public:
             EdgeShape shape(conf);
 
             // Left vertical
-            shape.Set(Length2D{-20_m, -20_m}, Length2D{-20_m, 20_m});
+            shape.Set(Length2{-20_m, -20_m}, Length2{-20_m, 20_m});
             ground->CreateFixture(std::make_shared<EdgeShape>(shape));
 
             // Right vertical
-            shape.Set(Length2D{20_m, -20_m}, Length2D{20_m, 20_m});
+            shape.Set(Length2{20_m, -20_m}, Length2{20_m, 20_m});
             ground->CreateFixture(std::make_shared<EdgeShape>(shape));
 
             // Top horizontal
-            shape.Set(Length2D{-20_m, 20_m}, Length2D{20_m, 20_m});
+            shape.Set(Length2{-20_m, 20_m}, Length2{20_m, 20_m});
             ground->CreateFixture(std::make_shared<EdgeShape>(shape));
 
             // Bottom horizontal
-            shape.Set(Length2D{-20_m, -20_m}, Length2D{20_m, -20_m});
+            shape.Set(Length2{-20_m, -20_m}, Length2{20_m, -20_m});
             ground->CreateFixture(std::make_shared<EdgeShape>(shape));
         }
 
@@ -80,32 +80,32 @@ public:
             xf1.q = UnitVec2::Get(0.3524_rad * Pi);
             xf1.p = GetVec2(GetXAxis(xf1.q)) * 1_m;
 
-            Length2D vertices[3];
-            vertices[0] = Transform(Length2D{-1_m, 0_m}, xf1);
-            vertices[1] = Transform(Length2D{1_m, 0_m}, xf1);
-            vertices[2] = Transform(Length2D{0_m, 0.5_m}, xf1);
+            Length2 vertices[3];
+            vertices[0] = Transform(Length2{-1_m, 0_m}, xf1);
+            vertices[1] = Transform(Length2{1_m, 0_m}, xf1);
+            vertices[2] = Transform(Length2{0_m, 0.5_m}, xf1);
 
             auto conf = PolygonShape::Conf{};
 
             conf.density = 4_kgpm2;
-            const auto poly1 = PolygonShape(Span<const Length2D>(vertices, 3), conf);
+            const auto poly1 = PolygonShape(Span<const Length2>(vertices, 3), conf);
 
             Transformation xf2;
             xf2.q = UnitVec2::Get(-0.3524_rad * Pi);
             xf2.p = GetVec2(-GetXAxis(xf2.q)) * 1_m;
 
-            vertices[0] = Transform(Length2D{-1_m, 0_m}, xf2);
-            vertices[1] = Transform(Length2D{1_m, 0_m}, xf2);
-            vertices[2] = Transform(Length2D{0_m, 0.5_m}, xf2);
+            vertices[0] = Transform(Length2{-1_m, 0_m}, xf2);
+            vertices[1] = Transform(Length2{1_m, 0_m}, xf2);
+            vertices[2] = Transform(Length2{0_m, 0.5_m}, xf2);
 
             conf.density = 2_kgpm2;
-            const auto poly2 = PolygonShape(Span<const Length2D>(vertices, 3), conf);
+            const auto poly2 = PolygonShape(Span<const Length2>(vertices, 3), conf);
 
             BodyDef bd;
             bd.type = BodyType::Dynamic;
             bd.angularDamping = 2_Hz;
             bd.linearDamping = 0.5_Hz;
-            bd.location = Length2D{0_m, 2_m};
+            bd.location = Length2{0_m, 2_m};
             bd.angle = Pi * 1_rad;
             bd.allowSleep = false;
             m_body = m_world.CreateBody(bd);
@@ -124,7 +124,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.location = Length2D{0_m, (5.0f + 1.54f * i) * 1_m};
+                bd.location = Length2{0_m, (5.0f + 1.54f * i) * 1_m};
                 const auto body = m_world.CreateBody(bd);
 
                 body->CreateFixture(shape);
@@ -138,8 +138,8 @@ public:
                 const auto radius = Length{Real{std::sqrt(Real{radiusSquaredUnitless})} * 1_m};
 
                 FrictionJointDef jd;
-                jd.localAnchorA = Vec2_zero * 1_m;
-                jd.localAnchorB = Vec2_zero * 1_m;
+                jd.localAnchorA = Length2{};
+                jd.localAnchorB = Length2{};
                 jd.bodyA = ground;
                 jd.bodyB = body;
                 jd.collideConnected = true;

--- a/Testbed/Tests/BagOfDisks.hpp
+++ b/Testbed/Tests/BagOfDisks.hpp
@@ -68,13 +68,13 @@ namespace playrho {
             conf.vertexRadius = 0.125_m;
             conf.density = 10_kgpm2;
             conf.friction = 0.2f;
-            conf.vertex1 = Length2D{-halfSegmentLength, 0_m};
-            conf.vertex2 = Length2D{+halfSegmentLength, 0_m};
+            conf.vertex1 = Length2{-halfSegmentLength, 0_m};
+            conf.vertex2 = Length2{+halfSegmentLength, 0_m};
             const auto vertexOffset = Vec2(0, 14) * 1_m;
             const auto shape = std::make_shared<EdgeShape>(conf);
             auto prevBody = static_cast<Body*>(nullptr);
             auto firstBody = static_cast<Body*>(nullptr);
-            auto prevVertex = Optional<Length2D>{};
+            auto prevVertex = Optional<Length2>{};
             for (const auto& vertex: vertices)
             {
                 if (prevVertex.has_value())

--- a/Testbed/Tests/BodyTypes.hpp
+++ b/Testbed/Tests/BodyTypes.hpp
@@ -100,7 +100,7 @@ public:
                 (GetX(p) > +10_m && GetX(velocity.linear) > 0_mps))
             {
                 m_platform->SetVelocity(Velocity{
-                    LinearVelocity2D{-GetX(velocity.linear), GetY(velocity.linear)},
+                    LinearVelocity2{-GetX(velocity.linear), GetY(velocity.linear)},
                     velocity.angular
                 });
             }

--- a/Testbed/Tests/Breakable.hpp
+++ b/Testbed/Tests/Breakable.hpp
@@ -137,7 +137,7 @@ public:
     }
 
     Body* m_body1;
-    LinearVelocity2D m_velocity;
+    LinearVelocity2 m_velocity;
     AngularVelocity m_angularVelocity;
     std::shared_ptr<PolygonShape> m_shape1 = std::make_shared<PolygonShape>();
     std::shared_ptr<PolygonShape> m_shape2 = std::make_shared<PolygonShape>();

--- a/Testbed/Tests/BreakableTwo.hpp
+++ b/Testbed/Tests/BreakableTwo.hpp
@@ -42,16 +42,16 @@ public:
         m_shape = std::make_shared<PolygonShape>(0.5_m - vr, 0.5_m - vr, polygonConf);
         m_shape->SetDensity(100_kgpm2);
 
-        m_world.SetGravity(LinearAcceleration2D{});
+        m_world.SetGravity(LinearAcceleration2{});
 
         Body* bodies[20 * 20];
-        const auto startLoc = Length2D{-10_m, 10_m};
+        const auto startLoc = Length2{-10_m, 10_m};
         const auto bd = BodyDef{}.UseType(BodyType::Dynamic);
         for (auto y = 0; y < 20; ++y)
         {
             for (auto x = 0; x < 20; ++x)
             {
-                const auto location = startLoc + Length2D{x * 1_m, y * 1_m};
+                const auto location = startLoc + Length2{x * 1_m, y * 1_m};
                 bodies[y * 20 + x] = m_world.CreateBody(BodyDef{bd}.UseLocation(location));
                 bodies[y * 20 + x]->CreateFixture(m_shape);
                 
@@ -60,7 +60,7 @@ public:
                     const auto jd = WeldJointDef{
                         bodies[y * 20 + x - 1],
                         bodies[y * 20 + x],
-                        location + Length2D{-0.5_m, 0_m}
+                        location + Length2{-0.5_m, 0_m}
                     };
                     m_world.CreateJoint(jd);
                 }
@@ -69,7 +69,7 @@ public:
                     const auto jd = WeldJointDef{
                         bodies[(y - 1) * 20 + x],
                         bodies[(y + 0) * 20 + x],
-                        location + Length2D{0_m, -0.5_m}
+                        location + Length2{0_m, -0.5_m}
                     };
                     m_world.CreateJoint(jd);
                 }

--- a/Testbed/Tests/BulletTest.hpp
+++ b/Testbed/Tests/BulletTest.hpp
@@ -32,7 +32,7 @@ public:
     {
         {
             BodyDef bd;
-            bd.location = Vec2(0.0f, 0.0f) * 1_m;
+            bd.location = Length2{};
             Body* body = m_world.CreateBody(bd);
 
             body->CreateFixture(std::make_shared<EdgeShape>(Vec2(-10.0f, 0.0f) * 1_m, Vec2(10.0f, 0.0f) * 1_m));
@@ -72,7 +72,7 @@ public:
     void Launch()
     {
         m_body->SetTransform(Vec2(0.0f, 4.0f) * 1_m, 0_rad);
-        m_body->SetVelocity(Velocity{LinearVelocity2D{}, AngularVelocity{0}});
+        m_body->SetVelocity(Velocity{LinearVelocity2{}, AngularVelocity{0}});
 
         m_x = RandomFloat(-1.0f, 1.0f);
         m_bullet->SetTransform(Vec2(m_x, 10.0f) * 1_m, 0_rad);

--- a/Testbed/Tests/Car.hpp
+++ b/Testbed/Tests/Car.hpp
@@ -242,7 +242,7 @@ public:
 
     void PreStep(const Settings&, Drawer& drawer) override
     {
-        drawer.SetTranslation(Length2D{GetX(m_car->GetLocation()), GetY(drawer.GetTranslation())});
+        drawer.SetTranslation(Length2{GetX(m_car->GetLocation()), GetY(drawer.GetTranslation())});
     }
 
     void PostStep(const Settings&, Drawer&) override

--- a/Testbed/Tests/CharacterCollision.hpp
+++ b/Testbed/Tests/CharacterCollision.hpp
@@ -136,7 +136,7 @@ public:
         {
             const auto body = m_world.CreateBody(BodyDef{}.UseLocation(Vec2(-10.0f, 4.0f) * 1_m));
             auto conf = ChainShape::Conf{};
-            conf.vertices.push_back(Vec2(0.0f, 0.0f) * 1_m);
+            conf.vertices.push_back(Length2{});
             conf.vertices.push_back(Vec2(6.0f, 0.0f) * 1_m);
             conf.vertices.push_back(Vec2(6.0f, 2.0f) * 1_m);
             conf.vertices.push_back(Vec2(4.0f, 1.0f) * 1_m);
@@ -198,7 +198,7 @@ public:
 
             auto angle = Real{0.0f};
             const auto delta = Real{Pi / 3.0f};
-            Length2D vertices[6];
+            Length2 vertices[6];
             for (auto i = 0; i < 6; ++i)
             {
                 vertices[i] = Vec2(0.5f * std::cos(angle), 0.5f * std::sin(angle)) * 1_m;
@@ -208,7 +208,7 @@ public:
             auto conf = PolygonShape::Conf{};
             conf.density = 20_kgpm2;
             auto hexshape = std::make_shared<PolygonShape>(conf);
-            hexshape->Set(Span<const Length2D>(vertices, 6));
+            hexshape->Set(Span<const Length2>(vertices, 6));
             body->CreateFixture(hexshape);
         }
 

--- a/Testbed/Tests/CollisionFiltering.hpp
+++ b/Testbed/Tests/CollisionFiltering.hpp
@@ -58,12 +58,12 @@ public:
         }
 
         // Small triangle
-        Length2D vertices[3];
+        Length2 vertices[3];
         vertices[0] = Vec2(-1.0f, 0.0f) * 1_m;
         vertices[1] = Vec2(1.0f, 0.0f) * 1_m;
         vertices[2] = Vec2(0.0f, 2.0f) * 1_m;
         PolygonShape polygon;
-        polygon.Set(Span<const Length2D>{vertices, 3});
+        polygon.Set(Span<const Length2>{vertices, 3});
         polygon.SetDensity(1_kgpm2);
 
         FixtureDef triangleShapeDef;
@@ -83,7 +83,7 @@ public:
         vertices[0] *= 2.0f;
         vertices[1] *= 2.0f;
         vertices[2] *= 2.0f;
-        polygon.Set(Span<const Length2D>{vertices, 3});
+        polygon.Set(Span<const Length2>{vertices, 3});
         triangleShapeDef.filter.groupIndex = k_largeGroup;
         triangleBodyDef.location = Vec2(-5.0f, 6.0f) * 1_m;
         triangleBodyDef.fixedRotation = true; // look at me!
@@ -105,7 +105,7 @@ public:
             jd.bodyB = body;
             jd.enableLimit = true;
             jd.localAnchorA = Vec2(0.0f, 4.0f) * 1_m;
-            jd.localAnchorB = Vec2_zero * 1_m;
+            jd.localAnchorB = Length2{};
             jd.localAxisA = UnitVec2::GetTop();
             jd.lowerTranslation = -1.0_m;
             jd.upperTranslation = +1.0_m;

--- a/Testbed/Tests/CollisionProcessing.hpp
+++ b/Testbed/Tests/CollisionProcessing.hpp
@@ -42,13 +42,13 @@ public:
         auto yLo = 2.0f, yHi = 35.0f;
 
         // Small triangle
-        Length2D vertices[3];
+        Length2 vertices[3];
         vertices[0] = Vec2(-1.0f, 0.0f) * 1_m;
         vertices[1] = Vec2(1.0f, 0.0f) * 1_m;
         vertices[2] = Vec2(0.0f, 2.0f) * 1_m;
 
         PolygonShape polygon;
-        polygon.Set(Span<const Length2D>{vertices, 3});
+        polygon.Set(Span<const Length2>{vertices, 3});
         polygon.SetDensity(1_kgpm2);
 
         BodyDef triangleBodyDef;
@@ -62,7 +62,7 @@ public:
         vertices[0] *= 2.0f;
         vertices[1] *= 2.0f;
         vertices[2] *= 2.0f;
-        polygon.Set(Span<const Length2D>{vertices, 3});
+        polygon.Set(Span<const Length2>{vertices, 3});
 
         triangleBodyDef.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
 

--- a/Testbed/Tests/CompoundShapes.hpp
+++ b/Testbed/Tests/CompoundShapes.hpp
@@ -32,7 +32,7 @@ public:
     {
         {
             BodyDef bd;
-            bd.location = Vec2(0.0f, 0.0f) * 1_m;
+            bd.location = Length2{};
             const auto body = m_world.CreateBody(bd);
             body->CreateFixture(std::make_shared<EdgeShape>(Vec2(50.0f, 0.0f) * 1_m, Vec2(-50.0f, 0.0f) * 1_m));
         }
@@ -84,7 +84,7 @@ public:
             xf1.p = GetVec2(GetXAxis(xf1.q)) * 1_m;
 
             auto triangle1 = std::make_shared<PolygonShape>();
-            triangle1->Set(Span<const Length2D>{
+            triangle1->Set(Span<const Length2>{
                 Transform(Vec2(-1.0f, 0.0f) * 1_m, xf1),
                 Transform(Vec2(1.0f, 0.0f) * 1_m, xf1),
                 Transform(Vec2(0.0f, 0.5f) * 1_m, xf1)
@@ -96,7 +96,7 @@ public:
             xf2.p = -GetVec2(GetXAxis(xf2.q)) * 1_m;
 
             auto triangle2 = std::make_shared<PolygonShape>();
-            triangle2->Set(Span<const Length2D>{
+            triangle2->Set(Span<const Length2>{
                 Transform(Vec2(-1.0f, 0.0f) * 1_m, xf2),
                 Transform(Vec2(1.0f, 0.0f) * 1_m, xf2),
                 Transform(Vec2(0.0f, 0.5f) * 1_m, xf2)

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -97,11 +97,11 @@ public:
     {
         const auto body = CreateSquareEnclosingBody(m_world, wallLength, ShapeConf{
             }.UseVertexRadius(vertexRadius).UseRestitution(Finite<Real>(0)));
-        SetLocation(*body, Length2D{0_m, 20_m});
+        SetLocation(*body, Length2{0_m, 20_m});
         return body;
     }
 
-    Length2D GetRandomOffset() const
+    Length2 GetRandomOffset() const
     {
         const auto halfWL = StripUnit(wall_length) / 2;
         return Vec2{RandomFloat(-halfWL, +halfWL), RandomFloat(-halfWL, +halfWL)} * 1_m;
@@ -163,14 +163,14 @@ public:
             if (b.GetType() == BodyType::Dynamic)
             {
                 const auto position = b.GetLocation();
-                const auto centerPos = Length2D{
+                const auto centerPos = Length2{
                     GetX(position), GetY(position) - (wall_length / Real{2})
                 };
                 const auto angle_from_center = GetAngle(centerPos);
                 const auto direction = angle_from_center + Pi * 1_rad;
                 const auto magnitude = Sqrt(Square(StripUnit(wall_length)) * 2) *
                 	GetMass(b) * 20_mps;
-                const auto impulse = Momentum2D{magnitude * UnitVec2::Get(direction)};
+                const auto impulse = Momentum2{magnitude * UnitVec2::Get(direction)};
                 ApplyLinearImpulse(b, impulse, b.GetWorldCenter());
             }
         }        

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -90,7 +90,7 @@ public:
             }
         }
 
-        m_world.SetGravity(Vec2(0.0f, 0.0f) * MeterPerSquareSecond);
+        m_world.SetGravity(LinearAcceleration2{});
     }
     
     Body* CreateEnclosure(Length vertexRadius, Length wallLength)

--- a/Testbed/Tests/ContinuousTest.hpp
+++ b/Testbed/Tests/ContinuousTest.hpp
@@ -32,7 +32,7 @@ public:
     {
         {
             BodyDef bd;
-            bd.location = Vec2(0.0f, 0.0f) * 1_m;
+            bd.location = Length2{};
             Body* body = m_world.CreateBody(bd);
 
             body->CreateFixture(std::make_shared<EdgeShape>(Vec2(-10.0f, 0.0f) * 1_m, Vec2(10.0f, 0.0f) * 1_m));

--- a/Testbed/Tests/ConvexHull.hpp
+++ b/Testbed/Tests/ConvexHull.hpp
@@ -70,7 +70,7 @@ public:
     void PostStep(const Settings&, Drawer& drawer) override
     {
         const auto conf = PolygonShape::Conf{};
-        const auto shape = PolygonShape{Span<const Length2D>{&m_points[0], m_points.size()}, conf};
+        const auto shape = PolygonShape{Span<const Length2>{&m_points[0], m_points.size()}, conf};
 
         drawer.DrawPolygon(shape.GetVertices().begin(), shape.GetVertexCount(), Color(0.9f, 0.9f, 0.9f));
 
@@ -91,7 +91,7 @@ public:
         }
     }
 
-    std::vector<Length2D> m_points{e_count};
+    std::vector<Length2> m_points{e_count};
     bool m_auto;
 };
 

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -38,7 +38,7 @@ public:
     
     DistanceTest(): Test(GetTestConf())
     {
-        m_world.SetGravity(Vec2{0, 0} * MeterPerSquareSecond);
+        m_world.SetGravity(LinearAcceleration2{});
 
         const auto def = BodyDef{}
             .UseType(BodyType::Dynamic)
@@ -167,13 +167,13 @@ public:
         conf.vertexRadius = radius;
         PolygonShape polygonA{conf};
         //polygonA.SetAsBox(8.0f, 6.0f);
-        polygonA.Set(Span<const Length2D>{Vec2{-8, -6} * 1_m, Vec2{8, -6} * 1_m, Vec2{0, 6} * 1_m});
+        polygonA.Set(Span<const Length2>{Vec2{-8, -6} * 1_m, Vec2{8, -6} * 1_m, Vec2{0, 6} * 1_m});
         m_bodyA->CreateFixture(std::make_shared<PolygonShape>(polygonA));
         
         conf.vertexRadius = radius * Real{2};
         PolygonShape polygonB{conf};
         // polygonB.SetAsBox(7.2_m, 0.8_m);
-        polygonB.Set(Span<const Length2D>{Vec2{-7.2f, 0} * 1_m, Vec2{+7.2f, 0} * 1_m});
+        polygonB.Set(Span<const Length2>{Vec2{-7.2f, 0} * 1_m, Vec2{+7.2f, 0} * 1_m});
         //polygonB.Set(Span<const Vec2>{Vec2{float(-7.2), 0}, Vec2{float(7.2), 0}});
         m_bodyB->CreateFixture(std::make_shared<PolygonShape>(polygonB));
     }

--- a/Testbed/Tests/Dominos.hpp
+++ b/Testbed/Tests/Dominos.hpp
@@ -56,7 +56,7 @@ public:
 
         {
             PolygonShape shape;
-            SetAsBox(shape, 7.2_m, 0.25_m, Vec2_zero * 1_m, 0.3_rad);
+            SetAsBox(shape, 7.2_m, 0.25_m, Length2{}, 0.3_rad);
 
             BodyDef bd;
             bd.location = Vec2(1.2f, 6.0f) * 1_m;
@@ -165,7 +165,7 @@ public:
             {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
-                bd.location = Length2D{5.9_m + 2 * radius * static_cast<Real>(i), 2.4_m};
+                bd.location = Length2{5.9_m + 2 * radius * static_cast<Real>(i), 2.4_m};
                 const auto body = m_world.CreateBody(bd);
                 body->CreateFixture(shape);
             }

--- a/Testbed/Tests/DumpShell.hpp
+++ b/Testbed/Tests/DumpShell.hpp
@@ -42,7 +42,7 @@ public:
         //  but you can easily use it in other applications by providing
         //  a World for use as the 'm_world' variable in the code below.
 
-        LinearAcceleration2D g(Real{0.000000000000000e+00f} * MeterPerSquareSecond, Real{-1.000000000000000e+01f} * MeterPerSquareSecond);
+        LinearAcceleration2 g(Real{0.000000000000000e+00f} * MeterPerSquareSecond, Real{-1.000000000000000e+01f} * MeterPerSquareSecond);
         m_world.SetGravity(g);
         Body** bodies = (Body**)Alloc(3 * sizeof(Body*));
         Joint** joints = (Joint**)Alloc(0 * sizeof(Joint*));
@@ -64,12 +64,12 @@ public:
 
             {
                 PolygonShape shape;
-                Length2D vs[8];
+                Length2 vs[8];
                 vs[0] = Vec2(7.733039855957031e-01f, -1.497260034084320e-01f) * 1_m;
                 vs[1] = Vec2(-4.487270116806030e-01f, 1.138330027461052e-01f) * 1_m;
                 vs[2] = Vec2(-1.880589962005615e+00f, -1.365900039672852e-01f) * 1_m;
                 vs[3] = Vec2(3.972740173339844e-01f, -3.897832870483398e+00f) * 1_m;
-                shape.Set(Span<const Length2D>(vs, 4));
+                shape.Set(Span<const Length2>(vs, 4));
                 shape.SetFriction(Real(2.000000029802322e-01f));
                 shape.SetRestitution(Real(0.000000000000000e+00f));
                 shape.SetDensity(Real{1.000000000000000e+00f} * 1_kgpm2);
@@ -100,14 +100,14 @@ public:
 
             {
                 PolygonShape shape;
-                Length2D vs[8];
+                Length2 vs[8];
                 vs[0] = Vec2(3.473900079727173e+00f, -2.009889930486679e-01f) * 1_m;
                 vs[1] = Vec2(3.457079887390137e+00f, 3.694039955735207e-02f) * 1_m;
                 vs[2] = Vec2(-3.116359949111938e+00f, 2.348500071093440e-03f) * 1_m;
                 vs[3] = Vec2(-3.109960079193115e+00f, -3.581250011920929e-01f) * 1_m;
                 vs[4] = Vec2(-2.590820074081421e+00f, -5.472509860992432e-01f) * 1_m;
                 vs[5] = Vec2(2.819370031356812e+00f, -5.402340292930603e-01f) * 1_m;
-                shape.Set(Span<const Length2D>(vs, 6));
+                shape.Set(Span<const Length2>(vs, 6));
                 shape.SetFriction(Real(5.000000000000000e-01f));
                 shape.SetRestitution(Real(0.000000000000000e+00f));
                 shape.SetDensity(Real{5.000000000000000e+00f} * 1_kgpm2);
@@ -137,12 +137,12 @@ public:
 
             {
                 PolygonShape shape;
-                Length2D vs[8];
+                Length2 vs[8];
                 vs[0] = Vec2(1.639146506786346e-01f, 4.428443685173988e-02f) * 1_m;
                 vs[1] = Vec2(-1.639146655797958e-01f, 4.428443685173988e-02f) * 1_m;
                 vs[2] = Vec2(-1.639146655797958e-01f, -4.428443312644958e-02f) * 1_m;
                 vs[3] = Vec2(1.639146357774734e-01f, -4.428444057703018e-02f) * 1_m;
-                shape.Set(Span<const Length2D>(vs, 4));
+                shape.Set(Span<const Length2>(vs, 4));
                 shape.SetFriction(Real(9.499999880790710e-01f));
                 shape.SetRestitution(Real(0.000000000000000e+00f));
                 shape.SetDensity(Real{1.000000000000000e+01f} * 1_kgpm2);

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -103,11 +103,11 @@ public:
             }
 
             const auto p1 = GetLowerBound(actor->aabb);
-            const auto p2 = Length2D{
+            const auto p2 = Length2{
                 GetX(GetUpperBound(actor->aabb)), GetY(GetLowerBound(actor->aabb))
             };
             const auto p3 = GetUpperBound(actor->aabb);
-            const auto p4 = Length2D{
+            const auto p4 = Length2{
                 GetX(GetLowerBound(actor->aabb)), GetY(GetUpperBound(actor->aabb))
             };
             
@@ -122,11 +122,11 @@ public:
             // Draw the AABB.
 
             const auto p1 = GetLowerBound(m_queryAABB);
-            const auto p2 = Length2D{
+            const auto p2 = Length2{
                 GetX(GetUpperBound(m_queryAABB)), GetY(GetLowerBound(m_queryAABB))
             };
             const auto p3 = GetUpperBound(m_queryAABB);
-            const auto p4 = Length2D{
+            const auto p4 = Length2{
                 GetX(GetLowerBound(m_queryAABB)), GetY(GetUpperBound(m_queryAABB))
             };
             
@@ -232,7 +232,7 @@ private:
         const auto c0 = GetCenter(*aabb);
         const auto min = Vec2(-m_worldExtent, Real(0)) * 1_m;
         const auto max = Vec2(m_worldExtent, 2.0f * m_worldExtent) * 1_m;
-        const auto c = Length2D{
+        const auto c = Length2{
             Clamp(GetX(c0), GetX(min), GetX(max)), Clamp(GetY(c0), GetY(min), GetY(max))
         };
 

--- a/Testbed/Tests/EdgeShapes.hpp
+++ b/Testbed/Tests/EdgeShapes.hpp
@@ -173,10 +173,10 @@ public:
         const auto point2 = point1 + d;
 
         auto fixture = static_cast<Fixture*>(nullptr);
-        Length2D point;
+        Length2 point;
         UnitVec2 normal;
 
-        m_world.RayCast(point1, point2, [&](Fixture* f, ChildCounter, Length2D p, UnitVec2 n) {
+        m_world.RayCast(point1, point2, [&](Fixture* f, ChildCounter, Length2 p, UnitVec2 n) {
             fixture = f;
             point = p;
             normal = n;

--- a/Testbed/Tests/EdgeTest.hpp
+++ b/Testbed/Tests/EdgeTest.hpp
@@ -36,7 +36,7 @@ public:
             const auto v1 = Vec2(-10.0f, 0.0f) * 1_m;
             const auto v2 = Vec2(-7.0f, -2.0f) * 1_m;
             const auto v3 = Vec2(-4.0f, 0.0f) * 1_m;
-            const auto v4 = Vec2(0.0f, 0.0f) * 1_m;
+            const auto v4 = Length2{};
             const auto v5 = Vec2(4.0f, 0.0f) * 1_m;
             const auto v6 = Vec2(7.0f, 2.0f) * 1_m;
             const auto v7 = Vec2(10.0f, 0.0f) * 1_m;

--- a/Testbed/Tests/FifteenPuzzle.hpp
+++ b/Testbed/Tests/FifteenPuzzle.hpp
@@ -42,7 +42,7 @@ namespace playrho {
         
         FifteenPuzzle(): Test(GetTestConf())
         {
-            m_world.SetGravity(LinearAcceleration2D{});
+            m_world.SetGravity(LinearAcceleration2{});
             const auto enclosure = CreateSquareEnclosingBody(m_world,
                 16_m + 2 * GetVertexRadius(), ShapeConf{}
                 .UseVertexRadius(GetVertexRadius()));
@@ -61,7 +61,7 @@ namespace playrho {
             return DefaultLinearSlop * Real{100};
         }
 
-        Length2D GetCenter() const
+        Length2 GetCenter() const
         {
             return Vec2{Real{0}, Real{20}} * 1_m;
         }
@@ -71,7 +71,7 @@ namespace playrho {
             const auto sideLength = 4_m;
             const auto skinWidth = GetVertexRadius();
             const auto halfSide = sideLength / Real{2} - skinWidth;
-            const auto relPos = Length2D{(col - 2) * sideLength, (row - 2) * sideLength};
+            const auto relPos = Length2{(col - 2) * sideLength, (row - 2) * sideLength};
             
             auto conf = PolygonShape::Conf{};
             conf.density = 1_kgpm2;
@@ -80,7 +80,7 @@ namespace playrho {
             BodyDef bd;
             bd.type = BodyType::Dynamic;
             bd.bullet = true;
-            bd.location = GetCenter() + relPos + Length2D{sideLength / 2, sideLength / 2};
+            bd.location = GetCenter() + relPos + Length2{sideLength / 2, sideLength / 2};
             bd.linearDamping = 20_Hz;
             const auto body = m_world.CreateBody(bd);
             body->CreateFixture(std::make_shared<PolygonShape>(halfSide, halfSide, conf));

--- a/Testbed/Tests/JointsTest.hpp
+++ b/Testbed/Tests/JointsTest.hpp
@@ -60,46 +60,46 @@ public:
         auto centerY = Length{20_m + RowSize};
         {
             auto centerX = columnStart;
-            SetupDistanceJoint(Length2D{centerX, centerY}); // ok
+            SetupDistanceJoint(Length2{centerX, centerY}); // ok
             centerX += ColumnSize;
-            SetupFrictionJoint(Length2D{centerX, centerY});
+            SetupFrictionJoint(Length2{centerX, centerY});
             centerX += ColumnSize;
-            SetupGearJoint(Length2D{centerX, centerY});
+            SetupGearJoint(Length2{centerX, centerY});
             centerX += ColumnSize;
-            SetupMotorJoint(Length2D{centerX, centerY});
+            SetupMotorJoint(Length2{centerX, centerY});
         }
         
         // Row two...
         centerY -= RowSize;
         {
             auto centerX = columnStart;
-            SetupMouseJoint(Length2D{centerX, centerY});
+            SetupMouseJoint(Length2{centerX, centerY});
             centerX += ColumnSize;
-            SetupPrismaticJoint(Length2D{centerX, centerY});
+            SetupPrismaticJoint(Length2{centerX, centerY});
             centerX += ColumnSize;
-            SetupPulleyJoint(Length2D{centerX, centerY});
+            SetupPulleyJoint(Length2{centerX, centerY});
             centerX += ColumnSize;
-            SetupRevoluteJoint(Length2D{centerX, centerY});
+            SetupRevoluteJoint(Length2{centerX, centerY});
         }
 
         // Row three...
         centerY -= RowSize;
         {
             auto centerX = columnStart;
-            SetupRopeJoint(Length2D{centerX, centerY});
+            SetupRopeJoint(Length2{centerX, centerY});
             centerX += ColumnSize;
-            SetupWeldJoint(Length2D{centerX, centerY});
+            SetupWeldJoint(Length2{centerX, centerY});
             centerX += ColumnSize;
-            SetupWheelJoint(Length2D{centerX, centerY});
+            SetupWheelJoint(Length2{centerX, centerY});
         }
     }
     
 private:
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        const auto startLoc = Length2D{-1.5f * ColumnSize, 21_m + 0.5f * RowSize};
+        const auto startLoc = Length2{-1.5f * ColumnSize, 21_m + 0.5f * RowSize};
         {
-            auto loc = startLoc - Length2D{0_m, 0 * RowSize};
+            auto loc = startLoc - Length2{0_m, 0 * RowSize};
             drawer.DrawString(loc, Drawer::Center, "DistanceJoint (fixed length)");
             GetX(loc) += ColumnSize;
             drawer.DrawString(loc, Drawer::Center, "FrictionJoint (dampened point & angle)");
@@ -109,7 +109,7 @@ private:
             drawer.DrawString(loc, Drawer::Center, "MotorJoint");
         }
         {
-            auto loc = startLoc - Length2D{0_m, 1 * RowSize};
+            auto loc = startLoc - Length2{0_m, 1 * RowSize};
             drawer.DrawString(loc, Drawer::Center, "MouseJoint");
             GetX(loc) += ColumnSize;
             drawer.DrawString(loc, Drawer::Center, "PrismaticJoint (fixed line)");
@@ -119,7 +119,7 @@ private:
             drawer.DrawString(loc, Drawer::Center, "RevoluteJoint (fixed point)");
         }
         {
-            auto loc = startLoc - Length2D{0_m, 2 * RowSize};
+            auto loc = startLoc - Length2{0_m, 2 * RowSize};
             drawer.DrawString(loc, Drawer::Center, "RopeJoint (fixed max length)");
             GetX(loc) += ColumnSize;
             drawer.DrawString(loc, Drawer::Center, "WeldJoint (fixed point & angle)");
@@ -141,15 +141,15 @@ private:
         }
     }
 
-    Body* SetupContainer(Length2D center)
+    Body* SetupContainer(Length2 center)
     {
-        const auto b = CreateRectangularEnclosingBody(m_world, Length2D{ColumnSize, RowSize},
+        const auto b = CreateRectangularEnclosingBody(m_world, Length2{ColumnSize, RowSize},
                                                       ShapeDef{});
         SetLocation(*b, center);
         return b;
     }
 
-    void SetupRevoluteJoint(Length2D center)
+    void SetupRevoluteJoint(Length2 center)
     {
         const auto fb = m_world.CreateBody(BodyDef{StaticBD}.UseLocation(center - offset));
         fb->CreateFixture(m_rectShape);
@@ -160,9 +160,9 @@ private:
         SetupContainer(center);
     }
 
-    void SetupPrismaticJoint(Length2D center)
+    void SetupPrismaticJoint(Length2 center)
     {
-        const auto offs = Length2D{3.5_m, 3.5_m};
+        const auto offs = Length2{3.5_m, 3.5_m};
         const auto fb = m_world.CreateBody(BodyDef{StaticBD}.UseLocation(center));
         fb->CreateFixture(m_diskShape);
         const auto mb = m_world.CreateBody(BodyDef{DynamicBD}.UseLocation(center + offs));
@@ -175,7 +175,7 @@ private:
         SetupContainer(center);
     }
     
-    void SetupDistanceJoint(Length2D center)
+    void SetupDistanceJoint(Length2 center)
     {
         const auto fb = m_world.CreateBody(BodyDef{StaticBD}.UseLocation(center));
         fb->CreateFixture(m_diskShape);
@@ -186,11 +186,11 @@ private:
         SetupContainer(center);
     }
     
-    void SetupPulleyJoint(Length2D center)
+    void SetupPulleyJoint(Length2 center)
     {
         const auto cbody = SetupContainer(center);
-        const auto left  = Length2D{-2_m, +2.5_m};
-        const auto right = Length2D{+2_m, +2.5_m};
+        const auto left  = Length2{-2_m, +2.5_m};
+        const auto right = Length2{+2_m, +2.5_m};
         {
             const auto conf = DiskConf{}.UseVertexRadius(0.7_m);
             cbody->CreateFixture(std::make_shared<DiskShape>(DiskConf{conf}.UseLocation(left)));
@@ -201,8 +201,8 @@ private:
             const auto shape = std::make_shared<PolygonShape>(0.5_m, 0.5_m, pconf);
             const auto ganchor1 = center + left;
             const auto ganchor2 = center + right;
-            const auto anchor1 = ganchor1 - Length2D{0_m, 1.5_m};
-            const auto anchor2 = ganchor2 - Length2D{0_m, 5_m};
+            const auto anchor1 = ganchor1 - Length2{0_m, 1.5_m};
+            const auto anchor2 = ganchor2 - Length2{0_m, 5_m};
 
             const auto body1 = m_world.CreateBody(BodyDef{DynamicBD}.UseLocation(anchor1));
             body1->CreateFixture(shape);
@@ -215,14 +215,14 @@ private:
         }
     }
     
-    void SetupGearJoint(Length2D center)
+    void SetupGearJoint(Length2 center)
     {
         const auto containerBody = SetupContainer(center);
 
         const auto sr = m_smallDiskShape->GetVertexRadius();
         const auto nr = m_diskShape->GetVertexRadius();
         const auto tr = sr + nr;
-        const auto bd1 = BodyDef{DynamicBD}.UseLocation(center - Length2D{tr, 0_m});
+        const auto bd1 = BodyDef{DynamicBD}.UseLocation(center - Length2{tr, 0_m});
         const auto body1 = m_world.CreateBody(bd1);
         body1->CreateFixture(m_smallDiskShape);
         
@@ -242,7 +242,7 @@ private:
         const auto joint2 = static_cast<RevoluteJoint*>(m_world.CreateJoint(jd2));
         
         auto bd3 = BodyDef{DynamicBD}
-            .UseLocation(center + Length2D{nr + RectHHeight, RectHWidth})
+            .UseLocation(center + Length2{nr + RectHHeight, RectHWidth})
             .UseAngle(Pi * 1_rad / 2);
         const auto body3 = m_world.CreateBody(bd3);
         body3->CreateFixture(m_rectShape);
@@ -263,12 +263,12 @@ private:
         m_gearJoint1 = static_cast<GearJoint*>(m_world.CreateJoint(jd5));
     }
 
-    void SetupWheelJoint(Length2D center)
+    void SetupWheelJoint(Length2 center)
     {
         SetupContainer(center);
         
         // Vertices from car Testbed code.
-        const auto carVerts = std::vector<Length2D>({
+        const auto carVerts = std::vector<Length2>({
             Vec2(-1.5f, -0.5f) * 1_m,
             Vec2(1.5f, -0.5f) * 1_m,
             Vec2(1.5f, 0.0f) * 1_m,
@@ -276,7 +276,7 @@ private:
             Vec2(-1.15f, 0.9f) * 1_m,
             Vec2(-1.5f, 0.2f) * 1_m
         });
-        auto chassis = std::make_shared<PolygonShape>(Span<const Length2D>(carVerts.data(), carVerts.size()));
+        auto chassis = std::make_shared<PolygonShape>(Span<const Length2>(carVerts.data(), carVerts.size()));
         chassis->SetDensity(1_kgpm2);
         
         const auto circle = std::make_shared<DiskShape>(0.4_m);
@@ -317,9 +317,9 @@ private:
         }
     }
 
-    void SetupWeldJoint(Length2D center)
+    void SetupWeldJoint(Length2 center)
     {
-        const auto offs = Length2D{RectHWidth, 0_m};
+        const auto offs = Length2{RectHWidth, 0_m};
         const auto containerBody = SetupContainer(center);
         const auto fb = m_world.CreateBody(BodyDef{DynamicBD}.UseLocation(center - offs));
         fb->CreateFixture(m_rectShape);
@@ -333,7 +333,7 @@ private:
         m_weldJoint1 = static_cast<WeldJoint*>(m_world.CreateJoint(jd1));
     }
     
-    void SetupFrictionJoint(Length2D center)
+    void SetupFrictionJoint(Length2 center)
     {
         const auto fb = m_world.CreateBody(BodyDef{StaticBD}.UseLocation(center));
         fb->CreateFixture(m_diskShape);
@@ -345,26 +345,26 @@ private:
         SetupContainer(center);
     }
     
-    void SetupRopeJoint(Length2D center)
+    void SetupRopeJoint(Length2 center)
     {
         const auto fb = m_world.CreateBody(BodyDef{StaticBD}.UseLocation(center));
         fb->CreateFixture(m_diskShape);
         const auto mb = m_world.CreateBody(BodyDef{DynamicBD}.UseLocation(center + offset));
         mb->CreateFixture(m_squareShape);
         auto jd = RopeJointDef{fb, mb};
-        jd.localAnchorA = Length2D{};
-        jd.localAnchorB = Length2D{};
+        jd.localAnchorA = Length2{};
+        jd.localAnchorB = Length2{};
         jd.maxLength = 3_m;
         m_ropeJoint = static_cast<RopeJoint*>(m_world.CreateJoint(jd));
         SetupContainer(center);
     }
     
-    void SetupMouseJoint(Length2D ctr)
+    void SetupMouseJoint(Length2 ctr)
     {
         SetupContainer(ctr);
 
-        const auto lftOffs = Length2D{-2_m, 0.8_m};
-        const auto rgtOffs = Length2D{+2_m, 0.8_m};
+        const auto lftOffs = Length2{-2_m, 0.8_m};
+        const auto rgtOffs = Length2{+2_m, 0.8_m};
 
         {
             const auto lftEye = m_world.CreateBody(BodyDef{StaticBD}.UseLocation(ctr + lftOffs));
@@ -384,8 +384,8 @@ private:
         rgtPup->CreateFixture(m_smallDiskShape);
         
         // Remove gravity on dynamic bodies...
-        lftPup->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
-        rgtPup->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+        lftPup->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
+        rgtPup->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
 
         m_lftMouseJoint = static_cast<MouseJoint*>(m_world.CreateJoint(MouseJointDef{lftPup}
                                                                        .UseMaxForce(200_N)
@@ -397,7 +397,7 @@ private:
                                                                        .UseTarget(GetLocation(*rgtPup))));
     }
     
-    void SetupMotorJoint(Length2D center)
+    void SetupMotorJoint(Length2 center)
     {
         m_motorJointCenter = center;
         const auto containerBody = SetupContainer(center);
@@ -419,7 +419,7 @@ private:
 
         {
             // For the motor joint...
-            const auto linearOffset = Length2D{
+            const auto linearOffset = Length2{
                 static_cast<Real>(2.6 * std::sin(2 * m_time)) * 1_m,
                 static_cast<Real>(2.0 * std::sin(1 * m_time)) * 1_m
             };
@@ -440,10 +440,10 @@ private:
     std::shared_ptr<DiskShape> m_smallDiskShape;
     std::shared_ptr<PolygonShape> m_squareShape;
     std::shared_ptr<PolygonShape> m_rectShape;
-    const Length2D offset = Length2D{+2_m, 0_m};
+    const Length2 offset = Length2{+2_m, 0_m};
     
     double m_time = 0;
-    Length2D m_motorJointCenter = Length2D{};
+    Length2 m_motorJointCenter = Length2{};
     MouseJoint* m_lftMouseJoint = nullptr;
     MouseJoint* m_rgtMouseJoint = nullptr;
     MotorJoint* m_motorJoint = nullptr;

--- a/Testbed/Tests/Mobile.hpp
+++ b/Testbed/Tests/Mobile.hpp
@@ -44,13 +44,13 @@ public:
 
         RevoluteJointDef jointDef;
         jointDef.bodyA = ground;
-        jointDef.bodyB = AddNode(ground, Vec2_zero * 1_m, 0, 3.0f, static_cast<float>(a), shape);
-        jointDef.localAnchorA = Vec2_zero * 1_m;
+        jointDef.bodyB = AddNode(ground, Length2{}, 0, 3.0f, static_cast<float>(a), shape);
+        jointDef.localAnchorA = Length2{};
         jointDef.localAnchorB = Vec2(0, a) * 1_m;
         m_world.CreateJoint(jointDef);
     }
 
-    Body* AddNode(Body* parent, Length2D localAnchor, int depth, float offset, float a,
+    Body* AddNode(Body* parent, Length2 localAnchor, int depth, float offset, float a,
                   std::shared_ptr<Shape> shape)
     {
         const auto h = Vec2(0.0f, a) * 1_m;

--- a/Testbed/Tests/MobileBalanced.hpp
+++ b/Testbed/Tests/MobileBalanced.hpp
@@ -45,17 +45,17 @@ public:
         auto conf = PolygonShape::Conf{};
         conf.density = density;
         const auto shape = std::make_shared<const PolygonShape>(Real{0.25f} * a * 1_m, a * 1_m, conf);
-        const auto root = AddNode(ground, Vec2_zero * 1_m, 0, 3.0f, a, shape);
+        const auto root = AddNode(ground, Length2{}, 0, 3.0f, a, shape);
 
         RevoluteJointDef jointDef;
         jointDef.bodyA = ground;
         jointDef.bodyB = root;
-        jointDef.localAnchorA = Vec2_zero * 1_m;
+        jointDef.localAnchorA = Length2{};
         jointDef.localAnchorB = h;
         m_world.CreateJoint(jointDef);
     }
 
-    Body* AddNode(const Body* parent, const Length2D localAnchor, const int depth,
+    Body* AddNode(const Body* parent, const Length2 localAnchor, const int depth,
                   const Real offset, const Real a, std::shared_ptr<const Shape> shape)
     {
         const auto h = Vec2(0.0f, a) * 1_m;

--- a/Testbed/Tests/NewtonsCradle.hpp
+++ b/Testbed/Tests/NewtonsCradle.hpp
@@ -102,7 +102,7 @@ namespace playrho {
             m_frame = [&]() {
                 BodyDef bd;
                 bd.type = BodyType::Static;
-                bd.location = Length2D{0, frame_height};
+                bd.location = Length2{0, frame_height};
                 const auto body = m_world.CreateBody(bd);
                 
                 const auto frame_width = frame_width_per_arm * static_cast<Real>(m_num_arms);
@@ -119,13 +119,13 @@ namespace playrho {
                 BodyDef bd;
                 bd.type = BodyType::Dynamic;
                 bd.bullet = m_bullet_mode;
-                bd.location = Length2D{x, frame_height - (arm_length / Real{2})};
+                bd.location = Length2{x, frame_height - (arm_length / Real{2})};
                 
                 m_swings[i] = m_world.CreateBody(bd);
                 CreateArm(m_swings[i], arm_length);
-                CreateBall(m_swings[i], Length2D{0, -arm_length / Real{2}}, ball_radius);
+                CreateBall(m_swings[i], Length2{0, -arm_length / Real{2}}, ball_radius);
                 
-                m_world.CreateJoint(RevoluteJointDef(m_frame, m_swings[i], Length2D{x, frame_height}));
+                m_world.CreateJoint(RevoluteJointDef(m_frame, m_swings[i], Length2{x, frame_height}));
             }            
         }
 
@@ -155,7 +155,7 @@ namespace playrho {
 
                 BodyDef def;
                 def.type = BodyType::Static;
-                def.location = Length2D{frame_width / Real{2} + frame_width / Real{24}, frame_height - (arm_length / Real{2})};
+                def.location = Length2{frame_width / Real{2} + frame_width / Real{24}, frame_height - (arm_length / Real{2})};
                 const auto body = m_world.CreateBody(def);
                 
                 auto shape = PolygonShape((frame_width/Real{24}), (arm_length / Real{2} + frame_width / Real{24}));
@@ -173,7 +173,7 @@ namespace playrho {
 
                 BodyDef def;
                 def.type = BodyType::Static;
-                def.location = Length2D{
+                def.location = Length2{
                     -(frame_width / Real{2} + frame_width / Real{24}),
                     frame_height - (arm_length / Real{2})
                 };
@@ -205,7 +205,7 @@ namespace playrho {
             }
         }
 
-        Fixture* CreateBall(Body* body, Length2D pos, Length radius)
+        Fixture* CreateBall(Body* body, Length2 pos, Length radius)
         {
             auto conf = DiskShape::Conf{};
             conf.vertexRadius = radius;

--- a/Testbed/Tests/Orbiter.hpp
+++ b/Testbed/Tests/Orbiter.hpp
@@ -29,7 +29,7 @@ namespace playrho {
         
         Orbiter()
         {
-            m_world.SetGravity(Vec2{0, 0} * MeterPerSquareSecond);
+            m_world.SetGravity(LinearAcceleration2{});
 
             BodyDef bd;
             const auto radius = Real{12.0f};
@@ -42,7 +42,7 @@ namespace playrho {
             ctrBody->CreateFixture(ctrShape);
 
             bd.type = BodyType::Dynamic;
-            bd.location = Length2D{GetX(m_center), GetY(m_center) + radius * 1_m};
+            bd.location = Length2{GetX(m_center), GetY(m_center) + radius * 1_m};
             m_orbiter = m_world.CreateBody(bd);
             const auto ballShape = std::make_shared<DiskShape>();
             ballShape->SetRadius(0.5_m);
@@ -78,7 +78,7 @@ namespace playrho {
         
     private:
         Body* m_orbiter = nullptr;
-        Length2D const m_center = Vec2{0, 20} * 1_m;
+        Length2 const m_center = Vec2{0, 20} * 1_m;
 
     };
     

--- a/Testbed/Tests/Pinball.hpp
+++ b/Testbed/Tests/Pinball.hpp
@@ -67,7 +67,7 @@ public:
 
             RevoluteJointDef jd;
             jd.bodyA = ground;
-            jd.localAnchorB = Vec2_zero * 1_m;
+            jd.localAnchorB = Length2{};
             jd.enableMotor = true;
             jd.maxMotorTorque = 1000_Nm;
             jd.enableLimit = true;

--- a/Testbed/Tests/PolyCollision.hpp
+++ b/Testbed/Tests/PolyCollision.hpp
@@ -32,7 +32,7 @@ public:
     {
         {
             m_polygonA.SetAsBox(0.2_m, 0.4_m);
-            m_transformA = Transformation{Vec2(0.0f, 0.0f) * 1_m, UnitVec2::GetRight()};
+            m_transformA = Transformation{Length2{}, UnitVec2::GetRight()};
         }
 
         {
@@ -86,7 +86,7 @@ public:
             const auto color = Color(0.9f, 0.9f, 0.9f);
             {
                 const auto vertexCount = m_polygonA.GetVertexCount();
-                auto v = std::vector<Length2D>(vertexCount);
+                auto v = std::vector<Length2>(vertexCount);
                 for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
                 {
                     v[i] = Transform(m_polygonA.GetVertex(i), m_transformA);
@@ -96,7 +96,7 @@ public:
 
             {
                 const auto vertexCount = m_polygonB.GetVertexCount();
-                auto v = std::vector<Length2D>(vertexCount);
+                auto v = std::vector<Length2>(vertexCount);
                 for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
                 {
                     v[i] = Transform(m_polygonB.GetVertex(i), m_transformB);
@@ -120,7 +120,7 @@ public:
     Transformation m_transformA;
     Transformation m_transformB;
 
-    Length2D m_positionB;
+    Length2 m_positionB;
     Angle m_angleB;
 };
 

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -46,7 +46,7 @@ public:
     void Visit(const PolygonShape& shape) override
     {
         const auto vertexCount = shape.GetVertexCount();
-        auto vertices = std::vector<Length2D>(vertexCount);
+        auto vertices = std::vector<Length2>(vertexCount);
         for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
         {
             vertices[i] = Transform(shape.GetVertex(i), m_xf);

--- a/Testbed/Tests/Prismatic.hpp
+++ b/Testbed/Tests/Prismatic.hpp
@@ -47,7 +47,7 @@ public:
 
             // Bouncy limit
             const auto axis = GetUnitVector(Vec2(2.0f, 1.0f));
-            PrismaticJointDef pjd(ground, body, Vec2(0.0f, 0.0f) * 1_m, axis);
+            PrismaticJointDef pjd(ground, body, Length2{}, axis);
 
             // Non-bouncy limit
             //pjd.Initialize(ground, body, Vec2(-10.0f, 10.0f), Vec2(1.0f, 0.0f));

--- a/Testbed/Tests/RayCast.hpp
+++ b/Testbed/Tests/RayCast.hpp
@@ -210,11 +210,11 @@ public:
         if (m_mode == Mode::e_closest)
         {
             auto hit = false;
-            Length2D point;
+            Length2 point;
             UnitVec2 normal;
 
             m_world.RayCast(point1, point2, [&](Fixture* f, const ChildCounter,
-                                                 const Length2D& p, const UnitVec2& n)
+                                                 const Length2& p, const UnitVec2& n)
             {
                 const auto body = f->GetBody();
                 const auto userData = body->GetUserData();
@@ -254,13 +254,13 @@ public:
         else if (m_mode == Mode::e_any)
         {
             auto hit = false;
-            Length2D point;
+            Length2 point;
             UnitVec2 normal;
 
             // This callback finds any hit. Polygon 0 is filtered. For this type of query we are
             // just checking for obstruction, so the actual fixture and hit point are irrelevant.
             m_world.RayCast(point1, point2, [&](Fixture* f, const ChildCounter,
-                                                 const Length2D& p, const UnitVec2& n)
+                                                 const Length2& p, const UnitVec2& n)
             {
                 const auto body = f->GetBody();
                 const auto userData = body->GetUserData();
@@ -304,7 +304,7 @@ public:
             // The fixtures are not necessary reported in order, so we might not capture
             // the closest fixture.
             m_world.RayCast(point1, point2, [&](Fixture* f, const ChildCounter,
-                                                 const Length2D& p, const UnitVec2& n)
+                                                 const Length2& p, const UnitVec2& n)
             {
                 const auto body = f->GetBody();
                 const auto userData = body->GetUserData();

--- a/Testbed/Tests/RopeJoint.hpp
+++ b/Testbed/Tests/RopeJoint.hpp
@@ -81,7 +81,7 @@ public:
                 prevBody = body;
             }
 
-            m_ropeDef.localAnchorB = Vec2_zero * 1_m;
+            m_ropeDef.localAnchorB = Length2{};
 
             const auto extraLength = 0.01f;
             m_ropeDef.maxLength = Real(N - 1.0f + extraLength) * 1_m;

--- a/Testbed/Tests/SensorTest.hpp
+++ b/Testbed/Tests/SensorTest.hpp
@@ -154,7 +154,7 @@ public:
                 continue;
             }
 
-            const auto F = Force2D{GetUnitVector(d) * 100_N};
+            const auto F = Force2{GetUnitVector(d) * 100_N};
             ApplyForce(*body, F, position);
         }
     }

--- a/Testbed/Tests/ShapeEditing.hpp
+++ b/Testbed/Tests/ShapeEditing.hpp
@@ -39,7 +39,7 @@ public:
         m_body = m_world.CreateBody(bd);
 
         PolygonShape shape;
-        SetAsBox(shape, 4_m, 4_m, Vec2(0.0f, 0.0f) * 1_m, Angle{0});
+        SetAsBox(shape, 4_m, 4_m, Length2{}, Angle{0});
         shape.SetDensity(10_kgpm2);
         m_fixture1 = m_body->CreateFixture(std::make_shared<PolygonShape>(shape));
 

--- a/Testbed/Tests/SolarSystem.hpp
+++ b/Testbed/Tests/SolarSystem.hpp
@@ -78,7 +78,7 @@ public:
     
     SolarSystem(): Test(GetTestConf())
     {
-        m_world.SetGravity(LinearAcceleration2D{});
+        m_world.SetGravity(LinearAcceleration2{});
         const auto DynamicBD = BodyDef{}.UseType(BodyType::Dynamic);
         for (auto& sso: SolarSystemBodies)
         {
@@ -86,11 +86,11 @@ public:
             const auto c = sso.aveDist * Pi * 2;
             const auto n = &sso - SolarSystemBodies;
             const auto odds = n % 2;
-            const auto l = Length2D{odds? -sso.aveDist: sso.aveDist, 0_m};
+            const auto l = Length2{odds? -sso.aveDist: sso.aveDist, 0_m};
             const auto v = (p != 0_s)? (c / p) * (odds? -1: +1): 0_mps;
             const auto b = m_world.CreateBody(BodyDef{DynamicBD}.UseLocation(l));
             const auto a = 2 * Pi * 1_rad / sso.rotationalPeriod;
-            b->SetVelocity(Velocity{LinearVelocity2D{0_mps, v}, a});
+            b->SetVelocity(Velocity{LinearVelocity2{0_mps, v}, a});
             const auto d = sso.mass / (Pi * Square(sso.radius));
             const auto sconf = DiskShape::Conf{}.UseVertexRadius(sso.radius).UseDensity(d);
             const auto shape = std::make_shared<DiskShape>(sconf);

--- a/Testbed/Tests/SpinningCircle.hpp
+++ b/Testbed/Tests/SpinningCircle.hpp
@@ -34,12 +34,12 @@ namespace playrho {
         
         SpinningCircle()
         {
-            m_world.SetGravity(Vec2{0, 0} * MeterPerSquareSecond);
+            m_world.SetGravity(LinearAcceleration2{});
 
             auto bodyDef = BodyDef{};
             bodyDef.type = BodyType::Dynamic;
             bodyDef.angularVelocity = 45_deg / 1_s;
-            bodyDef.linearVelocity = LinearVelocity2D{};
+            bodyDef.linearVelocity = LinearVelocity2{};
             bodyDef.linearDamping = 0.8_Hz;
             bodyDef.bullet = true;
 
@@ -52,7 +52,7 @@ namespace playrho {
             shapeConf.density = 10_kgpm2;
 
             shapeConf.vertexRadius = 2_m;
-            shapeConf.location = Vec2{0, 0} * 1_m;
+            shapeConf.location = Length2{};
             auto circle = std::make_shared<DiskShape>(shapeConf);
 
             shapeConf.vertexRadius = 1.5_m;

--- a/Testbed/Tests/TheoJansen.hpp
+++ b/Testbed/Tests/TheoJansen.hpp
@@ -31,7 +31,7 @@ class TheoJansen : public Test
 {
 public:
 
-    void CreateLeg(Real s, const Length2D wheelAnchor)
+    void CreateLeg(Real s, const Length2 wheelAnchor)
     {
         const auto p1 = Vec2(5.4f * s, -6.1f) * 1_m;
         const auto p2 = Vec2(7.2f * s, -1.2f) * 1_m;
@@ -44,12 +44,12 @@ public:
         if (s > 0.0f)
         {
             poly1.Set({p1, p2, p3});
-            poly2.Set({Vec2_zero * 1_m, p5 - p4, p6 - p4});
+            poly2.Set({Length2{}, p5 - p4, p6 - p4});
         }
         else
         {
             poly1.Set({p1, p3, p2});
-            poly2.Set({Vec2_zero * 1_m, p6 - p4, p5 - p4});
+            poly2.Set({Length2{}, p6 - p4, p5 - p4});
         }
         poly1.SetDensity(1_kgpm2);
         poly2.SetDensity(1_kgpm2);
@@ -188,7 +188,7 @@ public:
         });
     }
 
-    Length2D m_offset;
+    Length2 m_offset;
     Body* m_chassis;
     Body* m_wheel;
     RevoluteJoint* m_motorJoint;

--- a/Testbed/Tests/TimeOfImpact.hpp
+++ b/Testbed/Tests/TimeOfImpact.hpp
@@ -74,7 +74,7 @@ public:
 
         {
             const auto vertexCount = m_shapeA.GetVertexCount();
-            auto vertices = std::vector<Length2D>(vertexCount);
+            auto vertices = std::vector<Length2>(vertexCount);
             const auto transformA = GetTransformation(sweepA, 0.0f);
             for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
             {
@@ -85,7 +85,7 @@ public:
 
         {
             const auto vertexCount = m_shapeB.GetVertexCount();
-            auto vertices = std::vector<Length2D>(vertexCount);
+            auto vertices = std::vector<Length2>(vertexCount);
             const auto transformB = GetTransformation(sweepB, 0.0f);
             for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
             {
@@ -96,7 +96,7 @@ public:
 
         {
             const auto vertexCount = m_shapeB.GetVertexCount();
-            auto vertices = std::vector<Length2D>(vertexCount);
+            auto vertices = std::vector<Length2>(vertexCount);
             const auto transformB = GetTransformation(sweepB, output.get_t());
             for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
             {
@@ -107,7 +107,7 @@ public:
 
         {
             const auto vertexCount = m_shapeB.GetVertexCount();
-            auto vertices = std::vector<Length2D>(vertexCount);
+            auto vertices = std::vector<Length2>(vertexCount);
             const auto transformB = GetTransformation(sweepB, 1.0f);
             for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
             {
@@ -121,7 +121,7 @@ public:
         {
             const auto transformB = GetTransformation(sweepB, t);
             const auto vertexCount = m_shapeB.GetVertexCount();
-            auto vertices = std::vector<Length2D>(vertexCount);
+            auto vertices = std::vector<Length2>(vertexCount);
             for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
             {
                 vertices[i] = Transform(m_shapeB.GetVertex(i), transformB);

--- a/Testbed/Tests/Tumbler.hpp
+++ b/Testbed/Tests/Tumbler.hpp
@@ -61,7 +61,7 @@ public:
         jd.bodyA = stable;
         jd.bodyB = turn;
         jd.localAnchorA = Vec2(0.0f, 10.0f) * 1_m;
-        jd.localAnchorB = Vec2(0.0f, 0.0f) * 1_m;
+        jd.localAnchorB = Length2{};
         jd.referenceAngle = Angle{0};
         jd.motorSpeed = Pi * 0.05_rad / 1_s;
         jd.maxMotorTorque = 100000_Nm; // 1e8f;

--- a/Testbed/Tests/Web.hpp
+++ b/Testbed/Tests/Web.hpp
@@ -64,7 +64,7 @@ public:
             m_bodies[3]->CreateFixture(shape);
 
             DistanceJointDef jd;
-            Length2D p1, p2, d;
+            Length2 p1, p2, d;
 
             jd.frequency = 2_Hz;
             jd.dampingRatio = 0.0f;

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -148,14 +148,14 @@ public:
         return m_body;
     }
     
-    LinearVelocity2D getLateralVelocity() const
+    LinearVelocity2 getLateralVelocity() const
     {
         const auto currentRightNormal = GetWorldVector(*m_body, UnitVec2::GetRight());
         const auto vel = GetLinearVelocity(*m_body);
         return Dot(currentRightNormal, vel) * currentRightNormal;
     }
     
-    LinearVelocity2D getForwardVelocity() const
+    LinearVelocity2 getForwardVelocity() const
     {
         const auto currentForwardNormal = GetWorldVector(*m_body, UnitVec2::GetTop());
         const auto vel = GetLinearVelocity(*m_body);
@@ -165,7 +165,7 @@ public:
     void updateFriction()
     {
         //lateral linear velocity
-        auto impulse = Momentum2D{GetMass(*m_body) * -getLateralVelocity()};
+        auto impulse = Momentum2{GetMass(*m_body) * -getLateralVelocity()};
         const auto length = GetLength(GetVec2(impulse)) * 1_kg * 1_mps;
         if ( length > m_maxLateralImpulse )
             impulse *= m_maxLateralImpulse / length;
@@ -181,7 +181,7 @@ public:
         auto currentForwardSpeed = 0_mps;
         const auto forwardDir = GetUnitVector(forwardVelocity, currentForwardSpeed, UnitVec2::GetZero());
         const auto dragForceMagnitude = -2 * currentForwardSpeed;
-        const auto newForce = Force2D{m_currentTraction * dragForceMagnitude * forwardDir * 1_kg / 1_s};
+        const auto newForce = Force2{m_currentTraction * dragForceMagnitude * forwardDir * 1_kg / 1_s};
         SetForce(*m_body, newForce, m_body->GetWorldCenter());
     }
     
@@ -208,7 +208,7 @@ public:
         else
             return;
         
-        const auto newForce = Force2D{m_currentTraction * forceMagnitude * currentForwardNormal};
+        const auto newForce = Force2{m_currentTraction * forceMagnitude * currentForwardNormal};
         SetForce(*m_body, newForce, m_body->GetWorldCenter());
     }
     
@@ -242,7 +242,7 @@ public:
         m_body = world->CreateBody(bodyDef);
         m_body->SetAngularDamping(3_Hz);
         
-        Length2D vertices[8];
+        Length2 vertices[8];
         vertices[0] = Vec2(+1.5f,  +0.0f) * 1_m;
         vertices[1] = Vec2(+3.0f,  +2.5f) * 1_m;
         vertices[2] = Vec2(+2.8f,  +5.5f) * 1_m;
@@ -252,7 +252,7 @@ public:
         vertices[6] = Vec2(-3.0f,  +2.5f) * 1_m;
         vertices[7] = Vec2(-1.5f,  +0.0f) * 1_m;
         PolygonShape polygonShape;
-        polygonShape.Set(Span<const Length2D>(vertices, 8));
+        polygonShape.Set(Span<const Length2>(vertices, 8));
         polygonShape.SetDensity(0.1_kgpm2);
         m_body->CreateFixture(std::make_shared<PolygonShape>(polygonShape));
         
@@ -262,7 +262,7 @@ public:
         jointDef.enableLimit = true;
         jointDef.lowerAngle = 0_deg;
         jointDef.upperAngle = 0_deg;
-        jointDef.localAnchorB = Vec2{0, 0} * 1_m; //center of tire
+        jointDef.localAnchorB = Length2{}; //center of tire
         
         const auto maxForwardSpeed = 250_mps;
         const auto maxBackwardSpeed = -40_mps;
@@ -378,7 +378,7 @@ public:
 
     iforce2d_TopdownCar(): Test(GetTestConf())
     {
-        m_world.SetGravity(Vec2{0, 0} * MeterPerSquareSecond);
+        m_world.SetGravity(LinearAcceleration2{});
         m_world.SetDestructionListener(&m_destructionListener);
         
         //set up ground areas

--- a/Testbed/Tests/iforce2d_Trajectories.hpp
+++ b/Testbed/Tests/iforce2d_Trajectories.hpp
@@ -63,19 +63,19 @@ public:
         //another ledge which we can move with the mouse
         BodyDef kinematicBody;
         kinematicBody.type = BodyType::Kinematic;
-        kinematicBody.location = Length2D{11_m, 22_m};
+        kinematicBody.location = Length2{11_m, 22_m};
         m_targetBody = m_world.CreateBody(kinematicBody);
         const auto w = BallSize * 1_m;
-        Length2D verts[3];
-        verts[0] = Length2D(  0_m, -2*w);
-        verts[1] = Length2D(  w,    0_m);
-        verts[2] = Length2D(  0_m,   -w);
-        polygonShape.Set(Span<const Length2D>(verts, 3));
+        Length2 verts[3];
+        verts[0] = Length2(  0_m, -2*w);
+        verts[1] = Length2(  w,    0_m);
+        verts[2] = Length2(  0_m,   -w);
+        polygonShape.Set(Span<const Length2>(verts, 3));
         m_targetBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
-        verts[0] = Length2D(  0_m, -2*w);
-        verts[2] = Length2D(  0_m,   -w);
-        verts[1] = Length2D( -w,    0_m);
-        polygonShape.Set(Span<const Length2D>(verts, 3));
+        verts[0] = Length2(  0_m, -2*w);
+        verts[2] = Length2(  0_m,   -w);
+        verts[1] = Length2( -w,    0_m);
+        polygonShape.Set(Span<const Length2>(verts, 3));
         m_targetBody->CreateFixture(std::make_shared<PolygonShape>(polygonShape), myFixtureDef);
         
         //create dynamic circle body
@@ -93,15 +93,15 @@ public:
         RevoluteJointDef revoluteJointDef;
         revoluteJointDef.bodyA = m_groundBody;
         revoluteJointDef.bodyB = m_launcherBody;
-        revoluteJointDef.localAnchorA = Length2D(-15_m, 5_m);
-        revoluteJointDef.localAnchorB = Length2D(0_m, 0_m);
+        revoluteJointDef.localAnchorA = Length2(-15_m, 5_m);
+        revoluteJointDef.localAnchorB = Length2(0_m, 0_m);
         revoluteJointDef.enableMotor = true;
         revoluteJointDef.maxMotorTorque = 250_Nm;
         revoluteJointDef.motorSpeed = 0;
         m_world.CreateJoint( revoluteJointDef );
         
         //create dynamic box body to fire
-        myBodyDef.location = Length2D(0_m, -5_m);//will be positioned later
+        myBodyDef.location = Length2(0_m, -5_m);//will be positioned later
         m_littleBox = m_world.CreateBody(myBodyDef);
         polygonShape.SetAsBox( 0.5_m, 0.5_m );
         polygonShape.SetDensity(1_kgpm2);
@@ -113,17 +113,17 @@ public:
         m_littleBox2->CreateFixture(std::make_shared<DiskShape>(circleShape), myFixtureDef);
         
         m_firing = false;
-        m_littleBox->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+        m_littleBox->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
         m_launchSpeed = 10_mps;
         
         m_firing2 = false;
-        m_littleBox2->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+        m_littleBox2->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
         m_littleBox2->SetVelocity(Velocity{});
 
         SetMouseWorld(Vec2(11,22) * 1_m);//sometimes is not set
         
         RegisterForKey(GLFW_KEY_Q, GLFW_PRESS, 0, "Launch projectile.", [&](KeyActionMods) {
-            const auto launchSpeed = LinearVelocity2D(m_launchSpeed, 0_mps);
+            const auto launchSpeed = LinearVelocity2(m_launchSpeed, 0_mps);
             m_littleBox->SetAwake();
             m_littleBox->SetAcceleration(Gravity, AngularAcceleration{});
             m_littleBox->SetVelocity(Velocity{});
@@ -135,7 +135,7 @@ public:
             m_firing = true;
         });
         RegisterForKey(GLFW_KEY_W, GLFW_PRESS, 0, "Reset projectile.", [&](KeyActionMods) {
-            m_littleBox->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+            m_littleBox->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
             m_littleBox->SetVelocity(Velocity{});
             m_firing = false;
         });
@@ -156,7 +156,7 @@ public:
             m_firing2 = true;
         });
         RegisterForKey(GLFW_KEY_F, GLFW_PRESS, 0, "Reset computer controlled projectile.", [&](KeyActionMods) {
-            m_littleBox2->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+            m_littleBox2->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
             m_littleBox2->SetVelocity(Velocity{});
             m_firing2 = false;
         });
@@ -166,13 +166,13 @@ public:
     }
     
     //this just returns the current top edge of the golf-tee thingy
-    Length2D getComputerTargetPosition()
+    Length2 getComputerTargetPosition()
     {
         return GetLocation(*m_targetBody) + Vec2(0, BallSize + 0.01f ) * 1_m;
     }
     
     //basic trajectory 'point at timestep n' formula
-    Length2D getTrajectoryPoint(Length2D startingPosition, LinearVelocity2D startingVelocity,
+    Length2 getTrajectoryPoint(Length2 startingPosition, LinearVelocity2 startingVelocity,
                                 float n /*time steps*/ )
     {
         const auto t = 1_s / 60.0f;
@@ -183,7 +183,7 @@ public:
     }
     
     //find out how many timesteps it will take for projectile to reach maximum height
-    float getTimestepsToTop(LinearVelocity2D startingVelocity)
+    float getTimestepsToTop(LinearVelocity2 startingVelocity)
     {
         const auto t = 1_s / 60.0f;
         const auto stepVelocity = t * startingVelocity; // m/s
@@ -192,7 +192,7 @@ public:
     }
     
     //find out the maximum height for this parabola
-    Length getMaxHeight(Length2D startingPosition, LinearVelocity2D startingVelocity)
+    Length getMaxHeight(Length2 startingPosition, LinearVelocity2 startingVelocity)
     {
         if ( GetY(startingVelocity) < 0_mps)
             return GetY(startingPosition);
@@ -231,11 +231,11 @@ public:
     }
     
     //calculate how the computer should launch the ball with the current target location
-    LinearVelocity2D getComputerLaunchVelocity()
+    LinearVelocity2 getComputerLaunchVelocity()
     {
         const auto targetLocation = getComputerTargetPosition();
         const auto verticalVelocity = calculateVerticalVelocityForHeight(GetY(targetLocation) - 5_m);//computer projectile starts at y = 5
-        const auto startingVelocity = LinearVelocity2D(0,verticalVelocity);//only interested in vertical here
+        const auto startingVelocity = LinearVelocity2(0,verticalVelocity);//only interested in vertical here
         const auto timestepsToTop = getTimestepsToTop(startingVelocity);
         auto targetEdgePos = GetX(GetLocation(*m_targetBody));
         if ( targetEdgePos > 15_m )
@@ -244,20 +244,20 @@ public:
             targetEdgePos += BallSize * 1_m;
         const auto distanceToTargetEdge = targetEdgePos - 15_m;
         const auto horizontalVelocity = 60 * distanceToTargetEdge / timestepsToTop / 1_s;
-        return LinearVelocity2D(horizontalVelocity, verticalVelocity);
+        return LinearVelocity2(horizontalVelocity, verticalVelocity);
     }
     
     void PreStep(const Settings&, Drawer& drawer) override
     {
         const auto startingPosition = GetWorldPoint(*m_launcherBody, Vec2(3,0) * 1_m);
         const auto rotVec = GetWorldVector(*m_launcherBody, UnitVec2::GetRight());
-        const auto startingVelocity = Rotate(LinearVelocity2D(m_launchSpeed, 0_mps), rotVec);
+        const auto startingVelocity = Rotate(LinearVelocity2(m_launchSpeed, 0_mps), rotVec);
         
         if ( !m_firing )
             m_littleBox->SetTransform( startingPosition, m_launcherBody->GetAngle() );
 
         auto hit = false;
-        auto point = Length2D{};
+        auto point = Length2{};
 
         //draw predicted trajectory
         auto lastTP = startingPosition;
@@ -266,7 +266,7 @@ public:
             
             if (i > 0) {
                 m_world.RayCast(lastTP, trajectoryPosition, [&](Fixture* f, ChildCounter,
-                                                                 Length2D p, UnitVec2) {
+                                                                 Length2 p, UnitVec2) {
                     if (f->GetBody() == m_littleBox)
                     {
                         return World::RayCastOpcode::IgnoreFixture;
@@ -302,7 +302,7 @@ public:
         
         //draw maximum height line
         const auto maxHeight = getMaxHeight( startingPosition, startingVelocity );
-        drawer.DrawSegment(Length2D(-20_m, maxHeight), Length2D(+20_m, maxHeight),
+        drawer.DrawSegment(Length2(-20_m, maxHeight), Length2(+20_m, maxHeight),
                            Color(1, 1, 1, 0.5f));
         
         //draw line to indicate velocity computer player will fire at
@@ -329,7 +329,7 @@ public:
     bool m_firing;
     bool m_firing2;
     LinearVelocity m_launchSpeed;
-    const LinearAcceleration2D Gravity{0 * MeterPerSquareSecond, -10 * MeterPerSquareSecond};
+    const LinearAcceleration2 Gravity{0 * MeterPerSquareSecond, -10 * MeterPerSquareSecond};
     const Real BallSize = 0.25f;
 };
 

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -54,13 +54,13 @@ TEST(AABB, Traits)
     //EXPECT_TRUE(std::is_nothrow_default_constructible<AABB>::value);
     EXPECT_FALSE(std::is_trivially_default_constructible<AABB>::value);
 
-    EXPECT_TRUE((std::is_constructible<AABB, Length2D>::value));
-    //EXPECT_FALSE((std::is_nothrow_constructible<AABB, Length2D>::value));
-    EXPECT_FALSE((std::is_trivially_constructible<AABB, Length2D>::value));
+    EXPECT_TRUE((std::is_constructible<AABB, Length2>::value));
+    //EXPECT_FALSE((std::is_nothrow_constructible<AABB, Length2>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<AABB, Length2>::value));
     
-    EXPECT_TRUE((std::is_constructible<AABB, Length2D, Length2D>::value));
-    //EXPECT_FALSE((std::is_nothrow_constructible<AABB, Length2D, Length2D>::value));
-    EXPECT_FALSE((std::is_trivially_constructible<AABB, Length2D, Length2D>::value));
+    EXPECT_TRUE((std::is_constructible<AABB, Length2, Length2>::value));
+    //EXPECT_FALSE((std::is_nothrow_constructible<AABB, Length2, Length2>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<AABB, Length2, Length2>::value));
     
     EXPECT_TRUE(std::is_copy_constructible<AABB>::value);
     //EXPECT_TRUE(std::is_nothrow_copy_constructible<AABB>::value);
@@ -87,21 +87,21 @@ TEST(AABB, DefaultAabbAddsToOther)
 {
     const auto default_aabb = AABB{};
     {
-        const auto other_aabb = AABB{Length2D{}, Length2D{}};
+        const auto other_aabb = AABB{Length2{}, Length2{}};
         const auto sum_aabb = GetEnclosingAABB(default_aabb, other_aabb);
         EXPECT_EQ(GetLowerBound(sum_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(sum_aabb), GetUpperBound(other_aabb));
     }
     {
-        const auto other_aabb = AABB{Length2D{}, Length2D{}};
+        const auto other_aabb = AABB{Length2{}, Length2{}};
         const auto sum_aabb = GetEnclosingAABB(other_aabb, default_aabb);
         EXPECT_EQ(GetLowerBound(sum_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(sum_aabb), GetUpperBound(other_aabb));
     }
     {
         const auto other_aabb = AABB{
-            Length2D{Real( -1) * Meter, Real(-2) * Meter},
-            Length2D{Real(+99) * Meter, Real(+3) * Meter}
+            Length2{Real( -1) * Meter, Real(-2) * Meter},
+            Length2{Real(+99) * Meter, Real(+3) * Meter}
         };
         const auto sum_aabb = GetEnclosingAABB(other_aabb, default_aabb);
         EXPECT_EQ(GetLowerBound(sum_aabb), GetLowerBound(other_aabb));
@@ -113,7 +113,7 @@ TEST(AABB, DefaultAabbIncrementsToOther)
 {
     {
         auto default_aabb = AABB{};
-        const auto other_aabb = AABB{Length2D{}, Length2D{}};
+        const auto other_aabb = AABB{Length2{}, Length2{}};
         Include(default_aabb, other_aabb);
         EXPECT_EQ(GetLowerBound(default_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(default_aabb), GetUpperBound(other_aabb));
@@ -121,8 +121,8 @@ TEST(AABB, DefaultAabbIncrementsToOther)
     {
         auto default_aabb = AABB{};
         const auto other_aabb = AABB{
-            Length2D{Real(-1) * Meter, Real(-2) * Meter},
-            Length2D{Real(+99) * Meter, Real(+3) * Meter}
+            Length2{Real(-1) * Meter, Real(-2) * Meter},
+            Length2{Real(+99) * Meter, Real(+3) * Meter}
         };
         Include(default_aabb, other_aabb);
         EXPECT_EQ(GetLowerBound(default_aabb), GetLowerBound(other_aabb));
@@ -140,8 +140,8 @@ TEST(AABB, InitializingConstruction)
     const auto center_x = (lower_x + upper_x) / Real{2};
     const auto center_y = (lower_y + upper_y) / Real{2};
 
-    const auto v0 = Length2D{upper_x, lower_y};
-    const auto v1 = Length2D{lower_x, upper_y};
+    const auto v0 = Length2{upper_x, lower_y};
+    const auto v1 = Length2{lower_x, upper_y};
     
     {
         AABB foo{v0, v1};
@@ -162,8 +162,8 @@ TEST(AABB, InitializingConstruction)
         EXPECT_EQ(GetY(GetUpperBound(foo)), upper_y);
     }
     {
-        const auto pa = Length2D{GetInvalid<Length>(), GetInvalid<Length>()};
-        const auto pb = Length2D{GetInvalid<Length>(), GetInvalid<Length>()};
+        const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
+        const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         AABB foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
@@ -171,8 +171,8 @@ TEST(AABB, InitializingConstruction)
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
-        const auto pa = Length2D{GetInvalid<Length>(), GetInvalid<Length>()};
-        const auto pb = Length2D{GetInvalid<Length>(), 0 * Meter};
+        const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
+        const auto pb = Length2{GetInvalid<Length>(), 0 * Meter};
         AABB foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
@@ -180,8 +180,8 @@ TEST(AABB, InitializingConstruction)
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
-        const auto pa = Length2D{GetInvalid<Length>(), 0 * Meter};
-        const auto pb = Length2D{GetInvalid<Length>(), GetInvalid<Length>()};
+        const auto pa = Length2{GetInvalid<Length>(), 0 * Meter};
+        const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         AABB foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
@@ -189,8 +189,8 @@ TEST(AABB, InitializingConstruction)
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
-        const auto pa = Length2D{GetInvalid<Length>(), 0 * Meter};
-        const auto pb = Length2D{GetInvalid<Length>(), 0 * Meter};
+        const auto pa = Length2{GetInvalid<Length>(), 0 * Meter};
+        const auto pb = Length2{GetInvalid<Length>(), 0 * Meter};
         AABB foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
@@ -214,7 +214,7 @@ TEST(AABB, Swappable)
     std::swap(a, b);
     EXPECT_EQ(a, b);
     const auto aBefore = a;
-    Include(a, Length2D{2 * Meter, 3 * Meter});
+    Include(a, Length2{2 * Meter, 3 * Meter});
     const auto aAfter = a;
     ASSERT_NE(a, b);
     std::swap(a, b);
@@ -224,11 +224,11 @@ TEST(AABB, Swappable)
 
 TEST(AABB, GetPerimeterOfPoint)
 {
-    EXPECT_EQ(GetPerimeter(AABB{Length2D{}}), Real(0) * Meter);
-    EXPECT_EQ(GetPerimeter(AABB{Length2D{Real(-1) * Meter, Real(-2) * Meter}}), Real(0) * Meter);
-    EXPECT_EQ(GetPerimeter(AABB{Length2D{Real(+99) * Meter, Real(+3) * Meter}}), Real(0) * Meter);
+    EXPECT_EQ(GetPerimeter(AABB{Length2{}}), Real(0) * Meter);
+    EXPECT_EQ(GetPerimeter(AABB{Length2{Real(-1) * Meter, Real(-2) * Meter}}), Real(0) * Meter);
+    EXPECT_EQ(GetPerimeter(AABB{Length2{Real(+99) * Meter, Real(+3) * Meter}}), Real(0) * Meter);
     EXPECT_TRUE(std::isnan(StripUnit(GetPerimeter(AABB{
-        Length2D{
+        Length2{
             Real(+std::numeric_limits<Real>::infinity()) * Meter,
             Real(+std::numeric_limits<Real>::infinity()) * Meter
         }
@@ -237,10 +237,10 @@ TEST(AABB, GetPerimeterOfPoint)
 
 TEST(AABB, Include)
 {
-    const auto p1 = Length2D{Real{2} * Meter, Real{3} * Meter};
-    const auto p2 = Length2D{Real{20} * Meter, Real{30} * Meter};
-    const auto p3 = Length2D{Real{-3} * Meter, Real{-4} * Meter};
-    const auto p4 = Length2D{Real{0} * Meter, Real{0} * Meter};
+    const auto p1 = Length2{Real{2} * Meter, Real{3} * Meter};
+    const auto p2 = Length2{Real{20} * Meter, Real{30} * Meter};
+    const auto p3 = Length2{Real{-3} * Meter, Real{-4} * Meter};
+    const auto p4 = Length2{Real{0} * Meter, Real{0} * Meter};
     const auto p5 = AABB{};
 
     auto foo = AABB{};
@@ -271,10 +271,10 @@ TEST(AABB, Include)
 TEST(AABB, Contains)
 {
     EXPECT_TRUE(Contains(AABB{}, AABB{}));
-    EXPECT_TRUE(Contains(AABB{Length2D{}}, AABB{Length2D{}}));
-    EXPECT_TRUE((Contains(AABB{Length2D{}, Length2D{}}, AABB{Length2D{}})));
-    EXPECT_TRUE((Contains(AABB{Length2D{}}, AABB{Length2D{}, Length2D{}})));
-    EXPECT_TRUE((Contains(AABB{Length2D{1 * Meter, 2 * Meter}}, AABB{})));
+    EXPECT_TRUE(Contains(AABB{Length2{}}, AABB{Length2{}}));
+    EXPECT_TRUE((Contains(AABB{Length2{}, Length2{}}, AABB{Length2{}})));
+    EXPECT_TRUE((Contains(AABB{Length2{}}, AABB{Length2{}, Length2{}})));
+    EXPECT_TRUE((Contains(AABB{Length2{1 * Meter, 2 * Meter}}, AABB{})));
     EXPECT_FALSE(Contains(GetInvalid<AABB>(), GetInvalid<AABB>()));
     EXPECT_FALSE(Contains(GetInvalid<AABB>(), AABB{}));
     EXPECT_FALSE(Contains(AABB{}, GetInvalid<AABB>()));
@@ -284,68 +284,68 @@ TEST(AABB, TestOverlap)
 {
     {
         AABB bb1{
-            Length2D{Real(-2) * Meter, Real(-3) * Meter},
-            Length2D{Real(-1) * Meter, Real( 0) * Meter}
+            Length2{Real(-2) * Meter, Real(-3) * Meter},
+            Length2{Real(-1) * Meter, Real( 0) * Meter}
         };
         EXPECT_TRUE(TestOverlap(bb1, bb1));
     }
     {
-        const auto vec = Length2D{Real(-2) * Meter, Real(-3) * Meter};
+        const auto vec = Length2{Real(-2) * Meter, Real(-3) * Meter};
         AABB bb1{vec, vec};
         EXPECT_TRUE(TestOverlap(bb1, bb1));
     }
     {
         AABB bb1{
-            Length2D{Real(-2) * Meter, Real(-3) * Meter},
-            Length2D{Real(-1) * Meter, Real( 0) * Meter}
+            Length2{Real(-2) * Meter, Real(-3) * Meter},
+            Length2{Real(-1) * Meter, Real( 0) * Meter}
         };
         AABB bb2{
-            Length2D{Real(-1) * Meter, Real(-1) * Meter},
-            Length2D{Real( 1) * Meter, Real( 2) * Meter}
+            Length2{Real(-1) * Meter, Real(-1) * Meter},
+            Length2{Real( 1) * Meter, Real( 2) * Meter}
         };
         EXPECT_TRUE(TestOverlap(bb1, bb2));
     }
     {
         AABB bb1{
-            Length2D{Real(-99) * Meter, Real(-3) * Meter},
-            Length2D{Real( -1) * Meter, Real( 0) * Meter}
+            Length2{Real(-99) * Meter, Real(-3) * Meter},
+            Length2{Real( -1) * Meter, Real( 0) * Meter}
         };
         AABB bb2{
-            Length2D{Real(76) * Meter, Real(-1) * Meter},
-            Length2D{Real(-2) * Meter, Real( 2) * Meter}
+            Length2{Real(76) * Meter, Real(-1) * Meter},
+            Length2{Real(-2) * Meter, Real( 2) * Meter}
         };
         EXPECT_TRUE(TestOverlap(bb1, bb2));
     }
     {
         AABB bb1{
-            Length2D{Real(-20) * Meter, Real(-3) * Meter},
-            Length2D{Real(-18) * Meter, Real( 0) * Meter}
+            Length2{Real(-20) * Meter, Real(-3) * Meter},
+            Length2{Real(-18) * Meter, Real( 0) * Meter}
         };
         AABB bb2{
-            Length2D{Real(-1) * Meter, Real(-1) * Meter},
-            Length2D{Real( 1) * Meter, Real( 2) * Meter}
+            Length2{Real(-1) * Meter, Real(-1) * Meter},
+            Length2{Real( 1) * Meter, Real( 2) * Meter}
         };
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
     {
         AABB bb1{
-            Length2D{Real(-2) * Meter, Real(-3) * Meter},
-            Length2D{Real(-1) * Meter, Real( 0) * Meter}
+            Length2{Real(-2) * Meter, Real(-3) * Meter},
+            Length2{Real(-1) * Meter, Real( 0) * Meter}
         };
         AABB bb2{
-            Length2D{Real(-1) * Meter, Real(+1) * Meter},
-            Length2D{Real( 1) * Meter, Real( 2) * Meter}
+            Length2{Real(-1) * Meter, Real(+1) * Meter},
+            Length2{Real( 1) * Meter, Real( 2) * Meter}
         };
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
     {
         AABB bb1{
-            Length2D{Real(-2) * Meter, Real(+3) * Meter},
-            Length2D{Real(-1) * Meter, Real( 0) * Meter}
+            Length2{Real(-2) * Meter, Real(+3) * Meter},
+            Length2{Real(-1) * Meter, Real( 0) * Meter}
         };
         AABB bb2{
-            Length2D{Real(-1) * Meter, Real(-1) * Meter},
-            Length2D{Real( 0) * Meter, Real(-2) * Meter}
+            Length2{Real(-1) * Meter, Real(-1) * Meter},
+            Length2{Real( 0) * Meter, Real(-2) * Meter}
         };
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
@@ -361,30 +361,30 @@ TEST(AABB, ComputeAabbForDefaultDistanceProxy)
 
 TEST(AABB, Move)
 {
-    const auto zeroLoc = Length2D{};
+    const auto zeroLoc = Length2{};
     const auto zeroAabb = AABB{zeroLoc};
     {
         auto aabb = AABB{};
         EXPECT_EQ(Move(aabb, zeroLoc), AABB{});
-        EXPECT_EQ(Move(aabb, Length2D{Real(10) * Meter, Real(-4) * Meter}), AABB{});
+        EXPECT_EQ(Move(aabb, Length2{Real(10) * Meter, Real(-4) * Meter}), AABB{});
     }
     {
-        auto aabb = AABB{Length2D{}};
-        EXPECT_EQ(Move(aabb, Length2D{}), zeroAabb);
+        auto aabb = AABB{Length2{}};
+        EXPECT_EQ(Move(aabb, Length2{}), zeroAabb);
     }
     {
-        const auto aabb1 = AABB{Length2D{Real(1) * Meter, Real(1) * Meter}};
-        const auto aabb2 = AABB{Length2D{Real(-10) * Meter, Real(11) * Meter}};
+        const auto aabb1 = AABB{Length2{Real(1) * Meter, Real(1) * Meter}};
+        const auto aabb2 = AABB{Length2{Real(-10) * Meter, Real(11) * Meter}};
         auto aabb = zeroAabb;
-        EXPECT_EQ(Move(aabb, Length2D{Real(1) * Meter, Real(1) * Meter}), aabb1);
-        EXPECT_EQ(Move(aabb, Length2D{Real(-1) * Meter, Real(-1) * Meter}), zeroAabb);
-        EXPECT_EQ(Move(aabb, Length2D{Real(-10) * Meter, Real(11) * Meter}), aabb2);
+        EXPECT_EQ(Move(aabb, Length2{Real(1) * Meter, Real(1) * Meter}), aabb1);
+        EXPECT_EQ(Move(aabb, Length2{Real(-1) * Meter, Real(-1) * Meter}), zeroAabb);
+        EXPECT_EQ(Move(aabb, Length2{Real(-10) * Meter, Real(11) * Meter}), aabb2);
     }
     {
-        const auto lower = Length2D{Real(-1) * Meter, Real(-1) * Meter};
-        const auto upper = Length2D{Real(+3) * Meter, Real(+9) * Meter};
+        const auto lower = Length2{Real(-1) * Meter, Real(-1) * Meter};
+        const auto upper = Length2{Real(+3) * Meter, Real(+9) * Meter};
         auto aabb = AABB{lower, upper};
-        const auto moveby = Length2D{Real(1) * Meter, Real(1) * Meter};
+        const auto moveby = Length2{Real(1) * Meter, Real(1) * Meter};
         EXPECT_EQ(Move(aabb, moveby), AABB(lower + moveby, upper + moveby));
     }
 }
@@ -472,7 +472,7 @@ TEST(AABB, ComputeAabbForFixtureOffFromBodyOrigin)
     const auto shape = std::make_shared<DiskShape>();
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
     
-    const auto bodyLocation = Length2D{2 * Meter, 3 * Meter};
+    const auto bodyLocation = Length2{2 * Meter, 3 * Meter};
     World world;
     const auto body = world.CreateBody(BodyDef{}.UseLocation(bodyLocation));
     const auto fixture = body->CreateFixture(shape);
@@ -508,8 +508,8 @@ TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
     ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
 
-    const auto bodyLocation0 = Length2D{+1 * Meter, 0 * Meter};
-    const auto bodyLocation1 = Length2D{-1 * Meter, 0 * Meter};
+    const auto bodyLocation0 = Length2{+1 * Meter, 0 * Meter};
+    const auto bodyLocation1 = Length2{-1 * Meter, 0 * Meter};
 
     World world;
     const auto body0 = world.CreateBody(BodyDef{}.UseLocation(bodyLocation0));
@@ -537,8 +537,8 @@ TEST(AABB, ComputeIntersectingAABBForContact)
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
     ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
     
-    const auto bodyLocation0 = Length2D{+1 * Meter, 0 * Meter};
-    const auto bodyLocation1 = Length2D{-1 * Meter, 0 * Meter};
+    const auto bodyLocation0 = Length2{+1 * Meter, 0 * Meter};
+    const auto bodyLocation1 = Length2{-1 * Meter, 0 * Meter};
     
     World world;
     const auto body0 = world.CreateBody(BodyDef{}.UseLocation(bodyLocation0));

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -99,10 +99,7 @@ TEST(AABB, DefaultAabbAddsToOther)
         EXPECT_EQ(GetUpperBound(sum_aabb), GetUpperBound(other_aabb));
     }
     {
-        const auto other_aabb = AABB{
-            Length2{Real( -1) * Meter, Real(-2) * Meter},
-            Length2{Real(+99) * Meter, Real(+3) * Meter}
-        };
+        const auto other_aabb = AABB{Length2{ -1_m, -2_m}, Length2{+99_m, +3_m}};
         const auto sum_aabb = GetEnclosingAABB(other_aabb, default_aabb);
         EXPECT_EQ(GetLowerBound(sum_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(sum_aabb), GetUpperBound(other_aabb));
@@ -120,10 +117,7 @@ TEST(AABB, DefaultAabbIncrementsToOther)
     }
     {
         auto default_aabb = AABB{};
-        const auto other_aabb = AABB{
-            Length2{Real(-1) * Meter, Real(-2) * Meter},
-            Length2{Real(+99) * Meter, Real(+3) * Meter}
-        };
+        const auto other_aabb = AABB{Length2{-1_m, -2_m}, Length2{+99_m, +3_m}};
         Include(default_aabb, other_aabb);
         EXPECT_EQ(GetLowerBound(default_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(default_aabb), GetUpperBound(other_aabb));
@@ -132,10 +126,10 @@ TEST(AABB, DefaultAabbIncrementsToOther)
 
 TEST(AABB, InitializingConstruction)
 {
-    const auto lower_x = Real(-2) * Meter;
-    const auto lower_y = Real(-3) * Meter;
-    const auto upper_x = Real(+1.6) * Meter;
-    const auto upper_y = Real(+1.9) * Meter;
+    const auto lower_x = -2_m;
+    const auto lower_y = -3_m;
+    const auto upper_x = +1.6_m;
+    const auto upper_y = +1.9_m;
     
     const auto center_x = (lower_x + upper_x) / Real{2};
     const auto center_y = (lower_y + upper_y) / Real{2};
@@ -172,7 +166,7 @@ TEST(AABB, InitializingConstruction)
     }
     {
         const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
-        const auto pb = Length2{GetInvalid<Length>(), 0 * Meter};
+        const auto pb = Length2{GetInvalid<Length>(), 0_m};
         AABB foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
@@ -180,7 +174,7 @@ TEST(AABB, InitializingConstruction)
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
-        const auto pa = Length2{GetInvalid<Length>(), 0 * Meter};
+        const auto pa = Length2{GetInvalid<Length>(), 0_m};
         const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         AABB foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
@@ -189,8 +183,8 @@ TEST(AABB, InitializingConstruction)
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
-        const auto pa = Length2{GetInvalid<Length>(), 0 * Meter};
-        const auto pb = Length2{GetInvalid<Length>(), 0 * Meter};
+        const auto pa = Length2{GetInvalid<Length>(), 0_m};
+        const auto pb = Length2{GetInvalid<Length>(), 0_m};
         AABB foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
@@ -198,8 +192,8 @@ TEST(AABB, InitializingConstruction)
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
-        const auto rangeX = Interval<Length>{-2 * Meter, +3 * Meter};
-        const auto rangeY = Interval<Length>{-8 * Meter, -4 * Meter};
+        const auto rangeX = Interval<Length>{-2_m, +3_m};
+        const auto rangeY = Interval<Length>{-8_m, -4_m};
         AABB foo{rangeX, rangeY};
         EXPECT_EQ(foo.rangeX, rangeX);
         EXPECT_EQ(foo.rangeY, rangeY);
@@ -214,7 +208,7 @@ TEST(AABB, Swappable)
     std::swap(a, b);
     EXPECT_EQ(a, b);
     const auto aBefore = a;
-    Include(a, Length2{2 * Meter, 3 * Meter});
+    Include(a, Length2{2_m, 3_m});
     const auto aAfter = a;
     ASSERT_NE(a, b);
     std::swap(a, b);
@@ -224,9 +218,9 @@ TEST(AABB, Swappable)
 
 TEST(AABB, GetPerimeterOfPoint)
 {
-    EXPECT_EQ(GetPerimeter(AABB{Length2{}}), Real(0) * Meter);
-    EXPECT_EQ(GetPerimeter(AABB{Length2{Real(-1) * Meter, Real(-2) * Meter}}), Real(0) * Meter);
-    EXPECT_EQ(GetPerimeter(AABB{Length2{Real(+99) * Meter, Real(+3) * Meter}}), Real(0) * Meter);
+    EXPECT_EQ(GetPerimeter(AABB{Length2{}}), 0_m);
+    EXPECT_EQ(GetPerimeter(AABB{Length2{-1_m, -2_m}}), 0_m);
+    EXPECT_EQ(GetPerimeter(AABB{Length2{+99_m, +3_m}}), 0_m);
     EXPECT_TRUE(std::isnan(StripUnit(GetPerimeter(AABB{
         Length2{
             Real(+std::numeric_limits<Real>::infinity()) * Meter,
@@ -237,10 +231,10 @@ TEST(AABB, GetPerimeterOfPoint)
 
 TEST(AABB, Include)
 {
-    const auto p1 = Length2{Real{2} * Meter, Real{3} * Meter};
-    const auto p2 = Length2{Real{20} * Meter, Real{30} * Meter};
-    const auto p3 = Length2{Real{-3} * Meter, Real{-4} * Meter};
-    const auto p4 = Length2{Real{0} * Meter, Real{0} * Meter};
+    const auto p1 = Length2{2_m, 3_m};
+    const auto p2 = Length2{20_m, 30_m};
+    const auto p3 = Length2{-3_m, -4_m};
+    const auto p4 = Length2{0_m, 0_m};
     const auto p5 = AABB{};
 
     auto foo = AABB{};
@@ -274,7 +268,7 @@ TEST(AABB, Contains)
     EXPECT_TRUE(Contains(AABB{Length2{}}, AABB{Length2{}}));
     EXPECT_TRUE((Contains(AABB{Length2{}, Length2{}}, AABB{Length2{}})));
     EXPECT_TRUE((Contains(AABB{Length2{}}, AABB{Length2{}, Length2{}})));
-    EXPECT_TRUE((Contains(AABB{Length2{1 * Meter, 2 * Meter}}, AABB{})));
+    EXPECT_TRUE((Contains(AABB{Length2{1_m, 2_m}}, AABB{})));
     EXPECT_FALSE(Contains(GetInvalid<AABB>(), GetInvalid<AABB>()));
     EXPECT_FALSE(Contains(GetInvalid<AABB>(), AABB{}));
     EXPECT_FALSE(Contains(AABB{}, GetInvalid<AABB>()));
@@ -283,70 +277,37 @@ TEST(AABB, Contains)
 TEST(AABB, TestOverlap)
 {
     {
-        AABB bb1{
-            Length2{Real(-2) * Meter, Real(-3) * Meter},
-            Length2{Real(-1) * Meter, Real( 0) * Meter}
-        };
+        AABB bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
         EXPECT_TRUE(TestOverlap(bb1, bb1));
     }
     {
-        const auto vec = Length2{Real(-2) * Meter, Real(-3) * Meter};
+        const auto vec = Length2{-2_m, -3_m};
         AABB bb1{vec, vec};
         EXPECT_TRUE(TestOverlap(bb1, bb1));
     }
     {
-        AABB bb1{
-            Length2{Real(-2) * Meter, Real(-3) * Meter},
-            Length2{Real(-1) * Meter, Real( 0) * Meter}
-        };
-        AABB bb2{
-            Length2{Real(-1) * Meter, Real(-1) * Meter},
-            Length2{Real( 1) * Meter, Real( 2) * Meter}
-        };
+        AABB bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
+        AABB bb2{Length2{-1_m, -1_m}, Length2{ 1_m,  2_m}};
         EXPECT_TRUE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{
-            Length2{Real(-99) * Meter, Real(-3) * Meter},
-            Length2{Real( -1) * Meter, Real( 0) * Meter}
-        };
-        AABB bb2{
-            Length2{Real(76) * Meter, Real(-1) * Meter},
-            Length2{Real(-2) * Meter, Real( 2) * Meter}
-        };
+        AABB bb1{Length2{-99_m, -3_m}, Length2{-1_m,  0_m}};
+        AABB bb2{Length2{ 76_m, -1_m}, Length2{-2_m,  2_m}};
         EXPECT_TRUE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{
-            Length2{Real(-20) * Meter, Real(-3) * Meter},
-            Length2{Real(-18) * Meter, Real( 0) * Meter}
-        };
-        AABB bb2{
-            Length2{Real(-1) * Meter, Real(-1) * Meter},
-            Length2{Real( 1) * Meter, Real( 2) * Meter}
-        };
+        AABB bb1{Length2{-20_m, -3_m}, Length2{-18_m,  0_m}};
+        AABB bb2{Length2{ -1_m, -1_m}, Length2{  1_m,  2_m}};
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{
-            Length2{Real(-2) * Meter, Real(-3) * Meter},
-            Length2{Real(-1) * Meter, Real( 0) * Meter}
-        };
-        AABB bb2{
-            Length2{Real(-1) * Meter, Real(+1) * Meter},
-            Length2{Real( 1) * Meter, Real( 2) * Meter}
-        };
+        AABB bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
+        AABB bb2{Length2{-1_m, +1_m}, Length2{ 1_m,  2_m}};
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{
-            Length2{Real(-2) * Meter, Real(+3) * Meter},
-            Length2{Real(-1) * Meter, Real( 0) * Meter}
-        };
-        AABB bb2{
-            Length2{Real(-1) * Meter, Real(-1) * Meter},
-            Length2{Real( 0) * Meter, Real(-2) * Meter}
-        };
+        AABB bb1{Length2{-2_m, +3_m}, Length2{-1_m,  0_m}};
+        AABB bb2{Length2{-1_m, -1_m}, Length2{ 0_m, -2_m}};
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
 }
@@ -366,25 +327,25 @@ TEST(AABB, Move)
     {
         auto aabb = AABB{};
         EXPECT_EQ(Move(aabb, zeroLoc), AABB{});
-        EXPECT_EQ(Move(aabb, Length2{Real(10) * Meter, Real(-4) * Meter}), AABB{});
+        EXPECT_EQ(Move(aabb, Length2{10_m, -4_m}), AABB{});
     }
     {
         auto aabb = AABB{Length2{}};
         EXPECT_EQ(Move(aabb, Length2{}), zeroAabb);
     }
     {
-        const auto aabb1 = AABB{Length2{Real(1) * Meter, Real(1) * Meter}};
-        const auto aabb2 = AABB{Length2{Real(-10) * Meter, Real(11) * Meter}};
+        const auto aabb1 = AABB{Length2{1_m, 1_m}};
+        const auto aabb2 = AABB{Length2{-10_m, 11_m}};
         auto aabb = zeroAabb;
-        EXPECT_EQ(Move(aabb, Length2{Real(1) * Meter, Real(1) * Meter}), aabb1);
-        EXPECT_EQ(Move(aabb, Length2{Real(-1) * Meter, Real(-1) * Meter}), zeroAabb);
-        EXPECT_EQ(Move(aabb, Length2{Real(-10) * Meter, Real(11) * Meter}), aabb2);
+        EXPECT_EQ(Move(aabb, Length2{1_m, 1_m}), aabb1);
+        EXPECT_EQ(Move(aabb, Length2{-1_m, -1_m}), zeroAabb);
+        EXPECT_EQ(Move(aabb, Length2{-10_m, 11_m}), aabb2);
     }
     {
-        const auto lower = Length2{Real(-1) * Meter, Real(-1) * Meter};
-        const auto upper = Length2{Real(+3) * Meter, Real(+9) * Meter};
+        const auto lower = Length2{-1_m, -1_m};
+        const auto upper = Length2{+3_m, +9_m};
         auto aabb = AABB{lower, upper};
-        const auto moveby = Length2{Real(1) * Meter, Real(1) * Meter};
+        const auto moveby = Length2{1_m, 1_m};
         EXPECT_EQ(Move(aabb, moveby), AABB(lower + moveby, upper + moveby));
     }
 }
@@ -398,10 +359,10 @@ TEST(AABB, ComparisonOperators)
     EXPECT_FALSE(AABB{} < AABB{});
     EXPECT_FALSE(AABB{} > AABB{});
     
-    const auto vr0 = Interval<Length>{1 * Meter, 2 * Meter};
-    const auto vr1 = Interval<Length>{3 * Meter, 4 * Meter};
-    const auto vr2 = Interval<Length>{5 * Meter, 6 * Meter};
-    const auto vr3 = Interval<Length>{7 * Meter, 8 * Meter};
+    const auto vr0 = Interval<Length>{1_m, 2_m};
+    const auto vr1 = Interval<Length>{3_m, 4_m};
+    const auto vr2 = Interval<Length>{5_m, 6_m};
+    const auto vr3 = Interval<Length>{7_m, 8_m};
 
     EXPECT_FALSE(AABB(vr0, vr1) == AABB{});
     EXPECT_TRUE(AABB(vr0, vr1) != AABB{});
@@ -427,8 +388,8 @@ TEST(AABB, ComparisonOperators)
 
 TEST(AABB, StreamOutputOperator)
 {
-    const auto rangeX = Interval<Length>{-2 * Meter, +3 * Meter};
-    const auto rangeY = Interval<Length>{-8 * Meter, -4 * Meter};
+    const auto rangeX = Interval<Length>{-2_m, +3_m};
+    const auto rangeY = Interval<Length>{-8_m, -4_m};
     AABB foo{rangeX, rangeY};
     ASSERT_EQ(foo.rangeX, rangeX);
     ASSERT_EQ(foo.rangeY, rangeY);
@@ -472,7 +433,7 @@ TEST(AABB, ComputeAabbForFixtureOffFromBodyOrigin)
     const auto shape = std::make_shared<DiskShape>();
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
     
-    const auto bodyLocation = Length2{2 * Meter, 3 * Meter};
+    const auto bodyLocation = Length2{2_m, 3_m};
     World world;
     const auto body = world.CreateBody(BodyDef{}.UseLocation(bodyLocation));
     const auto fixture = body->CreateFixture(shape);
@@ -502,14 +463,14 @@ TEST(AABB, ComputeIntersectingAABBForSameFixture)
 
 TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
 {
-    const auto shapeInterval = LengthInterval{-2 * Meter, +2 * Meter};
+    const auto shapeInterval = LengthInterval{-2_m, +2_m};
 
-    const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}.UseVertexRadius(2 * Meter));
+    const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}.UseVertexRadius(2_m));
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
     ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
 
-    const auto bodyLocation0 = Length2{+1 * Meter, 0 * Meter};
-    const auto bodyLocation1 = Length2{-1 * Meter, 0 * Meter};
+    const auto bodyLocation0 = Length2{+1_m, 0_m};
+    const auto bodyLocation1 = Length2{-1_m, 0_m};
 
     World world;
     const auto body0 = world.CreateBody(BodyDef{}.UseLocation(bodyLocation0));
@@ -522,7 +483,7 @@ TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
     const auto fixtureAabb1 = ComputeAABB(*fixture1);
 
     const auto intersectingAabb = ComputeIntersectingAABB(*fixture0, 0, *fixture1, 0);
-    const auto intersectInterval = LengthInterval{-1 * Meter, +1 * Meter};
+    const auto intersectInterval = LengthInterval{-1_m, +1_m};
 
     ASSERT_NE(shapeAabb, fixtureAabb0);
     ASSERT_NE(shapeAabb, fixtureAabb1);
@@ -531,14 +492,14 @@ TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
 
 TEST(AABB, ComputeIntersectingAABBForContact)
 {
-    const auto shapeInterval = LengthInterval{-2 * Meter, +2 * Meter};
+    const auto shapeInterval = LengthInterval{-2_m, +2_m};
     
-    const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}.UseVertexRadius(2 * Meter));
+    const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}.UseVertexRadius(2_m));
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
     ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
     
-    const auto bodyLocation0 = Length2{+1 * Meter, 0 * Meter};
-    const auto bodyLocation1 = Length2{-1 * Meter, 0 * Meter};
+    const auto bodyLocation0 = Length2{+1_m, 0_m};
+    const auto bodyLocation1 = Length2{-1_m, 0_m};
     
     World world;
     const auto body0 = world.CreateBody(BodyDef{}.UseLocation(bodyLocation0));
@@ -551,7 +512,7 @@ TEST(AABB, ComputeIntersectingAABBForContact)
     const auto fixtureAabb1 = ComputeAABB(*fixture1);
     
     const auto intersectingAabb = ComputeIntersectingAABB(*fixture0, 0, *fixture1, 0);
-    const auto intersectInterval = LengthInterval{-1 * Meter, +1 * Meter};
+    const auto intersectInterval = LengthInterval{-1_m, +1_m};
     
     ASSERT_NE(shapeAabb, fixtureAabb0);
     ASSERT_NE(shapeAabb, fixtureAabb1);

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -41,8 +41,8 @@ TEST(AABB, ByteSizeIsTwiceVec2)
 TEST(AABB, DefaultConstruction)
 {
     const auto infinity = std::numeric_limits<Real>::infinity();
-    const auto lb = Vec2{infinity, infinity} * (Real(1) * Meter);
-    const auto ub = Vec2{-infinity, -infinity} * (Real(1) * Meter);
+    const auto lb = Vec2{infinity, infinity} * Meter;
+    const auto ub = Vec2{-infinity, -infinity} * Meter;
     const auto aabb = AABB{};
     EXPECT_EQ(GetLowerBound(aabb), lb);
     EXPECT_EQ(GetUpperBound(aabb), ub);

--- a/UnitTests/Acceleration.cpp
+++ b/UnitTests/Acceleration.cpp
@@ -37,16 +37,16 @@ TEST(Acceleration, ByteSize)
 TEST(Acceleration, Addition)
 {
     EXPECT_EQ(Acceleration{} + Acceleration{}, Acceleration{});
-    EXPECT_EQ((Acceleration{LinearAcceleration2D{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
-            + (Acceleration{LinearAcceleration2D{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
-              (Acceleration{LinearAcceleration2D{2_mps2, 2_mps2}, 2 * RadianPerSquareSecond}));
+    EXPECT_EQ((Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
+            + (Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
+              (Acceleration{LinearAcceleration2{2_mps2, 2_mps2}, 2 * RadianPerSquareSecond}));
 }
 
 TEST(Acceleration, Subtraction)
 {
     EXPECT_EQ(Acceleration{} - Acceleration{}, Acceleration{});
-    EXPECT_EQ((Acceleration{LinearAcceleration2D{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
-            - (Acceleration{LinearAcceleration2D{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
-              (Acceleration{LinearAcceleration2D{0_mps2, 0_mps2}, 0 * RadianPerSquareSecond}));
+    EXPECT_EQ((Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
+            - (Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
+              (Acceleration{LinearAcceleration2{0_mps2, 0_mps2}, 0 * RadianPerSquareSecond}));
 }
 

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -161,7 +161,7 @@ TEST(Body, WorldCreated)
 TEST(Body, SetVelocityDoesNothingToStatic)
 {
     const auto zeroVelocity = Velocity{
-        LinearVelocity2D{0_mps, 0_mps},
+        LinearVelocity2{0_mps, 0_mps},
         AngularVelocity{Real(0) * RadianPerSecond}
     };
 
@@ -175,7 +175,7 @@ TEST(Body, SetVelocityDoesNothingToStatic)
     ASSERT_EQ(body->GetVelocity(), zeroVelocity);
     
     const auto velocity = Velocity{
-        LinearVelocity2D{1.1_mps, 1.1_mps},
+        LinearVelocity2{1.1_mps, 1.1_mps},
         AngularVelocity{Real(1.1) * RadianPerSecond}
     };
     body->SetVelocity(velocity);
@@ -319,7 +319,7 @@ TEST(Body, SetTransform)
     bd.type = BodyType::Dynamic;
     World world;
     const auto body = world.CreateBody(bd);
-    const auto xfm1 = Transformation{Vec2_zero * 1_m, UnitVec2::GetRight()};
+    const auto xfm1 = Transformation{Length2{}, UnitVec2::GetRight()};
     ASSERT_EQ(body->GetTransformation(), xfm1);
     const auto xfm2 = Transformation{Vec2(10, -12) * 1_m, UnitVec2::GetLeft()};
     body->SetTransform(xfm2.p, GetAngle(xfm2.q));
@@ -430,10 +430,10 @@ TEST(Body, ApplyLinearAccelDoesNothingToStatic)
     ASSERT_FALSE(body->IsSpeedable());
     ASSERT_FALSE(body->IsAccelerable());
     
-    const auto zeroAccel = LinearAcceleration2D{
+    const auto zeroAccel = LinearAcceleration2{
         Real(0) * MeterPerSquareSecond, Real(0) * MeterPerSquareSecond
     };
-    const auto linAccel = LinearAcceleration2D{
+    const auto linAccel = LinearAcceleration2{
         Real(2) * MeterPerSquareSecond, Real(2) * MeterPerSquareSecond
     };
     ApplyLinearAcceleration(*body, linAccel);
@@ -445,9 +445,9 @@ TEST(Body, GetAccelerationFF)
 {
     World world;
     const auto body = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
-    body->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+    body->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
     
-    ASSERT_EQ(body->GetLinearAcceleration(), LinearAcceleration2D{});
+    ASSERT_EQ(body->GetLinearAcceleration(), LinearAcceleration2{});
     ASSERT_EQ(body->GetAngularAcceleration(), AngularAcceleration{});
     
     EXPECT_EQ(GetAcceleration(*body), Acceleration{});
@@ -457,13 +457,13 @@ TEST(Body, SetAccelerationFF)
 {
     World world;
     const auto body = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
-    body->SetAcceleration(LinearAcceleration2D{}, AngularAcceleration{});
+    body->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
     
-    ASSERT_EQ(body->GetLinearAcceleration(), LinearAcceleration2D{});
+    ASSERT_EQ(body->GetLinearAcceleration(), LinearAcceleration2{});
     ASSERT_EQ(body->GetAngularAcceleration(), AngularAcceleration{});
  
     const auto newAccel = Acceleration{
-        LinearAcceleration2D{2_mps2, 3_mps2}, AngularAcceleration{1.2f * RadianPerSquareSecond}
+        LinearAcceleration2{2_mps2, 3_mps2}, AngularAcceleration{1.2f * RadianPerSquareSecond}
     };
     SetAcceleration(*body, newAccel);
     EXPECT_EQ(GetAcceleration(*body), newAccel);
@@ -471,10 +471,10 @@ TEST(Body, SetAccelerationFF)
 
 TEST(Body, CalcGravitationalAcceleration)
 {
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
 
-    const auto l1 = Length2D{-8_m, 0_m};
-    const auto l2 = Length2D{+8_m, 0_m};
+    const auto l1 = Length2{-8_m, 0_m};
+    const auto l2 = Length2{+8_m, 0_m};
 
     const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}
                                                    .UseVertexRadius(2_m)

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -96,7 +96,7 @@ TEST(ChainShape, OneVertexLikeDisk)
 {
     const auto vertexRadius = 1_m;
     const auto density = 1_kgpm2;
-    const auto location = Length2D{};
+    const auto location = Length2{};
     const auto expectedMassData = ::GetMassData(vertexRadius, density, location);
     const auto expectedDistanceProxy = DistanceProxy{vertexRadius, 1, &location, nullptr};
 
@@ -118,8 +118,8 @@ TEST(ChainShape, TwoVertexLikeEdge)
 {
     const auto vertexRadius = 1_m;
     const auto density = NonNegative<Density>(1_kgpm2);
-    const auto locations = std::array<Length2D, 2>{{
-        Length2D{0_m, 0_m}, Length2D(4_m, 0_m)
+    const auto locations = std::array<Length2, 2>{{
+        Length2{0_m, 0_m}, Length2(4_m, 0_m)
     }};
     
     auto conf = ChainShape::Conf{};
@@ -137,8 +137,8 @@ TEST(ChainShape, TwoVertexDpLikeEdgeDp)
 {
     const auto vertexRadius = 1_m;
     const auto density = NonNegative<Density>(1_kgpm2);
-    const auto locations = std::array<Length2D, 2>{{
-        Length2D{0_m, 0_m}, Length2D(4_m, 0_m)
+    const auto locations = std::array<Length2, 2>{{
+        Length2{0_m, 0_m}, Length2(4_m, 0_m)
     }};
     const auto normals = std::array<UnitVec2, 2>{{UnitVec2::GetTop(), UnitVec2::GetBottom()}};
     const auto expectedDistanceProxy = DistanceProxy{vertexRadius, 2, locations.data(), normals.data()};
@@ -159,8 +159,8 @@ TEST(ChainShape, TwoVertexMassLikeEdgeMass)
 {
     const auto vertexRadius = 1_m;
     const auto density = NonNegative<Density>(1_kgpm2);
-    const auto locations = std::array<Length2D, 2>{{
-        Length2D{0_m, 0_m}, Length2D(4_m, 0_m)
+    const auto locations = std::array<Length2, 2>{{
+        Length2{0_m, 0_m}, Length2(4_m, 0_m)
     }};
     const auto expectedMassData = ::GetMassData(vertexRadius, density, locations[0], locations[1]);
     
@@ -186,26 +186,26 @@ TEST(ChainShape, FourVertex)
 {
     const auto vertexRadius = 1_m;
     const auto density = 1_kgpm2;
-    const auto locations = std::array<Length2D, 5>{{
-        Length2D(-4_m, -4_m),
-        Length2D(-4_m, +4_m),
-        Length2D(+4_m, +4_m),
-        Length2D(+4_m, -4_m),
-        Length2D(-4_m, -4_m)
+    const auto locations = std::array<Length2, 5>{{
+        Length2(-4_m, -4_m),
+        Length2(-4_m, +4_m),
+        Length2(+4_m, +4_m),
+        Length2(+4_m, -4_m),
+        Length2(-4_m, -4_m)
     }};
     const auto edgeMassData0 = ::GetMassData(vertexRadius, density, locations[0], locations[1]);
 
     auto conf = ChainShape::Conf{};
     conf.density = density;
     conf.vertexRadius = vertexRadius;
-    conf.vertices = std::vector<Length2D>(std::begin(locations), std::end(locations));
+    conf.vertices = std::vector<Length2>(std::begin(locations), std::end(locations));
     auto foo = ChainShape{conf};
     EXPECT_EQ(foo.GetChildCount(), ChildCounter{4});
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{5});
     EXPECT_EQ(foo.GetVertexRadius(), vertexRadius);
     
     const auto massData = foo.GetMassData();
-    EXPECT_EQ(massData.center, (Length2D{}));
+    EXPECT_EQ(massData.center, (Length2{}));
     const auto expectedMass = Mass{edgeMassData0.mass} * Real(4);
     EXPECT_EQ(massData.mass, NonNegative<Mass>{expectedMass});
 }
@@ -239,6 +239,6 @@ TEST(ChainShape, TooManyVertices)
     auto conf = ChainShape::Conf{};
     conf.density = density;
     conf.vertexRadius = vertexRadius;
-    conf.vertices = std::vector<Length2D>(MaxChildCount + 1);
+    conf.vertices = std::vector<Length2>(MaxChildCount + 1);
     EXPECT_THROW(ChainShape{conf}, InvalidArgument);
 }

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -732,11 +732,11 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
     ASSERT_EQ(shape0.GetVertex(3), Vec2(-2,-2) * Meter); // bottom left
     
     // Shape B: wide rectangle
-    const auto shape1 = PolygonShape(3_m, Real{1.5f} * Meter);
-    ASSERT_EQ(shape1.GetVertex(0), Length2(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
-    ASSERT_EQ(shape1.GetVertex(1), Length2(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
-    ASSERT_EQ(shape1.GetVertex(2), Length2(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
-    ASSERT_EQ(shape1.GetVertex(3), Length2(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
+    const auto shape1 = PolygonShape(3_m, 1.5_m);
+    ASSERT_EQ(shape1.GetVertex(0), Length2(+3.0_m, -1.5_m)); // bottom right
+    ASSERT_EQ(shape1.GetVertex(1), Length2(+3.0_m, +1.5_m)); // top right
+    ASSERT_EQ(shape1.GetVertex(2), Length2(-3.0_m, +1.5_m)); // top left
+    ASSERT_EQ(shape1.GetVertex(3), Length2(-3.0_m, -1.5_m)); // bottom left
 
     const auto xfm0 = Transformation{
         Vec2{-2, 0} * Meter,
@@ -811,11 +811,11 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
 TEST(CollideShapes, HorizontalOverlappingRects2)
 {
     // Shape A: wide rectangle
-    const auto shape0 = PolygonShape(3_m, Real{1.5f} * Meter);
-    ASSERT_EQ(shape0.GetVertex(0), Length2(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
-    ASSERT_EQ(shape0.GetVertex(1), Length2(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
-    ASSERT_EQ(shape0.GetVertex(2), Length2(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
-    ASSERT_EQ(shape0.GetVertex(3), Length2(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
+    const auto shape0 = PolygonShape(3_m, 1.5_m);
+    ASSERT_EQ(shape0.GetVertex(0), Length2(+3.0_m, -1.5_m)); // bottom right
+    ASSERT_EQ(shape0.GetVertex(1), Length2(+3.0_m, +1.5_m)); // top right
+    ASSERT_EQ(shape0.GetVertex(2), Length2(-3.0_m, +1.5_m)); // top left
+    ASSERT_EQ(shape0.GetVertex(3), Length2(-3.0_m, -1.5_m)); // bottom left
     
     // Shape B: square
     const auto shape1 = PolygonShape(2_m, 2_m);
@@ -1383,7 +1383,7 @@ TEST(CollideShapes, EdgePolygonFaceB1)
 TEST(CollideShapes, EdgePolygonFaceB2)
 {
     auto conf = EdgeShape::Conf{};
-    conf.vertexRadius = Real{0.000199999995f} * Meter;
+    conf.vertexRadius = 0.000199999995_m;
     const auto edge_shape = EdgeShape(Vec2(-6, 2) * Meter, Vec2(-6, 0) * Meter, conf);
     const auto edge_xfm = Transformation{Vec2(-9.99999904f, 4.0f) * Meter, GetUnitVector(Vec2(Real(1), Real(0)))};
     const auto poly_shape = PolygonShape({

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -96,12 +96,12 @@ TEST(CollideShapes, CircleCircleOrientedVertically)
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_circles);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), Vec2_zero * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetLocalPoint(), Length2{});
     
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2_zero * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, Length2{});
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_vertex);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexA, 0);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
@@ -117,7 +117,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointBelow)
     const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
     const auto triangle = PolygonShape({triangleLeftPt, triangleRightPt, triangleTopPt});
     const auto triangleXfm = Transformation{
-        Vec2{0, 0} * (Real(1) * Meter),
+        Length2{},
         UnitVec2::GetRight()
     };
     const auto circleXfm = Transformation{
@@ -131,7 +131,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointBelow)
     EXPECT_EQ(manifold.GetLocalPoint(), triangleTopPt);
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2_zero * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, Length2{});
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_vertex);
     EXPECT_EQ(triangle.GetVertex(manifold.GetPoint(0).contactFeature.indexA), triangleTopPt);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
@@ -151,7 +151,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointLeft)
         UnitVec2::GetRight()
     };
     const auto triangleXfm = Transformation{
-        Vec2{0, 0} * (Real(1) * Meter),
+        Length2{},
         UnitVec2::GetRight()
     };
     
@@ -161,7 +161,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointLeft)
     EXPECT_EQ(manifold.GetLocalPoint(), triangleLeftPt);
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2D{}));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2{}));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_vertex);
     EXPECT_EQ(triangle.GetVertex(manifold.GetPoint(0).contactFeature.indexA), triangleLeftPt);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
@@ -180,7 +180,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointRight)
         triangleRightPt + UnitVec2::Get(-45_deg) * circleRadius,
         UnitVec2::GetRight()
     };
-    const auto triangleXfm = Transformation{Vec2{0, 0} * Meter, UnitVec2::GetRight()};
+    const auto triangleXfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(triangle.GetChild(0), triangleXfm, circle.GetChild(0), circleXfm);
     
@@ -188,7 +188,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointRight)
     EXPECT_EQ(manifold.GetLocalPoint(), triangleRightPt);
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2D{}));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2{}));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_vertex);
     EXPECT_EQ(triangle.GetVertex(manifold.GetPoint(0).contactFeature.indexA), triangleRightPt);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
@@ -210,7 +210,7 @@ TEST(CollideShapes, CircleJustPastTrianglePointRightDoesntCollide)
         UnitVec2::GetRight()
     };
     const auto triangleXfm = Transformation{
-        Length2D{},
+        Length2{},
         UnitVec2::GetRight()
     };
     
@@ -233,7 +233,7 @@ TEST(CollideShapes, CircleOverRightFaceOfTriangle)
         UnitVec2::GetRight()
     };
     const auto triangleXfm = Transformation{
-        Vec2{0, 0} * (Real(1) * Meter),
+        Length2{},
         UnitVec2::GetRight()
     };
     
@@ -266,7 +266,7 @@ TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
         UnitVec2::GetRight()
     };
     const auto triangleXfm = Transformation{
-        Vec2{0, 0} * (Real(1) * Meter),
+        Length2{},
         UnitVec2::GetRight()
     };
     
@@ -280,7 +280,7 @@ TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2D{}));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2{}));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
     EXPECT_EQ(triangle.GetNormal(manifold.GetPoint(0).contactFeature.indexA), manifold.GetLocalNormal());
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
@@ -322,7 +322,7 @@ TEST(CollideShapes, TallRectangleLeftCircleRight)
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2D{}));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Length2{}));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
     EXPECT_EQ(s1.GetNormal(manifold.GetPoint(0).contactFeature.indexA), manifold.GetLocalNormal());
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
@@ -338,7 +338,7 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim1)
     ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * (Real(1) * Meter))); // top left
     ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * (Real(1) * Meter))); // bottom left
     
-    const auto xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(shape.GetChild(0), xfm, shape.GetChild(0), xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
@@ -379,7 +379,7 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim2)
     ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * (Real(1) * Meter))); // top left
     ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * (Real(1) * Meter))); // bottom left
     
-    const auto xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(shape.GetChild(0), xfm, shape.GetChild(0), xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
@@ -709,7 +709,7 @@ TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(world_manifold.GetNormal()))),
                 +1.0, 1.0/100000.0);
 
-    const auto corner_point = Rotate(Length2D{dim, dim}, UnitVec2::Get(rot0)) + xfm0.p;
+    const auto corner_point = Rotate(Length2{dim, dim}, UnitVec2::Get(rot0)) + xfm0.p;
     EXPECT_NEAR(double(Real{GetX(corner_point) / Meter}), 0.0,        0.02);
     EXPECT_NEAR(double(Real{GetY(corner_point) / Meter}), 0.82842684, 0.02);
     
@@ -733,10 +733,10 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
     
     // Shape B: wide rectangle
     const auto shape1 = PolygonShape(Real{3} * Meter, Real{1.5f} * Meter);
-    ASSERT_EQ(shape1.GetVertex(0), Length2D(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
-    ASSERT_EQ(shape1.GetVertex(1), Length2D(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
-    ASSERT_EQ(shape1.GetVertex(2), Length2D(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
-    ASSERT_EQ(shape1.GetVertex(3), Length2D(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
+    ASSERT_EQ(shape1.GetVertex(0), Length2(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
+    ASSERT_EQ(shape1.GetVertex(1), Length2(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
+    ASSERT_EQ(shape1.GetVertex(2), Length2(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
+    ASSERT_EQ(shape1.GetVertex(3), Length2(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
 
     const auto xfm0 = Transformation{
         Vec2{-2, 0} * (Real(1) * Meter),
@@ -812,17 +812,17 @@ TEST(CollideShapes, HorizontalOverlappingRects2)
 {
     // Shape A: wide rectangle
     const auto shape0 = PolygonShape(Real{3} * Meter, Real{1.5f} * Meter);
-    ASSERT_EQ(shape0.GetVertex(0), Length2D(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
-    ASSERT_EQ(shape0.GetVertex(1), Length2D(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
-    ASSERT_EQ(shape0.GetVertex(2), Length2D(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
-    ASSERT_EQ(shape0.GetVertex(3), Length2D(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
+    ASSERT_EQ(shape0.GetVertex(0), Length2(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
+    ASSERT_EQ(shape0.GetVertex(1), Length2(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
+    ASSERT_EQ(shape0.GetVertex(2), Length2(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
+    ASSERT_EQ(shape0.GetVertex(3), Length2(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
     
     // Shape B: square
     const auto shape1 = PolygonShape(Real{2} * Meter, Real{2} * Meter);
-    ASSERT_EQ(shape1.GetVertex(0), Length2D(+Real(2) * Meter,-Real(2) * Meter)); // bottom right
-    ASSERT_EQ(shape1.GetVertex(1), Length2D(+Real(2) * Meter,+Real(2) * Meter)); // top right
-    ASSERT_EQ(shape1.GetVertex(2), Length2D(-Real(2) * Meter,+Real(2) * Meter)); // top left
-    ASSERT_EQ(shape1.GetVertex(3), Length2D(-Real(2) * Meter,-Real(2) * Meter)); // bottom left
+    ASSERT_EQ(shape1.GetVertex(0), Length2(+Real(2) * Meter,-Real(2) * Meter)); // bottom right
+    ASSERT_EQ(shape1.GetVertex(1), Length2(+Real(2) * Meter,+Real(2) * Meter)); // top right
+    ASSERT_EQ(shape1.GetVertex(2), Length2(-Real(2) * Meter,+Real(2) * Meter)); // top left
+    ASSERT_EQ(shape1.GetVertex(3), Length2(-Real(2) * Meter,-Real(2) * Meter)); // bottom left
     
     const auto xfm0 = Transformation{
         Vec2{-2, 0} * (Real(1) * Meter),
@@ -897,7 +897,7 @@ TEST(CollideShapes, EdgeBelowPolygon)
     const auto hy = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(hx, hy);
     const auto polygon_xfm = Transformation{
-        Vec2{0, 0} * (Real(1) * Meter),
+        Length2{},
         UnitVec2::GetRight()
     };
 
@@ -905,7 +905,7 @@ TEST(CollideShapes, EdgeBelowPolygon)
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 0.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -942,13 +942,13 @@ TEST(CollideShapes, EdgeAbovePolygon)
     const auto hx = Real(1) * Meter;
     const auto hy = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(hx, hy);
-    const auto polygon_xfm = Transformation{Vec2{0, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 +0.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -985,13 +985,13 @@ TEST(CollideShapes, EdgeLeftOfPolygon)
     const auto hx = Real(1) * Meter;
     const auto hy = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(hx, hy);
-    const auto polygon_xfm = Transformation{Vec2{0, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1010,13 +1010,13 @@ TEST(CollideShapes, EdgeRightOfPolygon)
     const auto hx = Real(1) * Meter;
     const auto hy = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(hx, hy);
-    const auto polygon_xfm = Transformation{Vec2{0, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 -1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1030,15 +1030,15 @@ TEST(CollideShapes, EdgeInsideSquare)
     const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
     const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Vec2{0, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto s = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(s, s);
-    const auto polygon_xfm = Transformation{Vec2{0, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1055,15 +1055,15 @@ TEST(CollideShapes, EdgeTwiceInsideSquare)
     const auto p1 = Vec2(0, -2) * (Real(1) * Meter);
     const auto p2 = Vec2(0, +2) * (Real(1) * Meter);
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto s = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(s, s);
-    const auto polygon_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1080,15 +1080,15 @@ TEST(CollideShapes, EdgeHalfInsideSquare)
     const auto p1 = Vec2(0, -0.5) * (Real(1) * Meter);
     const auto p2 = Vec2(0, +0.5) * (Real(1) * Meter);
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto s = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(s, s);
-    const auto polygon_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1105,10 +1105,10 @@ TEST(CollideShapes, EdgeR90InsideSquare)
     const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
     const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Length2D{}, UnitVec2::GetTop()};
+    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetTop()};
     const auto s = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(s, s);
-    const auto polygon_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     // Sets up a collision between a line segment (A) and a square (B) where the line segment is
     // fully inside the square and bisects the square into an upper and low rectangular area like
@@ -1130,7 +1130,7 @@ TEST(CollideShapes, EdgeR90InsideSquare)
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1161,15 +1161,15 @@ TEST(CollideShapes, EdgeR45InsideSquare)
     const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
     const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Length2D{}, UnitVec2::Get(45_deg)};
+    const auto edge_xfm = Transformation{Length2{}, UnitVec2::Get(45_deg)};
     const auto s = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(s, s);
-    const auto polygon_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1204,15 +1204,15 @@ TEST(CollideShapes, EdgeR180InsideSquare)
     const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
     const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Length2D{}, UnitVec2::GetLeft()};
+    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetLeft()};
     const auto s = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(s, s);
-    const auto polygon_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1270,12 +1270,12 @@ TEST(CollideShapes, EdgeTwiceR180Square)
     };
     const auto s = Real(1) * Meter;
     const auto polygon_shape = PolygonShape(s, s);
-    const auto polygon_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -1334,13 +1334,13 @@ TEST(CollideShapes, EdgeFooTriangle)
     const auto triangleLeftPt = Vec2{-1, -1} * (Real(1) * Meter);
     const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
     polygon_shape.Set({triangleLeftPt, triangleRightPt, triangleTopPt});
-    const auto polygon_xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm,
                                         polygon_shape.GetChild(0), polygon_xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Length2D{}));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Length2{}));
     EXPECT_NEAR(double(GetX(GetVec2(manifold.GetLocalNormal()))), -0.707107, 0.0001);
     EXPECT_NEAR(double(GetY(GetVec2(manifold.GetLocalNormal()))), -0.707107, 0.0001);
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
@@ -1353,7 +1353,7 @@ TEST(CollideShapes, EdgePolygonFaceB1)
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = 0;
     const auto edge_shape = EdgeShape(Vec2(6, 8) * (Real(1) * Meter), Vec2(7, 8) * (Real(1) * Meter), conf);
-    const auto edge_xfm = Transformation{Length2D{}, GetUnitVector(Vec2(Real(0.707106769), Real(0.707106769)))};
+    const auto edge_xfm = Transformation{Length2{}, GetUnitVector(Vec2(Real(0.707106769), Real(0.707106769)))};
     const auto poly_shape = PolygonShape({
         Vec2(0.5, 0) * (Real(1) * Meter),
         Vec2(0.249999985f, 0.433012724f) * (Real(1) * Meter),
@@ -1390,7 +1390,7 @@ TEST(CollideShapes, EdgePolygonFaceB2)
         Vec2(0.5f, -0.5f) * (Real(1) * Meter),
         Vec2(0.5f, 0.5f) * (Real(1) * Meter),
         Vec2(-0.5f, 0.5f) * (Real(1) * Meter),
-        Vec2(0.0f, 0.0f) * (Real(1) * Meter)
+        Length2{}
     });
     const auto poly_xfm = Transformation{Vec2(-16.0989342f, 3.49960017f) * (Real(1) * Meter), GetUnitVector(Vec2(1, 0))};
     
@@ -1505,8 +1505,8 @@ TEST(CollideShapes, R0EdgePerpendicularCrossingFromR0Edge)
     conf.vertexRadius = 0;
     auto edge_shape = EdgeShape(conf);
     edge_shape.Set(p1, p2);
-    const auto xfm1 = Transformation{Length2D{}, UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Length2D{}, UnitVec2::GetTop()};
+    const auto xfm1 = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation{Length2{}, UnitVec2::GetTop()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), xfm1, edge_shape.GetChild(0), xfm2);
     

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -30,7 +30,7 @@ TEST(CollideShapes, IdenticalOverlappingCircles)
 {
     const auto radius = Real(1) * Meter;
     const auto shape = DiskShape{radius};
-    const auto position = Vec2{11, -4} * (Real(1) * Meter);
+    const auto position = Vec2{11, -4} * Meter;
     const auto xfm = Transformation{position, UnitVec2::GetRight()};
     
     // put shape 1 to left of shape 2
@@ -56,8 +56,8 @@ TEST(CollideShapes, CircleCircleOrientedHorizontally)
     const auto r2 = Real(1) * Meter;
     const auto s1 = DiskShape{r1};
     const auto s2 = DiskShape{r2};
-    const auto p1 = Vec2{11, -4} * (Real(1) * Meter);
-    const auto p2 = Vec2{13, -4} * (Real(1) * Meter);
+    const auto p1 = Vec2{11, -4} * Meter;
+    const auto p2 = Vec2{13, -4} * Meter;
     const auto t1 = Transformation{p1, UnitVec2::GetRight()};
     const auto t2 = Transformation{p2, UnitVec2::GetRight()};
     
@@ -84,8 +84,8 @@ TEST(CollideShapes, CircleCircleOrientedVertically)
     const auto r2 = Real(1) * Meter;
     const auto s1 = DiskShape{r1};
     const auto s2 = DiskShape{r2};
-    const auto p1 = Vec2{7, -2} * (Real(1) * Meter);
-    const auto p2 = Vec2{7, -1} * (Real(1) * Meter);
+    const auto p1 = Vec2{7, -2} * Meter;
+    const auto p2 = Vec2{7, -1} * Meter;
     
     // Rotations don't matter so long as circle shapes' centers are at (0, 0).
     const auto t1 = Transformation{p1, UnitVec2::Get(45_deg)};
@@ -112,9 +112,9 @@ TEST(CollideShapes, CircleTouchingTrianglePointBelow)
 {
     const auto circleRadius = Real(1) * Meter;
     const auto circle = DiskShape(circleRadius);
-    const auto triangleTopPt = Vec2{0, +1} * (Real(1) * Meter);
-    const auto triangleLeftPt = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
+    const auto triangleTopPt = Vec2{0, +1} * Meter;
+    const auto triangleLeftPt = Vec2{-1, -1} * Meter;
+    const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShape({triangleLeftPt, triangleRightPt, triangleTopPt});
     const auto triangleXfm = Transformation{
         Length2{},
@@ -142,9 +142,9 @@ TEST(CollideShapes, CircleTouchingTrianglePointLeft)
 {
     const auto circleRadius = Real(1) * Meter;
     const auto circle = DiskShape(circleRadius);
-    const auto triangleTopPt = Vec2{0, +1} * (Real(1) * Meter);
-    const auto triangleLeftPt = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
+    const auto triangleTopPt = Vec2{0, +1} * Meter;
+    const auto triangleLeftPt = Vec2{-1, -1} * Meter;
+    const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShape({triangleLeftPt, triangleRightPt, triangleTopPt});
     const auto circleXfm = Transformation{
         triangleLeftPt + UnitVec2::Get(225_deg) * circleRadius,
@@ -172,9 +172,9 @@ TEST(CollideShapes, CircleTouchingTrianglePointRight)
 {
     const auto circleRadius = Real(1) * Meter;
     const auto circle = DiskShape(circleRadius);
-    const auto triangleTopPt = Vec2{0, +1} * (Real(1) * Meter);
-    const auto triangleLeftPt = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
+    const auto triangleTopPt = Vec2{0, +1} * Meter;
+    const auto triangleLeftPt = Vec2{-1, -1} * Meter;
+    const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShape({triangleLeftPt, triangleRightPt, triangleTopPt});
     const auto circleXfm = Transformation{
         triangleRightPt + UnitVec2::Get(-45_deg) * circleRadius,
@@ -199,9 +199,9 @@ TEST(CollideShapes, CircleJustPastTrianglePointRightDoesntCollide)
 {
     const auto circleRadius = Real(1) * Meter;
     const auto circle = DiskShape(circleRadius);
-    const auto triangleTopPt = Vec2{0, +1} * (Real(1) * Meter);
-    const auto triangleLeftPt = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
+    const auto triangleTopPt = Vec2{0, +1} * Meter;
+    const auto triangleLeftPt = Vec2{-1, -1} * Meter;
+    const auto triangleRightPt = Vec2{+1, -1} * Meter;
     auto triangle = PolygonShape{};
     triangle.SetVertexRadius(Real{0.0001f * 2} * Meter);
     triangle.Set({triangleLeftPt, triangleRightPt, triangleTopPt});
@@ -224,12 +224,12 @@ TEST(CollideShapes, CircleOverRightFaceOfTriangle)
 {
     const auto circleRadius = Real(1) * Meter;
     const auto circle = DiskShape(circleRadius);
-    const auto triangleTopPt = Vec2{0, +1} * (Real(1) * Meter);
-    const auto triangleLeftPt = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
+    const auto triangleTopPt = Vec2{0, +1} * Meter;
+    const auto triangleLeftPt = Vec2{-1, -1} * Meter;
+    const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShape({triangleLeftPt, triangleRightPt, triangleTopPt});
     const auto circleXfm = Transformation{
-        Vec2{1, 1} * (Real(1) * Meter),
+        Vec2{1, 1} * Meter,
         UnitVec2::GetRight()
     };
     const auto triangleXfm = Transformation{
@@ -253,16 +253,16 @@ TEST(CollideShapes, CircleOverRightFaceOfTriangle)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 0);
 
-    EXPECT_EQ(triangle.GetVertex(0), (Vec2{+1, -1} * (Real(1) * Meter)));
+    EXPECT_EQ(triangle.GetVertex(0), (Vec2{+1, -1} * Meter));
 }
 
 TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
 {
     const auto circleRadius = Real(1) * Meter;
     const auto circle = DiskShape(circleRadius);
-    const auto triangle = PolygonShape({Vec2{-1, -1} * (Real(1) * Meter), Vec2{+1, -1} * (Real(1) * Meter), Vec2{0, +1} * (Real(1) * Meter)});
+    const auto triangle = PolygonShape({Vec2{-1, -1} * Meter, Vec2{+1, -1} * Meter, Vec2{0, +1} * Meter});
     const auto circleXfm = Transformation{
-        Vec2{-1, 1} * (Real(1) * Meter),
+        Vec2{-1, 1} * Meter,
         UnitVec2::GetRight()
     };
     const auto triangleXfm = Transformation{
@@ -273,7 +273,7 @@ TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
     const auto manifold = CollideShapes(triangle.GetChild(0), triangleXfm, circle.GetChild(0), circleXfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{-0.5f, 0} * (Real(1) * Meter)));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{-0.5f, 0} * Meter));
     EXPECT_NEAR(double(manifold.GetLocalNormal().GetX()), -0.894427,   0.0002);
     EXPECT_NEAR(double(manifold.GetLocalNormal().GetY()),  0.44721359, 0.0002);
     
@@ -286,7 +286,7 @@ TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeB, ContactFeature::e_vertex);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 0);
     
-    EXPECT_EQ(triangle.GetVertex(0), (Vec2{+1, -1} * (Real(1) * Meter)));
+    EXPECT_EQ(triangle.GetVertex(0), (Vec2{+1, -1} * Meter));
 }
 
 TEST(CollideShapes, TallRectangleLeftCircleRight)
@@ -296,15 +296,15 @@ TEST(CollideShapes, TallRectangleLeftCircleRight)
     const auto hy = Real(4.8);
 
     const auto s1 = PolygonShape(hx * Meter, hy * Meter);
-    ASSERT_EQ(s1.GetVertex(0), (Vec2{+hx, -hy} * (Real(1) * Meter))); // bottom right
-    ASSERT_EQ(s1.GetVertex(1), (Vec2{+hx, +hy} * (Real(1) * Meter))); // top right
-    ASSERT_EQ(s1.GetVertex(2), (Vec2{-hx, +hy} * (Real(1) * Meter))); // top left
-    ASSERT_EQ(s1.GetVertex(3), (Vec2{-hx, -hy} * (Real(1) * Meter))); // bottom left
+    ASSERT_EQ(s1.GetVertex(0), (Vec2{+hx, -hy} * Meter)); // bottom right
+    ASSERT_EQ(s1.GetVertex(1), (Vec2{+hx, +hy} * Meter)); // top right
+    ASSERT_EQ(s1.GetVertex(2), (Vec2{-hx, +hy} * Meter)); // top left
+    ASSERT_EQ(s1.GetVertex(3), (Vec2{-hx, -hy} * Meter)); // bottom left
 
     const auto s2 = DiskShape{r2};
     
-    const auto p1 = Vec2{-1, 0} * (Real(1) * Meter);
-    const auto p2 = Vec2{3, 0} * (Real(1) * Meter);
+    const auto p1 = Vec2{-1, 0} * Meter;
+    const auto p2 = Vec2{3, 0} * Meter;
     const auto t1 = Transformation{p1, UnitVec2::Get(45_deg)};
     const auto t2 = Transformation{p2, UnitVec2::GetRight()};
     
@@ -317,7 +317,7 @@ TEST(CollideShapes, TallRectangleLeftCircleRight)
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
                 0.0, 1.0/100000.0);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{hx, 0} * (Real(1) * Meter)));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{hx, 0} * Meter));
     
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     
@@ -333,10 +333,10 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim1)
 {
     const auto dim = Real(1);
     const auto shape = PolygonShape(dim * Meter, dim * Meter);
-    ASSERT_EQ(shape.GetVertex(0), (Vec2{+dim, -dim} * (Real(1) * Meter))); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), (Vec2{+dim, +dim} * (Real(1) * Meter))); // top right
-    ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * (Real(1) * Meter))); // top left
-    ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * (Real(1) * Meter))); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), (Vec2{+dim, -dim} * Meter)); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), (Vec2{+dim, +dim} * Meter)); // top right
+    ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * Meter)); // top left
+    ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * Meter)); // bottom left
     
     const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(shape.GetChild(0), xfm, shape.GetChild(0), xfm);
@@ -347,12 +347,12 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim1)
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
                 0.0, 1.0/100000.0);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{+dim, 0} * (Real(1) * Meter)));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{+dim, 0} * Meter));
     
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(2));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Vec2{-dim, +dim} * (Real(1) * Meter))); // top left
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Vec2{-dim, +dim} * Meter)); // top left
     EXPECT_EQ(manifold.GetPoint(0).normalImpulse, 0_Ns);
     EXPECT_EQ(manifold.GetPoint(0).tangentImpulse, 0_Ns);
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
@@ -361,7 +361,7 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim1)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 2);
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(1));
-    EXPECT_EQ(manifold.GetPoint(1).localPoint, (Vec2{-dim, -dim} * (Real(1) * Meter))); // bottom left
+    EXPECT_EQ(manifold.GetPoint(1).localPoint, (Vec2{-dim, -dim} * Meter)); // bottom left
     EXPECT_EQ(manifold.GetPoint(1).normalImpulse, 0_Ns);
     EXPECT_EQ(manifold.GetPoint(1).tangentImpulse, 0_Ns);
     EXPECT_EQ(manifold.GetPoint(1).contactFeature.typeA, ContactFeature::e_face);
@@ -374,10 +374,10 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim2)
 {
     const auto dim = Real(2);
     const auto shape = PolygonShape(dim * Meter, dim * Meter);
-    ASSERT_EQ(shape.GetVertex(0), (Vec2{+dim, -dim} * (Real(1) * Meter))); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), (Vec2{+dim, +dim} * (Real(1) * Meter))); // top right
-    ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * (Real(1) * Meter))); // top left
-    ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * (Real(1) * Meter))); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), (Vec2{+dim, -dim} * Meter)); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), (Vec2{+dim, +dim} * Meter)); // top right
+    ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * Meter)); // top left
+    ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * Meter)); // bottom left
     
     const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(shape.GetChild(0), xfm, shape.GetChild(0), xfm);
@@ -388,12 +388,12 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim2)
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
                 0.0, 1.0/100000.0);
-    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{+dim, 0} * (Real(1) * Meter)));
+    EXPECT_EQ(manifold.GetLocalPoint(), (Vec2{+dim, 0} * Meter));
     
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(2));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Vec2{-dim, +dim} * (Real(1) * Meter))); // top left
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, (Vec2{-dim, +dim} * Meter)); // top left
     EXPECT_EQ(manifold.GetPoint(0).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
@@ -402,7 +402,7 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim2)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 2);
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(1));
-    EXPECT_EQ(manifold.GetPoint(1).localPoint, (Vec2{-dim, -dim} * (Real(1) * Meter))); // bottom left
+    EXPECT_EQ(manifold.GetPoint(1).localPoint, (Vec2{-dim, -dim} * Meter)); // bottom left
     EXPECT_EQ(manifold.GetPoint(1).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).contactFeature.typeA, ContactFeature::e_face);
@@ -415,24 +415,24 @@ TEST(CollideShapes, IdenticalVerticalTouchingSquares)
 {
     const auto dim = Real(2) * Meter;
     const auto shape = PolygonShape(dim, dim);
-    ASSERT_EQ(shape.GetVertex(0), (Vec2{+2, -2} * (Real(1) * Meter))); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), (Vec2{+2, +2} * (Real(1) * Meter))); // top right
-    ASSERT_EQ(shape.GetVertex(2), (Vec2{-2, +2} * (Real(1) * Meter))); // top left
-    ASSERT_EQ(shape.GetVertex(3), (Vec2{-2, -2} * (Real(1) * Meter))); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), (Vec2{+2, -2} * Meter)); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), (Vec2{+2, +2} * Meter)); // top right
+    ASSERT_EQ(shape.GetVertex(2), (Vec2{-2, +2} * Meter)); // top left
+    ASSERT_EQ(shape.GetVertex(3), (Vec2{-2, -2} * Meter)); // bottom left
 
     const auto xfm0 = Transformation{
-        Vec2{0, -1} * (Real(1) * Meter),
+        Vec2{0, -1} * Meter,
         UnitVec2::GetRight()
     }; // bottom
     const auto xfm1 = Transformation{
-        Vec2{0, +1} * (Real(1) * Meter),
+        Vec2{0, +1} * Meter,
         UnitVec2::GetRight()
     }; // top
     const auto manifold = CollideShapes(shape.GetChild(0), xfm0, shape.GetChild(0), xfm1);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(0,+2) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(0,+2) * Meter);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 0.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -441,7 +441,7 @@ TEST(CollideShapes, IdenticalVerticalTouchingSquares)
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(2));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, -2) * (Real(1) * Meter)); // bottom left
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, -2) * Meter); // bottom left
     EXPECT_EQ(manifold.GetPoint(0).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
@@ -450,7 +450,7 @@ TEST(CollideShapes, IdenticalVerticalTouchingSquares)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 3);
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(1));
-    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, -2) * (Real(1) * Meter)); // bottom right
+    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, -2) * Meter); // bottom right
     EXPECT_EQ(manifold.GetPoint(1).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).contactFeature.typeA, ContactFeature::e_face);
@@ -463,24 +463,24 @@ TEST(CollideShapes, IdenticalHorizontalTouchingSquares)
 {
     const auto dim = Real(2) * Meter;
     const auto shape = PolygonShape(dim, dim);
-    ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * (Real(1) * Meter)); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * (Real(1) * Meter)); // top right
-    ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * (Real(1) * Meter)); // top left
-    ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * (Real(1) * Meter)); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * Meter); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * Meter); // top right
+    ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * Meter); // top left
+    ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * Meter); // bottom left
 
     const auto xfm0 = Transformation{
-        Vec2{-2, 0} * (Real(1) * Meter),
+        Vec2{-2, 0} * Meter,
         UnitVec2::GetRight()
     }; // left
     const auto xfm1 = Transformation{
-        Vec2{+2, 0} * (Real(1) * Meter),
+        Vec2{+2, 0} * Meter,
         UnitVec2::GetRight()
     }; // right
     const auto manifold = CollideShapes(shape.GetChild(0), xfm0, shape.GetChild(0), xfm1);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(+2, 0) * (Real(1) * Meter));    
+    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(+2, 0) * Meter);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -489,7 +489,7 @@ TEST(CollideShapes, IdenticalHorizontalTouchingSquares)
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(2));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, +2) * (Real(1) * Meter)); // top left
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, +2) * Meter); // top left
     EXPECT_EQ(manifold.GetPoint(0).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
@@ -498,7 +498,7 @@ TEST(CollideShapes, IdenticalHorizontalTouchingSquares)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 2);
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(1));
-    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, -2) * (Real(1) * Meter)); // bottom left
+    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, -2) * Meter); // bottom left
     EXPECT_EQ(manifold.GetPoint(1).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).contactFeature.typeA, ContactFeature::e_face);
@@ -510,16 +510,16 @@ TEST(CollideShapes, IdenticalHorizontalTouchingSquares)
 TEST(CollideShapes, GetMaxSeparationFreeFunction1)
 {
     const auto rot0 = 45_deg;
-    const auto xfm0 = Transformation{Vec2{0, -2} * (Real(1) * Meter), UnitVec2::Get(rot0)}; // bottom
-    const auto xfm1 = Transformation{Vec2{0, +2} * (Real(1) * Meter), UnitVec2::GetRight()}; // top
+    const auto xfm0 = Transformation{Vec2{0, -2} * Meter, UnitVec2::Get(rot0)}; // bottom
+    const auto xfm1 = Transformation{Vec2{0, +2} * Meter, UnitVec2::GetRight()}; // top
     
     const auto dim = 2_m;
     const auto shape0 = PolygonShape(dim, dim);
     const auto shape1 = PolygonShape(dim, dim);
-    ASSERT_EQ(shape0.GetVertex(0), Vec2(+2, -2) * (Real(1) * Meter)); // bottom right
-    ASSERT_EQ(shape0.GetVertex(1), Vec2(+2, +2) * (Real(1) * Meter)); // top right
-    ASSERT_EQ(shape0.GetVertex(2), Vec2(-2, +2) * (Real(1) * Meter)); // top left
-    ASSERT_EQ(shape0.GetVertex(3), Vec2(-2, -2) * (Real(1) * Meter)); // bottom left
+    ASSERT_EQ(shape0.GetVertex(0), Vec2(+2, -2) * Meter); // bottom right
+    ASSERT_EQ(shape0.GetVertex(1), Vec2(+2, +2) * Meter); // top right
+    ASSERT_EQ(shape0.GetVertex(2), Vec2(-2, +2) * Meter); // top left
+    ASSERT_EQ(shape0.GetVertex(3), Vec2(-2, -2) * Meter); // bottom left
 
     // Rotate square A and put it below square B.
     // In ASCII art terms:
@@ -601,13 +601,13 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction2)
 {
     const auto dim = Real(2) * Meter;
     const auto shape = PolygonShape(dim, dim);
-    ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * (Real(1) * Meter)); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * (Real(1) * Meter)); // top right
-    ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * (Real(1) * Meter)); // top left
-    ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * (Real(1) * Meter)); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * Meter); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * Meter); // top right
+    ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * Meter); // top left
+    ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * Meter); // bottom left
 
-    const auto xfm0 = Transformation{Vec2{0, -1} * (Real(1) * Meter), UnitVec2::GetRight()}; // bottom
-    const auto xfm1 = Transformation{Vec2{0, +1} * (Real(1) * Meter), UnitVec2::GetRight()}; // top
+    const auto xfm0 = Transformation{Vec2{0, -1} * Meter, UnitVec2::GetRight()}; // bottom
+    const auto xfm1 = Transformation{Vec2{0, +1} * Meter, UnitVec2::GetRight()}; // top
     const auto totalRadius = shape.GetVertexRadius() * Real(2);
 
     const auto child0 = shape.GetChild(0);
@@ -644,14 +644,14 @@ TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
 
     // creates a square
     const auto shape = PolygonShape(dim, dim);
-    ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * (Real(1) * Meter)); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * (Real(1) * Meter)); // top right
-    ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * (Real(1) * Meter)); // top left
-    ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * (Real(1) * Meter)); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * Meter); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * Meter); // top right
+    ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * Meter); // top left
+    ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * Meter); // bottom left
     
     const auto rot0 = 45_deg;
-    const auto xfm0 = Transformation{Vec2{0, -2} * (Real(1) * Meter), UnitVec2::Get(rot0)}; // bottom
-    const auto xfm1 = Transformation{Vec2{0, +2} * (Real(1) * Meter), UnitVec2::GetRight()}; // top
+    const auto xfm0 = Transformation{Vec2{0, -2} * Meter, UnitVec2::Get(rot0)}; // bottom
+    const auto xfm1 = Transformation{Vec2{0, +2} * Meter, UnitVec2::GetRight()}; // top
     
     // Rotate square A and put it below square B.
     // In ASCII art terms:
@@ -683,7 +683,7 @@ TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
                 -1.0, 1.0/100000.0);
 
-    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(0, -2) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(0, -2) * Meter);
     
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(1));
     
@@ -726,10 +726,10 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
 {
     // Shape A: square
     const auto shape0 = PolygonShape(Real{2} * Meter, Real{2} * Meter);
-    ASSERT_EQ(shape0.GetVertex(0), Vec2(+2,-2) * (Real(1) * Meter)); // bottom right
-    ASSERT_EQ(shape0.GetVertex(1), Vec2(+2,+2) * (Real(1) * Meter)); // top right
-    ASSERT_EQ(shape0.GetVertex(2), Vec2(-2,+2) * (Real(1) * Meter)); // top left
-    ASSERT_EQ(shape0.GetVertex(3), Vec2(-2,-2) * (Real(1) * Meter)); // bottom left
+    ASSERT_EQ(shape0.GetVertex(0), Vec2(+2,-2) * Meter); // bottom right
+    ASSERT_EQ(shape0.GetVertex(1), Vec2(+2,+2) * Meter); // top right
+    ASSERT_EQ(shape0.GetVertex(2), Vec2(-2,+2) * Meter); // top left
+    ASSERT_EQ(shape0.GetVertex(3), Vec2(-2,-2) * Meter); // bottom left
     
     // Shape B: wide rectangle
     const auto shape1 = PolygonShape(Real{3} * Meter, Real{1.5f} * Meter);
@@ -739,11 +739,11 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
     ASSERT_EQ(shape1.GetVertex(3), Length2(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
 
     const auto xfm0 = Transformation{
-        Vec2{-2, 0} * (Real(1) * Meter),
+        Vec2{-2, 0} * Meter,
         UnitVec2::GetRight()
     }; // left
     const auto xfm1 = Transformation{
-        Vec2{+2, 0} * (Real(1) * Meter),
+        Vec2{+2, 0} * Meter,
         UnitVec2::GetRight()
     }; // right
     
@@ -765,7 +765,7 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(Real(+2), Real(0)) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(Real(+2), Real(0)) * Meter);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -774,7 +774,7 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(2));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(Real(-3.0), Real(+1.5)) * (Real(1) * Meter)); // top left shape B
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(Real(-3.0), Real(+1.5)) * Meter); // top left shape B
     EXPECT_EQ(manifold.GetPoint(0).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
@@ -783,7 +783,7 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 2);
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(1));
-    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(Real(-3.0), Real(-1.5)) * (Real(1) * Meter)); // bottom left shape B
+    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(Real(-3.0), Real(-1.5)) * Meter); // bottom left shape B
     EXPECT_EQ(manifold.GetPoint(1).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).contactFeature.typeA, ContactFeature::e_face);
@@ -825,11 +825,11 @@ TEST(CollideShapes, HorizontalOverlappingRects2)
     ASSERT_EQ(shape1.GetVertex(3), Length2(-Real(2) * Meter,-Real(2) * Meter)); // bottom left
     
     const auto xfm0 = Transformation{
-        Vec2{-2, 0} * (Real(1) * Meter),
+        Vec2{-2, 0} * Meter,
         UnitVec2::GetRight()
     }; // left
     const auto xfm1 = Transformation{
-        Vec2{+2, 0} * (Real(1) * Meter),
+        Vec2{+2, 0} * Meter,
         UnitVec2::GetRight()
     }; // right
 
@@ -838,7 +838,7 @@ TEST(CollideShapes, HorizontalOverlappingRects2)
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(Real(+3), Real(0)) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(Real(+3), Real(0)) * Meter);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))),
                 1.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))),
@@ -885,11 +885,11 @@ TEST(CollideShapes, HorizontalOverlappingRects2)
 
 TEST(CollideShapes, EdgeBelowPolygon)
 {
-    const auto p1 = Vec2(-1, 0) * (Real(1) * Meter);
-    const auto p2 = Vec2(+1, 0) * (Real(1) * Meter);
+    const auto p1 = Vec2(-1, 0) * Meter;
+    const auto p2 = Vec2(+1, 0) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{
-        Vec2{0, -1} * (Real(1) * Meter),
+        Vec2{0, -1} * Meter,
         UnitVec2::GetRight()
     };
 
@@ -914,7 +914,7 @@ TEST(CollideShapes, EdgeBelowPolygon)
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(2));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(-1, -1) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(-1, -1) * Meter);
     EXPECT_EQ(manifold.GetPoint(0).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
@@ -923,7 +923,7 @@ TEST(CollideShapes, EdgeBelowPolygon)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 3);
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(1));
-    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(+1, -1) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(+1, -1) * Meter);
     EXPECT_EQ(manifold.GetPoint(1).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).contactFeature.typeA, ContactFeature::e_face);
@@ -934,10 +934,10 @@ TEST(CollideShapes, EdgeBelowPolygon)
 
 TEST(CollideShapes, EdgeAbovePolygon)
 {
-    const auto p1 = Vec2(-1, 0) * (Real(1) * Meter);
-    const auto p2 = Vec2(+1, 0) * (Real(1) * Meter);
+    const auto p1 = Vec2(-1, 0) * Meter;
+    const auto p2 = Vec2(+1, 0) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Vec2{0, +1} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation{Vec2{0, +1} * Meter, UnitVec2::GetRight()};
     
     const auto hx = Real(1) * Meter;
     const auto hy = Real(1) * Meter;
@@ -957,7 +957,7 @@ TEST(CollideShapes, EdgeAbovePolygon)
     EXPECT_EQ(manifold.GetPointCount(), Manifold::size_type(2));
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(0));
-    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(+1, +1) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetPoint(0).localPoint, Vec2(+1, +1) * Meter);
     EXPECT_EQ(manifold.GetPoint(0).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.typeA, ContactFeature::e_face);
@@ -966,7 +966,7 @@ TEST(CollideShapes, EdgeAbovePolygon)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 1);
     
     ASSERT_GT(manifold.GetPointCount(), Manifold::size_type(1));
-    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(-1, +1) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetPoint(1).localPoint, Vec2(-1, +1) * Meter);
     EXPECT_EQ(manifold.GetPoint(1).normalImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).tangentImpulse, Momentum(0));
     EXPECT_EQ(manifold.GetPoint(1).contactFeature.typeA, ContactFeature::e_face);
@@ -977,10 +977,10 @@ TEST(CollideShapes, EdgeAbovePolygon)
 
 TEST(CollideShapes, EdgeLeftOfPolygon)
 {
-    const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -1) * Meter;
+    const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Vec2{-1, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation{Vec2{-1, 0} * Meter, UnitVec2::GetRight()};
     
     const auto hx = Real(1) * Meter;
     const auto hy = Real(1) * Meter;
@@ -1002,10 +1002,10 @@ TEST(CollideShapes, EdgeLeftOfPolygon)
 
 TEST(CollideShapes, EdgeRightOfPolygon)
 {
-    const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -1) * Meter;
+    const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
-    const auto edge_xfm = Transformation{Vec2{+1, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
     
     const auto hx = Real(1) * Meter;
     const auto hy = Real(1) * Meter;
@@ -1027,8 +1027,8 @@ TEST(CollideShapes, EdgeRightOfPolygon)
 
 TEST(CollideShapes, EdgeInsideSquare)
 {
-    const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -1) * Meter;
+    const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto s = Real(1) * Meter;
@@ -1052,8 +1052,8 @@ TEST(CollideShapes, EdgeInsideSquare)
 
 TEST(CollideShapes, EdgeTwiceInsideSquare)
 {
-    const auto p1 = Vec2(0, -2) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +2) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -2) * Meter;
+    const auto p2 = Vec2(0, +2) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto s = Real(1) * Meter;
@@ -1077,8 +1077,8 @@ TEST(CollideShapes, EdgeTwiceInsideSquare)
 
 TEST(CollideShapes, EdgeHalfInsideSquare)
 {
-    const auto p1 = Vec2(0, -0.5) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +0.5) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -0.5) * Meter;
+    const auto p2 = Vec2(0, +0.5) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto s = Real(1) * Meter;
@@ -1102,8 +1102,8 @@ TEST(CollideShapes, EdgeHalfInsideSquare)
 
 TEST(CollideShapes, EdgeR90InsideSquare)
 {
-    const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -1) * Meter;
+    const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetTop()};
     const auto s = Real(1) * Meter;
@@ -1158,8 +1158,8 @@ TEST(CollideShapes, EdgeR90InsideSquare)
 
 TEST(CollideShapes, EdgeR45InsideSquare)
 {
-    const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -1) * Meter;
+    const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::Get(45_deg)};
     const auto s = Real(1) * Meter;
@@ -1201,8 +1201,8 @@ TEST(CollideShapes, EdgeR45InsideSquare)
 
 TEST(CollideShapes, EdgeR180InsideSquare)
 {
-    const auto p1 = Vec2(0, -1) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +1) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -1) * Meter;
+    const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetLeft()};
     const auto s = Real(1) * Meter;
@@ -1261,11 +1261,11 @@ TEST(CollideShapes, EdgeR180InsideSquare)
 
 TEST(CollideShapes, EdgeTwiceR180Square)
 {
-    const auto p1 = Vec2(0, -2) * (Real(1) * Meter);
-    const auto p2 = Vec2(0, +2) * (Real(1) * Meter);
+    const auto p1 = Vec2(0, -2) * Meter;
+    const auto p2 = Vec2(0, +2) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{
-        Vec2{0, 1} * (Real(1) * Meter),
+        Vec2{0, 1} * Meter,
         UnitVec2::GetLeft()
     };
     const auto s = Real(1) * Meter;
@@ -1323,16 +1323,16 @@ TEST(CollideShapes, EdgeTwiceR180Square)
 
 TEST(CollideShapes, EdgeFooTriangle)
 {
-    const auto p1 = Vec2(2, -2) * (Real(1) * Meter);
-    const auto p2 = Vec2(-2, +2) * (Real(1) * Meter);
+    const auto p1 = Vec2(2, -2) * Meter;
+    const auto p2 = Vec2(-2, +2) * Meter;
     const auto edge_shape = EdgeShape(p2, p1,
                                       EdgeShape::Conf{}.UseVertexRadius(Real(0) * Meter));
     const auto edge_xfm = Transformation{Vec2(0, 0.5) * Meter, UnitVec2::Get(-5_deg)};
     auto polygon_shape = PolygonShape{};
     polygon_shape.SetVertexRadius(Real{0} * Meter);
-    const auto triangleTopPt = Vec2{0, +1} * (Real(1) * Meter);
-    const auto triangleLeftPt = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto triangleRightPt = Vec2{+1, -1} * (Real(1) * Meter);
+    const auto triangleTopPt = Vec2{0, +1} * Meter;
+    const auto triangleLeftPt = Vec2{-1, -1} * Meter;
+    const auto triangleRightPt = Vec2{+1, -1} * Meter;
     polygon_shape.Set({triangleLeftPt, triangleRightPt, triangleTopPt});
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1352,17 +1352,17 @@ TEST(CollideShapes, EdgePolygonFaceB1)
 {
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = 0;
-    const auto edge_shape = EdgeShape(Vec2(6, 8) * (Real(1) * Meter), Vec2(7, 8) * (Real(1) * Meter), conf);
+    const auto edge_shape = EdgeShape(Vec2(6, 8) * Meter, Vec2(7, 8) * Meter, conf);
     const auto edge_xfm = Transformation{Length2{}, GetUnitVector(Vec2(Real(0.707106769), Real(0.707106769)))};
     const auto poly_shape = PolygonShape({
-        Vec2(0.5, 0) * (Real(1) * Meter),
-        Vec2(0.249999985f, 0.433012724f) * (Real(1) * Meter),
-        Vec2(-0.25000003f, 0.433012694f) * (Real(1) * Meter),
-        Vec2(-0.5f, -0.0000000437113883f) * (Real(1) * Meter),
-        Vec2(-0.249999955f, -0.433012724f) * (Real(1) * Meter),
-        Vec2(0.249999955f, -0.433012724f) * (Real(1) * Meter)
+        Vec2(0.5, 0) * Meter,
+        Vec2(0.249999985f, 0.433012724f) * Meter,
+        Vec2(-0.25000003f, 0.433012694f) * Meter,
+        Vec2(-0.5f, -0.0000000437113883f) * Meter,
+        Vec2(-0.249999955f, -0.433012724f) * Meter,
+        Vec2(0.249999955f, -0.433012724f) * Meter
     });
-    const auto poly_xfm = Transformation{Vec2(-0.797443091f, 11.0397148f) * (Real(1) * Meter), GetUnitVector(Vec2(1, 0))};
+    const auto poly_xfm = Transformation{Vec2(-0.797443091f, 11.0397148f) * Meter, GetUnitVector(Vec2(1, 0))};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, poly_shape.GetChild(0), poly_xfm);
     
@@ -1384,15 +1384,15 @@ TEST(CollideShapes, EdgePolygonFaceB2)
 {
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Real{0.000199999995f} * Meter;
-    const auto edge_shape = EdgeShape(Vec2(-6, 2) * (Real(1) * Meter), Vec2(-6, 0) * (Real(1) * Meter), conf);
-    const auto edge_xfm = Transformation{Vec2(-9.99999904f, 4.0f) * (Real(1) * Meter), GetUnitVector(Vec2(Real(1), Real(0)))};
+    const auto edge_shape = EdgeShape(Vec2(-6, 2) * Meter, Vec2(-6, 0) * Meter, conf);
+    const auto edge_xfm = Transformation{Vec2(-9.99999904f, 4.0f) * Meter, GetUnitVector(Vec2(Real(1), Real(0)))};
     const auto poly_shape = PolygonShape({
-        Vec2(0.5f, -0.5f) * (Real(1) * Meter),
-        Vec2(0.5f, 0.5f) * (Real(1) * Meter),
-        Vec2(-0.5f, 0.5f) * (Real(1) * Meter),
+        Vec2(0.5f, -0.5f) * Meter,
+        Vec2(0.5f, 0.5f) * Meter,
+        Vec2(-0.5f, 0.5f) * Meter,
         Length2{}
     });
-    const auto poly_xfm = Transformation{Vec2(-16.0989342f, 3.49960017f) * (Real(1) * Meter), GetUnitVector(Vec2(1, 0))};
+    const auto poly_xfm = Transformation{Vec2(-16.0989342f, 3.49960017f) * Meter, GetUnitVector(Vec2(1, 0))};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), edge_xfm, poly_shape.GetChild(0), poly_xfm);
     
@@ -1425,14 +1425,14 @@ TEST(CollideShapes, EdgeOverlapsItself)
 
 TEST(CollideShapes, R0EdgeCollinearAndTouchingR0Edge)
 {
-    const auto p1 = Vec2(-1, 0) * (Real(1) * Meter);
-    const auto p2 = Vec2(+1, 0) * (Real(1) * Meter);
+    const auto p1 = Vec2(-1, 0) * Meter;
+    const auto p2 = Vec2(+1, 0) * Meter;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = 0;
     auto edge_shape = EdgeShape(conf);
     edge_shape.Set(p1, p2);
-    const auto xfm1 = Transformation{Vec2{+1, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{+3, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto xfm1 = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation{Vec2{+3, 0} * Meter, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), xfm1, edge_shape.GetChild(0), xfm2);
     
@@ -1443,19 +1443,19 @@ TEST(CollideShapes, R0EdgeCollinearAndTouchingR0Edge)
         EXPECT_NEAR(static_cast<double>(StripUnit(GetX(manifold.GetLocalNormal()))),  0.0, 0.001);
         EXPECT_NEAR(static_cast<double>(StripUnit(GetY(manifold.GetLocalNormal()))), -1.0, 0.001);
     }
-    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(1, 0) * (Real(1) * Meter));
+    EXPECT_EQ(manifold.GetLocalPoint(), Vec2(1, 0) * Meter);
 }
 
 TEST(CollideShapes, R1EdgeCollinearAndTouchingR1Edge)
 {
-    const auto p1 = Vec2(-1, 0) * (Real(1) * Meter);
-    const auto p2 = Vec2(+1, 0) * (Real(1) * Meter);
+    const auto p1 = Vec2(-1, 0) * Meter;
+    const auto p2 = Vec2(+1, 0) * Meter;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Real{1} * Meter;
     auto edge_shape = EdgeShape(conf);
     edge_shape.Set(p1, p2);
-    const auto xfm1 = Transformation{Vec2{+1, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{+5, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto xfm1 = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation{Vec2{+5, 0} * Meter, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), xfm1, edge_shape.GetChild(0), xfm2);
 
@@ -1467,14 +1467,14 @@ TEST(CollideShapes, R1EdgeCollinearAndTouchingR1Edge)
 
 TEST(CollideShapes, R0EdgeCollinearAndSeparateFromR0Edge)
 {
-    const auto p1 = Vec2(-1, 0) * (Real(1) * Meter);
-    const auto p2 = Vec2(+1, 0) * (Real(1) * Meter);
+    const auto p1 = Vec2(-1, 0) * Meter;
+    const auto p2 = Vec2(+1, 0) * Meter;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = 0;
     auto edge_shape = EdgeShape(conf);
     edge_shape.Set(p1, p2);
-    const auto xfm1 = Transformation{Vec2{+1, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{+4, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto xfm1 = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation{Vec2{+4, 0} * Meter, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), xfm1, edge_shape.GetChild(0), xfm2);
     
@@ -1483,14 +1483,14 @@ TEST(CollideShapes, R0EdgeCollinearAndSeparateFromR0Edge)
 
 TEST(CollideShapes, R0EdgeParallelAndSeparateFromR0Edge)
 {
-    const auto p1 = Vec2(-1, 0) * (Real(1) * Meter);
-    const auto p2 = Vec2(+1, 0) * (Real(1) * Meter);
+    const auto p1 = Vec2(-1, 0) * Meter;
+    const auto p2 = Vec2(+1, 0) * Meter;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = 0;
     auto edge_shape = EdgeShape(conf);
     edge_shape.Set(p1, p2);
-    const auto xfm1 = Transformation{Vec2{-4, 1} * (Real(1) * Meter), UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{-4, 0} * (Real(1) * Meter), UnitVec2::GetRight()};
+    const auto xfm1 = Transformation{Vec2{-4, 1} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation{Vec2{-4, 0} * Meter, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(edge_shape.GetChild(0), xfm1, edge_shape.GetChild(0), xfm2);
     
@@ -1499,8 +1499,8 @@ TEST(CollideShapes, R0EdgeParallelAndSeparateFromR0Edge)
 
 TEST(CollideShapes, R0EdgePerpendicularCrossingFromR0Edge)
 {
-    const auto p1 = Vec2(-1, 0) * (Real(1) * Meter);
-    const auto p2 = Vec2(+1, 0) * (Real(1) * Meter);
+    const auto p1 = Vec2(-1, 0) * Meter;
+    const auto p2 = Vec2(+1, 0) * Meter;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = 0;
     auto edge_shape = EdgeShape(conf);

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -28,7 +28,7 @@ using namespace playrho;
 
 TEST(CollideShapes, IdenticalOverlappingCircles)
 {
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto shape = DiskShape{radius};
     const auto position = Vec2{11, -4} * Meter;
     const auto xfm = Transformation{position, UnitVec2::GetRight()};
@@ -52,8 +52,8 @@ TEST(CollideShapes, IdenticalOverlappingCircles)
 
 TEST(CollideShapes, CircleCircleOrientedHorizontally)
 {
-    const auto r1 = Real(1) * Meter;
-    const auto r2 = Real(1) * Meter;
+    const auto r1 = 1_m;
+    const auto r2 = 1_m;
     const auto s1 = DiskShape{r1};
     const auto s2 = DiskShape{r2};
     const auto p1 = Vec2{11, -4} * Meter;
@@ -80,8 +80,8 @@ TEST(CollideShapes, CircleCircleOrientedHorizontally)
 
 TEST(CollideShapes, CircleCircleOrientedVertically)
 {
-    const auto r1 = Real(1) * Meter;
-    const auto r2 = Real(1) * Meter;
+    const auto r1 = 1_m;
+    const auto r2 = 1_m;
     const auto s1 = DiskShape{r1};
     const auto s2 = DiskShape{r2};
     const auto p1 = Vec2{7, -2} * Meter;
@@ -110,7 +110,7 @@ TEST(CollideShapes, CircleCircleOrientedVertically)
 
 TEST(CollideShapes, CircleTouchingTrianglePointBelow)
 {
-    const auto circleRadius = Real(1) * Meter;
+    const auto circleRadius = 1_m;
     const auto circle = DiskShape(circleRadius);
     const auto triangleTopPt = Vec2{0, +1} * Meter;
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
@@ -140,7 +140,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointBelow)
 
 TEST(CollideShapes, CircleTouchingTrianglePointLeft)
 {
-    const auto circleRadius = Real(1) * Meter;
+    const auto circleRadius = 1_m;
     const auto circle = DiskShape(circleRadius);
     const auto triangleTopPt = Vec2{0, +1} * Meter;
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
@@ -170,7 +170,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointLeft)
 
 TEST(CollideShapes, CircleTouchingTrianglePointRight)
 {
-    const auto circleRadius = Real(1) * Meter;
+    const auto circleRadius = 1_m;
     const auto circle = DiskShape(circleRadius);
     const auto triangleTopPt = Vec2{0, +1} * Meter;
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
@@ -197,7 +197,7 @@ TEST(CollideShapes, CircleTouchingTrianglePointRight)
 
 TEST(CollideShapes, CircleJustPastTrianglePointRightDoesntCollide)
 {
-    const auto circleRadius = Real(1) * Meter;
+    const auto circleRadius = 1_m;
     const auto circle = DiskShape(circleRadius);
     const auto triangleTopPt = Vec2{0, +1} * Meter;
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
@@ -222,7 +222,7 @@ TEST(CollideShapes, CircleJustPastTrianglePointRightDoesntCollide)
 
 TEST(CollideShapes, CircleOverRightFaceOfTriangle)
 {
-    const auto circleRadius = Real(1) * Meter;
+    const auto circleRadius = 1_m;
     const auto circle = DiskShape(circleRadius);
     const auto triangleTopPt = Vec2{0, +1} * Meter;
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
@@ -258,7 +258,7 @@ TEST(CollideShapes, CircleOverRightFaceOfTriangle)
 
 TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
 {
-    const auto circleRadius = Real(1) * Meter;
+    const auto circleRadius = 1_m;
     const auto circle = DiskShape(circleRadius);
     const auto triangle = PolygonShape({Vec2{-1, -1} * Meter, Vec2{+1, -1} * Meter, Vec2{0, +1} * Meter});
     const auto circleXfm = Transformation{
@@ -291,7 +291,7 @@ TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
 
 TEST(CollideShapes, TallRectangleLeftCircleRight)
 {
-    const auto r2 = Real(1) * Meter;
+    const auto r2 = 1_m;
     const auto hx = Real(2.2);
     const auto hy = Real(4.8);
 
@@ -413,7 +413,7 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim2)
 
 TEST(CollideShapes, IdenticalVerticalTouchingSquares)
 {
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     ASSERT_EQ(shape.GetVertex(0), (Vec2{+2, -2} * Meter)); // bottom right
     ASSERT_EQ(shape.GetVertex(1), (Vec2{+2, +2} * Meter)); // top right
@@ -461,7 +461,7 @@ TEST(CollideShapes, IdenticalVerticalTouchingSquares)
 
 TEST(CollideShapes, IdenticalHorizontalTouchingSquares)
 {
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * Meter); // bottom right
     ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * Meter); // top right
@@ -599,7 +599,7 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction1)
 
 TEST(CollideShapes, GetMaxSeparationFreeFunction2)
 {
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     ASSERT_EQ(shape.GetVertex(0), Vec2(+2, -2) * Meter); // bottom right
     ASSERT_EQ(shape.GetVertex(1), Vec2(+2, +2) * Meter); // top right
@@ -640,7 +640,7 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction2)
 
 TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
 {
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
 
     // creates a square
     const auto shape = PolygonShape(dim, dim);
@@ -701,7 +701,7 @@ TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
     EXPECT_EQ(manifold.GetPoint(0).contactFeature.indexB, 3); // Shape B bottom edge
     
     // Also check things in terms of world coordinates...
-    const auto world_manifold = GetWorldManifold(manifold, xfm0, Real(0) * Meter, xfm1, Real(0) * Meter);
+    const auto world_manifold = GetWorldManifold(manifold, xfm0, 0_m, xfm1, 0_m);
     EXPECT_EQ(world_manifold.GetPointCount(), manifold.GetPointCount());
     
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(world_manifold.GetNormal()))),
@@ -715,9 +715,9 @@ TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
     
     ASSERT_GT(world_manifold.GetPointCount(), Manifold::size_type(0));
     EXPECT_NEAR(double(Real{GetX(world_manifold.GetPoint(0)) / Meter}),
-                double(Real{GetX(corner_point) / (Real{2} * Meter)}), 0.04);
+                double(Real{GetX(corner_point) / (2_m)}), 0.04);
     EXPECT_NEAR(double(Real{GetY(world_manifold.GetPoint(0)) / Meter}),
-                double(Real{GetY(corner_point) / (Real{2} * Meter)}), 0.04);
+                double(Real{GetY(corner_point) / (2_m)}), 0.04);
     EXPECT_NEAR(double(Real{world_manifold.GetSeparation(0) / Meter}),
                 double(Real{GetY(-corner_point) / Meter}), 0.008);
 }
@@ -725,14 +725,14 @@ TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
 TEST(CollideShapes, HorizontalOverlappingRects1)
 {
     // Shape A: square
-    const auto shape0 = PolygonShape(Real{2} * Meter, Real{2} * Meter);
+    const auto shape0 = PolygonShape(2_m, 2_m);
     ASSERT_EQ(shape0.GetVertex(0), Vec2(+2,-2) * Meter); // bottom right
     ASSERT_EQ(shape0.GetVertex(1), Vec2(+2,+2) * Meter); // top right
     ASSERT_EQ(shape0.GetVertex(2), Vec2(-2,+2) * Meter); // top left
     ASSERT_EQ(shape0.GetVertex(3), Vec2(-2,-2) * Meter); // bottom left
     
     // Shape B: wide rectangle
-    const auto shape1 = PolygonShape(Real{3} * Meter, Real{1.5f} * Meter);
+    const auto shape1 = PolygonShape(3_m, Real{1.5f} * Meter);
     ASSERT_EQ(shape1.GetVertex(0), Length2(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
     ASSERT_EQ(shape1.GetVertex(1), Length2(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
     ASSERT_EQ(shape1.GetVertex(2), Length2(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
@@ -811,18 +811,18 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
 TEST(CollideShapes, HorizontalOverlappingRects2)
 {
     // Shape A: wide rectangle
-    const auto shape0 = PolygonShape(Real{3} * Meter, Real{1.5f} * Meter);
+    const auto shape0 = PolygonShape(3_m, Real{1.5f} * Meter);
     ASSERT_EQ(shape0.GetVertex(0), Length2(Real(+3.0) * Meter, Real(-1.5) * Meter)); // bottom right
     ASSERT_EQ(shape0.GetVertex(1), Length2(Real(+3.0) * Meter, Real(+1.5) * Meter)); // top right
     ASSERT_EQ(shape0.GetVertex(2), Length2(Real(-3.0) * Meter, Real(+1.5) * Meter)); // top left
     ASSERT_EQ(shape0.GetVertex(3), Length2(Real(-3.0) * Meter, Real(-1.5) * Meter)); // bottom left
     
     // Shape B: square
-    const auto shape1 = PolygonShape(Real{2} * Meter, Real{2} * Meter);
-    ASSERT_EQ(shape1.GetVertex(0), Length2(+Real(2) * Meter,-Real(2) * Meter)); // bottom right
-    ASSERT_EQ(shape1.GetVertex(1), Length2(+Real(2) * Meter,+Real(2) * Meter)); // top right
-    ASSERT_EQ(shape1.GetVertex(2), Length2(-Real(2) * Meter,+Real(2) * Meter)); // top left
-    ASSERT_EQ(shape1.GetVertex(3), Length2(-Real(2) * Meter,-Real(2) * Meter)); // bottom left
+    const auto shape1 = PolygonShape(2_m, 2_m);
+    ASSERT_EQ(shape1.GetVertex(0), Length2(+2_m,-2_m)); // bottom right
+    ASSERT_EQ(shape1.GetVertex(1), Length2(+2_m,+2_m)); // top right
+    ASSERT_EQ(shape1.GetVertex(2), Length2(-2_m,+2_m)); // top left
+    ASSERT_EQ(shape1.GetVertex(3), Length2(-2_m,-2_m)); // bottom left
     
     const auto xfm0 = Transformation{
         Vec2{-2, 0} * Meter,
@@ -893,8 +893,8 @@ TEST(CollideShapes, EdgeBelowPolygon)
         UnitVec2::GetRight()
     };
 
-    const auto hx = Real(1) * Meter;
-    const auto hy = Real(1) * Meter;
+    const auto hx = 1_m;
+    const auto hy = 1_m;
     const auto polygon_shape = PolygonShape(hx, hy);
     const auto polygon_xfm = Transformation{
         Length2{},
@@ -939,8 +939,8 @@ TEST(CollideShapes, EdgeAbovePolygon)
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Vec2{0, +1} * Meter, UnitVec2::GetRight()};
     
-    const auto hx = Real(1) * Meter;
-    const auto hy = Real(1) * Meter;
+    const auto hx = 1_m;
+    const auto hy = 1_m;
     const auto polygon_shape = PolygonShape(hx, hy);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -982,8 +982,8 @@ TEST(CollideShapes, EdgeLeftOfPolygon)
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Vec2{-1, 0} * Meter, UnitVec2::GetRight()};
     
-    const auto hx = Real(1) * Meter;
-    const auto hy = Real(1) * Meter;
+    const auto hx = 1_m;
+    const auto hy = 1_m;
     const auto polygon_shape = PolygonShape(hx, hy);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1007,8 +1007,8 @@ TEST(CollideShapes, EdgeRightOfPolygon)
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
     
-    const auto hx = Real(1) * Meter;
-    const auto hy = Real(1) * Meter;
+    const auto hx = 1_m;
+    const auto hy = 1_m;
     const auto polygon_shape = PolygonShape(hx, hy);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1031,7 +1031,7 @@ TEST(CollideShapes, EdgeInsideSquare)
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
-    const auto s = Real(1) * Meter;
+    const auto s = 1_m;
     const auto polygon_shape = PolygonShape(s, s);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1056,7 +1056,7 @@ TEST(CollideShapes, EdgeTwiceInsideSquare)
     const auto p2 = Vec2(0, +2) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
-    const auto s = Real(1) * Meter;
+    const auto s = 1_m;
     const auto polygon_shape = PolygonShape(s, s);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1081,7 +1081,7 @@ TEST(CollideShapes, EdgeHalfInsideSquare)
     const auto p2 = Vec2(0, +0.5) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
-    const auto s = Real(1) * Meter;
+    const auto s = 1_m;
     const auto polygon_shape = PolygonShape(s, s);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1106,7 +1106,7 @@ TEST(CollideShapes, EdgeR90InsideSquare)
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetTop()};
-    const auto s = Real(1) * Meter;
+    const auto s = 1_m;
     const auto polygon_shape = PolygonShape(s, s);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1162,7 +1162,7 @@ TEST(CollideShapes, EdgeR45InsideSquare)
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::Get(45_deg)};
-    const auto s = Real(1) * Meter;
+    const auto s = 1_m;
     const auto polygon_shape = PolygonShape(s, s);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1205,7 +1205,7 @@ TEST(CollideShapes, EdgeR180InsideSquare)
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShape(p1, p2);
     const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetLeft()};
-    const auto s = Real(1) * Meter;
+    const auto s = 1_m;
     const auto polygon_shape = PolygonShape(s, s);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1268,7 +1268,7 @@ TEST(CollideShapes, EdgeTwiceR180Square)
         Vec2{0, 1} * Meter,
         UnitVec2::GetLeft()
     };
-    const auto s = Real(1) * Meter;
+    const auto s = 1_m;
     const auto polygon_shape = PolygonShape(s, s);
     const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     
@@ -1326,10 +1326,10 @@ TEST(CollideShapes, EdgeFooTriangle)
     const auto p1 = Vec2(2, -2) * Meter;
     const auto p2 = Vec2(-2, +2) * Meter;
     const auto edge_shape = EdgeShape(p2, p1,
-                                      EdgeShape::Conf{}.UseVertexRadius(Real(0) * Meter));
+                                      EdgeShape::Conf{}.UseVertexRadius(0_m));
     const auto edge_xfm = Transformation{Vec2(0, 0.5) * Meter, UnitVec2::Get(-5_deg)};
     auto polygon_shape = PolygonShape{};
-    polygon_shape.SetVertexRadius(Real{0} * Meter);
+    polygon_shape.SetVertexRadius(0_m);
     const auto triangleTopPt = Vec2{0, +1} * Meter;
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
     const auto triangleRightPt = Vec2{+1, -1} * Meter;
@@ -1451,7 +1451,7 @@ TEST(CollideShapes, R1EdgeCollinearAndTouchingR1Edge)
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
     auto conf = EdgeShape::Conf{};
-    conf.vertexRadius = Real{1} * Meter;
+    conf.vertexRadius = 1_m;
     auto edge_shape = EdgeShape(conf);
     edge_shape.Set(p1, p2);
     const auto xfm1 = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -35,7 +35,7 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
     const auto old_vA = Velocity{LinearVelocity2{}, Angle{0} / 1_s};
     const auto old_vB = Velocity{LinearVelocity2{}, Angle{0} / 1_s};
 
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
     const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
@@ -55,7 +55,7 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
         lcB, old_pB, old_vB
     };
-    const auto pc = PositionConstraint{manifold, bA, Real{0} * Meter, bB, Real{0} * Meter};
+    const auto pc = PositionConstraint{manifold, bA, 0_m, bB, 0_m};
     
     const auto conf = ConstraintSolverConf{};
     const auto solution = GaussSeidel::SolvePositionConstraint(pc, true, true, conf);
@@ -78,7 +78,7 @@ TEST(ContactSolver, SolvePosConstraintsForVerTouchingDoesntMove)
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
     
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
     const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
@@ -116,7 +116,7 @@ TEST(ContactSolver, SolvePosConstraintsForVerTouchingDoesntMove)
 
 TEST(ContactSolver, SolvePosConstraintsForOverlappingZeroRateDoesntMove)
 {
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto xfmB = Transformation{Length2{}, UnitVec2::GetRight()};
@@ -170,7 +170,7 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly1)
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
     
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
     const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
@@ -224,7 +224,7 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly2)
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
     const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
@@ -278,7 +278,7 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly1)
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
     const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
@@ -344,7 +344,7 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
     const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
@@ -403,7 +403,7 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
 
 TEST(ContactSolver, SolvePosConstraintsForPerfectlyOverlappingSquares)
 {
-    const auto dim = Real(2) * Meter;
+    const auto dim = 2_m;
     const auto shape = PolygonShape(dim, dim);
     const auto xfmA = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto xfmB = Transformation{Length2{}, UnitVec2::GetRight()};

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -30,8 +30,8 @@ static constexpr auto Baumgarte = Real{2} / Real{10};
 
 TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 {
-    const auto old_pA = Position{Vec2{-2, 0} * (Real(1) * Meter), Angle{0}};
-    const auto old_pB = Position{Vec2{+2, 0} * (Real(1) * Meter), Angle{0}};
+    const auto old_pA = Position{Vec2{-2, 0} * Meter, Angle{0}};
+    const auto old_pB = Position{Vec2{+2, 0} * Meter, Angle{0}};
     const auto old_vA = Velocity{LinearVelocity2{}, Angle{0} / 1_s};
     const auto old_vB = Velocity{LinearVelocity2{}, Angle{0} / 1_s};
 
@@ -73,8 +73,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 
 TEST(ContactSolver, SolvePosConstraintsForVerTouchingDoesntMove)
 {
-    const auto old_pA = Position{Vec2{0, -2} * (Real(1) * Meter), Angle{0}};
-    const auto old_pB = Position{Vec2{0, +2} * (Real(1) * Meter), Angle{0}};
+    const auto old_pA = Position{Vec2{0, -2} * Meter, Angle{0}};
+    const auto old_pB = Position{Vec2{0, +2} * Meter, Angle{0}};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
     
@@ -164,8 +164,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly1)
     const auto ctr_x = Real(100);
     
     // square A is left of square B
-    const auto old_pA = Position{Vec2{ctr_x - 1, 0} * (Real(1) * Meter), Angle{0}};
-    const auto old_pB = Position{Vec2{ctr_x + 1, 0} * (Real(1) * Meter), Angle{0}};
+    const auto old_pA = Position{Vec2{ctr_x - 1, 0} * Meter, Angle{0}};
+    const auto old_pB = Position{Vec2{ctr_x + 1, 0} * Meter, Angle{0}};
 
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
@@ -178,10 +178,10 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly1)
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))), +1.0, 0.00001);
     ASSERT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))), +0.0, 0.00001);
-    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(+2, 0) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(+2, 0) * Meter);
     ASSERT_EQ(manifold.GetPointCount(), 2);
-    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, +2) * (Real(1) * Meter));
-    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, -2) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, +2) * Meter);
+    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, -2) * Meter);
     
     const auto lcA = Length2{};
     const auto lcB = Length2{};
@@ -219,8 +219,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly2)
     const auto ctr_x = Real(100);
     
     // square A is right of square B
-    const auto old_pA = Position{Vec2{ctr_x + 1, 0} * (Real(1) * Meter), Angle{0}};
-    const auto old_pB = Position{Vec2{ctr_x - 1, 0} * (Real(1) * Meter), Angle{0}};
+    const auto old_pA = Position{Vec2{ctr_x + 1, 0} * Meter, Angle{0}};
+    const auto old_pB = Position{Vec2{ctr_x - 1, 0} * Meter, Angle{0}};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
@@ -232,10 +232,10 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly2)
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))), -1.0, 0.00001);
     ASSERT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))), +0.0, 0.00001);
-    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(-2, 0) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(-2, 0) * Meter);
     ASSERT_EQ(manifold.GetPointCount(), 2);
-    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(+2, -2) * (Real(1) * Meter));
-    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, +2) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(+2, -2) * Meter);
+    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, +2) * Meter);
     
     const auto lcA = Length2{};
     const auto lcB = Length2{};
@@ -273,8 +273,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly1)
     const auto ctr_y = Real(100);
     
     // square A is below square B
-    const auto old_pA = Position{Vec2{0, ctr_y - 1} * (Real(1) * Meter), Angle{0}};
-    const auto old_pB = Position{Vec2{0, ctr_y + 1} * (Real(1) * Meter), Angle{0}};
+    const auto old_pA = Position{Vec2{0, ctr_y - 1} * Meter, Angle{0}};
+    const auto old_pB = Position{Vec2{0, ctr_y + 1} * Meter, Angle{0}};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
@@ -286,10 +286,10 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly1)
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))), +0.0, 0.00001);
     ASSERT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))), +1.0, 0.00001);
-    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(0, 2) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(0, 2) * Meter);
     ASSERT_EQ(manifold.GetPointCount(), 2);
-    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, -2) * (Real(1) * Meter));
-    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, -2) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, -2) * Meter);
+    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, -2) * Meter);
     
     const auto lcA = Length2{};
     const auto lcB = Length2{};
@@ -339,8 +339,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
     const auto ctr_y = Real(100);
 
     // square A is above square B
-    const auto old_pA = Position{Vec2{0, ctr_y + 1} * (Real(1) * Meter), Angle{0}};
-    const auto old_pB = Position{Vec2{0, ctr_y - 1} * (Real(1) * Meter), Angle{0}};
+    const auto old_pA = Position{Vec2{0, ctr_y + 1} * Meter, Angle{0}};
+    const auto old_pB = Position{Vec2{0, ctr_y - 1} * Meter, Angle{0}};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
@@ -353,10 +353,10 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))), +0.0, 0.00001);
     ASSERT_NEAR(static_cast<double>(GetY(GetVec2(manifold.GetLocalNormal()))), -1.0, 0.00001);
-    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(0, -2) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetLocalPoint(), Vec2(0, -2) * Meter);
     ASSERT_EQ(manifold.GetPointCount(), 2);
-    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(+2, +2) * (Real(1) * Meter));
-    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, +2) * (Real(1) * Meter));
+    ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(+2, +2) * Meter);
+    ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, +2) * Meter);
     
     const auto lcA = Length2{};
     const auto lcB = Length2{};

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -32,8 +32,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 {
     const auto old_pA = Position{Vec2{-2, 0} * (Real(1) * Meter), Angle{0}};
     const auto old_pB = Position{Vec2{+2, 0} * (Real(1) * Meter), Angle{0}};
-    const auto old_vA = Velocity{LinearVelocity2D{}, Angle{0} / 1_s};
-    const auto old_vB = Velocity{LinearVelocity2D{}, Angle{0} / 1_s};
+    const auto old_vA = Velocity{LinearVelocity2{}, Angle{0} / 1_s};
+    const auto old_vB = Velocity{LinearVelocity2{}, Angle{0} / 1_s};
 
     const auto dim = Real(2) * Meter;
     const auto shape = PolygonShape(dim, dim);
@@ -43,8 +43,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
 
-    const auto lcA = Length2D{};
-    const auto lcB = Length2D{};
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
@@ -86,8 +86,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerTouchingDoesntMove)
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
     
-    const auto lcA = Length2D{};
-    const auto lcB = Length2D{};
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
@@ -118,16 +118,16 @@ TEST(ContactSolver, SolvePosConstraintsForOverlappingZeroRateDoesntMove)
 {
     const auto dim = Real(2) * Meter;
     const auto shape = PolygonShape(dim, dim);
-    const auto xfmA = Transformation{Length2D{}, UnitVec2::GetRight()};
-    const auto xfmB = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto xfmA = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfmB = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(shape.GetChild(0), xfmA, shape.GetChild(0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
     
-    const auto lcA = Vec2{} * (Real(1) * Meter);
-    const auto lcB = Vec2{} * (Real(1) * Meter);
-    const auto old_pA = Position{Length2D{}, Angle{0}};
-    const auto old_pB = Position{Length2D{}, Angle{0}};
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
+    const auto old_pA = Position{Length2{}, Angle{0}};
+    const auto old_pB = Position{Length2{}, Angle{0}};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
     auto bA = BodyConstraint{
@@ -183,8 +183,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly1)
     ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, +2) * (Real(1) * Meter));
     ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, -2) * (Real(1) * Meter));
     
-    const auto lcA = Length2D{};
-    const auto lcB = Length2D{};
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
@@ -237,8 +237,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly2)
     ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(+2, -2) * (Real(1) * Meter));
     ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, +2) * (Real(1) * Meter));
     
-    const auto lcA = Length2D{};
-    const auto lcB = Length2D{};
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
@@ -291,8 +291,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly1)
     ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(-2, -2) * (Real(1) * Meter));
     ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(+2, -2) * (Real(1) * Meter));
     
-    const auto lcA = Length2D{};
-    const auto lcB = Length2D{};
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
@@ -358,8 +358,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
     ASSERT_EQ(manifold.GetPoint(0).localPoint, Vec2(+2, +2) * (Real(1) * Meter));
     ASSERT_EQ(manifold.GetPoint(1).localPoint, Vec2(-2, +2) * (Real(1) * Meter));
     
-    const auto lcA = Length2D{};
-    const auto lcB = Length2D{};
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
@@ -405,19 +405,19 @@ TEST(ContactSolver, SolvePosConstraintsForPerfectlyOverlappingSquares)
 {
     const auto dim = Real(2) * Meter;
     const auto shape = PolygonShape(dim, dim);
-    const auto xfmA = Transformation{Length2D{}, UnitVec2::GetRight()};
-    const auto xfmB = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto xfmA = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfmB = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(shape.GetChild(0), xfmA, shape.GetChild(0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
 
-    const auto old_pA = Position{Length2D{}, Angle{0}};
-    const auto old_pB = Position{Length2D{}, Angle{0}};
+    const auto old_pA = Position{Length2{}, Angle{0}};
+    const auto old_pB = Position{Length2{}, Angle{0}};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
-    const auto lcA = Vec2{} * (Real(1) * Meter);
-    const auto lcB = Vec2{} * (Real(1) * Meter);
+    const auto lcA = Length2{};
+    const auto lcB = Length2{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -50,7 +50,7 @@ TEST(DiskShape, DefaultConstruction)
 TEST(DiskShape, InitConstruction)
 {
     const auto radius = 1_m;
-    const auto position = Length2D{-1_m, 1_m};
+    const auto position = Length2{-1_m, 1_m};
     auto conf = DiskShape::Conf{};
     conf.vertexRadius = radius;
     conf.location = position;
@@ -105,25 +105,25 @@ TEST(DiskShape, BaseVisitorForDiskShape)
 TEST(DiskShape, TestPoint)
 {
     const auto radius = 1_m;
-    const auto position = Length2D{};
+    const auto position = Length2{};
     auto conf = DiskShape::Conf{};
     conf.vertexRadius = radius;
     conf.location = position;
     DiskShape foo{conf};
-    EXPECT_TRUE(TestPoint(foo, Length2D{ 0_m,  0_m}));
-    EXPECT_TRUE(TestPoint(foo, Length2D{+1_m,  0_m}));
-    EXPECT_TRUE(TestPoint(foo, Length2D{ 0_m, +1_m}));
-    EXPECT_TRUE(TestPoint(foo, Length2D{ 0_m, -1_m}));
-    EXPECT_TRUE(TestPoint(foo, Length2D{-1_m,  0_m}));
-    EXPECT_FALSE(TestPoint(foo, Length2D{-1_m,  -1_m}));
-    EXPECT_FALSE(TestPoint(foo, Length2D{+1_m,  +1_m}));
-    EXPECT_FALSE(TestPoint(foo, Length2D{+0.9_m,  +0.9_m}));
+    EXPECT_TRUE(TestPoint(foo, Length2{ 0_m,  0_m}));
+    EXPECT_TRUE(TestPoint(foo, Length2{+1_m,  0_m}));
+    EXPECT_TRUE(TestPoint(foo, Length2{ 0_m, +1_m}));
+    EXPECT_TRUE(TestPoint(foo, Length2{ 0_m, -1_m}));
+    EXPECT_TRUE(TestPoint(foo, Length2{-1_m,  0_m}));
+    EXPECT_FALSE(TestPoint(foo, Length2{-1_m,  -1_m}));
+    EXPECT_FALSE(TestPoint(foo, Length2{+1_m,  +1_m}));
+    EXPECT_FALSE(TestPoint(foo, Length2{+0.9_m,  +0.9_m}));
 }
 
 TEST(DiskShape, ComputeAABB)
 {
     const auto radius = 2.4_m;
-    const auto position = Length2D{2_m, 1_m};
+    const auto position = Length2{2_m, 1_m};
     auto conf = DiskShape::Conf{};
     conf.vertexRadius = radius;
     conf.location = position;

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -27,11 +27,11 @@ TEST(Distance, MatchingCircles)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2{Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2{Real(2) * Meter, Real(2) * Meter};
+    const auto pos1 = Length2{2_m, 2_m};
+    const auto pos2 = Length2{2_m, 2_m};
     const auto normal = UnitVec2{};
-    DistanceProxy dp1{Real{1} * Meter, 1, &pos1, &normal};
-    DistanceProxy dp2{Real{1} * Meter, 1, &pos2, &normal};
+    DistanceProxy dp1{1_m, 1, &pos1, &normal};
+    DistanceProxy dp2{1_m, 1, &pos2, &normal};
 
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     const auto edges = output.simplex.GetEdges();
@@ -64,11 +64,11 @@ TEST(Distance, OpposingCircles)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2{Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2{-Real(2) * Meter, -Real(2) * Meter};
+    const auto pos1 = Length2{2_m, 2_m};
+    const auto pos2 = Length2{-2_m, -2_m};
     const auto normal = UnitVec2{};
-    DistanceProxy dp1{Real{2} * Meter, 1, &pos1, &normal};
-    DistanceProxy dp2{Real{2} * Meter, 1, &pos2, &normal};
+    DistanceProxy dp1{2_m, 1, &pos1, &normal};
+    DistanceProxy dp2{2_m, 1, &pos2, &normal};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -96,15 +96,15 @@ TEST(Distance, HorTouchingCircles)
 {
     DistanceConf conf;
     
-    const auto pos1 = Length2{-Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2{+Real(2) * Meter, Real(2) * Meter};
+    const auto pos1 = Length2{-2_m, 2_m};
+    const auto pos2 = Length2{+2_m, 2_m};
     const auto normal = UnitVec2{};
 
     const auto output = [&]() {
         Transformation xf1 = Transform_identity;
         Transformation xf2 = Transform_identity;
-        DistanceProxy dp1{Real{2} * Meter, 1, &pos1, &normal};
-        DistanceProxy dp2{Real{2} * Meter, 1, &pos2, &normal};
+        DistanceProxy dp1{2_m, 1, &pos1, &normal};
+        DistanceProxy dp2{2_m, 1, &pos2, &normal};
         return Distance(dp1, xf1, dp2, xf2, conf);
     }();
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -133,11 +133,11 @@ TEST(Distance, OverlappingCirclesPN)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2{Real(1) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2{-Real(1) * Meter, -Real(1) * Meter};
+    const auto pos1 = Length2{1_m, 1_m};
+    const auto pos2 = Length2{-1_m, -1_m};
     const auto normal = UnitVec2{};
-    DistanceProxy dp1{Real{2} * Meter, 1, &pos1, &normal};
-    DistanceProxy dp2{Real{2} * Meter, 1, &pos2, &normal};
+    DistanceProxy dp1{2_m, 1, &pos1, &normal};
+    DistanceProxy dp2{2_m, 1, &pos2, &normal};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -166,11 +166,11 @@ TEST(Distance, OverlappingCirclesNP)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2{-Real(1) * Meter, -Real(1) * Meter};
-    const auto pos2 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const auto pos1 = Length2{-1_m, -1_m};
+    const auto pos2 = Length2{1_m, 1_m};
     const auto normal = UnitVec2{};
-    DistanceProxy dp1{Real{2} * Meter, 1, &pos1, &normal};
-    DistanceProxy dp2{Real{2} * Meter, 1, &pos2, &normal};
+    DistanceProxy dp1{2_m, 1, &pos1, &normal};
+    DistanceProxy dp2{2_m, 1, &pos2, &normal};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -200,11 +200,11 @@ TEST(Distance, SeparatedCircles)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2{Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2{-Real(2) * Meter, -Real(2) * Meter};
+    const auto pos1 = Length2{2_m, 2_m};
+    const auto pos2 = Length2{-2_m, -2_m};
     const auto normal = UnitVec2{};
-    DistanceProxy dp1{Real{1} * Meter, 1, &pos1, &normal};
-    DistanceProxy dp2{Real{1} * Meter, 1, &pos2, &normal};
+    DistanceProxy dp1{1_m, 1, &pos1, &normal};
+    DistanceProxy dp2{1_m, 1, &pos2, &normal};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -234,16 +234,16 @@ TEST(Distance, EdgeCircleOverlapping)
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
 
-    const auto pos1 = Length2{Real(0) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2{Real(4) * Meter, Real(2) * Meter};
+    const auto pos1 = Length2{0_m, 2_m};
+    const auto pos2 = Length2{4_m, 2_m};
     const Length2 vertices[] = {pos1, pos2};
     const auto normal1 = GetUnitVector(pos2 - pos1);
     const UnitVec2 normals[] = {normal1, -normal1};
-    DistanceProxy dp1{Real(0.1) * Meter, 2, vertices, normals};
+    DistanceProxy dp1{0.1_m, 2, vertices, normals};
     
-    const auto pos3 = Length2{Real(2) * Meter, Real(2) * Meter};
+    const auto pos3 = Length2{2_m, 2_m};
     const auto normal = UnitVec2{};
-    DistanceProxy dp2{Real{1} * Meter, 1, &pos3, &normal};
+    DistanceProxy dp2{1_m, 1, &pos3, &normal};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -277,15 +277,15 @@ TEST(Distance, EdgeCircleOverlapping2)
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
     
-    const auto pos1 = Length2{-Real(3) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2{Real(7) * Meter, Real(2) * Meter};
+    const auto pos1 = Length2{-3_m, 2_m};
+    const auto pos2 = Length2{7_m, 2_m};
     const Length2 vertices[] = {pos1, pos2};
     const auto normal1 = GetUnitVector(pos2 - pos1);
     const UnitVec2 normals[] = {normal1, -normal1};
-    DistanceProxy dp1{Real(0.1) * Meter, 2, vertices, normals};
+    DistanceProxy dp1{0.1_m, 2, vertices, normals};
 
-    const auto pos3 = Length2{Real(2) * Meter, Real(2) * Meter};
-    DistanceProxy dp2{Real{1} * Meter, 1, &pos3, nullptr};
+    const auto pos3 = Length2{2_m, 2_m};
+    DistanceProxy dp2{1_m, 1, &pos3, nullptr};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -319,25 +319,25 @@ TEST(Distance, EdgeCircleTouching)
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
     
-    const auto pos1 = Length2{Real(0) * Meter, Real(3) * Meter};
-    const auto pos2 = Length2{Real(4) * Meter, Real(3) * Meter};
+    const auto pos1 = Length2{0_m, 3_m};
+    const auto pos2 = Length2{4_m, 3_m};
     const Length2 vertices[] = {pos1, pos2};
     const auto normal1 = GetUnitVector(pos2 - pos1);
     const UnitVec2 normals[] = {normal1, -normal1};
-    DistanceProxy dp1{Real(1) * Meter, 2, vertices, normals};
+    DistanceProxy dp1{1_m, 2, vertices, normals};
 
-    const auto pos3 = Length2{Real(2) * Meter, Real(1) * Meter};
-    DistanceProxy dp2{Real{1} * Meter, 1, &pos3, normals};
+    const auto pos3 = Length2{2_m, 1_m};
+    DistanceProxy dp2{1_m, 1, &pos3, normals};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), Real{2} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.a), Real{3} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.a), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.a), 3_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), Real{2} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.b), Real{1} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.b), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.b), 1_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
@@ -357,24 +357,24 @@ TEST(Distance, EdgeCircleTouching)
 
 TEST(Distance, HorEdgeSquareTouching)
 {
-    const auto pos1 = Length2{Real(1) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2{Real(1) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2{Real(3) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2{Real(3) * Meter, Real(1) * Meter};
+    const auto pos1 = Length2{1_m, 1_m};
+    const auto pos2 = Length2{1_m, 3_m};
+    const auto pos3 = Length2{3_m, 3_m};
+    const auto pos4 = Length2{3_m, 1_m};
     const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
     const auto n4 = GetUnitVector(pos1 - pos4);
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
-    DistanceProxy dp1{Real(0.5) * Meter, 4, square, squareNormals};
+    DistanceProxy dp1{0.5_m, 4, square, squareNormals};
 
-    const auto pos5 = Length2{-Real(2) * Meter, Real(0) * Meter};
-    const auto pos6 = Length2{Real(6) * Meter, Real(0) * Meter};
+    const auto pos5 = Length2{-2_m, 0_m};
+    const auto pos6 = Length2{6_m, 0_m};
     const Length2 vertices[] = {pos5, pos6};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const UnitVec2 normals[] = {n5, -n5};
-    DistanceProxy dp2{Real(0.5) * Meter, 2, vertices, normals};
+    DistanceProxy dp2{0.5_m, 2, vertices, normals};
     
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
@@ -384,11 +384,11 @@ TEST(Distance, HorEdgeSquareTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), Real{1} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.a), Real{1} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.a), 1_m);
+    EXPECT_EQ(GetY(witnessPoints.a), 1_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), Real{1} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.b), Real{0} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.b), 1_m);
+    EXPECT_EQ(GetY(witnessPoints.b), 0_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
@@ -408,24 +408,24 @@ TEST(Distance, HorEdgeSquareTouching)
 
 TEST(Distance, VerEdgeSquareTouching)
 {
-    const auto pos1 = Length2{Real(1) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2{Real(1) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2{Real(3) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2{Real(3) * Meter, Real(1) * Meter};
+    const auto pos1 = Length2{1_m, 1_m};
+    const auto pos2 = Length2{1_m, 3_m};
+    const auto pos3 = Length2{3_m, 3_m};
+    const auto pos4 = Length2{3_m, 1_m};
     const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
     const auto n4 = GetUnitVector(pos1 - pos4);
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
-    DistanceProxy dp1{Real(0.5) * Meter, 4, square, squareNormals};
+    DistanceProxy dp1{0.5_m, 4, square, squareNormals};
     
-    const auto pos5 = Length2{Real(4) * Meter, -Real(2) * Meter};
-    const auto pos6 = Length2{Real(4) * Meter, Real(6) * Meter};
+    const auto pos5 = Length2{4_m, -2_m};
+    const auto pos6 = Length2{4_m, 6_m};
     const Length2 vertices[] = {pos5, pos6};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const UnitVec2 normals[] = {n5, -n5};
-    DistanceProxy dp2{Real(0.5) * Meter, 2, vertices, normals};
+    DistanceProxy dp2{0.5_m, 2, vertices, normals};
     
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
@@ -437,11 +437,11 @@ TEST(Distance, VerEdgeSquareTouching)
 
     EXPECT_NEAR(static_cast<double>(Real{Sqrt(GetLengthSquared(witnessPoints.a - witnessPoints.b)) / Meter}),
                 1.0, 0.000001);
-    EXPECT_EQ(GetX(witnessPoints.a), Real{3} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.a), Real{2} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.a), 3_m);
+    EXPECT_EQ(GetY(witnessPoints.a), 2_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), Real{4} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.b), Real{2} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.b), 4_m);
+    EXPECT_EQ(GetY(witnessPoints.b), 2_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
@@ -471,7 +471,7 @@ TEST(Distance, SquareTwice)
     const auto n3 = GetUnitVector(pos4 - pos3);
     const auto n4 = GetUnitVector(pos1 - pos4);
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
-    DistanceProxy dp1{Real(0.05) * Meter, 4, square, squareNormals};
+    DistanceProxy dp1{0.05_m, 4, square, squareNormals};
 
     DistanceConf conf;
     Transformation xfm = Transform_identity;
@@ -480,11 +480,11 @@ TEST(Distance, SquareTwice)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), Real{2} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.a), Real{2} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.a), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.a), 2_m);
 
-    EXPECT_EQ(GetX(witnessPoints.b), Real{2} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.b), Real{2} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.b), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.b), 2_m);
 
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
@@ -511,7 +511,7 @@ TEST(Distance, SquareSquareTouchingVertically)
     const auto n3 = GetUnitVector(pos4 - pos3);
     const auto n4 = GetUnitVector(pos1 - pos4);
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
-    DistanceProxy dp1{Real(0.05) * Meter, 4, square, squareNormals};
+    DistanceProxy dp1{0.05_m, 4, square, squareNormals};
     
     const auto pos5 = Vec2{4, 2} * Meter;
     const auto pos6 = Vec2{4, 4} * Meter;
@@ -523,7 +523,7 @@ TEST(Distance, SquareSquareTouchingVertically)
     const auto n7 = GetUnitVector(pos8 - pos7);
     const auto n8 = GetUnitVector(pos5 - pos8);
     const UnitVec2 normals2[] = {n5, n6, n7, n8};
-    DistanceProxy dp2{Real(0.05) * Meter, 4, square2, normals2};
+    DistanceProxy dp2{0.05_m, 4, square2, normals2};
 
     DistanceConf conf;
     Transformation xfm = Transform_identity;
@@ -532,11 +532,11 @@ TEST(Distance, SquareSquareTouchingVertically)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), Real{4} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.a), Real{3} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.a), 4_m);
+    EXPECT_EQ(GetY(witnessPoints.a), 3_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), Real{4} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.b), Real{3} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.b), 4_m);
+    EXPECT_EQ(GetY(witnessPoints.b), 3_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
@@ -562,7 +562,7 @@ TEST(Distance, SquareSquareDiagonally)
     const auto n3 = GetUnitVector(pos4 - pos3);
     const auto n4 = GetUnitVector(pos1 - pos4);
     const UnitVec2 normals1[] = {n1, n2, n3, n4};
-    DistanceProxy dp1{Real(0.05) * Meter, 4, square1, normals1};
+    DistanceProxy dp1{0.05_m, 4, square1, normals1};
     
     const auto pos5 = Vec2{1, 3} * Meter;
     const auto pos6 = Vec2{3, 3} * Meter;
@@ -574,7 +574,7 @@ TEST(Distance, SquareSquareDiagonally)
     const auto n7 = GetUnitVector(pos8 - pos7);
     const auto n8 = GetUnitVector(pos5 - pos8);
     const UnitVec2 normals2[] = {n5, n6, n7, n8};
-    DistanceProxy dp2{Real(0.05) * Meter, 4, square2, normals2};
+    DistanceProxy dp2{0.05_m, 4, square2, normals2};
     
     DistanceConf conf;
     Transformation xfm = Transform_identity;
@@ -583,11 +583,11 @@ TEST(Distance, SquareSquareDiagonally)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), Real{-1} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.a), Real{-1} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.a), -1_m);
+    EXPECT_EQ(GetY(witnessPoints.a), -1_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), Real{1} * Meter);
-    EXPECT_EQ(GetY(witnessPoints.b), Real{1} * Meter);
+    EXPECT_EQ(GetX(witnessPoints.b), 1_m);
+    EXPECT_EQ(GetY(witnessPoints.b), 1_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -461,10 +461,10 @@ TEST(Distance, VerEdgeSquareTouching)
 
 TEST(Distance, SquareTwice)
 {
-    const auto pos1 = Vec2{2, 2} * (Real(1) * Meter);
-    const auto pos2 = Vec2{2, 4} * (Real(1) * Meter);
-    const auto pos3 = Vec2{4, 4} * (Real(1) * Meter);
-    const auto pos4 = Vec2{4, 2} * (Real(1) * Meter);
+    const auto pos1 = Vec2{2, 2} * Meter;
+    const auto pos2 = Vec2{2, 4} * Meter;
+    const auto pos3 = Vec2{4, 4} * Meter;
+    const auto pos4 = Vec2{4, 2} * Meter;
     const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
@@ -501,10 +501,10 @@ TEST(Distance, SquareTwice)
 
 TEST(Distance, SquareSquareTouchingVertically)
 {
-    const auto pos1 = Vec2{2, 2} * (Real(1) * Meter);
-    const auto pos2 = Vec2{2, 4} * (Real(1) * Meter);
-    const auto pos3 = Vec2{4, 4} * (Real(1) * Meter);
-    const auto pos4 = Vec2{4, 2} * (Real(1) * Meter);
+    const auto pos1 = Vec2{2, 2} * Meter;
+    const auto pos2 = Vec2{2, 4} * Meter;
+    const auto pos3 = Vec2{4, 4} * Meter;
+    const auto pos4 = Vec2{4, 2} * Meter;
     const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
@@ -513,10 +513,10 @@ TEST(Distance, SquareSquareTouchingVertically)
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
     DistanceProxy dp1{Real(0.05) * Meter, 4, square, squareNormals};
     
-    const auto pos5 = Vec2{4, 2} * (Real(1) * Meter);
-    const auto pos6 = Vec2{4, 4} * (Real(1) * Meter);
-    const auto pos7 = Vec2{6, 4} * (Real(1) * Meter);
-    const auto pos8 = Vec2{6, 2} * (Real(1) * Meter);
+    const auto pos5 = Vec2{4, 2} * Meter;
+    const auto pos6 = Vec2{4, 4} * Meter;
+    const auto pos7 = Vec2{6, 4} * Meter;
+    const auto pos8 = Vec2{6, 2} * Meter;
     const Length2 square2[] = {pos5, pos6, pos7, pos8};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const auto n6 = GetUnitVector(pos7 - pos6);
@@ -552,10 +552,10 @@ TEST(Distance, SquareSquareTouchingVertically)
 
 TEST(Distance, SquareSquareDiagonally)
 {
-    const auto pos1 = Vec2{-3, -3} * (Real(1) * Meter);
-    const auto pos2 = Vec2{-3, -1} * (Real(1) * Meter);
-    const auto pos3 = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto pos4 = Vec2{-1, -3} * (Real(1) * Meter);
+    const auto pos1 = Vec2{-3, -3} * Meter;
+    const auto pos2 = Vec2{-3, -1} * Meter;
+    const auto pos3 = Vec2{-1, -1} * Meter;
+    const auto pos4 = Vec2{-1, -3} * Meter;
     const Length2 square1[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
@@ -564,10 +564,10 @@ TEST(Distance, SquareSquareDiagonally)
     const UnitVec2 normals1[] = {n1, n2, n3, n4};
     DistanceProxy dp1{Real(0.05) * Meter, 4, square1, normals1};
     
-    const auto pos5 = Vec2{1, 3} * (Real(1) * Meter);
-    const auto pos6 = Vec2{3, 3} * (Real(1) * Meter);
-    const auto pos7 = Vec2{3, 1} * (Real(1) * Meter);
-    const auto pos8 = Vec2{1, 1} * (Real(1) * Meter);
+    const auto pos5 = Vec2{1, 3} * Meter;
+    const auto pos6 = Vec2{3, 3} * Meter;
+    const auto pos7 = Vec2{3, 1} * Meter;
+    const auto pos8 = Vec2{1, 1} * Meter;
     const Length2 square2[] = {pos5, pos6, pos7, pos8};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const auto n6 = GetUnitVector(pos7 - pos6);
@@ -615,10 +615,10 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
      *  +-----3-+
      */
     // Go counter-clockwise...
-    const auto pos1 = Vec2{-3, 1} * (Real(1) * Meter);
-    const auto pos2 = Vec2{-3, -3} * (Real(1) * Meter);
-    const auto pos3 = Vec2{1, -3} * (Real(1) * Meter);
-    const auto pos4 = Vec2{1, 1} * (Real(1) * Meter);
+    const auto pos1 = Vec2{-3, 1} * Meter;
+    const auto pos2 = Vec2{-3, -3} * Meter;
+    const auto pos3 = Vec2{1, -3} * Meter;
+    const auto pos4 = Vec2{1, 1} * Meter;
     const Length2 square1[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
@@ -639,10 +639,10 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
      *  +-1-----+
      */
     // Go counter-clockwise...
-    const auto pos5 = Vec2{3, 3} * (Real(1) * Meter);
-    const auto pos6 = Vec2{-1, 3} * (Real(1) * Meter);
-    const auto pos7 = Vec2{-1, -1} * (Real(1) * Meter);
-    const auto pos8 = Vec2{-1, 3} * (Real(1) * Meter);
+    const auto pos5 = Vec2{3, 3} * Meter;
+    const auto pos6 = Vec2{-1, 3} * Meter;
+    const auto pos7 = Vec2{-1, -1} * Meter;
+    const auto pos8 = Vec2{-1, 3} * Meter;
     const Length2 square2[] = {pos5, pos6, pos7, pos8};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const auto n6 = GetUnitVector(pos7 - pos6);

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -27,8 +27,8 @@ TEST(Distance, MatchingCircles)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2D{Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2D{Real(2) * Meter, Real(2) * Meter};
+    const auto pos1 = Length2{Real(2) * Meter, Real(2) * Meter};
+    const auto pos2 = Length2{Real(2) * Meter, Real(2) * Meter};
     const auto normal = UnitVec2{};
     DistanceProxy dp1{Real{1} * Meter, 1, &pos1, &normal};
     DistanceProxy dp2{Real{1} * Meter, 1, &pos2, &normal};
@@ -64,8 +64,8 @@ TEST(Distance, OpposingCircles)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2D{Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2D{-Real(2) * Meter, -Real(2) * Meter};
+    const auto pos1 = Length2{Real(2) * Meter, Real(2) * Meter};
+    const auto pos2 = Length2{-Real(2) * Meter, -Real(2) * Meter};
     const auto normal = UnitVec2{};
     DistanceProxy dp1{Real{2} * Meter, 1, &pos1, &normal};
     DistanceProxy dp2{Real{2} * Meter, 1, &pos2, &normal};
@@ -96,8 +96,8 @@ TEST(Distance, HorTouchingCircles)
 {
     DistanceConf conf;
     
-    const auto pos1 = Length2D{-Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2D{+Real(2) * Meter, Real(2) * Meter};
+    const auto pos1 = Length2{-Real(2) * Meter, Real(2) * Meter};
+    const auto pos2 = Length2{+Real(2) * Meter, Real(2) * Meter};
     const auto normal = UnitVec2{};
 
     const auto output = [&]() {
@@ -133,8 +133,8 @@ TEST(Distance, OverlappingCirclesPN)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2D{Real(1) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2D{-Real(1) * Meter, -Real(1) * Meter};
+    const auto pos1 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const auto pos2 = Length2{-Real(1) * Meter, -Real(1) * Meter};
     const auto normal = UnitVec2{};
     DistanceProxy dp1{Real{2} * Meter, 1, &pos1, &normal};
     DistanceProxy dp2{Real{2} * Meter, 1, &pos2, &normal};
@@ -166,8 +166,8 @@ TEST(Distance, OverlappingCirclesNP)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2D{-Real(1) * Meter, -Real(1) * Meter};
-    const auto pos2 = Length2D{Real(1) * Meter, Real(1) * Meter};
+    const auto pos1 = Length2{-Real(1) * Meter, -Real(1) * Meter};
+    const auto pos2 = Length2{Real(1) * Meter, Real(1) * Meter};
     const auto normal = UnitVec2{};
     DistanceProxy dp1{Real{2} * Meter, 1, &pos1, &normal};
     DistanceProxy dp2{Real{2} * Meter, 1, &pos2, &normal};
@@ -200,8 +200,8 @@ TEST(Distance, SeparatedCircles)
     DistanceConf conf;
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
-    const auto pos1 = Length2D{Real(2) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2D{-Real(2) * Meter, -Real(2) * Meter};
+    const auto pos1 = Length2{Real(2) * Meter, Real(2) * Meter};
+    const auto pos2 = Length2{-Real(2) * Meter, -Real(2) * Meter};
     const auto normal = UnitVec2{};
     DistanceProxy dp1{Real{1} * Meter, 1, &pos1, &normal};
     DistanceProxy dp2{Real{1} * Meter, 1, &pos2, &normal};
@@ -234,14 +234,14 @@ TEST(Distance, EdgeCircleOverlapping)
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
 
-    const auto pos1 = Length2D{Real(0) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2D{Real(4) * Meter, Real(2) * Meter};
-    const Length2D vertices[] = {pos1, pos2};
+    const auto pos1 = Length2{Real(0) * Meter, Real(2) * Meter};
+    const auto pos2 = Length2{Real(4) * Meter, Real(2) * Meter};
+    const Length2 vertices[] = {pos1, pos2};
     const auto normal1 = GetUnitVector(pos2 - pos1);
     const UnitVec2 normals[] = {normal1, -normal1};
     DistanceProxy dp1{Real(0.1) * Meter, 2, vertices, normals};
     
-    const auto pos3 = Length2D{Real(2) * Meter, Real(2) * Meter};
+    const auto pos3 = Length2{Real(2) * Meter, Real(2) * Meter};
     const auto normal = UnitVec2{};
     DistanceProxy dp2{Real{1} * Meter, 1, &pos3, &normal};
     
@@ -277,14 +277,14 @@ TEST(Distance, EdgeCircleOverlapping2)
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
     
-    const auto pos1 = Length2D{-Real(3) * Meter, Real(2) * Meter};
-    const auto pos2 = Length2D{Real(7) * Meter, Real(2) * Meter};
-    const Length2D vertices[] = {pos1, pos2};
+    const auto pos1 = Length2{-Real(3) * Meter, Real(2) * Meter};
+    const auto pos2 = Length2{Real(7) * Meter, Real(2) * Meter};
+    const Length2 vertices[] = {pos1, pos2};
     const auto normal1 = GetUnitVector(pos2 - pos1);
     const UnitVec2 normals[] = {normal1, -normal1};
     DistanceProxy dp1{Real(0.1) * Meter, 2, vertices, normals};
 
-    const auto pos3 = Length2D{Real(2) * Meter, Real(2) * Meter};
+    const auto pos3 = Length2{Real(2) * Meter, Real(2) * Meter};
     DistanceProxy dp2{Real{1} * Meter, 1, &pos3, nullptr};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
@@ -319,14 +319,14 @@ TEST(Distance, EdgeCircleTouching)
     Transformation xf1 = Transform_identity;
     Transformation xf2 = Transform_identity;
     
-    const auto pos1 = Length2D{Real(0) * Meter, Real(3) * Meter};
-    const auto pos2 = Length2D{Real(4) * Meter, Real(3) * Meter};
-    const Length2D vertices[] = {pos1, pos2};
+    const auto pos1 = Length2{Real(0) * Meter, Real(3) * Meter};
+    const auto pos2 = Length2{Real(4) * Meter, Real(3) * Meter};
+    const Length2 vertices[] = {pos1, pos2};
     const auto normal1 = GetUnitVector(pos2 - pos1);
     const UnitVec2 normals[] = {normal1, -normal1};
     DistanceProxy dp1{Real(1) * Meter, 2, vertices, normals};
 
-    const auto pos3 = Length2D{Real(2) * Meter, Real(1) * Meter};
+    const auto pos3 = Length2{Real(2) * Meter, Real(1) * Meter};
     DistanceProxy dp2{Real{1} * Meter, 1, &pos3, normals};
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
@@ -357,11 +357,11 @@ TEST(Distance, EdgeCircleTouching)
 
 TEST(Distance, HorEdgeSquareTouching)
 {
-    const auto pos1 = Length2D{Real(1) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2D{Real(1) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2D{Real(3) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2D{Real(3) * Meter, Real(1) * Meter};
-    const Length2D square[] = {pos1, pos2, pos3, pos4};
+    const auto pos1 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const auto pos2 = Length2{Real(1) * Meter, Real(3) * Meter};
+    const auto pos3 = Length2{Real(3) * Meter, Real(3) * Meter};
+    const auto pos4 = Length2{Real(3) * Meter, Real(1) * Meter};
+    const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
@@ -369,9 +369,9 @@ TEST(Distance, HorEdgeSquareTouching)
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
     DistanceProxy dp1{Real(0.5) * Meter, 4, square, squareNormals};
 
-    const auto pos5 = Length2D{-Real(2) * Meter, Real(0) * Meter};
-    const auto pos6 = Length2D{Real(6) * Meter, Real(0) * Meter};
-    const Length2D vertices[] = {pos5, pos6};
+    const auto pos5 = Length2{-Real(2) * Meter, Real(0) * Meter};
+    const auto pos6 = Length2{Real(6) * Meter, Real(0) * Meter};
+    const Length2 vertices[] = {pos5, pos6};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const UnitVec2 normals[] = {n5, -n5};
     DistanceProxy dp2{Real(0.5) * Meter, 2, vertices, normals};
@@ -408,11 +408,11 @@ TEST(Distance, HorEdgeSquareTouching)
 
 TEST(Distance, VerEdgeSquareTouching)
 {
-    const auto pos1 = Length2D{Real(1) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2D{Real(1) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2D{Real(3) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2D{Real(3) * Meter, Real(1) * Meter};
-    const Length2D square[] = {pos1, pos2, pos3, pos4};
+    const auto pos1 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const auto pos2 = Length2{Real(1) * Meter, Real(3) * Meter};
+    const auto pos3 = Length2{Real(3) * Meter, Real(3) * Meter};
+    const auto pos4 = Length2{Real(3) * Meter, Real(1) * Meter};
+    const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
@@ -420,9 +420,9 @@ TEST(Distance, VerEdgeSquareTouching)
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
     DistanceProxy dp1{Real(0.5) * Meter, 4, square, squareNormals};
     
-    const auto pos5 = Length2D{Real(4) * Meter, -Real(2) * Meter};
-    const auto pos6 = Length2D{Real(4) * Meter, Real(6) * Meter};
-    const Length2D vertices[] = {pos5, pos6};
+    const auto pos5 = Length2{Real(4) * Meter, -Real(2) * Meter};
+    const auto pos6 = Length2{Real(4) * Meter, Real(6) * Meter};
+    const Length2 vertices[] = {pos5, pos6};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const UnitVec2 normals[] = {n5, -n5};
     DistanceProxy dp2{Real(0.5) * Meter, 2, vertices, normals};
@@ -465,7 +465,7 @@ TEST(Distance, SquareTwice)
     const auto pos2 = Vec2{2, 4} * (Real(1) * Meter);
     const auto pos3 = Vec2{4, 4} * (Real(1) * Meter);
     const auto pos4 = Vec2{4, 2} * (Real(1) * Meter);
-    const Length2D square[] = {pos1, pos2, pos3, pos4};
+    const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
@@ -505,7 +505,7 @@ TEST(Distance, SquareSquareTouchingVertically)
     const auto pos2 = Vec2{2, 4} * (Real(1) * Meter);
     const auto pos3 = Vec2{4, 4} * (Real(1) * Meter);
     const auto pos4 = Vec2{4, 2} * (Real(1) * Meter);
-    const Length2D square[] = {pos1, pos2, pos3, pos4};
+    const Length2 square[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
@@ -517,7 +517,7 @@ TEST(Distance, SquareSquareTouchingVertically)
     const auto pos6 = Vec2{4, 4} * (Real(1) * Meter);
     const auto pos7 = Vec2{6, 4} * (Real(1) * Meter);
     const auto pos8 = Vec2{6, 2} * (Real(1) * Meter);
-    const Length2D square2[] = {pos5, pos6, pos7, pos8};
+    const Length2 square2[] = {pos5, pos6, pos7, pos8};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const auto n6 = GetUnitVector(pos7 - pos6);
     const auto n7 = GetUnitVector(pos8 - pos7);
@@ -556,7 +556,7 @@ TEST(Distance, SquareSquareDiagonally)
     const auto pos2 = Vec2{-3, -1} * (Real(1) * Meter);
     const auto pos3 = Vec2{-1, -1} * (Real(1) * Meter);
     const auto pos4 = Vec2{-1, -3} * (Real(1) * Meter);
-    const Length2D square1[] = {pos1, pos2, pos3, pos4};
+    const Length2 square1[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
@@ -568,7 +568,7 @@ TEST(Distance, SquareSquareDiagonally)
     const auto pos6 = Vec2{3, 3} * (Real(1) * Meter);
     const auto pos7 = Vec2{3, 1} * (Real(1) * Meter);
     const auto pos8 = Vec2{1, 1} * (Real(1) * Meter);
-    const Length2D square2[] = {pos5, pos6, pos7, pos8};
+    const Length2 square2[] = {pos5, pos6, pos7, pos8};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const auto n6 = GetUnitVector(pos7 - pos6);
     const auto n7 = GetUnitVector(pos8 - pos7);
@@ -619,7 +619,7 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
     const auto pos2 = Vec2{-3, -3} * (Real(1) * Meter);
     const auto pos3 = Vec2{1, -3} * (Real(1) * Meter);
     const auto pos4 = Vec2{1, 1} * (Real(1) * Meter);
-    const Length2D square1[] = {pos1, pos2, pos3, pos4};
+    const Length2 square1[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(pos2 - pos1);
     const auto n2 = GetUnitVector(pos3 - pos2);
     const auto n3 = GetUnitVector(pos4 - pos3);
@@ -643,7 +643,7 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
     const auto pos6 = Vec2{-1, 3} * (Real(1) * Meter);
     const auto pos7 = Vec2{-1, -1} * (Real(1) * Meter);
     const auto pos8 = Vec2{-1, 3} * (Real(1) * Meter);
-    const Length2D square2[] = {pos5, pos6, pos7, pos8};
+    const Length2 square2[] = {pos5, pos6, pos7, pos8};
     const auto n5 = GetUnitVector(pos6 - pos5);
     const auto n6 = GetUnitVector(pos7 - pos6);
     const auto n7 = GetUnitVector(pos8 - pos7);

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -659,10 +659,10 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
     EXPECT_EQ(GetX(witnessPoints.a), Length{0});
-    EXPECT_EQ(GetY(witnessPoints.a), Real{0.5f} * Meter);
+    EXPECT_EQ(GetY(witnessPoints.a), 0.5_m);
     
     EXPECT_EQ(GetX(witnessPoints.b), Length{0});
-    EXPECT_EQ(GetY(witnessPoints.b), Real{0.5f} * Meter);
+    EXPECT_EQ(GetY(witnessPoints.b), 0.5_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -50,14 +50,14 @@ TEST(DistanceJointDef, DefaultConstruction)
     
     EXPECT_EQ(def.localAnchorA, (Length2{}));
     EXPECT_EQ(def.localAnchorB, (Length2{}));
-    EXPECT_EQ(def.length, Real(1) * Meter);
+    EXPECT_EQ(def.length, 1_m);
     EXPECT_EQ(def.frequency, Frequency(0));
     EXPECT_EQ(def.dampingRatio, Real(0));
 }
 
 TEST(DistanceJointDef, UseLength)
 {
-    const auto value = Length(Real(31) * Meter);
+    const auto value = Length(31_m);
     EXPECT_NE(DistanceJointDef{}.length, value);
     EXPECT_EQ(DistanceJointDef{}.UseLength(value).length, value);
 }
@@ -102,12 +102,12 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
 
     const auto shape = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     
-    const auto location1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto location1 = Length2{-1_m, 0_m};
     const auto body1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location1));
     ASSERT_EQ(body1->GetLocation(), location1);
     ASSERT_NE(body1->CreateFixture(shape), nullptr);
     
-    const auto location2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto location2 = Length2{+1_m, 0_m};
     const auto body2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location2));
     ASSERT_EQ(body2->GetLocation(), location2);
     ASSERT_NE(body2->CreateFixture(shape), nullptr);
@@ -118,7 +118,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
     jointdef.collideConnected = false;
     jointdef.localAnchorA = Length2{};
     jointdef.localAnchorB = Length2{};
-    jointdef.length = Real{5} * Meter;
+    jointdef.length = 5_m;
     jointdef.frequency = 0;
     jointdef.dampingRatio = 0;
     EXPECT_NE(world.CreateJoint(jointdef), nullptr);
@@ -157,12 +157,12 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
     const auto shape = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     shape->SetDensity(1_kgpm2);
     
-    const auto location1 = Length2{-Real(10) * Meter, Real(10) * Meter};
+    const auto location1 = Length2{-10_m, 10_m};
     const auto body1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location1));
     ASSERT_EQ(body1->GetLocation(), location1);
     ASSERT_NE(body1->CreateFixture(shape), nullptr);
     
-    const auto location2 = Length2{+Real(10) * Meter, -Real(10) * Meter};
+    const auto location2 = Length2{+10_m, -10_m};
     const auto body2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location2));
     ASSERT_EQ(body2->GetLocation(), location2);
     ASSERT_NE(body2->CreateFixture(shape), nullptr);
@@ -173,7 +173,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
     jointdef.collideConnected = false;
     jointdef.localAnchorA = Length2{};
     jointdef.localAnchorB = Length2{};
-    jointdef.length = Real{5} * Meter;
+    jointdef.length = 5_m;
     jointdef.frequency = 60_Hz;
     jointdef.dampingRatio = 0;
     EXPECT_NE(world.CreateJoint(jointdef), nullptr);
@@ -222,9 +222,9 @@ TEST(DistanceJointDef, GetDistanceJointDefFreeFunction)
     def.bodyB = bB;
     def.collideConnected = false;
     def.userData = reinterpret_cast<void*>(71);
-    def.localAnchorA = Length2(Real(21) * Meter, Real(-2) * Meter);
-    def.localAnchorB = Length2(Real(13) * Meter, Real(12) * Meter);
-    def.length = Real{5} * Meter;
+    def.localAnchorA = Length2(21_m, -2_m);
+    def.localAnchorB = Length2(13_m, 12_m);
+    def.length = 5_m;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);
     

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -48,8 +48,8 @@ TEST(DistanceJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, false);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, (Length2D{}));
-    EXPECT_EQ(def.localAnchorB, (Length2D{}));
+    EXPECT_EQ(def.localAnchorA, (Length2{}));
+    EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.length, Real(1) * Meter);
     EXPECT_EQ(def.frequency, Frequency(0));
     EXPECT_EQ(def.dampingRatio, Real(0));
@@ -86,7 +86,7 @@ TEST(DistanceJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
 
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
@@ -98,16 +98,16 @@ TEST(DistanceJoint, Construction)
 
 TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
 
     const auto shape = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     
-    const auto location1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
+    const auto location1 = Length2{-Real(1) * Meter, Real(0) * Meter};
     const auto body1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location1));
     ASSERT_EQ(body1->GetLocation(), location1);
     ASSERT_NE(body1->CreateFixture(shape), nullptr);
     
-    const auto location2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto location2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto body2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location2));
     ASSERT_EQ(body2->GetLocation(), location2);
     ASSERT_NE(body2->CreateFixture(shape), nullptr);
@@ -116,8 +116,8 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
     jointdef.bodyA = body1;
     jointdef.bodyB = body2;
     jointdef.collideConnected = false;
-    jointdef.localAnchorA = Length2D{};
-    jointdef.localAnchorB = Length2D{};
+    jointdef.localAnchorA = Length2{};
+    jointdef.localAnchorB = Length2{};
     jointdef.length = Real{5} * Meter;
     jointdef.frequency = 0;
     jointdef.dampingRatio = 0;
@@ -152,17 +152,17 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
 
 TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{0, Real(10) * MeterPerSquareSecond})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{0, Real(10) * MeterPerSquareSecond})};
     
     const auto shape = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     shape->SetDensity(1_kgpm2);
     
-    const auto location1 = Length2D{-Real(10) * Meter, Real(10) * Meter};
+    const auto location1 = Length2{-Real(10) * Meter, Real(10) * Meter};
     const auto body1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location1));
     ASSERT_EQ(body1->GetLocation(), location1);
     ASSERT_NE(body1->CreateFixture(shape), nullptr);
     
-    const auto location2 = Length2D{+Real(10) * Meter, -Real(10) * Meter};
+    const auto location2 = Length2{+Real(10) * Meter, -Real(10) * Meter};
     const auto body2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location2));
     ASSERT_EQ(body2->GetLocation(), location2);
     ASSERT_NE(body2->CreateFixture(shape), nullptr);
@@ -171,8 +171,8 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
     jointdef.bodyA = body1;
     jointdef.bodyB = body2;
     jointdef.collideConnected = false;
-    jointdef.localAnchorA = Length2D{};
-    jointdef.localAnchorB = Length2D{};
+    jointdef.localAnchorA = Length2{};
+    jointdef.localAnchorB = Length2{};
     jointdef.length = Real{5} * Meter;
     jointdef.frequency = 60_Hz;
     jointdef.dampingRatio = 0;
@@ -222,8 +222,8 @@ TEST(DistanceJointDef, GetDistanceJointDefFreeFunction)
     def.bodyB = bB;
     def.collideConnected = false;
     def.userData = reinterpret_cast<void*>(71);
-    def.localAnchorA = Length2D(Real(21) * Meter, Real(-2) * Meter);
-    def.localAnchorB = Length2D(Real(13) * Meter, Real(12) * Meter);
+    def.localAnchorA = Length2(Real(21) * Meter, Real(-2) * Meter);
+    def.localAnchorB = Length2(Real(13) * Meter, Real(12) * Meter);
     def.length = Real{5} * Meter;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -100,7 +100,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
 {
     World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
 
-    const auto shape = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto shape = std::make_shared<DiskShape>(0.2_m);
     
     const auto location1 = Length2{-1_m, 0_m};
     const auto body1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location1));
@@ -142,7 +142,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
             EXPECT_GE(newDistance, oldDistance);
         }
         
-        if (!distanceMet && (Abs(newDistance - jointdef.length) < Real{0.01f} * Meter))
+        if (!distanceMet && (Abs(newDistance - jointdef.length) < 0.01_m))
         {
             distanceMet = i;
         }
@@ -154,7 +154,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
 {
     World world{WorldDef{}.UseGravity(LinearAcceleration2{0, Real(10) * MeterPerSquareSecond})};
     
-    const auto shape = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto shape = std::make_shared<DiskShape>(0.2_m);
     shape->SetDensity(1_kgpm2);
     
     const auto location1 = Length2{-10_m, 10_m};

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -49,13 +49,13 @@ TEST(DistanceProxy, DefaultInitialization)
     const auto defaultDp = DistanceProxy{};
     
     EXPECT_EQ(defaultDp.GetVertexCount(), 0);
-    EXPECT_EQ(defaultDp.GetVertexRadius(), (Real(0) * Meter));
+    EXPECT_EQ(defaultDp.GetVertexRadius(), (0_m));
 }
 
 TEST(DistanceProxy, OneVecInitialization)
 {
-    const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2{Real(2) * Meter, Real(-3) * Meter};
+    const auto radius = 1_m;
+    const auto vertex0 = Length2{2_m, -3_m};
     const auto normal0 = UnitVec2{};
     const DistanceProxy foo{radius, 1, &vertex0, &normal0};
     EXPECT_EQ(radius, foo.GetVertexRadius());
@@ -65,8 +65,8 @@ TEST(DistanceProxy, OneVecInitialization)
 
 TEST(DistanceProxy, OneVecSupportIndex)
 {
-    const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2{Real(2) * Meter, Real(-3) * Meter};
+    const auto radius = 1_m;
+    const auto vertex0 = Length2{2_m, -3_m};
     const auto normal0 = UnitVec2{};
     const DistanceProxy foo{radius, 1, &vertex0, &normal0};
     EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(vertex0)));
@@ -76,9 +76,9 @@ TEST(DistanceProxy, OneVecSupportIndex)
 
 TEST(DistanceProxy, TwoVecInitialization)
 {
-    const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2{Real(2) * Meter, Real(3) * Meter};
-    const auto vertex1 = Length2{Real(-10) * Meter, Real(-1) * Meter};
+    const auto radius = 1_m;
+    const auto vertex0 = Length2{2_m, 3_m};
+    const auto vertex1 = Length2{-10_m, -1_m};
     const Length2 vertices[] = {vertex0, vertex1};
     const auto normal0 = GetUnitVector(vertex1 - vertex0);
     const UnitVec2 normals[] = {normal0, -normal0};
@@ -91,27 +91,27 @@ TEST(DistanceProxy, TwoVecInitialization)
 
 TEST(DistanceProxy, TwoVecSupportIndex)
 {
-    const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2{Real(2) * Meter, Real(3) * Meter};
-    const auto vertex1 = Length2{Real(-10) * Meter, Real(-1) * Meter};
+    const auto radius = 1_m;
+    const auto vertex0 = Length2{2_m, 3_m};
+    const auto vertex1 = Length2{-10_m, -1_m};
     const Length2 vertices[] = {vertex0, vertex1};
     const auto normal0 = GetUnitVector(vertex1 - vertex0);
     const UnitVec2 normals[] = {normal0, -normal0};
     const DistanceProxy foo{radius, 2, vertices, normals};
     EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(vertex0)));
     EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2{GetY(vertex0), GetX(vertex0)})));
-    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2{Real(0) * Meter, Real(0) * Meter})));
+    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2{0_m, 0_m})));
     EXPECT_EQ(1, GetSupportIndex(foo, GetVec2(vertex1)));
     EXPECT_EQ(1, GetSupportIndex(foo, GetVec2(Length2{GetY(vertex1), GetX(vertex1)})));
 }
 
 TEST(DistanceProxy, ThreeVertices)
 {
-    const auto radius = Real(33) * Meter;
+    const auto radius = 33_m;
     const auto count = DistanceProxy::size_type(3);
-    const auto v0 = Length2{Real(1) * Meter, Real(2) * Meter};
-    const auto v1 = Length2{Real(-3) * Meter, Real(-4) * Meter};
-    const auto v2 = Length2{Real(-6) * Meter, Real(5) * Meter};
+    const auto v0 = Length2{1_m, 2_m};
+    const auto v1 = Length2{-3_m, -4_m};
+    const auto v2 = Length2{-6_m, 5_m};
     const Length2 vertices[] = {v0, v1, v2};
     const auto n0 = GetUnitVector(v1 - v0);
     const auto n1 = GetUnitVector(v2 - v1);
@@ -147,20 +147,20 @@ TEST(DistanceProxy, TestPointWithEmptyProxyReturnsFalse)
 
 TEST(DistanceProxy, TestPoint)
 {
-    const auto pos1 = Length2{Real(3) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2{Real(3) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2{Real(1) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const auto pos1 = Length2{3_m, 1_m};
+    const auto pos2 = Length2{3_m, 3_m};
+    const auto pos3 = Length2{1_m, 3_m};
+    const auto pos4 = Length2{1_m, 1_m};
     const Length2 squareVerts[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(GetFwdPerpendicular(pos2 - pos1));
     const auto n2 = GetUnitVector(GetFwdPerpendicular(pos3 - pos2));
     const auto n3 = GetUnitVector(GetFwdPerpendicular(pos4 - pos3));
     const auto n4 = GetUnitVector(GetFwdPerpendicular(pos1 - pos4));
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
-    const auto radius = Real(0.5) * Meter;
+    const auto radius = 0.5_m;
     DistanceProxy dp{radius, 4, squareVerts, squareNormals};
 
-    const auto pos0 = Length2{Real(2) * Meter, Real(2) * Meter};
+    const auto pos0 = Length2{2_m, 2_m};
     
     ASSERT_EQ(dp.GetVertexCount(), 4);
     EXPECT_TRUE(TestPoint(dp, pos0));
@@ -171,27 +171,27 @@ TEST(DistanceProxy, TestPoint)
     EXPECT_TRUE(TestPoint(dp, Length2{Real(3.2f) * Meter, Real(3.2f) * Meter}));
     EXPECT_TRUE(TestPoint(dp, pos2 + Length2{radius, radius} / Real(2)));
     EXPECT_FALSE(TestPoint(dp, pos2 + Length2{radius, radius}));
-    EXPECT_FALSE(TestPoint(dp, Length2{Real(10) * Meter, Real(10) * Meter}));
-    EXPECT_FALSE(TestPoint(dp, Length2{-Real(10) * Meter, Real(10) * Meter}));
-    EXPECT_FALSE(TestPoint(dp, Length2{Real(10) * Meter, -Real(10) * Meter}));
+    EXPECT_FALSE(TestPoint(dp, Length2{10_m, 10_m}));
+    EXPECT_FALSE(TestPoint(dp, Length2{-10_m, 10_m}));
+    EXPECT_FALSE(TestPoint(dp, Length2{10_m, -10_m}));
 }
 
 TEST(DistanceProxy, GetMaxSeparationFromWorld)
 {
-    const auto pos1 = Length2{Real(3) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2{Real(3) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2{Real(1) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const auto pos1 = Length2{3_m, 1_m};
+    const auto pos2 = Length2{3_m, 3_m};
+    const auto pos3 = Length2{1_m, 3_m};
+    const auto pos4 = Length2{1_m, 1_m};
     const Length2 squareVerts[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(GetFwdPerpendicular(pos2 - pos1));
     const auto n2 = GetUnitVector(GetFwdPerpendicular(pos3 - pos2));
     const auto n3 = GetUnitVector(GetFwdPerpendicular(pos4 - pos3));
     const auto n4 = GetUnitVector(GetFwdPerpendicular(pos1 - pos4));
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
-    const auto radius = Real(0.5) * Meter;
+    const auto radius = 0.5_m;
     const auto squareDp = DistanceProxy{radius, 4, squareVerts, squareNormals};
     
-    const auto pos5 = Length2{Real(-2) * Meter, Real(2) * Meter};
+    const auto pos5 = Length2{-2_m, 2_m};
     const Length2 circleVerts[] = {pos5};
     const auto n5 = UnitVec2::GetZero();
     const UnitVec2 circleNormals[] = {n5};
@@ -203,7 +203,7 @@ TEST(DistanceProxy, GetMaxSeparationFromWorld)
     EXPECT_EQ(result1.index1, static_cast<decltype(result1.index1)>(2));
     EXPECT_EQ(result1.index2, static_cast<decltype(result1.index2)>(0));
     
-    const auto result2 = GetMaxSeparation(squareDp, circleDp, Real(0) * Meter);
+    const auto result2 = GetMaxSeparation(squareDp, circleDp, 0_m);
     
     EXPECT_NEAR(static_cast<double>(Real(result2.separation / Meter)), 3.0, 0.0001);
     EXPECT_EQ(result2.index1, static_cast<decltype(result2.index1)>(2));

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -55,7 +55,7 @@ TEST(DistanceProxy, DefaultInitialization)
 TEST(DistanceProxy, OneVecInitialization)
 {
     const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2D{Real(2) * Meter, Real(-3) * Meter};
+    const auto vertex0 = Length2{Real(2) * Meter, Real(-3) * Meter};
     const auto normal0 = UnitVec2{};
     const DistanceProxy foo{radius, 1, &vertex0, &normal0};
     EXPECT_EQ(radius, foo.GetVertexRadius());
@@ -66,20 +66,20 @@ TEST(DistanceProxy, OneVecInitialization)
 TEST(DistanceProxy, OneVecSupportIndex)
 {
     const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2D{Real(2) * Meter, Real(-3) * Meter};
+    const auto vertex0 = Length2{Real(2) * Meter, Real(-3) * Meter};
     const auto normal0 = UnitVec2{};
     const DistanceProxy foo{radius, 1, &vertex0, &normal0};
     EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(vertex0)));
-    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2D{})));
-    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2D{GetY(vertex0), GetX(vertex0)})));
+    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2{})));
+    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2{GetY(vertex0), GetX(vertex0)})));
 }
 
 TEST(DistanceProxy, TwoVecInitialization)
 {
     const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2D{Real(2) * Meter, Real(3) * Meter};
-    const auto vertex1 = Length2D{Real(-10) * Meter, Real(-1) * Meter};
-    const Length2D vertices[] = {vertex0, vertex1};
+    const auto vertex0 = Length2{Real(2) * Meter, Real(3) * Meter};
+    const auto vertex1 = Length2{Real(-10) * Meter, Real(-1) * Meter};
+    const Length2 vertices[] = {vertex0, vertex1};
     const auto normal0 = GetUnitVector(vertex1 - vertex0);
     const UnitVec2 normals[] = {normal0, -normal0};
     const DistanceProxy foo{radius, 2, vertices, normals};
@@ -92,27 +92,27 @@ TEST(DistanceProxy, TwoVecInitialization)
 TEST(DistanceProxy, TwoVecSupportIndex)
 {
     const auto radius = Real{1} * Meter;
-    const auto vertex0 = Length2D{Real(2) * Meter, Real(3) * Meter};
-    const auto vertex1 = Length2D{Real(-10) * Meter, Real(-1) * Meter};
-    const Length2D vertices[] = {vertex0, vertex1};
+    const auto vertex0 = Length2{Real(2) * Meter, Real(3) * Meter};
+    const auto vertex1 = Length2{Real(-10) * Meter, Real(-1) * Meter};
+    const Length2 vertices[] = {vertex0, vertex1};
     const auto normal0 = GetUnitVector(vertex1 - vertex0);
     const UnitVec2 normals[] = {normal0, -normal0};
     const DistanceProxy foo{radius, 2, vertices, normals};
     EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(vertex0)));
-    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2D{GetY(vertex0), GetX(vertex0)})));
-    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2D{Real(0) * Meter, Real(0) * Meter})));
+    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2{GetY(vertex0), GetX(vertex0)})));
+    EXPECT_EQ(0, GetSupportIndex(foo, GetVec2(Length2{Real(0) * Meter, Real(0) * Meter})));
     EXPECT_EQ(1, GetSupportIndex(foo, GetVec2(vertex1)));
-    EXPECT_EQ(1, GetSupportIndex(foo, GetVec2(Length2D{GetY(vertex1), GetX(vertex1)})));
+    EXPECT_EQ(1, GetSupportIndex(foo, GetVec2(Length2{GetY(vertex1), GetX(vertex1)})));
 }
 
 TEST(DistanceProxy, ThreeVertices)
 {
     const auto radius = Real(33) * Meter;
     const auto count = DistanceProxy::size_type(3);
-    const auto v0 = Length2D{Real(1) * Meter, Real(2) * Meter};
-    const auto v1 = Length2D{Real(-3) * Meter, Real(-4) * Meter};
-    const auto v2 = Length2D{Real(-6) * Meter, Real(5) * Meter};
-    const Length2D vertices[] = {v0, v1, v2};
+    const auto v0 = Length2{Real(1) * Meter, Real(2) * Meter};
+    const auto v1 = Length2{Real(-3) * Meter, Real(-4) * Meter};
+    const auto v2 = Length2{Real(-6) * Meter, Real(5) * Meter};
+    const Length2 vertices[] = {v0, v1, v2};
     const auto n0 = GetUnitVector(v1 - v0);
     const auto n1 = GetUnitVector(v2 - v1);
     const auto n2 = GetUnitVector(v0 - v2);
@@ -132,8 +132,8 @@ TEST(DistanceProxy, ThreeVertices)
 
 TEST(DistanceProxy, FindLowestRightMostVertex)
 {
-    const auto vertices = std::vector<Length2D>();
-    const auto span = Span<const Length2D>(vertices.data(), std::size_t{0});
+    const auto vertices = std::vector<Length2>();
+    const auto span = Span<const Length2>(vertices.data(), std::size_t{0});
     const auto result = FindLowestRightMostVertex(span);
     EXPECT_EQ(result, static_cast<std::size_t>(-1));
 }
@@ -142,16 +142,16 @@ TEST(DistanceProxy, TestPointWithEmptyProxyReturnsFalse)
 {
     const auto defaultDp = DistanceProxy{};
     ASSERT_EQ(defaultDp.GetVertexCount(), 0);
-    EXPECT_FALSE(TestPoint(defaultDp, Length2D{}));
+    EXPECT_FALSE(TestPoint(defaultDp, Length2{}));
 }
 
 TEST(DistanceProxy, TestPoint)
 {
-    const auto pos1 = Length2D{Real(3) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2D{Real(3) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2D{Real(1) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2D{Real(1) * Meter, Real(1) * Meter};
-    const Length2D squareVerts[] = {pos1, pos2, pos3, pos4};
+    const auto pos1 = Length2{Real(3) * Meter, Real(1) * Meter};
+    const auto pos2 = Length2{Real(3) * Meter, Real(3) * Meter};
+    const auto pos3 = Length2{Real(1) * Meter, Real(3) * Meter};
+    const auto pos4 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const Length2 squareVerts[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(GetFwdPerpendicular(pos2 - pos1));
     const auto n2 = GetUnitVector(GetFwdPerpendicular(pos3 - pos2));
     const auto n3 = GetUnitVector(GetFwdPerpendicular(pos4 - pos3));
@@ -160,7 +160,7 @@ TEST(DistanceProxy, TestPoint)
     const auto radius = Real(0.5) * Meter;
     DistanceProxy dp{radius, 4, squareVerts, squareNormals};
 
-    const auto pos0 = Length2D{Real(2) * Meter, Real(2) * Meter};
+    const auto pos0 = Length2{Real(2) * Meter, Real(2) * Meter};
     
     ASSERT_EQ(dp.GetVertexCount(), 4);
     EXPECT_TRUE(TestPoint(dp, pos0));
@@ -168,21 +168,21 @@ TEST(DistanceProxy, TestPoint)
     EXPECT_TRUE(TestPoint(dp, pos2));
     EXPECT_TRUE(TestPoint(dp, pos3));
     EXPECT_TRUE(TestPoint(dp, pos4));
-    EXPECT_TRUE(TestPoint(dp, Length2D{Real(3.2f) * Meter, Real(3.2f) * Meter}));
-    EXPECT_TRUE(TestPoint(dp, pos2 + Length2D{radius, radius} / Real(2)));
-    EXPECT_FALSE(TestPoint(dp, pos2 + Length2D{radius, radius}));
-    EXPECT_FALSE(TestPoint(dp, Length2D{Real(10) * Meter, Real(10) * Meter}));
-    EXPECT_FALSE(TestPoint(dp, Length2D{-Real(10) * Meter, Real(10) * Meter}));
-    EXPECT_FALSE(TestPoint(dp, Length2D{Real(10) * Meter, -Real(10) * Meter}));
+    EXPECT_TRUE(TestPoint(dp, Length2{Real(3.2f) * Meter, Real(3.2f) * Meter}));
+    EXPECT_TRUE(TestPoint(dp, pos2 + Length2{radius, radius} / Real(2)));
+    EXPECT_FALSE(TestPoint(dp, pos2 + Length2{radius, radius}));
+    EXPECT_FALSE(TestPoint(dp, Length2{Real(10) * Meter, Real(10) * Meter}));
+    EXPECT_FALSE(TestPoint(dp, Length2{-Real(10) * Meter, Real(10) * Meter}));
+    EXPECT_FALSE(TestPoint(dp, Length2{Real(10) * Meter, -Real(10) * Meter}));
 }
 
 TEST(DistanceProxy, GetMaxSeparationFromWorld)
 {
-    const auto pos1 = Length2D{Real(3) * Meter, Real(1) * Meter};
-    const auto pos2 = Length2D{Real(3) * Meter, Real(3) * Meter};
-    const auto pos3 = Length2D{Real(1) * Meter, Real(3) * Meter};
-    const auto pos4 = Length2D{Real(1) * Meter, Real(1) * Meter};
-    const Length2D squareVerts[] = {pos1, pos2, pos3, pos4};
+    const auto pos1 = Length2{Real(3) * Meter, Real(1) * Meter};
+    const auto pos2 = Length2{Real(3) * Meter, Real(3) * Meter};
+    const auto pos3 = Length2{Real(1) * Meter, Real(3) * Meter};
+    const auto pos4 = Length2{Real(1) * Meter, Real(1) * Meter};
+    const Length2 squareVerts[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(GetFwdPerpendicular(pos2 - pos1));
     const auto n2 = GetUnitVector(GetFwdPerpendicular(pos3 - pos2));
     const auto n3 = GetUnitVector(GetFwdPerpendicular(pos4 - pos3));
@@ -191,8 +191,8 @@ TEST(DistanceProxy, GetMaxSeparationFromWorld)
     const auto radius = Real(0.5) * Meter;
     const auto squareDp = DistanceProxy{radius, 4, squareVerts, squareNormals};
     
-    const auto pos5 = Length2D{Real(-2) * Meter, Real(2) * Meter};
-    const Length2D circleVerts[] = {pos5};
+    const auto pos5 = Length2{Real(-2) * Meter, Real(2) * Meter};
+    const Length2 circleVerts[] = {pos5};
     const auto n5 = UnitVec2::GetZero();
     const UnitVec2 circleNormals[] = {n5};
     const auto circleDp = DistanceProxy{radius, 1, circleVerts, circleNormals};

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -168,7 +168,7 @@ TEST(DistanceProxy, TestPoint)
     EXPECT_TRUE(TestPoint(dp, pos2));
     EXPECT_TRUE(TestPoint(dp, pos3));
     EXPECT_TRUE(TestPoint(dp, pos4));
-    EXPECT_TRUE(TestPoint(dp, Length2{Real(3.2f) * Meter, Real(3.2f) * Meter}));
+    EXPECT_TRUE(TestPoint(dp, Length2{3.2_m, 3.2_m}));
     EXPECT_TRUE(TestPoint(dp, pos2 + Length2{radius, radius} / Real(2)));
     EXPECT_FALSE(TestPoint(dp, pos2 + Length2{radius, radius}));
     EXPECT_FALSE(TestPoint(dp, Length2{10_m, 10_m}));

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -101,8 +101,8 @@ TEST(DynamicTree, CopyConstruction)
     }
 
     const auto aabb = AABB{
-        Length2{Real(0) * Meter, Real(0) * Meter},
-        Length2(Real(1) * Meter, Real(1) * Meter)
+        Length2{0_m, 0_m},
+        Length2(1_m, 1_m)
     };
     const auto pid = orig.CreateLeaf(aabb, DynamicTree::LeafData{nullptr, nullptr, 0u});
     {
@@ -132,8 +132,8 @@ TEST(DynamicTree, CopyAssignment)
     }
     
     const auto aabb = AABB{
-        Length2{Real(0) * Meter, Real(0) * Meter},
-        Length2{Real(1) * Meter, Real(1) * Meter}
+        Length2{0_m, 0_m},
+        Length2{1_m, 1_m}
     };
     const auto pid = orig.CreateLeaf(aabb, DynamicTree::LeafData{nullptr, nullptr, 0u});
     {
@@ -157,8 +157,8 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
-        Length2{Real(3) * Meter, Real(1) * Meter},
-        Length2{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{3_m, 1_m},
+        Length2{-5_m, -2_m}
     };
     const auto userdata = DynamicTree::LeafData{nullptr, nullptr, 0u};
 
@@ -189,8 +189,8 @@ TEST(DynamicTree, FourIdenticalProxies)
     ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
-        Length2{Real(3) * Meter, Real(1) * Meter},
-        Length2{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{3_m, 1_m},
+        Length2{-5_m, -2_m}
     };
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
 
@@ -261,8 +261,8 @@ TEST(DynamicTree, MoveConstruction)
     DynamicTree foo;
     
     const auto aabb = AABB{
-        Length2{Real(3) * Meter, Real(1) * Meter},
-        Length2{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{3_m, 1_m},
+        Length2{-5_m, -2_m}
     };
 
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
@@ -301,8 +301,8 @@ TEST(DynamicTree, MoveAssignment)
     DynamicTree foo;
     
     const auto aabb = AABB{
-        Length2{Real(3) * Meter, Real(1) * Meter},
-        Length2{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{3_m, 1_m},
+        Length2{-5_m, -2_m}
     };
     
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
@@ -346,8 +346,8 @@ TEST(DynamicTree, CapacityIncreases)
     ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
-        Length2{Real(3) * Meter, Real(1) * Meter},
-        Length2{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{3_m, 1_m},
+        Length2{-5_m, -2_m}
     };
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
 

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -101,8 +101,8 @@ TEST(DynamicTree, CopyConstruction)
     }
 
     const auto aabb = AABB{
-        Length2D{Real(0) * Meter, Real(0) * Meter},
-        Length2D(Real(1) * Meter, Real(1) * Meter)
+        Length2{Real(0) * Meter, Real(0) * Meter},
+        Length2(Real(1) * Meter, Real(1) * Meter)
     };
     const auto pid = orig.CreateLeaf(aabb, DynamicTree::LeafData{nullptr, nullptr, 0u});
     {
@@ -132,8 +132,8 @@ TEST(DynamicTree, CopyAssignment)
     }
     
     const auto aabb = AABB{
-        Length2D{Real(0) * Meter, Real(0) * Meter},
-        Length2D{Real(1) * Meter, Real(1) * Meter}
+        Length2{Real(0) * Meter, Real(0) * Meter},
+        Length2{Real(1) * Meter, Real(1) * Meter}
     };
     const auto pid = orig.CreateLeaf(aabb, DynamicTree::LeafData{nullptr, nullptr, 0u});
     {
@@ -157,8 +157,8 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
-        Length2D{Real(3) * Meter, Real(1) * Meter},
-        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{Real(3) * Meter, Real(1) * Meter},
+        Length2{-Real(5) * Meter, -Real(2) * Meter}
     };
     const auto userdata = DynamicTree::LeafData{nullptr, nullptr, 0u};
 
@@ -189,8 +189,8 @@ TEST(DynamicTree, FourIdenticalProxies)
     ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
-        Length2D{Real(3) * Meter, Real(1) * Meter},
-        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{Real(3) * Meter, Real(1) * Meter},
+        Length2{-Real(5) * Meter, -Real(2) * Meter}
     };
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
 
@@ -261,8 +261,8 @@ TEST(DynamicTree, MoveConstruction)
     DynamicTree foo;
     
     const auto aabb = AABB{
-        Length2D{Real(3) * Meter, Real(1) * Meter},
-        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{Real(3) * Meter, Real(1) * Meter},
+        Length2{-Real(5) * Meter, -Real(2) * Meter}
     };
 
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
@@ -301,8 +301,8 @@ TEST(DynamicTree, MoveAssignment)
     DynamicTree foo;
     
     const auto aabb = AABB{
-        Length2D{Real(3) * Meter, Real(1) * Meter},
-        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{Real(3) * Meter, Real(1) * Meter},
+        Length2{-Real(5) * Meter, -Real(2) * Meter}
     };
     
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
@@ -346,8 +346,8 @@ TEST(DynamicTree, CapacityIncreases)
     ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(0));
 
     const auto aabb = AABB{
-        Length2D{Real(3) * Meter, Real(1) * Meter},
-        Length2D{-Real(5) * Meter, -Real(2) * Meter}
+        Length2{Real(3) * Meter, Real(1) * Meter},
+        Length2{-Real(5) * Meter, -Real(2) * Meter}
     };
     const auto leafData = DynamicTree::LeafData{nullptr, nullptr, 0u};
 

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -70,7 +70,7 @@ TEST(Fixture, CreateMatchesDef)
 TEST(Fixture, SetSensor)
 {
     const auto shapeA = std::make_shared<DiskShape>();
-    const auto bodyCtrPos = Length2D(1_m, 2_m);
+    const auto bodyCtrPos = Length2(1_m, 2_m);
     
     World world;
     const auto body = world.CreateBody(BodyDef{}.UseLocation(bodyCtrPos));
@@ -86,13 +86,13 @@ TEST(Fixture, SetSensor)
 TEST(Fixture, TestPointFreeFunction)
 {
     const auto shapeA = std::make_shared<DiskShape>();
-    const auto bodyCtrPos = Length2D(1_m, 2_m);
+    const auto bodyCtrPos = Length2(1_m, 2_m);
 
     World world;
     const auto body = world.CreateBody(BodyDef{}.UseLocation(bodyCtrPos));
     const auto fixture = body->CreateFixture(shapeA);
     EXPECT_TRUE(TestPoint(*fixture, bodyCtrPos));
-    EXPECT_FALSE(TestPoint(*fixture, Length2D{}));
+    EXPECT_FALSE(TestPoint(*fixture, Length2{}));
 }
 
 TEST(Fixture, SetAwakeFreeFunction)

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -49,20 +49,20 @@ TEST(FrictionJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, false);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, (Length2D{}));
-    EXPECT_EQ(def.localAnchorB, (Length2D{}));
+    EXPECT_EQ(def.localAnchorA, (Length2{}));
+    EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.maxForce, 0_N);
     EXPECT_EQ(def.maxTorque, 0_Nm);
 }
 
 TEST(FrictionJointDef, InitializingConstructor)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-1_m, 0_m};
-    const auto p2 = Length2D{+1_m, 0_m};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
-    const auto anchor = Length2D{0_m, 0_m};
+    const auto anchor = Length2{0_m, 0_m};
     const auto def = FrictionJointDef{b1, b2, anchor};
     EXPECT_EQ(def.bodyA, b1);
     EXPECT_EQ(def.bodyB, b2);
@@ -80,7 +80,7 @@ TEST(FrictionJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
     
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
@@ -112,8 +112,8 @@ TEST(FrictionJoint, GetFrictionJointDef)
     EXPECT_EQ(cdef.collideConnected, false);
     EXPECT_EQ(cdef.userData, nullptr);
     
-    EXPECT_EQ(cdef.localAnchorA, (Length2D{}));
-    EXPECT_EQ(cdef.localAnchorB, (Length2D{}));
+    EXPECT_EQ(cdef.localAnchorA, (Length2{}));
+    EXPECT_EQ(cdef.localAnchorB, (Length2{}));
     EXPECT_EQ(cdef.maxForce, 0_N);
     EXPECT_EQ(cdef.maxTorque, 0_Nm);
 }
@@ -121,9 +121,9 @@ TEST(FrictionJoint, GetFrictionJointDef)
 TEST(FrictionJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(0.2_m);
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-1_m, 0_m};
-    const auto p2 = Length2D{+1_m, 0_m};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -84,7 +84,7 @@ TEST(GearJoint, ByteSize)
 TEST(GearJoint, Construction)
 {
     Body body{nullptr, BodyDef{}};
-    RevoluteJointDef rdef{&body, &body, Length2D{}};
+    RevoluteJointDef rdef{&body, &body, Length2{}};
     RevoluteJoint revJoint1{rdef};
     RevoluteJoint revJoint2{rdef};
     GearJointDef def{&revJoint1, &revJoint2};
@@ -95,7 +95,7 @@ TEST(GearJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.joint2->GetBodyB());
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
     
     EXPECT_EQ(joint.GetLocalAnchorA(), revJoint1.GetLocalAnchorB());
@@ -108,7 +108,7 @@ TEST(GearJoint, Construction)
 TEST(GearJoint, SetRatio)
 {
     Body body{nullptr, BodyDef{}};
-    RevoluteJointDef rdef{&body, &body, Length2D{}};
+    RevoluteJointDef rdef{&body, &body, Length2{}};
     RevoluteJoint revJoint1{rdef};
     RevoluteJoint revJoint2{rdef};
     auto def = GearJointDef{&revJoint1, &revJoint2};
@@ -121,7 +121,7 @@ TEST(GearJoint, SetRatio)
 TEST(GearJoint, GetGearJointDef)
 {
     Body body{nullptr, BodyDef{}};
-    RevoluteJointDef rdef{&body, &body, Length2D{}};
+    RevoluteJointDef rdef{&body, &body, Length2{}};
     RevoluteJoint revJoint1{rdef};
     RevoluteJoint revJoint2{rdef};
     GearJointDef def{&revJoint1, &revJoint2};
@@ -154,11 +154,11 @@ TEST(GearJoint, GetGearJointDef)
 TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
-    const auto p3 = Length2D{+Real(2) * Meter, Real(0) * Meter};
-    const auto p4 = Length2D{+Real(3) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p3 = Length2{+Real(2) * Meter, Real(0) * Meter};
+    const auto p4 = Length2{+Real(3) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p3));
@@ -166,8 +166,8 @@ TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
     GearJointDef def{
-        world.CreateJoint(RevoluteJointDef{b1, b2, Length2D{}}),
-        world.CreateJoint(RevoluteJointDef{b4, b3, Length2D{}})
+        world.CreateJoint(RevoluteJointDef{b1, b2, Length2{}}),
+        world.CreateJoint(RevoluteJointDef{b4, b3, Length2{}})
     };
     ASSERT_NE(def.joint1, nullptr);
     ASSERT_NE(def.joint2, nullptr);
@@ -185,11 +185,11 @@ TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
 TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
-    const auto p3 = Length2D{+Real(2) * Meter, Real(0) * Meter};
-    const auto p4 = Length2D{+Real(3) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p3 = Length2{+Real(2) * Meter, Real(0) * Meter};
+    const auto p4 = Length2{+Real(3) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p3));
@@ -197,8 +197,8 @@ TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
     GearJointDef def{
-        world.CreateJoint(PrismaticJointDef{b1, b2, Length2D{}, UnitVec2::GetTop()}),
-        world.CreateJoint(PrismaticJointDef{b4, b3, Length2D{}, UnitVec2::GetTop()})
+        world.CreateJoint(PrismaticJointDef{b1, b2, Length2{}, UnitVec2::GetTop()}),
+        world.CreateJoint(PrismaticJointDef{b4, b3, Length2{}, UnitVec2::GetTop()})
     };
     ASSERT_NE(def.joint1, nullptr);
     ASSERT_NE(def.joint2, nullptr);
@@ -216,11 +216,11 @@ TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
 TEST(GearJoint, GetAnchorAandB)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
-    const auto p3 = Length2D{+Real(2) * Meter, Real(0) * Meter};
-    const auto p4 = Length2D{+Real(3) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p3 = Length2{+Real(2) * Meter, Real(0) * Meter};
+    const auto p4 = Length2{+Real(3) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p3));
@@ -228,8 +228,8 @@ TEST(GearJoint, GetAnchorAandB)
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
     GearJointDef def{
-        world.CreateJoint(RevoluteJointDef{b1, b2, Length2D{}}),
-        world.CreateJoint(RevoluteJointDef{b4, b3, Length2D{}})
+        world.CreateJoint(RevoluteJointDef{b1, b2, Length2{}}),
+        world.CreateJoint(RevoluteJointDef{b4, b3, Length2{}})
     };
     ASSERT_NE(def.joint1, nullptr);
     ASSERT_NE(def.joint2, nullptr);

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -153,7 +153,7 @@ TEST(GearJoint, GetGearJointDef)
 
 TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -184,7 +184,7 @@ TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
 
 TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -215,7 +215,7 @@ TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
 
 TEST(GearJoint, GetAnchorAandB)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -155,10 +155,10 @@ TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
-    const auto p3 = Length2{+Real(2) * Meter, Real(0) * Meter};
-    const auto p4 = Length2{+Real(3) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
+    const auto p3 = Length2{+2_m, 0_m};
+    const auto p4 = Length2{+3_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p3));
@@ -186,10 +186,10 @@ TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
-    const auto p3 = Length2{+Real(2) * Meter, Real(0) * Meter};
-    const auto p4 = Length2{+Real(3) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
+    const auto p3 = Length2{+2_m, 0_m};
+    const auto p4 = Length2{+3_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p3));
@@ -217,10 +217,10 @@ TEST(GearJoint, GetAnchorAandB)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
-    const auto p3 = Length2{+Real(2) * Meter, Real(0) * Meter};
-    const auto p4 = Length2{+Real(3) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
+    const auto p3 = Length2{+2_m, 0_m};
+    const auto p4 = Length2{+3_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p3));

--- a/UnitTests/Manifold.cpp
+++ b/UnitTests/Manifold.cpp
@@ -76,7 +76,7 @@ TEST(Manifold, GetForFaceA)
         EXPECT_EQ(foo.GetPointCount(), Manifold::size_type(0));
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
+        const auto pl = Length2{-0.12_m, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 0);
         const auto ni = 2.9_Ns;
         const auto ti = .7_Ns;
@@ -93,7 +93,7 @@ TEST(Manifold, GetForFaceA)
         EXPECT_EQ(p0.tangentImpulse, ti);
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
+        const auto pl = Length2{-0.12_m, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 1);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -128,7 +128,7 @@ TEST(Manifold, GetForFaceB)
         EXPECT_EQ(foo.GetPointCount(), Manifold::size_type(0));
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
+        const auto pl = Length2{-0.12_m, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 0);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -145,7 +145,7 @@ TEST(Manifold, GetForFaceB)
         EXPECT_EQ(p0.tangentImpulse, ti);
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
+        const auto pl = Length2{-0.12_m, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 1);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;

--- a/UnitTests/Manifold.cpp
+++ b/UnitTests/Manifold.cpp
@@ -41,7 +41,7 @@ TEST(Manifold, DefaultConstruction)
 
 TEST(Manifold, PointInitializingConstructor)
 {
-    const auto lp = Length2{Real(3) * Meter, Real(4) * Meter};
+    const auto lp = Length2{3_m, 4_m};
     const auto ni = 1.2_Ns;
     const auto ti = 2.4_Ns;
     const auto cf = ContactFeature{};
@@ -55,7 +55,7 @@ TEST(Manifold, PointInitializingConstructor)
 
 TEST(Manifold, GetForCircles)
 {
-    const auto ctr = Length2{Real(99) * Meter, Real(21) * Meter};
+    const auto ctr = Length2{99_m, 21_m};
     const auto foo = Manifold::GetForCircles(ctr, 0, ctr, 0);
     EXPECT_EQ(foo.GetType(), Manifold::e_circles);
     EXPECT_EQ(foo.GetLocalPoint(), ctr);
@@ -76,7 +76,7 @@ TEST(Manifold, GetForFaceA)
         EXPECT_EQ(foo.GetPointCount(), Manifold::size_type(0));
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 0);
         const auto ni = 2.9_Ns;
         const auto ti = .7_Ns;
@@ -93,7 +93,7 @@ TEST(Manifold, GetForFaceA)
         EXPECT_EQ(p0.tangentImpulse, ti);
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 1);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -128,7 +128,7 @@ TEST(Manifold, GetForFaceB)
         EXPECT_EQ(foo.GetPointCount(), Manifold::size_type(0));
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 0);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -145,7 +145,7 @@ TEST(Manifold, GetForFaceB)
         EXPECT_EQ(p0.tangentImpulse, ti);
     }
     {
-        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, 0.34_m};
         const auto cf = GetFaceFaceContactFeature(0, 1);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -170,8 +170,8 @@ TEST(Manifold, GetForFaceB)
 
 TEST(Manifold, PointEqualsFreeFunction)
 {
-    const auto localPoint1 = Length2{Real(1) * Meter, Real(2) * Meter};
-    const auto localPoint2 = Length2{Real(3) * Meter, Real(-1) * Meter};
+    const auto localPoint1 = Length2{1_m, 2_m};
+    const auto localPoint2 = Length2{3_m, -1_m};
     const auto cf1 = ContactFeature{ContactFeature::e_vertex, 1, ContactFeature::e_vertex, 2};
     const auto cf2 = ContactFeature{ContactFeature::e_vertex, 0, ContactFeature::e_vertex, 1};
     const auto normalImpulse1 = 1_Ns;
@@ -197,15 +197,15 @@ TEST(Manifold, EqualsFreeFunction)
 {
     const auto ln0 = UnitVec2::GetLeft();
     const auto ln1 = UnitVec2::GetRight();
-    const auto lp0 = Length2{Real(0) * Meter, Real(0) * Meter};
-    const auto lp1 = Length2(Real(1) * Meter, Real(1) * Meter);
+    const auto lp0 = Length2{0_m, 0_m};
+    const auto lp1 = Length2(1_m, 1_m);
     const auto foo = Manifold::GetForFaceB(ln0, lp0);
     const auto boo = Manifold::GetForFaceA(ln0, lp0);
     const auto poo = Manifold::GetForFaceA(ln0, lp0);
     const auto goo = Manifold::GetForFaceA(ln0, lp1);
     const auto too = Manifold::GetForFaceA(ln1, lp0);
     //const auto nottoo = Manifold::GetForFaceA(UnitVec2{}, lp0);
-    const auto localPoint1 = Length2{Real(1) * Meter, Real(2) * Meter};
+    const auto localPoint1 = Length2{1_m, 2_m};
     const auto cf1 = ContactFeature{ContactFeature::e_vertex, 1, ContactFeature::e_vertex, 2};
     const auto cf2 = ContactFeature{ContactFeature::e_vertex, 0, ContactFeature::e_vertex, 1};
     const auto normalImpulse1 = 1_Ns;
@@ -237,8 +237,8 @@ TEST(Manifold, NotEqualsFreeFunction)
 {
     const auto ln0 = UnitVec2::GetLeft();
     const auto ln1 = UnitVec2::GetRight();
-    const auto lp0 = Length2{Real(0) * Meter, Real(0) * Meter};
-    const auto lp1 = Length2(Real(1) * Meter, Real(1) * Meter);
+    const auto lp0 = Length2{0_m, 0_m};
+    const auto lp1 = Length2(1_m, 1_m);
     const auto foo = Manifold::GetForFaceB(ln0, lp0);
     const auto boo = Manifold::GetForFaceA(ln0, lp0);
     const auto poo = Manifold::GetForFaceA(ln0, lp0);

--- a/UnitTests/Manifold.cpp
+++ b/UnitTests/Manifold.cpp
@@ -41,7 +41,7 @@ TEST(Manifold, DefaultConstruction)
 
 TEST(Manifold, PointInitializingConstructor)
 {
-    const auto lp = Length2D{Real(3) * Meter, Real(4) * Meter};
+    const auto lp = Length2{Real(3) * Meter, Real(4) * Meter};
     const auto ni = 1.2_Ns;
     const auto ti = 2.4_Ns;
     const auto cf = ContactFeature{};
@@ -55,7 +55,7 @@ TEST(Manifold, PointInitializingConstructor)
 
 TEST(Manifold, GetForCircles)
 {
-    const auto ctr = Length2D{Real(99) * Meter, Real(21) * Meter};
+    const auto ctr = Length2{Real(99) * Meter, Real(21) * Meter};
     const auto foo = Manifold::GetForCircles(ctr, 0, ctr, 0);
     EXPECT_EQ(foo.GetType(), Manifold::e_circles);
     EXPECT_EQ(foo.GetLocalPoint(), ctr);
@@ -67,7 +67,7 @@ TEST(Manifold, GetForCircles)
 TEST(Manifold, GetForFaceA)
 {
     const auto ln = UnitVec2::GetLeft();
-    const auto lp = Length2D{};
+    const auto lp = Length2{};
     {
         Manifold foo = Manifold::GetForFaceA(ln, lp);
         EXPECT_EQ(foo.GetType(), Manifold::e_faceA);
@@ -76,7 +76,7 @@ TEST(Manifold, GetForFaceA)
         EXPECT_EQ(foo.GetPointCount(), Manifold::size_type(0));
     }
     {
-        const auto pl = Length2D{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
         const auto cf = GetFaceFaceContactFeature(0, 0);
         const auto ni = 2.9_Ns;
         const auto ti = .7_Ns;
@@ -93,7 +93,7 @@ TEST(Manifold, GetForFaceA)
         EXPECT_EQ(p0.tangentImpulse, ti);
     }
     {
-        const auto pl = Length2D{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
         const auto cf = GetFaceFaceContactFeature(0, 1);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -119,7 +119,7 @@ TEST(Manifold, GetForFaceA)
 TEST(Manifold, GetForFaceB)
 {
     const auto ln = UnitVec2::GetLeft();
-    const auto lp = Length2D{};
+    const auto lp = Length2{};
     {
         Manifold foo = Manifold::GetForFaceB(ln, lp);
         EXPECT_EQ(foo.GetType(), Manifold::e_faceB);
@@ -128,7 +128,7 @@ TEST(Manifold, GetForFaceB)
         EXPECT_EQ(foo.GetPointCount(), Manifold::size_type(0));
     }
     {
-        const auto pl = Length2D{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
         const auto cf = GetFaceFaceContactFeature(0, 0);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -145,7 +145,7 @@ TEST(Manifold, GetForFaceB)
         EXPECT_EQ(p0.tangentImpulse, ti);
     }
     {
-        const auto pl = Length2D{Real(-0.12) * Meter, Real(0.34) * Meter};
+        const auto pl = Length2{Real(-0.12) * Meter, Real(0.34) * Meter};
         const auto cf = GetFaceFaceContactFeature(0, 1);
         const auto ni = 2.9_Ns;
         const auto ti = 0.7_Ns;
@@ -170,8 +170,8 @@ TEST(Manifold, GetForFaceB)
 
 TEST(Manifold, PointEqualsFreeFunction)
 {
-    const auto localPoint1 = Length2D{Real(1) * Meter, Real(2) * Meter};
-    const auto localPoint2 = Length2D{Real(3) * Meter, Real(-1) * Meter};
+    const auto localPoint1 = Length2{Real(1) * Meter, Real(2) * Meter};
+    const auto localPoint2 = Length2{Real(3) * Meter, Real(-1) * Meter};
     const auto cf1 = ContactFeature{ContactFeature::e_vertex, 1, ContactFeature::e_vertex, 2};
     const auto cf2 = ContactFeature{ContactFeature::e_vertex, 0, ContactFeature::e_vertex, 1};
     const auto normalImpulse1 = 1_Ns;
@@ -197,15 +197,15 @@ TEST(Manifold, EqualsFreeFunction)
 {
     const auto ln0 = UnitVec2::GetLeft();
     const auto ln1 = UnitVec2::GetRight();
-    const auto lp0 = Length2D{Real(0) * Meter, Real(0) * Meter};
-    const auto lp1 = Length2D(Real(1) * Meter, Real(1) * Meter);
+    const auto lp0 = Length2{Real(0) * Meter, Real(0) * Meter};
+    const auto lp1 = Length2(Real(1) * Meter, Real(1) * Meter);
     const auto foo = Manifold::GetForFaceB(ln0, lp0);
     const auto boo = Manifold::GetForFaceA(ln0, lp0);
     const auto poo = Manifold::GetForFaceA(ln0, lp0);
     const auto goo = Manifold::GetForFaceA(ln0, lp1);
     const auto too = Manifold::GetForFaceA(ln1, lp0);
     //const auto nottoo = Manifold::GetForFaceA(UnitVec2{}, lp0);
-    const auto localPoint1 = Length2D{Real(1) * Meter, Real(2) * Meter};
+    const auto localPoint1 = Length2{Real(1) * Meter, Real(2) * Meter};
     const auto cf1 = ContactFeature{ContactFeature::e_vertex, 1, ContactFeature::e_vertex, 2};
     const auto cf2 = ContactFeature{ContactFeature::e_vertex, 0, ContactFeature::e_vertex, 1};
     const auto normalImpulse1 = 1_Ns;
@@ -237,8 +237,8 @@ TEST(Manifold, NotEqualsFreeFunction)
 {
     const auto ln0 = UnitVec2::GetLeft();
     const auto ln1 = UnitVec2::GetRight();
-    const auto lp0 = Length2D{Real(0) * Meter, Real(0) * Meter};
-    const auto lp1 = Length2D(Real(1) * Meter, Real(1) * Meter);
+    const auto lp0 = Length2{Real(0) * Meter, Real(0) * Meter};
+    const auto lp1 = Length2(Real(1) * Meter, Real(1) * Meter);
     const auto foo = Manifold::GetForFaceB(ln0, lp0);
     const auto boo = Manifold::GetForFaceA(ln0, lp0);
     const auto poo = Manifold::GetForFaceA(ln0, lp0);

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -38,7 +38,7 @@ TEST(MassData, ByteSize)
 TEST(MassData, DefaultConstruct)
 {
     MassData foo;
-    EXPECT_EQ(foo.center, (Length2D{}));
+    EXPECT_EQ(foo.center, (Length2{}));
     EXPECT_EQ(foo.mass, Mass(0));
     EXPECT_EQ(foo.I, RotInertia(0));
 }
@@ -50,16 +50,16 @@ TEST(MassData, Traits)
     // EXPECT_TRUE(std::is_nothrow_default_constructible<MassData>::value); // gcc 6.3
     EXPECT_FALSE(std::is_trivially_default_constructible<MassData>::value);
     
-    EXPECT_FALSE((std::is_constructible<MassData, Length2D, Mass, RotInertia>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2D, Mass>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2D>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2D, NonNegative<Mass>, NonNegative<RotInertia>>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2D, NonNegative<Mass>>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2D>::value));
+    EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass, RotInertia>::value));
+    EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass>::value));
+    EXPECT_FALSE((std::is_constructible<MassData, Length2>::value));
+    EXPECT_FALSE((std::is_constructible<MassData, Length2, NonNegative<Mass>, NonNegative<RotInertia>>::value));
+    EXPECT_FALSE((std::is_constructible<MassData, Length2, NonNegative<Mass>>::value));
+    EXPECT_FALSE((std::is_constructible<MassData, Length2>::value));
     EXPECT_TRUE((std::is_constructible<MassData>::value));
     // EXPECT_FALSE(std::is_nothrow_constructible<MassData>::value); // clang 3.7 and 4.0
     // EXPECT_TRUE(std::is_nothrow_constructible<MassData>::value); // gcc 6.3
-    EXPECT_FALSE((std::is_trivially_constructible<MassData, Length2D, Mass, RotInertia>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<MassData, Length2, Mass, RotInertia>::value));
     
     EXPECT_TRUE(std::is_copy_constructible<MassData>::value);
     // EXPECT_TRUE(std::is_nothrow_copy_constructible<MassData>::value); // with clang-4.0 gcc 6.3
@@ -81,84 +81,84 @@ TEST(MassData, GetAreaOfPolygon)
 {
     {
         // empty
-        const auto vertices = Span<const Length2D>{};
+        const auto vertices = Span<const Length2>{};
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 0.0, 0.0);
     }
     {
         // point
-        const auto vertices = Vector<const Length2D, 1>{
-            Length2D{Real(-2) * Meter, Real(+0.5) * Meter},
+        const auto vertices = Vector<const Length2, 1>{
+            Length2{Real(-2) * Meter, Real(+0.5) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 0.0, 0.0);
     }
     {
         // edge
-        const auto vertices = Vector<const Length2D, 2>{
-            Length2D{Real(-2) * Meter, Real(+0.5) * Meter},
-            Length2D{Real(+2) * Meter, Real(+0.5) * Meter},
+        const auto vertices = Vector<const Length2, 2>{
+            Length2{Real(-2) * Meter, Real(+0.5) * Meter},
+            Length2{Real(+2) * Meter, Real(+0.5) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 0.0, 0.0);
     }
     {
         // CCW triangle
-        const auto vertices = Vector<const Length2D, 3>{
-            Length2D{Real(-2) * Meter, Real(+1.0) * Meter},
-            Length2D{Real(-2) * Meter, Real(-1.0) * Meter},
-            Length2D{Real(+2) * Meter, Real(+0.0) * Meter},
+        const auto vertices = Vector<const Length2, 3>{
+            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
+            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
+            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
     }
     {
         // CCW triangle
-        const auto vertices = Vector<const Length2D, 3>{
-            Length2D{Real(-2) * Meter, Real(-1.0) * Meter},
-            Length2D{Real(+2) * Meter, Real(+0.0) * Meter},
-            Length2D{Real(-2) * Meter, Real(+1.0) * Meter},
+        const auto vertices = Vector<const Length2, 3>{
+            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
+            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
+            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
     }
     {
         // CCW triangle
-        const auto vertices = Vector<const Length2D, 3>{
-            Length2D{Real(+2) * Meter, Real(+0.0) * Meter},
-            Length2D{Real(-2) * Meter, Real(+1.0) * Meter},
-            Length2D{Real(-2) * Meter, Real(-1.0) * Meter},
+        const auto vertices = Vector<const Length2, 3>{
+            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
+            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
+            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
     }
     {
         // CW triangle
-        const auto vertices = Vector<const Length2D, 3>{
-            Length2D{Real(+2) * Meter, Real(+0.0) * Meter},
-            Length2D{Real(-2) * Meter, Real(-1.0) * Meter},
-            Length2D{Real(-2) * Meter, Real(+1.0) * Meter},
+        const auto vertices = Vector<const Length2, 3>{
+            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
+            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
+            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
     }
     {
         // CCW triangle
-        const auto vertices = Vector<const Length2D, 3>{
-            Length2D{Real(+0) * Meter, Real(-2.0) * Meter},
-            Length2D{Real(-4) * Meter, Real(-1.0) * Meter},
-            Length2D{Real(-4) * Meter, Real(-3.0) * Meter},
+        const auto vertices = Vector<const Length2, 3>{
+            Length2{Real(+0) * Meter, Real(-2.0) * Meter},
+            Length2{Real(-4) * Meter, Real(-1.0) * Meter},
+            Length2{Real(-4) * Meter, Real(-3.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
     }
     {
         // CCW quadrilateral
-        const auto vertices = Vector<const Length2D, 4>{
-            Length2D{Real(-2) * Meter, Real(+0.5) * Meter},
-            Length2D{Real(-2) * Meter, Real(-0.5) * Meter},
-            Length2D{Real(+2) * Meter, Real(-0.5) * Meter},
-            Length2D{Real(+2) * Meter, Real(+0.5) * Meter}
+        const auto vertices = Vector<const Length2, 4>{
+            Length2{Real(-2) * Meter, Real(+0.5) * Meter},
+            Length2{Real(-2) * Meter, Real(-0.5) * Meter},
+            Length2{Real(+2) * Meter, Real(-0.5) * Meter},
+            Length2{Real(+2) * Meter, Real(+0.5) * Meter}
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -169,11 +169,11 @@ TEST(MassData, GetMassDataFreeFunctionForNoVertices)
 {
     const auto vertexRadius = Length{Real(1) * Meter};
     const auto density = NonNegative<Density>(1_kgpm2);
-    const auto vertices = Span<const Length2D>{
-        static_cast<const Length2D*>(nullptr), Span<const Length2D>::size_type{0}
+    const auto vertices = Span<const Length2>{
+        static_cast<const Length2*>(nullptr), Span<const Length2>::size_type{0}
     };
     const auto massData = GetMassData(vertexRadius, density, vertices);
-    EXPECT_EQ(massData.center, (Length2D{}));
+    EXPECT_EQ(massData.center, (Length2{}));
     EXPECT_EQ(massData.mass, Mass(0));
     EXPECT_EQ(massData.I, RotInertia(0));
 }
@@ -193,7 +193,7 @@ TEST(MassData, GetForOriginCenteredCircle)
 {
     auto conf = DiskShape::Conf{};
     conf.vertexRadius = Real{1} * Meter;
-    conf.location = Length2D{};
+    conf.location = Length2{};
     conf.density = 1_kgpm2;
     const auto foo = DiskShape{conf};
     const auto mass_data = foo.GetMassData();
@@ -211,7 +211,7 @@ TEST(MassData, GetForOriginCenteredCircle)
 TEST(MassData, GetForCircle)
 {
     const auto radius = Real(1) * Meter;
-    const auto position = Length2D{-Real(1) * Meter, Real(1) * Meter};
+    const auto position = Length2{-Real(1) * Meter, Real(1) * Meter};
     const auto density = 1_kgpm2;
     auto conf = DiskShape::Conf{};
     conf.vertexRadius = radius;
@@ -259,8 +259,8 @@ TEST(MassData, GetForZeroVertexRadiusRectangle)
 
 TEST(MassData, GetForZeroVertexRadiusEdge)
 {
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto density = 2.1_kgpm2;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Length{0};
@@ -276,7 +276,7 @@ TEST(MassData, GetForZeroVertexRadiusEdge)
 
 TEST(MassData, GetForSamePointedEdgeIsSameAsCircle)
 {
-    const auto v1 = Length2D{-Real(1) * Meter, Real(1) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(1) * Meter};
     const auto density = 1_kgpm2;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Real{1} * Meter;
@@ -300,8 +300,8 @@ TEST(MassData, GetForSamePointedEdgeIsSameAsCircle)
 
 TEST(MassData, GetForCenteredEdge)
 {
-    const auto v1 = Length2D{-Real(2) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(2) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(2) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(2) * Meter, Real(0) * Meter};
     const auto radius = Real{0.5f} * Meter;
     const auto density = 2.1_kgpm2;
     
@@ -321,11 +321,11 @@ TEST(MassData, GetForCenteredEdge)
     ASSERT_EQ(shape.GetVertex2(), v2);
     ASSERT_EQ(shape.GetDensity(), density);
     
-    const auto vertices = Vector<Length2D, 4>{
-        Length2D(Real(-2) * Meter, Real(+0.5) * Meter),
-        Length2D(Real(-2) * Meter, Real(-0.5) * Meter),
-        Length2D(Real(+2) * Meter, Real(-0.5) * Meter),
-        Length2D(Real(+2) * Meter, Real(+0.5) * Meter)
+    const auto vertices = Vector<Length2, 4>{
+        Length2(Real(-2) * Meter, Real(+0.5) * Meter),
+        Length2(Real(-2) * Meter, Real(-0.5) * Meter),
+        Length2(Real(+2) * Meter, Real(-0.5) * Meter),
+        Length2(Real(+2) * Meter, Real(+0.5) * Meter)
     };
     const auto polarMoment = GetPolarMoment(vertices);
     EXPECT_NEAR(static_cast<double>(Real{polarMoment / (SquareMeter * SquareMeter)}),
@@ -381,7 +381,7 @@ TEST(MassData, Equals)
     EXPECT_TRUE(foo == boo);
     
     const auto poo = MassData{
-        Length2D(1_m, 1_m), 4_kg, RotInertia{2_kg * SquareMeter / SquareRadian}
+        Length2(1_m, 1_m), 4_kg, RotInertia{2_kg * SquareMeter / SquareRadian}
     };
     EXPECT_FALSE(foo == poo);
 }
@@ -395,7 +395,7 @@ TEST(MassData, NotEquals)
     EXPECT_FALSE(foo != boo);
     
     const auto poo = MassData{
-        Length2D(1_m, 1_m), 4_kg, RotInertia{2_kg * SquareMeter / SquareRadian}
+        Length2(1_m, 1_m), 4_kg, RotInertia{2_kg * SquareMeter / SquareRadian}
     };
     EXPECT_TRUE(foo != poo);
 }

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -88,7 +88,7 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // point
         const auto vertices = Vector<const Length2, 1>{
-            Length2{Real(-2) * Meter, Real(+0.5) * Meter},
+            Length2{-2_m, Real(+0.5) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 0.0, 0.0);
@@ -96,8 +96,8 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // edge
         const auto vertices = Vector<const Length2, 2>{
-            Length2{Real(-2) * Meter, Real(+0.5) * Meter},
-            Length2{Real(+2) * Meter, Real(+0.5) * Meter},
+            Length2{-2_m, Real(+0.5) * Meter},
+            Length2{+2_m, Real(+0.5) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 0.0, 0.0);
@@ -105,9 +105,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
-            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
-            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
+            Length2{-2_m, Real(+1.0) * Meter},
+            Length2{-2_m, Real(-1.0) * Meter},
+            Length2{+2_m, Real(+0.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -115,9 +115,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
-            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
-            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
+            Length2{-2_m, Real(-1.0) * Meter},
+            Length2{+2_m, Real(+0.0) * Meter},
+            Length2{-2_m, Real(+1.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -125,9 +125,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
-            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
-            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
+            Length2{+2_m, Real(+0.0) * Meter},
+            Length2{-2_m, Real(+1.0) * Meter},
+            Length2{-2_m, Real(-1.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -135,9 +135,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{Real(+2) * Meter, Real(+0.0) * Meter},
-            Length2{Real(-2) * Meter, Real(-1.0) * Meter},
-            Length2{Real(-2) * Meter, Real(+1.0) * Meter},
+            Length2{+2_m, Real(+0.0) * Meter},
+            Length2{-2_m, Real(-1.0) * Meter},
+            Length2{-2_m, Real(+1.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -145,9 +145,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{Real(+0) * Meter, Real(-2.0) * Meter},
-            Length2{Real(-4) * Meter, Real(-1.0) * Meter},
-            Length2{Real(-4) * Meter, Real(-3.0) * Meter},
+            Length2{+0_m, Real(-2.0) * Meter},
+            Length2{-4_m, Real(-1.0) * Meter},
+            Length2{-4_m, Real(-3.0) * Meter},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -155,10 +155,10 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW quadrilateral
         const auto vertices = Vector<const Length2, 4>{
-            Length2{Real(-2) * Meter, Real(+0.5) * Meter},
-            Length2{Real(-2) * Meter, Real(-0.5) * Meter},
-            Length2{Real(+2) * Meter, Real(-0.5) * Meter},
-            Length2{Real(+2) * Meter, Real(+0.5) * Meter}
+            Length2{-2_m, Real(+0.5) * Meter},
+            Length2{-2_m, Real(-0.5) * Meter},
+            Length2{+2_m, Real(-0.5) * Meter},
+            Length2{+2_m, Real(+0.5) * Meter}
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -167,7 +167,7 @@ TEST(MassData, GetAreaOfPolygon)
 
 TEST(MassData, GetMassDataFreeFunctionForNoVertices)
 {
-    const auto vertexRadius = Length{Real(1) * Meter};
+    const auto vertexRadius = Length{1_m};
     const auto density = NonNegative<Density>(1_kgpm2);
     const auto vertices = Span<const Length2>{
         static_cast<const Length2*>(nullptr), Span<const Length2>::size_type{0}
@@ -185,14 +185,14 @@ TEST(MassData, GetForZeroVertexRadiusCircle)
     const auto mass_data = shape.GetMassData();
     EXPECT_EQ(mass_data.mass, NonNegative<Mass>(0_kg));
     EXPECT_EQ(mass_data.I, RotInertia{0});
-    EXPECT_EQ(GetX(mass_data.center), Real{0} * Meter);
-    EXPECT_EQ(GetY(mass_data.center), Real{0} * Meter);
+    EXPECT_EQ(GetX(mass_data.center), 0_m);
+    EXPECT_EQ(GetY(mass_data.center), 0_m);
 }
 
 TEST(MassData, GetForOriginCenteredCircle)
 {
     auto conf = DiskShape::Conf{};
-    conf.vertexRadius = Real{1} * Meter;
+    conf.vertexRadius = 1_m;
     conf.location = Length2{};
     conf.density = 1_kgpm2;
     const auto foo = DiskShape{conf};
@@ -210,8 +210,8 @@ TEST(MassData, GetForOriginCenteredCircle)
 
 TEST(MassData, GetForCircle)
 {
-    const auto radius = Real(1) * Meter;
-    const auto position = Length2{-Real(1) * Meter, Real(1) * Meter};
+    const auto radius = 1_m;
+    const auto position = Length2{-1_m, 1_m};
     const auto density = 1_kgpm2;
     auto conf = DiskShape::Conf{};
     conf.vertexRadius = radius;
@@ -231,9 +231,9 @@ TEST(MassData, GetForZeroVertexRadiusRectangle)
     conf.vertexRadius = 0;
     conf.density = density;
     auto shape = PolygonShape(conf);
-    shape.SetAsBox(Real{4} * Meter, Real{1} * Meter);
-    ASSERT_EQ(GetX(shape.GetCentroid()), Real(0) * Meter);
-    ASSERT_EQ(GetY(shape.GetCentroid()), Real(0) * Meter);
+    shape.SetAsBox(4_m, 1_m);
+    ASSERT_EQ(GetX(shape.GetCentroid()), 0_m);
+    ASSERT_EQ(GetY(shape.GetCentroid()), 0_m);
     const auto mass_data = shape.GetMassData();
     EXPECT_TRUE(AlmostEqual(Real(Mass{mass_data.mass} / 1_kg),
                              Real((density / KilogramPerSquareMeter) * (8 * 2))));
@@ -259,8 +259,8 @@ TEST(MassData, GetForZeroVertexRadiusRectangle)
 
 TEST(MassData, GetForZeroVertexRadiusEdge)
 {
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
     const auto density = 2.1_kgpm2;
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Length{0};
@@ -276,10 +276,10 @@ TEST(MassData, GetForZeroVertexRadiusEdge)
 
 TEST(MassData, GetForSamePointedEdgeIsSameAsCircle)
 {
-    const auto v1 = Length2{-Real(1) * Meter, Real(1) * Meter};
+    const auto v1 = Length2{-1_m, 1_m};
     const auto density = 1_kgpm2;
     auto conf = EdgeShape::Conf{};
-    conf.vertexRadius = Real{1} * Meter;
+    conf.vertexRadius = 1_m;
     conf.density = density;
     auto shape = EdgeShape(conf);
     shape.Set(v1, v1);
@@ -300,8 +300,8 @@ TEST(MassData, GetForSamePointedEdgeIsSameAsCircle)
 
 TEST(MassData, GetForCenteredEdge)
 {
-    const auto v1 = Length2{-Real(2) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(2) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-2_m, 0_m};
+    const auto v2 = Length2{+2_m, 0_m};
     const auto radius = Real{0.5f} * Meter;
     const auto density = 2.1_kgpm2;
     
@@ -322,10 +322,10 @@ TEST(MassData, GetForCenteredEdge)
     ASSERT_EQ(shape.GetDensity(), density);
     
     const auto vertices = Vector<Length2, 4>{
-        Length2(Real(-2) * Meter, Real(+0.5) * Meter),
-        Length2(Real(-2) * Meter, Real(-0.5) * Meter),
-        Length2(Real(+2) * Meter, Real(-0.5) * Meter),
-        Length2(Real(+2) * Meter, Real(+0.5) * Meter)
+        Length2(-2_m, Real(+0.5) * Meter),
+        Length2(-2_m, Real(-0.5) * Meter),
+        Length2(+2_m, Real(-0.5) * Meter),
+        Length2(+2_m, Real(+0.5) * Meter)
     };
     const auto polarMoment = GetPolarMoment(vertices);
     EXPECT_NEAR(static_cast<double>(Real{polarMoment / (SquareMeter * SquareMeter)}),

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -88,7 +88,7 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // point
         const auto vertices = Vector<const Length2, 1>{
-            Length2{-2_m, Real(+0.5) * Meter},
+            Length2{-2_m, +0.5_m},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 0.0, 0.0);
@@ -96,8 +96,8 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // edge
         const auto vertices = Vector<const Length2, 2>{
-            Length2{-2_m, Real(+0.5) * Meter},
-            Length2{+2_m, Real(+0.5) * Meter},
+            Length2{-2_m, +0.5_m},
+            Length2{+2_m, +0.5_m},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 0.0, 0.0);
@@ -105,9 +105,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{-2_m, Real(+1.0) * Meter},
-            Length2{-2_m, Real(-1.0) * Meter},
-            Length2{+2_m, Real(+0.0) * Meter},
+            Length2{-2_m, +1.0_m},
+            Length2{-2_m, -1.0_m},
+            Length2{+2_m, +0.0_m},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -115,9 +115,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{-2_m, Real(-1.0) * Meter},
-            Length2{+2_m, Real(+0.0) * Meter},
-            Length2{-2_m, Real(+1.0) * Meter},
+            Length2{-2_m, -1.0_m},
+            Length2{+2_m, +0.0_m},
+            Length2{-2_m, +1.0_m},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -125,9 +125,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{+2_m, Real(+0.0) * Meter},
-            Length2{-2_m, Real(+1.0) * Meter},
-            Length2{-2_m, Real(-1.0) * Meter},
+            Length2{+2_m, +0.0_m},
+            Length2{-2_m, +1.0_m},
+            Length2{-2_m, -1.0_m},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -135,9 +135,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{+2_m, Real(+0.0) * Meter},
-            Length2{-2_m, Real(-1.0) * Meter},
-            Length2{-2_m, Real(+1.0) * Meter},
+            Length2{+2_m, +0.0_m},
+            Length2{-2_m, -1.0_m},
+            Length2{-2_m, +1.0_m},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -145,9 +145,9 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW triangle
         const auto vertices = Vector<const Length2, 3>{
-            Length2{+0_m, Real(-2.0) * Meter},
-            Length2{-4_m, Real(-1.0) * Meter},
-            Length2{-4_m, Real(-3.0) * Meter},
+            Length2{+0_m, -2.0_m},
+            Length2{-4_m, -1.0_m},
+            Length2{-4_m, -3.0_m},
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -155,10 +155,10 @@ TEST(MassData, GetAreaOfPolygon)
     {
         // CCW quadrilateral
         const auto vertices = Vector<const Length2, 4>{
-            Length2{-2_m, Real(+0.5) * Meter},
-            Length2{-2_m, Real(-0.5) * Meter},
-            Length2{+2_m, Real(-0.5) * Meter},
-            Length2{+2_m, Real(+0.5) * Meter}
+            Length2{-2_m, +0.5_m},
+            Length2{-2_m, -0.5_m},
+            Length2{+2_m, -0.5_m},
+            Length2{+2_m, +0.5_m}
         };
         const auto area = GetAreaOfPolygon(vertices);
         EXPECT_NEAR(static_cast<double>(Real{area / SquareMeter}), 4.0, 0.0);
@@ -302,7 +302,7 @@ TEST(MassData, GetForCenteredEdge)
 {
     const auto v1 = Length2{-2_m, 0_m};
     const auto v2 = Length2{+2_m, 0_m};
-    const auto radius = Real{0.5f} * Meter;
+    const auto radius = 0.5_m;
     const auto density = 2.1_kgpm2;
     
     const auto radiusSquared = Area{radius * radius};
@@ -322,10 +322,10 @@ TEST(MassData, GetForCenteredEdge)
     ASSERT_EQ(shape.GetDensity(), density);
     
     const auto vertices = Vector<Length2, 4>{
-        Length2(-2_m, Real(+0.5) * Meter),
-        Length2(-2_m, Real(-0.5) * Meter),
-        Length2(+2_m, Real(-0.5) * Meter),
-        Length2(+2_m, Real(+0.5) * Meter)
+        Length2(-2_m, +0.5_m),
+        Length2(-2_m, -0.5_m),
+        Length2(+2_m, -0.5_m),
+        Length2(+2_m, +0.5_m)
     };
     const auto polarMoment = GetPolarMoment(vertices);
     EXPECT_NEAR(static_cast<double>(Real{polarMoment / (SquareMeter * SquareMeter)}),

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -360,10 +360,10 @@ TEST(Math, ComputeCentroidCenteredR1)
     const auto hy = Real(1);
     const auto real_center = Vec2{0, 0};
     const auto vertices = {
-        (real_center + Vec2{hx, hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, +hy}) * (Real(1) * Meter),
-        (real_center - Vec2{hx, hy}) * (Real(1) * Meter),
-        (real_center + Vec2{+hx, -hy}) * (Real(1) * Meter),
+        (real_center + Vec2{hx, hy}) * Meter,
+        (real_center + Vec2{-hx, +hy}) * Meter,
+        (real_center - Vec2{hx, hy}) * Meter,
+        (real_center + Vec2{+hx, -hy}) * Meter,
     };
     const auto center = ComputeCentroid(vertices);
     EXPECT_EQ(GetX(center), GetX(real_center) * Meter);
@@ -389,10 +389,10 @@ TEST(Math, ComputeCentroidCentered0R1000)
     const auto hy = Real(1000);
     const auto real_center = Vec2{0, 0};
     const auto vertices = {
-        (real_center + Vec2{hx, hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, +hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, -hy}) * (Real(1) * Meter),
-        (real_center + Vec2{+hx, -hy}) * (Real(1) * Meter)
+        (real_center + Vec2{hx, hy}) * Meter,
+        (real_center + Vec2{-hx, +hy}) * Meter,
+        (real_center + Vec2{-hx, -hy}) * Meter,
+        (real_center + Vec2{+hx, -hy}) * Meter
     };
     const auto center = ComputeCentroid(vertices);
     
@@ -409,10 +409,10 @@ TEST(Math, ComputeCentroidUpRight1000R1)
     const auto hy = Real(1);
     const auto real_center = Vec2{1000, 1000};
     const auto vertices = {
-        (real_center + Vec2{+hx, +hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, +hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, -hy}) * (Real(1) * Meter),
-        (real_center + Vec2{+hx, -hy}) * (Real(1) * Meter)
+        (real_center + Vec2{+hx, +hy}) * Meter,
+        (real_center + Vec2{-hx, +hy}) * Meter,
+        (real_center + Vec2{-hx, -hy}) * Meter,
+        (real_center + Vec2{+hx, -hy}) * Meter
     };
     const auto center = ComputeCentroid(vertices);
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
@@ -429,10 +429,10 @@ TEST(Math, ComputeCentroidUpRight1000R100)
     const auto hy = Real(100);
     const auto real_center = Vec2{1000, 1000};
     const auto vertices = {
-        (real_center + Vec2{+hx, +hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, +hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, -hy}) * (Real(1) * Meter),
-        (real_center + Vec2{+hx, -hy}) * (Real(1) * Meter)
+        (real_center + Vec2{+hx, +hy}) * Meter,
+        (real_center + Vec2{-hx, +hy}) * Meter,
+        (real_center + Vec2{-hx, -hy}) * Meter,
+        (real_center + Vec2{+hx, -hy}) * Meter
     };
     const auto center = ComputeCentroid(vertices);
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
@@ -449,10 +449,10 @@ TEST(Math, ComputeCentroidUpRight10000R01)
     const auto hy = Real(0.1);
     const auto real_center = Vec2{10000, 10000};
     const auto vertices = {
-        (real_center + Vec2{+hx, +hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, +hy}) * (Real(1) * Meter),
-        (real_center + Vec2{-hx, -hy}) * (Real(1) * Meter),
-        (real_center + Vec2{+hx, -hy}) * (Real(1) * Meter)
+        (real_center + Vec2{+hx, +hy}) * Meter,
+        (real_center + Vec2{-hx, +hy}) * Meter,
+        (real_center + Vec2{-hx, -hy}) * Meter,
+        (real_center + Vec2{+hx, -hy}) * Meter
     };
     const auto center = ComputeCentroid(vertices);
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.1);
@@ -469,10 +469,10 @@ TEST(Math, ComputeCentroidDownLeft1000R1)
     const auto hy = Real(1);
     const auto real_center = Vec2{-1000, -1000};
     const auto vertices = {
-        Vec2{GetX(real_center) + hx, GetY(real_center) + hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) - hx, GetY(real_center) + hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) - hx, GetY(real_center) - hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) + hx, GetY(real_center) - hy} * (Real(1) * Meter)
+        Vec2{GetX(real_center) + hx, GetY(real_center) + hy} * Meter,
+        Vec2{GetX(real_center) - hx, GetY(real_center) + hy} * Meter,
+        Vec2{GetX(real_center) - hx, GetY(real_center) - hy} * Meter,
+        Vec2{GetX(real_center) + hx, GetY(real_center) - hy} * Meter
     };
     const auto center = ComputeCentroid(vertices);
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
@@ -489,12 +489,12 @@ TEST(Math, ComputeCentroidOfHexagonalVertices)
     const auto hy = Real(1);
     const auto real_center = Vec2{-1000, -1000};
     const auto vertices = {
-        Vec2{GetX(real_center) + 00, GetY(real_center) + 2 * hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) - hx, GetY(real_center) + 1 * hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) - hx, GetY(real_center) - 1 * hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) + 00, GetY(real_center) - 2 * hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) + hx, GetY(real_center) - 1 * hy} * (Real(1) * Meter),
-        Vec2{GetX(real_center) + hx, GetY(real_center) + 1 * hy} * (Real(1) * Meter),
+        Vec2{GetX(real_center) + 00, GetY(real_center) + 2 * hy} * Meter,
+        Vec2{GetX(real_center) - hx, GetY(real_center) + 1 * hy} * Meter,
+        Vec2{GetX(real_center) - hx, GetY(real_center) - 1 * hy} * Meter,
+        Vec2{GetX(real_center) + 00, GetY(real_center) - 2 * hy} * Meter,
+        Vec2{GetX(real_center) + hx, GetY(real_center) - 1 * hy} * Meter,
+        Vec2{GetX(real_center) + hx, GetY(real_center) + 1 * hy} * Meter,
     };
     const auto center = ComputeCentroid(vertices);
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
@@ -618,7 +618,7 @@ TEST(Math, GetPosition)
     const auto y = Real{5.515012264251709e+00f};
     const auto value = Real{0.0866042823f};
 
-    const auto oldPos = Position{Vec2{x, y} * (Real(1) * Meter), 0_rad};
+    const auto oldPos = Position{Vec2{x, y} * Meter, 0_rad};
     const auto newPos = GetPosition(oldPos, oldPos, value);
     
     EXPECT_EQ(oldPos.linear, newPos.linear);

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -298,8 +298,8 @@ TEST(Math, InverseRotationRevertsRotation)
 
 TEST(Math, TransformIsRotatePlusTranslate)
 {
-    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
     
@@ -311,8 +311,8 @@ TEST(Math, TransformIsRotatePlusTranslate)
 
 TEST(Math, InverseTransformIsUntranslateAndInverseRotate)
 {
-    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
     
@@ -324,8 +324,8 @@ TEST(Math, InverseTransformIsUntranslateAndInverseRotate)
 
 TEST(Math, InverseTransformTransformedIsOriginal)
 {
-    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
 
@@ -340,8 +340,8 @@ TEST(Math, InverseTransformTransformedIsOriginal)
 
 TEST(Math, TransformInverseTransformedIsOriginal)
 {
-    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
 
@@ -730,19 +730,19 @@ TEST(Math, GetCircleVertices)
         EXPECT_EQ(vertices, std::vector<Length2>({Length2{}, Length2{}, Length2{}, Length2{}}));
     }
     {
-        const auto vertices = GetCircleVertices(Real(1) * Meter, 0);
+        const auto vertices = GetCircleVertices(1_m, 0);
         EXPECT_EQ(vertices, std::vector<Length2>());
     }
     {
-        const auto vertices = GetCircleVertices(Real(1) * Meter, 1);
-        EXPECT_EQ(vertices, std::vector<Length2>({Length2(Real(1) * Meter, Real(0) * Meter), Length2(Real(1) * Meter, Real(0) * Meter)}));
+        const auto vertices = GetCircleVertices(1_m, 1);
+        EXPECT_EQ(vertices, std::vector<Length2>({Length2(1_m, 0_m), Length2(1_m, 0_m)}));
     }
     {
-        const auto vertices = GetCircleVertices(Real(1) * Meter, 2);
-        EXPECT_EQ(vertices[0], Length2(Real(1) * Meter, Real(0) * Meter));
+        const auto vertices = GetCircleVertices(1_m, 2);
+        EXPECT_EQ(vertices[0], Length2(1_m, 0_m));
         EXPECT_NEAR(static_cast<double>(Real(GetX(vertices[1]) / Meter)), -1.0, 0.0001);
         EXPECT_NEAR(static_cast<double>(Real(GetY(vertices[1]) / Meter)),  0.0, 0.0001);
-        EXPECT_EQ(vertices[2], Length2(Real(1) * Meter, Real(0) * Meter));
+        EXPECT_EQ(vertices[2], Length2(1_m, 0_m));
     }
 }
 

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -298,7 +298,7 @@ TEST(Math, InverseRotationRevertsRotation)
 
 TEST(Math, TransformIsRotatePlusTranslate)
 {
-    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
@@ -311,7 +311,7 @@ TEST(Math, TransformIsRotatePlusTranslate)
 
 TEST(Math, InverseTransformIsUntranslateAndInverseRotate)
 {
-    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
@@ -324,7 +324,7 @@ TEST(Math, InverseTransformIsUntranslateAndInverseRotate)
 
 TEST(Math, InverseTransformTransformedIsOriginal)
 {
-    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
@@ -340,7 +340,7 @@ TEST(Math, InverseTransformTransformedIsOriginal)
 
 TEST(Math, TransformInverseTransformedIsOriginal)
 {
-    const auto vector = Length2{19_m, Real(-0.5) * Meter};
+    const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -298,8 +298,8 @@ TEST(Math, InverseRotationRevertsRotation)
 
 TEST(Math, TransformIsRotatePlusTranslate)
 {
-    const auto vector = Length2D{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2D{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
+    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
     
@@ -311,8 +311,8 @@ TEST(Math, TransformIsRotatePlusTranslate)
 
 TEST(Math, InverseTransformIsUntranslateAndInverseRotate)
 {
-    const auto vector = Length2D{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2D{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
+    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
     
@@ -324,8 +324,8 @@ TEST(Math, InverseTransformIsUntranslateAndInverseRotate)
 
 TEST(Math, InverseTransformTransformedIsOriginal)
 {
-    const auto vector = Length2D{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2D{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
+    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
 
@@ -340,8 +340,8 @@ TEST(Math, InverseTransformTransformedIsOriginal)
 
 TEST(Math, TransformInverseTransformedIsOriginal)
 {
-    const auto vector = Length2D{Real(19) * Meter, Real(-0.5) * Meter};
-    const auto translation = Length2D{Real(-3) * Meter, Real(+5) * Meter};
+    const auto vector = Length2{Real(19) * Meter, Real(-0.5) * Meter};
+    const auto translation = Length2{Real(-3) * Meter, Real(+5) * Meter};
     const auto rotation = UnitVec2::GetTop();
     const auto transformation = Transformation{translation, rotation};
 
@@ -369,7 +369,7 @@ TEST(Math, ComputeCentroidCenteredR1)
     EXPECT_EQ(GetX(center), GetX(real_center) * Meter);
     EXPECT_EQ(GetY(center), GetY(real_center) * Meter);
     
-    const auto average = Average<Length2D>(vertices);
+    const auto average = Average<Length2>(vertices);
     EXPECT_EQ(average, center);
 }
 
@@ -399,7 +399,7 @@ TEST(Math, ComputeCentroidCentered0R1000)
     EXPECT_EQ(GetX(center), GetX(real_center) * Meter);
     EXPECT_EQ(GetY(center), GetY(real_center) * Meter);
     
-    const auto average = Average<Length2D>(vertices);
+    const auto average = Average<Length2>(vertices);
     EXPECT_EQ(average, center);
 }
 
@@ -418,7 +418,7 @@ TEST(Math, ComputeCentroidUpRight1000R1)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2D>(vertices);
+    const auto average = Average<Length2>(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }
@@ -438,7 +438,7 @@ TEST(Math, ComputeCentroidUpRight1000R100)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2D>(vertices);
+    const auto average = Average<Length2>(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }
@@ -458,7 +458,7 @@ TEST(Math, ComputeCentroidUpRight10000R01)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.1);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.1);
     
-    const auto average = Average<Length2D>(vertices);
+    const auto average = Average<Length2>(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.1);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.1);
 }
@@ -478,7 +478,7 @@ TEST(Math, ComputeCentroidDownLeft1000R1)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2D>(vertices);
+    const auto average = Average<Length2>(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }
@@ -500,17 +500,17 @@ TEST(Math, ComputeCentroidOfHexagonalVertices)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2D>(vertices);
+    const auto average = Average<Length2>(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }
 
 TEST(Math, GetContactRelVelocity)
 {
-    const auto velA = Velocity{LinearVelocity2D(+1_mps, +4_mps), 3.2f * RadianPerSecond};
-    const auto velB = Velocity{LinearVelocity2D(+3_mps, +1_mps), 0.4f * RadianPerSecond};
-    const auto relA = Length2D{};
-    const auto relB = Length2D{};
+    const auto velA = Velocity{LinearVelocity2(+1_mps, +4_mps), 3.2f * RadianPerSecond};
+    const auto velB = Velocity{LinearVelocity2(+3_mps, +1_mps), 0.4f * RadianPerSecond};
+    const auto relA = Length2{};
+    const auto relB = Length2{};
     const auto result = GetContactRelVelocity(velA, relA, velB, relB);
     
     EXPECT_EQ(result, velB.linear - velA.linear);
@@ -715,34 +715,34 @@ TEST(Math, GetCircleVertices)
 {
     {
         const auto vertices = GetCircleVertices(Length{0}, 0);
-        EXPECT_EQ(vertices, std::vector<Length2D>());
+        EXPECT_EQ(vertices, std::vector<Length2>());
     }
     {
         const auto vertices = GetCircleVertices(Length{0}, 1);
-        EXPECT_EQ(vertices, std::vector<Length2D>({Length2D{}, Length2D{}}));
+        EXPECT_EQ(vertices, std::vector<Length2>({Length2{}, Length2{}}));
     }
     {
         const auto vertices = GetCircleVertices(Length{0}, 2);
-        EXPECT_EQ(vertices, std::vector<Length2D>({Length2D{}, Length2D{}, Length2D{}}));
+        EXPECT_EQ(vertices, std::vector<Length2>({Length2{}, Length2{}, Length2{}}));
     }
     {
         const auto vertices = GetCircleVertices(Length{0}, 3);
-        EXPECT_EQ(vertices, std::vector<Length2D>({Length2D{}, Length2D{}, Length2D{}, Length2D{}}));
+        EXPECT_EQ(vertices, std::vector<Length2>({Length2{}, Length2{}, Length2{}, Length2{}}));
     }
     {
         const auto vertices = GetCircleVertices(Real(1) * Meter, 0);
-        EXPECT_EQ(vertices, std::vector<Length2D>());
+        EXPECT_EQ(vertices, std::vector<Length2>());
     }
     {
         const auto vertices = GetCircleVertices(Real(1) * Meter, 1);
-        EXPECT_EQ(vertices, std::vector<Length2D>({Length2D(Real(1) * Meter, Real(0) * Meter), Length2D(Real(1) * Meter, Real(0) * Meter)}));
+        EXPECT_EQ(vertices, std::vector<Length2>({Length2(Real(1) * Meter, Real(0) * Meter), Length2(Real(1) * Meter, Real(0) * Meter)}));
     }
     {
         const auto vertices = GetCircleVertices(Real(1) * Meter, 2);
-        EXPECT_EQ(vertices[0], Length2D(Real(1) * Meter, Real(0) * Meter));
+        EXPECT_EQ(vertices[0], Length2(Real(1) * Meter, Real(0) * Meter));
         EXPECT_NEAR(static_cast<double>(Real(GetX(vertices[1]) / Meter)), -1.0, 0.0001);
         EXPECT_NEAR(static_cast<double>(Real(GetY(vertices[1]) / Meter)),  0.0, 0.0001);
-        EXPECT_EQ(vertices[2], Length2D(Real(1) * Meter, Real(0) * Meter));
+        EXPECT_EQ(vertices[2], Length2(Real(1) * Meter, Real(0) * Meter));
     }
 }
 

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -49,7 +49,7 @@ TEST(MotorJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, false);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.linearOffset, (Length2D{}));
+    EXPECT_EQ(def.linearOffset, (Length2{}));
     EXPECT_EQ(def.angularOffset, Angle(0));
     EXPECT_EQ(def.maxForce, 1_N);
     EXPECT_EQ(def.maxTorque, 1_Nm);
@@ -63,7 +63,7 @@ TEST(MotorJointDef, BuilderConstruction)
     const auto collideConnected = true;
     int tmp;
     const auto userData = &tmp;
-    const auto linearOffset = Length2D{2 * Meter, 3 * Meter};
+    const auto linearOffset = Length2{2 * Meter, 3 * Meter};
     const auto angularOffset = 33_rad;
     const auto maxForce = 22_N;
     const auto maxTorque = 31_Nm;
@@ -107,7 +107,7 @@ TEST(MotorJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
 
     EXPECT_EQ(joint.GetLinearOffset(), def.linearOffset);
@@ -153,7 +153,7 @@ TEST(MotorJoint, GetMotorJointDef)
     EXPECT_EQ(cdef.collideConnected, false);
     EXPECT_EQ(cdef.userData, nullptr);
     
-    EXPECT_EQ(cdef.linearOffset, (Length2D{}));
+    EXPECT_EQ(cdef.linearOffset, (Length2{}));
     EXPECT_EQ(cdef.angularOffset, Angle(0));
     EXPECT_EQ(cdef.maxForce, 1_N);
     EXPECT_EQ(cdef.maxTorque, 1_Nm);
@@ -163,14 +163,14 @@ TEST(MotorJoint, GetMotorJointDef)
 TEST(MotorJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    //const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    //const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
     const auto jd = MotorJointDef{b1, b2};
     const auto joint = static_cast<MotorJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);
@@ -189,21 +189,21 @@ TEST(MotorJoint, WithDynamicCircles)
 TEST(MotorJoint, SetLinearOffset)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    //const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    //const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
     const auto jd = MotorJointDef{b1, b2};
     const auto joint = static_cast<MotorJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);
     EXPECT_EQ(joint->GetAnchorA(), p1);
     EXPECT_EQ(joint->GetAnchorB(), p2);
     
-    const auto linearOffset = Length2D{2 * Meter, 1 * Meter};
+    const auto linearOffset = Length2{2 * Meter, 1 * Meter};
     ASSERT_EQ(joint->GetLinearOffset(), jd.linearOffset);
     ASSERT_NE(jd.linearOffset, linearOffset);
     joint->SetLinearOffset(linearOffset);

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -63,7 +63,7 @@ TEST(MotorJointDef, BuilderConstruction)
     const auto collideConnected = true;
     int tmp;
     const auto userData = &tmp;
-    const auto linearOffset = Length2{2 * Meter, 3 * Meter};
+    const auto linearOffset = Length2{2_m, 3_m};
     const auto angularOffset = 33_rad;
     const auto maxForce = 22_N;
     const auto maxTorque = 31_Nm;
@@ -164,13 +164,13 @@ TEST(MotorJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    //const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
+    //const auto anchor = Length2(2_m, 1_m);
     const auto jd = MotorJointDef{b1, b2};
     const auto joint = static_cast<MotorJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);
@@ -190,20 +190,20 @@ TEST(MotorJoint, SetLinearOffset)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    //const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
+    //const auto anchor = Length2(2_m, 1_m);
     const auto jd = MotorJointDef{b1, b2};
     const auto joint = static_cast<MotorJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);
     EXPECT_EQ(joint->GetAnchorA(), p1);
     EXPECT_EQ(joint->GetAnchorB(), p2);
     
-    const auto linearOffset = Length2{2 * Meter, 1 * Meter};
+    const auto linearOffset = Length2{2_m, 1_m};
     ASSERT_EQ(joint->GetLinearOffset(), jd.linearOffset);
     ASSERT_NE(jd.linearOffset, linearOffset);
     joint->SetLinearOffset(linearOffset);

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -162,7 +162,7 @@ TEST(MotorJoint, GetMotorJointDef)
 
 TEST(MotorJoint, WithDynamicCircles)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -188,7 +188,7 @@ TEST(MotorJoint, WithDynamicCircles)
 
 TEST(MotorJoint, SetLinearOffset)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/MouseJoint.cpp
+++ b/UnitTests/MouseJoint.cpp
@@ -24,7 +24,7 @@ using namespace playrho;
 
 TEST(MouseJointDef, UseTarget)
 {
-    const auto value = Length2(Real(19) * Meter, Real(-9) * Meter);
+    const auto value = Length2(19_m, -9_m);
     EXPECT_NE(MouseJointDef{}.target, value);
     EXPECT_EQ(MouseJointDef{}.UseTarget(value).target, value);
 }
@@ -95,7 +95,7 @@ TEST(MouseJoint, GetLocalAnchorB)
     def.bodyA = bA;
     def.bodyB = bB;
     def.userData = reinterpret_cast<void*>(71);
-    def.target = Length2(Real(-1.4) * Meter, Real(-2) * Meter);
+    def.target = Length2(Real(-1.4) * Meter, -2_m);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);
@@ -117,7 +117,7 @@ TEST(MouseJointDef, GetMouseJointDefFreeFunction)
     def.bodyA = bA;
     def.bodyB = bB;
     def.userData = reinterpret_cast<void*>(71);
-    def.target = Length2(Real(-1.4) * Meter, Real(-2) * Meter);
+    def.target = Length2(Real(-1.4) * Meter, -2_m);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);

--- a/UnitTests/MouseJoint.cpp
+++ b/UnitTests/MouseJoint.cpp
@@ -24,7 +24,7 @@ using namespace playrho;
 
 TEST(MouseJointDef, UseTarget)
 {
-    const auto value = Length2D(Real(19) * Meter, Real(-9) * Meter);
+    const auto value = Length2(Real(19) * Meter, Real(-9) * Meter);
     EXPECT_NE(MouseJointDef{}.target, value);
     EXPECT_EQ(MouseJointDef{}.UseTarget(value).target, value);
 }
@@ -71,7 +71,7 @@ TEST(MouseJoint, DefaultInitialized)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetAnchorA(), def.target);
     //EXPECT_FALSE(IsValid(joint.GetAnchorB()));
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
     EXPECT_EQ(joint.GetUserData(), nullptr);
     EXPECT_FALSE(joint.GetCollideConnected());
@@ -95,7 +95,7 @@ TEST(MouseJoint, GetLocalAnchorB)
     def.bodyA = bA;
     def.bodyB = bB;
     def.userData = reinterpret_cast<void*>(71);
-    def.target = Length2D(Real(-1.4) * Meter, Real(-2) * Meter);
+    def.target = Length2(Real(-1.4) * Meter, Real(-2) * Meter);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);
@@ -117,7 +117,7 @@ TEST(MouseJointDef, GetMouseJointDefFreeFunction)
     def.bodyA = bA;
     def.bodyB = bB;
     def.userData = reinterpret_cast<void*>(71);
-    def.target = Length2D(Real(-1.4) * Meter, Real(-2) * Meter);
+    def.target = Length2(Real(-1.4) * Meter, Real(-2) * Meter);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);

--- a/UnitTests/MouseJoint.cpp
+++ b/UnitTests/MouseJoint.cpp
@@ -95,7 +95,7 @@ TEST(MouseJoint, GetLocalAnchorB)
     def.bodyA = bA;
     def.bodyB = bB;
     def.userData = reinterpret_cast<void*>(71);
-    def.target = Length2(Real(-1.4) * Meter, -2_m);
+    def.target = Length2(-1.4_m, -2_m);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);
@@ -117,7 +117,7 @@ TEST(MouseJointDef, GetMouseJointDefFreeFunction)
     def.bodyA = bA;
     def.bodyB = bB;
     def.userData = reinterpret_cast<void*>(71);
-    def.target = Length2(Real(-1.4) * Meter, -2_m);
+    def.target = Length2(-1.4_m, -2_m);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
     def.dampingRatio = Real(0.8);

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -104,7 +104,7 @@ TEST(MultiShape, AddConvexHullWithOnePointSameAsDisk)
 
     auto conf = MultiShape::Conf{};
     conf.density = 2.3_kgpm2;
-    conf.vertexRadius = Real(0.7f) * Meter;
+    conf.vertexRadius = 0.7_m;
 
     auto foo = MultiShape{conf};
     ASSERT_EQ(foo.GetChildCount(), ChildCounter{0});
@@ -140,7 +140,7 @@ TEST(MultiShape, AddConvexHullWithTwoPointsSameAsEdge)
     
     auto conf = MultiShape::Conf{};
     conf.density = 2.3_kgpm2;
-    conf.vertexRadius = Real(0.7f) * Meter;
+    conf.vertexRadius = 0.7_m;
     
     auto foo = MultiShape{conf};
     ASSERT_EQ(foo.GetChildCount(), ChildCounter{0});
@@ -179,7 +179,7 @@ TEST(MultiShape, AddTwoConvexHullWithOnePoint)
 
     auto conf = MultiShape::Conf{};
     conf.density = 2.3_kgpm2;
-    conf.vertexRadius = Real(0.7f) * Meter;
+    conf.vertexRadius = 0.7_m;
     
     auto foo = MultiShape{conf};
     ASSERT_EQ(foo.GetChildCount(), ChildCounter{0});

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -95,7 +95,7 @@ TEST(MultiShape, BaseVisitorForDiskShape)
 TEST(MultiShape, AddConvexHullWithOnePointSameAsDisk)
 {
     const auto defaultMassData = MassData{};
-    const auto center = Length2(Real(1) * Meter, Real(-4) * Meter);
+    const auto center = Length2(1_m, -4_m);
 
     auto pointSet = VertexSet{};
     ASSERT_EQ(pointSet.size(), std::size_t(0));
@@ -129,8 +129,8 @@ TEST(MultiShape, AddConvexHullWithOnePointSameAsDisk)
 TEST(MultiShape, AddConvexHullWithTwoPointsSameAsEdge)
 {
     const auto defaultMassData = MassData{};
-    const auto p0 = Length2(Real(1) * Meter, Real(-4) * Meter);
-    const auto p1 = Length2(Real(1) * Meter, Real(+4) * Meter);
+    const auto p0 = Length2(1_m, -4_m);
+    const auto p1 = Length2(1_m, +4_m);
     
     auto pointSet = VertexSet{};
     ASSERT_EQ(pointSet.size(), std::size_t(0));
@@ -171,8 +171,8 @@ TEST(MultiShape, AddConvexHullWithTwoPointsSameAsEdge)
 TEST(MultiShape, AddTwoConvexHullWithOnePoint)
 {
     const auto defaultMassData = MassData{};
-    const auto p0 = Length2(Real(1) * Meter, Real(-4) * Meter);
-    const auto p1 = Length2(Real(1) * Meter, Real(+4) * Meter);
+    const auto p0 = Length2(1_m, -4_m);
+    const auto p1 = Length2(1_m, +4_m);
 
     auto pointSet = VertexSet{};
     ASSERT_EQ(pointSet.size(), std::size_t(0));

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -95,7 +95,7 @@ TEST(MultiShape, BaseVisitorForDiskShape)
 TEST(MultiShape, AddConvexHullWithOnePointSameAsDisk)
 {
     const auto defaultMassData = MassData{};
-    const auto center = Length2D(Real(1) * Meter, Real(-4) * Meter);
+    const auto center = Length2(Real(1) * Meter, Real(-4) * Meter);
 
     auto pointSet = VertexSet{};
     ASSERT_EQ(pointSet.size(), std::size_t(0));
@@ -129,8 +129,8 @@ TEST(MultiShape, AddConvexHullWithOnePointSameAsDisk)
 TEST(MultiShape, AddConvexHullWithTwoPointsSameAsEdge)
 {
     const auto defaultMassData = MassData{};
-    const auto p0 = Length2D(Real(1) * Meter, Real(-4) * Meter);
-    const auto p1 = Length2D(Real(1) * Meter, Real(+4) * Meter);
+    const auto p0 = Length2(Real(1) * Meter, Real(-4) * Meter);
+    const auto p1 = Length2(Real(1) * Meter, Real(+4) * Meter);
     
     auto pointSet = VertexSet{};
     ASSERT_EQ(pointSet.size(), std::size_t(0));
@@ -171,8 +171,8 @@ TEST(MultiShape, AddConvexHullWithTwoPointsSameAsEdge)
 TEST(MultiShape, AddTwoConvexHullWithOnePoint)
 {
     const auto defaultMassData = MassData{};
-    const auto p0 = Length2D(Real(1) * Meter, Real(-4) * Meter);
-    const auto p1 = Length2D(Real(1) * Meter, Real(+4) * Meter);
+    const auto p0 = Length2(Real(1) * Meter, Real(-4) * Meter);
+    const auto p1 = Length2(Real(1) * Meter, Real(+4) * Meter);
 
     auto pointSet = VertexSet{};
     ASSERT_EQ(pointSet.size(), std::size_t(0));

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -87,7 +87,7 @@ TEST(PolygonShape, FindLowestRightMostVertex)
 {
     Length2 vertices[4];
     
-    vertices[0] = Length2{Real(0) * Meter, +Real(1) * Meter};
+    vertices[0] = Length2{0_m, +1_m};
     vertices[1] = Vec2{-1, -2} * Meter;
     vertices[2] = Vec2{+3, -4} * Meter;
     vertices[3] = Vec2{+2, +2} * Meter;
@@ -99,8 +99,8 @@ TEST(PolygonShape, FindLowestRightMostVertex)
 
 TEST(PolygonShape, BoxConstruction)
 {
-    const auto hx = Real(2.3) * Meter;
-    const auto hy = Real(54.1) * Meter;
+    const auto hx = 2.3_m;
+    const auto hy = 54.1_m;
     const auto shape = PolygonShape{hx, hy};
 
     EXPECT_EQ(shape.GetCentroid(), (Length2{}));
@@ -126,8 +126,8 @@ TEST(PolygonShape, BoxConstruction)
 
 TEST(PolygonShape, Copy)
 {
-    const auto hx = Real(2.3) * Meter;
-    const auto hy = Real(54.1) * Meter;
+    const auto hx = 2.3_m;
+    const auto hy = 54.1_m;
     
     auto shape = PolygonShape{hx, hy};
     ASSERT_EQ(shape.GetCentroid(), (Length2{}));
@@ -170,8 +170,8 @@ TEST(PolygonShape, Copy)
 
 TEST(PolygonShape, Translate)
 {
-    const auto hx = Real(2.3) * Meter;
-    const auto hy = Real(54.1) * Meter;
+    const auto hx = 2.3_m;
+    const auto hy = 54.1_m;
     
     auto shape = PolygonShape{hx, hy};
     ASSERT_EQ(shape.GetCentroid(), (Length2{}));
@@ -190,7 +190,7 @@ TEST(PolygonShape, Translate)
     ASSERT_EQ(shape.GetNormal(2) * Real{1}, Vec2(-1, 0));
     ASSERT_EQ(shape.GetNormal(3) * Real{1}, Vec2(0, -1));
     
-    const auto new_ctr = Length2{-Real(3) * Meter, Real(67) * Meter};
+    const auto new_ctr = Length2{-3_m, 67_m};
     shape.Transform(Transformation{new_ctr, UnitVec2::GetRight()});
     
     EXPECT_EQ(shape.GetCentroid(), new_ctr);
@@ -212,8 +212,8 @@ TEST(PolygonShape, Translate)
 
 TEST(PolygonShape, SetAsBox)
 {
-    const auto hx = Real(2.3) * Meter;
-    const auto hy = Real(54.1) * Meter;
+    const auto hx = 2.3_m;
+    const auto hy = 54.1_m;
     PolygonShape shape;
     shape.SetAsBox(hx, hy);
     EXPECT_EQ(shape.GetCentroid(), (Length2{}));
@@ -237,8 +237,8 @@ TEST(PolygonShape, SetAsBox)
 
 TEST(PolygonShape, SetAsZeroCenteredRotatedBox)
 {
-    const auto hx = Real(2.3) * Meter;
-    const auto hy = Real(54.1) * Meter;
+    const auto hx = 2.3_m;
+    const auto hy = 54.1_m;
     PolygonShape shape;
     SetAsBox(shape, hx, hy, Length2{}, Angle{0});
     EXPECT_EQ(shape.GetCentroid(), (Length2{}));
@@ -262,11 +262,11 @@ TEST(PolygonShape, SetAsZeroCenteredRotatedBox)
 
 TEST(PolygonShape, SetAsCenteredBox)
 {
-    const auto hx = Real(2.3) * Meter;
-    const auto hy = Real(54.1) * Meter;
+    const auto hx = 2.3_m;
+    const auto hy = 54.1_m;
     PolygonShape shape;
-    const auto x_off = Real(10.2) * Meter;
-    const auto y_off = Real(-5) * Meter;
+    const auto x_off = 10.2_m;
+    const auto y_off = -5_m;
     SetAsBox(shape, hx, hy, Length2(x_off, y_off), Angle{0});
     EXPECT_EQ(shape.GetCentroid(), Length2(x_off, y_off));
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
@@ -295,8 +295,8 @@ TEST(PolygonShape, SetAsBoxAngledDegrees90)
     const auto angle = 90_deg;
     SetAsBox(shape, hx * Meter, hy * Meter, Length2{}, angle);
 
-    EXPECT_EQ(GetX(shape.GetCentroid()), Real(0) * Meter);
-    EXPECT_EQ(GetY(shape.GetCentroid()), Real(0) * Meter);
+    EXPECT_EQ(GetX(shape.GetCentroid()), 0_m);
+    EXPECT_EQ(GetY(shape.GetCentroid()), 0_m);
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
@@ -357,7 +357,7 @@ TEST(PolygonShape, CanSetTwoPoints)
         Vec2{-1, +0} * Meter,
         Vec2{+1, +0} * Meter
     };
-    const auto vertexRadius = Real(2) * Meter;
+    const auto vertexRadius = 2_m;
     PolygonShape shape;
     shape.SetVertexRadius(vertexRadius);
     shape.Set(points);
@@ -381,7 +381,7 @@ TEST(PolygonShape, CanSetTwoPoints)
 TEST(PolygonShape, CanSetOnePoint)
 {
     const auto points = Vector<const Length2, 1>{Length2{}};
-    const auto vertexRadius = Real(2) * Meter;
+    const auto vertexRadius = 2_m;
     PolygonShape shape;
     shape.SetVertexRadius(vertexRadius);
     shape.Set(points);

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -39,7 +39,7 @@ TEST(PolygonShape, DefaultConstruction)
 {
     PolygonShape shape;
     EXPECT_EQ(shape.GetVertexCount(), 0);
-    EXPECT_EQ(shape.GetCentroid(), (Length2D{}));
+    EXPECT_EQ(shape.GetCentroid(), (Length2{}));
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
 }
@@ -85,9 +85,9 @@ TEST(PolygonShape, BaseVisitorForDiskShape)
 
 TEST(PolygonShape, FindLowestRightMostVertex)
 {
-    Length2D vertices[4];
+    Length2 vertices[4];
     
-    vertices[0] = Length2D{Real(0) * Meter, +Real(1) * Meter};
+    vertices[0] = Length2{Real(0) * Meter, +Real(1) * Meter};
     vertices[1] = Vec2{-1, -2} * (Real(1) * Meter);
     vertices[2] = Vec2{+3, -4} * (Real(1) * Meter);
     vertices[3] = Vec2{+2, +2} * (Real(1) * Meter);
@@ -103,7 +103,7 @@ TEST(PolygonShape, BoxConstruction)
     const auto hy = Real(54.1) * Meter;
     const auto shape = PolygonShape{hx, hy};
 
-    EXPECT_EQ(shape.GetCentroid(), (Length2D{}));
+    EXPECT_EQ(shape.GetCentroid(), (Length2{}));
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
 
@@ -111,10 +111,10 @@ TEST(PolygonShape, BoxConstruction)
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
 
-    EXPECT_EQ(shape.GetVertex(0), Length2D(hx, -hy)); // bottom right
-    EXPECT_EQ(shape.GetVertex(1), Length2D(hx, hy)); // top right
-    EXPECT_EQ(shape.GetVertex(2), Length2D(-hx, hy)); // top left
-    EXPECT_EQ(shape.GetVertex(3), Length2D(-hx, -hy)); // bottom left
+    EXPECT_EQ(shape.GetVertex(0), Length2(hx, -hy)); // bottom right
+    EXPECT_EQ(shape.GetVertex(1), Length2(hx, hy)); // top right
+    EXPECT_EQ(shape.GetVertex(2), Length2(-hx, hy)); // top left
+    EXPECT_EQ(shape.GetVertex(3), Length2(-hx, -hy)); // bottom left
 
     EXPECT_EQ(shape.GetNormal(0) * Real{1}, Vec2(+1, 0));
     EXPECT_EQ(shape.GetNormal(1) * Real{1}, Vec2(0, +1));
@@ -130,16 +130,16 @@ TEST(PolygonShape, Copy)
     const auto hy = Real(54.1) * Meter;
     
     auto shape = PolygonShape{hx, hy};
-    ASSERT_EQ(shape.GetCentroid(), (Length2D{}));
+    ASSERT_EQ(shape.GetCentroid(), (Length2{}));
     ASSERT_EQ(shape.GetChildCount(), ChildCounter(1));
     ASSERT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
-    ASSERT_EQ(shape.GetVertex(0), Length2D(hx, -hy)); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), Length2D(hx, hy)); // top right
-    ASSERT_EQ(shape.GetVertex(2), Length2D(-hx, hy)); // top left
-    ASSERT_EQ(shape.GetVertex(3), Length2D(-hx, -hy)); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), Length2(hx, -hy)); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), Length2(hx, hy)); // top right
+    ASSERT_EQ(shape.GetVertex(2), Length2(-hx, hy)); // top left
+    ASSERT_EQ(shape.GetVertex(3), Length2(-hx, -hy)); // bottom left
     
     ASSERT_EQ(shape.GetNormal(0) * Real{1}, Vec2(+1, 0));
     ASSERT_EQ(shape.GetNormal(1) * Real{1}, Vec2(0, +1));
@@ -149,7 +149,7 @@ TEST(PolygonShape, Copy)
     const auto copy = shape;
     
     EXPECT_EQ(typeid(copy), typeid(shape));
-    EXPECT_EQ(copy.GetCentroid(), (Length2D{}));
+    EXPECT_EQ(copy.GetCentroid(), (Length2{}));
     EXPECT_EQ(copy.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(copy), PolygonShape::GetDefaultVertexRadius());
     
@@ -157,10 +157,10 @@ TEST(PolygonShape, Copy)
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
-    EXPECT_EQ(copy.GetVertex(0), Length2D(hx, -hy)); // bottom right
-    EXPECT_EQ(copy.GetVertex(1), Length2D(hx, hy)); // top right
-    EXPECT_EQ(copy.GetVertex(2), Length2D(-hx, hy)); // top left
-    EXPECT_EQ(copy.GetVertex(3), Length2D(-hx, -hy)); // bottom left
+    EXPECT_EQ(copy.GetVertex(0), Length2(hx, -hy)); // bottom right
+    EXPECT_EQ(copy.GetVertex(1), Length2(hx, hy)); // top right
+    EXPECT_EQ(copy.GetVertex(2), Length2(-hx, hy)); // top left
+    EXPECT_EQ(copy.GetVertex(3), Length2(-hx, -hy)); // bottom left
     
     EXPECT_EQ(copy.GetNormal(0) * Real{1}, Vec2(+1, 0));
     EXPECT_EQ(copy.GetNormal(1) * Real{1}, Vec2(0, +1));
@@ -174,23 +174,23 @@ TEST(PolygonShape, Translate)
     const auto hy = Real(54.1) * Meter;
     
     auto shape = PolygonShape{hx, hy};
-    ASSERT_EQ(shape.GetCentroid(), (Length2D{}));
+    ASSERT_EQ(shape.GetCentroid(), (Length2{}));
     ASSERT_EQ(shape.GetChildCount(), ChildCounter(1));
     ASSERT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
-    ASSERT_EQ(shape.GetVertex(0), Length2D(hx, -hy)); // bottom right
-    ASSERT_EQ(shape.GetVertex(1), Length2D(hx, hy)); // top right
-    ASSERT_EQ(shape.GetVertex(2), Length2D(-hx, hy)); // top left
-    ASSERT_EQ(shape.GetVertex(3), Length2D(-hx, -hy)); // bottom left
+    ASSERT_EQ(shape.GetVertex(0), Length2(hx, -hy)); // bottom right
+    ASSERT_EQ(shape.GetVertex(1), Length2(hx, hy)); // top right
+    ASSERT_EQ(shape.GetVertex(2), Length2(-hx, hy)); // top left
+    ASSERT_EQ(shape.GetVertex(3), Length2(-hx, -hy)); // bottom left
     
     ASSERT_EQ(shape.GetNormal(0) * Real{1}, Vec2(+1, 0));
     ASSERT_EQ(shape.GetNormal(1) * Real{1}, Vec2(0, +1));
     ASSERT_EQ(shape.GetNormal(2) * Real{1}, Vec2(-1, 0));
     ASSERT_EQ(shape.GetNormal(3) * Real{1}, Vec2(0, -1));
     
-    const auto new_ctr = Length2D{-Real(3) * Meter, Real(67) * Meter};
+    const auto new_ctr = Length2{-Real(3) * Meter, Real(67) * Meter};
     shape.Transform(Transformation{new_ctr, UnitVec2::GetRight()});
     
     EXPECT_EQ(shape.GetCentroid(), new_ctr);
@@ -199,10 +199,10 @@ TEST(PolygonShape, Translate)
 
     ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
 
-    EXPECT_EQ(shape.GetVertex(0), Length2D(hx, -hy) + new_ctr); // bottom right
-    EXPECT_EQ(shape.GetVertex(1), Length2D(hx, hy) + new_ctr); // top right
-    EXPECT_EQ(shape.GetVertex(2), Length2D(-hx, hy) + new_ctr); // top left
-    EXPECT_EQ(shape.GetVertex(3), Length2D(-hx, -hy) + new_ctr); // bottom left
+    EXPECT_EQ(shape.GetVertex(0), Length2(hx, -hy) + new_ctr); // bottom right
+    EXPECT_EQ(shape.GetVertex(1), Length2(hx, hy) + new_ctr); // top right
+    EXPECT_EQ(shape.GetVertex(2), Length2(-hx, hy) + new_ctr); // top left
+    EXPECT_EQ(shape.GetVertex(3), Length2(-hx, -hy) + new_ctr); // bottom left
 
     EXPECT_EQ(shape.GetNormal(0) * Real{1}, Vec2(+1, 0));
     EXPECT_EQ(shape.GetNormal(1) * Real{1}, Vec2(0, +1));
@@ -216,7 +216,7 @@ TEST(PolygonShape, SetAsBox)
     const auto hy = Real(54.1) * Meter;
     PolygonShape shape;
     shape.SetAsBox(hx, hy);
-    EXPECT_EQ(shape.GetCentroid(), (Length2D{}));
+    EXPECT_EQ(shape.GetCentroid(), (Length2{}));
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
@@ -224,10 +224,10 @@ TEST(PolygonShape, SetAsBox)
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
-    EXPECT_EQ(shape.GetVertex(0), Length2D(hx, -hy)); // bottom right
-    EXPECT_EQ(shape.GetVertex(1), Length2D(hx, hy)); // top right
-    EXPECT_EQ(shape.GetVertex(2), Length2D(-hx, hy)); // top left
-    EXPECT_EQ(shape.GetVertex(3), Length2D(-hx, -hy)); // bottom left
+    EXPECT_EQ(shape.GetVertex(0), Length2(hx, -hy)); // bottom right
+    EXPECT_EQ(shape.GetVertex(1), Length2(hx, hy)); // top right
+    EXPECT_EQ(shape.GetVertex(2), Length2(-hx, hy)); // top left
+    EXPECT_EQ(shape.GetVertex(3), Length2(-hx, -hy)); // bottom left
     
     EXPECT_EQ(shape.GetNormal(0) * Real{1}, Vec2(+1, 0));
     EXPECT_EQ(shape.GetNormal(1) * Real{1}, Vec2(0, +1));
@@ -240,8 +240,8 @@ TEST(PolygonShape, SetAsZeroCenteredRotatedBox)
     const auto hx = Real(2.3) * Meter;
     const auto hy = Real(54.1) * Meter;
     PolygonShape shape;
-    SetAsBox(shape, hx, hy, Length2D{}, Angle{0});
-    EXPECT_EQ(shape.GetCentroid(), (Length2D{}));
+    SetAsBox(shape, hx, hy, Length2{}, Angle{0});
+    EXPECT_EQ(shape.GetCentroid(), (Length2{}));
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
@@ -249,10 +249,10 @@ TEST(PolygonShape, SetAsZeroCenteredRotatedBox)
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
-    EXPECT_EQ(shape.GetVertex(0), Length2D(hx, -hy)); // bottom right
-    EXPECT_EQ(shape.GetVertex(1), Length2D(hx, hy)); // top right
-    EXPECT_EQ(shape.GetVertex(2), Length2D(-hx, hy)); // top left
-    EXPECT_EQ(shape.GetVertex(3), Length2D(-hx, -hy)); // bottom left
+    EXPECT_EQ(shape.GetVertex(0), Length2(hx, -hy)); // bottom right
+    EXPECT_EQ(shape.GetVertex(1), Length2(hx, hy)); // top right
+    EXPECT_EQ(shape.GetVertex(2), Length2(-hx, hy)); // top left
+    EXPECT_EQ(shape.GetVertex(3), Length2(-hx, -hy)); // bottom left
     
     EXPECT_EQ(shape.GetNormal(0) * Real{1}, Vec2(+1, 0));
     EXPECT_EQ(shape.GetNormal(1) * Real{1}, Vec2(0, +1));
@@ -267,8 +267,8 @@ TEST(PolygonShape, SetAsCenteredBox)
     PolygonShape shape;
     const auto x_off = Real(10.2) * Meter;
     const auto y_off = Real(-5) * Meter;
-    SetAsBox(shape, hx, hy, Length2D(x_off, y_off), Angle{0});
-    EXPECT_EQ(shape.GetCentroid(), Length2D(x_off, y_off));
+    SetAsBox(shape, hx, hy, Length2(x_off, y_off), Angle{0});
+    EXPECT_EQ(shape.GetCentroid(), Length2(x_off, y_off));
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
@@ -276,10 +276,10 @@ TEST(PolygonShape, SetAsCenteredBox)
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
-    EXPECT_EQ(shape.GetVertex(0), Length2D(hx + x_off, -hy + y_off)); // bottom right
-    EXPECT_EQ(shape.GetVertex(1), Length2D(hx + x_off, hy + y_off)); // top right
-    EXPECT_EQ(shape.GetVertex(2), Length2D(-hx + x_off, hy + y_off)); // top left
-    EXPECT_EQ(shape.GetVertex(3), Length2D(-hx + x_off, -hy + y_off)); // bottom left
+    EXPECT_EQ(shape.GetVertex(0), Length2(hx + x_off, -hy + y_off)); // bottom right
+    EXPECT_EQ(shape.GetVertex(1), Length2(hx + x_off, hy + y_off)); // top right
+    EXPECT_EQ(shape.GetVertex(2), Length2(-hx + x_off, hy + y_off)); // top left
+    EXPECT_EQ(shape.GetVertex(3), Length2(-hx + x_off, -hy + y_off)); // bottom left
     
     EXPECT_EQ(shape.GetNormal(0) * Real{1}, Vec2(+1, 0));
     EXPECT_EQ(shape.GetNormal(1) * Real{1}, Vec2(0, +1));
@@ -293,7 +293,7 @@ TEST(PolygonShape, SetAsBoxAngledDegrees90)
     const auto hy = Real(54.1);
     PolygonShape shape;
     const auto angle = 90_deg;
-    SetAsBox(shape, hx * Meter, hy * Meter, Length2D{}, angle);
+    SetAsBox(shape, hx * Meter, hy * Meter, Length2{}, angle);
 
     EXPECT_EQ(GetX(shape.GetCentroid()), Real(0) * Meter);
     EXPECT_EQ(GetY(shape.GetCentroid()), Real(0) * Meter);
@@ -329,7 +329,7 @@ TEST(PolygonShape, SetAsBoxAngledDegrees90)
 TEST(PolygonShape, SetPoints)
 {
     PolygonShape shape;
-    const auto points = Vector<const Length2D, 5>{
+    const auto points = Vector<const Length2, 5>{
         Vec2{-1, +2} * (Real(1) * Meter),
         Vec2{+3, +3} * (Real(1) * Meter),
         Vec2{+2, -1} * (Real(1) * Meter),
@@ -353,7 +353,7 @@ TEST(PolygonShape, SetPoints)
 
 TEST(PolygonShape, CanSetTwoPoints)
 {
-    const auto points = Vector<const Length2D, 2>{
+    const auto points = Vector<const Length2, 2>{
         Vec2{-1, +0} * (Real(1) * Meter),
         Vec2{+1, +0} * (Real(1) * Meter)
     };
@@ -372,7 +372,7 @@ TEST(PolygonShape, CanSetTwoPoints)
                 +0.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(shape.GetNormal(1)))),
                 -1.0, 1.0/100000.0);
-    EXPECT_EQ(shape.GetCentroid(), Average(Span<const Length2D>(points.data(), points.size())));
+    EXPECT_EQ(shape.GetCentroid(), Average(Span<const Length2>(points.data(), points.size())));
     EXPECT_EQ(shape.GetVertexRadius(), vertexRadius);
 
     EXPECT_TRUE(Validate(shape));
@@ -380,7 +380,7 @@ TEST(PolygonShape, CanSetTwoPoints)
 
 TEST(PolygonShape, CanSetOnePoint)
 {
-    const auto points = Vector<const Length2D, 1>{Length2D{}};
+    const auto points = Vector<const Length2, 1>{Length2{}};
     const auto vertexRadius = Real(2) * Meter;
     PolygonShape shape;
     shape.SetVertexRadius(vertexRadius);

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -88,9 +88,9 @@ TEST(PolygonShape, FindLowestRightMostVertex)
     Length2 vertices[4];
     
     vertices[0] = Length2{Real(0) * Meter, +Real(1) * Meter};
-    vertices[1] = Vec2{-1, -2} * (Real(1) * Meter);
-    vertices[2] = Vec2{+3, -4} * (Real(1) * Meter);
-    vertices[3] = Vec2{+2, +2} * (Real(1) * Meter);
+    vertices[1] = Vec2{-1, -2} * Meter;
+    vertices[2] = Vec2{+3, -4} * Meter;
+    vertices[3] = Vec2{+2, +2} * Meter;
 
     const auto index = FindLowestRightMostVertex(vertices);
     
@@ -330,11 +330,11 @@ TEST(PolygonShape, SetPoints)
 {
     PolygonShape shape;
     const auto points = Vector<const Length2, 5>{
-        Vec2{-1, +2} * (Real(1) * Meter),
-        Vec2{+3, +3} * (Real(1) * Meter),
-        Vec2{+2, -1} * (Real(1) * Meter),
-        Vec2{-1, -2} * (Real(1) * Meter),
-        Vec2{-4, -1} * (Real(1) * Meter)
+        Vec2{-1, +2} * Meter,
+        Vec2{+3, +3} * Meter,
+        Vec2{+2, -1} * Meter,
+        Vec2{-1, -2} * Meter,
+        Vec2{-4, -1} * Meter
     };
     shape.Set(points);
     
@@ -354,8 +354,8 @@ TEST(PolygonShape, SetPoints)
 TEST(PolygonShape, CanSetTwoPoints)
 {
     const auto points = Vector<const Length2, 2>{
-        Vec2{-1, +0} * (Real(1) * Meter),
-        Vec2{+1, +0} * (Real(1) * Meter)
+        Vec2{-1, +0} * Meter,
+        Vec2{+1, +0} * Meter
     };
     const auto vertexRadius = Real(2) * Meter;
     PolygonShape shape;

--- a/UnitTests/PositionSolverManifold.cpp
+++ b/UnitTests/PositionSolverManifold.cpp
@@ -38,8 +38,8 @@ TEST(PositionSolverManifold, ByteSizeIs_20_40_or_80)
 TEST(PositionSolverManifold, InitializingConstructor)
 {
     const auto normal = UnitVec2::GetBottom();
-    const auto point = Length2{-Real(1) * Meter, Real(3) * Meter};
-    const auto separation = Real(8.12) * Meter;
+    const auto point = Length2{-1_m, 3_m};
+    const auto separation = 8.12_m;
     
     const auto psm = PositionSolverManifold{normal, point, separation};
     
@@ -51,7 +51,7 @@ TEST(PositionSolverManifold, InitializingConstructor)
 TEST(PositionSolverManifold, GetPSM)
 {
     // wide rectangle
-    const auto shape0 = PolygonShape(Real{3} * Meter, Real{1.5f} * Meter);
+    const auto shape0 = PolygonShape(3_m, Real{1.5f} * Meter);
     ASSERT_EQ(GetX(shape0.GetVertex(0)), Real(+3.0) * Meter); // right
     ASSERT_EQ(GetY(shape0.GetVertex(0)), Real(-1.5) * Meter); // bottom
     ASSERT_EQ(GetX(shape0.GetVertex(1)), Real(+3.0) * Meter); // right
@@ -62,26 +62,26 @@ TEST(PositionSolverManifold, GetPSM)
     ASSERT_EQ(GetY(shape0.GetVertex(3)), Real(-1.5) * Meter); // bottom
     
     // square
-    const auto shape1 = PolygonShape(Real{2} * Meter, Real{2} * Meter);
-    ASSERT_EQ(GetX(shape1.GetVertex(0)), Real(+2) * Meter); // right
-    ASSERT_EQ(GetY(shape1.GetVertex(0)), Real(-2) * Meter); // bottom
-    ASSERT_EQ(GetX(shape1.GetVertex(1)), Real(+2) * Meter); // right
-    ASSERT_EQ(GetY(shape1.GetVertex(1)), Real(+2) * Meter); // top
-    ASSERT_EQ(GetX(shape1.GetVertex(2)), Real(-2) * Meter); // left
-    ASSERT_EQ(GetY(shape1.GetVertex(2)), Real(+2) * Meter); // top
-    ASSERT_EQ(GetX(shape1.GetVertex(3)), Real(-2) * Meter); // left
-    ASSERT_EQ(GetY(shape1.GetVertex(3)), Real(-2) * Meter); // bottom
+    const auto shape1 = PolygonShape(2_m, 2_m);
+    ASSERT_EQ(GetX(shape1.GetVertex(0)), +2_m); // right
+    ASSERT_EQ(GetY(shape1.GetVertex(0)), -2_m); // bottom
+    ASSERT_EQ(GetX(shape1.GetVertex(1)), +2_m); // right
+    ASSERT_EQ(GetY(shape1.GetVertex(1)), +2_m); // top
+    ASSERT_EQ(GetX(shape1.GetVertex(2)), -2_m); // left
+    ASSERT_EQ(GetY(shape1.GetVertex(2)), +2_m); // top
+    ASSERT_EQ(GetX(shape1.GetVertex(3)), -2_m); // left
+    ASSERT_EQ(GetY(shape1.GetVertex(3)), -2_m); // bottom
     
-    const auto xfm0 = Transformation{Length2{-Real(2) * Meter, Real(0) * Meter}, UnitVec2::GetRight()}; // left
-    const auto xfm1 = Transformation{Length2{+Real(2) * Meter, Real(0) * Meter}, UnitVec2::GetRight()}; // right
+    const auto xfm0 = Transformation{Length2{-2_m, 0_m}, UnitVec2::GetRight()}; // left
+    const auto xfm1 = Transformation{Length2{+2_m, 0_m}, UnitVec2::GetRight()}; // right
     
     // put wide rectangle on left, square on right
     const auto manifold = CollideShapes(shape0.GetChild(0), xfm0, shape1.GetChild(0), xfm1);
     
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     
-    ASSERT_EQ(GetX(manifold.GetLocalPoint()), Real(+3) * Meter);
-    ASSERT_EQ(GetY(manifold.GetLocalPoint()), Real(0) * Meter);
+    ASSERT_EQ(GetX(manifold.GetLocalPoint()), +3_m);
+    ASSERT_EQ(GetY(manifold.GetLocalPoint()), 0_m);
     
     ASSERT_NEAR(static_cast<double>(manifold.GetLocalNormal().GetX()), +1.0, 0.00001);
     ASSERT_NEAR(static_cast<double>(manifold.GetLocalNormal().GetY()), +0.0, 0.00001);

--- a/UnitTests/PositionSolverManifold.cpp
+++ b/UnitTests/PositionSolverManifold.cpp
@@ -38,7 +38,7 @@ TEST(PositionSolverManifold, ByteSizeIs_20_40_or_80)
 TEST(PositionSolverManifold, InitializingConstructor)
 {
     const auto normal = UnitVec2::GetBottom();
-    const auto point = Length2D{-Real(1) * Meter, Real(3) * Meter};
+    const auto point = Length2{-Real(1) * Meter, Real(3) * Meter};
     const auto separation = Real(8.12) * Meter;
     
     const auto psm = PositionSolverManifold{normal, point, separation};
@@ -72,8 +72,8 @@ TEST(PositionSolverManifold, GetPSM)
     ASSERT_EQ(GetX(shape1.GetVertex(3)), Real(-2) * Meter); // left
     ASSERT_EQ(GetY(shape1.GetVertex(3)), Real(-2) * Meter); // bottom
     
-    const auto xfm0 = Transformation{Length2D{-Real(2) * Meter, Real(0) * Meter}, UnitVec2::GetRight()}; // left
-    const auto xfm1 = Transformation{Length2D{+Real(2) * Meter, Real(0) * Meter}, UnitVec2::GetRight()}; // right
+    const auto xfm0 = Transformation{Length2{-Real(2) * Meter, Real(0) * Meter}, UnitVec2::GetRight()}; // left
+    const auto xfm1 = Transformation{Length2{+Real(2) * Meter, Real(0) * Meter}, UnitVec2::GetRight()}; // right
     
     // put wide rectangle on left, square on right
     const auto manifold = CollideShapes(shape0.GetChild(0), xfm0, shape1.GetChild(0), xfm1);

--- a/UnitTests/PositionSolverManifold.cpp
+++ b/UnitTests/PositionSolverManifold.cpp
@@ -51,15 +51,15 @@ TEST(PositionSolverManifold, InitializingConstructor)
 TEST(PositionSolverManifold, GetPSM)
 {
     // wide rectangle
-    const auto shape0 = PolygonShape(3_m, Real{1.5f} * Meter);
-    ASSERT_EQ(GetX(shape0.GetVertex(0)), Real(+3.0) * Meter); // right
-    ASSERT_EQ(GetY(shape0.GetVertex(0)), Real(-1.5) * Meter); // bottom
-    ASSERT_EQ(GetX(shape0.GetVertex(1)), Real(+3.0) * Meter); // right
-    ASSERT_EQ(GetY(shape0.GetVertex(1)), Real(+1.5) * Meter); // top
-    ASSERT_EQ(GetX(shape0.GetVertex(2)), Real(-3.0) * Meter); // left
-    ASSERT_EQ(GetY(shape0.GetVertex(2)), Real(+1.5) * Meter); // top
-    ASSERT_EQ(GetX(shape0.GetVertex(3)), Real(-3.0) * Meter); // left
-    ASSERT_EQ(GetY(shape0.GetVertex(3)), Real(-1.5) * Meter); // bottom
+    const auto shape0 = PolygonShape(3_m, 1.5_m);
+    ASSERT_EQ(GetX(shape0.GetVertex(0)), +3.0_m); // right
+    ASSERT_EQ(GetY(shape0.GetVertex(0)), -1.5_m); // bottom
+    ASSERT_EQ(GetX(shape0.GetVertex(1)), +3.0_m); // right
+    ASSERT_EQ(GetY(shape0.GetVertex(1)), +1.5_m); // top
+    ASSERT_EQ(GetX(shape0.GetVertex(2)), -3.0_m); // left
+    ASSERT_EQ(GetY(shape0.GetVertex(2)), +1.5_m); // top
+    ASSERT_EQ(GetX(shape0.GetVertex(3)), -3.0_m); // left
+    ASSERT_EQ(GetY(shape0.GetVertex(3)), -1.5_m); // bottom
     
     // square
     const auto shape1 = PolygonShape(2_m, 2_m);

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -200,7 +200,7 @@ TEST(PrismaticJoint, GetLinearVelocity)
 
 TEST(PrismaticJoint, WithDynamicCirclesAndLimitEnabled)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -44,8 +44,8 @@ TEST(PrismaticJoint, EnableLimit)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = PrismaticJoint{jd};
     EXPECT_FALSE(joint.IsLimitEnabled());
@@ -64,8 +64,8 @@ TEST(PrismaticJoint, EnableMotor)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = PrismaticJoint{jd};
     EXPECT_FALSE(joint.IsMotorEnabled());
@@ -84,8 +84,8 @@ TEST(PrismaticJoint, SetMaxMotorForce)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = PrismaticJoint{jd};
     ASSERT_EQ(joint.GetMaxMotorForce(), 0_N);
@@ -102,8 +102,8 @@ TEST(PrismaticJoint, MotorSpeed)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     const auto newValue = Real(5) * RadianPerSecond;
     auto joint = PrismaticJoint{jd};
@@ -122,11 +122,11 @@ TEST(PrismaticJoint, SetLimits)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
-    const auto upperValue = Real(+5) * Meter;
-    const auto lowerValue = Real(-8) * Meter;
+    const auto upperValue = +5_m;
+    const auto lowerValue = -8_m;
     auto joint = PrismaticJoint{jd};
     ASSERT_NE(joint.GetUpperLimit(), upperValue);
     ASSERT_NE(joint.GetLowerLimit(), lowerValue);
@@ -139,8 +139,8 @@ TEST(PrismaticJoint, GetAnchorAandB)
 {
     World world;
     
-    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2{Real(-2) * Meter, Real(+1.2f) * Meter};
+    const auto loc0 = Length2{+1_m, -3_m};
+    const auto loc1 = Length2{-2_m, Real(+1.2f) * Meter};
 
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -148,8 +148,8 @@ TEST(PrismaticJoint, GetAnchorAandB)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = PrismaticJoint{jd};
     ASSERT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
@@ -162,8 +162,8 @@ TEST(PrismaticJoint, GetJointTranslation)
 {
     World world;
     
-    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2{Real(+1) * Meter, Real(+3) * Meter};
+    const auto loc0 = Length2{+1_m, -3_m};
+    const auto loc1 = Length2{+1_m, +3_m};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -171,19 +171,19 @@ TEST(PrismaticJoint, GetJointTranslation)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(-1) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(+1) * Meter, Real(5) * Meter);
+    jd.localAnchorA = Length2(-1_m, 5_m);
+    jd.localAnchorB = Length2(+1_m, 5_m);
     
     auto joint = PrismaticJoint{jd};
-    EXPECT_EQ(GetJointTranslation(joint), Length(Real(2) * Meter));
+    EXPECT_EQ(GetJointTranslation(joint), Length(2_m));
 }
 
 TEST(PrismaticJoint, GetLinearVelocity)
 {
     World world;
     
-    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2{Real(+1) * Meter, Real(+3) * Meter};
+    const auto loc0 = Length2{+1_m, -3_m};
+    const auto loc1 = Length2{+1_m, +3_m};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -191,8 +191,8 @@ TEST(PrismaticJoint, GetLinearVelocity)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(-1) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(+1) * Meter, Real(5) * Meter);
+    jd.localAnchorA = Length2(-1_m, 5_m);
+    jd.localAnchorB = Length2(+1_m, 5_m);
     
     auto joint = PrismaticJoint{jd};
     EXPECT_EQ(GetLinearVelocity(joint), LinearVelocity(0));
@@ -202,13 +202,13 @@ TEST(PrismaticJoint, WithDynamicCirclesAndLimitEnabled)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(2_m, 1_m);
     const auto jd = PrismaticJointDef{b1, b2, anchor, UnitVec2::GetRight()}.UseEnableLimit(true);
     const auto joint = static_cast<PrismaticJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);
@@ -227,15 +227,15 @@ TEST(PrismaticJoint, WithDynamicCirclesAndLimitEnabled)
     EXPECT_EQ(joint->GetUpperLimit(), Length(0));
     EXPECT_EQ(joint->GetLimitState(), Joint::e_equalLimits);
     
-    joint->SetLimits(Real(0) * Meter, Real(2) * Meter);
+    joint->SetLimits(0_m, 2_m);
     Step(world, 1_s);
     EXPECT_EQ(joint->GetLowerLimit(), Length(0));
-    EXPECT_EQ(joint->GetUpperLimit(), Real(2) * Meter);
+    EXPECT_EQ(joint->GetUpperLimit(), 2_m);
     EXPECT_EQ(joint->GetLimitState(), Joint::e_atLowerLimit);
     
-    joint->SetLimits(Real(-2) * Meter, Real(0) * Meter);
+    joint->SetLimits(-2_m, 0_m);
     Step(world, 1_s);
-    EXPECT_EQ(joint->GetLowerLimit(), Real(-2) * Meter);
-    EXPECT_EQ(joint->GetUpperLimit(), Real(0) * Meter);
+    EXPECT_EQ(joint->GetLowerLimit(), -2_m);
+    EXPECT_EQ(joint->GetUpperLimit(), 0_m);
     EXPECT_EQ(joint->GetLimitState(), Joint::e_atUpperLimit);
 }

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -44,8 +44,8 @@ TEST(PrismaticJoint, EnableLimit)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = PrismaticJoint{jd};
     EXPECT_FALSE(joint.IsLimitEnabled());
@@ -64,8 +64,8 @@ TEST(PrismaticJoint, EnableMotor)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = PrismaticJoint{jd};
     EXPECT_FALSE(joint.IsMotorEnabled());
@@ -84,8 +84,8 @@ TEST(PrismaticJoint, SetMaxMotorForce)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = PrismaticJoint{jd};
     ASSERT_EQ(joint.GetMaxMotorForce(), 0_N);
@@ -102,8 +102,8 @@ TEST(PrismaticJoint, MotorSpeed)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     const auto newValue = Real(5) * RadianPerSecond;
     auto joint = PrismaticJoint{jd};
@@ -122,8 +122,8 @@ TEST(PrismaticJoint, SetLimits)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     const auto upperValue = Real(+5) * Meter;
     const auto lowerValue = Real(-8) * Meter;
@@ -139,8 +139,8 @@ TEST(PrismaticJoint, GetAnchorAandB)
 {
     World world;
     
-    const auto loc0 = Length2D{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2D{Real(-2) * Meter, Real(+1.2f) * Meter};
+    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
+    const auto loc1 = Length2{Real(-2) * Meter, Real(+1.2f) * Meter};
 
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -148,8 +148,8 @@ TEST(PrismaticJoint, GetAnchorAandB)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = PrismaticJoint{jd};
     ASSERT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
@@ -162,8 +162,8 @@ TEST(PrismaticJoint, GetJointTranslation)
 {
     World world;
     
-    const auto loc0 = Length2D{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2D{Real(+1) * Meter, Real(+3) * Meter};
+    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
+    const auto loc1 = Length2{Real(+1) * Meter, Real(+3) * Meter};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -171,8 +171,8 @@ TEST(PrismaticJoint, GetJointTranslation)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(-1) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(+1) * Meter, Real(5) * Meter);
+    jd.localAnchorA = Length2(Real(-1) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(+1) * Meter, Real(5) * Meter);
     
     auto joint = PrismaticJoint{jd};
     EXPECT_EQ(GetJointTranslation(joint), Length(Real(2) * Meter));
@@ -182,8 +182,8 @@ TEST(PrismaticJoint, GetLinearVelocity)
 {
     World world;
     
-    const auto loc0 = Length2D{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2D{Real(+1) * Meter, Real(+3) * Meter};
+    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
+    const auto loc1 = Length2{Real(+1) * Meter, Real(+3) * Meter};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -191,8 +191,8 @@ TEST(PrismaticJoint, GetLinearVelocity)
     auto jd = PrismaticJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(-1) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(+1) * Meter, Real(5) * Meter);
+    jd.localAnchorA = Length2(Real(-1) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(+1) * Meter, Real(5) * Meter);
     
     auto joint = PrismaticJoint{jd};
     EXPECT_EQ(GetLinearVelocity(joint), LinearVelocity(0));
@@ -201,14 +201,14 @@ TEST(PrismaticJoint, GetLinearVelocity)
 TEST(PrismaticJoint, WithDynamicCirclesAndLimitEnabled)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
     const auto jd = PrismaticJointDef{b1, b2, anchor, UnitVec2::GetRight()}.UseEnableLimit(true);
     const auto joint = static_cast<PrismaticJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -34,10 +34,10 @@ TEST(PulleyJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, true);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, (Length2{-1 * Meter, 0 * Meter}));
-    EXPECT_EQ(def.localAnchorB, (Length2{+1 * Meter, 0 * Meter}));
-    EXPECT_EQ(def.lengthA, Real(0) * Meter);
-    EXPECT_EQ(def.lengthB, Real(0) * Meter);
+    EXPECT_EQ(def.localAnchorA, (Length2{-1_m, 0_m}));
+    EXPECT_EQ(def.localAnchorB, (Length2{+1_m, 0_m}));
+    EXPECT_EQ(def.lengthA, 0_m);
+    EXPECT_EQ(def.lengthB, 0_m);
     EXPECT_EQ(def.ratio, Real(1));
 }
 
@@ -85,8 +85,8 @@ TEST(PulleyJoint, GetAnchorAandB)
 {
     World world;
     
-    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2{Real(-2) * Meter, Real(+1.2f) * Meter};
+    const auto loc0 = Length2{+1_m, -3_m};
+    const auto loc1 = Length2{-2_m, Real(+1.2f) * Meter};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -94,8 +94,8 @@ TEST(PulleyJoint, GetAnchorAandB)
     auto jd = PulleyJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = PulleyJoint{jd};
     ASSERT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
@@ -112,7 +112,7 @@ TEST(PulleyJoint, ShiftOrigin)
     ASSERT_EQ(joint.GetGroundAnchorA(), def.groundAnchorA);
     ASSERT_EQ(joint.GetGroundAnchorB(), def.groundAnchorB);
     
-    const auto newOrigin = Length2{1 * Meter, 1 * Meter};
+    const auto newOrigin = Length2{1_m, 1_m};
 
     joint.ShiftOrigin(newOrigin);
 

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -34,8 +34,8 @@ TEST(PulleyJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, true);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, (Length2D{-1 * Meter, 0 * Meter}));
-    EXPECT_EQ(def.localAnchorB, (Length2D{+1 * Meter, 0 * Meter}));
+    EXPECT_EQ(def.localAnchorA, (Length2{-1 * Meter, 0 * Meter}));
+    EXPECT_EQ(def.localAnchorB, (Length2{+1 * Meter, 0 * Meter}));
     EXPECT_EQ(def.lengthA, Real(0) * Meter);
     EXPECT_EQ(def.lengthB, Real(0) * Meter);
     EXPECT_EQ(def.ratio, Real(1));
@@ -69,7 +69,7 @@ TEST(PulleyJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
 
     EXPECT_EQ(joint.GetGroundAnchorA(), def.groundAnchorA);
@@ -85,8 +85,8 @@ TEST(PulleyJoint, GetAnchorAandB)
 {
     World world;
     
-    const auto loc0 = Length2D{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2D{Real(-2) * Meter, Real(+1.2f) * Meter};
+    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
+    const auto loc1 = Length2{Real(-2) * Meter, Real(+1.2f) * Meter};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -94,8 +94,8 @@ TEST(PulleyJoint, GetAnchorAandB)
     auto jd = PulleyJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = PulleyJoint{jd};
     ASSERT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
@@ -112,7 +112,7 @@ TEST(PulleyJoint, ShiftOrigin)
     ASSERT_EQ(joint.GetGroundAnchorA(), def.groundAnchorA);
     ASSERT_EQ(joint.GetGroundAnchorB(), def.groundAnchorB);
     
-    const auto newOrigin = Length2D{1 * Meter, 1 * Meter};
+    const auto newOrigin = Length2{1 * Meter, 1 * Meter};
 
     joint.ShiftOrigin(newOrigin);
 

--- a/UnitTests/RayCastOutput.cpp
+++ b/UnitTests/RayCastOutput.cpp
@@ -58,10 +58,10 @@ TEST(RayCastOutput, InitConstruction)
 
 TEST(RayCastOutput, RayCastFreeFunctionHits)
 {
-    const auto radius = Real(0.1) * Meter;
-    const auto location = Length2(Real(5) * Meter, Real(2) * Meter);
-    const auto p1 = Length2(Real(10) * Meter, Real(2) * Meter);
-    const auto p2 = Length2(Real(0) * Meter, Real(2) * Meter);
+    const auto radius = 0.1_m;
+    const auto location = Length2(5_m, 2_m);
+    const auto p1 = Length2(10_m, 2_m);
+    const auto p2 = Length2(0_m, 2_m);
     const auto maxFraction = Real(1);
     auto input = RayCastInput{p1, p2, maxFraction};
     const auto output = RayCast(radius, location, input);
@@ -78,20 +78,20 @@ TEST(RayCastOutput, RayCastFreeFunctionHits)
 TEST(RayCastOutput, RayCastLocationFreeFunctionMisses)
 {
     {
-        const auto radius = Real(0.1) * Meter;
-        const auto location = Length2(Real(15) * Meter, Real(2) * Meter);
-        const auto p1 = Length2(Real(10) * Meter, Real(2) * Meter);
-        const auto p2 = Length2(Real(0) * Meter, Real(2) * Meter);
+        const auto radius = 0.1_m;
+        const auto location = Length2(15_m, 2_m);
+        const auto p1 = Length2(10_m, 2_m);
+        const auto p2 = Length2(0_m, 2_m);
         const auto maxFraction = Real(1);
         auto input = RayCastInput{p1, p2, maxFraction};
         const auto output = RayCast(radius, location, input);
         EXPECT_FALSE(output.has_value());
     }
     {
-        const auto radius = Real(0.1) * Meter;
-        const auto location = Length2(Real(10) * Meter, Real(3) * Meter);
-        const auto p1 = Length2(Real(0) * Meter, Real(2) * Meter);
-        const auto p2 = Length2(Real(10) * Meter, Real(2) * Meter);
+        const auto radius = 0.1_m;
+        const auto location = Length2(10_m, 3_m);
+        const auto p1 = Length2(0_m, 2_m);
+        const auto p2 = Length2(10_m, 2_m);
         const auto maxFraction = Real(1);
         auto input = RayCastInput{p1, p2, maxFraction};
         const auto output = RayCast(radius, location, input);
@@ -102,8 +102,8 @@ TEST(RayCastOutput, RayCastLocationFreeFunctionMisses)
 TEST(RayCastOutput, RayCastAabbFreeFunction)
 {
     AABB aabb;
-    const auto p1 = Length2(Real(10) * Meter, Real(2) * Meter);
-    const auto p2 = Length2(Real(0) * Meter, Real(2) * Meter);
+    const auto p1 = Length2(10_m, 2_m);
+    const auto p2 = Length2(0_m, 2_m);
     const auto maxFraction = Real(1);
     RayCastInput input{p1, p2, maxFraction};
     const auto output = RayCast(aabb, input);
@@ -112,21 +112,21 @@ TEST(RayCastOutput, RayCastAabbFreeFunction)
 
 TEST(RayCastOutput, RayCastDistanceProxyFF)
 {
-    const auto pos1 = Length2{Real(3) * Meter, Real(1) * Meter}; // bottom right
-    const auto pos2 = Length2{Real(3) * Meter, Real(3) * Meter}; // top right
-    const auto pos3 = Length2{Real(1) * Meter, Real(3) * Meter}; // top left
-    const auto pos4 = Length2{Real(1) * Meter, Real(1) * Meter}; // bottom left
+    const auto pos1 = Length2{3_m, 1_m}; // bottom right
+    const auto pos2 = Length2{3_m, 3_m}; // top right
+    const auto pos3 = Length2{1_m, 3_m}; // top left
+    const auto pos4 = Length2{1_m, 1_m}; // bottom left
     const Length2 squareVerts[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(GetFwdPerpendicular(pos2 - pos1));
     const auto n2 = GetUnitVector(GetFwdPerpendicular(pos3 - pos2));
     const auto n3 = GetUnitVector(GetFwdPerpendicular(pos4 - pos3));
     const auto n4 = GetUnitVector(GetFwdPerpendicular(pos1 - pos4));
     const UnitVec2 squareNormals[] = {n1, n2, n3, n4};
-    const auto radius = Real(0.5) * Meter;
+    const auto radius = 0.5_m;
     DistanceProxy dp{radius, 4, squareVerts, squareNormals};
 
-    const auto p1 = Length2(Real(0) * Meter, Real(2) * Meter);
-    const auto p2 = Length2(Real(10) * Meter, Real(2) * Meter);
+    const auto p1 = Length2(0_m, 2_m);
+    const auto p2 = Length2(10_m, 2_m);
     const auto maxFraction = Real(1);
     const auto input0 = RayCastInput{p1, p2, maxFraction};
     {

--- a/UnitTests/RayCastOutput.cpp
+++ b/UnitTests/RayCastOutput.cpp
@@ -59,9 +59,9 @@ TEST(RayCastOutput, InitConstruction)
 TEST(RayCastOutput, RayCastFreeFunctionHits)
 {
     const auto radius = Real(0.1) * Meter;
-    const auto location = Length2D(Real(5) * Meter, Real(2) * Meter);
-    const auto p1 = Length2D(Real(10) * Meter, Real(2) * Meter);
-    const auto p2 = Length2D(Real(0) * Meter, Real(2) * Meter);
+    const auto location = Length2(Real(5) * Meter, Real(2) * Meter);
+    const auto p1 = Length2(Real(10) * Meter, Real(2) * Meter);
+    const auto p2 = Length2(Real(0) * Meter, Real(2) * Meter);
     const auto maxFraction = Real(1);
     auto input = RayCastInput{p1, p2, maxFraction};
     const auto output = RayCast(radius, location, input);
@@ -79,9 +79,9 @@ TEST(RayCastOutput, RayCastLocationFreeFunctionMisses)
 {
     {
         const auto radius = Real(0.1) * Meter;
-        const auto location = Length2D(Real(15) * Meter, Real(2) * Meter);
-        const auto p1 = Length2D(Real(10) * Meter, Real(2) * Meter);
-        const auto p2 = Length2D(Real(0) * Meter, Real(2) * Meter);
+        const auto location = Length2(Real(15) * Meter, Real(2) * Meter);
+        const auto p1 = Length2(Real(10) * Meter, Real(2) * Meter);
+        const auto p2 = Length2(Real(0) * Meter, Real(2) * Meter);
         const auto maxFraction = Real(1);
         auto input = RayCastInput{p1, p2, maxFraction};
         const auto output = RayCast(radius, location, input);
@@ -89,9 +89,9 @@ TEST(RayCastOutput, RayCastLocationFreeFunctionMisses)
     }
     {
         const auto radius = Real(0.1) * Meter;
-        const auto location = Length2D(Real(10) * Meter, Real(3) * Meter);
-        const auto p1 = Length2D(Real(0) * Meter, Real(2) * Meter);
-        const auto p2 = Length2D(Real(10) * Meter, Real(2) * Meter);
+        const auto location = Length2(Real(10) * Meter, Real(3) * Meter);
+        const auto p1 = Length2(Real(0) * Meter, Real(2) * Meter);
+        const auto p2 = Length2(Real(10) * Meter, Real(2) * Meter);
         const auto maxFraction = Real(1);
         auto input = RayCastInput{p1, p2, maxFraction};
         const auto output = RayCast(radius, location, input);
@@ -102,8 +102,8 @@ TEST(RayCastOutput, RayCastLocationFreeFunctionMisses)
 TEST(RayCastOutput, RayCastAabbFreeFunction)
 {
     AABB aabb;
-    const auto p1 = Length2D(Real(10) * Meter, Real(2) * Meter);
-    const auto p2 = Length2D(Real(0) * Meter, Real(2) * Meter);
+    const auto p1 = Length2(Real(10) * Meter, Real(2) * Meter);
+    const auto p2 = Length2(Real(0) * Meter, Real(2) * Meter);
     const auto maxFraction = Real(1);
     RayCastInput input{p1, p2, maxFraction};
     const auto output = RayCast(aabb, input);
@@ -112,11 +112,11 @@ TEST(RayCastOutput, RayCastAabbFreeFunction)
 
 TEST(RayCastOutput, RayCastDistanceProxyFF)
 {
-    const auto pos1 = Length2D{Real(3) * Meter, Real(1) * Meter}; // bottom right
-    const auto pos2 = Length2D{Real(3) * Meter, Real(3) * Meter}; // top right
-    const auto pos3 = Length2D{Real(1) * Meter, Real(3) * Meter}; // top left
-    const auto pos4 = Length2D{Real(1) * Meter, Real(1) * Meter}; // bottom left
-    const Length2D squareVerts[] = {pos1, pos2, pos3, pos4};
+    const auto pos1 = Length2{Real(3) * Meter, Real(1) * Meter}; // bottom right
+    const auto pos2 = Length2{Real(3) * Meter, Real(3) * Meter}; // top right
+    const auto pos3 = Length2{Real(1) * Meter, Real(3) * Meter}; // top left
+    const auto pos4 = Length2{Real(1) * Meter, Real(1) * Meter}; // bottom left
+    const Length2 squareVerts[] = {pos1, pos2, pos3, pos4};
     const auto n1 = GetUnitVector(GetFwdPerpendicular(pos2 - pos1));
     const auto n2 = GetUnitVector(GetFwdPerpendicular(pos3 - pos2));
     const auto n3 = GetUnitVector(GetFwdPerpendicular(pos4 - pos3));
@@ -125,8 +125,8 @@ TEST(RayCastOutput, RayCastDistanceProxyFF)
     const auto radius = Real(0.5) * Meter;
     DistanceProxy dp{radius, 4, squareVerts, squareNormals};
 
-    const auto p1 = Length2D(Real(0) * Meter, Real(2) * Meter);
-    const auto p2 = Length2D(Real(10) * Meter, Real(2) * Meter);
+    const auto p1 = Length2(Real(0) * Meter, Real(2) * Meter);
+    const auto p2 = Length2(Real(10) * Meter, Real(2) * Meter);
     const auto maxFraction = Real(1);
     const auto input0 = RayCastInput{p1, p2, maxFraction};
     {
@@ -139,7 +139,7 @@ TEST(RayCastOutput, RayCastDistanceProxyFF)
         }
     }
     
-    const auto p0 = Length2D{};
+    const auto p0 = Length2{};
     const auto input1 = RayCastInput{p0, p1, maxFraction};
     {
         const auto output = RayCast(dp, input1, Transform_identity);

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -54,8 +54,8 @@ TEST(RevoluteJoint, Construction)
     jd.collideConnected = true;
     jd.userData = reinterpret_cast<void*>(0x011);
 
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     jd.enableLimit = true;
     jd.enableMotor = true;
     jd.motorSpeed = Real{4.4f} * RadianPerSecond;
@@ -71,7 +71,7 @@ TEST(RevoluteJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), jd.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), jd.collideConnected);
     EXPECT_EQ(joint.GetUserData(), jd.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
 
     EXPECT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
@@ -94,8 +94,8 @@ TEST(RevoluteJoint, EnableMotor)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
 
     auto joint = RevoluteJoint{jd};
     EXPECT_FALSE(joint.IsMotorEnabled());
@@ -114,8 +114,8 @@ TEST(RevoluteJoint, MotorSpeed)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     const auto newValue = Real(5) * RadianPerSecond;
     auto joint = RevoluteJoint{jd};
@@ -134,8 +134,8 @@ TEST(RevoluteJoint, EnableLimit)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = RevoluteJoint{jd};
     EXPECT_FALSE(joint.IsLimitEnabled());
@@ -154,8 +154,8 @@ TEST(RevoluteJoint, SetLimits)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     const auto upperValue = +5_deg;
     const auto lowerValue = -8_deg;
@@ -176,8 +176,8 @@ TEST(RevoluteJoint, MaxMotorTorque)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     const auto newValue = 5_Nm;
     auto joint = RevoluteJoint{jd};
@@ -191,8 +191,8 @@ TEST(RevoluteJoint, MovesDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     World world;
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
@@ -221,13 +221,13 @@ TEST(RevoluteJoint, LimitEnabledDynamicCircles)
                                                     .UseVertexRadius(Real{0.2f} * Meter)
                                                     .UseDensity(1_kgpm2));
     World world;
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    auto jd = RevoluteJointDef{b1, b2, Length2D{}};
+    auto jd = RevoluteJointDef{b1, b2, Length2{}};
     jd.enableLimit = true;
     ASSERT_EQ(jd.lowerAngle, Angle(0));
     ASSERT_EQ(jd.upperAngle, Angle(0));
@@ -288,13 +288,13 @@ TEST(RevoluteJoint, LimitEnabledDynamicCircles)
 
 TEST(RevoluteJoint, DynamicJoinedToStaticStaysPut)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{
         Real(0) * MeterPerSquareSecond,
         -Real(10) * MeterPerSquareSecond
     })};
     
-    const auto p1 = Length2D{Real(0) * Meter, Real(4) * Meter}; // Vec2{-1, 0};
-    const auto p2 = Length2D{Real(0) * Meter, -Real(2) * Meter}; // Vec2{+1, 0};
+    const auto p1 = Length2{Real(0) * Meter, Real(4) * Meter}; // Vec2{-1, 0};
+    const auto p2 = Length2{Real(0) * Meter, -Real(2) * Meter}; // Vec2{+1, 0};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Static).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
 
@@ -307,7 +307,7 @@ TEST(RevoluteJoint, DynamicJoinedToStaticStaysPut)
     shape2->SetDensity(1_kgpm2);
     b2->CreateFixture(shape2);
     
-    auto jd = RevoluteJointDef{b1, b2, Length2D{}};
+    auto jd = RevoluteJointDef{b1, b2, Length2{}};
     const auto joint = world.CreateJoint(jd);
     
     for (auto i = 0; i < 1000; ++i)

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -54,8 +54,8 @@ TEST(RevoluteJoint, Construction)
     jd.collideConnected = true;
     jd.userData = reinterpret_cast<void*>(0x011);
 
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     jd.enableLimit = true;
     jd.enableMotor = true;
     jd.motorSpeed = Real{4.4f} * RadianPerSecond;
@@ -94,8 +94,8 @@ TEST(RevoluteJoint, EnableMotor)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
 
     auto joint = RevoluteJoint{jd};
     EXPECT_FALSE(joint.IsMotorEnabled());
@@ -114,8 +114,8 @@ TEST(RevoluteJoint, MotorSpeed)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     const auto newValue = Real(5) * RadianPerSecond;
     auto joint = RevoluteJoint{jd};
@@ -134,8 +134,8 @@ TEST(RevoluteJoint, EnableLimit)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = RevoluteJoint{jd};
     EXPECT_FALSE(joint.IsLimitEnabled());
@@ -154,8 +154,8 @@ TEST(RevoluteJoint, SetLimits)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     const auto upperValue = +5_deg;
     const auto lowerValue = -8_deg;
@@ -176,8 +176,8 @@ TEST(RevoluteJoint, MaxMotorTorque)
     auto jd = RevoluteJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     const auto newValue = 5_Nm;
     auto joint = RevoluteJoint{jd};
@@ -191,8 +191,8 @@ TEST(RevoluteJoint, MovesDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     World world;
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
@@ -221,8 +221,8 @@ TEST(RevoluteJoint, LimitEnabledDynamicCircles)
                                                     .UseVertexRadius(Real{0.2f} * Meter)
                                                     .UseDensity(1_kgpm2));
     World world;
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
@@ -293,13 +293,13 @@ TEST(RevoluteJoint, DynamicJoinedToStaticStaysPut)
         -Real(10) * MeterPerSquareSecond
     })};
     
-    const auto p1 = Length2{Real(0) * Meter, Real(4) * Meter}; // Vec2{-1, 0};
-    const auto p2 = Length2{Real(0) * Meter, -Real(2) * Meter}; // Vec2{+1, 0};
+    const auto p1 = Length2{0_m, 4_m}; // Vec2{-1, 0};
+    const auto p2 = Length2{0_m, -2_m}; // Vec2{+1, 0};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Static).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
 
     const auto shape1 = std::make_shared<PolygonShape>();
-    shape1->SetAsBox(Real{1} * Meter, Real{1} * Meter);
+    shape1->SetAsBox(1_m, 1_m);
     b1->CreateFixture(shape1);
     
     const auto shape2 = std::make_shared<PolygonShape>();

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -189,7 +189,7 @@ TEST(RevoluteJoint, MaxMotorTorque)
 
 TEST(RevoluteJoint, MovesDynamicCircles)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     World world;
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -218,7 +218,7 @@ TEST(RevoluteJoint, MovesDynamicCircles)
 TEST(RevoluteJoint, LimitEnabledDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(DiskShape::Conf{}
-                                                    .UseVertexRadius(Real{0.2f} * Meter)
+                                                    .UseVertexRadius(0.2_m)
                                                     .UseDensity(1_kgpm2));
     World world;
     const auto p1 = Length2{-1_m, 0_m};
@@ -303,7 +303,7 @@ TEST(RevoluteJoint, DynamicJoinedToStaticStaysPut)
     b1->CreateFixture(shape1);
     
     const auto shape2 = std::make_shared<PolygonShape>();
-    shape2->SetAsBox(Real{0.5f} * Meter, Real{0.5f} * Meter);
+    shape2->SetAsBox(0.5_m, 0.5_m);
     shape2->SetDensity(1_kgpm2);
     b2->CreateFixture(shape2);
     

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -49,8 +49,8 @@ TEST(RopeJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, false);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, Length2D(-Real(1) * Meter, Real(0) * Meter));
-    EXPECT_EQ(def.localAnchorB, Length2D(+Real(1) * Meter, Real(0) * Meter));
+    EXPECT_EQ(def.localAnchorA, Length2(-Real(1) * Meter, Real(0) * Meter));
+    EXPECT_EQ(def.localAnchorB, Length2(+Real(1) * Meter, Real(0) * Meter));
     EXPECT_EQ(def.maxLength, Length{0});
 }
 
@@ -75,7 +75,7 @@ TEST(RopeJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
 
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
@@ -88,8 +88,8 @@ TEST(RopeJoint, GetRopeJointDef)
     auto bodyA = Body{nullptr, BodyDef{}};
     auto bodyB = Body{nullptr, BodyDef{}};
     RopeJointDef def{&bodyA, &bodyB};
-    const auto localAnchorA = Length2D{-Real(2) * Meter, Real(0) * Meter};
-    const auto localAnchorB = Length2D{+Real(2) * Meter, Real(0) * Meter};
+    const auto localAnchorA = Length2{-Real(2) * Meter, Real(0) * Meter};
+    const auto localAnchorB = Length2{+Real(2) * Meter, Real(0) * Meter};
     def.localAnchorA = localAnchorA;
     def.localAnchorB = localAnchorB;
     RopeJoint joint{def};
@@ -119,9 +119,9 @@ TEST(RopeJoint, GetRopeJointDef)
 TEST(RopeJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -49,8 +49,8 @@ TEST(RopeJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, false);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, Length2(-Real(1) * Meter, Real(0) * Meter));
-    EXPECT_EQ(def.localAnchorB, Length2(+Real(1) * Meter, Real(0) * Meter));
+    EXPECT_EQ(def.localAnchorA, Length2(-1_m, 0_m));
+    EXPECT_EQ(def.localAnchorB, Length2(+1_m, 0_m));
     EXPECT_EQ(def.maxLength, Length{0});
 }
 
@@ -88,8 +88,8 @@ TEST(RopeJoint, GetRopeJointDef)
     auto bodyA = Body{nullptr, BodyDef{}};
     auto bodyB = Body{nullptr, BodyDef{}};
     RopeJointDef def{&bodyA, &bodyB};
-    const auto localAnchorA = Length2{-Real(2) * Meter, Real(0) * Meter};
-    const auto localAnchorB = Length2{+Real(2) * Meter, Real(0) * Meter};
+    const auto localAnchorA = Length2{-2_m, 0_m};
+    const auto localAnchorB = Length2{+2_m, 0_m};
     def.localAnchorA = localAnchorA;
     def.localAnchorB = localAnchorB;
     RopeJoint joint{def};
@@ -120,8 +120,8 @@ TEST(RopeJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
@@ -129,10 +129,10 @@ TEST(RopeJoint, WithDynamicCircles)
     const auto jd = RopeJointDef{b1, b2};
     world.CreateJoint(jd);
     Step(world, 1_s);
-    EXPECT_GT(GetX(b1->GetLocation()), Real(-1) * Meter);
-    EXPECT_EQ(GetY(b1->GetLocation()), Real(0) * Meter);
-    EXPECT_LT(GetX(b2->GetLocation()), Real(+1) * Meter);
-    EXPECT_EQ(GetY(b2->GetLocation()), Real(0) * Meter);
+    EXPECT_GT(GetX(b1->GetLocation()), -1_m);
+    EXPECT_EQ(GetY(b1->GetLocation()), 0_m);
+    EXPECT_LT(GetX(b2->GetLocation()), +1_m);
+    EXPECT_EQ(GetY(b2->GetLocation()), 0_m);
     EXPECT_EQ(b1->GetAngle(), Angle{0});
     EXPECT_EQ(b2->GetAngle(), Angle{0});
 }

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -118,7 +118,7 @@ TEST(RopeJoint, GetRopeJointDef)
 
 TEST(RopeJoint, WithDynamicCircles)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -39,7 +39,7 @@ TEST(SeparationFinder, ByteSizeIs_40_56_or_96)
 
 TEST(SeparationFinder, BehavesAsExpected)
 {
-    const auto shape = PolygonShape{Real{0.5f} * Meter, Real{0.5f} * Meter};
+    const auto shape = PolygonShape{0.5_m, 0.5_m};
     const auto distproxy = shape.GetChild(0);
 
     const auto x = Real(100);

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -44,12 +44,12 @@ TEST(SeparationFinder, BehavesAsExpected)
 
     const auto x = Real(100);
     const auto sweepA = Sweep{
-        Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}
     };
     const auto sweepB = Sweep{
-        Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}
     };
     
     auto t = Real{0}; // Will be set to value of t2
@@ -64,7 +64,7 @@ TEST(SeparationFinder, BehavesAsExpected)
     EXPECT_EQ(fcn.GetType(), SeparationFinder::e_faceA);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(fcn.GetAxis()))), 1.0, 0.000001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(fcn.GetAxis()))), 0.0, 0.000001);
-    EXPECT_EQ(fcn.GetLocalPoint(), Length2D(Real(0.5f) * Meter, Real(0) * Meter));
+    EXPECT_EQ(fcn.GetLocalPoint(), Length2(Real(0.5f) * Meter, Real(0) * Meter));
 
     auto last_min_sep = MaxFloat * Meter;
     for (auto i = 0u; i < 500; ++i)

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -64,7 +64,7 @@ TEST(SeparationFinder, BehavesAsExpected)
     EXPECT_EQ(fcn.GetType(), SeparationFinder::e_faceA);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(fcn.GetAxis()))), 1.0, 0.000001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(fcn.GetAxis()))), 0.0, 0.000001);
-    EXPECT_EQ(fcn.GetLocalPoint(), Length2(Real(0.5f) * Meter, 0_m));
+    EXPECT_EQ(fcn.GetLocalPoint(), Length2(0.5_m, 0_m));
 
     auto last_min_sep = MaxFloat * Meter;
     for (auto i = 0u; i < 500; ++i)

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -44,12 +44,12 @@ TEST(SeparationFinder, BehavesAsExpected)
 
     const auto x = Real(100);
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{-x * Meter, 0_m}, Angle{0}},
+        Position{Length2{+x * Meter, 0_m}, Angle{0}}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{+x * Meter, 0_m}, Angle{0}},
+        Position{Length2{-x * Meter, 0_m}, Angle{0}}
     };
     
     auto t = Real{0}; // Will be set to value of t2
@@ -64,7 +64,7 @@ TEST(SeparationFinder, BehavesAsExpected)
     EXPECT_EQ(fcn.GetType(), SeparationFinder::e_faceA);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(fcn.GetAxis()))), 1.0, 0.000001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(fcn.GetAxis()))), 0.0, 0.000001);
-    EXPECT_EQ(fcn.GetLocalPoint(), Length2(Real(0.5f) * Meter, Real(0) * Meter));
+    EXPECT_EQ(fcn.GetLocalPoint(), Length2(Real(0.5f) * Meter, 0_m));
 
     auto last_min_sep = MaxFloat * Meter;
     for (auto i = 0u; i < 500; ++i)

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -39,7 +39,7 @@ TEST(Shape, ByteSize)
 
 TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)
 {
-    const auto shape = DiskShape{Real{2} * Meter};
+    const auto shape = DiskShape{2_m};
     const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto child = shape.GetChild(0);
 
@@ -87,7 +87,7 @@ TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)
 
 TEST(Shape, TestOverlapFasterThanCollideShapesForPolygons)
 {
-    const auto shape = PolygonShape{Real{2} * Meter, Real{2} * Meter};
+    const auto shape = PolygonShape{2_m, 2_m};
     const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto child = shape.GetChild(0);
 

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -40,7 +40,7 @@ TEST(Shape, ByteSize)
 TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)
 {
     const auto shape = DiskShape{Real{2} * Meter};
-    const auto xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto child = shape.GetChild(0);
 
     const auto maxloops = 1000000u;
@@ -88,7 +88,7 @@ TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)
 TEST(Shape, TestOverlapFasterThanCollideShapesForPolygons)
 {
     const auto shape = PolygonShape{Real{2} * Meter, Real{2} * Meter};
-    const auto xfm = Transformation{Length2D{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
     const auto child = shape.GetChild(0);
 
     const auto maxloops = 1000000u;

--- a/UnitTests/Simplex.cpp
+++ b/UnitTests/Simplex.cpp
@@ -162,8 +162,8 @@ TEST(Simplex, DefaultConstruction)
 
 TEST(Simplex, Get1)
 {
-    const auto va = Length2{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va = Length2{-4_m, 33_m};
+    const auto vb = Length2{901.5_m, 0.06_m};
     const auto ia = SimplexEdge::index_type{2};
     const auto ib = SimplexEdge::index_type{7};
     const auto sv = SimplexEdge{va, ia, vb, ib};
@@ -184,8 +184,8 @@ TEST(Simplex, Get1)
 
 TEST(Simplex, Get2_of_same)
 {
-    const auto va = Length2{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va = Length2{-4_m, 33_m};
+    const auto vb = Length2{901.5_m, 0.06_m};
     const auto ia = SimplexEdge::index_type{2};
     const auto ib = SimplexEdge::index_type{7};
     const auto sv = SimplexEdge{va, ia, vb, ib};
@@ -207,8 +207,8 @@ TEST(Simplex, Get2_of_same)
 
 TEST(Simplex, Get2_fwd_perp)
 {
-    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb0 = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va0 = Length2{-4_m, 33_m};
+    const auto vb0 = Length2{901.5_m, 0.06_m};
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
@@ -247,8 +247,8 @@ TEST(Simplex, Get2_fwd_perp)
 
 TEST(Simplex, Get2_rev_perp)
 {
-    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb0 = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va0 = Length2{-4_m, 33_m};
+    const auto vb0 = Length2{901.5_m, 0.06_m};
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
@@ -287,8 +287,8 @@ TEST(Simplex, Get2_rev_perp)
 
 TEST(Simplex, Get2_rot_plus_45)
 {
-    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb0 = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va0 = Length2{-4_m, 33_m};
+    const auto vb0 = Length2{901.5_m, 0.06_m};
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
@@ -327,8 +327,8 @@ TEST(Simplex, Get2_rot_plus_45)
 
 TEST(Simplex, Get2_rot45_half)
 {
-    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter}; // upper left
-    const auto vb0 = Length2{Real(901) * Meter, Real(6) * Meter}; // lower right
+    const auto va0 = Length2{-4_m, 33_m}; // upper left
+    const auto vb0 = Length2{901_m, 6_m}; // lower right
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};

--- a/UnitTests/Simplex.cpp
+++ b/UnitTests/Simplex.cpp
@@ -162,8 +162,8 @@ TEST(Simplex, DefaultConstruction)
 
 TEST(Simplex, Get1)
 {
-    const auto va = Length2D{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb = Length2D{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va = Length2{-Real(4) * Meter, Real(33) * Meter};
+    const auto vb = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
     const auto ia = SimplexEdge::index_type{2};
     const auto ib = SimplexEdge::index_type{7};
     const auto sv = SimplexEdge{va, ia, vb, ib};
@@ -184,8 +184,8 @@ TEST(Simplex, Get1)
 
 TEST(Simplex, Get2_of_same)
 {
-    const auto va = Length2D{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb = Length2D{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va = Length2{-Real(4) * Meter, Real(33) * Meter};
+    const auto vb = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
     const auto ia = SimplexEdge::index_type{2};
     const auto ib = SimplexEdge::index_type{7};
     const auto sv = SimplexEdge{va, ia, vb, ib};
@@ -207,8 +207,8 @@ TEST(Simplex, Get2_of_same)
 
 TEST(Simplex, Get2_fwd_perp)
 {
-    const auto va0 = Length2D{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb0 = Length2D{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter};
+    const auto vb0 = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
@@ -247,8 +247,8 @@ TEST(Simplex, Get2_fwd_perp)
 
 TEST(Simplex, Get2_rev_perp)
 {
-    const auto va0 = Length2D{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb0 = Length2D{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter};
+    const auto vb0 = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
@@ -287,8 +287,8 @@ TEST(Simplex, Get2_rev_perp)
 
 TEST(Simplex, Get2_rot_plus_45)
 {
-    const auto va0 = Length2D{-Real(4) * Meter, Real(33) * Meter};
-    const auto vb0 = Length2D{Real(901.5) * Meter, Real(0.06) * Meter};
+    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter};
+    const auto vb0 = Length2{Real(901.5) * Meter, Real(0.06) * Meter};
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
@@ -327,8 +327,8 @@ TEST(Simplex, Get2_rot_plus_45)
 
 TEST(Simplex, Get2_rot45_half)
 {
-    const auto va0 = Length2D{-Real(4) * Meter, Real(33) * Meter}; // upper left
-    const auto vb0 = Length2D{Real(901) * Meter, Real(6) * Meter}; // lower right
+    const auto va0 = Length2{-Real(4) * Meter, Real(33) * Meter}; // upper left
+    const auto vb0 = Length2{Real(901) * Meter, Real(6) * Meter}; // lower right
     const auto ia0 = SimplexEdge::index_type{2};
     const auto ib0 = SimplexEdge::index_type{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};

--- a/UnitTests/SimplexEdge.cpp
+++ b/UnitTests/SimplexEdge.cpp
@@ -36,8 +36,8 @@ TEST(SimplexEdge, InitializingConstructor)
 {
     const auto iA = SimplexEdge::index_type{1};
     const auto iB = SimplexEdge::index_type{2};
-    const auto pA = Length2{Real(2.2) * Meter, Real(-3.1) * Meter};
-    const auto pB = Length2{Real(-9.2) * Meter, Real(0.003) * Meter};
+    const auto pA = Length2{2.2_m, -3.1_m};
+    const auto pB = Length2{-9.2_m, 0.003_m};
 
     const auto sv = SimplexEdge(pA, iA, pB, iB);
     

--- a/UnitTests/SimplexEdge.cpp
+++ b/UnitTests/SimplexEdge.cpp
@@ -36,8 +36,8 @@ TEST(SimplexEdge, InitializingConstructor)
 {
     const auto iA = SimplexEdge::index_type{1};
     const auto iB = SimplexEdge::index_type{2};
-    const auto pA = Length2D{Real(2.2) * Meter, Real(-3.1) * Meter};
-    const auto pB = Length2D{Real(-9.2) * Meter, Real(0.003) * Meter};
+    const auto pA = Length2{Real(2.2) * Meter, Real(-3.1) * Meter};
+    const auto pB = Length2{Real(-9.2) * Meter, Real(0.003) * Meter};
 
     const auto sv = SimplexEdge(pA, iA, pB, iB);
     

--- a/UnitTests/StepConf.cpp
+++ b/UnitTests/StepConf.cpp
@@ -62,7 +62,7 @@ TEST(StepConf, maxTranslation)
     ASSERT_GT(inc, Real(0));
     ASSERT_LT(inc, Real(1));
     const auto max_inc = inc * StepConf{}.maxTranslation;
-    EXPECT_GT(max_inc, Real(0) * Meter);
+    EXPECT_GT(max_inc, 0_m);
     EXPECT_LT(max_inc, DefaultLinearSlop / Real{2});
     EXPECT_LT(max_inc, Length{StepConf{}.linearSlop} / Real{2});
     EXPECT_LT(max_inc, Length{StepConf{}.tolerance});
@@ -76,8 +76,8 @@ TEST(StepConf, maxTranslation)
     
     {
         StepConf conf;
-        conf.tolerance = Real(0.0000001) * Meter;
-        conf.maxTranslation = Real(8.0) * Meter;
+        conf.tolerance = 0.0000001_m;
+        conf.maxTranslation = 8.0_m;
         switch (sizeof(Real))
         {
             case 4: EXPECT_FALSE(IsMaxTranslationWithinTolerance(conf)); break;

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -33,14 +33,14 @@ TEST(Sweep, ByteSizeIs_36_or_72)
 }
 
 TEST(Sweep, ConstructorSetsPos0and1) {
-    const auto pos = Position{Length2{Real(-0.4) * Meter, 2.34_m}, 3.14_rad};
+    const auto pos = Position{Length2{-0.4_m, 2.34_m}, 3.14_rad};
     Sweep sweep{pos};
     EXPECT_EQ(pos, sweep.pos0);
     EXPECT_EQ(pos, sweep.pos1);
 }
 
 TEST(Sweep, ResetSetsAlpha0to0) {
-    const auto pos = Position{Length2{Real(-0.4) * Meter, 2.34_m}, 3.14_rad};
+    const auto pos = Position{Length2{-0.4_m, 2.34_m}, 3.14_rad};
     Sweep sweep{pos, pos, Length2{}, Real(0.6)};
     EXPECT_NE(Real{0}, sweep.GetAlpha0());
     sweep.ResetAlpha0();
@@ -48,16 +48,16 @@ TEST(Sweep, ResetSetsAlpha0to0) {
 }
 
 TEST(Sweep, GetPosition) {
-    const auto pos0 = Position{Length2{Real(-0.4) * Meter, Real(+2.34) * Meter}, 3.14_rad};
-    const auto pos1 = Position{Length2{Real(+0.4) * Meter, Real(-2.34) * Meter}, -3.14_rad};
+    const auto pos0 = Position{Length2{-0.4_m, +2.34_m}, 3.14_rad};
+    const auto pos1 = Position{Length2{+0.4_m, -2.34_m}, -3.14_rad};
     Sweep sweep{pos0, pos1, Length2{}, Real(0.6)};
     EXPECT_EQ(pos0, GetPosition(sweep.pos0, sweep.pos1, 0));
     EXPECT_EQ(pos1, GetPosition(sweep.pos0, sweep.pos1, 1));
 }
 
 TEST(Sweep, Advance) {
-    const auto pos0 = Position{Length2{Real(-0.4) * Meter, Real(+2.34) * Meter}, 3.14_rad};
-    const auto pos1 = Position{Length2{Real(+0.4) * Meter, Real(-2.34) * Meter}, -3.14_rad};
+    const auto pos0 = Position{Length2{-0.4_m, +2.34_m}, 3.14_rad};
+    const auto pos1 = Position{Length2{+0.4_m, -2.34_m}, -3.14_rad};
     
     Sweep sweep{pos0, pos1, Length2{}, 0};
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -33,33 +33,33 @@ TEST(Sweep, ByteSizeIs_36_or_72)
 }
 
 TEST(Sweep, ConstructorSetsPos0and1) {
-    const auto pos = Position{Length2D{Real(-0.4) * Meter, Real(2.34) * Meter}, 3.14_rad};
+    const auto pos = Position{Length2{Real(-0.4) * Meter, Real(2.34) * Meter}, 3.14_rad};
     Sweep sweep{pos};
     EXPECT_EQ(pos, sweep.pos0);
     EXPECT_EQ(pos, sweep.pos1);
 }
 
 TEST(Sweep, ResetSetsAlpha0to0) {
-    const auto pos = Position{Length2D{Real(-0.4) * Meter, Real(2.34) * Meter}, 3.14_rad};
-    Sweep sweep{pos, pos, Length2D{}, Real(0.6)};
+    const auto pos = Position{Length2{Real(-0.4) * Meter, Real(2.34) * Meter}, 3.14_rad};
+    Sweep sweep{pos, pos, Length2{}, Real(0.6)};
     EXPECT_NE(Real{0}, sweep.GetAlpha0());
     sweep.ResetAlpha0();
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());    
 }
 
 TEST(Sweep, GetPosition) {
-    const auto pos0 = Position{Length2D{Real(-0.4) * Meter, Real(+2.34) * Meter}, 3.14_rad};
-    const auto pos1 = Position{Length2D{Real(+0.4) * Meter, Real(-2.34) * Meter}, -3.14_rad};
-    Sweep sweep{pos0, pos1, Length2D{}, Real(0.6)};
+    const auto pos0 = Position{Length2{Real(-0.4) * Meter, Real(+2.34) * Meter}, 3.14_rad};
+    const auto pos1 = Position{Length2{Real(+0.4) * Meter, Real(-2.34) * Meter}, -3.14_rad};
+    Sweep sweep{pos0, pos1, Length2{}, Real(0.6)};
     EXPECT_EQ(pos0, GetPosition(sweep.pos0, sweep.pos1, 0));
     EXPECT_EQ(pos1, GetPosition(sweep.pos0, sweep.pos1, 1));
 }
 
 TEST(Sweep, Advance) {
-    const auto pos0 = Position{Length2D{Real(-0.4) * Meter, Real(+2.34) * Meter}, 3.14_rad};
-    const auto pos1 = Position{Length2D{Real(+0.4) * Meter, Real(-2.34) * Meter}, -3.14_rad};
+    const auto pos0 = Position{Length2{Real(-0.4) * Meter, Real(+2.34) * Meter}, 3.14_rad};
+    const auto pos1 = Position{Length2{Real(+0.4) * Meter, Real(-2.34) * Meter}, -3.14_rad};
     
-    Sweep sweep{pos0, pos1, Length2D{}, 0};
+    Sweep sweep{pos0, pos1, Length2{}, 0};
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());
     
     sweep.Advance0(0);
@@ -70,7 +70,7 @@ TEST(Sweep, Advance) {
     sweep.Advance0(Real{1}/Real{2});
     EXPECT_EQ(Real{1}/Real{2}, sweep.GetAlpha0());
     EXPECT_EQ(pos1, sweep.pos1);
-    EXPECT_EQ((Position{Length2D{}, Angle{0}}), sweep.pos0);
+    EXPECT_EQ((Position{Length2{}, Angle{0}}), sweep.pos0);
 
     sweep.Advance0(0);
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());
@@ -81,49 +81,49 @@ TEST(Sweep, Advance) {
 TEST(Sweep, GetAnglesNormalized)
 {
     const auto sweep0 = Sweep{
-        Position{Length2D{}, Angle{0}},
-        Position{Length2D{}, Angle{0}}
+        Position{Length2{}, Angle{0}},
+        Position{Length2{}, Angle{0}}
     };
     EXPECT_EQ(GetAnglesNormalized(sweep0).pos0.angular, Angle{0});
     EXPECT_EQ(GetAnglesNormalized(sweep0).pos1.angular, Angle{0});
 
-    const auto sweep1 = Sweep{Position{Length2D{}, 90_deg}, Position{Length2D{}, 90_deg}};
+    const auto sweep1 = Sweep{Position{Length2{}, 90_deg}, Position{Length2{}, 90_deg}};
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep1).pos0.angular / Degree}),
                 double( 90), 0.03);
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep1).pos1.angular / Degree}),
                 double( 90), 0.03);
 
-    const auto sweep2 = Sweep{Position{Length2D{}, 180_deg}, Position{Length2D{}, 180_deg}};
+    const auto sweep2 = Sweep{Position{Length2{}, 180_deg}, Position{Length2{}, 180_deg}};
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep2).pos0.angular / Degree}),
                 double(180), 0.03);
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep2).pos1.angular / Degree}),
                 double(180), 0.03);
 
-    const auto sweep3 = Sweep{Position{Length2D{}, 270_deg}, Position{Length2D{}, 270_deg}};
+    const auto sweep3 = Sweep{Position{Length2{}, 270_deg}, Position{Length2{}, 270_deg}};
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep3).pos0.angular / Degree}),
                 double(270), 0.03);
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep3).pos1.angular / Degree}),
                        double(270), 0.03);
 
-    const auto sweep4 = Sweep{Position{Length2D{}, 361_deg}, Position{Length2D{}, 361_deg}};
+    const auto sweep4 = Sweep{Position{Length2{}, 361_deg}, Position{Length2{}, 361_deg}};
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep4).pos0.angular / Degree}),
                 double(1), 0.001);
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep4).pos1.angular / Degree}),
                 double(1), 0.001);
 
-    const auto sweep5 = Sweep{Position{Length2D{}, 722_deg}, Position{Length2D{}, 722_deg}};
+    const auto sweep5 = Sweep{Position{Length2{}, 722_deg}, Position{Length2{}, 722_deg}};
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep5).pos0.angular / Degree}),
                 double(2), 0.002);
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep5).pos1.angular / Degree}),
                 double(2), 0.002);
 
-    const auto sweep6 = Sweep{Position{Length2D{}, 726_deg}, Position{Length2D{}, 90_deg}};
+    const auto sweep6 = Sweep{Position{Length2{}, 726_deg}, Position{Length2{}, 90_deg}};
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep6).pos0.angular / Degree}),
                 double(6), 0.03);
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep6).pos1.angular / Degree}),
                 double(-630), 0.03);
     
-    const auto sweep7 = Sweep{Position{Length2D{}, -90_deg}, Position{Length2D{}, -90_deg}};
+    const auto sweep7 = Sweep{Position{Length2{}, -90_deg}, Position{Length2{}, -90_deg}};
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep7).pos0.angular / Degree}),
                 double( -90), 0.03);
     EXPECT_NEAR(double(Real{GetAnglesNormalized(sweep7).pos1.angular / Degree}),

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -33,14 +33,14 @@ TEST(Sweep, ByteSizeIs_36_or_72)
 }
 
 TEST(Sweep, ConstructorSetsPos0and1) {
-    const auto pos = Position{Length2{Real(-0.4) * Meter, Real(2.34) * Meter}, 3.14_rad};
+    const auto pos = Position{Length2{Real(-0.4) * Meter, 2.34_m}, 3.14_rad};
     Sweep sweep{pos};
     EXPECT_EQ(pos, sweep.pos0);
     EXPECT_EQ(pos, sweep.pos1);
 }
 
 TEST(Sweep, ResetSetsAlpha0to0) {
-    const auto pos = Position{Length2{Real(-0.4) * Meter, Real(2.34) * Meter}, 3.14_rad};
+    const auto pos = Position{Length2{Real(-0.4) * Meter, 2.34_m}, 3.14_rad};
     Sweep sweep{pos, pos, Length2{}, Real(0.6)};
     EXPECT_NE(Real{0}, sweep.GetAlpha0());
     sweep.ResetAlpha0();

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -479,10 +479,10 @@ TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
     };
 
     const Length2 vertices[] = {
-        Vec2{14.5f, -0.5f} * (Real(1) * Meter),
-        Vec2{14.5f, +0.5f} * (Real(1) * Meter),
-        Vec2{13.5f, +0.5f} * (Real(1) * Meter),
-        Vec2{13.5f, -0.5f} * (Real(1) * Meter)
+        Vec2{14.5f, -0.5f} * Meter,
+        Vec2{14.5f, +0.5f} * Meter,
+        Vec2{13.5f, +0.5f} * Meter,
+        Vec2{13.5f, -0.5f} * Meter
     };
 
     const UnitVec2 normals[] = {

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -76,12 +76,12 @@ TEST(TimeOfImpact, Overlapped)
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth((slop * 3) * Meter).UseTolerance((slop / 4) * Meter);
 
     const auto radius = Real(1) * Meter;
-    const auto pA = Length2D{};
+    const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2D{}, Angle{0}}};
-    const auto pB = Length2D{};
+    const auto sweepA = Sweep{Position{Length2{}, Angle{0}}};
+    const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2D{}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{}, Angle{0}}};
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     EXPECT_EQ(output.get_state(), TOIOutput::e_overlapped);
     EXPECT_EQ(output.get_t(), Real(0));
@@ -95,13 +95,13 @@ TEST(TimeOfImpact, Touching)
 
     const auto radius = Real(1.1) * Meter;
 
-    const auto pA = Length2D{};
+    const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2D{}, Angle{0}}};
+    const auto sweepA = Sweep{Position{Length2{}, Angle{0}}};
     
-    const auto pB = Length2D{};
+    const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2D{Real(2) * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{Real(2) * Meter, Real(0) * Meter}, Angle{0}}};
 
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -116,13 +116,13 @@ TEST(TimeOfImpact, Separated)
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
     const auto radius = Real(1) * Meter;
     
-    const auto pA = Length2D{};
+    const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2D{}, Angle{0}}};
+    const auto sweepA = Sweep{Position{Length2{}, Angle{0}}};
     
-    const auto pB = Length2D{};
+    const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2D{Real(4) * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{Real(4) * Meter, Real(0) * Meter}, Angle{0}}};
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -140,12 +140,12 @@ TEST(TimeOfImpact, CollideCirclesHorizontally)
     // with the other after they have moved roughly two-thirds of their sweep.
     const auto radius = Real(1) * Meter;
     const auto x = Real(2);
-    const auto pA = Length2D{};
+    const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2D{}, Angle{0}}};
-    const auto pB = Length2D{};
+    const auto sweepA = Sweep{Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{}, Angle{0}}};
+    const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2D{}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{}, Angle{0}}};
     
     // Compute the time of impact information now...
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
@@ -164,18 +164,18 @@ TEST(TimeOfImpact, CollideCirclesVertically)
     const auto radius = Real(1) * Meter;
     const auto y = Real(20);
 
-    const auto pos = Length2D{};
+    const auto pos = Length2{};
 
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2D{Real(0) * Meter, -y * Meter}, Angle{0}},
-        Position{Length2D{Real(0) * Meter, +y * Meter}, Angle{0}}
+        Position{Length2{Real(0) * Meter, -y * Meter}, Angle{0}},
+        Position{Length2{Real(0) * Meter, +y * Meter}, Angle{0}}
     };
     
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2D{Real(0) * Meter, +y * Meter}, Angle{0}},
-        Position{Length2D{Real(0) * Meter, -y * Meter}, Angle{0}}
+        Position{Length2{Real(0) * Meter, +y * Meter}, Angle{0}},
+        Position{Length2{Real(0) * Meter, -y * Meter}, Angle{0}}
     };
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
@@ -190,7 +190,7 @@ TEST(TimeOfImpact, CirclesPassingParallelSeparatedPathsDontCollide)
     const auto slop = Real{0.001f};
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
     
-    const auto pos = Length2D{};
+    const auto pos = Length2{};
 
     // Set up for two bodies moving toward each other at same speeds and each colliding
     // with the other after they have moved roughly two-thirds of their sweep.
@@ -199,13 +199,13 @@ TEST(TimeOfImpact, CirclesPassingParallelSeparatedPathsDontCollide)
     const auto y = Real(1);
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2D{-x * Meter, +y * Meter}, Angle{0}},
-        Position{Length2D{+x * Meter, +y * Meter}, Angle{0}}
+        Position{Length2{-x * Meter, +y * Meter}, Angle{0}},
+        Position{Length2{+x * Meter, +y * Meter}, Angle{0}}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2D{+x * Meter, -y * Meter}, Angle{0}},
-        Position{Length2D{-x * Meter, -y * Meter}, Angle{0}}
+        Position{Length2{+x * Meter, -y * Meter}, Angle{0}},
+        Position{Length2{-x * Meter, -y * Meter}, Angle{0}}
     };
     
     // Compute the time of impact information now...
@@ -225,21 +225,21 @@ TEST(TimeOfImpact, RodCircleMissAt360)
     // with the other after they have moved roughly two-thirds of their sweep.
     const auto radius = Real(1) * Meter;
     const auto x = Real(40);
-    const auto vA0 = Length2D{-Real(4) * Meter, Real(0) * Meter};
-    const auto vA1 = Length2D{Real(4) * Meter, Real(0) * Meter};
-    const Length2D vertices[] = {vA0, vA1};
+    const auto vA0 = Length2{-Real(4) * Meter, Real(0) * Meter};
+    const auto vA1 = Length2{Real(4) * Meter, Real(0) * Meter};
+    const Length2 vertices[] = {vA0, vA1};
     const auto nA0 = GetUnitVector(vA1 - vA0);
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
     const auto sweepA = Sweep{
-        Position{Length2D{-x * Meter, Real(4) * Meter}, 0_deg},
-        Position{Length2D{+x * Meter, Real(4) * Meter}, 360_deg}
+        Position{Length2{-x * Meter, Real(4) * Meter}, 0_deg},
+        Position{Length2{+x * Meter, Real(4) * Meter}, 360_deg}
     };
-    const auto pos = Length2D{};
+    const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2D{+x * Meter, Real(0) * Meter}, 0_deg},
-        Position{Length2D{-x * Meter, Real(0) * Meter}, 0_deg}
+        Position{Length2{+x * Meter, Real(0) * Meter}, 0_deg},
+        Position{Length2{-x * Meter, Real(0) * Meter}, 0_deg}
     };
     
     // Compute the time of impact information now...
@@ -259,21 +259,21 @@ TEST(TimeOfImpact, RodCircleHitAt180)
     // with the other after they have moved roughly two-thirds of their sweep.
     const auto radius = Real(1) * Meter;
     const auto x = Real(40);
-    const auto vA0 = Length2D{-Real(4) * Meter, Real(0) * Meter};
-    const auto vA1 = Length2D{Real(4) * Meter, Real(0) * Meter};
-    const Length2D vertices[] = {vA0, vA1};
+    const auto vA0 = Length2{-Real(4) * Meter, Real(0) * Meter};
+    const auto vA1 = Length2{Real(4) * Meter, Real(0) * Meter};
+    const Length2 vertices[] = {vA0, vA1};
     const auto nA0 = GetUnitVector(vA1 - vA0);
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
     const auto sweepA = Sweep{
-        Position{Length2D{-x * Meter, Real(4) * Meter}, Angle{0}},
-        Position{Length2D{+x * Meter, Real(4) * Meter}, Angle{Real{180.0f} * 1_deg}}
+        Position{Length2{-x * Meter, Real(4) * Meter}, Angle{0}},
+        Position{Length2{+x * Meter, Real(4) * Meter}, Angle{Real{180.0f} * 1_deg}}
     };
-    const auto pos = Length2D{};
+    const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}
     };
     
     // Compute the time of impact information now...
@@ -289,16 +289,16 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_1)
     const auto slop = Real{0.001f};
     const auto radius = Real(1) * Meter;
     const auto x = Real(200);
-    const auto pos = Length2D{};
+    const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}
     };
     
     const auto conf = ToiConf{}
@@ -322,16 +322,16 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
     const auto slop = Real{0.001f};
     const auto radius = Real(1) * Meter;
     const auto x = Real(400);
-    const auto pos = Length2D{};
+    const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2D{}, Angle{0}}
+        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{}, Angle{0}}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2D{}, Angle{0}}
+        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{}, Angle{0}}
     };
     
     const auto conf = ToiConf{}
@@ -386,11 +386,11 @@ TEST(TimeOfImpact, WithClosingSpeedOf1600)
     const auto slop = Real{0.001f};
     const auto radius = Real(1) * Meter;
     const auto x = Real(400);
-    const auto pos = Length2D{};
+    const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepA = Sweep{Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{Position{Length2D{+x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2D{-x * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}};
     
     const auto conf = ToiConf{}
         .UseMaxToiIters(200)
@@ -425,12 +425,12 @@ TEST(TimeOfImpact, ForNonCollidingShapesFails)
     const auto dpB = shapeB.GetChild(0);
 
     const auto sweepA = Sweep{
-        Position{Length2D{-Real(11) * Meter, Real(10) * Meter}, 2.95000005_rad},
-        Position{Length2D{-Real(11) * Meter, Real(10) * Meter}, 2.95000005_rad}
+        Position{Length2{-Real(11) * Meter, Real(10) * Meter}, 2.95000005_rad},
+        Position{Length2{-Real(11) * Meter, Real(10) * Meter}, 2.95000005_rad}
     };
     const auto sweepB = Sweep{
-        Position{Length2D{Real(18.4742737f) * Meter, Real(19.7474861f) * Meter}, 513.36676_rad},
-        Position{Length2D{Real(19.5954781f) * Meter, Real(18.9165268f) * Meter}, 513.627808_rad}
+        Position{Length2{Real(18.4742737f) * Meter, Real(19.7474861f) * Meter}, 513.36676_rad},
+        Position{Length2{Real(19.5954781f) * Meter, Real(18.9165268f) * Meter}, 513.627808_rad}
     };
     
     const auto conf = ToiConf{}
@@ -470,15 +470,15 @@ TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
     // separation has reached tolerance but t2 already equals t1.
 
     const auto sweepA = Sweep{
-        Position{Length2D{Real(0.0f) * Meter, Real(-0.5f) * Meter}, Angle{0}},
-        Position{Length2D{Real(0.0f) * Meter, Real(-0.5f) * Meter}, Angle{0}}
+        Position{Length2{Real(0.0f) * Meter, Real(-0.5f) * Meter}, Angle{0}},
+        Position{Length2{Real(0.0f) * Meter, Real(-0.5f) * Meter}, Angle{0}}
     };
     const auto sweepB = Sweep{
-        Position{Length2D{Real(14.3689661f) * Meter, Real(0.500306308f) * Meter}, 0.0000139930862_rad},
-        Position{Length2D{Real(14.3689451f) * Meter, Real(0.500254989f) * Meter}, 0.000260060915_rad}
+        Position{Length2{Real(14.3689661f) * Meter, Real(0.500306308f) * Meter}, 0.0000139930862_rad},
+        Position{Length2{Real(14.3689451f) * Meter, Real(0.500254989f) * Meter}, 0.000260060915_rad}
     };
 
-    const Length2D vertices[] = {
+    const Length2 vertices[] = {
         Vec2{14.5f, -0.5f} * (Real(1) * Meter),
         Vec2{14.5f, +0.5f} * (Real(1) * Meter),
         Vec2{13.5f, +0.5f} * (Real(1) * Meter),

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -75,7 +75,7 @@ TEST(TimeOfImpact, Overlapped)
     const auto slop = Real{0.001f};
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth((slop * 3) * Meter).UseTolerance((slop / 4) * Meter);
 
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
     const auto sweepA = Sweep{Position{Length2{}, Angle{0}}};
@@ -93,7 +93,7 @@ TEST(TimeOfImpact, Touching)
     const auto slop = Real{0.001f};
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth((slop * 3) * Meter).UseTolerance((slop / 4) * Meter);
 
-    const auto radius = Real(1.1) * Meter;
+    const auto radius = 1.1_m;
 
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
@@ -101,7 +101,7 @@ TEST(TimeOfImpact, Touching)
     
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2{Real(2) * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{2_m, 0_m}, Angle{0}}};
 
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -113,8 +113,8 @@ TEST(TimeOfImpact, Touching)
 TEST(TimeOfImpact, Separated)
 {
     const auto slop = Real{0.001f};
-    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
-    const auto radius = Real(1) * Meter;
+    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * 3_m).UseTolerance((slop / 4) * Meter);
+    const auto radius = 1_m;
     
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
@@ -122,7 +122,7 @@ TEST(TimeOfImpact, Separated)
     
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2{Real(4) * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{4_m, 0_m}, Angle{0}}};
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -134,18 +134,18 @@ TEST(TimeOfImpact, Separated)
 TEST(TimeOfImpact, CollideCirclesHorizontally)
 {
     const auto slop = Real{0.001f};
-    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
+    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * 3_m).UseTolerance((slop / 4) * Meter);
 
     // Set up for two bodies moving toward each other at same speeds and each colliding
     // with the other after they have moved roughly two-thirds of their sweep.
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(2);
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{}, Angle{0}}};
+    const auto sweepA = Sweep{Position{Length2{-x * Meter, 0_m}, Angle{0}}, Position{Length2{}, Angle{0}}};
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{+x * Meter, 0_m}, Angle{0}}, Position{Length2{}, Angle{0}}};
     
     // Compute the time of impact information now...
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
@@ -160,22 +160,22 @@ TEST(TimeOfImpact, CollideCirclesHorizontally)
 TEST(TimeOfImpact, CollideCirclesVertically)
 {
     const auto slop = Real{0.001f};
-    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
-    const auto radius = Real(1) * Meter;
+    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * 3_m).UseTolerance((slop / 4) * Meter);
+    const auto radius = 1_m;
     const auto y = Real(20);
 
     const auto pos = Length2{};
 
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{Real(0) * Meter, -y * Meter}, Angle{0}},
-        Position{Length2{Real(0) * Meter, +y * Meter}, Angle{0}}
+        Position{Length2{0_m, -y * Meter}, Angle{0}},
+        Position{Length2{0_m, +y * Meter}, Angle{0}}
     };
     
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{Real(0) * Meter, +y * Meter}, Angle{0}},
-        Position{Length2{Real(0) * Meter, -y * Meter}, Angle{0}}
+        Position{Length2{0_m, +y * Meter}, Angle{0}},
+        Position{Length2{0_m, -y * Meter}, Angle{0}}
     };
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
@@ -188,13 +188,13 @@ TEST(TimeOfImpact, CollideCirclesVertically)
 TEST(TimeOfImpact, CirclesPassingParallelSeparatedPathsDontCollide)
 {
     const auto slop = Real{0.001f};
-    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
+    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * 3_m).UseTolerance((slop / 4) * Meter);
     
     const auto pos = Length2{};
 
     // Set up for two bodies moving toward each other at same speeds and each colliding
     // with the other after they have moved roughly two-thirds of their sweep.
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(3);
     const auto y = Real(1);
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
@@ -219,27 +219,27 @@ TEST(TimeOfImpact, CirclesPassingParallelSeparatedPathsDontCollide)
 TEST(TimeOfImpact, RodCircleMissAt360)
 {
     const auto slop = Real{0.001f};
-    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
+    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * 3_m).UseTolerance((slop / 4) * Meter);
     
     // Set up for two bodies moving toward each other at same speeds and each colliding
     // with the other after they have moved roughly two-thirds of their sweep.
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(40);
-    const auto vA0 = Length2{-Real(4) * Meter, Real(0) * Meter};
-    const auto vA1 = Length2{Real(4) * Meter, Real(0) * Meter};
+    const auto vA0 = Length2{-4_m, 0_m};
+    const auto vA1 = Length2{4_m, 0_m};
     const Length2 vertices[] = {vA0, vA1};
     const auto nA0 = GetUnitVector(vA1 - vA0);
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, Real(4) * Meter}, 0_deg},
-        Position{Length2{+x * Meter, Real(4) * Meter}, 360_deg}
+        Position{Length2{-x * Meter, 4_m}, 0_deg},
+        Position{Length2{+x * Meter, 4_m}, 360_deg}
     };
     const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, Real(0) * Meter}, 0_deg},
-        Position{Length2{-x * Meter, Real(0) * Meter}, 0_deg}
+        Position{Length2{+x * Meter, 0_m}, 0_deg},
+        Position{Length2{-x * Meter, 0_m}, 0_deg}
     };
     
     // Compute the time of impact information now...
@@ -253,27 +253,27 @@ TEST(TimeOfImpact, RodCircleMissAt360)
 TEST(TimeOfImpact, RodCircleHitAt180)
 {
     const auto slop = Real{0.001f};
-    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * Real(3) * Meter).UseTolerance((slop / 4) * Meter);
+    const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * 3_m).UseTolerance((slop / 4) * Meter);
     
     // Set up for two bodies moving toward each other at same speeds and each colliding
     // with the other after they have moved roughly two-thirds of their sweep.
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(40);
-    const auto vA0 = Length2{-Real(4) * Meter, Real(0) * Meter};
-    const auto vA1 = Length2{Real(4) * Meter, Real(0) * Meter};
+    const auto vA0 = Length2{-4_m, 0_m};
+    const auto vA1 = Length2{4_m, 0_m};
     const Length2 vertices[] = {vA0, vA1};
     const auto nA0 = GetUnitVector(vA1 - vA0);
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, Real(4) * Meter}, Angle{0}},
-        Position{Length2{+x * Meter, Real(4) * Meter}, Angle{Real{180.0f} * 1_deg}}
+        Position{Length2{-x * Meter, 4_m}, Angle{0}},
+        Position{Length2{+x * Meter, 4_m}, Angle{Real{180.0f} * 1_deg}}
     };
     const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{+x * Meter, 0_m}, Angle{0}},
+        Position{Length2{-x * Meter, 0_m}, Angle{0}}
     };
     
     // Compute the time of impact information now...
@@ -287,18 +287,18 @@ TEST(TimeOfImpact, RodCircleHitAt180)
 TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_1)
 {
     const auto slop = Real{0.001f};
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(200);
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{-x * Meter, 0_m}, Angle{0}},
+        Position{Length2{+x * Meter, 0_m}, Angle{0}}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
-        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}
+        Position{Length2{+x * Meter, 0_m}, Angle{0}},
+        Position{Length2{-x * Meter, 0_m}, Angle{0}}
     };
     
     const auto conf = ToiConf{}
@@ -320,17 +320,17 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_1)
 TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
 {
     const auto slop = Real{0.001f};
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(400);
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{-x * Meter, 0_m}, Angle{0}},
         Position{Length2{}, Angle{0}}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}},
+        Position{Length2{+x * Meter, 0_m}, Angle{0}},
         Position{Length2{}, Angle{0}}
     };
     
@@ -384,13 +384,13 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
 TEST(TimeOfImpact, WithClosingSpeedOf1600)
 {
     const auto slop = Real{0.001f};
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(400);
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepA = Sweep{Position{Length2{-x * Meter, 0_m}, Angle{0}}, Position{Length2{+x * Meter, 0_m}, Angle{0}}};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{Position{Length2{+x * Meter, Real(0) * Meter}, Angle{0}}, Position{Length2{-x * Meter, Real(0) * Meter}, Angle{0}}};
+    const auto sweepB = Sweep{Position{Length2{+x * Meter, 0_m}, Angle{0}}, Position{Length2{-x * Meter, 0_m}, Angle{0}}};
     
     const auto conf = ToiConf{}
         .UseMaxToiIters(200)
@@ -425,8 +425,8 @@ TEST(TimeOfImpact, ForNonCollidingShapesFails)
     const auto dpB = shapeB.GetChild(0);
 
     const auto sweepA = Sweep{
-        Position{Length2{-Real(11) * Meter, Real(10) * Meter}, 2.95000005_rad},
-        Position{Length2{-Real(11) * Meter, Real(10) * Meter}, 2.95000005_rad}
+        Position{Length2{-11_m, 10_m}, 2.95000005_rad},
+        Position{Length2{-11_m, 10_m}, 2.95000005_rad}
     };
     const auto sweepB = Sweep{
         Position{Length2{Real(18.4742737f) * Meter, Real(19.7474861f) * Meter}, 513.36676_rad},

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -429,8 +429,8 @@ TEST(TimeOfImpact, ForNonCollidingShapesFails)
         Position{Length2{-11_m, 10_m}, 2.95000005_rad}
     };
     const auto sweepB = Sweep{
-        Position{Length2{Real(18.4742737f) * Meter, Real(19.7474861f) * Meter}, 513.36676_rad},
-        Position{Length2{Real(19.5954781f) * Meter, Real(18.9165268f) * Meter}, 513.627808_rad}
+        Position{Length2{18.4742737_m, 19.7474861_m}, 513.36676_rad},
+        Position{Length2{19.5954781_m, 18.9165268_m}, 513.627808_rad}
     };
     
     const auto conf = ToiConf{}
@@ -470,12 +470,12 @@ TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
     // separation has reached tolerance but t2 already equals t1.
 
     const auto sweepA = Sweep{
-        Position{Length2{Real(0.0f) * Meter, Real(-0.5f) * Meter}, Angle{0}},
-        Position{Length2{Real(0.0f) * Meter, Real(-0.5f) * Meter}, Angle{0}}
+        Position{Length2{0.0_m, -0.5_m}, Angle{0}},
+        Position{Length2{0.0_m, -0.5_m}, Angle{0}}
     };
     const auto sweepB = Sweep{
-        Position{Length2{Real(14.3689661f) * Meter, Real(0.500306308f) * Meter}, 0.0000139930862_rad},
-        Position{Length2{Real(14.3689451f) * Meter, Real(0.500254989f) * Meter}, 0.000260060915_rad}
+        Position{Length2{14.3689661_m, 0.500306308_m}, 0.0000139930862_rad},
+        Position{Length2{14.3689451_m, 0.500254989_m}, 0.000260060915_rad}
     };
 
     const Length2 vertices[] = {

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -415,11 +415,11 @@ TEST(TimeOfImpact, ForNonCollidingShapesFails)
 
     auto shapeA = PolygonShape{};
     shapeA.SetVertexRadius(Real{0.0001f * 2} * Meter);
-    shapeA.SetAsBox(Real{25.0f} * Meter, Real{5.0f} * Meter);
+    shapeA.SetAsBox(25.0_m, 5.0_m);
 
     auto shapeB = PolygonShape{};
     shapeB.SetVertexRadius(Real{0.0001f * 2} * Meter);
-    shapeB.SetAsBox(Real{2.5f} * Meter, Real{2.5f} * Meter);
+    shapeB.SetAsBox(2.5_m, 2.5_m);
 
     const auto dpA = shapeA.GetChild(0);
     const auto dpB = shapeB.GetChild(0);
@@ -493,12 +493,12 @@ TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
     };
 
     const auto dpA = DistanceProxy{
-        Real{0.000199999995f} * Meter, 4, vertices, normals
+        0.000199999995_m, 4, vertices, normals
     };
     
     auto shapeB = PolygonShape{};
     shapeB.SetVertexRadius(Real{0.0001f * 2} * Meter);
-    shapeB.SetAsBox(Real{0.5f} * Meter, Real{0.5f} * Meter);
+    shapeB.SetAsBox(0.5_m, 0.5_m);
     const auto dpB = shapeB.GetChild(0);
     
     const auto conf = ToiConf{}

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -41,7 +41,7 @@ TEST(Transformation, DefaultConstruct)
 
 TEST(Transformation, Initialize)
 {
-    const auto translation = Length2{Real(2) * Meter, Real(4) * Meter};
+    const auto translation = Length2{2_m, 4_m};
     const auto rotation = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation, rotation};
     EXPECT_EQ(translation, xfm.p);
@@ -50,7 +50,7 @@ TEST(Transformation, Initialize)
 
 TEST(Transformation, Equality)
 {
-    const auto translation = Length2{Real(2) * Meter, Real(4) * Meter};
+    const auto translation = Length2{2_m, 4_m};
     const auto rotation = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation, rotation};
     EXPECT_EQ(xfm, xfm);
@@ -58,11 +58,11 @@ TEST(Transformation, Equality)
 
 TEST(Transformation, Inequality)
 {
-    const auto translation1 = Length2{Real(2) * Meter, Real(4) * Meter};
+    const auto translation1 = Length2{2_m, 4_m};
     const auto rotation1 = UnitVec2::Get(1_rad * Pi * Real{0.7f});
     const Transformation xfm1{translation1, rotation1};
 
-    const auto translation2 = Length2{-Real(3) * Meter, Real(37) * Meter};
+    const auto translation2 = Length2{-3_m, 37_m};
     const auto rotation2 = UnitVec2::Get(1_rad * Pi * Real{0.002f});
     const Transformation xfm2{translation2, rotation2};
 
@@ -73,7 +73,7 @@ TEST(Transformation, Inequality)
 
 TEST(Transformation, Mul)
 {
-    const auto translation1 = Length2{Real(2) * Meter, Real(4) * Meter};
+    const auto translation1 = Length2{2_m, 4_m};
     const auto rotation1 = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation1, rotation1};
 
@@ -93,7 +93,7 @@ TEST(Transformation, Mul)
 
 TEST(Transformation, MulSameAsTransformTwice)
 {
-    const auto translation1 = Length2{Real(2) * Meter, Real(4) * Meter};
+    const auto translation1 = Length2{2_m, 4_m};
     const auto rotation1 = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation1, rotation1};
     const auto xfm2 = Mul(xfm, xfm);

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -35,13 +35,13 @@ TEST(Transformation, ByteSizeIs_16_32_or_64)
 TEST(Transformation, DefaultConstruct)
 {
     const Transformation xfm;
-    EXPECT_EQ(xfm.p, Length2D{});
+    EXPECT_EQ(xfm.p, Length2{});
     EXPECT_EQ(xfm.q, UnitVec2::GetRight());
 }
 
 TEST(Transformation, Initialize)
 {
-    const auto translation = Length2D{Real(2) * Meter, Real(4) * Meter};
+    const auto translation = Length2{Real(2) * Meter, Real(4) * Meter};
     const auto rotation = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation, rotation};
     EXPECT_EQ(translation, xfm.p);
@@ -50,7 +50,7 @@ TEST(Transformation, Initialize)
 
 TEST(Transformation, Equality)
 {
-    const auto translation = Length2D{Real(2) * Meter, Real(4) * Meter};
+    const auto translation = Length2{Real(2) * Meter, Real(4) * Meter};
     const auto rotation = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation, rotation};
     EXPECT_EQ(xfm, xfm);
@@ -58,11 +58,11 @@ TEST(Transformation, Equality)
 
 TEST(Transformation, Inequality)
 {
-    const auto translation1 = Length2D{Real(2) * Meter, Real(4) * Meter};
+    const auto translation1 = Length2{Real(2) * Meter, Real(4) * Meter};
     const auto rotation1 = UnitVec2::Get(1_rad * Pi * Real{0.7f});
     const Transformation xfm1{translation1, rotation1};
 
-    const auto translation2 = Length2D{-Real(3) * Meter, Real(37) * Meter};
+    const auto translation2 = Length2{-Real(3) * Meter, Real(37) * Meter};
     const auto rotation2 = UnitVec2::Get(1_rad * Pi * Real{0.002f});
     const Transformation xfm2{translation2, rotation2};
 
@@ -73,7 +73,7 @@ TEST(Transformation, Inequality)
 
 TEST(Transformation, Mul)
 {
-    const auto translation1 = Length2D{Real(2) * Meter, Real(4) * Meter};
+    const auto translation1 = Length2{Real(2) * Meter, Real(4) * Meter};
     const auto rotation1 = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation1, rotation1};
 
@@ -93,12 +93,12 @@ TEST(Transformation, Mul)
 
 TEST(Transformation, MulSameAsTransformTwice)
 {
-    const auto translation1 = Length2D{Real(2) * Meter, Real(4) * Meter};
+    const auto translation1 = Length2{Real(2) * Meter, Real(4) * Meter};
     const auto rotation1 = UnitVec2::Get(1_rad * Real{Pi / 2});
     const Transformation xfm{translation1, rotation1};
     const auto xfm2 = Mul(xfm, xfm);
 
-    const auto location = Length2D{Real(-23.4f) * Meter, Real(0.81f) * Meter};
+    const auto location = Length2{Real(-23.4f) * Meter, Real(0.81f) * Meter};
     const auto twice = Transform(Transform(location, xfm), xfm);
     const auto location2 = Transform(location, xfm2);
     EXPECT_NEAR(static_cast<double>(Real{GetX(twice) / Meter}),

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -98,7 +98,7 @@ TEST(Transformation, MulSameAsTransformTwice)
     const Transformation xfm{translation1, rotation1};
     const auto xfm2 = Mul(xfm, xfm);
 
-    const auto location = Length2{Real(-23.4f) * Meter, Real(0.81f) * Meter};
+    const auto location = Length2{-23.4_m, 0.81_m};
     const auto twice = Transform(Transform(location, xfm), xfm);
     const auto location2 = Transform(location, xfm2);
     EXPECT_NEAR(static_cast<double>(Real{GetX(twice) / Meter}),

--- a/UnitTests/VelocityConstraint.cpp
+++ b/UnitTests/VelocityConstraint.cpp
@@ -109,8 +109,8 @@ TEST(VelocityConstraint, AddPoint)
     const auto ni = Real(1.2);
     const auto ti = Real(0.3);
     
-    const auto rA = Vec2{0, 0};
-    const auto rB = Vec2{0, 0};
+    const auto rA = Length2{};
+    const auto rB = Length2{};
     
     vc.AddPoint(ni, ti, rA, rB, VelocityConstraint::Conf{});
     EXPECT_EQ(vc.GetPointCount(), VelocityConstraint::size_type(1));

--- a/UnitTests/VertexSet.cpp
+++ b/UnitTests/VertexSet.cpp
@@ -45,18 +45,18 @@ TEST(VertexSet, Add)
     auto set = VertexSet{};
     ASSERT_EQ(set.size(), std::size_t(0));
 
-    EXPECT_TRUE(set.add(Length2{Real(1) * Meter, Real(1) * Meter}));
+    EXPECT_TRUE(set.add(Length2{1_m, 1_m}));
     EXPECT_EQ(set.size(), std::size_t(1));
 
-    EXPECT_FALSE(set.add(Length2{Real(1) * Meter, Real(1) * Meter}));
+    EXPECT_FALSE(set.add(Length2{1_m, 1_m}));
     EXPECT_EQ(set.size(), std::size_t(1));
     
-    const auto v = Length2{Real(0) * Meter, Real(0) * Meter};
+    const auto v = Length2{0_m, 0_m};
 
     EXPECT_TRUE(set.add(v));
     EXPECT_EQ(set.size(), std::size_t(2));
     
-    EXPECT_FALSE(set.add(Length2{Real(1) * Meter, Real(1) * Meter}));
+    EXPECT_FALSE(set.add(Length2{1_m, 1_m}));
     EXPECT_EQ(set.size(), std::size_t(2));
     
     EXPECT_FALSE(set.add(v));
@@ -72,12 +72,12 @@ TEST(VertexSet, Add)
     EXPECT_FALSE(set.add(v_prime));
     EXPECT_EQ(set.size(), std::size_t(2));
     
-    EXPECT_TRUE(set.add(Length2{Real(4) * Meter, Real(5) * Meter}));
+    EXPECT_TRUE(set.add(Length2{4_m, 5_m}));
     EXPECT_EQ(set.size(), std::size_t(3));
     
-    EXPECT_TRUE(set.add(Length2{Real(6) * Meter, Real(5) * Meter}));
+    EXPECT_TRUE(set.add(Length2{6_m, 5_m}));
     EXPECT_EQ(set.size(), std::size_t(4));
 
-    EXPECT_TRUE(set.add(Length2{Real(8) * Meter, Real(5) * Meter}));
+    EXPECT_TRUE(set.add(Length2{8_m, 5_m}));
     EXPECT_EQ(set.size(), std::size_t(5));
 }

--- a/UnitTests/VertexSet.cpp
+++ b/UnitTests/VertexSet.cpp
@@ -37,7 +37,7 @@ TEST(VertexSet, DefaultConstruction)
     const auto set = VertexSet{};
     EXPECT_EQ(set.size(), std::size_t(0));
     EXPECT_EQ(set.begin(), set.end());
-    EXPECT_EQ(set.find(Length2D{}), set.end());
+    EXPECT_EQ(set.find(Length2{}), set.end());
 }
 
 TEST(VertexSet, Add)
@@ -45,24 +45,24 @@ TEST(VertexSet, Add)
     auto set = VertexSet{};
     ASSERT_EQ(set.size(), std::size_t(0));
 
-    EXPECT_TRUE(set.add(Length2D{Real(1) * Meter, Real(1) * Meter}));
+    EXPECT_TRUE(set.add(Length2{Real(1) * Meter, Real(1) * Meter}));
     EXPECT_EQ(set.size(), std::size_t(1));
 
-    EXPECT_FALSE(set.add(Length2D{Real(1) * Meter, Real(1) * Meter}));
+    EXPECT_FALSE(set.add(Length2{Real(1) * Meter, Real(1) * Meter}));
     EXPECT_EQ(set.size(), std::size_t(1));
     
-    const auto v = Length2D{Real(0) * Meter, Real(0) * Meter};
+    const auto v = Length2{Real(0) * Meter, Real(0) * Meter};
 
     EXPECT_TRUE(set.add(v));
     EXPECT_EQ(set.size(), std::size_t(2));
     
-    EXPECT_FALSE(set.add(Length2D{Real(1) * Meter, Real(1) * Meter}));
+    EXPECT_FALSE(set.add(Length2{Real(1) * Meter, Real(1) * Meter}));
     EXPECT_EQ(set.size(), std::size_t(2));
     
     EXPECT_FALSE(set.add(v));
     EXPECT_EQ(set.size(), std::size_t(2));
     
-    const auto v_prime = v + Length2D{
+    const auto v_prime = v + Length2{
         std::numeric_limits<Real>::min() * Meter,
         std::numeric_limits<Real>::min() * Meter
     };
@@ -72,12 +72,12 @@ TEST(VertexSet, Add)
     EXPECT_FALSE(set.add(v_prime));
     EXPECT_EQ(set.size(), std::size_t(2));
     
-    EXPECT_TRUE(set.add(Length2D{Real(4) * Meter, Real(5) * Meter}));
+    EXPECT_TRUE(set.add(Length2{Real(4) * Meter, Real(5) * Meter}));
     EXPECT_EQ(set.size(), std::size_t(3));
     
-    EXPECT_TRUE(set.add(Length2D{Real(6) * Meter, Real(5) * Meter}));
+    EXPECT_TRUE(set.add(Length2{Real(6) * Meter, Real(5) * Meter}));
     EXPECT_EQ(set.size(), std::size_t(4));
 
-    EXPECT_TRUE(set.add(Length2D{Real(8) * Meter, Real(5) * Meter}));
+    EXPECT_TRUE(set.add(Length2{Real(8) * Meter, Real(5) * Meter}));
     EXPECT_EQ(set.size(), std::size_t(5));
 }

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -49,8 +49,8 @@ TEST(WeldJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, false);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, (Length2D{}));
-    EXPECT_EQ(def.localAnchorB, (Length2D{}));
+    EXPECT_EQ(def.localAnchorA, (Length2{}));
+    EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.referenceAngle, Angle(0));
     EXPECT_EQ(def.frequency, 0_Hz);
     EXPECT_EQ(def.dampingRatio, Real(0));
@@ -77,7 +77,7 @@ TEST(WeldJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
 
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
@@ -91,7 +91,7 @@ TEST(WeldJoint, GetWeldJointDef)
 {
     auto bodyA = Body{nullptr, BodyDef{}};
     auto bodyB = Body{nullptr, BodyDef{}};
-    const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
     WeldJointDef def{&bodyA, &bodyB, anchor};
     WeldJoint joint{def};
     
@@ -124,14 +124,14 @@ TEST(WeldJoint, GetWeldJointDef)
 TEST(WeldJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
     const auto jd = WeldJointDef{b1, b2, anchor};
     world.CreateJoint(jd);
     Step(world, 1_s);
@@ -146,14 +146,14 @@ TEST(WeldJoint, WithDynamicCircles)
 TEST(WeldJoint, WithDynamicCircles2)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
     const auto jd = WeldJointDef{b1, b2, anchor}.UseFrequency(10_Hz);
     const auto joint = static_cast<WeldJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -91,7 +91,7 @@ TEST(WeldJoint, GetWeldJointDef)
 {
     auto bodyA = Body{nullptr, BodyDef{}};
     auto bodyB = Body{nullptr, BodyDef{}};
-    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(2_m, 1_m);
     WeldJointDef def{&bodyA, &bodyB, anchor};
     WeldJoint joint{def};
     
@@ -125,13 +125,13 @@ TEST(WeldJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(2_m, 1_m);
     const auto jd = WeldJointDef{b1, b2, anchor};
     world.CreateJoint(jd);
     Step(world, 1_s);
@@ -147,13 +147,13 @@ TEST(WeldJoint, WithDynamicCircles2)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(2_m, 1_m);
     const auto jd = WeldJointDef{b1, b2, anchor}.UseFrequency(10_Hz);
     const auto joint = static_cast<WeldJoint*>(world.CreateJoint(jd));
     ASSERT_NE(joint, nullptr);

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -123,7 +123,7 @@ TEST(WeldJoint, GetWeldJointDef)
 
 TEST(WeldJoint, WithDynamicCircles)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -145,7 +145,7 @@ TEST(WeldJoint, WithDynamicCircles)
 
 TEST(WeldJoint, WithDynamicCircles2)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -49,8 +49,8 @@ TEST(WheelJointDef, DefaultConstruction)
     EXPECT_EQ(def.collideConnected, false);
     EXPECT_EQ(def.userData, nullptr);
     
-    EXPECT_EQ(def.localAnchorA, (Length2D{}));
-    EXPECT_EQ(def.localAnchorB, (Length2D{}));
+    EXPECT_EQ(def.localAnchorA, (Length2{}));
+    EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.localAxisA, UnitVec2::GetRight());
     EXPECT_FALSE(def.enableMotor);
     EXPECT_EQ(def.maxMotorTorque, Torque(0));
@@ -80,7 +80,7 @@ TEST(WheelJoint, Construction)
     EXPECT_EQ(joint.GetBodyB(), def.bodyB);
     EXPECT_EQ(joint.GetCollideConnected(), def.collideConnected);
     EXPECT_EQ(joint.GetUserData(), def.userData);
-    EXPECT_EQ(joint.GetLinearReaction(), Momentum2D{});
+    EXPECT_EQ(joint.GetLinearReaction(), Momentum2{});
     EXPECT_EQ(joint.GetAngularReaction(), AngularMomentum{0});
 
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
@@ -102,8 +102,8 @@ TEST(WheelJoint, EnableMotor)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = WheelJoint{jd};
     EXPECT_FALSE(joint.IsMotorEnabled());
@@ -122,8 +122,8 @@ TEST(WheelJoint, MotorSpeed)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     const auto newValue = 5_rad / 1_s;
     auto joint = WheelJoint{jd};
@@ -142,8 +142,8 @@ TEST(WheelJoint, MaxMotorTorque)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     const auto newValue = 5_Nm;
     auto joint = WheelJoint{jd};
@@ -157,8 +157,8 @@ TEST(WheelJoint, GetAnchorAandB)
 {
     World world;
     
-    const auto loc0 = Length2D{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2D{Real(-2) * Meter, Real(+1.2f) * Meter};
+    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
+    const auto loc1 = Length2{Real(-2) * Meter, Real(+1.2f) * Meter};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -166,8 +166,8 @@ TEST(WheelJoint, GetAnchorAandB)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
     
     auto joint = WheelJoint{jd};
     ASSERT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
@@ -180,8 +180,8 @@ TEST(WheelJoint, GetJointTranslation)
 {
     World world;
     
-    const auto loc0 = Length2D{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2D{Real(+1) * Meter, Real(+3) * Meter};
+    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
+    const auto loc1 = Length2{Real(+1) * Meter, Real(+3) * Meter};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -189,8 +189,8 @@ TEST(WheelJoint, GetJointTranslation)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2D(Real(-1) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2D(Real(+1) * Meter, Real(5) * Meter);
+    jd.localAnchorA = Length2(Real(-1) * Meter, Real(5) * Meter);
+    jd.localAnchorB = Length2(Real(+1) * Meter, Real(5) * Meter);
     
     auto joint = WheelJoint{jd};
     EXPECT_EQ(GetJointTranslation(joint), Length(Real(2) * Meter));
@@ -223,8 +223,8 @@ TEST(WheelJoint, GetWheelJointDef)
     EXPECT_EQ(cdef.collideConnected, false);
     EXPECT_EQ(cdef.userData, nullptr);
     
-    EXPECT_EQ(cdef.localAnchorA, (Length2D{}));
-    EXPECT_EQ(cdef.localAnchorB, (Length2D{}));
+    EXPECT_EQ(cdef.localAnchorA, (Length2{}));
+    EXPECT_EQ(cdef.localAnchorB, (Length2{}));
     EXPECT_EQ(cdef.localAxisA, UnitVec2::GetRight());
     EXPECT_FALSE(cdef.enableMotor);
     EXPECT_EQ(cdef.maxMotorTorque, Torque(0));
@@ -236,14 +236,14 @@ TEST(WheelJoint, GetWheelJointDef)
 TEST(WheelJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
-    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2D{})};
-    const auto p1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2D(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
     const auto jd = WheelJointDef{b1, b2, anchor, UnitVec2::GetRight()};
     world.CreateJoint(jd);
     Step(world, 1_s);

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -235,7 +235,7 @@ TEST(WheelJoint, GetWheelJointDef)
 
 TEST(WheelJoint, WithDynamicCircles)
 {
-    const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -102,8 +102,8 @@ TEST(WheelJoint, EnableMotor)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = WheelJoint{jd};
     EXPECT_FALSE(joint.IsMotorEnabled());
@@ -122,8 +122,8 @@ TEST(WheelJoint, MotorSpeed)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     const auto newValue = 5_rad / 1_s;
     auto joint = WheelJoint{jd};
@@ -142,8 +142,8 @@ TEST(WheelJoint, MaxMotorTorque)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     const auto newValue = 5_Nm;
     auto joint = WheelJoint{jd};
@@ -157,8 +157,8 @@ TEST(WheelJoint, GetAnchorAandB)
 {
     World world;
     
-    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2{Real(-2) * Meter, Real(+1.2f) * Meter};
+    const auto loc0 = Length2{+1_m, -3_m};
+    const auto loc1 = Length2{-2_m, Real(+1.2f) * Meter};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -166,8 +166,8 @@ TEST(WheelJoint, GetAnchorAandB)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(4) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(6) * Meter, Real(7) * Meter);
+    jd.localAnchorA = Length2(4_m, 5_m);
+    jd.localAnchorB = Length2(6_m, 7_m);
     
     auto joint = WheelJoint{jd};
     ASSERT_EQ(joint.GetLocalAnchorA(), jd.localAnchorA);
@@ -180,8 +180,8 @@ TEST(WheelJoint, GetJointTranslation)
 {
     World world;
     
-    const auto loc0 = Length2{Real(+1) * Meter, Real(-3) * Meter};
-    const auto loc1 = Length2{Real(+1) * Meter, Real(+3) * Meter};
+    const auto loc0 = Length2{+1_m, -3_m};
+    const auto loc1 = Length2{+1_m, +3_m};
     
     const auto b0 = world.CreateBody(BodyDef{}.UseLocation(loc0));
     const auto b1 = world.CreateBody(BodyDef{}.UseLocation(loc1));
@@ -189,11 +189,11 @@ TEST(WheelJoint, GetJointTranslation)
     auto jd = WheelJointDef{};
     jd.bodyA = b0;
     jd.bodyB = b1;
-    jd.localAnchorA = Length2(Real(-1) * Meter, Real(5) * Meter);
-    jd.localAnchorB = Length2(Real(+1) * Meter, Real(5) * Meter);
+    jd.localAnchorA = Length2(-1_m, 5_m);
+    jd.localAnchorB = Length2(+1_m, 5_m);
     
     auto joint = WheelJoint{jd};
-    EXPECT_EQ(GetJointTranslation(joint), Length(Real(2) * Meter));
+    EXPECT_EQ(GetJointTranslation(joint), Length(2_m));
 }
 
 TEST(WheelJoint, GetWheelJointDef)
@@ -237,13 +237,13 @@ TEST(WheelJoint, WithDynamicCircles)
 {
     const auto circle = std::make_shared<DiskShape>(Real{0.2f} * Meter);
     auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
-    const auto p1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto p2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
     b1->CreateFixture(circle);
     b2->CreateFixture(circle);
-    const auto anchor = Length2(Real(2) * Meter, Real(1) * Meter);
+    const auto anchor = Length2(2_m, 1_m);
     const auto jd = WheelJointDef{b1, b2, anchor, UnitVec2::GetRight()};
     world.CreateJoint(jd);
     Step(world, 1_s);

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -132,7 +132,7 @@ TEST(World, DefaultInit)
     EXPECT_EQ(GetHeight(world.GetTree()), World::proxy_size_type(0));
     EXPECT_EQ(ComputePerimeterRatio(world.GetTree()), Real(0));
 
-    EXPECT_EQ(world.GetGravity(), EarthlyGravity2);
+    EXPECT_EQ(world.GetGravity(), EarthlyGravity2D);
 
     {
         const auto& bodies = world.GetBodies();
@@ -164,7 +164,7 @@ TEST(World, DefaultInit)
 
 TEST(World, Init)
 {
-    const auto gravity = LinearAcceleration2D{
+    const auto gravity = LinearAcceleration2{
         Real(-4.2) * MeterPerSquareSecond,
         Real(3.4) * MeterPerSquareSecond
     };
@@ -181,10 +181,10 @@ TEST(World, Init)
         EXPECT_EQ(calls, 0);
     }
     {
-        const auto p1 = Length2D{Real(0) * Meter, Real(0) * Meter};
-        const auto p2 = Length2D{Real(100) * Meter, Real(0) * Meter};
+        const auto p1 = Length2{Real(0) * Meter, Real(0) * Meter};
+        const auto p2 = Length2{Real(100) * Meter, Real(0) * Meter};
         auto calls = 0;
-        world.RayCast(p1, p2, [&](Fixture*, ChildCounter, Length2D, UnitVec2) {
+        world.RayCast(p1, p2, [&](Fixture*, ChildCounter, Length2, UnitVec2) {
             ++calls;
             return World::RayCastOpcode::ResetRay;
         });
@@ -243,10 +243,10 @@ TEST(World, CopyConstruction)
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
     b2->CreateFixture(shape);
 
-    world.CreateJoint(RevoluteJointDef{b1, b2, Length2D{}});
-    world.CreateJoint(PrismaticJointDef{b1, b2, Length2D{}, UnitVec2::GetRight()});
-    world.CreateJoint(PulleyJointDef{b1, b2, Length2D{}, Length2D{},
-        Length2D{}, Length2D{}}.UseRatio(Real(1)));
+    world.CreateJoint(RevoluteJointDef{b1, b2, Length2{}});
+    world.CreateJoint(PrismaticJointDef{b1, b2, Length2{}, UnitVec2::GetRight()});
+    world.CreateJoint(PulleyJointDef{b1, b2, Length2{}, Length2{},
+        Length2{}, Length2{}}.UseRatio(Real(1)));
     
     auto stepConf = StepConf{};
     world.Step(stepConf);
@@ -301,10 +301,10 @@ TEST(World, CopyAssignment)
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
     b2->CreateFixture(shape);
     
-    world.CreateJoint(RevoluteJointDef{b1, b2, Length2D{}});
-    world.CreateJoint(PrismaticJointDef{b1, b2, Length2D{}, UnitVec2::GetRight()});
-    world.CreateJoint(PulleyJointDef{b1, b2, Length2D{}, Length2D{},
-        Length2D{}, Length2D{}}.UseRatio(Real(1)));
+    world.CreateJoint(RevoluteJointDef{b1, b2, Length2{}});
+    world.CreateJoint(PrismaticJointDef{b1, b2, Length2{}, UnitVec2::GetRight()});
+    world.CreateJoint(PulleyJointDef{b1, b2, Length2{}, Length2{},
+        Length2{}, Length2{}}.UseRatio(Real(1)));
     
     auto stepConf = StepConf{};
     world.Step(stepConf);
@@ -336,7 +336,7 @@ TEST(World, CopyAssignment)
 
 TEST(World, SetGravity)
 {
-    const auto gravity = LinearAcceleration2D{
+    const auto gravity = LinearAcceleration2{
         Real(-4.2) * MeterPerSquareSecond,
         Real(3.4) * MeterPerSquareSecond
     };
@@ -378,7 +378,7 @@ TEST(World, CreateAndDestroyBody)
 
 TEST(World, QueryAABB)
 {
-    const auto zeroG = LinearAcceleration2D{
+    const auto zeroG = LinearAcceleration2{
         Real(0) * MeterPerSquareSecond, Real(0) * MeterPerSquareSecond
     };
     World world{WorldDef{}.UseGravity(zeroG)};
@@ -395,8 +395,8 @@ TEST(World, QueryAABB)
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), GetX(world.GetGravity()));
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), GetY(world.GetGravity()));
     
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Real{1} * Meter;
     conf.density = 1_kgpm2;
@@ -430,7 +430,7 @@ TEST(World, QueryAABB)
 
 TEST(World, RayCast)
 {
-    const auto zeroG = LinearAcceleration2D{
+    const auto zeroG = LinearAcceleration2{
         Real(0) * MeterPerSquareSecond, Real(0) * MeterPerSquareSecond
     };
     World world{WorldDef{}.UseGravity(zeroG)};
@@ -447,8 +447,8 @@ TEST(World, RayCast)
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), GetX(world.GetGravity()));
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), GetY(world.GetGravity()));
     
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Real{1} * Meter;
     conf.density = 1_kgpm2;
@@ -462,12 +462,12 @@ TEST(World, RayCast)
     world.Step(stepConf);
     
     {
-        const auto p1 = Length2D{Real(-2) * Meter, Real(0) * Meter};
-        const auto p2 = Length2D{Real(+2) * Meter, Real(0) * Meter};
+        const auto p1 = Length2{Real(-2) * Meter, Real(0) * Meter};
+        const auto p2 = Length2{Real(+2) * Meter, Real(0) * Meter};
 
         auto foundOurs = 0;
         auto foundOthers = 0;
-        world.RayCast(p1, p2, [&](Fixture* f, ChildCounter i, Length2D, UnitVec2) {
+        world.RayCast(p1, p2, [&](Fixture* f, ChildCounter i, Length2, UnitVec2) {
             if (f == fixture && i == 0)
             {
                 ++foundOurs;
@@ -497,8 +497,8 @@ TEST(World, ClearForcesFreeFunction)
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), GetX(world.GetGravity()));
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), GetY(world.GetGravity()));
     
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Real{1} * Meter;
     conf.density = 1_kgpm2;
@@ -506,7 +506,7 @@ TEST(World, ClearForcesFreeFunction)
     const auto fixture = body->CreateFixture(shape);
     ASSERT_NE(fixture, nullptr);
 
-    ApplyForceToCenter(*body, Force2D(2_N, 4_N));
+    ApplyForceToCenter(*body, Force2(2_N, 4_N));
     ASSERT_NE(GetX(body->GetLinearAcceleration()), GetX(world.GetGravity()));
     ASSERT_NE(GetY(body->GetLinearAcceleration()), GetY(world.GetGravity()));
     
@@ -519,7 +519,7 @@ TEST(World, SetAccelerationsFunctionalFF)
 {
     World world;
     const auto a1 = Acceleration{
-        LinearAcceleration2D{1_mps2, 2_mps2}, 2.1f * RadianPerSquareSecond
+        LinearAcceleration2{1_mps2, 2_mps2}, 2.1f * RadianPerSquareSecond
     };
     const auto a2 = a1 * 2;
     ASSERT_EQ(a1.linear * 2, a2.linear);
@@ -545,19 +545,19 @@ TEST(World, SetAccelerationsFunctionalFF)
 TEST(World, FindClosestBodyFF)
 {
     World world;
-    ASSERT_EQ(FindClosestBody(world, Length2D{}), nullptr);
-    const auto b1 = world.CreateBody(BodyDef{}.UseLocation(Length2D{10_m, 10_m}));
-    EXPECT_EQ(FindClosestBody(world, Length2D{0_m, 0_m}), b1);
-    const auto b2 = world.CreateBody(BodyDef{}.UseLocation(Length2D{1_m, -2_m}));
-    EXPECT_EQ(FindClosestBody(world, Length2D{0_m, 0_m}), b2);
-    const auto b3 = world.CreateBody(BodyDef{}.UseLocation(Length2D{-5_m, 4_m}));
-    EXPECT_NE(FindClosestBody(world, Length2D{0_m, 0_m}), b3);
-    EXPECT_EQ(FindClosestBody(world, Length2D{0_m, 0_m}), b2);
+    ASSERT_EQ(FindClosestBody(world, Length2{}), nullptr);
+    const auto b1 = world.CreateBody(BodyDef{}.UseLocation(Length2{10_m, 10_m}));
+    EXPECT_EQ(FindClosestBody(world, Length2{0_m, 0_m}), b1);
+    const auto b2 = world.CreateBody(BodyDef{}.UseLocation(Length2{1_m, -2_m}));
+    EXPECT_EQ(FindClosestBody(world, Length2{0_m, 0_m}), b2);
+    const auto b3 = world.CreateBody(BodyDef{}.UseLocation(Length2{-5_m, 4_m}));
+    EXPECT_NE(FindClosestBody(world, Length2{0_m, 0_m}), b3);
+    EXPECT_EQ(FindClosestBody(world, Length2{0_m, 0_m}), b2);
 }
 
 TEST(World, GetShapeCountFreeFunction)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     ASSERT_EQ(GetShapeCount(world), std::size_t(0));
     
@@ -567,8 +567,8 @@ TEST(World, GetShapeCountFreeFunction)
     const auto shapeConf = EdgeShape::Conf{}
         .UseVertexRadius(Real{1} * Meter)
         .UseDensity(1_kgpm2);
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
 
     const auto shape1 = std::make_shared<EdgeShape>(v1, v2, shapeConf);
     
@@ -589,7 +589,7 @@ TEST(World, GetShapeCountFreeFunction)
 
 TEST(World, GetFixtureCountFreeFunction)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     ASSERT_EQ(GetFixtureCount(world), std::size_t(0));
     
@@ -599,8 +599,8 @@ TEST(World, GetFixtureCountFreeFunction)
     const auto shapeConf = EdgeShape::Conf{}
         .UseVertexRadius(Real{1} * Meter)
         .UseDensity(1_kgpm2);
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     
     const auto shape = std::make_shared<EdgeShape>(v1, v2, shapeConf);
     
@@ -619,7 +619,7 @@ TEST(World, GetFixtureCountFreeFunction)
 
 TEST(World, AwakenFreeFunction)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     
     const auto body = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
@@ -631,8 +631,8 @@ TEST(World, AwakenFreeFunction)
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), Real(0) * MeterPerSquareSecond);
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), Real(0) * MeterPerSquareSecond);
     
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     const auto shape = std::make_shared<EdgeShape>(v1, v2,
                                                    EdgeShape::Conf{}
                                                    .UseVertexRadius(Real{1} * Meter)
@@ -659,7 +659,7 @@ TEST(World, CreateSquareEnclosingBody)
     EXPECT_EQ(body->GetType(), BodyType::Static);
     const auto fixtures = body->GetFixtures();
     EXPECT_GT(fixtures.size(), decltype(fixtures.size()){0});
-    auto vertices = std::set<Length2D>();
+    auto vertices = std::set<Length2>();
     for (auto& f: fixtures)
     {
         const auto s = f->GetShape();
@@ -712,8 +712,8 @@ TEST(World, GetTouchingCountFreeFunction)
 
 TEST(World, ShiftOrigin)
 {
-    const auto origin = Length2D{Real(0) * Meter, Real(0) * Meter};
-    const auto location = Length2D{Real(1) * Meter, Real(1) * Meter};
+    const auto origin = Length2{Real(0) * Meter, Real(0) * Meter};
+    const auto location = Length2{Real(1) * Meter, Real(1) * Meter};
     
     ASSERT_NE(origin, location);
 
@@ -738,8 +738,8 @@ TEST(World, DynamicEdgeBodyHasCorrectMass)
     const auto body = world.CreateBody(bodyDef);
     ASSERT_EQ(body->GetType(), BodyType::Dynamic);
     
-    const auto v1 = Length2D{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2D{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
+    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
     auto conf = EdgeShape::Conf{};
     conf.vertexRadius = Real{1} * Meter;
     const auto shape = std::make_shared<EdgeShape>(v1, v2, conf);
@@ -775,8 +775,8 @@ TEST(World, CreateAndDestroyJoint)
     EXPECT_TRUE(world.GetJoints().empty());
     EXPECT_EQ(world.GetJoints().begin(), world.GetJoints().end());
     
-    const auto anchorA = Length2D{Real(+0.4) * Meter, Real(-1.2) * Meter};
-    const auto anchorB = Length2D{Real(-2.3) * Meter, Real(+0.7) * Meter};
+    const auto anchorA = Length2{Real(+0.4) * Meter, Real(-1.2) * Meter};
+    const auto anchorB = Length2{Real(-2.3) * Meter, Real(+0.7) * Meter};
     const auto joint = world.CreateJoint(DistanceJointDef{body1, body2, anchorA, anchorB});
     EXPECT_EQ(GetJointCount(world), JointCounter(1));
     EXPECT_FALSE(world.GetJoints().empty());
@@ -830,12 +830,12 @@ TEST(World, MaxJoints)
 
 TEST(World, StepZeroTimeDoesNothing)
 {
-    const auto gravity = EarthlyGravity2;
+    const auto gravity = EarthlyGravity2D;
     
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.location = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
+    def.location = Length2{Real(31.9) * Meter, Real(-19.24) * Meter};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
@@ -868,14 +868,14 @@ TEST(World, StepZeroTimeDoesNothing)
 
 TEST(World, GravitationalBodyMovement)
 {
-    auto p0 = Length2D{Real(0) * Meter, Real(1) * Meter};
+    auto p0 = Length2{Real(0) * Meter, Real(1) * Meter};
 
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.location = p0;
 
     const auto a = Real(-10);
-    const auto gravity = LinearAcceleration2D{0, a * MeterPerSquareSecond};
+    const auto gravity = LinearAcceleration2{0, a * MeterPerSquareSecond};
     const auto t = .01_s;
     
     World world{WorldDef{}.UseGravity(gravity)};
@@ -912,12 +912,12 @@ TEST(World, GravitationalBodyMovement)
 
 TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
 {
-    const auto gravity = EarthlyGravity2;
+    const auto gravity = EarthlyGravity2D;
     
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.location = Length2D{Real(31.9) * Meter, Real(-19.24) * Meter};
+    def.location = Length2{Real(31.9) * Meter, Real(-19.24) * Meter};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
@@ -953,13 +953,13 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
 
 TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
 {
-    const auto gravity = EarthlyGravity2;
+    const auto gravity = EarthlyGravity2D;
     
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.location = Length2D{31.9_m, -19.24_m};
-    def.linearVelocity = LinearVelocity2D{0, -9.8_mps};
+    def.location = Length2{31.9_m, -19.24_m};
+    def.linearVelocity = LinearVelocity2{0, -9.8_mps};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
@@ -1053,8 +1053,8 @@ public:
     unsigned post_solves = 0;
     bool contacting = false;
     bool touching = false;
-    Length2D body_a[2] = {Length2D{}, Length2D{}};
-    Length2D body_b[2] = {Length2D{}, Length2D{}};
+    Length2 body_a[2] = {Length2{}, Length2{}};
+    Length2 body_b[2] = {Length2{}, Length2{}};
     PreSolver presolver;
     PostSolver postsolver;
     Ender ender;
@@ -1072,7 +1072,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
         [&](Contact&) {},
     };
 
-    const auto gravity = LinearAcceleration2D{};
+    const auto gravity = LinearAcceleration2{};
     World world{WorldDef{}.UseGravity(gravity)};
     world.SetContactListener(&listener);
     
@@ -1087,8 +1087,8 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1));
     
-    body_def.location = Length2D{-x * Meter, Real(0) * Meter};
-    body_def.linearVelocity = LinearVelocity2D{+x * 1_mps, 0_mps};
+    body_def.location = Length2{-x * Meter, Real(0) * Meter};
+    body_def.linearVelocity = LinearVelocity2{+x * 1_mps, 0_mps};
     const auto body_a = world.CreateBody(body_def);
     ASSERT_NE(body_a, nullptr);
     EXPECT_EQ(body_a->GetType(), BodyType::Dynamic);
@@ -1097,8 +1097,8 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     const auto fixture1 = body_a->CreateFixture(shape);
     ASSERT_NE(fixture1, nullptr);
     
-    body_def.location = Length2D{+x * Meter, Real(0) * Meter};
-    body_def.linearVelocity = LinearVelocity2D{-x * 1_mps, 0_mps};
+    body_def.location = Length2{+x * Meter, Real(0) * Meter};
+    body_def.linearVelocity = LinearVelocity2{-x * 1_mps, 0_mps};
     const auto body_b = world.CreateBody(body_def);
     ASSERT_NE(body_b, nullptr);
     const auto fixture2 = body_b->CreateFixture(shape);
@@ -1342,14 +1342,14 @@ TEST(World, PerfectlyOverlappedSameCirclesStayPut)
     const auto shape = std::make_shared<DiskShape>(radius);
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
-    const auto gravity = LinearAcceleration2D{};
+    const auto gravity = LinearAcceleration2{};
 
     World world{WorldDef{}.UseGravity(gravity)};
     
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.location = Length2D{Real(0) * Meter, Real(0) * Meter};
+    body_def.location = Length2{Real(0) * Meter, Real(0) * Meter};
 
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1387,14 +1387,14 @@ TEST(World, PerfectlyOverlappedConcentricCirclesStayPut)
     shape2->SetDensity(1_kgpm2);
     shape2->SetRestitution(Real(1)); // changes where bodies will be after collision
 
-    const auto gravity = LinearAcceleration2D{};
+    const auto gravity = LinearAcceleration2{};
     
     World world{WorldDef{}.UseGravity(gravity)};
     
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.location = Length2D{};
+    body_def.location = Length2{};
     
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1421,7 +1421,7 @@ TEST(World, PerfectlyOverlappedConcentricCirclesStayPut)
 
 TEST(World, ListenerCalledForCircleBodyWithinCircleBody)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
     MyContactListener listener{
         [&](Contact&, const Manifold&) {},
         [&](Contact&, const ContactImpulsesList&, ContactListener::iteration_type) {},
@@ -1431,7 +1431,7 @@ TEST(World, ListenerCalledForCircleBodyWithinCircleBody)
 
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2D{};
+    body_def.location = Length2{};
     const auto shape = std::make_shared<DiskShape>(Real{1} * Meter);
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1));
@@ -1457,7 +1457,7 @@ TEST(World, ListenerCalledForCircleBodyWithinCircleBody)
 
 TEST(World, ListenerCalledForSquareBodyWithinSquareBody)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
     MyContactListener listener{
         [&](Contact&, const Manifold&) {},
         [&](Contact&, const ContactImpulsesList&, ContactListener::iteration_type) {},
@@ -1467,7 +1467,7 @@ TEST(World, ListenerCalledForSquareBodyWithinSquareBody)
     
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2D{};
+    body_def.location = Length2{};
     auto shape = std::make_shared<PolygonShape>();
     shape->SetVertexRadius(Real{1} * Meter);
     shape->SetAsBox(Real{2} * Meter, Real{2} * Meter);
@@ -1497,7 +1497,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
 {
     const auto radius = Real(1);
     
-    const auto gravity = LinearAcceleration2D{};
+    const auto gravity = LinearAcceleration2{};
     World world{WorldDef{}.UseGravity(gravity)};
     
     auto body_def = BodyDef{};
@@ -1508,7 +1508,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
     
-    const auto body1pos = Length2D{-radius/Real(4) * Meter, Real(0) * Meter};
+    const auto body1pos = Length2{-radius/Real(4) * Meter, Real(0) * Meter};
     body_def.location = body1pos;
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1517,7 +1517,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     }
     ASSERT_EQ(body1->GetLocation(), body_def.location);
     
-    const auto body2pos = Length2D{+radius/Real(4) * Meter, Real(0) * Meter};
+    const auto body2pos = Length2{+radius/Real(4) * Meter, Real(0) * Meter};
     body_def.location = body2pos;
     const auto body2 = world.CreateBody(body_def);
     {
@@ -1599,14 +1599,14 @@ TEST(World, PerfectlyOverlappedSameSquaresSeparateHorizontally)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
 
-    const auto gravity = LinearAcceleration2D{};
+    const auto gravity = LinearAcceleration2{};
     
     World world{WorldDef{}.UseGravity(gravity)};
     
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.location = Length2D{};
+    body_def.location = Length2{};
     
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1660,7 +1660,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
      * This tests at a high level what the position solver code does with overlapping shapes.
      */
 
-    const auto gravity = LinearAcceleration2D{};
+    const auto gravity = LinearAcceleration2{};
     World world{WorldDef{}.UseGravity(gravity)};
     
     auto body_def = BodyDef{};
@@ -1672,7 +1672,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
     
-    const auto body1pos = Length2D{Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
+    const auto body1pos = Length2{Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
     body_def.location = body1pos;
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1681,7 +1681,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     }
     ASSERT_EQ(body1->GetLocation(), body1pos);
     
-    const auto body2pos = Length2D{-Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
+    const auto body2pos = Length2{-Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
     body_def.location = body2pos;
     const auto body2 = world.CreateBody(body_def);
     {
@@ -1821,7 +1821,7 @@ TEST(World, CollidingDynamicBodies)
         [&](Contact&) {},
     };
 
-    const auto gravity = LinearAcceleration2D{};
+    const auto gravity = LinearAcceleration2{};
     World world{WorldDef{}.UseGravity(gravity)};
     EXPECT_EQ(world.GetGravity(), gravity);
     world.SetContactListener(&listener);
@@ -1830,8 +1830,8 @@ TEST(World, CollidingDynamicBodies)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
 
-    body_def.location = Length2D{-(x + 1) * Meter, Real(0) * Meter};
-    body_def.linearVelocity = LinearVelocity2D{+x * 1_mps, 0_mps};
+    body_def.location = Length2{-(x + 1) * Meter, Real(0) * Meter};
+    body_def.linearVelocity = LinearVelocity2{+x * 1_mps, 0_mps};
     const auto body_a = world.CreateBody(body_def);
     ASSERT_NE(body_a, nullptr);
     EXPECT_EQ(body_a->GetType(), BodyType::Dynamic);
@@ -1840,8 +1840,8 @@ TEST(World, CollidingDynamicBodies)
     const auto fixture1 = body_a->CreateFixture(shape);
     ASSERT_NE(fixture1, nullptr);
 
-    body_def.location = Length2D{+(x + 1) * Meter, Real(0) * Meter};
-    body_def.linearVelocity = LinearVelocity2D{-x * 1_mps, 0_mps};
+    body_def.location = Length2{+(x + 1) * Meter, Real(0) * Meter};
+    body_def.linearVelocity = LinearVelocity2{-x * 1_mps, 0_mps};
     const auto body_b = world.CreateBody(body_def);
     ASSERT_NE(body_b, nullptr);
     const auto fixture2 = body_b->CreateFixture(shape);
@@ -1957,11 +1957,11 @@ TEST(World, TilesComesToRest)
     
     {
         const auto a = Real{0.5f};
-        const auto ground = m_world->CreateBody(BodyDef{}.UseLocation(Length2D{0, -a * Meter}));
+        const auto ground = m_world->CreateBody(BodyDef{}.UseLocation(Length2{0, -a * Meter}));
         
         const auto N = 200;
         const auto M = 10;
-        Length2D position;
+        Length2 position;
         GetY(position) = Real(0.0f) * Meter;
         for (auto j = 0; j < M; ++j)
         {
@@ -1982,10 +1982,10 @@ TEST(World, TilesComesToRest)
         const auto shape = std::make_shared<PolygonShape>(a * Meter, a * Meter, conf);
         shape->SetDensity(5_kgpm2);
         
-        Length2D x(Real(-7.0f) * Meter, Real(0.75f) * Meter);
-        Length2D y;
-        const auto deltaX = Length2D(Real(0.5625f) * Meter, Real(1.25f) * Meter);
-        const auto deltaY = Length2D(Real(1.125f) * Meter, Real(0.0f) * Meter);
+        Length2 x(Real(-7.0f) * Meter, Real(0.75f) * Meter);
+        Length2 y;
+        const auto deltaX = Length2(Real(0.5625f) * Meter, Real(1.25f) * Meter);
+        const auto deltaY = Length2(Real(1.125f) * Meter, Real(0.0f) * Meter);
         
         for (auto i = 0; i < e_count; ++i)
         {
@@ -2275,7 +2275,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     constexpr auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
     constexpr auto VertexRadius = playrho::Length{LinearSlop * playrho::Real(2)};
     
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{}).UseMinVertexRadius(VertexRadius)};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{}).UseMinVertexRadius(VertexRadius)};
 
     MyContactListener listener{
         [](Contact&, const Manifold&) {},
@@ -2292,14 +2292,14 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto edgeConf = EdgeShape::Conf{}
         .UseVertexRadius(VertexRadius)
         .UseRestitution(Real(1))
-        .UseVertex1(Length2D{Real(0) * Meter, +Real(10) * Meter})
-        .UseVertex2(Length2D{Real(0) * Meter, -Real(10) * Meter});
+        .UseVertex1(Length2{Real(0) * Meter, +Real(10) * Meter})
+        .UseVertex2(Length2{Real(0) * Meter, -Real(10) * Meter});
     const auto edge_shape = std::make_shared<EdgeShape>(edgeConf);
 
     BodyDef body_def;
     body_def.type = BodyType::Static;
 
-    body_def.location = Length2D{left_edge_x, Real{0} * Meter};
+    body_def.location = Length2{left_edge_x, Real{0} * Meter};
     const auto left_wall_body = world.CreateBody(body_def);
     ASSERT_NE(left_wall_body, nullptr);
     {
@@ -2307,7 +2307,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
         ASSERT_NE(wall_fixture, nullptr);
     }
 
-    body_def.location = Length2D{right_edge_x, Real{0} * Meter};
+    body_def.location = Length2{right_edge_x, Real{0} * Meter};
     const auto right_wall_body = world.CreateBody(body_def);
     ASSERT_NE(right_wall_body, nullptr);
     {
@@ -2318,7 +2318,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto begin_x = Real(0);
 
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2D{begin_x * Meter, Real(0) * Meter};
+    body_def.location = Length2{begin_x * Meter, Real(0) * Meter};
     body_def.bullet = false;
     const auto ball_body = world.CreateBody(body_def);
     ASSERT_NE(ball_body, nullptr);
@@ -2330,7 +2330,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto ball_fixture = ball_body->CreateFixture(circle_shape);
     ASSERT_NE(ball_fixture, nullptr);
 
-    const auto velocity = LinearVelocity2D{+1_mps, 0_mps};
+    const auto velocity = LinearVelocity2{+1_mps, 0_mps};
     ball_body->SetVelocity(Velocity{velocity, Angle{0} / 1_s});
 
     const auto time_inc = .01_s;
@@ -2391,7 +2391,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
             {
                 ++increments;
                 ball_body->SetVelocity(Velocity{
-                    LinearVelocity2D{
+                    LinearVelocity2{
                         static_cast<Real>(increments) * GetX(velocity),
                         GetY(ball_body->GetVelocity().linear)
                     }, ball_body->GetVelocity().angular});
@@ -2433,7 +2433,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
             {
                 ++increments;
                 ball_body->SetVelocity(Velocity{
-                    LinearVelocity2D{
+                    LinearVelocity2{
                         -static_cast<Real>(increments) * GetX(velocity),
                         GetY(ball_body->GetVelocity().linear)
                     }, ball_body->GetVelocity().angular});
@@ -2447,7 +2447,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
         
         ++increments;
         ball_body->SetVelocity(Velocity{
-            LinearVelocity2D{
+            LinearVelocity2{
                 static_cast<Real>(increments) * GetX(velocity),
                 GetY(ball_body->GetVelocity().linear)
             }, ball_body->GetVelocity().angular});
@@ -2456,7 +2456,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
 
 TEST(World, MouseJointWontCauseTunnelling)
 {
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{})};
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{})};
     
     const auto half_box_width = Real(0.2);
     const auto left_edge_x = -half_box_width;
@@ -2475,10 +2475,10 @@ TEST(World, MouseJointWontCauseTunnelling)
     body_def.type = BodyType::Static;
     
     // Setup vertical bounderies
-    edge_shape.Set(Length2D{0, +half_box_height * Real(2) * Meter},
-                   Length2D{0, -half_box_height * Real(2) * Meter});
+    edge_shape.Set(Length2{0, +half_box_height * Real(2) * Meter},
+                   Length2{0, -half_box_height * Real(2) * Meter});
 
-    body_def.location = Length2D{left_edge_x * Meter, Real(0) * Meter};
+    body_def.location = Length2{left_edge_x * Meter, Real(0) * Meter};
     {
         const auto left_wall_body = world.CreateBody(body_def);
         ASSERT_NE(left_wall_body, nullptr);
@@ -2489,7 +2489,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         Include(container_aabb, ComputeAABB(*left_wall_body));
     }
     
-    body_def.location = Length2D{right_edge_x * Meter, Real(0) * Meter};
+    body_def.location = Length2{right_edge_x * Meter, Real(0) * Meter};
     {
         const auto right_wall_body = world.CreateBody(body_def);
         ASSERT_NE(right_wall_body, nullptr);
@@ -2501,10 +2501,10 @@ TEST(World, MouseJointWontCauseTunnelling)
     }
 
     // Setup horizontal bounderies
-    edge_shape.Set(Length2D{-half_box_width * Real(2) * Meter, Real(0) * Meter},
-                   Length2D{+half_box_width * Real(2) * Meter, Real(0) * Meter});
+    edge_shape.Set(Length2{-half_box_width * Real(2) * Meter, Real(0) * Meter},
+                   Length2{+half_box_width * Real(2) * Meter, Real(0) * Meter});
     
-    body_def.location = Length2D{0, btm_edge_y * Meter};
+    body_def.location = Length2{0, btm_edge_y * Meter};
     {
         const auto btm_wall_body = world.CreateBody(body_def);
         ASSERT_NE(btm_wall_body, nullptr);
@@ -2515,7 +2515,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         Include(container_aabb, ComputeAABB(*btm_wall_body));
     }
     
-    body_def.location = Length2D{0, top_edge_y * Meter};
+    body_def.location = Length2{0, top_edge_y * Meter};
     {
         const auto top_wall_body = world.CreateBody(body_def);
         ASSERT_NE(top_wall_body, nullptr);
@@ -2527,7 +2527,7 @@ TEST(World, MouseJointWontCauseTunnelling)
     }
 
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2D{};
+    body_def.location = Length2{};
     body_def.bullet = true;
     
     const auto ball_body = world.CreateBody(body_def);
@@ -2544,14 +2544,14 @@ TEST(World, MouseJointWontCauseTunnelling)
     }
 
     constexpr unsigned numBodies = 1;
-    Length2D last_opos[numBodies];
+    Length2 last_opos[numBodies];
     Body *bodies[numBodies];
     for (auto i = decltype(numBodies){0}; i < numBodies; ++i)
     {
         const auto angle = i * 2 * Pi / numBodies;
         const auto x = ball_radius * Real(2.1) * Real(std::cos(angle));
         const auto y = ball_radius * Real(2.1) * Real(std::sin(angle));
-        body_def.location = Length2D{x, y};
+        body_def.location = Length2{x, y};
         bodies[i] = world.CreateBody(body_def);
         ASSERT_NE(bodies[i], nullptr);
         ASSERT_EQ(GetX(bodies[i]->GetLocation()), x);
@@ -2571,7 +2571,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         mjd.bodyA = spare_body;
         mjd.bodyB = ball_body;
         const auto ball_body_pos = ball_body->GetLocation();
-        mjd.target = Length2D{
+        mjd.target = Length2{
             GetX(ball_body_pos) - ball_radius / Real{2},
             GetY(ball_body_pos) + ball_radius / Real{2}
         };
@@ -2669,8 +2669,8 @@ TEST(World, MouseJointWontCauseTunnelling)
                     continue;
                 }
                 const auto bpos = body->GetLocation();
-                const auto lt = Length2D{right_edge_x * Meter, top_edge_y * Meter} - bpos;
-                const auto gt = bpos - Length2D{left_edge_x * Meter, btm_edge_y * Meter};
+                const auto lt = Length2{right_edge_x * Meter, top_edge_y * Meter} - bpos;
+                const auto gt = bpos - Length2{left_edge_x * Meter, btm_edge_y * Meter};
                 
                 if (GetX(lt) <= Length{0} || GetY(lt) <= Length{0} || GetX(gt) <= Length{0} || GetY(gt) <= Length{0})
                 {
@@ -2767,7 +2767,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         auto last_pos = ball_body->GetLocation();
         for (auto loops = unsigned{0};; ++loops)
         {
-            mouse_joint->SetTarget(Length2D{distance * std::cos(angle) * Meter, distance * std::sin(angle) * Meter});
+            mouse_joint->SetTarget(Length2{distance * std::cos(angle) * Meter, distance * std::sin(angle) * Meter});
             angle += anglular_speed;
             distance += distance_speed;
 
@@ -2822,7 +2822,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         anglular_speed *= anglular_accel;
         distance_speed *= distance_accel;
 
-        ASSERT_NE(ball_body->GetLocation(), (Length2D{}));
+        ASSERT_NE(ball_body->GetLocation(), (Length2{}));
 #if 0
         if (outer > 100)
         {
@@ -2853,7 +2853,7 @@ static void smaller_still_conserves_momentum(bool bullet, Real multiplier, Real 
     auto scale = Real(1);
     for (;;)
     {
-        const auto gravity = Vec2_zero;
+        const auto gravity = Vec2{};
         World world{WorldDef{}.UseGravity(gravity)};
         ASSERT_EQ(GetX(world.GetGravity()), 0);
         ASSERT_EQ(GetY(world.GetGravity()), 0);
@@ -2863,8 +2863,8 @@ static void smaller_still_conserves_momentum(bool bullet, Real multiplier, Real 
         auto maxPoints = 0u;
         auto numSteps = 0u;
         auto failed = false;
-        auto preB1 = Vec2_zero;
-        auto preB2 = Vec2_zero;
+        auto preB1 = Vec2{};
+        auto preB2 = Vec2{};
         
         MyContactListener listener{
             [&](Contact& contact, const Manifold&)
@@ -3008,8 +3008,8 @@ public:
     {
         const auto hw_ground = Real(40.0f) * Meter;
         const auto ground = world.CreateBody();
-        ground->CreateFixture(std::make_shared<EdgeShape>(Length2D{-hw_ground, Real(0) * Meter},
-                                                          Length2D{hw_ground, Real(0) * Meter}));
+        ground->CreateFixture(std::make_shared<EdgeShape>(Length2{-hw_ground, Real(0) * Meter},
+                                                          Length2{hw_ground, Real(0) * Meter}));
         
         const auto numboxes = boxes.size();
         
@@ -3021,7 +3021,7 @@ public:
         for (auto i = decltype(numboxes){0}; i < numboxes; ++i)
         {
             // (hdim + 0.05f) + (hdim * 2 + 0.1f) * i
-            const auto location = Length2D{original_x * Meter, (i + Real{1}) * hdim * Real{4}};
+            const auto location = Length2{original_x * Meter, (i + Real{1}) * hdim * Real{4}};
             const auto box = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(location));
             box->CreateFixture(boxShape);
             boxes[i] = box;
@@ -3040,7 +3040,7 @@ public:
     }
 
 protected:
-    World world{WorldDef{}.UseGravity(LinearAcceleration2D{
+    World world{WorldDef{}.UseGravity(LinearAcceleration2{
         Real(0) * MeterPerSquareSecond, -Real(10) * MeterPerSquareSecond
     })};
     std::size_t loopsTillSleeping = 0;

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -237,7 +237,7 @@ TEST(World, CopyConstruction)
     
     const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}
                                                    .UseDensity(1_kgpm2)
-                                                   .UseVertexRadius(Real(1) * Meter));
+                                                   .UseVertexRadius(1_m));
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
     b1->CreateFixture(shape);
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
@@ -295,7 +295,7 @@ TEST(World, CopyAssignment)
     
     const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}
                                                    .UseDensity(1_kgpm2)
-                                                   .UseVertexRadius(Real(1) * Meter));
+                                                   .UseVertexRadius(1_m));
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
     b1->CreateFixture(shape);
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1962,7 +1962,7 @@ TEST(World, TilesComesToRest)
         const auto N = 200;
         const auto M = 10;
         Length2 position;
-        GetY(position) = Real(0.0f) * Meter;
+        GetY(position) = 0.0_m;
         for (auto j = 0; j < M; ++j)
         {
             GetX(position) = -N * a * Meter;
@@ -1982,10 +1982,10 @@ TEST(World, TilesComesToRest)
         const auto shape = std::make_shared<PolygonShape>(a * Meter, a * Meter, conf);
         shape->SetDensity(5_kgpm2);
         
-        Length2 x(Real(-7.0f) * Meter, Real(0.75f) * Meter);
+        Length2 x(-7.0_m, 0.75_m);
         Length2 y;
-        const auto deltaX = Length2(Real(0.5625f) * Meter, Real(1.25f) * Meter);
-        const auto deltaY = Length2(Real(1.125f) * Meter, Real(0.0f) * Meter);
+        const auto deltaX = Length2(0.5625_m, 1.25_m);
+        const auto deltaY = Length2(1.125_m, 0.0_m);
         
         for (auto i = 0; i < e_count; ++i)
         {
@@ -2323,7 +2323,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto ball_body = world.CreateBody(body_def);
     ASSERT_NE(ball_body, nullptr);
     
-    const auto ball_radius = Real(.01) * Meter;
+    const auto ball_radius = 0.01_m;
     const auto circle_shape = std::make_shared<DiskShape>(ball_radius);
     circle_shape->SetDensity(1_kgpm2);
     circle_shape->SetRestitution(Real(1)); // changes where bodies will be after collision
@@ -3006,7 +3006,7 @@ class VerticalStackTest: public ::testing::TestWithParam<Real>
 public:
     virtual void SetUp()
     {
-        const auto hw_ground = Real(40.0f) * Meter;
+        const auto hw_ground = 40.0_m;
         const auto ground = world.CreateBody();
         ground->CreateFixture(std::make_shared<EdgeShape>(Length2{-hw_ground, 0_m},
                                                           Length2{hw_ground, 0_m}));

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -132,7 +132,7 @@ TEST(World, DefaultInit)
     EXPECT_EQ(GetHeight(world.GetTree()), World::proxy_size_type(0));
     EXPECT_EQ(ComputePerimeterRatio(world.GetTree()), Real(0));
 
-    EXPECT_EQ(world.GetGravity(), EarthlyGravity);
+    EXPECT_EQ(world.GetGravity(), EarthlyGravity2);
 
     {
         const auto& bodies = world.GetBodies();
@@ -830,7 +830,7 @@ TEST(World, MaxJoints)
 
 TEST(World, StepZeroTimeDoesNothing)
 {
-    const auto gravity = EarthlyGravity;
+    const auto gravity = EarthlyGravity2;
     
     World world{WorldDef{}.UseGravity(gravity)};
     
@@ -912,7 +912,7 @@ TEST(World, GravitationalBodyMovement)
 
 TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
 {
-    const auto gravity = EarthlyGravity;
+    const auto gravity = EarthlyGravity2;
     
     World world{WorldDef{}.UseGravity(gravity)};
     
@@ -953,7 +953,7 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
 
 TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
 {
-    const auto gravity = EarthlyGravity;
+    const auto gravity = EarthlyGravity2;
     
     World world{WorldDef{}.UseGravity(gravity)};
     

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -89,7 +89,7 @@ TEST(World, Def)
     ASSERT_GT(time_inc, 0_s);
     ASSERT_LT(time_inc, 1_s);
     const auto max_inc = time_inc * stepConf.maxTranslation;
-    EXPECT_GT(max_inc, Real(0) * Meter * 1_s);
+    EXPECT_GT(max_inc, 0_m * 1_s);
 }
 
 TEST(World, Traits)
@@ -181,8 +181,8 @@ TEST(World, Init)
         EXPECT_EQ(calls, 0);
     }
     {
-        const auto p1 = Length2{Real(0) * Meter, Real(0) * Meter};
-        const auto p2 = Length2{Real(100) * Meter, Real(0) * Meter};
+        const auto p1 = Length2{0_m, 0_m};
+        const auto p2 = Length2{100_m, 0_m};
         auto calls = 0;
         world.RayCast(p1, p2, [&](Fixture*, ChildCounter, Length2, UnitVec2) {
             ++calls;
@@ -194,8 +194,8 @@ TEST(World, Init)
 
 TEST(World, InvalidArgumentInit)
 {
-    const auto min = Positive<Length>(Real(4) * Meter);
-    const auto max = Positive<Length>(Real(8) * Meter);
+    const auto min = Positive<Length>(4_m);
+    const auto max = Positive<Length>(8_m);
     ASSERT_GT(max, min);
     const auto def = WorldDef{}.UseMinVertexRadius(max).UseMaxVertexRadius(min);
     EXPECT_THROW(World{def}, InvalidArgument);
@@ -390,15 +390,15 @@ TEST(World, QueryAABB)
     ASSERT_TRUE(body->IsSpeedable());
     ASSERT_TRUE(body->IsAccelerable());
     ASSERT_FALSE(body->IsImpenetrable());
-    ASSERT_EQ(GetX(body->GetLocation()), Real(0) * Meter);
-    ASSERT_EQ(GetY(body->GetLocation()), Real(0) * Meter);
+    ASSERT_EQ(GetX(body->GetLocation()), 0_m);
+    ASSERT_EQ(GetY(body->GetLocation()), 0_m);
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), GetX(world.GetGravity()));
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), GetY(world.GetGravity()));
     
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
     auto conf = EdgeShape::Conf{};
-    conf.vertexRadius = Real{1} * Meter;
+    conf.vertexRadius = 1_m;
     conf.density = 1_kgpm2;
     const auto shape = std::make_shared<EdgeShape>(v1, v2, conf);
     ASSERT_EQ(shape->GetChildCount(), ChildCounter(1));
@@ -442,15 +442,15 @@ TEST(World, RayCast)
     ASSERT_TRUE(body->IsSpeedable());
     ASSERT_TRUE(body->IsAccelerable());
     ASSERT_FALSE(body->IsImpenetrable());
-    ASSERT_EQ(GetX(body->GetLocation()), Real(0) * Meter);
-    ASSERT_EQ(GetY(body->GetLocation()), Real(0) * Meter);
+    ASSERT_EQ(GetX(body->GetLocation()), 0_m);
+    ASSERT_EQ(GetY(body->GetLocation()), 0_m);
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), GetX(world.GetGravity()));
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), GetY(world.GetGravity()));
     
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
     auto conf = EdgeShape::Conf{};
-    conf.vertexRadius = Real{1} * Meter;
+    conf.vertexRadius = 1_m;
     conf.density = 1_kgpm2;
     const auto shape = std::make_shared<EdgeShape>(v1, v2, conf);
     ASSERT_EQ(shape->GetChildCount(), ChildCounter(1));
@@ -462,8 +462,8 @@ TEST(World, RayCast)
     world.Step(stepConf);
     
     {
-        const auto p1 = Length2{Real(-2) * Meter, Real(0) * Meter};
-        const auto p2 = Length2{Real(+2) * Meter, Real(0) * Meter};
+        const auto p1 = Length2{-2_m, 0_m};
+        const auto p2 = Length2{+2_m, 0_m};
 
         auto foundOurs = 0;
         auto foundOthers = 0;
@@ -497,10 +497,10 @@ TEST(World, ClearForcesFreeFunction)
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), GetX(world.GetGravity()));
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), GetY(world.GetGravity()));
     
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
     auto conf = EdgeShape::Conf{};
-    conf.vertexRadius = Real{1} * Meter;
+    conf.vertexRadius = 1_m;
     conf.density = 1_kgpm2;
     const auto shape = std::make_shared<EdgeShape>(v1, v2, conf);
     const auto fixture = body->CreateFixture(shape);
@@ -565,10 +565,10 @@ TEST(World, GetShapeCountFreeFunction)
     ASSERT_NE(body, nullptr);
     
     const auto shapeConf = EdgeShape::Conf{}
-        .UseVertexRadius(Real{1} * Meter)
+        .UseVertexRadius(1_m)
         .UseDensity(1_kgpm2);
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
 
     const auto shape1 = std::make_shared<EdgeShape>(v1, v2, shapeConf);
     
@@ -597,10 +597,10 @@ TEST(World, GetFixtureCountFreeFunction)
     ASSERT_NE(body, nullptr);
     
     const auto shapeConf = EdgeShape::Conf{}
-        .UseVertexRadius(Real{1} * Meter)
+        .UseVertexRadius(1_m)
         .UseDensity(1_kgpm2);
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
     
     const auto shape = std::make_shared<EdgeShape>(v1, v2, shapeConf);
     
@@ -631,11 +631,11 @@ TEST(World, AwakenFreeFunction)
     ASSERT_EQ(GetX(body->GetLinearAcceleration()), Real(0) * MeterPerSquareSecond);
     ASSERT_EQ(GetY(body->GetLinearAcceleration()), Real(0) * MeterPerSquareSecond);
     
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
     const auto shape = std::make_shared<EdgeShape>(v1, v2,
                                                    EdgeShape::Conf{}
-                                                   .UseVertexRadius(Real{1} * Meter)
+                                                   .UseVertexRadius(1_m)
                                                    .UseDensity(1_kgpm2));
     const auto fixture = body->CreateFixture(shape);
     ASSERT_NE(fixture, nullptr);
@@ -654,7 +654,7 @@ TEST(World, CreateSquareEnclosingBody)
 {
     World world;
     Body* body = nullptr;
-    EXPECT_NO_THROW(body = CreateSquareEnclosingBody(world, 2 * Meter, ShapeDef{}));
+    EXPECT_NO_THROW(body = CreateSquareEnclosingBody(world, 2_m, ShapeDef{}));
     ASSERT_NE(body, nullptr);
     EXPECT_EQ(body->GetType(), BodyType::Static);
     const auto fixtures = body->GetFixtures();
@@ -712,8 +712,8 @@ TEST(World, GetTouchingCountFreeFunction)
 
 TEST(World, ShiftOrigin)
 {
-    const auto origin = Length2{Real(0) * Meter, Real(0) * Meter};
-    const auto location = Length2{Real(1) * Meter, Real(1) * Meter};
+    const auto origin = Length2{0_m, 0_m};
+    const auto location = Length2{1_m, 1_m};
     
     ASSERT_NE(origin, location);
 
@@ -738,13 +738,13 @@ TEST(World, DynamicEdgeBodyHasCorrectMass)
     const auto body = world.CreateBody(bodyDef);
     ASSERT_EQ(body->GetType(), BodyType::Dynamic);
     
-    const auto v1 = Length2{-Real(1) * Meter, Real(0) * Meter};
-    const auto v2 = Length2{+Real(1) * Meter, Real(0) * Meter};
+    const auto v1 = Length2{-1_m, 0_m};
+    const auto v2 = Length2{+1_m, 0_m};
     auto conf = EdgeShape::Conf{};
-    conf.vertexRadius = Real{1} * Meter;
+    conf.vertexRadius = 1_m;
     const auto shape = std::make_shared<EdgeShape>(v1, v2, conf);
     shape->SetDensity(1_kgpm2);
-    ASSERT_EQ(shape->GetVertexRadius(), Real(1) * Meter);
+    ASSERT_EQ(shape->GetVertexRadius(), 1_m);
 
     const auto fixture = body->CreateFixture(shape);
     ASSERT_NE(fixture, nullptr);
@@ -835,7 +835,7 @@ TEST(World, StepZeroTimeDoesNothing)
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.location = Length2{Real(31.9) * Meter, Real(-19.24) * Meter};
+    def.location = Length2{31.9_m, Real(-19.24) * Meter};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
@@ -868,7 +868,7 @@ TEST(World, StepZeroTimeDoesNothing)
 
 TEST(World, GravitationalBodyMovement)
 {
-    auto p0 = Length2{Real(0) * Meter, Real(1) * Meter};
+    auto p0 = Length2{0_m, 1_m};
 
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
@@ -917,7 +917,7 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.location = Length2{Real(31.9) * Meter, Real(-19.24) * Meter};
+    def.location = Length2{31.9_m, Real(-19.24) * Meter};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
@@ -1083,11 +1083,11 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     body_def.type = BodyType::Dynamic;
     body_def.bullet = true;
     
-    const auto shape = std::make_shared<DiskShape>(Real{1} * Meter);
+    const auto shape = std::make_shared<DiskShape>(1_m);
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1));
     
-    body_def.location = Length2{-x * Meter, Real(0) * Meter};
+    body_def.location = Length2{-x * Meter, 0_m};
     body_def.linearVelocity = LinearVelocity2{+x * 1_mps, 0_mps};
     const auto body_a = world.CreateBody(body_def);
     ASSERT_NE(body_a, nullptr);
@@ -1097,7 +1097,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     const auto fixture1 = body_a->CreateFixture(shape);
     ASSERT_NE(fixture1, nullptr);
     
-    body_def.location = Length2{+x * Meter, Real(0) * Meter};
+    body_def.location = Length2{+x * Meter, 0_m};
     body_def.linearVelocity = LinearVelocity2{-x * 1_mps, 0_mps};
     const auto body_b = world.CreateBody(body_def);
     ASSERT_NE(body_b, nullptr);
@@ -1133,9 +1133,9 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
         ++steps;
         
         EXPECT_TRUE(AlmostEqual(GetX(body_a->GetLocation()) / Meter, (GetX(pos_a) + x * time_inc * 1_mps) / Meter));
-        EXPECT_EQ(GetY(body_a->GetLocation()), Real{0} * Meter);
+        EXPECT_EQ(GetY(body_a->GetLocation()), 0_m);
         EXPECT_TRUE(AlmostEqual(GetX(body_b->GetLocation()) / Meter, (GetX(pos_b) - x * time_inc * 1_mps) / Meter));
-        EXPECT_EQ(GetY(body_b->GetLocation()), Real{0} * Meter);
+        EXPECT_EQ(GetY(body_b->GetLocation()), 0_m);
 
         EXPECT_EQ(GetX(GetLinearVelocity(*body_a)), +x * 1_mps);
         EXPECT_EQ(GetY(GetLinearVelocity(*body_a)), 0_mps);
@@ -1338,7 +1338,7 @@ TEST(World, HeavyOnLight)
 
 TEST(World, PerfectlyOverlappedSameCirclesStayPut)
 {
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto shape = std::make_shared<DiskShape>(radius);
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
@@ -1349,7 +1349,7 @@ TEST(World, PerfectlyOverlappedSameCirclesStayPut)
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.location = Length2{Real(0) * Meter, Real(0) * Meter};
+    body_def.location = Length2{0_m, 0_m};
 
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1376,8 +1376,8 @@ TEST(World, PerfectlyOverlappedSameCirclesStayPut)
 
 TEST(World, PerfectlyOverlappedConcentricCirclesStayPut)
 {
-    const auto radius1 = Real(1) * Meter;
-    const auto radius2 = Real(0.6) * Meter;
+    const auto radius1 = 1_m;
+    const auto radius2 = 0.6_m;
     
     const auto shape1 = std::make_shared<DiskShape>(radius1);
     shape1->SetDensity(1_kgpm2);
@@ -1432,7 +1432,7 @@ TEST(World, ListenerCalledForCircleBodyWithinCircleBody)
     auto body_def = BodyDef{};
     body_def.type = BodyType::Dynamic;
     body_def.location = Length2{};
-    const auto shape = std::make_shared<DiskShape>(Real{1} * Meter);
+    const auto shape = std::make_shared<DiskShape>(1_m);
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1));
     for (auto i = 0; i < 2; ++i)
@@ -1469,8 +1469,8 @@ TEST(World, ListenerCalledForSquareBodyWithinSquareBody)
     body_def.type = BodyType::Dynamic;
     body_def.location = Length2{};
     auto shape = std::make_shared<PolygonShape>();
-    shape->SetVertexRadius(Real{1} * Meter);
-    shape->SetAsBox(Real{2} * Meter, Real{2} * Meter);
+    shape->SetVertexRadius(1_m);
+    shape->SetAsBox(2_m, 2_m);
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1));
     for (auto i = 0; i < 2; ++i)
@@ -1508,7 +1508,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
     
-    const auto body1pos = Length2{-radius/Real(4) * Meter, Real(0) * Meter};
+    const auto body1pos = Length2{(-radius/4) * Meter, 0_m};
     body_def.location = body1pos;
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1517,7 +1517,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     }
     ASSERT_EQ(body1->GetLocation(), body_def.location);
     
-    const auto body2pos = Length2{+radius/Real(4) * Meter, Real(0) * Meter};
+    const auto body2pos = Length2{(+radius/4) * Meter, 0_m};
     body_def.location = body2pos;
     const auto body2 = world.CreateBody(body_def);
     {
@@ -1540,7 +1540,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     step.SetTime(time_inc);
 
     // Solver won't separate more than -step.linearSlop.
-    const auto full_separation = radius * Real{2} * Meter - Length{step.linearSlop};
+    const auto full_separation = radius * 2_m - Length{step.linearSlop};
     for (auto i = 0; i < 100; ++i)
     {
         world.Step(step);
@@ -1558,7 +1558,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
         if (new_distance == distance)
         {
             // position resolution has come to tolerance
-            ASSERT_GE(new_distance, radius * Real{2} * Meter - Length{step.linearSlop} * Real{4});
+            ASSERT_GE(new_distance, radius * 2_m - Length{step.linearSlop} * Real{4});
             break;
         }
         else // new_distance > distance
@@ -1595,7 +1595,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
 
 TEST(World, PerfectlyOverlappedSameSquaresSeparateHorizontally)
 {
-    const auto shape = std::make_shared<PolygonShape>(Real{1} * Meter, Real{1} * Meter);
+    const auto shape = std::make_shared<PolygonShape>(1_m, 1_m);
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
 
@@ -1672,7 +1672,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
     
-    const auto body1pos = Length2{Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
+    const auto body1pos = Length2{Real(half_dim/2) * Meter, 0_m}; // 0 causes additional y-axis separation
     body_def.location = body1pos;
     const auto body1 = world.CreateBody(body_def);
     {
@@ -1681,7 +1681,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     }
     ASSERT_EQ(body1->GetLocation(), body1pos);
     
-    const auto body2pos = Length2{-Real(half_dim/2) * Meter, Real(0) * Meter}; // 0 causes additional y-axis separation
+    const auto body2pos = Length2{-Real(half_dim/2) * Meter, 0_m}; // 0 causes additional y-axis separation
     body_def.location = body2pos;
     const auto body2 = world.CreateBody(body_def);
     {
@@ -1714,7 +1714,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     StepConf step;
     step.SetTime(1_s * time_inc);
     // Solver won't separate more than -step.linearSlop.
-    const auto full_separation = half_dim * Real{2} * Meter - Length{step.linearSlop};
+    const auto full_separation = half_dim * 2_m - Length{step.linearSlop};
     for (auto i = 0; i < 100; ++i)
     {
         Step(world, 1_s * time_inc, velocity_iters, position_iters);
@@ -1776,7 +1776,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
                 EXPECT_NE(GetY(body1->GetLocation()), GetY(lastpos1));
                 EXPECT_NE(GetY(body2->GetLocation()), GetY(lastpos2));
             }
-            ASSERT_GE(new_distance, Real(2) * Meter);
+            ASSERT_GE(new_distance, 2_m);
             break;
         }
         
@@ -1809,7 +1809,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
 
 TEST(World, CollidingDynamicBodies)
 {
-    const auto radius = Real(1) * Meter;
+    const auto radius = 1_m;
     const auto x = Real(10); // other test parameters tuned to this value being 10
 
     auto body_def = BodyDef{};
@@ -1830,7 +1830,7 @@ TEST(World, CollidingDynamicBodies)
     shape->SetDensity(1_kgpm2);
     shape->SetRestitution(Real(1)); // changes where bodies will be after collision
 
-    body_def.location = Length2{-(x + 1) * Meter, Real(0) * Meter};
+    body_def.location = Length2{-(x + 1) * Meter, 0_m};
     body_def.linearVelocity = LinearVelocity2{+x * 1_mps, 0_mps};
     const auto body_a = world.CreateBody(body_def);
     ASSERT_NE(body_a, nullptr);
@@ -1840,7 +1840,7 @@ TEST(World, CollidingDynamicBodies)
     const auto fixture1 = body_a->CreateFixture(shape);
     ASSERT_NE(fixture1, nullptr);
 
-    body_def.location = Length2{+(x + 1) * Meter, Real(0) * Meter};
+    body_def.location = Length2{+(x + 1) * Meter, 0_m};
     body_def.linearVelocity = LinearVelocity2{-x * 1_mps, 0_mps};
     const auto body_b = world.CreateBody(body_def);
     ASSERT_NE(body_b, nullptr);
@@ -1907,10 +1907,10 @@ TEST(World, CollidingDynamicBodies)
     EXPECT_GT(GetX(body_b->GetLocation()) / Meter, Real(+1) - tolerance);
     
     // and their deltas from -1 and +1 should be about equal.
-    EXPECT_TRUE(AlmostEqual((GetX(body_a->GetLocation()) + Real{1} * Meter) / Meter, (Real{1} * Meter - GetX(body_b->GetLocation())) / Meter));
+    EXPECT_TRUE(AlmostEqual((GetX(body_a->GetLocation()) + 1_m) / Meter, (1_m - GetX(body_b->GetLocation())) / Meter));
 
-    EXPECT_GE(GetX(listener.body_a[0]), Real{-1} * Meter);
-    EXPECT_LE(GetX(listener.body_b[0]), Real{+1} * Meter);
+    EXPECT_GE(GetX(listener.body_a[0]), -1_m);
+    EXPECT_LE(GetX(listener.body_b[0]), +1_m);
 
     for (;;)
     {
@@ -1926,14 +1926,14 @@ TEST(World, CollidingDynamicBodies)
     EXPECT_TRUE(AlmostEqual(elapsed_time, time_contacting + time_inc));
     
     // collision should be fully resolved now...
-    EXPECT_LT(GetX(body_a->GetLocation()), Real(-1) * Meter);
-    EXPECT_GT(GetX(body_b->GetLocation()), Real(+1) * Meter);
+    EXPECT_LT(GetX(body_a->GetLocation()), -1_m);
+    EXPECT_GT(GetX(body_b->GetLocation()), +1_m);
     
     // and their deltas from -1 and +1 should be about equal.
-    EXPECT_TRUE(AlmostEqual((GetX(body_a->GetLocation()) + Real{1} * Meter) / Meter, (Real{1} * Meter - GetX(body_b->GetLocation())) / Meter));
+    EXPECT_TRUE(AlmostEqual((GetX(body_a->GetLocation()) + 1_m) / Meter, (1_m - GetX(body_b->GetLocation())) / Meter));
 
-    EXPECT_LT(GetX(listener.body_a[1]), Real{-1} * Meter);
-    EXPECT_GT(GetX(listener.body_b[1]), Real{+1} * Meter);
+    EXPECT_LT(GetX(listener.body_a[1]), -1_m);
+    EXPECT_GT(GetX(listener.body_b[1]), +1_m);
     
     // confirm conservation of momentum:
     // velocities should now be same magnitude but in opposite directions
@@ -2292,14 +2292,14 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto edgeConf = EdgeShape::Conf{}
         .UseVertexRadius(VertexRadius)
         .UseRestitution(Real(1))
-        .UseVertex1(Length2{Real(0) * Meter, +Real(10) * Meter})
-        .UseVertex2(Length2{Real(0) * Meter, -Real(10) * Meter});
+        .UseVertex1(Length2{0_m, +10_m})
+        .UseVertex2(Length2{0_m, -10_m});
     const auto edge_shape = std::make_shared<EdgeShape>(edgeConf);
 
     BodyDef body_def;
     body_def.type = BodyType::Static;
 
-    body_def.location = Length2{left_edge_x, Real{0} * Meter};
+    body_def.location = Length2{left_edge_x, 0_m};
     const auto left_wall_body = world.CreateBody(body_def);
     ASSERT_NE(left_wall_body, nullptr);
     {
@@ -2307,7 +2307,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
         ASSERT_NE(wall_fixture, nullptr);
     }
 
-    body_def.location = Length2{right_edge_x, Real{0} * Meter};
+    body_def.location = Length2{right_edge_x, 0_m};
     const auto right_wall_body = world.CreateBody(body_def);
     ASSERT_NE(right_wall_body, nullptr);
     {
@@ -2318,7 +2318,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto begin_x = Real(0);
 
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2{begin_x * Meter, Real(0) * Meter};
+    body_def.location = Length2{begin_x * Meter, 0_m};
     body_def.bullet = false;
     const auto ball_body = world.CreateBody(body_def);
     ASSERT_NE(ball_body, nullptr);
@@ -2475,10 +2475,10 @@ TEST(World, MouseJointWontCauseTunnelling)
     body_def.type = BodyType::Static;
     
     // Setup vertical bounderies
-    edge_shape.Set(Length2{0, +half_box_height * Real(2) * Meter},
-                   Length2{0, -half_box_height * Real(2) * Meter});
+    edge_shape.Set(Length2{0, +half_box_height * 2_m},
+                   Length2{0, -half_box_height * 2_m});
 
-    body_def.location = Length2{left_edge_x * Meter, Real(0) * Meter};
+    body_def.location = Length2{left_edge_x * Meter, 0_m};
     {
         const auto left_wall_body = world.CreateBody(body_def);
         ASSERT_NE(left_wall_body, nullptr);
@@ -2489,7 +2489,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         Include(container_aabb, ComputeAABB(*left_wall_body));
     }
     
-    body_def.location = Length2{right_edge_x * Meter, Real(0) * Meter};
+    body_def.location = Length2{right_edge_x * Meter, 0_m};
     {
         const auto right_wall_body = world.CreateBody(body_def);
         ASSERT_NE(right_wall_body, nullptr);
@@ -2501,8 +2501,8 @@ TEST(World, MouseJointWontCauseTunnelling)
     }
 
     // Setup horizontal bounderies
-    edge_shape.Set(Length2{-half_box_width * Real(2) * Meter, Real(0) * Meter},
-                   Length2{+half_box_width * Real(2) * Meter, Real(0) * Meter});
+    edge_shape.Set(Length2{-half_box_width * 2_m, 0_m},
+                   Length2{+half_box_width * 2_m, 0_m});
     
     body_def.location = Length2{0, btm_edge_y * Meter};
     {
@@ -3008,8 +3008,8 @@ public:
     {
         const auto hw_ground = Real(40.0f) * Meter;
         const auto ground = world.CreateBody();
-        ground->CreateFixture(std::make_shared<EdgeShape>(Length2{-hw_ground, Real(0) * Meter},
-                                                          Length2{hw_ground, Real(0) * Meter}));
+        ground->CreateFixture(std::make_shared<EdgeShape>(Length2{-hw_ground, 0_m},
+                                                          Length2{hw_ground, 0_m}));
         
         const auto numboxes = boxes.size();
         

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -698,7 +698,7 @@ TEST(World, GetTouchingCountFreeFunction)
     const auto bd = BodyDef{}.UseType(BodyType::Dynamic);
     const auto lowerBodyDef = BodyDef(bd).UseLocation(Vec2(0.0f, 0.5f) * Meter);
     const auto diskConf = DiskShape::Conf{}.UseDensity(10_kgpm2);
-    const auto smallerDiskConf = DiskShape::Conf(diskConf).UseVertexRadius(Real{0.5f} * Meter);
+    const auto smallerDiskConf = DiskShape::Conf(diskConf).UseVertexRadius(0.5_m);
 
     const auto lowerBody = world.CreateBody(lowerBodyDef);
     lowerBody->CreateFixture(std::make_shared<DiskShape>(smallerDiskConf));
@@ -775,8 +775,8 @@ TEST(World, CreateAndDestroyJoint)
     EXPECT_TRUE(world.GetJoints().empty());
     EXPECT_EQ(world.GetJoints().begin(), world.GetJoints().end());
     
-    const auto anchorA = Length2{Real(+0.4) * Meter, Real(-1.2) * Meter};
-    const auto anchorB = Length2{Real(-2.3) * Meter, Real(+0.7) * Meter};
+    const auto anchorA = Length2{+0.4_m, -1.2_m};
+    const auto anchorB = Length2{-2.3_m, +0.7_m};
     const auto joint = world.CreateJoint(DistanceJointDef{body1, body2, anchorA, anchorB});
     EXPECT_EQ(GetJointCount(world), JointCounter(1));
     EXPECT_FALSE(world.GetJoints().empty());
@@ -835,7 +835,7 @@ TEST(World, StepZeroTimeDoesNothing)
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.location = Length2{31.9_m, Real(-19.24) * Meter};
+    def.location = Length2{31.9_m, -19.24_m};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
@@ -917,7 +917,7 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
     World world{WorldDef{}.UseGravity(gravity)};
     
     BodyDef def;
-    def.location = Length2{31.9_m, Real(-19.24) * Meter};
+    def.location = Length2{31.9_m, -19.24_m};
     def.type = BodyType::Dynamic;
     
     const auto body = world.CreateBody(def);
@@ -1170,8 +1170,8 @@ TEST(World, HeavyOnLight)
         .UseVertex2(Vec2(40.0f, 0.0f) * Meter);
     
     const auto diskConf = DiskShape::Conf{}.UseDensity(10_kgpm2);
-    const auto smallerDiskConf = DiskShape::Conf(diskConf).UseVertexRadius(Real{0.5f} * Meter);
-    const auto biggerDiskConf = DiskShape::Conf(diskConf).UseVertexRadius(Real{5.0f} * Meter);
+    const auto smallerDiskConf = DiskShape::Conf(diskConf).UseVertexRadius(0.5_m);
+    const auto biggerDiskConf = DiskShape::Conf(diskConf).UseVertexRadius(5.0_m);
     
     const auto baseStepConf = []() {
         auto step = StepConf{}.SetInvTime(60_Hz);
@@ -2286,8 +2286,8 @@ TEST(World, SpeedingBulletBallWontTunnel)
 
     ASSERT_EQ(listener.begin_contacts, unsigned{0});
 
-    const auto left_edge_x = Real(-0.1) * Meter;
-    const auto right_edge_x = Real(+0.1) * Meter;
+    const auto left_edge_x = -0.1_m;
+    const auto right_edge_x = +0.1_m;
 
     const auto edgeConf = EdgeShape::Conf{}
         .UseVertexRadius(VertexRadius)
@@ -3047,7 +3047,7 @@ protected:
     const std::size_t maxLoops = 10000;
     std::vector<Body*> boxes{10};
     Real original_x = 0;
-    const Length hdim = Real{0.1f} * Meter;
+    const Length hdim = 0.1_m;
 };
 
 TEST_P(VerticalStackTest, EndsBeforeMaxLoops)

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -73,14 +73,10 @@ TEST(WorldManifold, UnitVecConstruction)
 TEST(WorldManifold, GetWorldManifoldForUnsetManifold)
 {
     const auto manifold = Manifold{};
-    const auto xfA = Transformation{
-        Length2{Real(4-1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
-    };
-    const auto xfB = Transformation{
-        Length2{Real(4+1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
-    };
-    const auto rA = Real(1) * Meter;
-    const auto rB = Real(1) * Meter;
+    const auto xfA = Transformation{Length2{(4-1) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto xfB = Transformation{Length2{(4+1) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto rA = 1_m;
+    const auto rB = 1_m;
     const auto wm = GetWorldManifold(manifold, xfA, rA, xfB, rB);
     
     EXPECT_EQ(wm.GetPointCount(), decltype(wm.GetPointCount()){0});
@@ -91,34 +87,34 @@ TEST(WorldManifold, GetWorldManifoldForCirclesTouchingManifold)
 {
     const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
     const auto xfA = Transformation{
-        Length2{Real(4-1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(4-1) * Meter, 0_m}, UnitVec2::GetRight()
     };
     const auto xfB = Transformation{
-        Length2{Real(4+1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(4+1) * Meter, 0_m}, UnitVec2::GetRight()
     };
-    const auto rA = Real(1) * Meter;
-    const auto rB = Real(1) * Meter;
+    const auto rA = 1_m;
+    const auto rB = 1_m;
     const auto wm = GetWorldManifold(manifold, xfA, rA, xfB, rB);
     
     EXPECT_EQ(wm.GetPointCount(), decltype(wm.GetPointCount()){1});
     EXPECT_TRUE(IsValid(wm.GetNormal()));
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(wm.GetNormal()))), 1.0, 0.00001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(wm.GetNormal()))), 0.0, 0.00001);
-    EXPECT_EQ(wm.GetSeparation(0), Real{0} * Meter);
-    EXPECT_EQ(wm.GetPoint(0), Length2(Real(4) * Meter, Real(0) * Meter));
+    EXPECT_EQ(wm.GetSeparation(0), 0_m);
+    EXPECT_EQ(wm.GetPoint(0), Length2(4_m, 0_m));
 }
 
 TEST(WorldManifold, GetWorldManifoldForCirclesHalfOverlappingManifold)
 {
     const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
     const auto xfA = Transformation{
-        Length2{Real(7-0.5) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(7-0.5) * Meter, 0_m}, UnitVec2::GetRight()
     };
     const auto xfB = Transformation{
-        Length2{Real(7+0.5) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(7+0.5) * Meter, 0_m}, UnitVec2::GetRight()
     };
-    const auto rA = Real(1) * Meter;
-    const auto rB = Real(1) * Meter;
+    const auto rA = 1_m;
+    const auto rB = 1_m;
     const auto wm = GetWorldManifold(manifold, xfA, rA, xfB, rB);
     
     EXPECT_EQ(wm.GetPointCount(), decltype(wm.GetPointCount()){1});
@@ -126,23 +122,23 @@ TEST(WorldManifold, GetWorldManifoldForCirclesHalfOverlappingManifold)
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(wm.GetNormal()))), 1.0, 0.00001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(wm.GetNormal()))), 0.0, 0.00001);
     EXPECT_NEAR(static_cast<double>(Real{wm.GetSeparation(0)/Meter}), -1.0, 0.00001);
-    EXPECT_EQ(wm.GetPoint(0), Length2(Real(7) * Meter, Real(0) * Meter));
+    EXPECT_EQ(wm.GetPoint(0), Length2(7_m, 0_m));
 }
 
 TEST(WorldManifold, GetWorldManifoldForCirclesFullyOverlappingManifold)
 {
     const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
-    const auto xfA = Transformation{Length2{Real(3-0) * Meter, Real(0) * Meter}, UnitVec2::GetRight()};
-    const auto xfB = Transformation{Length2{Real(3+0) * Meter, Real(0) * Meter}, UnitVec2::GetRight()};
-    const auto rA = Real(1) * Meter;
-    const auto rB = Real(1) * Meter;
+    const auto xfA = Transformation{Length2{Real(3-0) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto xfB = Transformation{Length2{Real(3+0) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto rA = 1_m;
+    const auto rB = 1_m;
     const auto wm = GetWorldManifold(manifold, xfA, rA, xfB, rB);
     
     EXPECT_EQ(wm.GetPointCount(), decltype(wm.GetPointCount()){1});
-    EXPECT_EQ(wm.GetSeparation(0), Real{-2} * Meter);
+    EXPECT_EQ(wm.GetSeparation(0), -2_m);
     if (IsValid(wm.GetNormal()))
     {
-        EXPECT_EQ(wm.GetPoint(0), Length2(Real(3) * Meter, Real(0) * Meter));
+        EXPECT_EQ(wm.GetPoint(0), Length2(3_m, 0_m));
     }
     else
     {

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -74,10 +74,10 @@ TEST(WorldManifold, GetWorldManifoldForUnsetManifold)
 {
     const auto manifold = Manifold{};
     const auto xfA = Transformation{
-        Length2D{Real(4-1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(4-1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
     };
     const auto xfB = Transformation{
-        Length2D{Real(4+1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(4+1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
     };
     const auto rA = Real(1) * Meter;
     const auto rB = Real(1) * Meter;
@@ -89,12 +89,12 @@ TEST(WorldManifold, GetWorldManifoldForUnsetManifold)
 
 TEST(WorldManifold, GetWorldManifoldForCirclesTouchingManifold)
 {
-    const auto manifold = Manifold::GetForCircles(Length2D{}, 0, Length2D{}, 0);
+    const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
     const auto xfA = Transformation{
-        Length2D{Real(4-1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(4-1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
     };
     const auto xfB = Transformation{
-        Length2D{Real(4+1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(4+1) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
     };
     const auto rA = Real(1) * Meter;
     const auto rB = Real(1) * Meter;
@@ -105,17 +105,17 @@ TEST(WorldManifold, GetWorldManifoldForCirclesTouchingManifold)
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(wm.GetNormal()))), 1.0, 0.00001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(wm.GetNormal()))), 0.0, 0.00001);
     EXPECT_EQ(wm.GetSeparation(0), Real{0} * Meter);
-    EXPECT_EQ(wm.GetPoint(0), Length2D(Real(4) * Meter, Real(0) * Meter));
+    EXPECT_EQ(wm.GetPoint(0), Length2(Real(4) * Meter, Real(0) * Meter));
 }
 
 TEST(WorldManifold, GetWorldManifoldForCirclesHalfOverlappingManifold)
 {
-    const auto manifold = Manifold::GetForCircles(Length2D{}, 0, Length2D{}, 0);
+    const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
     const auto xfA = Transformation{
-        Length2D{Real(7-0.5) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(7-0.5) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
     };
     const auto xfB = Transformation{
-        Length2D{Real(7+0.5) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
+        Length2{Real(7+0.5) * Meter, Real(0) * Meter}, UnitVec2::GetRight()
     };
     const auto rA = Real(1) * Meter;
     const auto rB = Real(1) * Meter;
@@ -126,14 +126,14 @@ TEST(WorldManifold, GetWorldManifoldForCirclesHalfOverlappingManifold)
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(wm.GetNormal()))), 1.0, 0.00001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(wm.GetNormal()))), 0.0, 0.00001);
     EXPECT_NEAR(static_cast<double>(Real{wm.GetSeparation(0)/Meter}), -1.0, 0.00001);
-    EXPECT_EQ(wm.GetPoint(0), Length2D(Real(7) * Meter, Real(0) * Meter));
+    EXPECT_EQ(wm.GetPoint(0), Length2(Real(7) * Meter, Real(0) * Meter));
 }
 
 TEST(WorldManifold, GetWorldManifoldForCirclesFullyOverlappingManifold)
 {
-    const auto manifold = Manifold::GetForCircles(Length2D{}, 0, Length2D{}, 0);
-    const auto xfA = Transformation{Length2D{Real(3-0) * Meter, Real(0) * Meter}, UnitVec2::GetRight()};
-    const auto xfB = Transformation{Length2D{Real(3+0) * Meter, Real(0) * Meter}, UnitVec2::GetRight()};
+    const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
+    const auto xfA = Transformation{Length2{Real(3-0) * Meter, Real(0) * Meter}, UnitVec2::GetRight()};
+    const auto xfB = Transformation{Length2{Real(3+0) * Meter, Real(0) * Meter}, UnitVec2::GetRight()};
     const auto rA = Real(1) * Meter;
     const auto rB = Real(1) * Meter;
     const auto wm = GetWorldManifold(manifold, xfA, rA, xfB, rB);
@@ -142,7 +142,7 @@ TEST(WorldManifold, GetWorldManifoldForCirclesFullyOverlappingManifold)
     EXPECT_EQ(wm.GetSeparation(0), Real{-2} * Meter);
     if (IsValid(wm.GetNormal()))
     {
-        EXPECT_EQ(wm.GetPoint(0), Length2D(Real(3) * Meter, Real(0) * Meter));
+        EXPECT_EQ(wm.GetPoint(0), Length2(Real(3) * Meter, Real(0) * Meter));
     }
     else
     {


### PR DESCRIPTION
#### Description - What's this PR do?
Making use of user defined literals for Meter.
Replaces "(Real(1) * Meter)" with "Meter".
Strips the names of Length2D, LinearVelocity2D, LinearAcceleration2D, Force2D, and Momentum2D of their ending "D".
Extracts the gravitational constant and acceleration due to earth's gravity into unit constants.

#### Related Issues
- Issue #178.