### PR TITLE
Adds an entity editor to the Testbed for live updating and observation of PlayRho entities

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		477D20061E32B6E80069D610 /* Fixed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 477D20051E32B6E80069D610 /* Fixed.cpp */; };
 		477DB2AC1D1C4BE800846ED6 /* PositionSolverManifold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 477DB2AA1D1C4BE800846ED6 /* PositionSolverManifold.cpp */; };
 		477DB2AD1D1C4BE800846ED6 /* PositionSolverManifold.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 477DB2AB1D1C4BE800846ED6 /* PositionSolverManifold.hpp */; };
+		477FACC21FAD74C4001A6030 /* JointType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 477FACC11FAD74C4001A6030 /* JointType.cpp */; };
 		4787D6BA1F2E946E008C115E /* PrismaticJointDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4787D6B81F2E946E008C115E /* PrismaticJointDef.cpp */; };
 		4787D6BB1F2E946E008C115E /* PrismaticJointDef.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4787D6B91F2E946E008C115E /* PrismaticJointDef.hpp */; };
 		4787D6BE1F2E968E008C115E /* JointDef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4787D6BC1F2E968E008C115E /* JointDef.cpp */; };
@@ -520,6 +521,7 @@
 		477D20051E32B6E80069D610 /* Fixed.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Fixed.cpp; sourceTree = "<group>"; };
 		477DB2AA1D1C4BE800846ED6 /* PositionSolverManifold.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PositionSolverManifold.cpp; sourceTree = "<group>"; };
 		477DB2AB1D1C4BE800846ED6 /* PositionSolverManifold.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PositionSolverManifold.hpp; sourceTree = "<group>"; };
+		477FACC11FAD74C4001A6030 /* JointType.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JointType.cpp; sourceTree = "<group>"; };
 		4787D6B81F2E946E008C115E /* PrismaticJointDef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrismaticJointDef.cpp; sourceTree = "<group>"; };
 		4787D6B91F2E946E008C115E /* PrismaticJointDef.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PrismaticJointDef.hpp; sourceTree = "<group>"; };
 		4787D6BC1F2E968E008C115E /* JointDef.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JointDef.cpp; sourceTree = "<group>"; };
@@ -819,6 +821,7 @@
 				472E24651F82C4EA0051E192 /* Interval.cpp */,
 				4731DDFB1DC8FBEE00E7F931 /* Island.cpp */,
 				475A945C1D959537000CA9A8 /* Joint.cpp */,
+				477FACC11FAD74C4001A6030 /* JointType.cpp */,
 				474BC3FC1D41278800447DCD /* main.cpp */,
 				474BC3FD1D41278800447DCD /* Manifold.cpp */,
 				4731DE4C1DE90D8200E7F931 /* MassData.cpp */,
@@ -1538,6 +1541,7 @@
 				474BC42F1D413DC200447DCD /* Distance.cpp in Sources */,
 				4768D3F81E3E895A00574143 /* PrismaticJoint.cpp in Sources */,
 				473273211F44AB9B00E22AE2 /* ContactImpulsesList.cpp in Sources */,
+				477FACC21FAD74C4001A6030 /* JointType.cpp in Sources */,
 				474BC4301D413DC200447DCD /* DistanceProxy.cpp in Sources */,
 				47C85D0A1EFA251B00F70C56 /* WheelJoint.cpp in Sources */,
 				475A945D1D959537000CA9A8 /* Joint.cpp in Sources */,

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -423,10 +423,10 @@ template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
 constexpr auto Cross(T1 a, T2 b) noexcept
 {
-    assert(std::isfinite(Get<0>(a)));
-    assert(std::isfinite(Get<1>(a)));
-    assert(std::isfinite(Get<0>(b)));
-    assert(std::isfinite(Get<1>(b)));
+    assert(std::isfinite(StripUnit(Get<0>(a))));
+    assert(std::isfinite(StripUnit(Get<1>(a))));
+    assert(std::isfinite(StripUnit(Get<0>(b))));
+    assert(std::isfinite(StripUnit(Get<1>(b))));
 
     // Both vectors of same direction...
     // If a = Vec2{1, 2} and b = Vec2{1, 2} then: a x b = 1 * 2 - 2 * 1 = 0.
@@ -440,8 +440,8 @@ constexpr auto Cross(T1 a, T2 b) noexcept
     // If a = Vec2{1, 2} and b = Vec2{-1, 2} then: a x b = 1 * 2 - 2 * (-1) = 2 + 2 = 4.
     const auto minuend = Get<0>(a) * Get<1>(b);
     const auto subtrahend = Get<1>(a) * Get<0>(b);
-    assert(std::isfinite(minuend));
-    assert(std::isfinite(subtrahend));
+    assert(std::isfinite(StripUnit(minuend)));
+    assert(std::isfinite(StripUnit(subtrahend)));
     return minuend - subtrahend;
 }
 

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -367,6 +367,10 @@ namespace playrho
     /// @sa AngularAcceleration.
     constexpr auto RadianPerSquareSecond = Radian / (Second * Second);
 
+    /// @brief Degree per square second unit of AngularAcceleration.
+    /// @sa AngularAcceleration.
+    constexpr auto DegreePerSquareSecond = Degree / (Second * Second);
+
     /// @brief Newton unit of Force.
     /// @sa Force.
     constexpr auto Newton = PLAYRHO_UNIT(Force, boost::units::si::newton);
@@ -378,6 +382,10 @@ namespace playrho
     /// @brief Newton second unit of Momentum.
     /// @sa Momentum.
     constexpr auto NewtonSecond = Newton * Second;
+    
+    /// @brief Newton meter second unit of AngularMomentum.
+    /// @sa AngularMomentum.
+    constexpr auto NewtonMeterSecond = NewtonMeter * Second;
     
     /// @}
     

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -523,28 +523,32 @@ Force2 GetCentripetalForce(const Body& body, Length2 axis)
 
 Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
 {
-    const auto world = body.GetWorld();
-    const auto bodies = world->GetBodies();
     const auto m1 = GetMass(body);
-    const auto loc1 = GetLocation(body);
-    auto sumForce = Force2{};
-    for (auto jt = std::begin(bodies); jt != std::end(bodies); jt = std::next(jt))
+    if (m1 != 0_kg)
     {
-        const auto& b2 = *(*jt);
-        if (&b2 == &body)
+        const auto loc1 = GetLocation(body);
+        auto sumForce = Force2{};
+        const auto world = body.GetWorld();
+        const auto bodies = world->GetBodies();
+        for (auto jt = std::begin(bodies); jt != std::end(bodies); jt = std::next(jt))
         {
-            continue;
+            const auto& b2 = *(*jt);
+            if (&b2 == &body)
+            {
+                continue;
+            }
+            const auto m2 = GetMass(b2);
+            const auto delta = GetLocation(b2) - loc1;
+            const auto dir = GetUnitVector(delta);
+            const auto rr = GetLengthSquared(delta);
+            const auto orderedMass = std::minmax(m1, m2);
+            const auto f = (BigG * orderedMass.first) * (orderedMass.second / rr);
+            sumForce += f * dir;
         }
-        const auto m2 = GetMass(b2);
-        const auto delta = GetLocation(b2) - loc1;
-        const auto dir = GetUnitVector(delta);
-        const auto rr = GetLengthSquared(delta);
-        const auto orderedMass = std::minmax(m1, m2);
-        const auto f = (BigG * orderedMass.first) * (orderedMass.second / rr);
-        sumForce += f * dir;
+        // F = m a... i.e.  a = F / m.
+        return Acceleration{sumForce / m1, 0 * RadianPerSquareSecond};
     }
-    // F = m a... i.e.  a = F / m.
-    return Acceleration{sumForce / m1, 0 * RadianPerSquareSecond};
+    return Acceleration{};
 }
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -868,9 +868,11 @@ inline void SetAcceleration(Body& body, Acceleration value) noexcept
     body.SetAcceleration(value.linear, value.angular);
 }
 
-/// @brief Calculates the gravitationally associated acceleration of the given body
+/// @brief Calculates the gravitationally associated acceleration for the given body
 ///   within its world.
 /// @relatedalso Body
+/// @return Zero acceleration if given body is has no mass, else the acceleration of
+///    the body due to the gravitational attraction to the other bodies.
 Acceleration CalcGravitationalAcceleration(const Body& body) noexcept;
     
 /// @brief Awakens the body if it's asleep.
@@ -921,9 +923,16 @@ inline Mass GetMass(const Body& body) noexcept
 
 /// @brief Sets the given linear acceleration of the given body.
 /// @relatedalso Body
-inline void SetLinearAcceleration(Body& body, LinearAcceleration2 value)
+inline void SetLinearAcceleration(Body& body, LinearAcceleration2 value) noexcept
 {
     body.SetAcceleration(value, body.GetAngularAcceleration());
+}
+
+/// @brief Sets the given angular acceleration of the given body.
+/// @relatedalso Body
+inline void SetAngularAcceleration(Body& body, AngularAcceleration value) noexcept
+{
+    body.SetAcceleration(body.GetLinearAcceleration(), value);
 }
 
 /// @brief Applies the given linear acceleration to the given body.

