### PR TITLE
Changes for 2d vs 3d

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -202,7 +202,7 @@ static void FloatPositiveFmod(benchmark::State& state)
     }
 }
 
-static void AABB(benchmark::State& state)
+static void AABB2D(benchmark::State& state)
 {
     const auto pui0 = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
     const auto pui1 = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
@@ -215,8 +215,8 @@ static void AABB(benchmark::State& state)
     
     while (state.KeepRunning())
     {
-        const auto aabb0 = playrho::AABB{p0, p1};
-        const auto aabb1 = playrho::AABB{p2, p3};
+        const auto aabb0 = playrho::AABB2D{p0, p1};
+        const auto aabb1 = playrho::AABB2D{p2, p3};
         benchmark::DoNotOptimize(playrho::TestOverlap(aabb0, aabb1));
         benchmark::DoNotOptimize(playrho::Contains(aabb0, aabb1));
     }
@@ -1238,7 +1238,7 @@ public:
     Tumbler();
     void Step();
     void AddSquare();
-    bool IsWithin(const playrho::AABB& aabb) const;
+    bool IsWithin(const playrho::AABB2D& aabb) const;
 
 private:
     static playrho::Body* CreateEnclosure(playrho::World& world);
@@ -1310,7 +1310,7 @@ void Tumbler::AddSquare()
     b->CreateFixture(m_square);
 }
 
-bool Tumbler::IsWithin(const playrho::AABB& aabb) const
+bool Tumbler::IsWithin(const playrho::AABB2D& aabb) const
 {
     return playrho::Contains(aabb, GetAABB(m_world.GetTree()));
 }
