### PR TITLE
Misc updates 20171111

### DIFF
--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -344,7 +344,6 @@ inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
 /// @sa Atan2
 inline Angle GetNormalized(Angle value) noexcept
 {
-    assert(IsValid(value));
     constexpr auto oneRotationInRadians = Real{2 * Pi};
     auto angleInRadians = Real{value / Radian};
 #if defined(NORMALIZE_ANGLE_VIA_FMOD)
@@ -374,7 +373,6 @@ inline Angle GetNormalized(Angle value) noexcept
 /// @note Use to prevent unbounded angles in positions.
 inline Position GetNormalized(const Position& val) noexcept
 {
-    assert(IsValid(val));
     return Position{val.linear, GetNormalized(val.angular)};
 }
 

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -344,6 +344,7 @@ inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
 /// @sa Atan2
 inline Angle GetNormalized(Angle value) noexcept
 {
+    assert(IsValid(value));
     constexpr auto oneRotationInRadians = Real{2 * Pi};
     auto angleInRadians = Real{value / Radian};
 #if defined(NORMALIZE_ANGLE_VIA_FMOD)
@@ -373,6 +374,7 @@ inline Angle GetNormalized(Angle value) noexcept
 /// @note Use to prevent unbounded angles in positions.
 inline Position GetNormalized(const Position& val) noexcept
 {
+    assert(IsValid(val));
     return Position{val.linear, GetNormalized(val.angular)};
 }
 
@@ -1011,6 +1013,13 @@ constexpr inline T GetModuloPrev(T value, T count) noexcept
 /// @return Angle between -Pi and Pi radians inclusively.
 /// @sa GetNormalized
 Angle GetDelta(Angle a1, Angle a2) noexcept;
+
+/// Gets the reverse (counter) clockwise rotational angle to go from angle 1 to angle 2.
+/// @return Angular rotation in the counter clockwise direction to go from angle 1 to angle 2.
+constexpr inline Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
+{
+    return (a1 > a2)? 360_deg - (a1 - a2): a2 - a1;
+}
 
 /// Gets the unit vector for the given value.
 /// @param value Value to get the unit vector for.

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -128,6 +128,10 @@ namespace playrho
     constexpr Position GetPosition(const Position pos0, const Position pos1,
                                    const Real beta) noexcept
     {
+        assert(IsValid(pos0));
+        assert(IsValid(pos1));
+        assert(IsValid(beta));
+
         // Note: have to be careful how this is done.
         //   If pos0 == pos1 then return value should always be equal to pos0 too.
         //   But if Real is float, pos0 * (1 - beta) + pos1 * beta can fail this requirement.

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -156,6 +156,9 @@ public:
     /// @warning Behavior is undefined if given an invalid index.
     /// @return Fixture proxy value.
     FixtureProxy GetProxy(ChildCounter index) const noexcept;
+    
+    /// @brief Gets the proxies.
+    Span<const FixtureProxy> GetProxies() const noexcept;
 
 private:
 
@@ -169,9 +172,6 @@ private:
         std::array<FixtureProxy, 2> asArray; ///< Values accessed as a local array.
         std::unique_ptr<FixtureProxy[]> asBuffer; ///< Values accessed as pointer to array.
     };
-    
-    /// @brief Gets the proxies.
-    Span<const FixtureProxy> GetProxies() const noexcept;
     
     /// @brief Sets the proxies.
     void SetProxies(std::unique_ptr<FixtureProxy[]> value, std::size_t count) noexcept;

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -34,6 +34,8 @@
 
 namespace playrho {
 
+Camera g_camera;
+
 namespace {
 
 static void sCheckGLError()
@@ -121,7 +123,7 @@ static GLuint sCreateShaderProgram(const char* vs, const char* fs)
 } // namespace
 
 
-Length2 ConvertScreenToWorld(const Camera& camera, const Coord2D ps)
+Length2 ConvertScreenToWorld(const Coord2D ps, const Camera& camera)
 {
     const auto w = float(camera.m_width);
     const auto h = float(camera.m_height);
@@ -156,7 +158,7 @@ AABB2D ConvertScreenToWorld(const Camera& camera)
     };
 }
 
-Coord2D ConvertWorldToScreen(const Camera& camera, const Length2 pw)
+Coord2D ConvertWorldToScreen(const Length2 pw, const Camera& camera)
 {
     const auto w = float(camera.m_width);
     const auto h = float(camera.m_height);
@@ -174,7 +176,7 @@ Coord2D ConvertWorldToScreen(const Camera& camera, const Length2 pw)
 
 // Convert from world coordinates to normalized device coordinates.
 // http://www.songho.ca/opengl/gl_projectionmatrix.html
-ProjectionMatrix GetProjectionMatrix(const Camera& camera, float zBias)
+ProjectionMatrix GetProjectionMatrix(float zBias, const Camera& camera)
 {
     const auto w = float(camera.m_width);
     const auto h = float(camera.m_height);
@@ -302,7 +304,7 @@ struct GLRenderPoints
         
         glUseProgram(m_programId);
         
-        const auto proj = GetProjectionMatrix(camera, 0.0f);
+        const auto proj = GetProjectionMatrix(0.0f, camera);
         
         glUniformMatrix4fv(m_projectionUniform, 1, GL_FALSE, proj.m);
         
@@ -434,7 +436,7 @@ struct GLRenderLines
         
         glUseProgram(m_programId);
         
-        const auto proj = GetProjectionMatrix(camera, 0.1f);
+        const auto proj = GetProjectionMatrix(0.1f, camera);
         
         glUniformMatrix4fv(m_projectionUniform, 1, GL_FALSE, proj.m);
         
@@ -559,7 +561,7 @@ struct GLRenderTriangles
         
         glUseProgram(m_programId);
         
-        const auto proj = GetProjectionMatrix(camera, 0.2f);
+        const auto proj = GetProjectionMatrix(0.2f, camera);
         
         glUniformMatrix4fv(m_projectionUniform, 1, GL_FALSE, proj.m);
         
@@ -711,7 +713,7 @@ void DebugDraw::DrawSolidCircle(const Length2& center, Length radius, const Colo
 
 void DebugDraw::DrawString(const Length2& pw, TextAlign align, const char *string, ...)
 {
-    auto ps = ConvertWorldToScreen(m_camera, pw);
+    auto ps = ConvertWorldToScreen(pw, m_camera);
 
     char buffer[512];
     va_list arg;

--- a/Testbed/Framework/DebugDraw.hpp
+++ b/Testbed/Framework/DebugDraw.hpp
@@ -79,10 +79,12 @@ struct Camera
     int m_height = 800;
 };
 
-Length2 ConvertScreenToWorld(const Camera& camera, const Coord2D screenPoint);
-AABB2D ConvertScreenToWorld(const Camera& camera);
-Coord2D ConvertWorldToScreen(const Camera& camera, const Length2 worldPoint);
-ProjectionMatrix GetProjectionMatrix(const Camera& camera, float zBias);
+extern Camera g_camera;
+    
+Length2 ConvertScreenToWorld(const Coord2D screenPoint, const Camera& camera = g_camera);
+AABB2D ConvertScreenToWorld(const Camera& camera = g_camera);
+Coord2D ConvertWorldToScreen(const Length2 worldPoint, const Camera& camera = g_camera);
+ProjectionMatrix GetProjectionMatrix(float zBias, const Camera& camera = g_camera);
 
 class DebugDraw : public Drawer
 {

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -50,6 +50,7 @@ struct Settings
     float minDt = 1.0f / 120;
     float maxDt = 1.0f / 5;
 
+    float minStillTimeToSleep = static_cast<float>(Real{DefaultMinStillTimeToSleep / Second});
     float maxLinearCorrection = static_cast<float>(Real{DefaultMaxLinearCorrection / Meter}); // in meters
     float maxAngularCorrection = static_cast<float>(Real{DefaultMaxAngularCorrection / Degree}); // in degrees
 
@@ -142,7 +143,7 @@ public:
     void ShiftMouseDown(const Length2& p);
     void MouseMove(const Length2& p);
     void LaunchBomb();
-    void LaunchBomb(const Length2& position, const LinearVelocity2 velocity);
+    void LaunchBomb(const Length2& at, const LinearVelocity2 velocity);
     void SpawnBomb(const Length2& worldPt);
     void CompleteBombSpawn(const Length2& p);
     void ShiftOrigin(const Length2& newOrigin);
@@ -342,6 +343,7 @@ private:
     Length2 m_bombSpawnPoint;
     bool m_bombSpawning = false;
     Length2 m_mouseWorld = Length2{};
+    Time m_lastDeltaTime = 0_s;
     double m_sumDeltaTime = 0.0;
     int m_stepCount = 0;
     StepStats m_stepStats;

--- a/Testbed/Tests/SolarSystem.hpp
+++ b/Testbed/Tests/SolarSystem.hpp
@@ -39,15 +39,15 @@ struct SolarSystemObject
 };
 
 static constexpr SolarSystemObject SolarSystemBodies[] = {
-    { "Sun",    696342_km, 1988550000.0_Yg,     0.000_d,    0_Gm,   25.050_d },
-    { "Mercury",  2439_km,        330.2_Yg,    87.969_d,   57_Gm,   58.646_d },
-    { "Venus",    6051_km,       4868.5_Yg,   224.701_d,  108_Gm, -243.025_d },
-    { "Earth",    6371_km,       5973.6_Yg,   365.256_d,  150_Gm,    0.997_d },
-    { "Mars",     3389_km,        641.8_Yg,   686.971_d,  230_Gm,    1.025_d },
-    { "Jupiter", 69911_km,    1898600.0_Yg,  4332.590_d,  778_Gm,    0.413_d },
-    { "Saturn",  58232_km,     568460.0_Yg, 10759.220_d, 1430_Gm,    0.439_d },
-    { "Uranus",  25362_km,      86832.0_Yg, 30688.500_d, 2880_Gm,   -0.718_d },
-    { "Neptune", 24622_km,     102430.0_Yg, 60182.000_d, 4500_Gm,    0.671_d },
+    { "The Sun", 696342_km, 1988550000.0_Yg,     0.000_d,    0_Gm,   25.050_d },
+    { "Mercury",   2439_km,        330.2_Yg,    87.969_d,   57_Gm,   58.646_d },
+    { "Venus",     6051_km,       4868.5_Yg,   224.701_d,  108_Gm, -243.025_d },
+    { "Earth",     6371_km,       5973.6_Yg,   365.256_d,  150_Gm,    0.997_d },
+    { "Mars",      3389_km,        641.8_Yg,   686.971_d,  230_Gm,    1.025_d },
+    { "Jupiter",  69911_km,    1898600.0_Yg,  4332.590_d,  778_Gm,    0.413_d },
+    { "Saturn",   58232_km,     568460.0_Yg, 10759.220_d, 1430_Gm,    0.439_d },
+    { "Uranus",   25362_km,      86832.0_Yg, 30688.500_d, 2880_Gm,   -0.718_d },
+    { "Neptune",  24622_km,     102430.0_Yg, 60182.000_d, 4500_Gm,    0.671_d },
 };
 
 class SolarSystem: public Test
@@ -55,10 +55,37 @@ class SolarSystem: public Test
 public:
     static Test::Conf GetTestConf()
     {
+        auto minRadius = std::numeric_limits<Length>::max();
+        auto minName = "";
+        auto maxRadius = std::numeric_limits<Length>::min();
+        auto maxName = "";
+
+        for (auto& sso: SolarSystemBodies)
+        {
+            if (minRadius > sso.radius)
+            {
+                minRadius = sso.radius;
+                minName = sso.name;
+            }
+            if (maxRadius < sso.radius)
+            {
+                maxRadius = sso.radius;
+                maxName = sso.name;
+            }
+        }
+        
+        std::ostringstream os;
+        os << "A demo of grand scales!";
+        os << " The Sun and planets radiuses, masses, orbital and rotational periods";
+        os << " are all simulated to scale.";
+        os << " Radiuses range from ";
+        os << static_cast<float>(minRadius / 1_km);
+        os << " km (" << minName << "), to ";
+        os << static_cast<float>(maxRadius / 1_km);
+        os << " km (" << maxName << ").";
+
         auto conf = Test::Conf{};
-        conf.description = "A demo of grand scales."
-            " The Sun and planets radiuses, masses, orbital and rotational periods"
-            " are all simulated to scale.";
+        conf.description = os.str();
         conf.worldDef = WorldDef{}.UseMaxVertexRadius(700000_km);
         conf.neededSettings = 0;
         conf.neededSettings |= (1u << NeedLinearSlopField);
@@ -66,7 +93,7 @@ public:
         conf.neededSettings |= (1u << NeedDrawLabelsField);
         conf.neededSettings |= (1u << NeedMaxTranslation);
         conf.neededSettings |= (1u << NeedDeltaTime);
-        conf.settings.linearSlop = 1000.0f;
+        conf.settings.linearSlop = 1000.0f; // minRadius / 1000_m;
         conf.settings.cameraZoom = 2.2e11f;
         conf.settings.drawLabels = true;
         conf.settings.maxTranslation = std::numeric_limits<float>::infinity();
@@ -112,19 +139,22 @@ public:
     {
         SetAccelerations(m_world, CalcGravitationalAcceleration);
 
+        std::ostringstream os;
         if (m_focalBody)
         {
             const auto location = m_focalBody->GetLocation();
             drawer.SetTranslation(location);
             
-            std::ostringstream os;
-            os << "Camera locked on planet " << GetWorldIndex(m_focalBody) << ".";
-            m_status = os.str();
+            const auto index = GetWorldIndex(m_focalBody);
+            os << "Camera locked on body " << index << ": ";
+            os << SolarSystemBodies[index].name;
+            os << ".";
         }
         else
         {
-            m_status = "Camera unlocked from following any planet.";
+            os << "Camera unlocked from following any planet.";
         }
+        m_status = os.str();
     }
     
     const Body* m_focalBody = nullptr;

--- a/UnitTests/Angle.cpp
+++ b/UnitTests/Angle.cpp
@@ -38,6 +38,21 @@ TEST(Angle, DegreeAndRadian)
                 double(Real{((Pi * 1_rad) / Real{180}) / 1_rad}), 0.0001);
 }
 
+TEST(Angle, GetRevRotationalAngle)
+{
+    EXPECT_EQ(GetRevRotationalAngle(0_deg, 0_deg), 0_deg);
+    EXPECT_EQ(GetRevRotationalAngle(0_deg, 10_deg), 10_deg);
+    // GetRevRotationalAngle(100 * Degree, 110 * Degree) almost equals 10 * Degree (but not exactly)
+    EXPECT_EQ(GetRevRotationalAngle(-10_deg, 0_deg), 10_deg);
+    EXPECT_NEAR(static_cast<double>(Real{GetRevRotationalAngle(90_deg, -90_deg)/1_deg}), 180.0, 0.0001);
+    EXPECT_NEAR(double(Real{GetRevRotationalAngle(100_deg, 110_deg) / 1_deg}),  10.0, 0.0001);
+    EXPECT_NEAR(double(Real{GetRevRotationalAngle( 10_deg,   0_deg) / 1_deg}), 350.0, 0.0001);
+    EXPECT_NEAR(double(Real{GetRevRotationalAngle( -2_deg,  +3_deg) / 1_deg}),   5.0, 0.001);
+    EXPECT_NEAR(double(Real{GetRevRotationalAngle( +2_deg,  -3_deg) / 1_deg}), 355.0, 0.001);
+    EXPECT_NEAR(double(Real{GetRevRotationalAngle(-13_deg,  -3_deg) / 1_deg}),  10.0, 0.001);
+    EXPECT_NEAR(double(Real{GetRevRotationalAngle(-10_deg, -20_deg) / 1_deg}), 350.0, 0.001);
+}
+
 TEST(Angle, GetDelta)
 {
     EXPECT_EQ(GetDelta(0_deg, 0_deg), 0_deg);


### PR DESCRIPTION
#### Description - What's this PR do?
- Moves the camera global from Main.cpp into DebugDraw for wider usage.
- Exposes control of the StepConf::minStillTimeToSleep parameter to the Testbed UI.
- Provides an entity editor UI interface to shapes.
- Makes use of GetRevRotationalAngle to Testbed's DrawCorner code to fix missing arc seen in Distance Test.
- Updates the Testbed code for drawing center of masses to scale the segments based on the cubed root of the mass in question.
- Updates the bomb spawning code to better handle scales like that of the Solar System test.
- Updates the Solar System Testbed test to provide more info to users.
- Makes Fixture::GetProxies() public on seeing no reason to hide it.
- Adds more sanity checking of inputs.
- Adds GetRevRotationalAngle back since GetDelta doesn't do what's needed for things like DrawCorner.