--- a/PlayRho/Dynamics/Filter.hpp
+++ b/PlayRho/Dynamics/Filter.hpp
@@ -59,6 +59,22 @@ namespace playrho {
         index_type groupIndex = 0;
     };
     
+    /// @brief Equality operator.
+    /// @relatedalso Filter
+    constexpr bool operator== (const Filter lhs, const Filter rhs) noexcept
+    {
+        return lhs.categoryBits == rhs.categoryBits
+            && lhs.maskBits == rhs.maskBits
+            && lhs.groupIndex == rhs.groupIndex;
+    }
+
+    /// @brief Inequality operator.
+    /// @relatedalso Filter
+    constexpr bool operator!= (const Filter lhs, const Filter rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
     /// @brief Determines whether collision processing should be performed.
     inline bool ShouldCollide(const Filter filterA, const Filter filterB) noexcept
     {

--- a/PlayRho/Dynamics/Joints/DistanceJoint.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.cpp
@@ -68,6 +68,11 @@ void DistanceJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void DistanceJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void DistanceJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
                                             const StepConf& step,
                                             const ConstraintSolverConf&)

--- a/PlayRho/Dynamics/Joints/DistanceJoint.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.hpp
@@ -47,6 +47,7 @@ public:
     DistanceJoint(const DistanceJointDef& data);
 
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
 

--- a/PlayRho/Dynamics/Joints/FrictionJoint.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.cpp
@@ -54,6 +54,11 @@ void FrictionJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void FrictionJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void FrictionJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step,
                                             const ConstraintSolverConf&)
 {

--- a/PlayRho/Dynamics/Joints/FrictionJoint.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.hpp
@@ -43,6 +43,7 @@ public:
     FrictionJoint(const FrictionJointDef& def);
 
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;

--- a/PlayRho/Dynamics/Joints/GearJoint.cpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.cpp
@@ -132,6 +132,11 @@ void GearJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void GearJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void GearJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step,
                                         const ConstraintSolverConf&)
 {

--- a/PlayRho/Dynamics/Joints/GearJoint.hpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.hpp
@@ -50,6 +50,7 @@ public:
     GearJoint(const GearJointDef& data);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;

--- a/PlayRho/Dynamics/Joints/Joint.cpp
+++ b/PlayRho/Dynamics/Joints/Joint.cpp
@@ -171,4 +171,16 @@ BodyConstraintPtr& At(std::unordered_map<const Body*, BodyConstraint*>& containe
     return container.at(key);
 }
 
+const char* ToString(Joint::LimitState val) noexcept
+{
+    switch (val)
+    {
+        case Joint::e_inactiveLimit: return "inactive";
+        case Joint::e_atLowerLimit: return "at lower";
+        case Joint::e_atUpperLimit: return "at upper";
+        case Joint::e_equalLimits: return "equal";
+    }
+    return "unknown";
+}
+
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -106,6 +106,9 @@ public:
     
     /// @brief Accepts a visitor.
     virtual void Accept(JointVisitor& visitor) const = 0;
+    
+    /// @brief Accepts a visitor.
+    virtual void Accept(JointVisitor& visitor) = 0;
 
     /// Get the user data pointer.
     void* GetUserData() const noexcept;
@@ -257,6 +260,9 @@ BodyConstraintPtr& At(std::vector<BodyConstraintPair>& container, const Body* ke
 /// @brief Provides referenced access to the identified element of the given container.
 BodyConstraintPtr& At(std::unordered_map<const Body*, BodyConstraint*>& container,
                       const Body* key);
+
+/// @brief Provides a human readable C-style string uniquely identifying the given limit state.
+const char* ToString(Joint::LimitState val) noexcept;
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/Joints/JointType.cpp
+++ b/PlayRho/Dynamics/Joints/JointType.cpp
@@ -31,4 +31,23 @@ JointType GetType(const Joint& joint) noexcept
     return visitor.GetType().value_or(JointType::Unknown);
 }
 
+const char* ToString(JointType type) noexcept
+{
+    switch (type)
+    {
+        case JointType::Revolute: return "Revolute";
+        case JointType::Prismatic: return "Prismatic";
+        case JointType::Distance: return "Distance";
+        case JointType::Pulley: return "Pulley";
+        case JointType::Mouse: return "Mouse";
+        case JointType::Gear: return "Gear";
+        case JointType::Wheel: return "Wheel";
+        case JointType::Weld: return "Weld";
+        case JointType::Friction: return "Friction";
+        case JointType::Rope: return "Rope";
+        case JointType::Motor: return "Motor";
+        case JointType::Unknown: return "Unknown";
+    }
+}
+
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/JointType.hpp
+++ b/PlayRho/Dynamics/Joints/JointType.hpp
@@ -49,6 +49,10 @@ class Joint;
 /// @relatedalso Joint
 JointType GetType(const Joint& joint) noexcept;
 
+/// @brief Provides a C-style (null-terminated) string name for given joint type.
+/// @return C-style English-language human-readable string uniquely identifying the joint type.
+const char* ToString(JointType type) noexcept;
+
 } // namespace playrho
 
 #endif // PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP

--- a/PlayRho/Dynamics/Joints/JointVisitor.hpp
+++ b/PlayRho/Dynamics/Joints/JointVisitor.hpp
@@ -49,35 +49,68 @@ public:
     /// @brief Visits a RevoluteJoint.
     virtual void Visit(const RevoluteJoint& joint) = 0;
     
+    /// @brief Visits a RevoluteJoint.
+    virtual void Visit(RevoluteJoint& joint) = 0;
+    
     /// @brief Visits a PrismaticJoint.
     virtual void Visit(const PrismaticJoint& joint) = 0;
+    
+    /// @brief Visits a PrismaticJoint.
+    virtual void Visit(PrismaticJoint& joint) = 0;
     
     /// @brief Visits a DistanceJoint.
     virtual void Visit(const DistanceJoint& joint) = 0;
     
+    /// @brief Visits a DistanceJoint.
+    virtual void Visit(DistanceJoint& joint) = 0;
+    
     /// @brief Visits a PulleyJoint.
     virtual void Visit(const PulleyJoint& joint) = 0;
     
+    /// @brief Visits a PulleyJoint.
+    virtual void Visit(PulleyJoint& joint) = 0;
+
     /// @brief Visits a MouseJoint.
     virtual void Visit(const MouseJoint& joint) = 0;
-    
+
+    /// @brief Visits a MouseJoint.
+    virtual void Visit(MouseJoint& joint) = 0;
+
     /// @brief Visits a GearJoint.
     virtual void Visit(const GearJoint& joint) = 0;
-    
+
+    /// @brief Visits a GearJoint.
+    virtual void Visit(GearJoint& joint) = 0;
+
     /// @brief Visits a WheelJoint.
     virtual void Visit(const WheelJoint& joint) = 0;
+
+    /// @brief Visits a WheelJoint.
+    virtual void Visit(WheelJoint& joint) = 0;
     
     /// @brief Visits a WeldJoint.
     virtual void Visit(const WeldJoint& joint) = 0;
     
+    /// @brief Visits a WeldJoint.
+    virtual void Visit(WeldJoint& joint) = 0;
+    
     /// @brief Visits a FrictionJoint.
     virtual void Visit(const FrictionJoint& joint) = 0;
+    
+    /// @brief Visits a FrictionJoint.
+    virtual void Visit(FrictionJoint& joint) = 0;
     
     /// @brief Visits a RopeJoint.
     virtual void Visit(const RopeJoint& joint) = 0;
     
+    /// @brief Visits a RopeJoint.
+    virtual void Visit(RopeJoint& joint) = 0;
+
     /// @brief Visits a MotorJoint.
     virtual void Visit(const MotorJoint& joint) = 0;
+
+    /// @brief Visits a MotorJoint.
+    virtual void Visit(MotorJoint& joint) = 0;
     
 protected:
     JointVisitor() = default;

--- a/PlayRho/Dynamics/Joints/MotorJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.cpp
@@ -55,6 +55,11 @@ void MotorJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void MotorJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void MotorJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step, const ConstraintSolverConf&)
 {
     auto& bodyConstraintA = At(bodies, GetBodyA());

--- a/PlayRho/Dynamics/Joints/MotorJoint.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.hpp
@@ -42,6 +42,7 @@ public:
     MotorJoint(const MotorJointDef& def);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;

--- a/PlayRho/Dynamics/Joints/MouseJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.cpp
@@ -68,6 +68,11 @@ void MouseJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void MouseJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void MouseJoint::SetTarget(const Length2 target) noexcept
 {
     assert(IsValid(target));

--- a/PlayRho/Dynamics/Joints/MouseJoint.hpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.hpp
@@ -52,6 +52,7 @@ public:
     MouseJoint(const MouseJointDef& def);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
 

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
@@ -116,6 +116,11 @@ void PrismaticJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void PrismaticJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void PrismaticJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
                                              const StepConf& step,
                                              const ConstraintSolverConf& conf)
@@ -595,11 +600,6 @@ void PrismaticJoint::SetMaxMotorForce(Force force) noexcept
         GetBodyA()->SetAwake();
         GetBodyB()->SetAwake();
     }
