### PR TITLE
Fixes double-free bug with Body::SetEnabled(false).

### DIFF
--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -275,6 +275,7 @@ inline void Fixture::ResetProxies() noexcept
     {
         m_proxies.asBuffer.reset();
     }
+    m_proxyCount = 0;
 }
 
 // Free functions...

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -1120,8 +1120,7 @@ static void EntityUI(Body& b)
         auto v = b.IsEnabled();
         if (ImGui::Checkbox("Enabled", &v))
         {
-            // XXX lou: commented out because disabling/enabling causes problems ATM.
-            //b.SetEnabled(v);
+            b.SetEnabled(v);
         }
     }
     

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -20,6 +20,7 @@
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyDef.hpp>
 #include <PlayRho/Dynamics/World.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Collision/Shapes/DiskShape.hpp>
@@ -197,21 +198,36 @@ TEST(Body, CreateFixture)
 
 TEST(Body, SetEnabled)
 {
+    auto stepConf = StepConf{};
     World world;
     const auto body = world.CreateBody();
     const auto valid_shape = std::make_shared<DiskShape>(1_m);
     
-    ASSERT_NE(body->CreateFixture(valid_shape, FixtureDef{}), nullptr);
+    const auto fixture = body->CreateFixture(valid_shape, FixtureDef{});
+    ASSERT_NE(fixture, nullptr);
     ASSERT_TRUE(body->IsEnabled());
+    ASSERT_EQ(fixture->GetProxyCount(), 0u);
+
+    world.Step(stepConf);
+    EXPECT_EQ(fixture->GetProxyCount(), 1u);
 
     // Test that set enabled to flag already set is not a toggle
     body->SetEnabled(true);
     EXPECT_TRUE(body->IsEnabled());
+    EXPECT_EQ(fixture->GetProxyCount(), 1u);
 
     body->SetEnabled(false);
     EXPECT_FALSE(body->IsEnabled());
+    EXPECT_EQ(fixture->GetProxyCount(), 1u);
+
+    world.Step(stepConf);
+    EXPECT_EQ(fixture->GetProxyCount(), 0u);
+    
     body->SetEnabled(true);
     EXPECT_TRUE(body->IsEnabled());
+
+    world.Step(stepConf);
+    EXPECT_EQ(fixture->GetProxyCount(), 1u);
 }
 
 TEST(Body, SetFixedRotation)


### PR DESCRIPTION
#### Description - What's this PR do?
- Fixes double-free bug with Body::SetEnabled(false).
- Enables the body enable checkbox in the Testbed GUI.
- Adds unit test code to confirm issue/fix.