### PR TITLE
Removes the caching of the sum of the inverse body mass from VelocityConstraint

### DIFF
--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
@@ -78,7 +78,6 @@ VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
                                        Conf conf):
     m_friction{friction}, m_restitution{restitution}, m_tangentSpeed{tangentSpeed},
     m_bodyA{&bA}, m_bodyB{&bB},
-    m_invMass{bA.GetInvMass() + bB.GetInvMass()},
     m_normal{worldManifold.GetNormal()}
 {
     assert(IsValid(friction));
@@ -135,10 +134,12 @@ VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
     const auto bodyA = GetBodyA();
     const auto bodyB = GetBodyB();
     
-    const auto invMass = GetInvMass();
     const auto invRotInertiaA = bodyA->GetInvRotInertia();
+    const auto invMassA = bodyA->GetInvMass();
     const auto invRotInertiaB = bodyB->GetInvRotInertia();
-    
+    const auto invMassB = bodyB->GetInvMass();
+    const auto invMass = invMassA + invMassB;
+
     Point point;
     point.normalImpulse = normalImpulse;
     point.tangentImpulse = tangentImpulse;

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -30,7 +30,7 @@ namespace playrho {
     /// Contact velocity constraint.
     ///
     /// @note A valid contact velocity constraint must have a point count of either 1 or 2.
-    /// @note This data structure is 160-bytes large (on at least one 64-bit platform).
+    /// @note This data structure is 144-bytes large (on at least one 64-bit platform).
     ///
     /// @invariant The "K" value cannot be changed independent of: the total inverse mass,
     ///   the normal, and the point relative positions.
@@ -89,9 +89,6 @@ namespace playrho {
         
         /// @brief Gets the tangent.
         UnitVec2 GetTangent() const noexcept { return GetFwdPerpendicular(m_normal); }
-        
-        /// @brief Gets the inverse mass.
-        InvMass GetInvMass() const noexcept { return m_invMass; }
         
         /// Gets the count of points added to this object.
         /// @return Value between 0 and MaxManifoldPoints
@@ -277,8 +274,6 @@ namespace playrho {
         BodyConstraint* m_bodyB = nullptr; ///< Body B contact velocity constraint data.
         
         UnitVec2 m_normal = GetInvalid<UnitVec2>(); ///< Normal of the world manifold. 8-bytes.
-        
-        InvMass m_invMass = GetInvalid<InvMass>(); ///< Total inverse mass.
         
         /// Friction coefficient (4-bytes). Usually in the range of [0,1].
         Real m_friction = GetInvalid<Real>();

--- a/UnitTests/VelocityConstraint.cpp
+++ b/UnitTests/VelocityConstraint.cpp
@@ -27,9 +27,9 @@ TEST(VelocityConstraint, ByteSize)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(VelocityConstraint), std::size_t(152)); break;
-        case  8: EXPECT_EQ(sizeof(VelocityConstraint), std::size_t(280)); break;
-        case 16: EXPECT_EQ(sizeof(VelocityConstraint), std::size_t(544)); break;
+        case  4: EXPECT_EQ(sizeof(VelocityConstraint), std::size_t(144)); break;
+        case  8: EXPECT_EQ(sizeof(VelocityConstraint), std::size_t(272)); break;
+        case 16: EXPECT_EQ(sizeof(VelocityConstraint), std::size_t(528)); break;
         default: FAIL(); break;
     }
 }


### PR DESCRIPTION
#### Description - What's this PR do?
Removes the caching of the sum of the inverse body mass from VelocityConstraint. The sum was only used in VelocityConstraint::GetPoint which is only called during VelocityConstraint construction and as such had limited use. Benchmark #s don't appear to be reliably effected by this change.