-}
-
-Force PrismaticJoint::GetMotorForce(Frequency inv_dt) const noexcept
-{
-    return inv_dt * m_motorImpulse;
 }
 
 Length GetJointTranslation(const PrismaticJoint& joint) noexcept

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.hpp
@@ -48,6 +48,7 @@ public:
     PrismaticJoint(const PrismaticJointDef& def);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;
@@ -100,8 +101,8 @@ public:
     /// @brief Gets the maximum motor force.
     Force GetMaxMotorForce() const noexcept { return m_maxMotorForce; }
 
-    /// @brief Gets the current motor force given the inverse time step.
-    Force GetMotorForce(Frequency inv_dt) const noexcept;
+    /// @brief Gets the current motor impulse.
+    Momentum GetMotorImpulse() const noexcept { return m_motorImpulse; }
 
     /// @brief Gets the current limit state.
     /// @note This will be <code>e_inactiveLimit</code> unless the joint limit has been
@@ -179,6 +180,13 @@ Length GetJointTranslation(const PrismaticJoint& joint) noexcept;
 /// @brief Get the current joint translation speed.
 /// @relatedalso PrismaticJoint
 LinearVelocity GetLinearVelocity(const PrismaticJoint& joint) noexcept;
+
+/// @brief Gets the current motor force for the given joint, given the inverse time step.
+/// @relatedalso PrismaticJoint
+inline Force GetMotorForce(const PrismaticJoint& joint, Frequency inv_dt) noexcept
+{
+    return joint.GetMotorImpulse() * inv_dt;
+}
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/Joints/PulleyJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.cpp
@@ -59,6 +59,11 @@ void PulleyJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void PulleyJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void PulleyJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
                                           const StepConf& step,
                                           const ConstraintSolverConf&)

--- a/PlayRho/Dynamics/Joints/PulleyJoint.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.hpp
@@ -51,6 +51,7 @@ public:
     PulleyJoint(const PulleyJointDef& data);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     /// @brief Gets the local anchor A.
     Length2 GetLocalAnchorA() const noexcept;

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -61,6 +61,11 @@ void RevoluteJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void RevoluteJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void RevoluteJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
                                             const StepConf& step,
                                             const ConstraintSolverConf& conf)
@@ -447,11 +452,6 @@ void RevoluteJoint::EnableMotor(bool flag)
 	    GetBodyA()->SetAwake();
     	GetBodyB()->SetAwake();
     }
-}
-
-Torque RevoluteJoint::GetMotorTorque(Frequency inv_dt) const
-{
-    return inv_dt * m_motorImpulse;
 }
 
 void RevoluteJoint::SetMotorSpeed(AngularVelocity speed)

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.hpp
@@ -50,6 +50,7 @@ public:
     RevoluteJoint(const RevoluteJointDef& def);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;
@@ -102,8 +103,8 @@ public:
     /// Get the angular reaction due to the joint limit.
     AngularMomentum GetAngularReaction() const override;
 
-    /// Get the current motor torque given the inverse time step.
-    Torque GetMotorTorque(Frequency inv_dt) const;
+    /// @brief Gets the current motor impulse.
+    AngularMomentum GetMotorImpulse() const noexcept;
     
     /// @brief Gets the current limit state.
     /// @note This will be <code>e_inactiveLimit</code> unless the joint limit has been
@@ -174,6 +175,11 @@ inline Joint::LimitState RevoluteJoint::GetLimitState() const noexcept
     return m_limitState;
 }
 
+inline AngularMomentum RevoluteJoint::GetMotorImpulse() const noexcept
+{
+    return m_motorImpulse;
+}
+
 // Free functions...
 
 /// @brief Gets the current joint angle.
@@ -183,6 +189,13 @@ Angle GetJointAngle(const RevoluteJoint& joint);
 /// @brief Gets the current joint angle speed.
 /// @relatedalso RevoluteJoint
 AngularVelocity GetAngularVelocity(const RevoluteJoint& joint);
+
+/// @brief Gets the current motor torque for the given joint given the inverse time step.
+/// @relatedalso RevoluteJoint
+inline Torque GetMotorTorque(const RevoluteJoint& joint, Frequency inv_dt) noexcept
+{
+    return joint.GetMotorImpulse() * inv_dt;
+}
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/Joints/RopeJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.cpp
@@ -49,6 +49,11 @@ void RopeJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void RopeJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void RopeJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
                                         const StepConf& step,
                                         const ConstraintSolverConf& conf)

--- a/PlayRho/Dynamics/Joints/RopeJoint.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.hpp
@@ -48,6 +48,7 @@ public:
     RopeJoint(const RopeJointDef& data);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;

--- a/PlayRho/Dynamics/Joints/TypeJointVisitor.hpp
+++ b/PlayRho/Dynamics/Joints/TypeJointVisitor.hpp
@@ -41,6 +41,7 @@ public:
     void Visit(RevoluteJoint& /*joint*/) override
     {
         m_type = JointType::Revolute;
+        m_writable = true;
     }
 
     void Visit(const PrismaticJoint& /*joint*/) override
@@ -51,6 +52,7 @@ public:
     void Visit(PrismaticJoint& /*joint*/) override
     {
         m_type = JointType::Prismatic;
+        m_writable = true;
     }
 
     void Visit(const DistanceJoint& /*joint*/) override
@@ -61,6 +63,7 @@ public:
     void Visit(DistanceJoint& /*joint*/) override
     {
         m_type = JointType::Distance;
+        m_writable = true;
     }
     
     void Visit(const PulleyJoint& /*joint*/) override
@@ -71,6 +74,7 @@ public:
     void Visit(PulleyJoint& /*joint*/) override
     {
         m_type = JointType::Pulley;
+        m_writable = true;
     }
 
     void Visit(const MouseJoint& /*joint*/) override
@@ -81,6 +85,7 @@ public:
     void Visit(MouseJoint& /*joint*/) override
     {
         m_type = JointType::Mouse;
+        m_writable = true;
     }
     
     void Visit(const GearJoint& /*joint*/) override
@@ -91,6 +96,7 @@ public:
     void Visit(GearJoint& /*joint*/) override
     {
         m_type = JointType::Gear;
+        m_writable = true;
     }
 
     void Visit(const WheelJoint& /*joint*/) override
@@ -101,6 +107,7 @@ public:
     void Visit(WheelJoint& /*joint*/) override
     {
         m_type = JointType::Wheel;
+        m_writable = true;
     }
 
     void Visit(const WeldJoint& /*joint*/) override
@@ -111,6 +118,7 @@ public:
     void Visit(WeldJoint& /*joint*/) override
     {
         m_type = JointType::Weld;
+        m_writable = true;
     }
 
     void Visit(const FrictionJoint& /*joint*/) override
@@ -121,6 +129,7 @@ public:
     void Visit(FrictionJoint& /*joint*/) override
     {
         m_type = JointType::Friction;
+        m_writable = true;
     }
     
     void Visit(const RopeJoint& /*joint*/) override
@@ -131,6 +140,7 @@ public:
     void Visit(RopeJoint& /*joint*/) override
     {
         m_type = JointType::Rope;
+        m_writable = true;
     }
     
     void Visit(const MotorJoint& /*joint*/) override
@@ -141,6 +151,7 @@ public:
     void Visit(MotorJoint& /*joint*/) override
     {
         m_type = JointType::Motor;
+        m_writable = true;
     }
 
     /// @brief Gets the type of joint that had been visited.
@@ -149,8 +160,15 @@ public:
         return m_type;
     }
     
+    /// @brief Gets whether the visited type was writable or not.
+    bool GetWritable() const noexcept
+    {
+        return m_writable;
+    }
+    
 private:
     Optional<JointType> m_type; ///< Optional type of the joint (set if visited).
+    bool m_writable = false; ///< Whether visited type was writable.
 };
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/TypeJointVisitor.hpp
+++ b/PlayRho/Dynamics/Joints/TypeJointVisitor.hpp
@@ -38,12 +38,27 @@ public:
         m_type = JointType::Revolute;
     }
     
+    void Visit(RevoluteJoint& /*joint*/) override
+    {
+        m_type = JointType::Revolute;
+    }
+
     void Visit(const PrismaticJoint& /*joint*/) override
     {
         m_type = JointType::Prismatic;
     }
     
+    void Visit(PrismaticJoint& /*joint*/) override
+    {
+        m_type = JointType::Prismatic;
+    }
+
     void Visit(const DistanceJoint& /*joint*/) override
