### PR TITLE
For issue #214 and issue #215.

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -42,6 +42,7 @@
 #include <condition_variable>
 #include <queue>
 #include <atomic>
+#include <ctime>
 
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/OptionalValue.hpp>
@@ -1519,7 +1520,8 @@ static void AddPairStressTest(benchmark::State& state, int count)
             for (auto i = 0; i < count; ++i)
             {
                 const auto location = playrho::Vec2(Rand(minX, maxX), Rand(minY, maxY)) * playrho::Meter;
-                const auto body = world.CreateBody(playrho::BodyDef{bd}.UseLocation(location));
+                // Uses parenthesis here to work around Visual C++'s const propagating of the copy.
+                const auto body = world.CreateBody(playrho::BodyDef(bd).UseLocation(location));
                 body->CreateFixture(diskShape);
             }
         }

--- a/Benchmark/CMakeLists.txt
+++ b/Benchmark/CMakeLists.txt
@@ -2,6 +2,15 @@
 # Top level docs for 3.1.3 at: https://cmake.org/cmake/help/v3.1/
 # Commands herein described at: https://cmake.org/cmake/help/v3.1/manual/cmake-commands.7.html
 
+# Hides options.
+mark_as_advanced(FORCE LIBRT)
+mark_as_advanced(FORCE BENCHMARK_BUILD_32_BITS)
+mark_as_advanced(FORCE BENCHMARK_ENABLE_EXCEPTIONS)
+mark_as_advanced(FORCE BENCHMARK_ENABLE_INSTALL)
+mark_as_advanced(FORCE BENCHMARK_ENABLE_TESTING)
+mark_as_advanced(FORCE BENCHMARK_ENABLE_LTO)
+mark_as_advanced(FORCE BENCHMARK_USE_LIBCXX)
+
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Enable testing of the benchmark library.")
 
 # Add subdirectory to build.

--- a/Benchmark/README.md
+++ b/Benchmark/README.md
@@ -6,71 +6,123 @@ This application provides benchmark data for various functions and methods of Pl
 
 ## Build Instructions
 
-Coming.
+### Configure &amp; Generate The Project Via CMake
+
+Enable the `PLAYRHO_BUILD_BENCHMARK` CMake option and specify the `Release` CMake build type.
+
+From the command line using `cmake` and `make`, this can be achieved by running the following:
+    cd $BUILD_DIR && cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DPLAYRHO_BUILD_BENCHMARK=ON $SOURCE_DIR
+
+From the CMake GUI:
+1. If needed, specify the generator for the project and use the default native compilers. For 64-bit Windows machines, choose `Visual Studio 15 2017 Win64`.
+1. Specify the source folder.
+1. Specify where to build the binaries. Choose a different folder than where the source is.
+1. Press the CMake *Configure* button. You should see information output to the bottom CMake window and a window with `Name` and `Value` columns.
+1. Select and open the `PLAYRHO` row to reveal rows of name and value pairs that begin with `PLAYRHO_`.
+1. Check/enable the boolean value option for `PLAYRHO_BUILD_BENCHMARK`.
+1. Press the CMake *Configure* button again. This will reconfigure things based on the new settings.
+1. Press the CMake *Generate* button and wait for that to finish. It should finish much quicker than the configure steps.
+1. Exit the CMake GUI.
+
+### Build The Project
+
+#### Via Visual Studio
+1. If you're on a Windows machine and chose a `Visual Studio...` generator option then startup that version of Visual Studio and open the project or solution file that should now be in the build folder.
+1. Build the project.
+
+#### Via Make &amp; The Command Line
+1. Run `make`.
+1. Optionally, run `make install`.
+1. Run the `Benchmark` binary executable.
+1. Optionally, contribute the output results for your machine back to PlayRho.
 
 ## Sample Output
 