@@ -1324,7 +1324,7 @@ static void TumblerAddSquaresForSteps(benchmark::State& state,
     const auto rangeY = playrho::Interval<playrho::Length>{
         -5 * playrho::Meter, +25 * playrho::Meter
     };
-    const auto aabb = playrho::AABB{rangeX, rangeY};
+    const auto aabb = playrho::AABB2D{rangeX, rangeY};
     while (state.KeepRunning())
     {
         Tumbler tumbler;
@@ -1380,7 +1380,7 @@ BENCHMARK(FloatCos);
 BENCHMARK(FloatSinCos);
 BENCHMARK(FloatAtan2);
 
-BENCHMARK(AABB);
+BENCHMARK(AABB2D);
 
 BENCHMARK(DotProduct);
 BENCHMARK(CrossProduct);

--- a/PlayRho/Collision/AABB.cpp
+++ b/PlayRho/Collision/AABB.cpp
@@ -29,10 +29,10 @@
 
 namespace playrho {
 
-AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept
+AABB2D ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept
 {
     assert(IsValid(xf));
-    auto result = AABB{};
+    auto result = AABB2D{};
     const auto count = proxy.GetVertexCount();
     for (auto i = decltype(count){0}; i < count; ++i)
     {
@@ -41,12 +41,12 @@ AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept
     return GetFattenedAABB(result, proxy.GetVertexRadius());
 }
 
-AABB ComputeAABB(const DistanceProxy& proxy,
-                 const Transformation& xfm0, const Transformation& xfm1) noexcept
+AABB2D ComputeAABB(const DistanceProxy& proxy,
+                   const Transformation& xfm0, const Transformation& xfm1) noexcept
 {
     assert(IsValid(xfm0));
     assert(IsValid(xfm1));
-    auto result = AABB{};
+    auto result = AABB2D{};
     const auto count = proxy.GetVertexCount();
     for (auto i = decltype(count){0}; i < count; ++i)
     {
@@ -57,9 +57,9 @@ AABB ComputeAABB(const DistanceProxy& proxy,
     return GetFattenedAABB(result, proxy.GetVertexRadius());
 }
 
-AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept
+AABB2D ComputeAABB(const Shape& shape, const Transformation& xf) noexcept
 {
-    auto sum = AABB{};
+    auto sum = AABB2D{};
     const auto childCount = shape.GetChildCount();
     for (auto i = decltype(childCount){0}; i < childCount; ++i)
     {
@@ -68,14 +68,14 @@ AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept
     return sum;
 }
 
-AABB ComputeAABB(const Fixture& fixture) noexcept
+AABB2D ComputeAABB(const Fixture& fixture) noexcept
 {
     return ComputeAABB(*fixture.GetShape(), fixture.GetBody()->GetTransformation());
 }
 
-AABB ComputeAABB(const Body& body)
+AABB2D ComputeAABB(const Body& body)
 {
-    auto sum = AABB{};
+    auto sum = AABB2D{};
     const auto xf = body.GetTransformation();
     for (auto&& f: body.GetFixtures())
     {
@@ -84,7 +84,7 @@ AABB ComputeAABB(const Body& body)
     return sum;
 }
 
-AABB ComputeIntersectingAABB(const Fixture& fA, ChildCounter iA,
+AABB2D ComputeIntersectingAABB(const Fixture& fA, ChildCounter iA,
                              const Fixture& fB, ChildCounter iB) noexcept
 {
     const auto xA = fA.GetBody()->GetTransformation();
@@ -96,7 +96,7 @@ AABB ComputeIntersectingAABB(const Fixture& fA, ChildCounter iA,
     return GetIntersectingAABB(aabbA, aabbB);
 }
 
-AABB ComputeIntersectingAABB(const Contact& contact)
+AABB2D ComputeIntersectingAABB(const Contact& contact)
 {
     return ComputeIntersectingAABB(*contact.GetFixtureA(), contact.GetChildIndexA(),
                                    *contact.GetFixtureB(), contact.GetChildIndexB());

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -158,14 +158,14 @@ void DynamicTree::SetNodeCapacity(Size value) noexcept
     m_freeListIndex = m_nodeCount;
 }
 
-DynamicTree::Size DynamicTree::AllocateNode(const LeafData& node, AABB aabb) noexcept
+DynamicTree::Size DynamicTree::AllocateNode(const LeafData& node, AABB2D aabb) noexcept
 {
     const auto index = AllocateNode();
     m_nodes[index] = TreeNode{node, aabb};
     return index;
 }
 
-DynamicTree::Size DynamicTree::AllocateNode(const BranchData& node, AABB aabb,
+DynamicTree::Size DynamicTree::AllocateNode(const BranchData& node, AABB2D aabb,
                                             Height height, Size parent) noexcept
 {
     assert(height > 0);
@@ -226,7 +226,7 @@ DynamicTree::Size DynamicTree::FindReference(Size index) const noexcept
     return (it != m_nodes + m_nodeCapacity)? static_cast<Size>(it - m_nodes): GetInvalidSize();
 }
 
-DynamicTree::Size DynamicTree::CreateLeaf(const AABB& aabb, LeafData leafData)
+DynamicTree::Size DynamicTree::CreateLeaf(const AABB2D& aabb, LeafData leafData)
 {
     assert(IsValid(aabb));
     const auto index = AllocateNode(leafData, aabb);
@@ -247,7 +247,7 @@ void DynamicTree::DestroyLeaf(Size index)
     FreeNode(index);
 }
 
-void DynamicTree::UpdateLeaf(Size index, const AABB& aabb)
+void DynamicTree::UpdateLeaf(Size index, const AABB2D& aabb)
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
@@ -258,7 +258,7 @@ void DynamicTree::UpdateLeaf(Size index, const AABB& aabb)
     InsertLeaf(index);
 }
 
-DynamicTree::Size DynamicTree::FindLowestCostNode(AABB leafAABB) const noexcept
+DynamicTree::Size DynamicTree::FindLowestCostNode(AABB2D leafAABB) const noexcept
 {
     assert(m_root != GetInvalidSize());
     assert(IsValid(leafAABB));
@@ -780,7 +780,7 @@ void DynamicTree::ShiftOrigin(Length2 newOrigin)
 
 // Free functions...
 
-void Query(const DynamicTree& tree, const AABB& aabb, const DynamicTreeSizeCB& callback)
+void Query(const DynamicTree& tree, const AABB2D& aabb, const DynamicTreeSizeCB& callback)
 {
     GrowableStack<DynamicTree::Size, 256> stack;
     stack.push(tree.GetRootIndex());
@@ -831,7 +831,7 @@ void RayCast(const DynamicTree& tree, const RayCastInput& input,
     auto maxFraction = input.maxFraction;
     
     // Build a bounding box for the segment.
-    auto segmentAABB = AABB{p1, p1 + maxFraction * delta};
+    auto segmentAABB = AABB2D{p1, p1 + maxFraction * delta};
     
     GrowableStack<DynamicTree::Size, 256> stack;
     stack.push(tree.GetRootIndex());
@@ -884,7 +884,7 @@ void RayCast(const DynamicTree& tree, const RayCastInput& input,
                 // Update segment bounding box.
                 maxFraction = value;
                 const auto t = p1 + maxFraction * (p2 - p1);
-                segmentAABB = AABB{p1, t};
+                segmentAABB = AABB2D{p1, t};
             }
         }
     }

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -125,7 +125,7 @@ public:
     /// @post If the root index had been the GetInvalidSize(), then it will be set to the index
     ///   returned from this method.
     /// @return Index of the created leaf node.
-    Size CreateLeaf(const AABB& aabb, LeafData leafData);
+    Size CreateLeaf(const AABB2D& aabb, LeafData leafData);
 
     /// @brief Destroys a leaf node.
     /// @warning Behavior is undefined if the given index is not valid.
@@ -135,7 +135,7 @@ public:
     /// @warning Behavior is undefined if the given index is not valid.
     /// @param index Leaf node's ID. Behavior is undefined if this is not a valid ID.
     /// @param aabb New axis aligned bounding box for the leaf node.
-    void UpdateLeaf(Size index, const AABB& aabb);
+    void UpdateLeaf(Size index, const AABB2D& aabb);
 
     /// @brief Gets the user data for the node identified by the given identifier.
     /// @warning Behavior is undefined if the given index is not valid.
@@ -149,7 +149,7 @@ public:
     /// @brief Gets the AABB for a leaf or branch (a non-unused node).
     /// @warning Behavior is undefined if the given index is not valid.
     /// @param index Leaf or branch node's ID. Must be a valid ID.
-    AABB GetAABB(Size index) const noexcept;
+    AABB2D GetAABB(Size index) const noexcept;
 
     /// @brief Gets the height value for the identified node.
     /// @warning Behavior is undefined if the given index is not valid.
@@ -217,7 +217,7 @@ public:
 
     /// @brief Finds the lowest cost node.
     /// @warning Behavior is undefined if the tree doesn't have a valid root.
-    Size FindLowestCostNode(AABB leafAABB) const noexcept;
+    Size FindLowestCostNode(AABB2D leafAABB) const noexcept;
 
 private:
     
@@ -231,12 +231,12 @@ private:
 
     /// @brief Allocates a leaf node.
     /// @details This allocates a node from the free list as a leaf node.
-    Size AllocateNode(const LeafData& node, AABB aabb) noexcept;
+    Size AllocateNode(const LeafData& node, AABB2D aabb) noexcept;
 
     /// @brief Allocates a branch node.
     /// @details This allocates a node from the free list as a branch node.
     /// @post The free list no longer references the returned index.
-    Size AllocateNode(const BranchData& node, AABB aabb, Height height,
+    Size AllocateNode(const BranchData& node, AABB2D aabb, Height height,
                       Size parent = GetInvalidSize()) noexcept;
     
     /// @brief Finds first node which references the given index.
@@ -292,7 +292,7 @@ private:
     void SetChild2(Size index, Size value) noexcept;
     
     /// @brief Sets the AABB of the node identified by the given index to the given value.
-    void SetAABB(Size index, AABB value) noexcept;
+    void SetAABB(Size index, AABB2D value) noexcept;
     
     /// @brief Swaps the child index of the node identified by the given index.
     void SwapChild(Size index, Size oldChild, Size newChild) noexcept;
@@ -447,7 +447,7 @@ public:
     }
 
     /// @brief Initializing constructor.
-    constexpr TreeNode(const LeafData& value, AABB aabb,
+    constexpr TreeNode(const LeafData& value, AABB2D aabb,
                        Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{0}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -455,7 +455,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr TreeNode(const BranchData& value, AABB aabb, Height height,
+    constexpr TreeNode(const BranchData& value, AABB2D aabb, Height height,
                        Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{height}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -513,13 +513,13 @@ public:
     }
 
     /// @brief Gets the node's AABB.
-    constexpr AABB GetAABB() const noexcept
+    constexpr AABB2D GetAABB() const noexcept
     {
         return m_aabb;
     }
 
     /// @brief Sets the node's AABB.
-    constexpr TreeNode& SetAABB(AABB value) noexcept
+    constexpr TreeNode& SetAABB(AABB2D value) noexcept
     {
         m_aabb = value;
         return *this;
@@ -605,7 +605,7 @@ private:
     Size m_other = DynamicTree::GetInvalidSize(); ///< Index of another node.
     
     /// @brief AABB.
-    AABB m_aabb;
+    AABB2D m_aabb;
     
     /// @brief Variant data for the node.
     VariantData m_variant;
@@ -650,7 +650,7 @@ inline void DynamicTree::SetHeight(Size index, Height value) noexcept
     m_nodes[index].SetHeight(value);
 }
 
-inline AABB DynamicTree::GetAABB(Size index) const noexcept
+inline AABB2D DynamicTree::GetAABB(Size index) const noexcept
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
@@ -658,7 +658,7 @@ inline AABB DynamicTree::GetAABB(Size index) const noexcept
     return m_nodes[index].GetAABB();
 }
 
-inline void DynamicTree::SetAABB(Size index, AABB value) noexcept
+inline void DynamicTree::SetAABB(Size index, AABB2D value) noexcept
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
@@ -757,7 +757,7 @@ constexpr inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
 
 /// @brief Gets the AABB of the given DynamicTree node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
+constexpr inline AABB2D GetAABB(const DynamicTree::TreeNode& node) noexcept
 {
     assert(!IsUnused(node));
     return node.GetAABB();
@@ -802,10 +802,10 @@ inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
 ///   given DynamicTree.
 /// @return Enclosing AABB or the "unset" AABB.
 /// @relatedalso DynamicTree
-inline AABB GetAABB(const DynamicTree& tree) noexcept
+inline AABB2D GetAABB(const DynamicTree& tree) noexcept
 {
     const auto index = tree.GetRootIndex();
-    return (index != DynamicTree::GetInvalidSize())? tree.GetAABB(index): AABB{};
+    return (index != DynamicTree::GetInvalidSize())? tree.GetAABB(index): AABB2D{};
 }
 
 /// @brief Tests for overlap of the elements identified in the given dynamic tree.
@@ -843,7 +843,7 @@ using DynamicTreeSizeCB = std::function<DynamicTreeOpcode(DynamicTree::Size)>;
 
 /// @brief Query the given dynamic tree and find nodes overlapping the given AABB.
 /// @note The callback instance is called for each leaf node that overlaps the supplied AABB.
-void Query(const DynamicTree& tree, const AABB& aabb,
+void Query(const DynamicTree& tree, const AABB2D& aabb,
            const DynamicTreeSizeCB& callback);
 
 /// @brief Ray-cast against the leafs in the given tree.

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -29,7 +29,7 @@
 
 namespace playrho {
 
-MassData GetMassData(Length r, NonNegative<Density> density, Length2 location)
+MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location)
 {
     // Uses parallel axis theorem, perpendicular axis theorem, and the second moment of area.
     // See: https://en.wikipedia.org/wiki/Second_moment_of_area
@@ -46,13 +46,13 @@ MassData GetMassData(Length r, NonNegative<Density> density, Length2 location)
     // Iz = Pi * r^2 * ((r^2 / 2) + (dx^2 + dy^2))
     const auto r_squared = r * r;
     const auto area = r_squared * Pi;
-    const auto mass = Mass{Density{density} * area};
+    const auto mass = Mass{AreaDensity{density} * area};
     const auto Iz = SecondMomentOfArea{area * ((r_squared / Real{2}) + GetLengthSquared(location))};
-    const auto I = RotInertia{Iz * Density{density} / SquareRadian};
+    const auto I = RotInertia{Iz * AreaDensity{density} / SquareRadian};
     return MassData{location, mass, I};
 }
 
-MassData GetMassData(Length r, NonNegative<Density> density, Length2 v0, Length2 v1)
+MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1)
 {
     const auto r_squared = Area{r * r};
     const auto circle_area = r_squared * Pi;
@@ -86,7 +86,7 @@ MassData GetMassData(Length r, NonNegative<Density> density, Length2 v0, Length2
     return MassData{center, totalMass, I};
 }
 
-MassData GetMassData(Length vertexRadius, NonNegative<Density> density,
+MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
                               Span<const Length2> vertices)
 {
     // See: https://en.wikipedia.org/wiki/Centroid#Centroid_of_polygon
@@ -159,7 +159,7 @@ MassData GetMassData(Length vertexRadius, NonNegative<Density> density,
     }
     
     // Total mass
-    const auto mass = Mass{Density{density} * area};
+    const auto mass = Mass{AreaDensity{density} * area};
     
     // Center of mass
     assert((area > Area{0}) && !AlmostZero(StripUnit(area)));
@@ -171,7 +171,7 @@ MassData GetMassData(Length vertexRadius, NonNegative<Density> density,
     const auto massCenterOffset = GetLengthSquared(massDataCenter);
     const auto centerOffset = GetLengthSquared(center);
     const auto intertialLever = massCenterOffset - centerOffset;
-    const auto massDataI = RotInertia{((Density{density} * I) + (mass * intertialLever)) / SquareRadian};
+    const auto massDataI = RotInertia{((AreaDensity{density} * I) + (mass * intertialLever)) / SquareRadian};
     
     return MassData{massDataCenter, mass, massDataI};
 }
@@ -189,7 +189,7 @@ MassData ComputeMassData(const Body& body) noexcept
     for (auto&& f: body.GetFixtures())
     {
         const auto& fixture = GetRef(f);
-        if (fixture.GetDensity() > Density{0})
+        if (fixture.GetDensity() > AreaDensity{0})
         {
             const auto massData = GetMassData(fixture);
             mass += Mass{massData.mass};

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -74,7 +74,7 @@ namespace playrho {
     ///
     /// @relatedalso MassData
     ///
-    MassData GetMassData(Length r, NonNegative<Density> density, Length2 location);
+    MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location);
 
     /// @brief Computes the mass data for a linear shape.
     ///
@@ -85,12 +85,12 @@ namespace playrho {
     ///
     /// @relatedalso MassData
     ///
-    MassData GetMassData(Length r, NonNegative<Density> density, Length2 v0, Length2 v1);
+    MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1);
 
     /// @brief Gets the mass data for the given collection of vertices with the given
     ///    properties.
     /// @relatedalso MassData
-    MassData GetMassData(Length vertexRadius, NonNegative<Density> density,
+    MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
                          Span<const Length2> vertices);
     
     /// @brief Computes the mass data for the given fixture.

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -63,7 +63,7 @@ RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input
     return RayCastOutput{};
 }
 
-RayCastOutput RayCast(const AABB& aabb, const RayCastInput& input) noexcept
+RayCastOutput RayCast(const AABB2D& aabb, const RayCastInput& input) noexcept
 {
     // From Real-time Collision Detection, p179.
 

--- a/PlayRho/Collision/RayCastOutput.hpp
+++ b/PlayRho/Collision/RayCastOutput.hpp
@@ -26,11 +26,11 @@
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/BoundedValue.hpp>
 #include <PlayRho/Common/OptionalValue.hpp>
+#include <PlayRho/Collision/AABB.hpp>
 
 namespace playrho
 {
     struct RayCastInput;
-    struct AABB;
     class Shape;
     class DistanceProxy;
     
@@ -66,7 +66,7 @@ namespace playrho
     /// @param aabb Axis Aligned Bounding Box.
     /// @param input the ray-cast input parameters.
     /// @relatedalso AABB
-    RayCastOutput RayCast(const AABB& aabb, const RayCastInput& input) noexcept;
+    RayCastOutput RayCast(const AABB2D& aabb, const RayCastInput& input) noexcept;
     
     /// @brief Cast a ray against the distance proxy.
     /// @param proxy Distance-proxy object (in local coordinates).

--- a/PlayRho/Collision/Shapes/ChainShape.cpp
+++ b/PlayRho/Collision/Shapes/ChainShape.cpp
@@ -73,7 +73,7 @@ ChainShape::ChainShape(const Conf& conf):
 MassData ChainShape::GetMassData() const noexcept
 {
     const auto density = GetDensity();
-    if (density > Density(0))
+    if (density > AreaDensity(0))
     {
         const auto vertexCount = GetVertexCount();
         if (vertexCount > 1)

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -109,13 +109,13 @@ public:
 
     /// @brief Gets the density of this fixture.
     /// @return Non-negative density (in mass per area).
-    NonNegative<Density> GetDensity() const noexcept;
+    NonNegative<AreaDensity> GetDensity() const noexcept;
 
     /// @brief Sets the density of this fixture.
     /// @note This will _not_ automatically adjust the mass of the body.
     ///   You must call Body::ResetMassData to update the body's mass.
     /// @param density Non-negative density (in mass per area).
-    void SetDensity(NonNegative<Density> density) noexcept;
+    void SetDensity(NonNegative<AreaDensity> density) noexcept;
     
     /// @brief Gets the coefficient of friction.
     /// @return Value of 0 or higher.
@@ -160,8 +160,8 @@ private:
     /// @brief Vertex radius.
     NonNegative<Length> m_vertexRadius = NonNegative<Length>{0_m};
     
-    /// @brief Density.
-    NonNegative<Density> m_density = NonNegative<Density>{0_kgpm2};
+    /// @brief AreaDensity.
+    NonNegative<AreaDensity> m_density = NonNegative<AreaDensity>{0_kgpm2};
     
     /// @brief Friction as a coefficient.
     NonNegative<Real> m_friction = NonNegative<Real>{Real{2} / Real{10}};
@@ -180,7 +180,7 @@ inline void Shape::SetVertexRadius(NonNegative<Length> vertexRadius) noexcept
     m_vertexRadius = vertexRadius;
 }
 
-inline NonNegative<Density> Shape::GetDensity() const noexcept
+inline NonNegative<AreaDensity> Shape::GetDensity() const noexcept
 {
     return m_density;
 }
@@ -195,7 +195,7 @@ inline Real Shape::GetRestitution() const noexcept
     return m_restitution;
 }
 
-inline void Shape::SetDensity(NonNegative<Density> density) noexcept
+inline void Shape::SetDensity(NonNegative<AreaDensity> density) noexcept
 {
     m_density = density;
 }

--- a/PlayRho/Collision/Shapes/ShapeDef.hpp
+++ b/PlayRho/Collision/Shapes/ShapeDef.hpp
@@ -62,12 +62,12 @@ struct ShapeDef
     ///
     Finite<Real> restitution = Finite<Real>{0};
     
-    /// @brief Density of the associated shape.
+    /// @brief AreaDensity of the associated shape.
     ///
     /// @note This must be a non-negative value.
     /// @note Use 0 to indicate that the shape's associated mass should be 0.
     ///
-    NonNegative<Density> density = NonNegative<Density>{0};
+    NonNegative<AreaDensity> density = NonNegative<AreaDensity>{0};
 };
 
 /// @brief Builder configuration structure.
@@ -98,7 +98,7 @@ struct ShapeDefBuilder: ShapeDef
     constexpr ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
     
     /// @brief Uses the given density.
-    constexpr ConcreteConf& UseDensity(NonNegative<Density> value) noexcept;
+    constexpr ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
 };
 
 template <typename ConcreteConf>
@@ -127,7 +127,7 @@ ShapeDefBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
 
 template <typename ConcreteConf>
 constexpr ConcreteConf&
-ShapeDefBuilder<ConcreteConf>::UseDensity(NonNegative<Density> value) noexcept
+ShapeDefBuilder<ConcreteConf>::UseDensity(NonNegative<AreaDensity> value) noexcept
 {
     density = value;
     return static_cast<ConcreteConf&>(*this);

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -171,7 +171,7 @@ namespace playrho
     /// @sa Area.
     /// @sa KilogramPerSquareMeter.
     /// @sa https://en.wikipedia.org/wiki/Area_density
-    using Density = PLAYRHO_QUANTITY(boost::units::si::surface_density);
+    using AreaDensity = PLAYRHO_QUANTITY(boost::units::si::surface_density);
     
     /// @brief Angle quantity.
     /// @details This is the type alias for the plane angle base quantity.
@@ -336,9 +336,9 @@ namespace playrho
     /// @brief Cubic meter unit of Volume.
     constexpr auto CubicMeter = Meter * Meter * Meter;
 
-    /// @brief Kilogram per square meter unit of Density.
-    /// @sa Density.
-    constexpr auto KilogramPerSquareMeter = PLAYRHO_UNIT(Density,
+    /// @brief Kilogram per square meter unit of AreaDensity.
+    /// @sa AreaDensity.
+    constexpr auto KilogramPerSquareMeter = PLAYRHO_UNIT(AreaDensity,
         boost::units::si::kilogram_per_square_meter);
 
     /// @brief Radian unit of Angle.
@@ -721,13 +721,13 @@ namespace playrho
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    constexpr Density operator"" _kgpm2(unsigned long long int v) noexcept
+    constexpr AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    constexpr Density operator"" _kgpm2(long double v) noexcept
+    constexpr AreaDensity operator"" _kgpm2(long double v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }

--- a/PlayRho/Dynamics/Fixture.cpp
+++ b/PlayRho/Dynamics/Fixture.cpp
@@ -59,7 +59,7 @@ Fixture::Fixture(const Fixture& other):
     }
 }
 
-Density Fixture::GetDensity() const noexcept
+AreaDensity Fixture::GetDensity() const noexcept
 {
     return m_shape->GetDensity();
 }

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -71,7 +71,7 @@ public:
     /// @param body Body the new fixture is to be associated with.
     /// @param def Initial fixture settings.
     ///    Friction must be greater-than-or-equal-to zero.
-    ///    Density must be greater-than-or-equal-to zero.
+    ///    AreaDensity must be greater-than-or-equal-to zero.
     /// @param shape Sharable shape to associate fixture with. Must be non-null.
     ///
     Fixture(NonNull<Body*> body, const FixtureDef& def, const std::shared_ptr<const Shape>& shape):
@@ -134,7 +134,7 @@ public:
 
     /// @brief Gets the density of this fixture.
     /// @return Non-negative density (in mass per area).
-    Density GetDensity() const noexcept;
+    AreaDensity GetDensity() const noexcept;
 
     /// @brief Gets the coefficient of friction.
     /// @return Value of 0 or higher.

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2087,7 +2087,7 @@ StepStats World::Step(const StepConf& conf)
     return stepStats;
 }
 
-void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
+void World::QueryAABB(const AABB2D& aabb, QueryFixtureCallback callback) const
 {
     Query(m_tree, aabb, [&](DynamicTree::Size treeId) {
         const auto leafData = m_tree.GetLeafData(treeId);

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2698,7 +2698,7 @@ Fixture* World::CreateFixture(Body& body, const std::shared_ptr<const Shape>& sh
     }
     
     // Adjust mass properties if needed.
-    if (fixture->GetDensity() > Density{0})
+    if (fixture->GetDensity() > AreaDensity{0})
     {
         BodyAtty::SetMassDataDirty(body);
         if (resetMassData)

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -215,7 +215,7 @@ public:
     /// @brief Queries the world for all fixtures that potentially overlap the provided AABB.
     /// @param aabb the query box.
     /// @param callback User implemented callback function.
-    void QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const;
+    void QueryAABB(const AABB2D& aabb, QueryFixtureCallback callback) const;
 
     /// @brief Ray-cast operation code.
     ///

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -139,7 +139,7 @@ Length2 ConvertScreenToWorld(const Camera& camera, const Coord2D ps)
     return Length2{x * Meter, y * Meter};
 }
 
-AABB ConvertScreenToWorld(const Camera& camera)
+AABB2D ConvertScreenToWorld(const Camera& camera)
 {
     const auto w = float(camera.m_width);
     const auto h = float(camera.m_height);
@@ -150,7 +150,7 @@ AABB ConvertScreenToWorld(const Camera& camera)
     const auto lower = camera.m_center - extents;
     const auto upper = camera.m_center + extents;
     
-    return AABB{
+    return AABB2D{
         Length2{Real{lower.x} * Meter, Real{lower.y} * Meter},
         Length2{Real{upper.x} * Meter, Real{upper.y} * Meter}
     };

--- a/Testbed/Framework/DebugDraw.hpp
+++ b/Testbed/Framework/DebugDraw.hpp
@@ -29,8 +29,6 @@ struct GLRenderPoints;
 struct GLRenderLines;
 struct GLRenderTriangles;
 
-struct AABB;
-
 struct ProjectionMatrix
 {
     float m[16];
@@ -82,7 +80,7 @@ struct Camera
 };
 
 Length2 ConvertScreenToWorld(const Camera& camera, const Coord2D screenPoint);
-AABB ConvertScreenToWorld(const Camera& camera);
+AABB2D ConvertScreenToWorld(const Camera& camera);
 Coord2D ConvertWorldToScreen(const Camera& camera, const Length2 worldPoint);
 ProjectionMatrix GetProjectionMatrix(const Camera& camera, float zBias);
 

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -285,13 +285,13 @@ static void Draw(Drawer& drawer, const Joint& joint)
     }
 }
 
-static void Draw(Drawer& drawer, const AABB& aabb, const Color& color)
+static void Draw(Drawer& drawer, const AABB2D& aabb, const Color& color)
 {
     Length2 vs[4];
-    vs[0] = Length2{aabb.rangeX.GetMin(), aabb.rangeY.GetMin()};
-    vs[1] = Length2{aabb.rangeX.GetMax(), aabb.rangeY.GetMin()};
-    vs[2] = Length2{aabb.rangeX.GetMax(), aabb.rangeY.GetMax()};
-    vs[3] = Length2{aabb.rangeX.GetMin(), aabb.rangeY.GetMax()};
+    vs[0] = Length2{aabb.ranges[0].GetMin(), aabb.ranges[1].GetMin()};
+    vs[1] = Length2{aabb.ranges[0].GetMax(), aabb.ranges[1].GetMin()};
+    vs[2] = Length2{aabb.ranges[0].GetMax(), aabb.ranges[1].GetMax()};
+    vs[3] = Length2{aabb.ranges[0].GetMin(), aabb.ranges[1].GetMax()};
     drawer.DrawPolygon(vs, 4, color);
 }
 
@@ -489,7 +489,7 @@ void Test::MouseDown(const Length2& p)
     }
 
     // Make a small box.
-    const auto aabb = GetFattenedAABB(AABB{p}, 1_m / 1000);
+    const auto aabb = GetFattenedAABB(AABB2D{p}, 1_m / 1000);
 
     auto fixtures = FixtureSet{};
 

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -334,7 +334,7 @@ private:
 
     FixtureSet m_selectedFixtures;
     BodySet m_selectedBodies;
-    AABB m_maxAABB;
+    AABB2D m_maxAABB;
     ContactPoints m_points;
     DestructionListenerImpl m_destructionListener;
     Body* m_bomb = nullptr;

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -48,7 +48,7 @@ public:
         m_stepCount = 0;
 
         const auto h = m_worldExtent;
-        m_queryAABB = AABB{Vec2(-3.0f, -4.0f + h) * 1_m, Vec2(5.0f, 6.0f + h) * 1_m};
+        m_queryAABB = AABB2D{Vec2(-3.0f, -4.0f + h) * 1_m, Vec2(5.0f, 6.0f + h) * 1_m};
 
         m_rayCastInput.p1 = Vec2(-5.0f, 5.0f + h) * 1_m;
         m_rayCastInput.p2 = Vec2(7.0f, -4.0f + h) * 1_m;
@@ -206,23 +206,23 @@ private:
 
     struct Actor
     {
-        AABB aabb;
+        AABB2D aabb;
         Real fraction;
         bool overlap;
         DynamicTree::Size treeId;
     };
 
-    AABB GetRandomAABB()
+    AABB2D GetRandomAABB()
     {
         const auto w = Vec2(m_proxyExtent * 2, m_proxyExtent * 2) * 1_m;
         //aabb->lowerBound.x = -m_proxyExtent;
         //aabb->lowerBound.y = -m_proxyExtent + m_worldExtent;
         const auto lowerBound = Vec2(RandomFloat(-m_worldExtent, m_worldExtent), RandomFloat(0.0f, 2.0f * m_worldExtent)) * 1_m;
         const auto upperBound = lowerBound + w;
-        return AABB{lowerBound, upperBound};
+        return AABB2D{lowerBound, upperBound};
     }
 
-    void MoveAABB(AABB* aabb)
+    void MoveAABB(AABB2D* aabb)
     {
         const auto d = Vec2{RandomFloat(-0.5f, 0.5f), RandomFloat(-0.5f, 0.5f)} * 1_m;
         //d.x = 2.0f;
@@ -371,7 +371,7 @@ private:
     Real m_proxyExtent;
 
     DynamicTree m_tree;
-    AABB m_queryAABB;
+    AABB2D m_queryAABB;
     RayCastInput m_rayCastInput;
     RayCastOutput m_rayCastOutput;
     Actor* m_rayActor;

--- a/Testbed/Tests/HeavyOnLight.hpp
+++ b/Testbed/Tests/HeavyOnLight.hpp
@@ -59,7 +59,7 @@ public:
         });
     }
 
-    void ChangeDensity(Density change)
+    void ChangeDensity(AreaDensity change)
     {
         const auto oldDensity = m_top->GetShape()->GetDensity();
         const auto newDensity = std::max(oldDensity + change, 1_kgpm2);
@@ -86,7 +86,7 @@ public:
     void PostStep(const Settings&, Drawer&) override
     {
         std::stringstream stream;
-        stream << "Density of top shape: ";
+        stream << "Area density of top shape: ";
         stream << double(Real{m_top->GetShape()->GetDensity() / 1_kgpm2});
         stream << " kg/m^2.";
         m_status = stream.str();

--- a/Testbed/Tests/MobileBalanced.hpp
+++ b/Testbed/Tests/MobileBalanced.hpp
@@ -33,7 +33,7 @@ public:
         e_depth = 4
     };
 
-    const Density density = 20_kgpm2;
+    const AreaDensity density = 20_kgpm2;
 
     MobileBalanced()
     {

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -33,98 +33,98 @@
 
 using namespace playrho;
 
-TEST(AABB, ByteSizeIsTwiceVec2)
+TEST(AABB2D, ByteSizeIsTwiceVec2)
 {
-    EXPECT_EQ(sizeof(AABB), sizeof(Vec2) * 2);
+    EXPECT_EQ(sizeof(AABB2D), sizeof(Vec2) * 2);
 }
 
-TEST(AABB, DefaultConstruction)
+TEST(AABB2D, DefaultConstruction)
 {
     const auto infinity = std::numeric_limits<Real>::infinity();
     const auto lb = Vec2{infinity, infinity} * Meter;
     const auto ub = Vec2{-infinity, -infinity} * Meter;
-    const auto aabb = AABB{};
+    const auto aabb = AABB2D{};
     EXPECT_EQ(GetLowerBound(aabb), lb);
     EXPECT_EQ(GetUpperBound(aabb), ub);
 }
 
-TEST(AABB, Traits)
+TEST(AABB2D, Traits)
 {
-    EXPECT_TRUE(std::is_default_constructible<AABB>::value);
-    //EXPECT_TRUE(std::is_nothrow_default_constructible<AABB>::value);
-    EXPECT_FALSE(std::is_trivially_default_constructible<AABB>::value);
+    EXPECT_TRUE(std::is_default_constructible<AABB2D>::value);
+    //EXPECT_TRUE(std::is_nothrow_default_constructible<AABB2D>::value);
+    EXPECT_FALSE(std::is_trivially_default_constructible<AABB2D>::value);
 
-    EXPECT_TRUE((std::is_constructible<AABB, Length2>::value));
-    //EXPECT_FALSE((std::is_nothrow_constructible<AABB, Length2>::value));
-    EXPECT_FALSE((std::is_trivially_constructible<AABB, Length2>::value));
+    EXPECT_TRUE((std::is_constructible<AABB2D, Length2>::value));
+    //EXPECT_FALSE((std::is_nothrow_constructible<AABB2D, Length2>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<AABB2D, Length2>::value));
     
-    EXPECT_TRUE((std::is_constructible<AABB, Length2, Length2>::value));
-    //EXPECT_FALSE((std::is_nothrow_constructible<AABB, Length2, Length2>::value));
-    EXPECT_FALSE((std::is_trivially_constructible<AABB, Length2, Length2>::value));
+    EXPECT_TRUE((std::is_constructible<AABB2D, Length2, Length2>::value));
+    //EXPECT_FALSE((std::is_nothrow_constructible<AABB2D, Length2, Length2>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<AABB2D, Length2, Length2>::value));
     
-    EXPECT_TRUE(std::is_copy_constructible<AABB>::value);
-    //EXPECT_TRUE(std::is_nothrow_copy_constructible<AABB>::value);
-    //EXPECT_TRUE(std::is_trivially_copy_constructible<AABB>::value);
+    EXPECT_TRUE(std::is_copy_constructible<AABB2D>::value);
+    //EXPECT_TRUE(std::is_nothrow_copy_constructible<AABB2D>::value);
+    //EXPECT_TRUE(std::is_trivially_copy_constructible<AABB2D>::value);
 
-    EXPECT_TRUE(std::is_move_constructible<AABB>::value);
-    //EXPECT_TRUE(std::is_nothrow_move_constructible<AABB>::value);
-    //EXPECT_FALSE(std::is_trivially_move_constructible<AABB>::value);
+    EXPECT_TRUE(std::is_move_constructible<AABB2D>::value);
+    //EXPECT_TRUE(std::is_nothrow_move_constructible<AABB2D>::value);
+    //EXPECT_FALSE(std::is_trivially_move_constructible<AABB2D>::value);
 
-    EXPECT_TRUE(std::is_copy_assignable<AABB>::value);
-    //EXPECT_FALSE(std::is_nothrow_copy_assignable<AABB>::value);
-    //EXPECT_FALSE(std::is_trivially_copy_assignable<AABB>::value);
+    EXPECT_TRUE(std::is_copy_assignable<AABB2D>::value);
+    //EXPECT_FALSE(std::is_nothrow_copy_assignable<AABB2D>::value);
+    //EXPECT_FALSE(std::is_trivially_copy_assignable<AABB2D>::value);
 
-    EXPECT_TRUE(std::is_move_assignable<AABB>::value);
-    //EXPECT_FALSE(std::is_nothrow_move_assignable<AABB>::value);
-    //EXPECT_FALSE(std::is_trivially_move_assignable<AABB>::value);
+    EXPECT_TRUE(std::is_move_assignable<AABB2D>::value);
+    //EXPECT_FALSE(std::is_nothrow_move_assignable<AABB2D>::value);
+    //EXPECT_FALSE(std::is_trivially_move_assignable<AABB2D>::value);
 
-    EXPECT_TRUE(std::is_destructible<AABB>::value);
-    EXPECT_TRUE(std::is_nothrow_destructible<AABB>::value);
-    EXPECT_TRUE(std::is_trivially_destructible<AABB>::value);
+    EXPECT_TRUE(std::is_destructible<AABB2D>::value);
+    EXPECT_TRUE(std::is_nothrow_destructible<AABB2D>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<AABB2D>::value);
 }
 
-TEST(AABB, DefaultAabbAddsToOther)
+TEST(AABB2D, DefaultAabbAddsToOther)
 {
-    const auto default_aabb = AABB{};
+    const auto default_aabb = AABB2D{};
     {
-        const auto other_aabb = AABB{Length2{}, Length2{}};
+        const auto other_aabb = AABB2D{Length2{}, Length2{}};
         const auto sum_aabb = GetEnclosingAABB(default_aabb, other_aabb);
         EXPECT_EQ(GetLowerBound(sum_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(sum_aabb), GetUpperBound(other_aabb));
     }
     {
-        const auto other_aabb = AABB{Length2{}, Length2{}};
+        const auto other_aabb = AABB2D{Length2{}, Length2{}};
         const auto sum_aabb = GetEnclosingAABB(other_aabb, default_aabb);
         EXPECT_EQ(GetLowerBound(sum_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(sum_aabb), GetUpperBound(other_aabb));
     }
     {
-        const auto other_aabb = AABB{Length2{ -1_m, -2_m}, Length2{+99_m, +3_m}};
+        const auto other_aabb = AABB2D{Length2{ -1_m, -2_m}, Length2{+99_m, +3_m}};
         const auto sum_aabb = GetEnclosingAABB(other_aabb, default_aabb);
         EXPECT_EQ(GetLowerBound(sum_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(sum_aabb), GetUpperBound(other_aabb));
     }
 }
 
-TEST(AABB, DefaultAabbIncrementsToOther)
+TEST(AABB2D, DefaultAabbIncrementsToOther)
 {
     {
-        auto default_aabb = AABB{};
-        const auto other_aabb = AABB{Length2{}, Length2{}};
+        auto default_aabb = AABB2D{};
+        const auto other_aabb = AABB2D{Length2{}, Length2{}};
         Include(default_aabb, other_aabb);
         EXPECT_EQ(GetLowerBound(default_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(default_aabb), GetUpperBound(other_aabb));
     }
     {
-        auto default_aabb = AABB{};
-        const auto other_aabb = AABB{Length2{-1_m, -2_m}, Length2{+99_m, +3_m}};
+        auto default_aabb = AABB2D{};
+        const auto other_aabb = AABB2D{Length2{-1_m, -2_m}, Length2{+99_m, +3_m}};
         Include(default_aabb, other_aabb);
         EXPECT_EQ(GetLowerBound(default_aabb), GetLowerBound(other_aabb));
         EXPECT_EQ(GetUpperBound(default_aabb), GetUpperBound(other_aabb));
     }
 }
 
-TEST(AABB, InitializingConstruction)
+TEST(AABB2D, InitializingConstruction)
 {
     const auto lower_x = -2_m;
     const auto lower_y = -3_m;
@@ -138,7 +138,7 @@ TEST(AABB, InitializingConstruction)
     const auto v1 = Length2{lower_x, upper_y};
     
     {
-        AABB foo{v0, v1};
+        AABB2D foo{v0, v1};
         EXPECT_EQ(GetX(GetCenter(foo)), center_x);
         EXPECT_EQ(GetY(GetCenter(foo)), center_y);
         EXPECT_EQ(GetX(GetLowerBound(foo)), lower_x);
@@ -147,7 +147,7 @@ TEST(AABB, InitializingConstruction)
         EXPECT_EQ(GetY(GetUpperBound(foo)), upper_y);
     }
     {
-        AABB foo{v1, v0};
+        AABB2D foo{v1, v0};
         EXPECT_EQ(GetX(GetCenter(foo)), center_x);
         EXPECT_EQ(GetY(GetCenter(foo)), center_y);
         EXPECT_EQ(GetX(GetLowerBound(foo)), lower_x);
@@ -158,7 +158,7 @@ TEST(AABB, InitializingConstruction)
     {
         const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
-        AABB foo{pa, pb};
+        AABB2D foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
@@ -167,7 +167,7 @@ TEST(AABB, InitializingConstruction)
     {
         const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         const auto pb = Length2{GetInvalid<Length>(), 0_m};
-        AABB foo{pa, pb};
+        AABB2D foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
@@ -176,7 +176,7 @@ TEST(AABB, InitializingConstruction)
     {
         const auto pa = Length2{GetInvalid<Length>(), 0_m};
         const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
-        AABB foo{pa, pb};
+        AABB2D foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
@@ -185,7 +185,7 @@ TEST(AABB, InitializingConstruction)
     {
         const auto pa = Length2{GetInvalid<Length>(), 0_m};
         const auto pb = Length2{GetInvalid<Length>(), 0_m};
-        AABB foo{pa, pb};
+        AABB2D foo{pa, pb};
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
         EXPECT_FALSE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
         EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
@@ -194,16 +194,16 @@ TEST(AABB, InitializingConstruction)
     {
         const auto rangeX = Interval<Length>{-2_m, +3_m};
         const auto rangeY = Interval<Length>{-8_m, -4_m};
-        AABB foo{rangeX, rangeY};
-        EXPECT_EQ(foo.rangeX, rangeX);
-        EXPECT_EQ(foo.rangeY, rangeY);
+        AABB2D foo{rangeX, rangeY};
+        EXPECT_EQ(foo.ranges[0], rangeX);
+        EXPECT_EQ(foo.ranges[1], rangeY);
     }
 }
 
-TEST(AABB, Swappable)
+TEST(AABB2D, Swappable)
 {
-    auto a = AABB{};
-    auto b = AABB{};
+    auto a = AABB2D{};
+    auto b = AABB2D{};
     ASSERT_EQ(a, b);
     std::swap(a, b);
     EXPECT_EQ(a, b);
@@ -216,12 +216,12 @@ TEST(AABB, Swappable)
     EXPECT_EQ(b, aAfter);
 }
 
-TEST(AABB, GetPerimeterOfPoint)
+TEST(AABB2D, GetPerimeterOfPoint)
 {
-    EXPECT_EQ(GetPerimeter(AABB{Length2{}}), 0_m);
-    EXPECT_EQ(GetPerimeter(AABB{Length2{-1_m, -2_m}}), 0_m);
-    EXPECT_EQ(GetPerimeter(AABB{Length2{+99_m, +3_m}}), 0_m);
-    EXPECT_TRUE(std::isnan(StripUnit(GetPerimeter(AABB{
+    EXPECT_EQ(GetPerimeter(AABB2D{Length2{}}), 0_m);
+    EXPECT_EQ(GetPerimeter(AABB2D{Length2{-1_m, -2_m}}), 0_m);
+    EXPECT_EQ(GetPerimeter(AABB2D{Length2{+99_m, +3_m}}), 0_m);
+    EXPECT_TRUE(std::isnan(StripUnit(GetPerimeter(AABB2D{
         Length2{
             Real(+std::numeric_limits<Real>::infinity()) * Meter,
             Real(+std::numeric_limits<Real>::infinity()) * Meter
@@ -229,15 +229,15 @@ TEST(AABB, GetPerimeterOfPoint)
     }))));
 }
 
-TEST(AABB, Include)
+TEST(AABB2D, Include)
 {
     const auto p1 = Length2{2_m, 3_m};
     const auto p2 = Length2{20_m, 30_m};
     const auto p3 = Length2{-3_m, -4_m};
     const auto p4 = Length2{0_m, 0_m};
-    const auto p5 = AABB{};
+    const auto p5 = AABB2D{};
 
-    auto foo = AABB{};
+    auto foo = AABB2D{};
     
     Include(foo, p1);
     EXPECT_EQ(GetLowerBound(foo), p1);
@@ -259,83 +259,83 @@ TEST(AABB, Include)
         const auto copyOfFoo = foo;
         EXPECT_EQ(Include(foo, p5), copyOfFoo);
     }
-    EXPECT_EQ(GetEnclosingAABB(AABB{}, foo), foo);
+    EXPECT_EQ(GetEnclosingAABB(AABB2D{}, foo), foo);
 }
 
-TEST(AABB, Contains)
+TEST(AABB2D, Contains)
 {
-    EXPECT_TRUE(Contains(AABB{}, AABB{}));
-    EXPECT_TRUE(Contains(AABB{Length2{}}, AABB{Length2{}}));
-    EXPECT_TRUE((Contains(AABB{Length2{}, Length2{}}, AABB{Length2{}})));
-    EXPECT_TRUE((Contains(AABB{Length2{}}, AABB{Length2{}, Length2{}})));
-    EXPECT_TRUE((Contains(AABB{Length2{1_m, 2_m}}, AABB{})));
-    EXPECT_FALSE(Contains(GetInvalid<AABB>(), GetInvalid<AABB>()));
-    EXPECT_FALSE(Contains(GetInvalid<AABB>(), AABB{}));
-    EXPECT_FALSE(Contains(AABB{}, GetInvalid<AABB>()));
+    EXPECT_TRUE(Contains(AABB2D{}, AABB2D{}));
+    EXPECT_TRUE(Contains(AABB2D{Length2{}}, AABB2D{Length2{}}));
+    EXPECT_TRUE((Contains(AABB2D{Length2{}, Length2{}}, AABB2D{Length2{}})));
+    EXPECT_TRUE((Contains(AABB2D{Length2{}}, AABB2D{Length2{}, Length2{}})));
+    EXPECT_TRUE((Contains(AABB2D{Length2{1_m, 2_m}}, AABB2D{})));
+    EXPECT_FALSE(Contains(GetInvalid<AABB2D>(), GetInvalid<AABB2D>()));
+    EXPECT_FALSE(Contains(GetInvalid<AABB2D>(), AABB2D{}));
+    EXPECT_FALSE(Contains(AABB2D{}, GetInvalid<AABB2D>()));
 }
 
-TEST(AABB, TestOverlap)
+TEST(AABB2D, TestOverlap)
 {
     {
-        AABB bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
+        AABB2D bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
         EXPECT_TRUE(TestOverlap(bb1, bb1));
     }
     {
         const auto vec = Length2{-2_m, -3_m};
-        AABB bb1{vec, vec};
+        AABB2D bb1{vec, vec};
         EXPECT_TRUE(TestOverlap(bb1, bb1));
     }
     {
-        AABB bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
-        AABB bb2{Length2{-1_m, -1_m}, Length2{ 1_m,  2_m}};
+        AABB2D bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
+        AABB2D bb2{Length2{-1_m, -1_m}, Length2{ 1_m,  2_m}};
         EXPECT_TRUE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{Length2{-99_m, -3_m}, Length2{-1_m,  0_m}};
-        AABB bb2{Length2{ 76_m, -1_m}, Length2{-2_m,  2_m}};
+        AABB2D bb1{Length2{-99_m, -3_m}, Length2{-1_m,  0_m}};
+        AABB2D bb2{Length2{ 76_m, -1_m}, Length2{-2_m,  2_m}};
         EXPECT_TRUE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{Length2{-20_m, -3_m}, Length2{-18_m,  0_m}};
-        AABB bb2{Length2{ -1_m, -1_m}, Length2{  1_m,  2_m}};
+        AABB2D bb1{Length2{-20_m, -3_m}, Length2{-18_m,  0_m}};
+        AABB2D bb2{Length2{ -1_m, -1_m}, Length2{  1_m,  2_m}};
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
-        AABB bb2{Length2{-1_m, +1_m}, Length2{ 1_m,  2_m}};
+        AABB2D bb1{Length2{-2_m, -3_m}, Length2{-1_m,  0_m}};
+        AABB2D bb2{Length2{-1_m, +1_m}, Length2{ 1_m,  2_m}};
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
     {
-        AABB bb1{Length2{-2_m, +3_m}, Length2{-1_m,  0_m}};
-        AABB bb2{Length2{-1_m, -1_m}, Length2{ 0_m, -2_m}};
+        AABB2D bb1{Length2{-2_m, +3_m}, Length2{-1_m,  0_m}};
+        AABB2D bb2{Length2{-1_m, -1_m}, Length2{ 0_m, -2_m}};
         EXPECT_FALSE(TestOverlap(bb1, bb2));
     }
 }
 
-TEST(AABB, ComputeAabbForDefaultDistanceProxy)
+TEST(AABB2D, ComputeAabbForDefaultDistanceProxy)
 {
-    const auto defaultAabb = AABB{};
+    const auto defaultAabb = AABB2D{};
     const auto proxyAabb = ComputeAABB(DistanceProxy{}, Transform_identity);
     
     EXPECT_EQ(defaultAabb, proxyAabb);
 }
 
-TEST(AABB, Move)
+TEST(AABB2D, Move)
 {
     const auto zeroLoc = Length2{};
-    const auto zeroAabb = AABB{zeroLoc};
+    const auto zeroAabb = AABB2D{zeroLoc};
     {
-        auto aabb = AABB{};
-        EXPECT_EQ(Move(aabb, zeroLoc), AABB{});
-        EXPECT_EQ(Move(aabb, Length2{10_m, -4_m}), AABB{});
+        auto aabb = AABB2D{};
+        EXPECT_EQ(Move(aabb, zeroLoc), AABB2D{});
+        EXPECT_EQ(Move(aabb, Length2{10_m, -4_m}), AABB2D{});
     }
     {
-        auto aabb = AABB{Length2{}};
+        auto aabb = AABB2D{Length2{}};
         EXPECT_EQ(Move(aabb, Length2{}), zeroAabb);
     }
     {
-        const auto aabb1 = AABB{Length2{1_m, 1_m}};
-        const auto aabb2 = AABB{Length2{-10_m, 11_m}};
+        const auto aabb1 = AABB2D{Length2{1_m, 1_m}};
+        const auto aabb2 = AABB2D{Length2{-10_m, 11_m}};
         auto aabb = zeroAabb;
         EXPECT_EQ(Move(aabb, Length2{1_m, 1_m}), aabb1);
         EXPECT_EQ(Move(aabb, Length2{-1_m, -1_m}), zeroAabb);
@@ -344,55 +344,55 @@ TEST(AABB, Move)
     {
         const auto lower = Length2{-1_m, -1_m};
         const auto upper = Length2{+3_m, +9_m};
-        auto aabb = AABB{lower, upper};
+        auto aabb = AABB2D{lower, upper};
         const auto moveby = Length2{1_m, 1_m};
-        EXPECT_EQ(Move(aabb, moveby), AABB(lower + moveby, upper + moveby));
+        EXPECT_EQ(Move(aabb, moveby), AABB2D(lower + moveby, upper + moveby));
     }
 }
 
-TEST(AABB, ComparisonOperators)
+TEST(AABB2D, ComparisonOperators)
 {
-    EXPECT_TRUE(AABB{} == AABB{});
-    EXPECT_FALSE(AABB{} != AABB{});
-    EXPECT_TRUE(AABB{} <= AABB{});
-    EXPECT_TRUE(AABB{} >= AABB{});
-    EXPECT_FALSE(AABB{} < AABB{});
-    EXPECT_FALSE(AABB{} > AABB{});
+    EXPECT_TRUE(AABB2D{} == AABB2D{});
+    EXPECT_FALSE(AABB2D{} != AABB2D{});
+    EXPECT_TRUE(AABB2D{} <= AABB2D{});
+    EXPECT_TRUE(AABB2D{} >= AABB2D{});
+    EXPECT_FALSE(AABB2D{} < AABB2D{});
+    EXPECT_FALSE(AABB2D{} > AABB2D{});
     
     const auto vr0 = Interval<Length>{1_m, 2_m};
     const auto vr1 = Interval<Length>{3_m, 4_m};
     const auto vr2 = Interval<Length>{5_m, 6_m};
     const auto vr3 = Interval<Length>{7_m, 8_m};
 
-    EXPECT_FALSE(AABB(vr0, vr1) == AABB{});
-    EXPECT_TRUE(AABB(vr0, vr1) != AABB{});
-    EXPECT_TRUE(AABB(vr0, vr1) <= AABB{});
-    EXPECT_FALSE(AABB(vr0, vr1) >= AABB{});
-    EXPECT_TRUE(AABB(vr0, vr1) < AABB{});
-    EXPECT_FALSE(AABB(vr0, vr1) > AABB{});
+    EXPECT_FALSE(AABB2D(vr0, vr1) == AABB2D{});
+    EXPECT_TRUE(AABB2D(vr0, vr1) != AABB2D{});
+    EXPECT_TRUE(AABB2D(vr0, vr1) <= AABB2D{});
+    EXPECT_FALSE(AABB2D(vr0, vr1) >= AABB2D{});
+    EXPECT_TRUE(AABB2D(vr0, vr1) < AABB2D{});
+    EXPECT_FALSE(AABB2D(vr0, vr1) > AABB2D{});
 
-    EXPECT_FALSE(AABB{} == AABB(vr0, vr1));
-    EXPECT_TRUE(AABB{} != AABB(vr0, vr1));
-    EXPECT_FALSE(AABB{} <= AABB(vr0, vr1));
-    EXPECT_TRUE(AABB{} >= AABB(vr0, vr1));
-    EXPECT_FALSE(AABB{} < AABB(vr0, vr1));
-    EXPECT_TRUE(AABB{} > AABB(vr0, vr1));
+    EXPECT_FALSE(AABB2D{} == AABB2D(vr0, vr1));
+    EXPECT_TRUE(AABB2D{} != AABB2D(vr0, vr1));
+    EXPECT_FALSE(AABB2D{} <= AABB2D(vr0, vr1));
+    EXPECT_TRUE(AABB2D{} >= AABB2D(vr0, vr1));
+    EXPECT_FALSE(AABB2D{} < AABB2D(vr0, vr1));
+    EXPECT_TRUE(AABB2D{} > AABB2D(vr0, vr1));
 
-    EXPECT_FALSE(AABB(vr0, vr1) == AABB(vr2, vr3));
-    EXPECT_TRUE(AABB(vr0, vr1) != AABB(vr2, vr3));
-    EXPECT_TRUE(AABB(vr0, vr1) <= AABB(vr2, vr3));
-    EXPECT_FALSE(AABB(vr0, vr1) >= AABB(vr2, vr3));
-    EXPECT_TRUE(AABB(vr0, vr1) < AABB(vr2, vr3));
-    EXPECT_FALSE(AABB(vr0, vr1) > AABB(vr2, vr3));
+    EXPECT_FALSE(AABB2D(vr0, vr1) == AABB2D(vr2, vr3));
+    EXPECT_TRUE(AABB2D(vr0, vr1) != AABB2D(vr2, vr3));
+    EXPECT_TRUE(AABB2D(vr0, vr1) <= AABB2D(vr2, vr3));
+    EXPECT_FALSE(AABB2D(vr0, vr1) >= AABB2D(vr2, vr3));
+    EXPECT_TRUE(AABB2D(vr0, vr1) < AABB2D(vr2, vr3));
+    EXPECT_FALSE(AABB2D(vr0, vr1) > AABB2D(vr2, vr3));
 }
 
-TEST(AABB, StreamOutputOperator)
+TEST(AABB2D, StreamOutputOperator)
 {
     const auto rangeX = Interval<Length>{-2_m, +3_m};
     const auto rangeY = Interval<Length>{-8_m, -4_m};
-    AABB foo{rangeX, rangeY};
-    ASSERT_EQ(foo.rangeX, rangeX);
-    ASSERT_EQ(foo.rangeY, rangeY);
+    AABB2D foo{rangeX, rangeY};
+    ASSERT_EQ(foo.ranges[0], rangeX);
+    ASSERT_EQ(foo.ranges[1], rangeY);
     
     std::stringstream aabbStream;
     ASSERT_TRUE(aabbStream.str().empty());
@@ -400,10 +400,10 @@ TEST(AABB, StreamOutputOperator)
     ASSERT_FALSE(aabbStream.str().empty());
     
     std::stringstream xRangeStream;
-    xRangeStream << foo.rangeX;
+    xRangeStream << foo.ranges[0];
     
     std::stringstream yRangeStream;
-    yRangeStream << foo.rangeY;
+    yRangeStream << foo.ranges[1];
     
     std::string comp;
     comp += '{';
@@ -414,7 +414,7 @@ TEST(AABB, StreamOutputOperator)
     EXPECT_STREQ(aabbStream.str().c_str(), comp.c_str());
 }
 
-TEST(AABB, ComputeAabbForFixtureAtBodyOrigin)
+TEST(AABB2D, ComputeAabbForFixtureAtBodyOrigin)
 {
     const auto shape = std::make_shared<DiskShape>();
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
@@ -424,11 +424,11 @@ TEST(AABB, ComputeAabbForFixtureAtBodyOrigin)
     const auto fixture = body->CreateFixture(shape);
     const auto fixtureAabb = ComputeAABB(*fixture);
     
-    ASSERT_NE(shapeAabb, AABB{});
+    ASSERT_NE(shapeAabb, AABB2D{});
     EXPECT_EQ(shapeAabb, fixtureAabb);
 }
 
-TEST(AABB, ComputeAabbForFixtureOffFromBodyOrigin)
+TEST(AABB2D, ComputeAabbForFixtureOffFromBodyOrigin)
 {
     const auto shape = std::make_shared<DiskShape>();
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
@@ -439,12 +439,12 @@ TEST(AABB, ComputeAabbForFixtureOffFromBodyOrigin)
     const auto fixture = body->CreateFixture(shape);
     const auto fixtureAabb = ComputeAABB(*fixture);
     
-    ASSERT_NE(shapeAabb, AABB{});
+    ASSERT_NE(shapeAabb, AABB2D{});
     ASSERT_NE(shapeAabb, fixtureAabb);
     EXPECT_EQ(GetMovedAABB(shapeAabb, bodyLocation), fixtureAabb);
 }
 
-TEST(AABB, ComputeIntersectingAABBForSameFixture)
+TEST(AABB2D, ComputeIntersectingAABBForSameFixture)
 {
     const auto shape = std::make_shared<DiskShape>();
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
@@ -456,18 +456,18 @@ TEST(AABB, ComputeIntersectingAABBForSameFixture)
     
     const auto intersectingAabb = ComputeIntersectingAABB(*fixture, 0, *fixture, 0);
     
-    ASSERT_NE(shapeAabb, AABB{});
+    ASSERT_NE(shapeAabb, AABB2D{});
     ASSERT_EQ(shapeAabb, fixtureAabb);
     EXPECT_EQ(fixtureAabb, intersectingAabb);
 }
 
-TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
+TEST(AABB2D, ComputeIntersectingAABBForTwoFixtures)
 {
     const auto shapeInterval = LengthInterval{-2_m, +2_m};
 
     const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}.UseVertexRadius(2_m));
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
-    ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
+    ASSERT_EQ(shapeAabb, (AABB2D{shapeInterval, shapeInterval}));
 
     const auto bodyLocation0 = Length2{+1_m, 0_m};
     const auto bodyLocation1 = Length2{-1_m, 0_m};
@@ -487,16 +487,16 @@ TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
 
     ASSERT_NE(shapeAabb, fixtureAabb0);
     ASSERT_NE(shapeAabb, fixtureAabb1);
-    EXPECT_EQ(intersectingAabb, (AABB{intersectInterval, shapeInterval}));
+    EXPECT_EQ(intersectingAabb, (AABB2D{intersectInterval, shapeInterval}));
 }
 
-TEST(AABB, ComputeIntersectingAABBForContact)
+TEST(AABB2D, ComputeIntersectingAABBForContact)
 {
     const auto shapeInterval = LengthInterval{-2_m, +2_m};
     
     const auto shape = std::make_shared<DiskShape>(DiskShape::Conf{}.UseVertexRadius(2_m));
     const auto shapeAabb = ComputeAABB(*shape, Transformation{});
-    ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
+    ASSERT_EQ(shapeAabb, (AABB2D{shapeInterval, shapeInterval}));
     
     const auto bodyLocation0 = Length2{+1_m, 0_m};
     const auto bodyLocation1 = Length2{-1_m, 0_m};
@@ -516,7 +516,7 @@ TEST(AABB, ComputeIntersectingAABBForContact)
     
     ASSERT_NE(shapeAabb, fixtureAabb0);
     ASSERT_NE(shapeAabb, fixtureAabb1);
-    ASSERT_EQ(intersectingAabb, (AABB{intersectInterval, shapeInterval}));
+    ASSERT_EQ(intersectingAabb, (AABB2D{intersectInterval, shapeInterval}));
     
     const auto contact = Contact{fixture0, 0, fixture1, 0};
     const auto contactAabb = ComputeIntersectingAABB(contact);

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -117,7 +117,7 @@ TEST(ChainShape, OneVertexLikeDisk)
 TEST(ChainShape, TwoVertexLikeEdge)
 {
     const auto vertexRadius = 1_m;
-    const auto density = NonNegative<Density>(1_kgpm2);
+    const auto density = NonNegative<AreaDensity>(1_kgpm2);
     const auto locations = std::array<Length2, 2>{{
         Length2{0_m, 0_m}, Length2(4_m, 0_m)
     }};
@@ -136,7 +136,7 @@ TEST(ChainShape, TwoVertexLikeEdge)
 TEST(ChainShape, TwoVertexDpLikeEdgeDp)
 {
     const auto vertexRadius = 1_m;
-    const auto density = NonNegative<Density>(1_kgpm2);
+    const auto density = NonNegative<AreaDensity>(1_kgpm2);
     const auto locations = std::array<Length2, 2>{{
         Length2{0_m, 0_m}, Length2(4_m, 0_m)
     }};
@@ -158,7 +158,7 @@ TEST(ChainShape, TwoVertexDpLikeEdgeDp)
 TEST(ChainShape, TwoVertexMassLikeEdgeMass)
 {
     const auto vertexRadius = 1_m;
-    const auto density = NonNegative<Density>(1_kgpm2);
+    const auto density = NonNegative<AreaDensity>(1_kgpm2);
     const auto locations = std::array<Length2, 2>{{
         Length2{0_m, 0_m}, Length2(4_m, 0_m)
     }};

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -100,7 +100,7 @@ TEST(DynamicTree, CopyConstruction)
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
     }
 
-    const auto aabb = AABB{
+    const auto aabb = AABB2D{
         Length2{0_m, 0_m},
         Length2(1_m, 1_m)
     };
@@ -131,7 +131,7 @@ TEST(DynamicTree, CopyAssignment)
         EXPECT_EQ(copy.GetMaxBalance(), orig.GetMaxBalance());
     }
     
-    const auto aabb = AABB{
+    const auto aabb = AABB2D{
         Length2{0_m, 0_m},
         Length2{1_m, 1_m}
     };
@@ -156,7 +156,7 @@ TEST(DynamicTree, CreateAndDestroyProxy)
     ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
     ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
-    const auto aabb = AABB{
+    const auto aabb = AABB2D{
         Length2{3_m, 1_m},
         Length2{-5_m, -2_m}
     };
@@ -188,7 +188,7 @@ TEST(DynamicTree, FourIdenticalProxies)
     ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::GetDefaultInitialNodeCapacity());
     ASSERT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));
 
-    const auto aabb = AABB{
+    const auto aabb = AABB2D{
         Length2{3_m, 1_m},
         Length2{-5_m, -2_m}
     };
@@ -260,7 +260,7 @@ TEST(DynamicTree, MoveConstruction)
 {
     DynamicTree foo;
     
-    const auto aabb = AABB{
+    const auto aabb = AABB2D{
         Length2{3_m, 1_m},
         Length2{-5_m, -2_m}
     };
@@ -300,7 +300,7 @@ TEST(DynamicTree, MoveAssignment)
 {
     DynamicTree foo;
     
-    const auto aabb = AABB{
+    const auto aabb = AABB2D{
         Length2{3_m, 1_m},
         Length2{-5_m, -2_m}
     };
@@ -345,7 +345,7 @@ TEST(DynamicTree, CapacityIncreases)
     ASSERT_EQ(foo.GetNodeCapacity(), DynamicTree::Size(1));
     ASSERT_EQ(foo.GetLeafCount(), DynamicTree::Size(0));
 
-    const auto aabb = AABB{
+    const auto aabb = AABB2D{
         Length2{3_m, 1_m},
         Length2{-5_m, -2_m}
     };

--- a/UnitTests/Interval.cpp
+++ b/UnitTests/Interval.cpp
@@ -317,3 +317,25 @@ TEST_F(Interval, GreaterThanOrEqualTo)
         }
     }
 }
+
+TEST_F(Interval, GetLowest)
+{
+    EXPECT_EQ(playrho::Interval<int>::GetLowest(), std::numeric_limits<int>::lowest());
+    EXPECT_EQ(playrho::Interval<float>::GetLowest(), -std::numeric_limits<float>::infinity());
+}
+
+TEST_F(Interval, GetHighest)
+{
+    EXPECT_EQ(playrho::Interval<int>::GetHighest(), std::numeric_limits<int>::max());
+    EXPECT_EQ(playrho::Interval<float>::GetHighest(), std::numeric_limits<float>::infinity());
+}
+
+TEST_F(Interval, DefaultConstruction)
+{
+    EXPECT_EQ(playrho::Interval<int>{}, playrho::Interval<int>{});
+    EXPECT_EQ(playrho::Interval<int>{}.GetMin(), std::numeric_limits<int>::max());
+    EXPECT_EQ(playrho::Interval<int>{}.GetMax(), std::numeric_limits<int>::lowest());
+    EXPECT_EQ(playrho::Interval<float>{}, playrho::Interval<float>{});
+    EXPECT_EQ(playrho::Interval<float>{}.GetMin(),  std::numeric_limits<float>::infinity());
+    EXPECT_EQ(playrho::Interval<float>{}.GetMax(), -std::numeric_limits<float>::infinity());
+}

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -168,7 +168,7 @@ TEST(MassData, GetAreaOfPolygon)
 TEST(MassData, GetMassDataFreeFunctionForNoVertices)
 {
     const auto vertexRadius = Length{1_m};
-    const auto density = NonNegative<Density>(1_kgpm2);
+    const auto density = NonNegative<AreaDensity>(1_kgpm2);
     const auto vertices = Span<const Length2>{
         static_cast<const Length2*>(nullptr), Span<const Length2>::size_type{0}
     };
@@ -202,7 +202,7 @@ TEST(MassData, GetForOriginCenteredCircle)
     const auto squareVertexRadius = Square(Length{conf.vertexRadius});
     const auto expectedI = RotInertia{
         // L^2 M QP^-2
-        Density{conf.density} * squareVertexRadius * squareVertexRadius * Pi / (2 * 1_rad * 1_rad)
+        AreaDensity{conf.density} * squareVertexRadius * squareVertexRadius * Pi / (2 * 1_rad * 1_rad)
     };
     EXPECT_TRUE(AlmostEqual(StripUnit(mass_data.I), StripUnit(expectedI)));
     EXPECT_EQ(mass_data.center, conf.location);

--- a/UnitTests/RayCastOutput.cpp
+++ b/UnitTests/RayCastOutput.cpp
@@ -101,7 +101,7 @@ TEST(RayCastOutput, RayCastLocationFreeFunctionMisses)
 
 TEST(RayCastOutput, RayCastAabbFreeFunction)
 {
-    AABB aabb;
+    AABB2D aabb;
     const auto p1 = Length2(10_m, 2_m);
     const auto p2 = Length2(0_m, 2_m);
     const auto maxFraction = Real(1);

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -178,7 +178,7 @@ TEST(World, Init)
     
     {
         auto calls = 0;
-        world.QueryAABB(AABB{}, [&](Fixture*, ChildCounter) {
+        world.QueryAABB(AABB2D{}, [&](Fixture*, ChildCounter) {
             ++calls;
             return true;
         });
@@ -433,7 +433,7 @@ TEST(World, QueryAABB)
     {
         auto foundOurs = 0;
         auto foundOthers = 0;
-        world.QueryAABB(AABB{v1, v2}, [&](Fixture* f, ChildCounter i) {
+        world.QueryAABB(AABB2D{v1, v2}, [&](Fixture* f, ChildCounter i) {
             if (f == fixture && i == 0)
             {
                 ++foundOurs;
@@ -2487,7 +2487,7 @@ TEST(World, MouseJointWontCauseTunnelling)
     const auto btm_edge_y = -half_box_height;
     const auto top_edge_y = +half_box_height;
 
-    AABB container_aabb;
+    AABB2D container_aabb;
 
     BodyDef body_def;
     EdgeShape edge_shape;


### PR DESCRIPTION
#### Description - What's this PR do?
- Generalizes the AABB to N-dimensions and replaces the 2-dimensional AABB class with the AABB2D type alias.
- Renames Density to AreaDensity.

#### Related Issues
- Issue #178.