+    {
+        m_type = JointType::Distance;
+    }
+    
+    void Visit(DistanceJoint& /*joint*/) override
     {
         m_type = JointType::Distance;
     }
@@ -53,48 +68,81 @@ public:
         m_type = JointType::Pulley;
     }
     
-    /// @brief Visits a MouseJoint.
+    void Visit(PulleyJoint& /*joint*/) override
+    {
+        m_type = JointType::Pulley;
+    }
+
     void Visit(const MouseJoint& /*joint*/) override
     {
         m_type = JointType::Mouse;
     }
+
+    void Visit(MouseJoint& /*joint*/) override
+    {
+        m_type = JointType::Mouse;
+    }
     
-    /// @brief Visits a GearJoint.
     void Visit(const GearJoint& /*joint*/) override
     {
         m_type = JointType::Gear;
     }
     
-    /// @brief Visits a WheelJoint.
+    void Visit(GearJoint& /*joint*/) override
+    {
+        m_type = JointType::Gear;
+    }
+
     void Visit(const WheelJoint& /*joint*/) override
     {
         m_type = JointType::Wheel;
     }
-    
-    /// @brief Visits a WeldJoint.
+
+    void Visit(WheelJoint& /*joint*/) override
+    {
+        m_type = JointType::Wheel;
+    }
+
     void Visit(const WeldJoint& /*joint*/) override
     {
         m_type = JointType::Weld;
     }
-    
-    /// @brief Visits a FrictionJoint.
+
+    void Visit(WeldJoint& /*joint*/) override
+    {
+        m_type = JointType::Weld;
+    }
+
     void Visit(const FrictionJoint& /*joint*/) override
     {
         m_type = JointType::Friction;
     }
+
+    void Visit(FrictionJoint& /*joint*/) override
+    {
+        m_type = JointType::Friction;
+    }
     
-    /// @brief Visits a RopeJoint.
     void Visit(const RopeJoint& /*joint*/) override
     {
         m_type = JointType::Rope;
     }
     
-    /// @brief Visits a MotorJoint.
+    void Visit(RopeJoint& /*joint*/) override
+    {
+        m_type = JointType::Rope;
+    }
+    
     void Visit(const MotorJoint& /*joint*/) override
     {
         m_type = JointType::Motor;
     }
     
+    void Visit(MotorJoint& /*joint*/) override
+    {
+        m_type = JointType::Motor;
+    }
+
     /// @brief Gets the type of joint that had been visited.
     Optional<JointType> GetType() const noexcept
     {

--- a/PlayRho/Dynamics/Joints/WeldJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.cpp
@@ -58,6 +58,11 @@ void WeldJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void WeldJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void WeldJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step,
                                         const ConstraintSolverConf&)
 {

--- a/PlayRho/Dynamics/Joints/WeldJoint.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.hpp
@@ -42,6 +42,7 @@ public:
     WeldJoint(const WeldJointDef& def);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;

--- a/PlayRho/Dynamics/Joints/WheelJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.cpp
@@ -64,6 +64,11 @@ void WheelJoint::Accept(JointVisitor& visitor) const
     visitor.Visit(*this);
 }
 
+void WheelJoint::Accept(JointVisitor& visitor)
+{
+    visitor.Visit(*this);
+}
+
 void WheelJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepConf& step, const ConstraintSolverConf&)
 {
     auto& bodyConstraintA = At(bodies, GetBodyA());
@@ -320,11 +325,6 @@ Momentum2 WheelJoint::GetLinearReaction() const
     return m_impulse * m_ay + m_springImpulse * m_ax;
 }
 
-AngularMomentum WheelJoint::GetAngularReaction() const
-{
-    return m_motorImpulse;
-}
-
 void WheelJoint::EnableMotor(bool flag)
 {
     if (m_enableMotor != flag)
@@ -359,11 +359,6 @@ void WheelJoint::SetMaxMotorTorque(Torque torque)
     	GetBodyA()->SetAwake();
     	GetBodyB()->SetAwake();
     }
-}
-
-Torque WheelJoint::GetMotorTorque(Frequency inv_dt) const
-{
-    return inv_dt * m_motorImpulse;
 }
 
 Length GetJointTranslation(const WheelJoint& joint) noexcept

--- a/PlayRho/Dynamics/Joints/WheelJoint.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.hpp
@@ -47,6 +47,7 @@ public:
     WheelJoint(const WheelJointDef& def);
     
     void Accept(JointVisitor& visitor) const override;
+    void Accept(JointVisitor& visitor) override;
 
     Length2 GetAnchorA() const override;
     Length2 GetAnchorB() const override;
@@ -80,9 +81,6 @@ public:
 
     /// @brief Gets the maximum motor torque.
     Torque GetMaxMotorTorque() const;
-
-    /// Get the current motor torque given the inverse time step.
-    Torque GetMotorTorque(Frequency inv_dt) const;
 
     /// @brief Sets the spring frequency.
     /// @note Setting the frequency to zero disables the spring.
@@ -139,6 +137,11 @@ private:
     InvMass m_gamma = InvMass{0}; ///< Gamma.
 };
 