-Note that the following times are for running the named benchmarks which may have way more overhead than their names suggests. What's seemingly significant from this output however, is that operations like sine and cosine take significantly longer than square root or division.
+Note that the following times are for running the named benchmarks which may have way more overhead than their names suggests. Don't put much weight into these results unless you're clear on the code that's being timed.
 
 ```sh
+$ ./Benchmark
 Run on (8 X 2600 MHz CPU s)
-2017-08-08 20:51:19
---------------------------------------------------------------------------
-Benchmark                                   Time           CPU Iterations
---------------------------------------------------------------------------
-FloatAdd                                    2 ns          2 ns  368982294
-FloatMult                                   2 ns          2 ns  366233291
-FloatDiv                                    2 ns          2 ns  358505544
-FloatSqrt                                   2 ns          2 ns  382018915
-FloatSin                                    7 ns          7 ns  113156916
-FloatCos                                    6 ns          6 ns  110023105
-FloatAtan2                                  7 ns          7 ns   99072960
-DotProduct                                  2 ns          2 ns  373072680
-CrossProduct                                2 ns          2 ns  363119508
-LengthSquaredViaDotProduct                  2 ns          2 ns  351751724
-GetLengthSquared                            2 ns          2 ns  379617779
-GetLength                                   2 ns          2 ns  384497078
-hypot                                       4 ns          4 ns  175868792
-UnitVectorFromVector                        2 ns          2 ns  294130005
-UnitVectorFromVectorAndBack                 2 ns          2 ns  297693724
-UnitVecFromAngle                            8 ns          8 ns   80838877
-TwoRandValues                              13 ns         13 ns   54730686
-FloatAddTwoRand                            13 ns         13 ns   54026102
-FloatMultTwoRand                           13 ns         13 ns   53356505
-FloatDivTwoRand                            13 ns         13 ns   53571702
-FloatSqrtTwoRand                           13 ns         13 ns   53826280
-FloatSinTwoRand                            36 ns         36 ns   18716828
-FloatCosTwoRand                            35 ns         35 ns   20197240
-FloatAtan2TwoRand                          28 ns         28 ns   25564146
-DoubleAddTwoRand                           14 ns         14 ns   53771288
-DoubleMultTwoRand                          14 ns         14 ns   51642604
-DoubleDivTwoRand                           18 ns         17 ns   40536706
-DoubleSqrtTwoRand                          18 ns         18 ns   38975718
-DoubleSinTwoRand                           49 ns         49 ns   14750226
-DoubleCosTwoRand                           48 ns         48 ns   14213313
-DoubleAtan2TwoRand                         69 ns         69 ns   10425199
-LengthSquaredViaDotProductTwoRand          14 ns         14 ns   50312657
-GetLengthSquaredTwoRand                    15 ns         15 ns   48167237
-GetLengthTwoRand                           14 ns         14 ns   50834780
-hypotTwoRand                               15 ns         15 ns   44679900
-UnitVectorFromVectorTwoRand                17 ns         17 ns   43387444
-UnitVectorFromVectorAndBackTwoRand         17 ns         17 ns   41706884
-FourRandValues                             28 ns         28 ns   24096717
-DotProductFourRand                         29 ns         29 ns   24427097
-CrossProductFourRand                       29 ns         29 ns   24291133
-ConstructAndAssignVC                       33 ns         33 ns   20916126
-SolveVC                                    44 ns         44 ns   15413987
-MaxSepBetweenAbsRectangles                 74 ns         74 ns    9816020
-MaxSepBetweenRel4x4                        80 ns         80 ns    8796069
-MaxSepBetweenRel2_4x4                      82 ns         82 ns    8408913
-MaxSepBetweenRelRectanglesNoStop          104 ns        104 ns    6918432
-MaxSepBetweenRelRectangles2NoStop         103 ns        103 ns    6850119
-MaxSepBetweenRelRectangles                104 ns        104 ns    6884275
-MaxSepBetweenRelRectangles2               100 ns        100 ns    7195058
-ManifoldForTwoSquares1                    156 ns        155 ns    4617475
-ManifoldForTwoSquares2                    157 ns        157 ns    4675863
-TilesComesToRest12                   57637128 ns   57506769 ns         13
-TilesComesToRest20                  375657450 ns  375055500 ns          2
-TilesComesToRest36                 3974857636 ns 3973611000 ns          1
-Program ended with exit code: 0
+2017-11-20 18:31:48
+-------------------------------------------------------------------------
+Benchmark                                  Time           CPU Iterations
+-------------------------------------------------------------------------
+FloatAdd/1000                            581 ns        579 ns    1174911
+FloatMul/1000                            574 ns        573 ns    1217158
+FloatDiv/1000                           1995 ns       1994 ns     342374
+FloatSqrt/1000                          2045 ns       2045 ns     332186
+FloatSin/1000                           6805 ns       6798 ns     101185
+FloatCos/1000                           7144 ns       7134 ns      95021
+FloatSinCos/1000                        6914 ns       6905 ns      93443
+FloatAtan2/1000                         6982 ns       6977 ns      97983
+FloatHypot/1000                         4015 ns       4015 ns     174633
+DoubleAdd/1000                           585 ns        585 ns    1173256
+DoubleMul/1000                           589 ns        588 ns    1121184
+DoubleDiv/1000                          4041 ns       4040 ns     171622
+DoubleSqrt/1000                         3996 ns       3992 ns     174198
+DoubleSin/1000                         11520 ns      11518 ns      59252
+DoubleCos/1000                         12289 ns      12281 ns      56609
+DoubleSinCos/1000                      13203 ns      13199 ns      52519
+DoubleAtan2/1000                       25459 ns      25455 ns      27246
+DoubleHypot/1000                        4911 ns       4907 ns     138726
+AlmostEqual1/1000                       3177 ns       3176 ns     218750
+AlmostEqual2/1000                       1244 ns       1244 ns     520477
+DiffSignsViaSignbit/1000                 897 ns        896 ns     773600
+DiffSignsViaMul/1000                     869 ns        868 ns     787747
+ModuloViaTrunc/1000                     1990 ns       1990 ns     340677
+ModuloViaFmod/1000                      6586 ns       6581 ns     105415
+DotProduct/1000                          897 ns        896 ns     753596
+CrossProduct/1000                        752 ns        751 ns     920859
+LengthSquaredViaDotProduct/1000          868 ns        868 ns     796251
+GetLengthSquared/1000                    604 ns        603 ns    1076509
+GetLength/1000                          1988 ns       1988 ns     333072
+UnitVectorFromVector/1000               4480 ns       4476 ns     136012
+UnitVectorFromVectorAndBack/1000        4465 ns       4464 ns     153616
+UnitVecFromAngle/1000                   7142 ns       7134 ns      97723
+AABB2D/1000                             7572 ns       7566 ns      82166
+ConstructAndAssignVC                      26 ns         26 ns   26404333
+SolveVC                                   43 ns         43 ns   16475007
+MaxSepBetweenAbsRectangles                77 ns         77 ns    9091854
+MaxSepBetweenRel4x4                       85 ns         85 ns    7717836
+MaxSepBetweenRel2_4x4                     86 ns         86 ns    7984214
+MaxSepBetweenRelRectanglesNoStop          97 ns         96 ns    7213520
+MaxSepBetweenRelRectangles2NoStop         95 ns         95 ns    7001750
+MaxSepBetweenRelRectangles               100 ns         99 ns    6777495
+MaxSepBetweenRelRectangles2              100 ns         99 ns    6898115
+ManifoldForTwoSquares1                   143 ns        143 ns    4644158
+ManifoldForTwoSquares2                   138 ns        138 ns    4873532
+AsyncFutureDeferred                      281 ns        281 ns    2465752
+AsyncFutureAsync                       21436 ns      19139 ns      35243
+ThreadCreateAndDestroy                 24129 ns      18756 ns      37133
+MultiThreadQD                          10471 ns       5552 ns     100000
+MultiThreadQDE                         10048 ns       5336 ns     100000
+MultiThreadQDA                           154 ns        154 ns    4572832
+MultiThreadQDAQ                       248591 ns     248497 ns      13713
+WorldStep                                 75 ns         75 ns    9143633
+WorldStepWithStatsStatic/0                87 ns         87 ns    7893105
+WorldStepWithStatsStatic/1                93 ns         92 ns    7351088
+WorldStepWithStatsStatic/10              128 ns        128 ns    5280986
+WorldStepWithStatsStatic/100             362 ns        362 ns    1913991
+WorldStepWithStatsStatic/1000           5592 ns       5587 ns     120688
+WorldStepWithStatsStatic/10000         91228 ns      91141 ns       7512
+DropDisks/0                               76 ns         76 ns    9250449
+DropDisks/1                              941 ns        940 ns     739528
+DropDisks/10                            9395 ns       9388 ns      70862
+DropDisks/100                         100451 ns     100382 ns       6838
+DropDisks/1000                        990632 ns     989579 ns        705
+DropDisks/10000                     10088055 ns   10079884 ns         69
+TumblerAdd100SquaresPlus100Steps    42491661 ns   42488688 ns         16
+TumblerAdd200SquaresPlus200Steps   192134232 ns  192130667 ns          3
+AddPairStressTest400/0               2906973 ns    2906795 ns        234
+AddPairStressTest400/10              1298488 ns    1298009 ns        546
+AddPairStressTest400/15              1440968 ns    1440525 ns        493
+AddPairStressTest400/16             21259641 ns   21253969 ns         32
+AddPairStressTest400/17             48492777 ns   48438417 ns         12
+AddPairStressTest400/18             84638874 ns   84596571 ns          7
+AddPairStressTest400/19             25832690 ns   25819296 ns         27
+AddPairStressTest400/20             21288679 ns   21287455 ns         33
+AddPairStressTest400/30              7102015 ns    7099620 ns        100
+TilesComesToRest/12                 60359953 ns   60309250 ns         12
+TilesComesToRest/20                359062532 ns  358925000 ns          2
+TilesComesToRest/36               4043229240 ns 4042139000 ns          1
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,16 +49,6 @@ install:
   - if "%platform%" equ "Win32" vcpkg install glew:x86-windows-static
   - if "%platform%" equ "Win32" vcpkg install glfw3:x86-windows-static
 
-#test_script:
-#- ps: |
-#    If ($env:PLATFORM -Match "Win32") {
-#      $env:PLAYRHO_EXE="x32"
-#    }
-#    If ($env:PLATFORM -Match "x64") {
-#      $env:PLAYRHO_EXE="x64"
-#    }
-#    Start-Process -FilePath "\projects\playrho\Build\vs2017\bin\$env:PLAYRHO_EXE\$env:CONFIGURATION\HelloWorld.exe" -RedirectStandardOutput "Hello.txt" -Wait -NoNewWindow
-
 before_build:
   - echo %APPVEYOR_BUILD_FOLDER%
   - if "%platform%" equ "Win32" set generator=Visual Studio 15 2017
@@ -68,18 +58,24 @@ before_build:
   - if "%platform%" equ "x64" set triplet=x64-windows-static
   - if "%platform%" equ "x64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
 
+# Handle building the library & binary executables or generating the doxygen docs
+# depending on the current environment matrix variable settings.
+# Only builds Benchmark app for Release builds. No sense benchmarking Debug builds.
 build_script:
   - if "%platform%" neq "noarch" cd %APPVEYOR_BUILD_FOLDER%\Build
-  - if "%platform%" neq "noarch" cmake -G"%generator%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%triplet% -DPLAYRHO_BUILD_HELLOWORLD=ON -DPLAYRHO_BUILD_UNIT_TESTS=ON -DPLAYRHO_BUILD_TESTBED=ON ..
+  - if "%configuration%" equ "Debug" cmake -G"%generator%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%triplet% -DPLAYRHO_BUILD_HELLOWORLD=ON -DPLAYRHO_BUILD_UNIT_TESTS=ON -DPLAYRHO_BUILD_TESTBED=ON ..
+  - if "%configuration%" equ "Release" cmake -G"%generator%" -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=%triplet% -DPLAYRHO_BUILD_HELLOWORLD=ON -DPLAYRHO_BUILD_UNIT_TESTS=ON -DPLAYRHO_BUILD_TESTBED=ON -DPLAYRHO_BUILD_BENCHMARK=ON ..
   - if "%platform%" neq "noarch" cmake --build . --config "%configuration%"
   - if "%platform%" equ "noarch" cd %APPVEYOR_BUILD_FOLDER%\Documentation
   - if "%platform%" equ "noarch" set PATH=c:\Program Files (x86)\graphviz2.38\bin;%PATH%
   - if "%platform%" equ "noarch" doxygen Doxyfile
   - cd ..
 
+# Run the UnitTests application via CMake's ctest command.
+# Just run ctest for Release builds since it's much faster than the Debug build.
 test_script:
   - if "%platform%" neq "noarch" cd %APPVEYOR_BUILD_FOLDER%\Build
-  - if "%platform%" neq "noarch" ctest --output-on-failure
+  - if "%configuration%" equ "Release" ctest --output-on-failure
   - if "%platform%" neq "noarch" cd ..
 
 #build:


### PR DESCRIPTION
#### Description - What's this PR do?
- Adds build instructions for the Benchmark application.
- Hides away BENCHMARK CMake options as advanced.
- Adds the ctime header to fix Visual C++ compiler error on not finding std::time.
- Switches from copy construction via braced initialization to parenthesis.

#### Related Issues
- Issue #214.
- Issue #215.