### PR TITLE
Fix assertions under debug build unit testing with Visual Studio.

### DIFF
--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -144,9 +144,9 @@ namespace playrho {
     template <std::size_t N>
     inline bool operator<= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
     {
-        return std::lexicographical_compare(std::cbegin(lhs.ranges), std::cend(lhs.ranges),
-                                            std::cbegin(rhs.ranges), std::cend(rhs.ranges),
-                                            std::less_equal<LengthInterval>{});
+        const auto lhsEnd = std::cend(lhs.ranges);
+        const auto diff = std::mismatch(std::cbegin(lhs.ranges), lhsEnd, std::cbegin(rhs.ranges));
+        return (diff.first == lhsEnd) || (*diff.first < *diff.second);
     }
     
     /// @brief Greater-than operator.
@@ -164,9 +164,9 @@ namespace playrho {
     template <std::size_t N>
     inline bool operator>= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
     {
-        return std::lexicographical_compare(std::cbegin(lhs.ranges), std::cend(lhs.ranges),
-                                            std::cbegin(rhs.ranges), std::cend(rhs.ranges),
-                                            std::greater_equal<LengthInterval>{});
+        const auto lhsEnd = std::cend(lhs.ranges);
+        const auto diff = std::mismatch(std::cbegin(lhs.ranges), lhsEnd, std::cbegin(rhs.ranges));
+        return (diff.first == lhsEnd) || (*diff.first > *diff.second);
     }
 
     /// @brief Tests for overlap between two axis aligned bounding boxes.

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -400,8 +400,9 @@ constexpr bool operator< (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noex
 template <typename T, std::size_t N>
 constexpr bool operator<= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
-    return std::lexicographical_compare(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
-                                        std::less_equal<T>{});
+    const auto lhsEnd = std::cend(lhs);
+    const auto diff = std::mismatch(std::cbegin(lhs), lhsEnd, std::cbegin(rhs));
+    return (diff.first == lhsEnd) || (*diff.first < *diff.second);
 }
 
 /// @brief Lexicographical greater-than operator.
@@ -418,8 +419,9 @@ constexpr bool operator> (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noex
 template <typename T, std::size_t N>
 constexpr bool operator>= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
-    return std::lexicographical_compare(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
-                                        std::greater_equal<T>{});
+    const auto lhsEnd = std::cend(lhs);
+    const auto diff = std::mismatch(std::cbegin(lhs), lhsEnd, std::cbegin(rhs));
+    return (diff.first == lhsEnd) || (*diff.first > *diff.second);
 }
 
 /// @brief Gets the I'th element of the given collection.


### PR DESCRIPTION
#### Description - What's this PR do?
Re-implements <= and >= for AABB and Vector using `std::mismatch` instead of `std::lexicographical_compare`.

#### Related Issues
- Issue #1 .