+inline AngularMomentum WheelJoint::GetAngularReaction() const
+{
+    return m_motorImpulse;
+}
+
 inline AngularVelocity WheelJoint::GetMotorSpeed() const
 {
     return m_motorSpeed;
@@ -178,6 +181,12 @@ Length GetJointTranslation(const WheelJoint& joint) noexcept;
 /// @brief Get the current joint translation speed.
 /// @relatedalso WheelJoint
 AngularVelocity GetAngularVelocity(const WheelJoint& joint) noexcept;
+
+/// @brief Gets the current motor torque for the given joint for the given the inverse time step.
+inline Torque GetMotorTorque(const WheelJoint& joint, Frequency inv_dt) noexcept
+{
+    return joint.GetAngularReaction() * inv_dt;
+}
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -762,8 +762,8 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
         void Visit(const MouseJoint& oldJoint) override
         {
             auto def = GetMouseJointDef(oldJoint);
-            def.bodyA = bodyMap.at(def.bodyA);
-            def.bodyB = bodyMap.at(def.bodyB);
+            def.bodyA = (def.bodyA)? bodyMap.at(def.bodyA): nullptr;
+            def.bodyB = (def.bodyB)? bodyMap.at(def.bodyB): nullptr;
             const auto newJoint = JointAtty::Create(def);
             if (newJoint != nullptr)
             {

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -687,7 +687,6 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             // Intentionally empty.
         }
 
-        /// @brief Visits a RevoluteJoint.
         void Visit(const RevoluteJoint& oldJoint) override
         {
             auto def = GetRevoluteJointDef(oldJoint);
@@ -701,7 +700,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a PrismaticJoint.
+        void Visit(RevoluteJoint& oldJoint) override
+        {
+            Visit(const_cast<const RevoluteJoint&>(oldJoint));
+        }
+
         void Visit(const PrismaticJoint& oldJoint) override
         {
             auto def = GetPrismaticJointDef(oldJoint);
@@ -715,7 +718,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a DistanceJoint.
+        void Visit(PrismaticJoint& oldJoint) override
+        {
+            Visit(const_cast<const PrismaticJoint&>(oldJoint));
+        }
+
         void Visit(const DistanceJoint& oldJoint) override
         {
             auto def = GetDistanceJointDef(oldJoint);
@@ -729,7 +736,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a PulleyJoint.
+        void Visit(DistanceJoint& oldJoint) override
+        {
+            Visit(const_cast<const DistanceJoint&>(oldJoint));
+        }
+
         void Visit(const PulleyJoint& oldJoint) override
         {
             auto def = GetPulleyJointDef(oldJoint);
@@ -743,7 +754,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a MouseJoint.
+        void Visit(PulleyJoint& oldJoint) override
+        {
+            Visit(const_cast<const PulleyJoint&>(oldJoint));
+        }
+
         void Visit(const MouseJoint& oldJoint) override
         {
             auto def = GetMouseJointDef(oldJoint);
@@ -757,7 +772,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a GearJoint.
+        void Visit(MouseJoint& oldJoint) override
+        {
+            Visit(const_cast<const MouseJoint&>(oldJoint));
+        }
+        
         void Visit(const GearJoint& oldJoint) override
         {
             auto def = GetGearJointDef(oldJoint);
@@ -773,7 +792,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a WheelJoint.
+        void Visit(GearJoint& oldJoint) override
+        {
+            Visit(const_cast<const GearJoint&>(oldJoint));
+        }
+
         void Visit(const WheelJoint& oldJoint) override
         {
             auto def = GetWheelJointDef(oldJoint);
@@ -787,7 +810,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
     
-        /// @brief Visits a WeldJoint.
+        void Visit(WheelJoint& oldJoint) override
+        {
+            Visit(const_cast<const WheelJoint&>(oldJoint));
+        }
+
         void Visit(const WeldJoint& oldJoint) override
         {
             auto def = GetWeldJointDef(oldJoint);
@@ -801,7 +828,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a FrictionJoint.
+        void Visit(WeldJoint& oldJoint) override
+        {
+            Visit(const_cast<const WeldJoint&>(oldJoint));
+        }
+
         void Visit(const FrictionJoint& oldJoint) override
         {
             auto def = GetFrictionJointDef(oldJoint);
@@ -815,7 +846,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a RopeJoint.
+        void Visit(FrictionJoint& oldJoint) override
+        {
+            Visit(const_cast<const FrictionJoint&>(oldJoint));
+        }
+
         void Visit(const RopeJoint& oldJoint) override
         {
             auto def = GetRopeJointDef(oldJoint);
@@ -829,7 +864,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
             }
         }
         
-        /// @brief Visits a MotorJoint.
+        void Visit(RopeJoint& oldJoint) override
+        {
+            Visit(const_cast<const RopeJoint&>(oldJoint));
+        }
+
         void Visit(const MotorJoint& oldJoint) override
         {
             auto def = GetMotorJointDef(oldJoint);
@@ -841,6 +880,11 @@ void World::CopyJoints(const std::map<const Body*, Body*>& bodyMap,
                 world.Add(newJoint, def.bodyA, def.bodyB);
                 jointMap[&oldJoint] = newJoint;
             }
+        }
+        
+        void Visit(MotorJoint& oldJoint) override
+        {
+            Visit(const_cast<const MotorJoint&>(oldJoint));
         }
         
         World& world;
@@ -1214,7 +1258,6 @@ RegStepStats World::SolveReg(const StepConf& conf)
     {
         auto& body = GetRef(b);
         assert(!body.IsAwake() || body.IsSpeedable());
-        assert(!body.IsAwake() || body.IsEnabled());
         if (!IsIslanded(&body) && body.IsAwake() && body.IsEnabled())
         {
             ++stats.islandsFound;
@@ -2765,8 +2808,9 @@ void World::DestroyProxies(Fixture& fixture)
         // Destroy proxies in reverse order from what they were created in.
         for (auto i = childCount - 1; i < childCount; --i)
         {
-            UnregisterForProcessing(proxies[i].treeId);
-            m_tree.DestroyLeaf(proxies[i].treeId);
+            const auto treeId = proxies[i].treeId;
+            UnregisterForProcessing(treeId);
+            m_tree.DestroyLeaf(treeId);
         }
     }
     FixtureAtty::ResetProxies(fixture);

--- a/Testbed/Framework/UiState.hpp
+++ b/Testbed/Framework/UiState.hpp
@@ -28,6 +28,7 @@ struct UiState
     bool showAboutTest = true;
     bool showStats = false;
     bool showContactsHistory = false;
+    bool showEntities = false;
 };
 
 #endif /* UiState_hpp */

--- a/Testbed/Framework/imgui.cpp
+++ b/Testbed/Framework/imgui.cpp
@@ -10163,6 +10163,24 @@ int ImGui::GetColumnsCount()
     return window->DC.ColumnsCount;
 }
 
+void ImGui::SetColumnWidths(float remainingWidth, std::initializer_list<float> widths)
+{
+    const auto numColumns = GetColumnsCount();
+    auto column = decltype(numColumns){0};
+    for (auto width: widths)
+    {
+        SetColumnWidth(column, width);
+        remainingWidth -= width;
+        ++column;
+    }
+    const auto remainingColumns = numColumns - column;
+    const auto widthPerRemainingColumn = remainingWidth / remainingColumns;
+    for (auto i = column; i < numColumns; ++i)
+    {
+        SetColumnWidth(i, widthPerRemainingColumn);
+    }
+}
+
 static float OffsetNormToPixels(ImGuiWindow* window, float offset_norm)
 {
     return offset_norm * (window->DC.ColumnsMaxX - window->DC.ColumnsMinX);

--- a/Testbed/Framework/imgui.h
+++ b/Testbed/Framework/imgui.h
@@ -16,6 +16,7 @@
 #include <stddef.h>         // ptrdiff_t, NULL
 #include <string.h>         // memset, memmove, memcpy, strlen, strchr, strcpy, strcmp
 #include <string>
+#include <initializer_list>
 
 #define IMGUI_VERSION       "1.52 WIP"
 
@@ -221,6 +222,19 @@ namespace ImGui
     // Parameters stacks (current window)
     IMGUI_API void          PushItemWidth(float item_width);                                    // width of items for the common item+label case, pixels. 0.0f = default to ~2/3 of windows width, >0.0f: width in pixels, <0.0f align xx pixels to the right of window (so -1.0f always align width to the right side)
     IMGUI_API void          PopItemWidth();
+    
+    struct ItemWidthContext
+    {
+        ItemWidthContext(float item_width)
+        {
+            PushItemWidth(item_width);
+        }
+        ~ItemWidthContext()
+        {
+            PopItemWidth();
+        }
+    };
+
     IMGUI_API float         CalcItemWidth();                                                    // width of item given pushed settings and current cursor position
     IMGUI_API void          PushTextWrapPos(float wrap_pos_x = 0.0f);                           // word-wrapping for Text*() commands. < 0.0f: no wrapping; 0.0f: wrap to end of window (or column); > 0.0f: wrap at 'wrap_pos_x' position in window local space
     IMGUI_API void          PopTextWrapPos();
@@ -249,8 +263,15 @@ namespace ImGui
     IMGUI_API void          Dummy(const ImVec2& size);                                          // add a dummy item of given size
     IMGUI_API void          Indent(float indent_w = 0.0f);                                      // move content position toward the right, by style.IndentSpacing or indent_w if >0
     IMGUI_API void          Unindent(float indent_w = 0.0f);                                    // move content position back to the left, by style.IndentSpacing or indent_w if >0
+    
     IMGUI_API void          BeginGroup();                                                       // lock horizontal starting position + capture group bounding box into one "item" (so you can use IsItemHovered() or layout primitives such as SameLine() on whole group, etc.)
     IMGUI_API void          EndGroup();
+    struct GroupContext
+    {
+        GroupContext() { BeginGroup(); }
+        ~GroupContext() { EndGroup(); }
+    };
+    
     IMGUI_API ImVec2        GetCursorPos();                                                     // cursor position is relative to window position
     IMGUI_API float         GetCursorPosX();                                                    // "
     IMGUI_API float         GetCursorPosY();                                                    // "
@@ -275,6 +296,8 @@ namespace ImGui
     IMGUI_API float         GetColumnOffset(int column_index = -1);                             // get position of column line (in pixels, from the left side of the contents region). pass -1 to use current column, otherwise 0..GetColumnsCount() inclusive. column 0 is typically 0.0f
     IMGUI_API void          SetColumnOffset(int column_index, float offset_x);                  // set position of column line (in pixels, from the left side of the contents region). pass -1 to use current column
     IMGUI_API int           GetColumnsCount();
+    
+    void SetColumnWidths(float remainingWidth, std::initializer_list<float> widths);
 
     class ColumnsContext
     {

--- a/Testbed/Tests/Bridge.hpp
+++ b/Testbed/Tests/Bridge.hpp
@@ -33,7 +33,7 @@ public:
     Bridge()
     {
         const auto ground = m_world.CreateBody();
-        ground->CreateFixture(std::make_shared<EdgeShape>(Vec2(-40, 0) * 1_m, Vec2(40, 0) * 1_m));
+        ground->CreateFixture(std::make_shared<EdgeShape>(GetGroundEdgeConf()));
 
         {
             auto conf = PolygonShape::Conf{};

--- a/Testbed/Tests/Cantilever.hpp
+++ b/Testbed/Tests/Cantilever.hpp
@@ -42,7 +42,7 @@ public:
         const auto ground = m_world.CreateBody();
 
         // Creates bottom ground
-        ground->CreateFixture(std::make_shared<EdgeShape>(Vec2(-40, 0) * 1_m, Vec2(40, 0) * 1_m));
+        ground->CreateFixture(std::make_shared<EdgeShape>(GetGroundEdgeConf()));
 
         // Creates left-end-fixed 8-part plank (below the top one)
         {

--- a/Testbed/Tests/Chain.hpp
+++ b/Testbed/Tests/Chain.hpp
@@ -30,7 +30,7 @@ public:
     Chain()
     {
         const auto ground = m_world.CreateBody();
-        ground->CreateFixture(std::make_shared<EdgeShape>(Vec2(-40, 0) * 1_m, Vec2(40, 0) * 1_m));
+        ground->CreateFixture(std::make_shared<EdgeShape>(GetGroundEdgeConf()));
         {
             const auto shape = std::make_shared<PolygonShape>(0.6_m, 0.125_m);
             shape->SetDensity(20_kgpm2);

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -54,7 +54,7 @@ public:
         
         RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Move selected shape left.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -64,7 +64,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_D, GLFW_PRESS, 0, "Move selected shape right.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -74,7 +74,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_W, GLFW_PRESS, 0, "Move selected shape up.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -84,7 +84,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_S, GLFW_PRESS, 0, "Move selected shape down.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -94,7 +94,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_Q, GLFW_PRESS, 0, "Move selected counter-clockwise.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -104,7 +104,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_E, GLFW_PRESS, 0, "Move selected clockwise.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -114,7 +114,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_KP_ADD, GLFW_PRESS, 0, "increase vertex radius of selected shape", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body && fixture)
             {
@@ -122,14 +122,15 @@ public:
                 auto polygon = *static_cast<const PolygonShape*>(shape.get());
                 polygon.SetVertexRadius(shape->GetVertexRadius() + RadiusIncrement);
                 const auto newf = body->CreateFixture(std::make_shared<PolygonShape>(polygon));
-                fixtures[0] = newf;
+                fixtures.erase(fixtures.begin());
+                fixtures.insert(newf);
                 SetSelectedFixtures(fixtures);
                 body->DestroyFixture(fixture);
             }
         });
         RegisterForKey(GLFW_KEY_KP_SUBTRACT, GLFW_PRESS, 0, "decrease vertex radius of selected shape", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? fixtures[0]: nullptr;
+            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body && fixture)
             {
@@ -143,7 +144,8 @@ public:
                     auto newf = body->CreateFixture(std::make_shared<PolygonShape>(polygon));
                     if (newf)
                     {
-                        fixtures[0] = newf;
+                        fixtures.erase(fixtures.begin());
+                        fixtures.insert(newf);
                         SetSelectedFixtures(fixtures);
                         body->DestroyFixture(fixture);
                     }

--- a/Testbed/Tests/HeavyOnLight.hpp
+++ b/Testbed/Tests/HeavyOnLight.hpp
@@ -66,7 +66,7 @@ public:
         if (newDensity != oldDensity)
         {
             auto selectedFixtures = GetSelectedFixtures();
-            const auto selectedFixture = selectedFixtures.size() == 1? selectedFixtures[0]: nullptr;
+            const auto selectedFixture = selectedFixtures.size() == 1? *(selectedFixtures.begin()): nullptr;
             const auto wasSelected = selectedFixture == m_top;
             const auto body = m_top->GetBody();
             body->DestroyFixture(m_top);
@@ -76,7 +76,8 @@ public:
             m_top = body->CreateFixture(std::make_shared<DiskShape>(conf));
             if (wasSelected)
             {
-                selectedFixtures[0] = m_top;
+                selectedFixtures.erase(selectedFixtures.begin());
+                selectedFixtures.insert(m_top);
                 SetSelectedFixtures(selectedFixtures);
             }
         }

--- a/Testbed/Tests/HeavyOnLightTwo.hpp
+++ b/Testbed/Tests/HeavyOnLightTwo.hpp
@@ -3,22 +3,24 @@
  * Modified work Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
 #ifndef PLAYRHO_HEAVY_ON_LIGHT_TWO_HPP
-#define  PLAYRHO_HEAVY_ON_LIGHT_TWO_HPP
+#define PLAYRHO_HEAVY_ON_LIGHT_TWO_HPP
 
 #include "../Framework/Test.hpp"
 
@@ -27,21 +29,11 @@ namespace playrho {
 class HeavyOnLightTwo : public Test
 {
 public:
-    
     HeavyOnLightTwo()
     {
-        const auto ground = m_world.CreateBody();
-        ground->CreateFixture(std::make_shared<EdgeShape>(Vec2(-40.0f, 0.0f) * 1_m, Vec2(40.0f, 0.0f) * 1_m));
-        
-        const auto shape = std::make_shared<DiskShape>(0.5_m);
-        shape->SetDensity(10_kgpm2);
-
-        const auto body1 = m_world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(Vec2(0.0f, 2.5f) * 1_m));
-        body1->CreateFixture(shape);
-        
-        const auto body2 = m_world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(Vec2(0.0f, 3.5f) * 1_m));
-        body2->CreateFixture(shape);
-        
+        m_world.CreateBody()->CreateFixture(std::make_shared<EdgeShape>(GetGroundEdgeConf()));
+        m_world.CreateBody(BodyDef{DynBD}.UseLocation(Length2{0_m, 2.5_m}))->CreateFixture(lilDisk);
+        m_world.CreateBody(BodyDef{DynBD}.UseLocation(Length2{0_m, 3.5_m}))->CreateFixture(lilDisk);
         RegisterForKey(GLFW_KEY_H, GLFW_PRESS, 0, "Toggle Heavy", [&](KeyActionMods) {
             ToggleHeavy();
         });
@@ -56,15 +48,15 @@ public:
         }
         else
         {
-            m_heavy = m_world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(Vec2(0.0f, 9.0f) * 1_m));
-            
-            auto conf = DiskShape::Conf{};
-            conf.density = 10_kgpm2;
-            conf.vertexRadius = 5_m;
-            m_heavy->CreateFixture(std::make_shared<DiskShape>(conf));
+            m_heavy = m_world.CreateBody(BodyDef{DynBD}.UseLocation(Length2{0_m, 9_m}));
+            m_heavy->CreateFixture(bigDisk);
         }
     }
     
+    const BodyDef DynBD = BodyDef{}.UseType(BodyType::Dynamic);
+    const DiskShape::Conf DiskDef = DiskShape::Conf{}.UseDensity(10_kgpm2);
+    const std::shared_ptr<DiskShape> lilDisk = std::make_shared<DiskShape>(0.5_m, DiskDef);
+    const std::shared_ptr<DiskShape> bigDisk = std::make_shared<DiskShape>(5.0_m, DiskDef);
     Body* m_heavy = nullptr;
 };
 

--- a/Testbed/Tests/Prismatic.hpp
+++ b/Testbed/Tests/Prismatic.hpp
@@ -75,7 +75,7 @@ public:
 
     void PostStep(const Settings& settings, Drawer&) override
     {
-        const auto force = m_joint->GetMotorForce((1.0f / settings.dt) * 1_Hz);
+        const auto force = GetMotorForce(*m_joint, (1.0f / settings.dt) * 1_Hz);
         std::stringstream stream;
         stream << "Motor Force: ";
         stream << static_cast<double>(Real{force / 1_N});

--- a/Testbed/Tests/SliderCrank.hpp
+++ b/Testbed/Tests/SliderCrank.hpp
@@ -116,7 +116,7 @@ public:
 
     void PostStep(const Settings& settings, Drawer&) override
     {
-        const auto torque = m_joint1->GetMotorTorque(1_Hz / settings.dt);
+        const auto torque = GetMotorTorque(*m_joint1, 1_Hz / settings.dt);
         std::stringstream stream;
         stream << "Motor Torque = ";
         stream << static_cast<double>(Real{torque / 1_Nm});

--- a/Testbed/Tests/VaryingFriction.hpp
+++ b/Testbed/Tests/VaryingFriction.hpp
@@ -30,7 +30,7 @@ public:
 
     VaryingFriction()
     {
-        m_world.CreateBody()->CreateFixture(std::make_shared<EdgeShape>(Vec2(-40, 0) * 1_m, Vec2(40, 0) * 1_m));
+        m_world.CreateBody()->CreateFixture(std::make_shared<EdgeShape>(GetGroundEdgeConf()));
         
         const auto sliderPlank = std::make_shared<PolygonShape>(13_m, 0.25_m);
         const auto sliderWall = std::make_shared<PolygonShape>(0.25_m, 1_m);

--- a/Testbed/Tests/VaryingRestitution.hpp
+++ b/Testbed/Tests/VaryingRestitution.hpp
@@ -33,7 +33,7 @@ public:
     VaryingRestitution()
     {
         const auto ground = m_world.CreateBody();
-        ground->CreateFixture(std::make_shared<EdgeShape>(Vec2(-40, 0) * 1_m, Vec2(40, 0) * 1_m));
+        ground->CreateFixture(std::make_shared<EdgeShape>(GetGroundEdgeConf()));
 
         const auto shapeConf = DiskShape::Conf{}.UseVertexRadius(1_m).UseDensity(1_kgpm2);
         auto shape = DiskShape(shapeConf);

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -200,9 +200,14 @@ TEST(Body, SetEnabled)
     World world;
     const auto body = world.CreateBody();
     const auto valid_shape = std::make_shared<DiskShape>(1_m);
-    ASSERT_NE(body->CreateFixture(valid_shape, FixtureDef{}), nullptr);
     
+    ASSERT_NE(body->CreateFixture(valid_shape, FixtureDef{}), nullptr);
+    ASSERT_TRUE(body->IsEnabled());
+
+    // Test that set enabled to flag already set is not a toggle
+    body->SetEnabled(true);
     EXPECT_TRUE(body->IsEnabled());
+
     body->SetEnabled(false);
     EXPECT_FALSE(body->IsEnabled());
     body->SetEnabled(true);
@@ -214,9 +219,14 @@ TEST(Body, SetFixedRotation)
     World world;
     const auto body = world.CreateBody();
     const auto valid_shape = std::make_shared<DiskShape>(1_m);
+
     ASSERT_NE(body->CreateFixture(valid_shape, FixtureDef{}), nullptr);
-    
+    ASSERT_FALSE(body->IsFixedRotation());
+
+    // Test that set fixed rotation to flag already set is not a toggle
+    body->SetFixedRotation(false);
     EXPECT_FALSE(body->IsFixedRotation());
+
     body->SetFixedRotation(true);
     EXPECT_TRUE(body->IsFixedRotation());
     body->SetFixedRotation(false);
@@ -475,6 +485,7 @@ TEST(Body, CalcGravitationalAcceleration)
 
     const auto l1 = Length2{-8_m, 0_m};
     const auto l2 = Length2{+8_m, 0_m};
+    const auto l3 = Length2{+16_m, 0_m};
 
     const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}
                                                    .UseVertexRadius(2_m)
@@ -491,4 +502,7 @@ TEST(Body, CalcGravitationalAcceleration)
                 0.032761313021183014, 0.000001);
     EXPECT_EQ(GetY(accel.linear), 0 * MeterPerSquareSecond);
     EXPECT_EQ(accel.angular, 0 * RadianPerSquareSecond);
+    
+    const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Static).UseLocation(l3));
+    EXPECT_EQ(CalcGravitationalAcceleration(*b3), Acceleration{});
 }

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -24,6 +24,7 @@
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Collision/Shapes/DiskShape.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 
 using namespace playrho;
 
@@ -94,6 +95,10 @@ TEST(DistanceJoint, Construction)
     EXPECT_EQ(joint.GetLength(), def.length);
     EXPECT_EQ(joint.GetFrequency(), def.frequency);
     EXPECT_EQ(joint.GetDampingRatio(), def.dampingRatio);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Distance);
 }
 
 TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)

--- a/UnitTests/Filter.cpp
+++ b/UnitTests/Filter.cpp
@@ -62,3 +62,17 @@ TEST(Filter, ShouldCollide)
     filter.groupIndex = Filter::index_type(-1);
     EXPECT_FALSE(ShouldCollide(filter, filter));
 }
+
+TEST(Filter, Equals)
+{
+    EXPECT_TRUE(  Filter{} == Filter{});
+    EXPECT_TRUE( (Filter{0x1u, 0x2u, -3}) == (Filter{0x1u, 0x2u, -3}));
+    EXPECT_FALSE((Filter{0x1u, 0x2u, -3}) == (Filter{0x3u, 0x2u, -1}));
+}
+
+TEST(Filter, NotEquals)
+{
+    EXPECT_FALSE( Filter{} != Filter{});
+    EXPECT_FALSE((Filter{0x1u, 0x2u, -3}) != (Filter{0x1u, 0x2u, -3}));
+    EXPECT_TRUE( (Filter{0x1u, 0x2u, -3}) != (Filter{0x3u, 0x2u, -1}));
+}

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Dynamics/Joints/FrictionJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Collision/Shapes/DiskShape.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
@@ -87,6 +88,10 @@ TEST(FrictionJoint, Construction)
     EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);
     EXPECT_EQ(joint.GetMaxForce(), def.maxForce);
     EXPECT_EQ(joint.GetMaxTorque(), def.maxTorque);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Friction);
 }
 
 TEST(FrictionJoint, GetFrictionJointDef)

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -23,6 +23,7 @@
 #include <PlayRho/Dynamics/Joints/GearJoint.hpp>
 #include <PlayRho/Dynamics/Joints/RevoluteJoint.hpp>
 #include <PlayRho/Dynamics/Joints/PrismaticJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/World.hpp>
@@ -103,6 +104,10 @@ TEST(GearJoint, Construction)
     EXPECT_EQ(joint.GetJoint1(), def.joint1);
     EXPECT_EQ(joint.GetJoint2(), def.joint2);
     EXPECT_EQ(joint.GetRatio(), def.ratio);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Gear);
 }
 
 TEST(GearJoint, SetRatio)

--- a/UnitTests/Joint.cpp
+++ b/UnitTests/Joint.cpp
@@ -114,3 +114,22 @@ TEST(Joint, GetWorldIndexFreeFunction)
 {
     EXPECT_EQ(GetWorldIndex(static_cast<const Joint*>(nullptr)), JointCounter(-1));
 }
+
+TEST(Joint, LimitStateToStringFF)
+{
+    const auto equalLimitsString = std::string(ToString(Joint::e_equalLimits));
+    const auto inactiveLimitString = std::string(ToString(Joint::e_inactiveLimit));
+    const auto upperLimitsString = std::string(ToString(Joint::e_atUpperLimit));
+    const auto lowerLimitsString = std::string(ToString(Joint::e_atLowerLimit));
+    
+    EXPECT_FALSE(equalLimitsString.empty());
+    EXPECT_FALSE(inactiveLimitString.empty());
+    EXPECT_FALSE(upperLimitsString.empty());
+    EXPECT_FALSE(lowerLimitsString.empty());
+    std::set<std::string> names;
+    names.insert(equalLimitsString);
+    names.insert(inactiveLimitString);
+    names.insert(upperLimitsString);
+    names.insert(lowerLimitsString);
+    EXPECT_EQ(names.size(), decltype(names.size()){4});
+}

--- a/UnitTests/JointType.cpp
+++ b/UnitTests/JointType.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "gtest/gtest.h"
+#include <PlayRho/Dynamics/Joints/JointType.hpp>
+
+using namespace playrho;
+
+TEST(JointType, ToString)
+{
+    EXPECT_STREQ(ToString(JointType::Revolute), "Revolute");
+    EXPECT_STREQ(ToString(JointType::Prismatic), "Prismatic");
+    EXPECT_STREQ(ToString(JointType::Distance), "Distance");
+    EXPECT_STREQ(ToString(JointType::Pulley), "Pulley");
+    EXPECT_STREQ(ToString(JointType::Mouse), "Mouse");
+    EXPECT_STREQ(ToString(JointType::Gear), "Gear");
+    EXPECT_STREQ(ToString(JointType::Wheel), "Wheel");
+    EXPECT_STREQ(ToString(JointType::Weld), "Weld");
+    EXPECT_STREQ(ToString(JointType::Friction), "Friction");
+    EXPECT_STREQ(ToString(JointType::Rope), "Rope");
+    EXPECT_STREQ(ToString(JointType::Motor), "Motor");
+    EXPECT_STREQ(ToString(JointType::Unknown), "Unknown");
+}

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 
 #include <PlayRho/Dynamics/Joints/MotorJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/World.hpp>
@@ -115,6 +116,10 @@ TEST(MotorJoint, Construction)
     EXPECT_EQ(joint.GetMaxForce(), def.maxForce);
     EXPECT_EQ(joint.GetMaxTorque(), def.maxTorque);
     EXPECT_EQ(joint.GetCorrectionFactor(), def.correctionFactor);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Motor);
 }
 
 TEST(MotorJoint, SetCorrectionFactor)
@@ -208,4 +213,26 @@ TEST(MotorJoint, SetLinearOffset)
     ASSERT_NE(jd.linearOffset, linearOffset);
     joint->SetLinearOffset(linearOffset);
     EXPECT_EQ(joint->GetLinearOffset(), linearOffset);
+}
+
+TEST(MotorJoint, SetAngularOffset)
+{
+    const auto circle = std::make_shared<DiskShape>(0.2_m);
+    auto world = World{WorldDef{}.UseGravity(LinearAcceleration2{})};
+    const auto p1 = Length2{-1_m, 0_m};
+    const auto p2 = Length2{+1_m, 0_m};
+    const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    b1->CreateFixture(circle);
+    b2->CreateFixture(circle);
+    //const auto anchor = Length2(2_m, 1_m);
+    const auto jd = MotorJointDef{b1, b2};
+    const auto joint = static_cast<MotorJoint*>(world.CreateJoint(jd));
+    ASSERT_NE(joint, nullptr);
+    EXPECT_EQ(joint->GetAnchorA(), p1);
+    EXPECT_EQ(joint->GetAnchorB(), p2);
+
+    ASSERT_EQ(joint->GetAngularOffset(), 0_deg);
+    joint->SetAngularOffset(45_deg);
+    EXPECT_EQ(joint->GetAngularOffset(), 45_deg);
 }

--- a/UnitTests/MouseJoint.cpp
+++ b/UnitTests/MouseJoint.cpp
@@ -65,7 +65,7 @@ TEST(MouseJoint, ByteSize)
 TEST(MouseJoint, DefaultInitialized)
 {
     const auto def = MouseJointDef{};
-    const auto joint = MouseJoint{def};
+    auto joint = MouseJoint{def};
     
     EXPECT_EQ(GetType(joint), JointType::Mouse);
     EXPECT_EQ(joint.GetBodyA(), def.bodyA);
@@ -85,6 +85,7 @@ TEST(MouseJoint, DefaultInitialized)
     TypeJointVisitor visitor;
     joint.Accept(visitor);
     EXPECT_EQ(visitor.GetType().value(), JointType::Mouse);
+    EXPECT_TRUE(visitor.GetWritable());
 }
 
 TEST(MouseJoint, GetLocalAnchorB)

--- a/UnitTests/MouseJoint.cpp
+++ b/UnitTests/MouseJoint.cpp
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Dynamics/Joints/MouseJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 
 using namespace playrho;
@@ -80,6 +81,10 @@ TEST(MouseJoint, DefaultInitialized)
     EXPECT_EQ(joint.GetMaxForce(), def.maxForce);
     EXPECT_EQ(joint.GetFrequency(), def.frequency);
     EXPECT_EQ(joint.GetDampingRatio(), def.dampingRatio);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Mouse);
 }
 
 TEST(MouseJoint, GetLocalAnchorB)

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Dynamics/Joints/PrismaticJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Collision/Shapes/DiskShape.hpp>
@@ -53,6 +54,13 @@ TEST(PrismaticJoint, EnableLimit)
     EXPECT_FALSE(joint.IsLimitEnabled());
     joint.EnableLimit(true);
     EXPECT_TRUE(joint.IsLimitEnabled());
+    EXPECT_EQ(joint.GetMotorImpulse(), Momentum{0});
+
+    EXPECT_EQ(GetMotorForce(joint, 1_Hz), 0 * Newton);
+
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Prismatic);
 }
 
 TEST(PrismaticJoint, EnableMotor)

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Dynamics/Joints/PulleyJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 
 using namespace playrho;
@@ -79,6 +80,10 @@ TEST(PulleyJoint, Construction)
     EXPECT_EQ(joint.GetLengthA(), def.lengthA);
     EXPECT_EQ(joint.GetLengthB(), def.lengthB);
     EXPECT_EQ(joint.GetRatio(), def.ratio);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Pulley);
 }
 
 TEST(PulleyJoint, GetAnchorAandB)

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -65,7 +65,7 @@ TEST(RevoluteJoint, Construction)
     jd.upperAngle = 40_deg;
     jd.referenceAngle = 45_deg;
     
-    const auto joint = RevoluteJoint{jd};
+    auto joint = RevoluteJoint{jd};
 
     EXPECT_EQ(GetType(joint), jd.type);
     EXPECT_EQ(joint.GetBodyA(), jd.bodyA);

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -20,6 +20,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Dynamics/Joints/RevoluteJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
@@ -83,6 +84,14 @@ TEST(RevoluteJoint, Construction)
     EXPECT_EQ(joint.IsMotorEnabled(), jd.enableMotor);
     EXPECT_EQ(joint.GetMaxMotorTorque(), jd.maxMotorTorque);
     EXPECT_EQ(joint.IsLimitEnabled(), jd.enableLimit);
+    EXPECT_EQ(joint.GetMotorImpulse(), AngularMomentum{0});
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Revolute);
+    
+    EXPECT_EQ(GetMotorTorque(joint, 1_Hz), 0 * NewtonMeter);
+    EXPECT_EQ(GetAngularVelocity(joint), 0 * RadianPerSecond);
 }
 
 TEST(RevoluteJoint, EnableMotor)

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 
 #include <PlayRho/Dynamics/Joints/RopeJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/World.hpp>
@@ -81,6 +82,11 @@ TEST(RopeJoint, Construction)
     EXPECT_EQ(joint.GetLocalAnchorA(), def.localAnchorA);
     EXPECT_EQ(joint.GetLocalAnchorB(), def.localAnchorB);
     EXPECT_EQ(joint.GetMaxLength(), def.maxLength);
+    EXPECT_EQ(joint.GetLimitState(), Joint::e_inactiveLimit);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Rope);
 }
 
 TEST(RopeJoint, GetRopeJointDef)

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 
 #include <PlayRho/Dynamics/Joints/WeldJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/World.hpp>
@@ -85,6 +86,10 @@ TEST(WeldJoint, Construction)
     EXPECT_EQ(joint.GetReferenceAngle(), def.referenceAngle);
     EXPECT_EQ(joint.GetFrequency(), def.frequency);
     EXPECT_EQ(joint.GetDampingRatio(), def.dampingRatio);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Weld);
 }
 
 TEST(WeldJoint, GetWeldJointDef)

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 
 #include <PlayRho/Dynamics/Joints/WheelJoint.hpp>
+#include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/World.hpp>
@@ -91,6 +92,12 @@ TEST(WheelJoint, Construction)
     EXPECT_EQ(joint.GetMotorSpeed(), def.motorSpeed);
     EXPECT_EQ(joint.GetSpringFrequency(), def.frequency);
     EXPECT_EQ(joint.GetSpringDampingRatio(), def.dampingRatio);
+    
+    TypeJointVisitor visitor;
+    joint.Accept(visitor);
+    EXPECT_EQ(visitor.GetType().value(), JointType::Wheel);
+    
+    EXPECT_EQ(GetMotorTorque(joint, 1_Hz), 0 * NewtonMeter);
 }
 
 TEST(WheelJoint, EnableMotor)
@@ -245,7 +252,7 @@ TEST(WheelJoint, WithDynamicCircles)
     b2->CreateFixture(circle);
     const auto anchor = Length2(2_m, 1_m);
     const auto jd = WheelJointDef{b1, b2, anchor, UnitVec2::GetRight()};
-    world.CreateJoint(jd);
+    const auto joint = static_cast<WheelJoint*>(world.CreateJoint(jd));
     Step(world, 1_s);
     EXPECT_NEAR(double(Real{GetX(b1->GetLocation()) / Meter}), -1.0, 0.001);
     EXPECT_NEAR(double(Real{GetY(b1->GetLocation()) / Meter}), 0.0, 0.001);
@@ -253,4 +260,5 @@ TEST(WheelJoint, WithDynamicCircles)
     EXPECT_NEAR(double(Real{GetY(b2->GetLocation()) / Meter}), 0.0, 0.01);
     EXPECT_EQ(b1->GetAngle(), Angle{0});
     EXPECT_EQ(b2->GetAngle(), Angle{0});
+    EXPECT_EQ(GetAngularVelocity(*joint), 0 * RadianPerSecond);
 }

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -35,6 +35,10 @@
 #include <PlayRho/Dynamics/Joints/PrismaticJoint.hpp>
 #include <PlayRho/Dynamics/Joints/DistanceJoint.hpp>
 #include <PlayRho/Dynamics/Joints/PulleyJoint.hpp>
+#include <PlayRho/Dynamics/Joints/WeldJoint.hpp>
+#include <PlayRho/Dynamics/Joints/FrictionJoint.hpp>
+#include <PlayRho/Dynamics/Joints/MotorJoint.hpp>
+#include <PlayRho/Dynamics/Joints/WheelJoint.hpp>
 #include <PlayRho/Common/LengthError.hpp>
 #include <PlayRho/Common/WrongState.hpp>
 #include <chrono>
@@ -242,14 +246,31 @@ TEST(World, CopyConstruction)
     b1->CreateFixture(shape);
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
     b2->CreateFixture(shape);
+    
+    // Add another body on top of previous and that's not part of any joints to ensure at 1 contact
+    const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
+    b3->CreateFixture(shape);
+
+    const auto b4 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
+    b4->CreateFixture(shape);
+    const auto b5 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic));
+    b5->CreateFixture(shape);
 
     world.CreateJoint(RevoluteJointDef{b1, b2, Length2{}});
     world.CreateJoint(PrismaticJointDef{b1, b2, Length2{}, UnitVec2::GetRight()});
     world.CreateJoint(PulleyJointDef{b1, b2, Length2{}, Length2{},
         Length2{}, Length2{}}.UseRatio(Real(1)));
-    
+    world.CreateJoint(DistanceJointDef{b4, b5});
+    world.CreateJoint(WeldJointDef{b4, b5, Length2{}});
+    world.CreateJoint(FrictionJointDef{b4, b5, Length2{}});
+    world.CreateJoint(RopeJointDef{b4, b5});
+    world.CreateJoint(MotorJointDef{b4, b5});
+    world.CreateJoint(WheelJointDef{b4, b5, Length2{}, UnitVec2::GetRight()});
+    world.CreateJoint(MouseJointDef{b4});
+
     auto stepConf = StepConf{};
     world.Step(stepConf);
+    ASSERT_FALSE(world.GetContacts().empty());
 
     {
         const auto copy = World{world};


### PR DESCRIPTION
#### Description - What's this PR do?
- Adds an entity editor to the Testbed for live updating and observation of PlayRho entities.
- Fixes assertion code in the math `Cross` function.
- Adds defensive code to `CalcGravitationalAcceleration` to avoid division by zero.
- Adds a couple more unit entries to facilitate usage of units.
- Adds mutable Joint visitation.
- Adds ==, != support to `Filter` class.
- Refactors joint methods that took `Frequency` input into methods that returned member data and free functions that used them along with the `Frequency` as free function substitutes for the former.
- Moves entity based UI code out from `Test` and into `main.cpp`.
- Adds lots more entity UI code into `main.cpp` to provide the new Entities Editor window to the Testbed.