### PR TITLE
Misc changes 20171125

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -105,6 +105,14 @@ static std::pair<double, double> RandPair(double lo, double hi)
     return std::make_pair(first, second);
 }
 
+static std::tuple<float, float, float> RandTriplet(float lo, float hi)
+{
+    const auto first = Rand(lo, hi);
+    const auto second = Rand(lo, hi);
+    const auto third = Rand(lo, hi);
+    return std::make_tuple(first, second, third);
+}
+
 static std::tuple<float, float, float, float> RandQuad(float lo, float hi)
 {
     const auto first = Rand(lo, hi);
@@ -145,6 +153,28 @@ static std::vector<std::pair<double, double>> RandPairs(unsigned count, double l
     for (auto i = decltype(count){0}; i < count; ++i)
     {
         rands.push_back(RandPair(lo, hi));
+    }
+    return rands;
+}
+
+static std::vector<std::tuple<float, float, float>> RandTriplets(unsigned count, float lo, float hi)
+{
+    auto rands = std::vector<std::tuple<float, float, float>>{};
+    rands.reserve(count);
+    for (auto i = decltype(count){0}; i < count; ++i)
+    {
+        rands.push_back(RandTriplet(lo, hi));
+    }
+    return rands;
+}
+
+static std::vector<std::tuple<double, double, double>> RandTriplets(unsigned count, double lo, double hi)
+{
+    auto rands = std::vector<std::tuple<double, double, double>>{};
+    rands.reserve(count);
+    for (auto i = decltype(count){0}; i < count; ++i)
+    {
+        rands.push_back(RandTriplet(lo, hi));
     }
     return rands;
 }
@@ -283,6 +313,30 @@ static void FloatHypot(benchmark::State& state)
     }
 }
 
+static void FloatMulAdd(benchmark::State& state)
+{
+    const auto vals = RandTriplets(static_cast<unsigned>(state.range()), -1000.0f, 1000.0f);
+    for (auto _: state)
+    {
+        for (const auto& val: vals)
+        {
+            benchmark::DoNotOptimize((std::get<0>(val) * std::get<1>(val)) + std::get<2>(val));
+        }
+    }
+}
+
+static void FloatFma(benchmark::State& state)
+{
+    const auto vals = RandTriplets(static_cast<unsigned>(state.range()), -1000.0f, 1000.0f);
+    for (auto _: state)
+    {
+        for (const auto& val: vals)
+        {
+            benchmark::DoNotOptimize(std::fma(std::get<0>(val), std::get<1>(val), std::get<2>(val)));
+        }
+    }
+}
+
 // ----
 
 static void DoubleAdd(benchmark::State& state)
@@ -391,6 +445,30 @@ static void DoubleHypot(benchmark::State& state)
         for (const auto& val: vals)
         {
             benchmark::DoNotOptimize(std::hypot(val.first, val.second));
+        }
+    }
+}
+
+static void DoubleMulAdd(benchmark::State& state)
+{
+    const auto vals = RandTriplets(static_cast<unsigned>(state.range()), -1000.0, 1000.0);
+    for (auto _: state)
+    {
+        for (const auto& val: vals)
+        {
+            benchmark::DoNotOptimize((std::get<0>(val) * std::get<1>(val)) + std::get<2>(val));
+        }
+    }
+}
+
+static void DoubleFma(benchmark::State& state)
+{
+    const auto vals = RandTriplets(static_cast<unsigned>(state.range()), -1000.0, 1000.0);
+    for (auto _: state)
+    {
+        for (const auto& val: vals)
+        {
+            benchmark::DoNotOptimize(std::fma(std::get<0>(val), std::get<1>(val), std::get<2>(val)));
         }
     }
 }
@@ -1758,6 +1836,7 @@ static void TumblerAdd200SquaresPlus200Steps(benchmark::State& state)
 
 BENCHMARK(FloatAdd)->Arg(1000);
 BENCHMARK(FloatMul)->Arg(1000);
+BENCHMARK(FloatMulAdd)->Arg(1000);
 BENCHMARK(FloatDiv)->Arg(1000);
 BENCHMARK(FloatSqrt)->Arg(1000);
 BENCHMARK(FloatSin)->Arg(1000);
@@ -1765,9 +1844,11 @@ BENCHMARK(FloatCos)->Arg(1000);
 BENCHMARK(FloatSinCos)->Arg(1000);
 BENCHMARK(FloatAtan2)->Arg(1000);
 BENCHMARK(FloatHypot)->Arg(1000);
+BENCHMARK(FloatFma)->Arg(1000);
 
 BENCHMARK(DoubleAdd)->Arg(1000);
 BENCHMARK(DoubleMul)->Arg(1000);
+BENCHMARK(DoubleMulAdd)->Arg(1000);
 BENCHMARK(DoubleDiv)->Arg(1000);
 BENCHMARK(DoubleSqrt)->Arg(1000);
 BENCHMARK(DoubleSin)->Arg(1000);
@@ -1775,6 +1856,7 @@ BENCHMARK(DoubleCos)->Arg(1000);
 BENCHMARK(DoubleSinCos)->Arg(1000);
 BENCHMARK(DoubleAtan2)->Arg(1000);
 BENCHMARK(DoubleHypot)->Arg(1000);
+BENCHMARK(DoubleFma)->Arg(1000);
 
 BENCHMARK(AlmostEqual1)->Arg(1000);
 BENCHMARK(AlmostEqual2)->Arg(1000);

--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -854,26 +854,26 @@ static void LengthSquaredViaDotProduct(benchmark::State& state)
     }
 }
 
-static void GetLengthSquared(benchmark::State& state)
+static void GetMagnitudeSquared(benchmark::State& state)
 {
     const auto vals = RandPairs(static_cast<unsigned>(state.range()), -100.0f, 100.0f);
     for (auto _: state)
     {
         for (const auto& val: vals)
         {
-            benchmark::DoNotOptimize(playrho::GetLengthSquared(playrho::Vec2(val.first, val.second)));
+            benchmark::DoNotOptimize(playrho::GetMagnitudeSquared(playrho::Vec2(val.first, val.second)));
         }
     }
 }
 
-static void GetLength(benchmark::State& state)
+static void GetMagnitude(benchmark::State& state)
 {
     const auto vals = RandPairs(static_cast<unsigned>(state.range()), -100.0f, 100.0f);
     for (auto _: state)
     {
         for (const auto& val: vals)
         {
-            benchmark::DoNotOptimize(playrho::GetLength(playrho::Vec2(val.first, val.second)));
+            benchmark::DoNotOptimize(playrho::GetMagnitude(playrho::Vec2(val.first, val.second)));
         }
     }
 }
@@ -1786,8 +1786,8 @@ BENCHMARK(ModuloViaFmod)->Arg(1000);
 BENCHMARK(DotProduct)->Arg(1000);
 BENCHMARK(CrossProduct)->Arg(1000);
 BENCHMARK(LengthSquaredViaDotProduct)->Arg(1000);
-BENCHMARK(GetLengthSquared)->Arg(1000);
-BENCHMARK(GetLength)->Arg(1000);
+BENCHMARK(GetMagnitudeSquared)->Arg(1000);
+BENCHMARK(GetMagnitude)->Arg(1000);
 BENCHMARK(UnitVectorFromVector)->Arg(1000);
 BENCHMARK(UnitVectorFromVectorAndBack)->Arg(1000);
 BENCHMARK(UnitVecFromAngle)->Arg(1000);

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -2020,14 +2020,11 @@
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
-					"DO_GJK_PROFILING=1",
 					"$(inherited)",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-Wall",
 					"-Wextra",
-					"-mllvm",
-					"-inline-threshold=-1",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -2042,15 +2039,10 @@
 				DEPLOYMENT_LOCATION = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				EXECUTABLE_PREFIX = lib;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DO_GJK_PROFILING=1",
-					"NDEBUG=1",
-				);
+				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
 				OTHER_CPLUSPLUSFLAGS = (
 					"-Wall",
 					"-Wextra",
-					"-mllvm",
-					"-inline-threshold=-1",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		4768D3F81E3E895A00574143 /* PrismaticJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4768D3F71E3E895A00574143 /* PrismaticJoint.cpp */; };
 		4768D3FD1E414A0100574143 /* Vector2.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4768D3FA1E414A0100574143 /* Vector2.hpp */; };
 		4768D4001E54E7CC00574143 /* StepConf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4768D3FF1E54E7CB00574143 /* StepConf.cpp */; };
+		476E8ABE1FC8CD9F00705BB5 /* UnitVec2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 476E8ABD1FC8CD9F00705BB5 /* UnitVec2.cpp */; };
 		4775A9381E05B032001C2332 /* StepConf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4775A9371E05B032001C2332 /* StepConf.cpp */; };
 		47791F801F92DB0700E257AF /* imgui_draw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47791F7A1F92D78F00E257AF /* imgui_draw.cpp */; };
 		47791F811F92DB0D00E257AF /* imgui_impl_glfw_gl3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47791F7C1F92D83500E257AF /* imgui_impl_glfw_gl3.cpp */; };
@@ -510,6 +511,7 @@
 		4768D3F71E3E895A00574143 /* PrismaticJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrismaticJoint.cpp; sourceTree = "<group>"; };
 		4768D3FA1E414A0100574143 /* Vector2.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Vector2.hpp; sourceTree = "<group>"; };
 		4768D3FF1E54E7CB00574143 /* StepConf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StepConf.cpp; sourceTree = "<group>"; };
+		476E8ABD1FC8CD9F00705BB5 /* UnitVec2.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnitVec2.cpp; sourceTree = "<group>"; };
 		477329D61F9BEFA200C521B4 /* SolarSystem.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SolarSystem.hpp; sourceTree = "<group>"; };
 		4775A9371E05B032001C2332 /* StepConf.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StepConf.cpp; sourceTree = "<group>"; };
 		47791F761F901B8700E257AF /* iforce2d_Trajectories.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = iforce2d_Trajectories.hpp; sourceTree = "<group>"; };
@@ -987,6 +989,7 @@
 				47C85D1E1F0DA14500F70C56 /* Templates.hpp */,
 				470F9B151EDF2959007EF7B6 /* Transformation.hpp */,
 				47C85D181F0D9D8D00F70C56 /* Units.hpp */,
+				476E8ABD1FC8CD9F00705BB5 /* UnitVec2.cpp */,
 				4731DE551DEC908600E7F931 /* UnitVec2.hpp */,
 				474FFC3A1F2CEE6C0037CCE0 /* Vector.hpp */,
 				4768D3FA1E414A0100574143 /* Vector2.hpp */,
@@ -1660,6 +1663,7 @@
 				80BB898F141C3E5900F1753A /* Distance.cpp in Sources */,
 				4787D6D61F2ECD87008C115E /* PulleyJointDef.cpp in Sources */,
 				80BB8991141C3E5900F1753A /* DynamicTree.cpp in Sources */,
+				476E8ABE1FC8CD9F00705BB5 /* UnitVec2.cpp in Sources */,
 				47D28D8E1F6E2C7C0094C032 /* JointType.cpp in Sources */,
 				80BB8993141C3E5900F1753A /* TimeOfImpact.cpp in Sources */,
 				470F9B4C1EEF20B6007EF7B6 /* BodyDef.cpp in Sources */,

--- a/PlayRho/Collision/Collision.cpp
+++ b/PlayRho/Collision/Collision.cpp
@@ -93,7 +93,7 @@ ClipList ClipSegmentToLine(const ClipList& vIn, const UnitVec2& normal, Length o
         }
 
         // If we didn't already find two points & the points are on different sides of the plane...
-        if (vOut.size() < 2 && std::signbit(StripUnit(distance0)) != std::signbit(StripUnit(distance1)))
+        if (vOut.size() < 2 && SignBit(StripUnit(distance0)) != SignBit(StripUnit(distance1)))
         {
             // Neither distance0 nor distance1 is 0 and either one or the other is negative (but not both).
             // Find intersection point of edge and plane

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -156,7 +156,7 @@ DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& trans
 #if defined(DO_COMPUTE_CLOSEST_POINT)
         // Compute closest point.
         const auto p = GetClosestPoint(simplexEdges);
-        const auto distanceSqr2 = GetLengthSquared(p);
+        const auto distanceSqr2 = GetMagnitudeSquared(p);
 
         // Ensure progress
         if (distanceSqr2 >= distanceSqr1)
@@ -170,7 +170,7 @@ DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& trans
         assert(IsValid(d));
 
         // Ensure the search direction is numerically fit.
-        if (AlmostZero(StripUnit(GetLengthSquared(d))))
+        if (AlmostZero(StripUnit(GetMagnitudeSquared(d))))
         {
             state = DistanceOutput::UnfitSearchDir;
 
@@ -212,7 +212,7 @@ Area TestOverlap(const DistanceProxy& proxyA, const Transformation& xfA,
     assert(distanceInfo.state != DistanceOutput::Unknown && distanceInfo.state != DistanceOutput::HitMaxIters);
     
     const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
-    const auto distanceSquared = GetLengthSquared(witnessPoints.a - witnessPoints.b);
+    const auto distanceSquared = GetMagnitudeSquared(GetDelta(witnessPoints));
     const auto totalRadiusSquared = Square(proxyA.GetVertexRadius() + proxyB.GetVertexRadius());
     return totalRadiusSquared - distanceSquared;
 }

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -37,6 +37,12 @@ namespace playrho {
     /// @brief Gets the witness points of the given simplex.
     WitnessPoints GetWitnessPoints(const Simplex& simplex) noexcept;
     
+    /// @brief Gets the delta of the two points of the given witness points.
+    constexpr Length2 GetDelta(WitnessPoints arg) noexcept
+    {
+        return arg.a - arg.b;
+    }
+    
     /// @brief Distance Configuration.
     struct DistanceConf
     {

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -121,7 +121,7 @@ std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices)
                 const auto r = vertices[ie] - vertices[ih];
                 const auto v = vertices[j] - vertices[ih];
                 const auto c = Cross(r, v);
-                if ((c < Area{0}) || ((c == Area{0}) && (GetLengthSquared(v) > GetLengthSquared(r))))
+                if ((c < Area{0}) || ((c == Area{0}) && (GetMagnitudeSquared(v) > GetMagnitudeSquared(r))))
                 {
                     ie = j;
                 }
@@ -158,7 +158,7 @@ bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept
     {
         const auto v0 = proxy.GetVertex(0);
         const auto delta = point - v0;
-        return GetLengthSquared(delta) <= Square(vr);
+        return GetMagnitudeSquared(delta) <= Square(vr);
     }
     
     auto maxDot = -MaxFloat * Meter;
@@ -191,14 +191,14 @@ bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept
     if (d0 >= Area{0})
     {
         // point is nearest v0 and not within edge
-        return GetLengthSquared(delta0) <= Square(vr);
+        return GetMagnitudeSquared(delta0) <= Square(vr);
     }
     const auto delta1 = point - v1;
     const auto d1 = Dot(edge, delta1);
     if (d1 >= Area{0})
     {
         // point is nearest v1 and not within edge
-        return GetLengthSquared(delta1) <= Square(vr);
+        return GetMagnitudeSquared(delta1) <= Square(vr);
     }
     return true;
 }

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -56,7 +56,7 @@ bool operator== (const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept
 DistanceProxy::size_type GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept
 {
     auto index = DistanceProxy::InvalidIndex; ///< Index of vertex that when dotted with d has the max value.
-    auto maxValue = -MaxFloat * Meter; ///< Max dot value.
+    auto maxValue = -std::numeric_limits<Length>::infinity(); ///< Max dot value.
     const auto count = proxy.GetVertexCount();
     for (auto i = decltype(count){0}; i < count; ++i)
     {

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -79,7 +79,7 @@ Manifold GetFaceManifold(const Manifold::Type type,
     const auto shape0_abs_v0 = Transform(shape0_rel_v0, xf0);
     const auto shape0_abs_v1 = Transform(shape0_rel_v1, xf0);
     
-    auto shape0_len_edge0 = GetLengthSquared(shape0_rel_v1 - shape0_rel_v0);
+    auto shape0_len_edge0 = GetMagnitudeSquared(shape0_rel_v1 - shape0_rel_v0);
 
     // Clip incident edge against extruded edge1 side edges.
     // Side offsets, extended by polytope skin thickness.
@@ -170,7 +170,7 @@ Manifold GetFaceManifold(const Manifold::Type type,
     // or a face manifold.
     const auto totalRadiusSquared = Square(totalRadius);
     const auto mustUseFaceManifold = shape0_len_edge0 > Square(conf.maxCirclesRatio * r0);
-    if (GetLengthSquared(shape0_abs_v0 - shape1_abs_v0) <= totalRadiusSquared)
+    if (GetMagnitudeSquared(shape0_abs_v0 - shape1_abs_v0) <= totalRadiusSquared)
     {
         // shape 1 vertex 1 is colliding with shape 2 vertex 1
         // shape 1 vertex 1 is the vertex at index idx0, or one before idx0Next.
@@ -199,7 +199,7 @@ Manifold GetFaceManifold(const Manifold::Type type,
                 break;
         }
     }
-    else if (GetLengthSquared(shape0_abs_v0 - shape1_abs_v1) <= totalRadiusSquared)
+    else if (GetMagnitudeSquared(shape0_abs_v0 - shape1_abs_v1) <= totalRadiusSquared)
     {
         // shape 1 vertex 1 is colliding with shape 2 vertex 2
         switch (type)
@@ -224,7 +224,7 @@ Manifold GetFaceManifold(const Manifold::Type type,
                 break;
         }
     }
-    else if (GetLengthSquared(shape0_abs_v1 - shape1_abs_v1) <= totalRadiusSquared)
+    else if (GetMagnitudeSquared(shape0_abs_v1 - shape1_abs_v1) <= totalRadiusSquared)
     {
         // shape 1 vertex 2 is colliding with shape 2 vertex 2
         switch (type)
@@ -249,7 +249,7 @@ Manifold GetFaceManifold(const Manifold::Type type,
                 break;
         }
     }
-    else if (GetLengthSquared(shape0_abs_v1 - shape1_abs_v0) <= totalRadiusSquared)
+    else if (GetMagnitudeSquared(shape0_abs_v1 - shape1_abs_v0) <= totalRadiusSquared)
     {
         // shape 1 vertex 2 is colliding with shape 2 vertex 1
         switch (type)
@@ -337,7 +337,7 @@ Manifold CollideShapes(Manifold::Type type, Length totalRadius,
     if (Dot(cLocalV1, v2 - v1) <= Area{0})
     {
         // Circle's center right of v1 (in direction of v1 to v2).
-        if (GetLengthSquared(cLocalV1) > Square(totalRadius))
+        if (GetMagnitudeSquared(cLocalV1) > Square(totalRadius))
         {
             return Manifold{};
         }
@@ -356,7 +356,7 @@ Manifold CollideShapes(Manifold::Type type, Length totalRadius,
     if (Dot(ClocalV2, v1 - v2) <= Area{0})
     {
         // Circle's center left of v2 (in direction of v2 to v1).
-        if (GetLengthSquared(ClocalV2) > Square(totalRadius))
+        if (GetMagnitudeSquared(ClocalV2) > Square(totalRadius))
         {
             return Manifold{};
         }
@@ -397,7 +397,7 @@ inline Manifold CollideShapes(Length2 locationA, const Transformation& xfA,
     const auto pA = Transform(locationA, xfA);
     const auto pB = Transform(locationB, xfB);
     // Intermediary results here for debugging...
-    const auto lenSq = GetLengthSquared(pB - pA);
+    const auto lenSq = GetMagnitudeSquared(pB - pA);
     const auto totSq = Square(totalRadius);
     return (lenSq > totSq)? Manifold{}: Manifold::GetForCircles(locationA, 0, locationB, 0);
 }
@@ -580,7 +580,7 @@ Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transfor
     const auto totalRadius = proxyA.GetVertexRadius() + proxyB.GetVertexRadius();
     const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
 
-    const auto distance = Sqrt(GetLengthSquared(witnessPoints.a - witnessPoints.b));
+    const auto distance = Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
     if (distance > totalRadius)
     {
         // no collision

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -47,7 +47,7 @@ MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 locatio
     const auto r_squared = r * r;
     const auto area = r_squared * Pi;
     const auto mass = Mass{AreaDensity{density} * area};
-    const auto Iz = SecondMomentOfArea{area * ((r_squared / Real{2}) + GetLengthSquared(location))};
+    const auto Iz = SecondMomentOfArea{area * ((r_squared / Real{2}) + GetMagnitudeSquared(location))};
     const auto I = RotInertia{Iz * AreaDensity{density} / SquareRadian};
     return MassData{location, mass, I};
 }
@@ -59,7 +59,7 @@ MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Len
     const auto circle_mass = density * circle_area;
     const auto d = v1 - v0;
     const auto offset = GetRevPerpendicular(GetUnitVector(d, UnitVec2::GetZero())) * r;
-    const auto b = GetLength(d);
+    const auto b = GetMagnitude(d);
     const auto h = r * Real{2};
     const auto rect_mass = density * b * h;
     const auto totalMass = circle_mass + rect_mass;
@@ -77,8 +77,8 @@ MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Len
         Length2{v1 + offset}
     };
     const auto I_z = GetPolarMoment(vertices);
-    const auto I0 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetLengthSquared(v0))};
-    const auto I1 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetLengthSquared(v1))};
+    const auto I0 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v0))};
+    const auto I1 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v1))};
     assert(I0 >= SecondMomentOfArea{0});
     assert(I1 >= SecondMomentOfArea{0});
     assert(I_z >= SecondMomentOfArea{0});
@@ -168,8 +168,8 @@ MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
     
     // Inertia tensor relative to the local origin (point s).
     // Shift to center of mass then to original body origin.
-    const auto massCenterOffset = GetLengthSquared(massDataCenter);
-    const auto centerOffset = GetLengthSquared(center);
+    const auto massCenterOffset = GetMagnitudeSquared(massDataCenter);
+    const auto centerOffset = GetMagnitudeSquared(center);
     const auto intertialLever = massCenterOffset - centerOffset;
     const auto massDataI = RotInertia{((AreaDensity{density} * I) + (mass * intertialLever)) / SquareRadian};
     

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -35,12 +35,12 @@ RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input
     // norm(x) = radius
     
     const auto s = input.p1 - location;
-    const auto b = GetLengthSquared(s) - Square(radius);
+    const auto b = GetMagnitudeSquared(s) - Square(radius);
     
     // Solve quadratic equation.
     const auto raySegment = input.p2 - input.p1; // Length2
     const auto c =  Dot(s, raySegment); // Area
-    const auto rr = GetLengthSquared(raySegment); // Area
+    const auto rr = GetMagnitudeSquared(raySegment); // Area
     const auto sigma = Real{(Square(c) - rr * b) / (SquareMeter * SquareMeter)};
     
     // Check for negative discriminant and short segment.

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -41,7 +41,7 @@ RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input
     const auto raySegment = input.p2 - input.p1; // Length2
     const auto c =  Dot(s, raySegment); // Area
     const auto rr = GetLengthSquared(raySegment); // Area
-    const auto sigma = (Square(c) - rr * b) / (SquareMeter * SquareMeter);
+    const auto sigma = Real{(Square(c) - rr * b) / (SquareMeter * SquareMeter)};
     
     // Check for negative discriminant and short segment.
     if ((sigma < Real{0}) || AlmostZero(Real{rr / SquareMeter}))
@@ -171,7 +171,7 @@ RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
     const auto ray0 = transformedInput.p1;
     const auto ray = transformedInput.p2 - transformedInput.p1; // Ray delta (p2 - p1)
     
-    auto minT = std::nextafter(Real{input.maxFraction}, Real(2));
+    auto minT = NextAfter(Real{input.maxFraction}, Real(2));
     auto normalFound = GetInvalid<UnitVec2>();
     
     for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)

--- a/PlayRho/Collision/Shapes/ChainShape.cpp
+++ b/PlayRho/Collision/Shapes/ChainShape.cpp
@@ -33,7 +33,7 @@ namespace {
             const auto delta = vertices[i-1] - vertices[i];
             
             // XXX not quite right unit-wise but this works well enough.
-            if (GetLengthSquared(GetVec2(delta)) * Meter <= DefaultLinearSlop)
+            if (GetMagnitudeSquared(GetVec2(delta)) * Meter <= DefaultLinearSlop)
             {
                 return false;
             }
@@ -95,7 +95,7 @@ MassData ChainShape::GetMassData() const noexcept
                 I += RotInertia{massData.I};
                 
                 const auto d = v - vprev;
-                const auto b = GetLength(d);
+                const auto b = GetMagnitude(d);
                 const auto h = vertexRadius * Real{2};
                 area += b * h + circle_area;
 

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -272,7 +272,7 @@ namespace playrho {
             case 2:
             {
                 const auto delta = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
-                return Sqrt(GetLengthSquared(GetVec2(delta)));
+                return Sqrt(GetMagnitudeSquared(GetVec2(delta)));
             }
             case 3:
             {

--- a/PlayRho/Collision/TimeOfImpact.cpp
+++ b/PlayRho/Collision/TimeOfImpact.cpp
@@ -28,7 +28,7 @@ namespace {
         
 inline DistanceConf GetDistanceConf(const ToiConf& conf)
 {
-    DistanceConf distanceConf;
+    auto distanceConf = DistanceConf{};
     distanceConf.maxIterations = conf.maxDistIters;
     return distanceConf;
 }
@@ -44,7 +44,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
     // CCD via the local separating axis method. This seeks progression
     // by computing the largest time at which separation is maintained.
     
-    auto stats = TOIOutput::Stats{};
+    auto stats = TOIOutput::Statistics{};
 
     assert(conf.tMax >= 0 && conf.tMax <=1);
     assert(conf.tolerance > 0_m);
@@ -99,12 +99,12 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
         // If the shapes aren't separated, give up on continuous collision.
         if (distanceSquared <= Area{0}) // Failure!
         {
-            return TOIOutput{TOIOutput::e_overlapped, 0, stats};
+            return TOIOutput{0, stats, TOIOutput::e_overlapped};
         }
 
         if (distanceSquared <= maxTargetSquared) // Victory!
         {
-            return TOIOutput{TOIOutput::e_touching, t1, stats};
+            return TOIOutput{t1, stats, TOIOutput::e_touching};
         }
 
         // From here on, the real distance squared at time t1 is > than maxTargetSquared
@@ -134,7 +134,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
                 // t2 seems more appropriate however given s2 was derived from it.
                 // Meanwhile t2 always seems equal to input.tMax at this point.
                 stats.sum_finder_iters += pbIter;
-                return TOIOutput{TOIOutput::e_separated, t2, stats};
+                return TOIOutput{t2, stats, TOIOutput::e_separated};
             }
 
             // From here on, t2MinSeparation.distance <= maxTarget
@@ -149,14 +149,13 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
                     //
                     // This state happens when the real distance is greater than maxTarget but the
                     // t2MinSeparation distance is less than maxTarget. If function not stopped,
-                    // it runs till stats.toi_iters == conf.maxToiIters and returns
-                    // TOIOutput{TOIOutput::e_failed, t1, stats}. Given that the function can't
-                    // advance anymore, there's certainly no need to run anymore. Additionally,
-                    // given that t1 is the same as t2 and the real distance is separated, this
-                    // function can return the separated state.
+                    // it runs till stats.toi_iters == conf.maxToiIters and returns a failed state.
+                    // Given that the function can't advance anymore, there's no need to run
+                    // anymore. Additionally, given that t1 is the same as t2 and the real
+                    // distance is separated, this function can return the separated state.
                     //
                     stats.sum_finder_iters += pbIter;
-                    return TOIOutput{TOIOutput::e_separated, t2, stats};
+                    return TOIOutput{t2, stats, TOIOutput::e_separated};
                 }
 
                 // Advance the sweeps
@@ -177,7 +176,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
             if (t1EvaluatedDistance < minTarget)
             {
                 stats.sum_finder_iters += pbIter;
-                return TOIOutput{TOIOutput::e_failed, t1, stats};
+                return TOIOutput{t1, stats, TOIOutput::e_belowMinTarget};
             }
 
             // Check for touching
@@ -185,7 +184,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
             {
                 // Victory! t1 should hold the TOI (could be 0.0).
                 stats.sum_finder_iters += pbIter;
-                return TOIOutput{TOIOutput::e_touching, t1, stats};
+                return TOIOutput{t1, stats, TOIOutput::e_touching};
             }
 
             // Now: t1EvaluatedDistance > maxTarget
@@ -201,7 +200,20 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
                 assert(!AlmostZero((s2 - s1) / Meter));
                 assert(a1 <= a2);
 
-                if ((roots == conf.maxRootIters) || (a1 == a2) || (std::nextafter(a1, a2) >= a2))
+                auto state = TOIOutput::e_unknown;
+                if (roots == conf.maxRootIters)
+                {
+                    state = TOIOutput::e_maxRootIters;
+                }
+                else if (a1 == a2)
+                {
+                    state = TOIOutput::e_indifferent;
+                }
+                else if (std::nextafter(a1, a2) >= a2)
+                {
+                    state = TOIOutput::e_nextAfter;
+                }
+                if (state != TOIOutput::e_unknown)
                 {
                     // Reached max root iterations or...
                     // Reached the limit of the Real type's precision!
@@ -210,13 +222,11 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
                     stats.sum_finder_iters += pbIter;
                     stats.sum_root_iters += roots;
                     stats.max_root_iters = std::max(stats.max_root_iters, roots);
-                    return TOIOutput{TOIOutput::e_failed, a1, stats};
+                    return TOIOutput{a1, stats, state};
                 }
 
-                // Uses secant method to improve convergence (see https://en.wikipedia.org/wiki/Secant_method ).
-                // Uses bisection method to guarantee progress (see https://en.wikipedia.org/wiki/Bisection_method ).
-                const auto t = ((roots & 1u) != 0u)?
-                    a1 + (target - s1) * (a2 - a1) / (s2 - s1): (a1 + a2) / 2;
+                // Uses secant to improve convergence & bisection to guarantee progress.
+                const auto t = IsOdd(roots)? Secant(target, a1, s1, a2, s2): Bisect(a1, a2);
                 
                 // Using secant method, t may equal a2 now.
                 //assert(t != a1);
@@ -261,7 +271,24 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
     // stats.toi_iters == conf.maxToiIters
     // Root finder got stuck.
     // This can happen if the two shapes never actually collide within their sweeps.
-    return TOIOutput{TOIOutput::e_failed, t1, stats};
+    return TOIOutput{t1, stats, TOIOutput::e_maxToiIters};
+}
+
+const char *GetName(TOIOutput::State state) noexcept
+{
+    switch (state)
+    {
+        case TOIOutput::e_unknown: return "unknown";
+        case TOIOutput::e_touching: return "touching";
+        case TOIOutput::e_separated: return "separated";
+        case TOIOutput::e_overlapped: return "overlapped";
+        case TOIOutput::e_nextAfter: return "next-after";
+        case TOIOutput::e_indifferent: return "indifferent";
+        case TOIOutput::e_maxRootIters: return "max-root-iters";
+        case TOIOutput::e_maxToiIters: return "max-toi-iters";
+        case TOIOutput::e_belowMinTarget: return "below-min-target";
+    }
+    return "unknown";
 }
 
 } // namespace playrho

--- a/PlayRho/Collision/TimeOfImpact.cpp
+++ b/PlayRho/Collision/TimeOfImpact.cpp
@@ -94,7 +94,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
         distanceConf.cache = Simplex::GetCache(dinfo.simplex.GetEdges());
         
         // Get the real distance squared between shapes at the time of t1.
-        const auto distSquared = GetLengthSquared(GetDelta(GetWitnessPoints(dinfo.simplex)));
+        const auto distSquared = GetMagnitudeSquared(GetDelta(GetWitnessPoints(dinfo.simplex)));
         
         // If the shapes aren't separated, give up on continuous collision.
         if (distSquared <= Area{0}) // Failure!

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -82,7 +82,11 @@ namespace playrho {
         /// @note Value must be less than twice the minimum vertex radius of any shape.
         Length targetDepth = DefaultLinearSlop * Real{3};
 
-        Length tolerance = DefaultLinearSlop / Real{4}; ///< Tolerance.
+        /// @brief Tolerance.
+        /// @note Use the default value unless you really know what you're doing.
+        /// @note Use 0 to require a TOI at exactly the target depth. This is ill-advised.
+        /// @note Use a negative value to prevent the calculation of a TOI.
+        Length tolerance = DefaultLinearSlop / Real{4};
         
         /// @brief Maximum number of root finder iterations.
         /// @details This is the maximum number of iterations for calculating the 1D root of
@@ -184,10 +188,10 @@ namespace playrho {
             e_touching,
             e_separated,
             e_maxRootIters,
-            e_indifferent,
             e_nextAfter,
             e_maxToiIters,
             e_belowMinTarget,
+            e_maxDistIters,
         };
         
         /// @brief Default constructor.
@@ -213,7 +217,8 @@ namespace playrho {
     ///
     /// @sa https://en.wikipedia.org/wiki/Hyperplane_separation_theorem
     /// @pre The given sweeps are both at the same alpha0.
-    /// @warning Behavior is undefined if the given sweeps are not at the same alpha0.
+    /// @warning Behavior is undefined if sweeps are not at the same alpha0.
+    /// @warning Behavior is undefined if conf's <code>tMax</code> is not between 0 and 1 inclusive.
     /// @note Uses Distance to compute the contact point and normal at the time of impact.
     /// @note This only works for two disjoint convex sets.
     ///

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -142,88 +142,63 @@ namespace playrho {
     }
 
     /// @brief Output data for time of impact.
-    class TOIOutput
+    struct TOIOutput
     {
-    public:
-        
-        /// @brief TOI iterations type.
-        using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
-
-        /// @brief Distance iterations type.
-        using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
-        
-        /// @brief Root iterations type.
-        using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
-        
-        /// @brief TOI iterations sum type.
-        using toi_sum_type = Wider<toi_iter_type>::type;
-        
-        /// @brief Distance iterations sum type.
-        using dist_sum_type = Wider<dist_iter_type>::type;
-        
-        /// @brief Root iterations sum type.
-        using root_sum_type = Wider<root_iter_type>::type;
-
         /// @brief Time of impact statistics.
-        struct Stats
+        struct Statistics
         {
+            /// @brief TOI iterations type.
+            using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
+            
+            /// @brief Distance iterations type.
+            using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+            
+            /// @brief Root iterations type.
+            using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
+            
+            /// @brief TOI iterations sum type.
+            using toi_sum_type = Wider<toi_iter_type>::type;
+            
+            /// @brief Distance iterations sum type.
+            using dist_sum_type = Wider<dist_iter_type>::type;
+            
+            /// @brief Root iterations sum type.
+            using root_sum_type = Wider<root_iter_type>::type;
+
+            // 6-bytes
+            toi_sum_type sum_finder_iters = 0; ///< Sum total TOI iterations.
+            dist_sum_type sum_dist_iters = 0; ///< Sum total distance iterations.
+            root_sum_type sum_root_iters = 0; ///< Sum total of root finder iterations.
+
             // 3-bytes
             toi_iter_type toi_iters = 0; ///< Time of impact iterations.
             dist_iter_type max_dist_iters = 0; ///< Max. distance iterations count.
             root_iter_type max_root_iters = 0; ///< Max. root finder iterations for all TOI iterations.
-
-            // 4-bytes
-            toi_sum_type sum_finder_iters = 0; ///< Sum total TOI iterations.
-            dist_sum_type sum_dist_iters = 0; ///< Sum total distance iterations.
-            root_sum_type sum_root_iters = 0; ///< Sum total of root finder iterations.
         };
-
+        
         /// @brief State.
-        enum State: std::uint16_t
+        enum State: std::uint8_t
         {
             e_unknown,
-            e_failed,
             e_overlapped,
             e_touching,
-            e_separated
+            e_separated,
+            e_maxRootIters,
+            e_indifferent,
+            e_nextAfter,
+            e_maxToiIters,
+            e_belowMinTarget,
         };
-
+        
+        /// @brief Default constructor.
         TOIOutput() = default;
         
         /// @brief Initializing constructor.
-        constexpr TOIOutput(State state, Real time, Stats stats):
-            m_state(state), m_time(time), m_stats(stats)
-        {
-            assert(time >= 0);
-            assert(time <= 1);
-        }
+        TOIOutput(Real t, Statistics s, State z) noexcept: time{t}, stats{s}, state{z} {}
 
-        /// @brief Gets the state at time factor.
-        State get_state() const noexcept { return m_state; }
-
-        /// @brief Gets time factor at which state occurs.
-        /// @return Time factor in range of [0,1] into the future.
-        Real get_t() const noexcept { return m_time; }
-
-        /// @brief Gets the TOI iterations.
-        toi_iter_type get_toi_iters() const noexcept { return m_stats.toi_iters; }
-        
-        /// @brief Gets the sum distance iterations.
-        dist_sum_type get_sum_dist_iters() const noexcept { return m_stats.sum_dist_iters; }
-        
-        /// @brief Gets the max distance iterations.
-        dist_iter_type get_max_dist_iters() const noexcept { return m_stats.max_dist_iters; }
-
-        /// @brief Gets the sum root iterations.
-        root_sum_type get_sum_root_iters() const noexcept { return m_stats.sum_root_iters; }
-        
-        /// @brief Gets the max root iterations.
-        root_iter_type get_max_root_iters() const noexcept { return m_stats.max_root_iters; }
-        
-    private:
-        State m_state = e_unknown; ///< State at time factor.
-        Real m_time = 0; ///< Time factor in range of [0,1] into the future.
-        Stats m_stats; ///< Statistics.
+        Real time = 0; ///< Time factor in range of [0,1] into the future.
+        Statistics stats; ///< Statistics.
+        State state = e_unknown; ///< State at time factor.
     };
 
     /// @brief Gets the time of impact for two disjoint convex sets using the
@@ -255,6 +230,10 @@ namespace playrho {
     TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
                            const DistanceProxy& proxyB, const Sweep& sweepB,
                            ToiConf conf = GetDefaultToiConf());
+    
+    
+    /// @brief Gets a human readable name for the given output state.
+    const char *GetName(TOIOutput::State state) noexcept;
 
 } // namespace playrho
 

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -85,8 +85,8 @@ std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle sta
         while (i < slices)
         {
             const auto angleInRadians = Real{(start + (Real(i) * deltaAngle)) / Radian};
-            const auto x = radius * static_cast<Real>(std::cos(angleInRadians));
-            const auto y = radius * static_cast<Real>(std::sin(angleInRadians));
+            const auto x = radius * Cos(angleInRadians);
+            const auto y = radius * Sin(angleInRadians);
             vertices.emplace_back(x, y);
             ++i;
         }
@@ -98,8 +98,8 @@ std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle sta
         else
         {
             const auto angleInRadians = Real{(start + (Real(i) * deltaAngle)) / Radian};
-            const auto x = radius * static_cast<Real>(std::cos(angleInRadians));
-            const auto y = radius * static_cast<Real>(std::sin(angleInRadians));
+            const auto x = radius * Cos(angleInRadians);
+            const auto y = radius * Sin(angleInRadians);
             vertices.emplace_back(x, y);
         }
     }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -97,6 +97,32 @@ constexpr inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
 ///   especially those with mixed input and output types.
 /// @{
 
+/// @brief Secant method.
+/// @sa https://en.wikipedia.org/wiki/Secant_method
+template <typename T, typename U>
+constexpr inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
+{
+    static_assert(IsArithmetic<T>::value && IsArithmetic<U>::value, "Arithmetic types required.");
+    return (a1 + (target - s1) * (a2 - a1) / (s2 - s1));
+}
+
+/// @brief Bisection method.
+/// @sa https://en.wikipedia.org/wiki/Bisection_method
+template <typename T>
+constexpr inline T Bisect(T a1, T a2) noexcept
+{
+    return (a1 + a2) / 2;
+}
+
+/// @brief Is-odd.
+/// @details Determines whether the given integral value is odd (as opposed to being even).
+template <typename T>
+constexpr inline bool IsOdd(T val) noexcept
+{
+    static_assert(std::is_integral<T>::value, "Integral type required.");
+    return val % 2;
+}
+
 /// @brief Squares the given value.
 template<class TYPE>
 constexpr inline auto Square(TYPE t) noexcept { return t * t; }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -129,18 +129,94 @@ constexpr inline auto Square(TYPE t) noexcept { return t * t; }
 
 /// @brief Square root's the given value.
 template<typename T>
-inline auto Sqrt(T t)
+inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Sqrt(T t)
 {
     // Note that std::sqrt is not declared noexcept at cppreference.com.
     // See: http://en.cppreference.com/w/cpp/numeric/math/sqrt
-    return std::sqrt(StripUnit(t));
+    return std::sqrt(t);
+}
+
+/// @brief Determines if the given argument is normal.
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type IsNormal(T arg)
+{
+    return std::isnormal(arg);
+}
+
+/// @brief Gets whether the given value is not-a-number.
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type IsNan(T arg)
+{
+    return std::isnan(arg);
+}
+
+/// @brief Gets whether the given value is finite.
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type IsFinite(T arg)
+{
+    return std::isfinite(arg);
+}
+
+/// @brief Rounds the given value.
+template <typename T>
+inline T Round(T arg)
+{
+    return std::round(arg);
+}
+
+/// @brief Truncates the given value.
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Trunc(T arg)
+{
+    return std::trunc(arg);
+}
+
+/// @brief Determines whether the given value is negative.
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type SignBit(T value) noexcept
+{
+    return std::signbit(value);
+}
+
+/// @brief Gets the next representable value after the given from value and going towards
+///   the to value.
+template <typename T>
+inline T NextAfter(T from, T to)
+{
+    return static_cast<T>(std::nextafter(from, to));
+}
+
+/// @brief Computes the cosine of the argument.
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Cos(T arg)
+{
+    return std::cos(arg);
+}
+
+/// @brief Computes the sine of the argument.
+template <typename T>
+inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Sin(T arg)
+{
+    return std::sin(arg);
 }
 
 #ifdef USE_BOOST_UNITS
-template<>
+/// @brief Square roots the given area.
 inline auto Sqrt(Area t)
 {
-    return std::sqrt(StripUnit(t)) * Meter;
+    return Sqrt(StripUnit(t)) * Meter;
+}
+
+/// @brief Computes the cosine of the argument.
+inline Real Cos(Angle a)
+{
+    return Cos(Real{a / Radian});
+}
+
+/// @brief Computes the sine of the argument.
+inline Real Sin(Angle a)
+{
+    return Sin(Real{a / Radian});
 }
 #endif
 
@@ -162,13 +238,6 @@ inline auto Atan2(double y, double x)
     return Angle{static_cast<Real>(std::atan2(y, x)) * Radian};
 }
 
-/// @brief Computes the absolute value of the given value.
-template <typename T>
-constexpr inline T Abs(T a)
-{
-    return (a >= T{0}) ? a : -a;
-}
-
 /// @brief Computes the average of the given values.
 template <typename T>
 inline auto Average(Span<const T> span)
@@ -188,11 +257,11 @@ inline auto Average(Span<const T> span)
 
 /// @brief Computes the rounded value of the given value.
 template <typename T>
-inline T Round(T value, unsigned precision = 100000);
+inline T RoundOff(T value, unsigned precision = 100000);
 
 /// @brief Computes the rounded value of the given value.
 template <>
-inline float Round(float value, std::uint32_t precision)
+inline float RoundOff(float value, std::uint32_t precision)
 {
     const auto factor = float(static_cast<std::int64_t>(precision));
     return std::round(value * factor) / factor;
@@ -200,7 +269,7 @@ inline float Round(float value, std::uint32_t precision)
 
 /// @brief Computes the rounded value of the given value.
 template <>
-inline double Round(double value, std::uint32_t precision)
+inline double RoundOff(double value, std::uint32_t precision)
 {
     const auto factor = double(static_cast<std::int64_t>(precision));
     return std::round(value * factor) / factor;
@@ -208,7 +277,7 @@ inline double Round(double value, std::uint32_t precision)
 
 /// @brief Computes the rounded value of the given value.
 template <>
-inline long double Round(long double value, std::uint32_t precision)
+inline long double RoundOff(long double value, std::uint32_t precision)
 {
     using ldouble = long double;
     const auto factor = ldouble(static_cast<std::int64_t>(precision));
@@ -217,27 +286,27 @@ inline long double Round(long double value, std::uint32_t precision)
 
 /// @brief Computes the rounded value of the given value.
 template <>
-inline Fixed32 Round(Fixed32 value, std::uint32_t precision)
+inline Fixed32 RoundOff(Fixed32 value, std::uint32_t precision)
 {
     const auto factor = Fixed32(precision);
-    return std::round(value * factor) / factor;
+    return Round(value * factor) / factor;
 }
 
 #ifndef _WIN32
 /// @brief Computes the rounded value of the given value.
 template <>
-inline Fixed64 Round(Fixed64 value, std::uint32_t precision)
+inline Fixed64 RoundOff(Fixed64 value, std::uint32_t precision)
 {
     const auto factor = Fixed64(precision);
-    return std::round(value * factor) / factor;
+    return Round(value * factor) / factor;
 }
 #endif
 
 /// @brief Computes the rounded value of the given value.
 template <>
-inline Vec2 Round(Vec2 value, std::uint32_t precision)
+inline Vec2 RoundOff(Vec2 value, std::uint32_t precision)
 {
-    return Vec2{Round(value[0], precision), Round(value[1], precision)};
+    return Vec2{RoundOff(value[0], precision), RoundOff(value[1], precision)};
 }
 
 /// @brief Gets a Vec2 representation of the given value.
@@ -360,7 +429,7 @@ template <typename T>
 inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
 {
     const auto quotient = dividend / divisor;
-    const auto integer = static_cast<T>(std::trunc(quotient));
+    const auto integer = static_cast<T>(Trunc(quotient));
     const auto remainder = quotient - integer;
     return remainder * divisor;
 }
@@ -527,10 +596,10 @@ template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
 constexpr auto Cross(T1 a, T2 b) noexcept
 {
-    assert(std::isfinite(StripUnit(Get<0>(a))));
-    assert(std::isfinite(StripUnit(Get<1>(a))));
-    assert(std::isfinite(StripUnit(Get<0>(b))));
-    assert(std::isfinite(StripUnit(Get<1>(b))));
+    assert(IsFinite(StripUnit(Get<0>(a))));
+    assert(IsFinite(StripUnit(Get<1>(a))));
+    assert(IsFinite(StripUnit(Get<0>(b))));
+    assert(IsFinite(StripUnit(Get<1>(b))));
 
     // Both vectors of same direction...
     // If a = Vec2{1, 2} and b = Vec2{1, 2} then: a x b = 1 * 2 - 2 * 1 = 0.
@@ -544,8 +613,8 @@ constexpr auto Cross(T1 a, T2 b) noexcept
     // If a = Vec2{1, 2} and b = Vec2{-1, 2} then: a x b = 1 * 2 - 2 * (-1) = 2 + 2 = 4.
     const auto minuend = Get<0>(a) * Get<1>(b);
     const auto subtrahend = Get<1>(a) * Get<0>(b);
-    assert(std::isfinite(StripUnit(minuend)));
-    assert(std::isfinite(StripUnit(subtrahend)));
+    assert(IsFinite(StripUnit(minuend)));
+    assert(IsFinite(StripUnit(subtrahend)));
     return minuend - subtrahend;
 }
 
@@ -559,12 +628,12 @@ template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 3 && std::tuple_size<T2>::value == 3, int> = 0>
 constexpr auto Cross(T1 a, T2 b) noexcept
 {
-    assert(std::isfinite(Get<0>(a)));
-    assert(std::isfinite(Get<1>(a)));
-    assert(std::isfinite(Get<2>(a)));
-    assert(std::isfinite(Get<0>(b)));
-    assert(std::isfinite(Get<1>(b)));
-    assert(std::isfinite(Get<2>(b)));
+    assert(IsFinite(Get<0>(a)));
+    assert(IsFinite(Get<1>(a)));
+    assert(IsFinite(Get<2>(a)));
+    assert(IsFinite(Get<0>(b)));
+    assert(IsFinite(Get<1>(b)));
+    assert(IsFinite(Get<2>(b)));
 
     using OT = decltype(Get<0>(a) * Get<0>(b));
     return Vector<OT, 3>{

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -499,11 +499,11 @@ inline Angle GetAngle(const Vector2<T> value)
     return Atan2(GetY(value), GetX(value));
 }
 
-/// @brief Gets the square of the length/magnitude of the given iterable value.
-/// @note For performance, use this instead of GetLength(T value) (if possible).
+/// @brief Gets the square of the magnitude of the given iterable value.
+/// @note For performance, use this instead of GetMagnitude(T value) (if possible).
 /// @return Non-negative value.
 template <typename T>
-constexpr inline auto GetLengthSquared(T value) noexcept
+constexpr inline auto GetMagnitudeSquared(T value) noexcept
 {
     using VT = typename T::value_type;
     using OT = decltype(VT{} * VT{});
@@ -515,12 +515,12 @@ constexpr inline auto GetLengthSquared(T value) noexcept
     return result;
 }
 
-/// @brief Gets the length/magnitude of the given value.
-/// @note Works for any type for which <code>GetLengthSquared</code> also works.
+/// @brief Gets the magnitude of the given value.
+/// @note Works for any type for which <code>GetMagnitudeSquared</code> also works.
 template <typename T>
-inline auto GetLength(T value)
+inline auto GetMagnitude(T value)
 {
-    return Sqrt(GetLengthSquared(value));
+    return Sqrt(GetMagnitudeSquared(value));
 }
 
 /// @brief Performs the dot product on two vectors (A and B).
@@ -534,7 +534,7 @@ inline auto GetLength(T value)
 ///   (at an angle of +/- 90 degrees from each other).
 ///
 /// @note This operation is commutative. I.e. Dot(a, b) == Dot(b, a).
-/// @note If A and B are the same vectors, GetLengthSquared(Vec2) returns the same value
+/// @note If A and B are the same vectors, GetMagnitudeSquared(Vec2) returns the same value
 ///   using effectively one less input parameter.
 /// @note This is similar to the <code>std::inner_product</code> standard library algorithm
 ///   except benchmark tests suggest this implementation is faster at least for
@@ -1032,7 +1032,7 @@ inline Transformation GetTransform1(const Sweep& sweep) noexcept
 /// @brief Converts the given vector into a unit vector and returns its original length.
 inline Real Normalize(Vec2& vector)
 {
-    const auto length = GetLength(vector);
+    const auto length = GetMagnitude(vector);
     if (!AlmostZero(length))
     {
         const auto invLength = 1 / length;
@@ -1199,7 +1199,7 @@ SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices);
 inline bool IsUnderActive(Velocity velocity,
                           LinearVelocity linSleepTol, AngularVelocity angSleepTol) noexcept
 {
-    const auto linVelSquared = GetLengthSquared(velocity.linear);
+    const auto linVelSquared = GetMagnitudeSquared(velocity.linear);
     const auto angVelSquared = Square(velocity.angular);
     return (angVelSquared <= Square(angSleepTol)) && (linVelSquared <= Square(linSleepTol));
 }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -499,23 +499,24 @@ inline Angle GetAngle(const Vector2<T> value)
     return Atan2(GetY(value), GetX(value));
 }
 
-/// @brief Gets the square of the length/magnitude of the given value.
+/// @brief Gets the square of the length/magnitude of the given iterable value.
 /// @note For performance, use this instead of GetLength(T value) (if possible).
 /// @return Non-negative value.
 template <typename T>
 constexpr inline auto GetLengthSquared(T value) noexcept
 {
-    return Square(GetX(value)) + Square(GetY(value));
-}
-
-/// @brief Gets the square of the length/magnitude of the given value.
-template <>
-constexpr inline auto GetLengthSquared(Vec3 value) noexcept
-{
-    return Square(GetX(value)) + Square(GetY(value)) + Square(GetZ(value));
+    using VT = typename T::value_type;
+    using OT = decltype(VT{} * VT{});
+    auto result = OT{};
+    for (auto&& e: value)
+    {
+        result += Square(e);
+    }
+    return result;
 }
 
 /// @brief Gets the length/magnitude of the given value.
+/// @note Works for any type for which <code>GetLengthSquared</code> also works.
 template <typename T>
 inline auto GetLength(T value)
 {

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -206,6 +206,13 @@ namespace playrho
         decltype(T{} + T{}), decltype(T{} - T{}), decltype(T{} * T{}), decltype(T{} / T{})
     > >: std::true_type {};
     
+    /// @brief Computes the absolute value of the given value.
+    template <typename T>
+    constexpr inline T Abs(T a)
+    {
+        return (a >= T{0}) ? a : -a;
+    }
+    
 } // namespace playrho
 
 #endif // PLAYRHO_COMMON_TEMPLATES_HPP

--- a/PlayRho/Common/UnitVec2.cpp
+++ b/PlayRho/Common/UnitVec2.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include <PlayRho/Common/UnitVec2.hpp>
+#include <PlayRho/Common/Math.hpp>
+
+namespace playrho {
+
+UnitVec2 UnitVec2::Get(const Real x, const Real y, Real& magnitude,
+                       const UnitVec2 fallback) noexcept
+{
+    // XXX perhaps this should use std::hypot() instead like so:
+    //    magnitude = std::hypot(x, y);
+    magnitude = Sqrt(x * x + y * y);
+    return (IsNormal(magnitude)) ? UnitVec2{x / magnitude, y / magnitude} : fallback;
+}
+
+UnitVec2 UnitVec2::Get(const Angle angle) noexcept
+{
+    return UnitVec2{Cos(angle), Sin(angle)};
+}
+
+} // namespace playrho
+

--- a/PlayRho/Common/UnitVec2.hpp
+++ b/PlayRho/Common/UnitVec2.hpp
@@ -26,7 +26,6 @@
 
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/InvalidArgument.hpp>
-#include <cmath>
 #include <iostream>
 
 namespace playrho
@@ -101,13 +100,7 @@ public:
 
     /// @brief Gets the unit vector from the given parameters.
     static UnitVec2 Get(const Real x, const Real y, Real& magnitude,
-                        const UnitVec2 fallback = GetDefaultFallback()) noexcept
-    {
-        // XXX perhaps this should use std::hypot() instead like so:
-        //    magnitude = std::hypot(x, y);
-        magnitude = std::sqrt(x * x + y * y);
-        return (std::isnormal(magnitude)) ? UnitVec2{x / magnitude, y / magnitude} : fallback;
-    }
+                        const UnitVec2 fallback = GetDefaultFallback()) noexcept;
 
     /// @brief Gets the given angled unit vector.
     ///
@@ -115,10 +108,7 @@ public:
     ///   better accuracy will be had by using one of the four oriented unit
     ///   vector returning methods - for the right, top, left, bottom orientations.
     ///
-    static UnitVec2 Get(const Angle angle) noexcept
-    {
-        return UnitVec2{std::cos(angle / Radian), std::sin(angle / Radian)};
-    }
+    static UnitVec2 Get(const Angle angle) noexcept;
 
     constexpr UnitVec2() noexcept = default;
     
@@ -257,7 +247,7 @@ public:
     /// @brief Gets the absolute value.
     constexpr inline UnitVec2 Absolute() const noexcept
     {
-        return UnitVec2{std::abs(GetX()), std::abs(GetY())};
+        return UnitVec2{Abs(GetX()), Abs(GetY())};
     }
 
 private:

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -89,7 +89,7 @@ namespace playrho {
             // i.e. won't obey the property that square(sqrt(a)) == a and sqrt(square(a)) == a.
             return std::find_if(begin(), end(), [&](Length2 elem) {
                 // length squared must be large enough to have a reasonable enough unit vector.
-                return GetLengthSquared(value - elem) <= m_minSepSquared;
+                return GetMagnitudeSquared(value - elem) <= m_minSepSquared;
             });
         }
 

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -491,8 +491,8 @@ void RotateAboutWorldPoint(Body& body, Angle amount, Length2 worldPoint)
 {
     const auto xfm = body.GetTransformation();
     const auto p = xfm.p - worldPoint;
-    const auto c = Real{std::cos(amount / Radian)};
-    const auto s = Real{std::sin(amount / Radian)};
+    const auto c = Cos(amount);
+    const auto s = Sin(amount);
     const auto x = GetX(p) * c - GetY(p) * s;
     const auto y = GetX(p) * s + GetY(p) * c;
     const auto pos = Length2{x, y} + worldPoint;

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -162,7 +162,7 @@ void Body::ResetMassData()
     if ((massData.I > RotInertia{0}) && (!IsFixedRotation()))
     {
         // Center the inertia about the center of mass.
-        const auto lengthSquared = GetLengthSquared(localCenter);
+        const auto lengthSquared = GetMagnitudeSquared(localCenter);
         const auto I = RotInertia{massData.I} - RotInertia{(mass * lengthSquared / SquareRadian)};
         //assert((massData.I - mass * lengthSquared) > 0);
         m_invRotI = Real{1} / I;
@@ -201,7 +201,7 @@ void Body::SetMassData(const MassData& massData)
 
     if ((massData.I > RotInertia{0}) && (!IsFixedRotation()))
     {
-        const auto lengthSquared = GetLengthSquared(massData.center);
+        const auto lengthSquared = GetMagnitudeSquared(massData.center);
         // L^2 M QP^-2
         const auto I = RotInertia{massData.I} - RotInertia{(mass * lengthSquared) / SquareRadian};
         assert(I > RotInertia{0});
@@ -462,7 +462,7 @@ Velocity GetVelocity(const Body& body, Time h, MovementConf conf) noexcept
     // Enforce maximums...
 
     const auto translation = h * velocity.linear;
-    const auto lsquared = GetLengthSquared(translation);
+    const auto lsquared = GetMagnitudeSquared(translation);
     if (lsquared > Square(conf.maxTranslation))
     {
         // Scale back linear velocity so max translation not exceeded.
@@ -512,13 +512,13 @@ Force2 GetCentripetalForce(const Body& body, Length2 axis)
 
     // Force is M L T^-2.
     const auto velocity = GetLinearVelocity(body);
-    const auto magnitude = GetLength(GetVec2(velocity)) * MeterPerSecond;
+    const auto magnitudeOfVelocity = GetMagnitude(GetVec2(velocity)) * MeterPerSecond;
     const auto location = body.GetLocation();
     const auto mass = GetMass(body);
-    const auto delta = Length2{axis - location};
-    const auto radius = GetLength(delta);
+    const auto delta = axis - location;
+    const auto radius = GetMagnitude(delta);
     const auto dir = delta / radius;
-    return Force2{dir * mass * Square(magnitude) / radius};
+    return Force2{dir * mass * Square(magnitudeOfVelocity) / radius};
 }
 
 Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
@@ -540,7 +540,7 @@ Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
             const auto m2 = GetMass(b2);
             const auto delta = GetLocation(b2) - loc1;
             const auto dir = GetUnitVector(delta);
-            const auto rr = GetLengthSquared(delta);
+            const auto rr = GetMagnitudeSquared(delta);
             const auto orderedMass = std::minmax(m1, m2);
             const auto f = (BigG * orderedMass.first) * (orderedMass.second / rr);
             sumForce += f * dir;

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -1070,7 +1070,7 @@ inline RotInertia GetRotInertia(const Body& body) noexcept
 inline RotInertia GetLocalRotInertia(const Body& body) noexcept
 {
     return GetRotInertia(body)
-         + GetMass(body) * GetLengthSquared(body.GetLocalCenter()) / SquareRadian;
+         + GetMass(body) * GetMagnitudeSquared(body.GetLocalCenter()) / SquareRadian;
 }
 
 /// @brief Gets the linear velocity of the center of mass.

--- a/PlayRho/Dynamics/Contacts/Contact.cpp
+++ b/PlayRho/Dynamics/Contacts/Contact.cpp
@@ -167,7 +167,7 @@ void Contact::Update(const UpdateConf& conf, ContactListener* listener)
                 for (auto j = decltype(old_point_count){0}; j < old_point_count; ++j)
                 {
                     const auto oldPt = oldManifold.GetPoint(j);
-                    const auto squareDiff = GetLengthSquared(oldPt.localPoint - newPt.localPoint);
+                    const auto squareDiff = GetMagnitudeSquared(oldPt.localPoint - newPt.localPoint);
                     if (leastSquareDiff > squareDiff)
                     {
                         leastSquareDiff = squareDiff;

--- a/PlayRho/Dynamics/Joints/DistanceJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointDef.cpp
@@ -30,7 +30,7 @@ DistanceJointDef::DistanceJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
     super{super{JointType::Distance}.UseBodyA(bA).UseBodyB(bB)},
     localAnchorA{GetLocalPoint(*bA, anchor1)},
     localAnchorB{GetLocalPoint(*bB, anchor2)},
-    length{GetLength(anchor2 - anchor1)}
+    length{GetMagnitude(anchor2 - anchor1)}
 {
     // Intentionally empty.
 }

--- a/PlayRho/Dynamics/Joints/FrictionJoint.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.cpp
@@ -183,7 +183,7 @@ bool FrictionJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
 
         const auto maxImpulse = h * m_maxForce;
 
-        if (GetLengthSquared(m_linearImpulse) > Square(maxImpulse))
+        if (GetMagnitudeSquared(m_linearImpulse) > Square(maxImpulse))
         {
             m_linearImpulse = GetUnitVector(m_linearImpulse, UnitVec2::GetZero()) * maxImpulse;
         }

--- a/PlayRho/Dynamics/Joints/MotorJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.cpp
@@ -194,7 +194,7 @@ bool MotorJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
 
         const auto maxImpulse = h * m_maxForce;
 
-        if (GetLengthSquared(m_linearImpulse) > Square(maxImpulse))
+        if (GetMagnitudeSquared(m_linearImpulse) > Square(maxImpulse))
         {
             m_linearImpulse = GetUnitVector(m_linearImpulse, UnitVec2::GetZero()) * maxImpulse;
         }

--- a/PlayRho/Dynamics/Joints/MouseJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.cpp
@@ -177,7 +177,7 @@ bool MouseJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
     assert(IsValid(addImpulse));
     m_impulse += addImpulse;
     const auto maxImpulse = step.GetTime() * Force{m_maxForce};
-    if (GetLengthSquared(m_impulse) > Square(maxImpulse))
+    if (GetMagnitudeSquared(m_impulse) > Square(maxImpulse))
     {
         m_impulse = GetUnitVector(m_impulse, UnitVec2::GetZero()) * maxImpulse;
     }

--- a/PlayRho/Dynamics/Joints/PulleyJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.cpp
@@ -240,13 +240,13 @@ void PulleyJoint::ShiftOrigin(const Length2 newOrigin)
 
 Length GetCurrentLengthA(const PulleyJoint& joint)
 {
-    return GetLength(GetWorldPoint(*joint.GetBodyA(),
+    return GetMagnitude(GetWorldPoint(*joint.GetBodyA(),
                                    joint.GetLocalAnchorA()) - joint.GetGroundAnchorA());
 }
 
 Length GetCurrentLengthB(const PulleyJoint& joint)
 {
-    return GetLength(GetWorldPoint(*joint.GetBodyB(),
+    return GetMagnitude(GetWorldPoint(*joint.GetBodyB(),
                                    joint.GetLocalAnchorB()) - joint.GetGroundAnchorB());
 }
 

--- a/PlayRho/Dynamics/Joints/PulleyJointDef.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointDef.cpp
@@ -33,8 +33,8 @@ PulleyJointDef::PulleyJointDef(NonNull<Body*> bA, NonNull<Body*> bB,
     groundAnchorB{groundB},
     localAnchorA{GetLocalPoint(*bA, anchorA)},
     localAnchorB{GetLocalPoint(*bB, anchorB)},
-    lengthA{GetLength(anchorA - groundA)},
-    lengthB{GetLength(anchorB - groundB)}
+    lengthA{GetMagnitude(anchorA - groundA)},
+    lengthB{GetMagnitude(anchorB - groundB)}
 {
     // Intentionally empty.
 }

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -386,7 +386,7 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
         const auto rB = Length2{Rotate(m_localAnchorB - bodyConstraintB->GetLocalCenter(), qB)};
 
         const auto C = (posB.linear + rB) - (posA.linear + rA);
-        positionError = GetLengthSquared(C);
+        positionError = GetMagnitudeSquared(C);
 
         const auto invMassA = bodyConstraintA->GetInvMass();
         const auto invMassB = bodyConstraintB->GetInvMass();

--- a/PlayRho/Dynamics/Joints/WeldJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.cpp
@@ -327,7 +327,7 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     {
         const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
 
-        positionError = GetLength(C1);
+        positionError = GetMagnitude(C1);
         angularError = 0_deg;
 
         const auto P = -Solve22(K, C1) * Kilogram;
@@ -342,7 +342,7 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
         const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
         const auto C2 = Angle{posB.angular - posA.angular - m_referenceAngle};
 
-        positionError = GetLength(C1);
+        positionError = GetMagnitude(C1);
         angularError = Abs(C2);
 
         const auto C = Vec3{StripUnit(GetX(C1)), StripUnit(GetY(C1)), StripUnit(C2)};

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2893,7 +2893,7 @@ Body* FindClosestBody(const World& world, Length2 location) noexcept
     {
         auto& body = GetRef(b);
         const auto bodyLoc = body.GetLocation();
-        const auto lengthSquared = GetLengthSquared(bodyLoc - location);
+        const auto lengthSquared = GetMagnitudeSquared(bodyLoc - location);
         if (minLengthSquared > lengthSquared)
         {
             minLengthSquared = lengthSquared;

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -603,8 +603,8 @@ struct GLRenderTriangles
 
 DebugDraw::DebugDraw(Camera& camera):
     m_camera(camera),
-    m_cosInc{std::cos((2 * Pi) / m_circleParts)},
-    m_sinInc{std::sin((2 * Pi) / m_circleParts)}
+    m_cosInc{Cos((2 * Pi) / m_circleParts)},
+    m_sinInc{Sin((2 * Pi) / m_circleParts)}
 {
     m_points = new GLRenderPoints;
     m_lines = new GLRenderLines;

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -1575,7 +1575,7 @@ static void EntityUI(MouseJoint& j)
         }
     }
     {
-        auto v = static_cast<float>(j.GetDampingRatio());
+        auto v = static_cast<float>(Real{j.GetDampingRatio()});
         if (ImGui::InputFloat("Damping Ratio", &v))
         {
             j.SetDampingRatio(static_cast<Real>(v));
@@ -1939,7 +1939,7 @@ static void EntityUI(Contact& c)
         }
     }
     {
-        auto val = static_cast<float>(c.GetTangentSpeed() / MeterPerSecond);
+        auto val = static_cast<float>(Real{c.GetTangentSpeed() / MeterPerSecond});
         if (ImGui::InputFloat("Belt Speed", &val, 0, 0, -1, ImGuiInputTextFlags_EnterReturnsTrue))
         {
             c.SetTangentSpeed(val * MeterPerSecond);
@@ -1947,7 +1947,7 @@ static void EntityUI(Contact& c)
     }
     if (c.HasValidToi())
     {
-        ImGui::LabelText("TOI", "%f", c.GetToi());
+        ImGui::LabelText("TOI", "%f", static_cast<double>(c.GetToi()));
     }
     ImGui::LabelText("TOI Count", "%d", c.GetToiCount());
 

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -534,7 +534,7 @@ void Test::CompleteBombSpawn(const Length2& p)
 
     const auto deltaTime = m_lastDeltaTime;
     const auto relP = m_bombSpawnPoint - p;
-    const auto vel = (deltaTime != 0)? LinearVelocity2{
+    const auto vel = (deltaTime != 0_s)? LinearVelocity2{
         Real{0.25f} * GetX(relP) / deltaTime,
         Real{0.25f} * GetY(relP) / deltaTime
     }: LinearVelocity2{};
@@ -587,7 +587,7 @@ void Test::LaunchBomb()
     const auto centerX = GetCenter(viewport.ranges[0]);
     const auto height = GetSize(viewport.ranges[1]);
     const auto atB = Length2{centerX, viewport.ranges[1].GetMax() - (height * 9.0f / 10.0f)};
-    const auto v = (deltaTime != 0)? (atB - atA) / (deltaTime * 30): LinearVelocity2{};
+    const auto v = (deltaTime != 0_s)? (atB - atA) / (deltaTime * 30): LinearVelocity2{};
     LaunchBomb(atA, v);
 }
 

--- a/Testbed/Tests/ApplyForce.hpp
+++ b/Testbed/Tests/ApplyForce.hpp
@@ -135,7 +135,7 @@ public:
 
                 // For a circle: I = 0.5 * m * r * r ==> r = sqrt(2 * I / m)
                 const auto radiusSquaredUnitless = 2 * I * invMass * SquareRadian / SquareMeter;
-                const auto radius = Length{Real{std::sqrt(Real{radiusSquaredUnitless})} * 1_m};
+                const auto radius = Length{Sqrt(Real{radiusSquaredUnitless}) * 1_m};
 
                 FrictionJointDef jd;
                 jd.localAnchorA = Length2{};

--- a/Testbed/Tests/BagOfDisks.hpp
+++ b/Testbed/Tests/BagOfDisks.hpp
@@ -62,7 +62,7 @@ namespace playrho {
             m_ground->CreateFixture(std::make_shared<ChainShape>(boundaryConf));
             
             const auto vertices = GetCircleVertices(10_m, 90);
-            const auto halfSegmentLength = GetLength(vertices[1] - vertices[0]) / 2;
+            const auto halfSegmentLength = GetMagnitude(vertices[1] - vertices[0]) / 2;
 
             auto conf = EdgeShape::Conf{};
             conf.vertexRadius = 0.125_m;

--- a/Testbed/Tests/CharacterCollision.hpp
+++ b/Testbed/Tests/CharacterCollision.hpp
@@ -201,7 +201,7 @@ public:
             Length2 vertices[6];
             for (auto i = 0; i < 6; ++i)
             {
-                vertices[i] = Vec2(0.5f * std::cos(angle), 0.5f * std::sin(angle)) * 1_m;
+                vertices[i] = Vec2(0.5f * Cos(angle), 0.5f * Sin(angle)) * 1_m;
                 angle += delta;
             }
 

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -260,7 +260,7 @@ public:
         const auto output = Distance(proxyA, xfmA, proxyB, xfmB, distanceConf);
         distanceConf.cache = Simplex::GetCache(output.simplex.GetEdges());
         const auto witnessPoints = GetWitnessPoints(output.simplex);
-        const auto outputDistance = Sqrt(GetLengthSquared(witnessPoints.a - witnessPoints.b));
+        const auto outputDistance = Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
         
         const auto rA = proxyA.GetVertexRadius();
         const auto rB = proxyB.GetVertexRadius();

--- a/Testbed/Tests/Dominos.hpp
+++ b/Testbed/Tests/Dominos.hpp
@@ -152,7 +152,7 @@ public:
         djd.localAnchorA = Vec2(6.0f, 0.0f) * 1_m;
         djd.localAnchorB = Vec2(0.0f, -1.0f) * 1_m;
         const auto d = GetWorldPoint(*djd.bodyB, djd.localAnchorB) - GetWorldPoint(*djd.bodyA, djd.localAnchorA);
-        djd.length = GetLength(d);
+        djd.length = GetMagnitude(d);
         m_world.CreateJoint(djd);
 
         {

--- a/Testbed/Tests/EdgeShapes.hpp
+++ b/Testbed/Tests/EdgeShapes.hpp
@@ -169,7 +169,7 @@ public:
     {
         const auto L = Real(25);
         const auto point1 = Vec2(0.0f, 10.0f) * 1_m;
-        const auto d = Vec2(L * std::cos(m_angle), -L * Abs(std::sin(m_angle))) * 1_m;
+        const auto d = Vec2(L * Cos(m_angle), -L * Abs(Sin(m_angle))) * 1_m;
         const auto point2 = point1 + d;
 
         auto fixture = static_cast<Fixture*>(nullptr);

--- a/Testbed/Tests/MotorJoint.hpp
+++ b/Testbed/Tests/MotorJoint.hpp
@@ -71,7 +71,7 @@ public:
             m_time += settings.dt;
         }
 
-        const auto linearOffset = Vec2{6 * std::sin(2 * m_time), 8 + 4 * std::sin(m_time)} * 1_m;
+        const auto linearOffset = Vec2{6 * Sin(2 * m_time), 8 + 4 * Sin(m_time)} * 1_m;
 
         m_joint->SetLinearOffset(linearOffset);
         m_joint->SetAngularOffset(4_rad * m_time);

--- a/Testbed/Tests/RayCast.hpp
+++ b/Testbed/Tests/RayCast.hpp
@@ -204,7 +204,7 @@ public:
 
         const auto L = 11.0f;
         const auto point1 = Vec2(0.0f, 10.0f) * 1_m;
-        const auto d = Vec2(L * std::cos(m_angle), L * std::sin(m_angle)) * 1_m;
+        const auto d = Vec2(L * Cos(m_angle), L * Sin(m_angle)) * 1_m;
         const auto point2 = point1 + d;
 
         if (m_mode == Mode::e_closest)

--- a/Testbed/Tests/SensorTest.hpp
+++ b/Testbed/Tests/SensorTest.hpp
@@ -149,7 +149,7 @@ public:
             const auto position = body->GetLocation();
 
             const auto d = center - position;
-            if (AlmostZero(GetLengthSquared(d) / SquareMeter))
+            if (AlmostZero(GetMagnitudeSquared(d) / SquareMeter))
             {
                 continue;
             }

--- a/Testbed/Tests/SolarSystem.hpp
+++ b/Testbed/Tests/SolarSystem.hpp
@@ -79,9 +79,9 @@ public:
         os << " The Sun and planets radiuses, masses, orbital and rotational periods";
         os << " are all simulated to scale.";
         os << " Radiuses range from ";
-        os << static_cast<float>(minRadius / 1_km);
+        os << static_cast<float>(Real{minRadius / 1_km});
         os << " km (" << minName << "), to ";
-        os << static_cast<float>(maxRadius / 1_km);
+        os << static_cast<float>(Real{maxRadius / 1_km});
         os << " km (" << maxName << ").";
 
         auto conf = Test::Conf{};

--- a/Testbed/Tests/TimeOfImpact.hpp
+++ b/Testbed/Tests/TimeOfImpact.hpp
@@ -33,21 +33,7 @@ public:
         m_shapeA.SetAsBox(25_m, 5_m);
         m_shapeB.SetAsBox(2.5_m, 2.5_m);
     }
-
-    static const char *GetName(TOIOutput::State state)
-    {
-        switch (state)
-        {
-            case TOIOutput::e_failed: return "failed";
-            case TOIOutput::e_unknown: return "unknown";
-            case TOIOutput::e_touching: return "touching";
-            case TOIOutput::e_separated: return "separated";
-            case TOIOutput::e_overlapped: return "overlapped";
-            default: break;
-        }
-        return "unknown";
-    }
-
+    
     void PostStep(const Settings&, Drawer& drawer) override
     {
         const auto offset = Vec2{Real(-35), Real(70)} * 1_m;
@@ -64,11 +50,11 @@ public:
 
         std::stringstream stream;
         stream << "At TOI ";
-        stream << static_cast<float>(output.get_t());
+        stream << static_cast<float>(output.time);
         stream << ", state is ";
-        stream << GetName(output.get_state());
-        stream << ". TOI iterations is " << unsigned{output.get_toi_iters()};
-        stream << ", max root iterations is " << unsigned{output.get_max_root_iters()};
+        stream << GetName(output.state);
+        stream << ". TOI iterations is " << unsigned{output.stats.toi_iters};
+        stream << ", max root iterations is " << unsigned{output.stats.max_root_iters};
         stream << ".";
         m_status = stream.str();
 
@@ -97,7 +83,7 @@ public:
         {
             const auto vertexCount = m_shapeB.GetVertexCount();
             auto vertices = std::vector<Length2>(vertexCount);
-            const auto transformB = GetTransformation(sweepB, output.get_t());
+            const auto transformB = GetTransformation(sweepB, output.time);
             for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
             {
                 vertices[i] = Transform(m_shapeB.GetVertex(i), transformB);

--- a/Testbed/Tests/Web.hpp
+++ b/Testbed/Tests/Web.hpp
@@ -76,7 +76,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[0] = m_world.CreateJoint(jd);
 
             jd.bodyA = ground;
@@ -86,7 +86,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[1] = m_world.CreateJoint(jd);
 
             jd.bodyA = ground;
@@ -96,7 +96,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[2] = m_world.CreateJoint(jd);
 
             jd.bodyA = ground;
@@ -106,7 +106,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[3] = m_world.CreateJoint(jd);
 
             jd.bodyA = m_bodies[0];
@@ -116,7 +116,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[4] = m_world.CreateJoint(jd);
 
             jd.bodyA = m_bodies[1];
@@ -126,7 +126,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[5] = m_world.CreateJoint(jd);
 
             jd.bodyA = m_bodies[2];
@@ -136,7 +136,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[6] = m_world.CreateJoint(jd);
 
             jd.bodyA = m_bodies[3];
@@ -146,7 +146,7 @@ public:
             p1 = GetWorldPoint(*jd.bodyA, jd.localAnchorA);
             p2 = GetWorldPoint(*jd.bodyB, jd.localAnchorB);
             d = p2 - p1;
-            jd.length = GetLength(d);
+            jd.length = GetMagnitude(d);
             m_joints[7] = m_world.CreateJoint(jd);
         }
         

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -166,7 +166,7 @@ public:
     {
         //lateral linear velocity
         auto impulse = Momentum2{GetMass(*m_body) * -getLateralVelocity()};
-        const auto length = GetLength(GetVec2(impulse)) * 1_kg * 1_mps;
+        const auto length = GetMagnitude(GetVec2(impulse)) * 1_kg * 1_mps;
         if ( length > m_maxLateralImpulse )
             impulse *= m_maxLateralImpulse / length;
         ApplyLinearImpulse(*m_body, m_currentTraction * impulse, m_body->GetWorldCenter());

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -159,37 +159,37 @@ TEST(AABB2D, InitializingConstruction)
         const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         const auto pb = Length2{GetInvalid<Length>(), 0_m};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_FALSE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_FALSE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto pa = Length2{GetInvalid<Length>(), 0_m};
         const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_FALSE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_FALSE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto pa = Length2{GetInvalid<Length>(), 0_m};
         const auto pb = Length2{GetInvalid<Length>(), 0_m};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_FALSE(std::isnan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(std::isnan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_FALSE(std::isnan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_FALSE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_FALSE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto rangeX = Interval<Length>{-2_m, +3_m};
@@ -221,7 +221,7 @@ TEST(AABB2D, GetPerimeterOfPoint)
     EXPECT_EQ(GetPerimeter(AABB2D{Length2{}}), 0_m);
     EXPECT_EQ(GetPerimeter(AABB2D{Length2{-1_m, -2_m}}), 0_m);
     EXPECT_EQ(GetPerimeter(AABB2D{Length2{+99_m, +3_m}}), 0_m);
-    EXPECT_TRUE(std::isnan(StripUnit(GetPerimeter(AABB2D{
+    EXPECT_TRUE(IsNan(StripUnit(GetPerimeter(AABB2D{
         Length2{
             Real(+std::numeric_limits<Real>::infinity()) * Meter,
             Real(+std::numeric_limits<Real>::infinity()) * Meter

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -147,7 +147,7 @@ TEST(ContactSolver, SolvePosConstraintsForOverlappingZeroRateDoesntMove)
     const auto solution = GaussSeidel::SolvePositionConstraint(pc, true, true, conf);
 
     EXPECT_NEAR(static_cast<double>(Real{solution.min_separation / Meter}),
-                static_cast<double>(Real{-2} * dim / Meter),
+                static_cast<double>(Real{-2 * dim / Meter}),
                 0.0001);
     
     EXPECT_EQ(GetX(old_pA.linear), GetX(solution.pos_a.linear));

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -435,7 +435,7 @@ TEST(Distance, VerEdgeSquareTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_NEAR(static_cast<double>(Real{Sqrt(GetLengthSquared(witnessPoints.a - witnessPoints.b)) / Meter}),
+    EXPECT_NEAR(static_cast<double>(Real{Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b)) / Meter}),
                 1.0, 0.000001);
     EXPECT_EQ(GetX(witnessPoints.a), 3_m);
     EXPECT_EQ(GetY(witnessPoints.a), 2_m);

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -138,7 +138,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
     jointdef.dampingRatio = 0;
     EXPECT_NE(world.CreateJoint(jointdef), nullptr);
     
-    auto oldDistance = GetLength(body1->GetLocation() - body2->GetLocation());
+    auto oldDistance = GetMagnitude(body1->GetLocation() - body2->GetLocation());
     
     auto distanceMet = 0u;
     StepConf stepConf;
@@ -146,7 +146,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
     {
         world.Step(stepConf);
 
-        const auto newDistance = GetLength(body1->GetLocation() - body2->GetLocation());
+        const auto newDistance = GetMagnitude(body1->GetLocation() - body2->GetLocation());
         if (distanceMet)
         {
             EXPECT_NEAR(double(Real{newDistance / Meter}),
@@ -193,7 +193,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
     jointdef.dampingRatio = 0;
     EXPECT_NE(world.CreateJoint(jointdef), nullptr);
     
-    auto oldDistance = GetLength(body1->GetLocation() - body2->GetLocation());
+    auto oldDistance = GetMagnitude(body1->GetLocation() - body2->GetLocation());
     
     auto distanceMet = 0u;
     StepConf stepConf;
@@ -201,7 +201,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
     {
         world.Step(stepConf);
         
-        const auto newDistance = GetLength(body1->GetLocation() - body2->GetLocation());
+        const auto newDistance = GetMagnitude(body1->GetLocation() - body2->GetLocation());
         if (!distanceMet && (newDistance - oldDistance) >= 0_m)
         {
             distanceMet = i;

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -341,16 +341,16 @@ TEST(Fixed32, Division)
 TEST(Fixed32, Sin)
 {
     EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(0))), 0.0f);
-    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(1))), std::sin(1.0f));
-    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(2))), std::sin(2.0f));
-    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(Pi/2))), 1.0f);
+    EXPECT_NEAR(static_cast<double>(Sin(Fixed32(1))), std::sin(1.0), 0.002);
+    EXPECT_NEAR(static_cast<double>(Sin(Fixed32(2))), std::sin(2.0), 0.002);
+    EXPECT_NEAR(static_cast<double>(Sin(Fixed32(Pi/2))), 1.0, 0.002);
 }
 
 TEST(Fixed32, Cos)
 {
     EXPECT_FLOAT_EQ(static_cast<float>(Cos(Fixed32(0))), float(1));
-    EXPECT_FLOAT_EQ(static_cast<float>(Cos(Fixed32(1))), std::cos(1.0f));
-    EXPECT_FLOAT_EQ(static_cast<float>(Cos(Fixed32(2))), std::cos(2.0f));
+    EXPECT_NEAR(static_cast<double>(Cos(Fixed32(1))), std::cos(1.0), 0.002);
+    EXPECT_NEAR(static_cast<double>(Cos(Fixed32(2))), std::cos(2.0), 0.002);
     EXPECT_LT(static_cast<float>(Cos(Fixed32(Pi/2))), +0.001f);
     EXPECT_GT(static_cast<float>(Cos(Fixed32(Pi/2))), -0.001f);
 }

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -124,10 +124,10 @@ DECL_INT_CONSTRUCTION_AND_COMPARE_TEST(Fixed64)
 #define DECL_ISFINITE_TEST(type) \
 TEST(type, isfinite) \
 { \
-    EXPECT_TRUE(std::isfinite(type(0))); \
-    EXPECT_FALSE(std::isfinite( type::GetInfinity())); \
-    EXPECT_FALSE(std::isfinite(-type::GetInfinity())); \
-    EXPECT_FALSE(std::isfinite(type::GetNaN())); \
+    EXPECT_TRUE(IsFinite(type(0))); \
+    EXPECT_FALSE(IsFinite( type::GetInfinity())); \
+    EXPECT_FALSE(IsFinite(-type::GetInfinity())); \
+    EXPECT_FALSE(IsFinite(type::GetNaN())); \
 }
 
 DECL_ISFINITE_TEST(Fixed32)
@@ -135,24 +135,24 @@ DECL_ISFINITE_TEST(Fixed32)
 DECL_ISFINITE_TEST(Fixed64)
 #endif
 
-// Tests of std::isnan(Fixed<T>)
+// Tests of IsNan(Fixed<T>)
 
 #define DECL_ISNAN_TEST(type) \
 TEST(type, isnan) \
 { \
-    EXPECT_FALSE(std::isnan(type( 0))); \
-    EXPECT_FALSE(std::isnan(type( 1))); \
-    EXPECT_FALSE(std::isnan(type(-1))); \
-    EXPECT_FALSE(std::isnan( type::GetInfinity())); \
-    EXPECT_FALSE(std::isnan(-type::GetInfinity())); \
-    EXPECT_FALSE(std::isnan( type::GetNegativeInfinity())); \
-    EXPECT_TRUE(std::isnan(type::GetNaN())); \
-    EXPECT_TRUE(std::isnan(type(std::numeric_limits<float>::quiet_NaN()))); \
-    EXPECT_TRUE(std::isnan(type(std::numeric_limits<float>::signaling_NaN()))); \
-    EXPECT_TRUE(std::isnan(type(std::numeric_limits<double>::quiet_NaN()))); \
-    EXPECT_TRUE(std::isnan(type(std::numeric_limits<double>::signaling_NaN()))); \
-    EXPECT_TRUE(std::isnan(type(std::numeric_limits<long double>::quiet_NaN()))); \
-    EXPECT_TRUE(std::isnan(type(std::numeric_limits<long double>::signaling_NaN()))); \
+    EXPECT_FALSE(IsNan(type( 0))); \
+    EXPECT_FALSE(IsNan(type( 1))); \
+    EXPECT_FALSE(IsNan(type(-1))); \
+    EXPECT_FALSE(IsNan( type::GetInfinity())); \
+    EXPECT_FALSE(IsNan(-type::GetInfinity())); \
+    EXPECT_FALSE(IsNan( type::GetNegativeInfinity())); \
+    EXPECT_TRUE(IsNan(type::GetNaN())); \
+    EXPECT_TRUE(IsNan(type(std::numeric_limits<float>::quiet_NaN()))); \
+    EXPECT_TRUE(IsNan(type(std::numeric_limits<float>::signaling_NaN()))); \
+    EXPECT_TRUE(IsNan(type(std::numeric_limits<double>::quiet_NaN()))); \
+    EXPECT_TRUE(IsNan(type(std::numeric_limits<double>::signaling_NaN()))); \
+    EXPECT_TRUE(IsNan(type(std::numeric_limits<long double>::quiet_NaN()))); \
+    EXPECT_TRUE(IsNan(type(std::numeric_limits<long double>::signaling_NaN()))); \
 }
 
 DECL_ISNAN_TEST(Fixed32)
@@ -223,8 +223,8 @@ TEST(Fixed32, FloatConstruction)
     EXPECT_EQ(Fixed32(std::numeric_limits<float>::infinity()), Fixed32::GetInfinity());
     EXPECT_EQ(Fixed32(-std::numeric_limits<float>::infinity()), -Fixed32::GetInfinity());
     EXPECT_EQ(Fixed32(-std::numeric_limits<float>::infinity()), Fixed32::GetNegativeInfinity());
-    EXPECT_TRUE(std::isnan(Fixed32(std::numeric_limits<float>::quiet_NaN())));
-    EXPECT_TRUE(std::isnan(Fixed32(std::numeric_limits<float>::signaling_NaN())));
+    EXPECT_TRUE(IsNan(Fixed32(std::numeric_limits<float>::quiet_NaN())));
+    EXPECT_TRUE(IsNan(Fixed32(std::numeric_limits<float>::signaling_NaN())));
 
     const auto range = 30000;
     for (auto i = -range; i < range; ++i)
@@ -314,8 +314,8 @@ TEST(Fixed32, Multiplication)
     EXPECT_EQ(Fixed32(9) * Fixed32(3), Fixed32(27));
     EXPECT_EQ(Fixed32(-5) * Fixed32(-4), Fixed32(20));
     EXPECT_EQ(Fixed32(0.5) * Fixed32(0.5), Fixed32(0.25));
-    EXPECT_EQ(Round(Fixed32(-0.05) * Fixed32(0.05), 1000), Round(Fixed32(-0.0025), 1000));
-    EXPECT_EQ(Round(Fixed32(Pi) * 2, 100), Round(Fixed32(Pi * 2), 100));
+    EXPECT_EQ(RoundOff(Fixed32(-0.05) * Fixed32(0.05), 1000), RoundOff(Fixed32(-0.0025), 1000));
+    EXPECT_EQ(RoundOff(Fixed32(Pi) * 2, 100), RoundOff(Fixed32(Pi * 2), 100));
     EXPECT_EQ(Fixed32(181) * Fixed32(181), Fixed32(32761));
 }
 
@@ -340,19 +340,19 @@ TEST(Fixed32, Division)
 
 TEST(Fixed32, Sin)
 {
-    EXPECT_FLOAT_EQ(std::sin(Fixed32(0)), 0.0f);
-    EXPECT_FLOAT_EQ(std::sin(Fixed32(1)), std::sin(1.0f));
-    EXPECT_FLOAT_EQ(std::sin(Fixed32(2)), std::sin(2.0f));
-    EXPECT_FLOAT_EQ(std::sin(Fixed32(Pi/2)), 1.0f);
+    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(0))), 0.0f);
+    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(1))), std::sin(1.0f));
+    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(2))), std::sin(2.0f));
+    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(Pi/2))), 1.0f);
 }
 
 TEST(Fixed32, Cos)
 {
-    EXPECT_FLOAT_EQ(std::cos(Fixed32(0)), float(1));
-    EXPECT_FLOAT_EQ(std::cos(Fixed32(1)), std::cos(1.0f));
-    EXPECT_FLOAT_EQ(std::cos(Fixed32(2)), std::cos(2.0f));
-    EXPECT_LT(std::cos(Fixed32(Pi/2)), +0.001f);
-    EXPECT_GT(std::cos(Fixed32(Pi/2)), -0.001f);
+    EXPECT_FLOAT_EQ(static_cast<float>(Cos(Fixed32(0))), float(1));
+    EXPECT_FLOAT_EQ(static_cast<float>(Cos(Fixed32(1))), std::cos(1.0f));
+    EXPECT_FLOAT_EQ(static_cast<float>(Cos(Fixed32(2))), std::cos(2.0f));
+    EXPECT_LT(static_cast<float>(Cos(Fixed32(Pi/2))), +0.001f);
+    EXPECT_GT(static_cast<float>(Cos(Fixed32(Pi/2))), -0.001f);
 }
 
 TEST(Fixed32, Max)
@@ -462,7 +462,7 @@ TEST(Fixed32, InifnityDividedByPositiveIsInfinity)
 
 TEST(Fixed32, InfinityDividedByInfinityIsNaN)
 {
-    EXPECT_TRUE(std::isnan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
+    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
 }
 
 TEST(Fixed32, InifnityTimesNegativeIsNegativeInfinity)
@@ -491,25 +491,25 @@ TEST(Fixed32, NegativeInfinityMinusInfinityIsNegativeInfinity)
 
 TEST(Fixed32, NaN)
 {
-    EXPECT_TRUE(std::isnan(Fixed32::GetNaN()));
-    EXPECT_TRUE(std::isnan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
-    EXPECT_TRUE(std::isnan(Fixed32::GetInfinity() - Fixed32::GetInfinity()));
-    EXPECT_TRUE(std::isnan(-Fixed32::GetInfinity() - -Fixed32::GetInfinity()));
-    EXPECT_TRUE(std::isnan(-Fixed32::GetInfinity() + Fixed32::GetInfinity()));
+    EXPECT_TRUE(IsNan(Fixed32::GetNaN()));
+    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
+    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() - Fixed32::GetInfinity()));
+    EXPECT_TRUE(IsNan(-Fixed32::GetInfinity() - -Fixed32::GetInfinity()));
+    EXPECT_TRUE(IsNan(-Fixed32::GetInfinity() + Fixed32::GetInfinity()));
 
-    EXPECT_FALSE(std::isnan(Fixed32{0}));
-    EXPECT_FALSE(std::isnan(Fixed32{10.0f}));
-    EXPECT_FALSE(std::isnan(Fixed32{-10.0f}));
-    EXPECT_FALSE(std::isnan(Fixed32::GetInfinity()));
-    EXPECT_FALSE(std::isnan(Fixed32::GetNegativeInfinity()));
-    EXPECT_FALSE(std::isnan(Fixed32::GetMax()));
-    EXPECT_FALSE(std::isnan(Fixed32::GetMin()));
-    EXPECT_FALSE(std::isnan(Fixed32::GetLowest()));
+    EXPECT_FALSE(IsNan(Fixed32{0}));
+    EXPECT_FALSE(IsNan(Fixed32{10.0f}));
+    EXPECT_FALSE(IsNan(Fixed32{-10.0f}));
+    EXPECT_FALSE(IsNan(Fixed32::GetInfinity()));
+    EXPECT_FALSE(IsNan(Fixed32::GetNegativeInfinity()));
+    EXPECT_FALSE(IsNan(Fixed32::GetMax()));
+    EXPECT_FALSE(IsNan(Fixed32::GetMin()));
+    EXPECT_FALSE(IsNan(Fixed32::GetLowest()));
 }
 
 TEST(Fixed32, InfinityTimesZeroIsNaN)
 {
-    EXPECT_TRUE(std::isnan(Fixed32::GetInfinity() * 0));
+    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() * 0));
 }
 
 TEST(Fixed32, Comparators)

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -19,6 +19,7 @@
 #include "gtest/gtest.h"
 #include <PlayRho/Common/Fixed.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <iostream>
 
 using namespace playrho;
 
@@ -551,6 +552,95 @@ TEST(Fixed32, BiggerValsIdenticallyInaccurate)
     }
 }
 
+TEST(Fixed32, AdditionAssignment)
+{
+    Fixed32 foo;
+    foo = 0;
+    foo += Fixed32::GetNegativeInfinity();
+    EXPECT_EQ(foo, -std::numeric_limits<Fixed32>::infinity());
+    foo = std::numeric_limits<Fixed32>::lowest();
+    foo += -1;
+    EXPECT_EQ(foo, Fixed32::GetNegativeInfinity());
+}
+
+TEST(Fixed32, SubtractionAssignment)
+{
+    Fixed32 foo;
+    foo = 0;
+    foo -= 0;
+    EXPECT_EQ(foo, Fixed32{0});
+    foo = 0;
+    foo -= 1;
+    EXPECT_EQ(foo, Fixed32{-1});
+    foo = std::numeric_limits<Fixed32>::max();
+    foo -= Fixed32{-2};
+    EXPECT_EQ(foo, Fixed32::GetInfinity());
+}
+
+TEST(Fixed32, MultiplicationAssignment)
+{
+    Fixed32 foo;
+    foo = Fixed32::GetNaN();
+    foo *= Fixed32{0};
+    EXPECT_TRUE(foo.isnan());
+    foo = 0;
+    foo *= Fixed32::GetNaN();
+    EXPECT_TRUE(foo.isnan());
+    foo = std::numeric_limits<Fixed32>::min();
+    foo *= std::numeric_limits<Fixed32>::min();
+    EXPECT_EQ(foo, Fixed32(0));
+    foo = std::numeric_limits<Fixed32>::lowest();
+    foo *= 2;
+    EXPECT_EQ(foo, Fixed32::GetNegativeInfinity());
+}
+
+TEST(Fixed32, DivisionAssignment)
+{
+    Fixed32 foo;
+    foo = Fixed32::GetNaN();
+    foo /= Fixed32{1};
+    EXPECT_TRUE(foo.isnan());
+    foo = 0;
+    foo /= Fixed32::GetNaN();
+    EXPECT_TRUE(foo.isnan());
+    foo = 1;
+    foo /= Fixed32::GetInfinity();
+    EXPECT_EQ(foo, Fixed32(0));
+    foo = std::numeric_limits<Fixed32>::max();
+    ASSERT_EQ(foo, std::numeric_limits<Fixed32>::max());
+    foo /= Fixed32(0.5f);
+    EXPECT_EQ(foo, Fixed32::GetInfinity());
+    foo = std::numeric_limits<Fixed32>::lowest();
+    ASSERT_TRUE(foo.isfinite());
+    foo /= Fixed32(0.5);
+    EXPECT_EQ(foo, Fixed32::GetNegativeInfinity());
+}
+
+TEST(Fixed32, GetSign)
+{
+    Fixed32 foo;
+    foo = 0;
+    EXPECT_GT(foo.getsign(), 0);
+    foo = Fixed32(-32.412);
+    EXPECT_LT(foo.getsign(), 0);
+}
+
+TEST(Fixed32, StreamOut)
+{
+    std::ostringstream os;
+    os << Fixed32(2.2f);
+    EXPECT_STREQ(os.str().c_str(), "2.19922");
+}
+
+#ifndef _WIN32
+TEST(Fixed64, StreamOut)
+{
+    std::ostringstream os;
+    os << Fixed64(2.2f);
+    EXPECT_STREQ(os.str().c_str(), "2.2");
+}
+#endif
+
 TEST(Fixed, Int32TypeAnd0bits)
 {
     using fixed = Fixed<std::int32_t, 0>;
@@ -580,4 +670,28 @@ TEST(Fixed, Int32TypeAnd0bits)
     EXPECT_EQ(one * two, two);
     EXPECT_EQ(two / two, one);
     EXPECT_EQ(two - two, zero);
+}
+
+TEST(Fixed, LessThan)
+{
+    using fixed_32_0 = Fixed<std::int32_t, 0>;
+    EXPECT_LT(fixed_32_0(0), fixed_32_0(1));
+}
+
+TEST(Fixed, nextafter)
+{
+    using fixed_32_0 = Fixed<std::int32_t, 0>;
+    EXPECT_EQ(std::nextafter(fixed_32_0(0), fixed_32_0( 0)),  0.0);
+    EXPECT_EQ(std::nextafter(fixed_32_0(0), fixed_32_0(+1)), +1.0);
+    EXPECT_EQ(std::nextafter(fixed_32_0(0), fixed_32_0(-1)), -1.0);
+
+    using fixed_32_1 = Fixed<std::int32_t, 1>;
+    EXPECT_EQ(std::nextafter(fixed_32_1(0), fixed_32_1( 0)),  0.0);
+    EXPECT_EQ(std::nextafter(fixed_32_1(0), fixed_32_1(+1)), +0.5);
+    EXPECT_EQ(std::nextafter(fixed_32_1(0), fixed_32_1(-1)), -0.5);
+
+    using fixed_32_2 = Fixed<std::int32_t, 2>;
+    EXPECT_EQ(std::nextafter(fixed_32_2(0), fixed_32_2( 0)),  0.0);
+    EXPECT_EQ(std::nextafter(fixed_32_2(0), fixed_32_2(+1)), +0.25);
+    EXPECT_EQ(std::nextafter(fixed_32_2(0), fixed_32_2(-1)), -0.25);
 }

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -345,8 +345,8 @@ TEST(MassData, GetForCenteredEdge)
 
     const auto halfCircleArea = circleArea / Real{2};
     const auto halfRSquared = radiusSquared / Real{2};
-    const auto I1 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetLengthSquared(v1))};
-    const auto I2 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetLengthSquared(v2))};
+    const auto I1 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v1))};
+    const auto I2 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v2))};
     EXPECT_NEAR(static_cast<double>(Real{I1 / (SquareMeter * SquareMeter)}),
                 1.6198837757110596, 1.6198837757110596 / 1000000.0);
     EXPECT_NEAR(static_cast<double>(Real{I2 / (SquareMeter * SquareMeter)}),

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -227,23 +227,23 @@ TEST(Math, CrossProductOfTwoVecTwoIsAntiCommutative)
 
 TEST(Math, DotProductOfInvalidIsInvalid)
 {
-    EXPECT_TRUE(std::isnan(Dot(GetInvalid<Vec2>(), GetInvalid<Vec2>())));
+    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(), GetInvalid<Vec2>())));
 
-    EXPECT_TRUE(std::isnan(Dot(Vec2(0, 0), GetInvalid<Vec2>())));
-    EXPECT_TRUE(std::isnan(Dot(Vec2(0, 0), Vec2(GetInvalid<Real>(), 0))));
-    EXPECT_TRUE(std::isnan(Dot(Vec2(0, 0), Vec2(0, GetInvalid<Real>()))));
+    EXPECT_TRUE(IsNan(Dot(Vec2(0, 0), GetInvalid<Vec2>())));
+    EXPECT_TRUE(IsNan(Dot(Vec2(0, 0), Vec2(GetInvalid<Real>(), 0))));
+    EXPECT_TRUE(IsNan(Dot(Vec2(0, 0), Vec2(0, GetInvalid<Real>()))));
     
-    EXPECT_TRUE(std::isnan(Dot(GetInvalid<Vec2>(),             Vec2(0, 0))));
-    EXPECT_TRUE(std::isnan(Dot(Vec2(GetInvalid<Real>(), 0), Vec2(0, 0))));
-    EXPECT_TRUE(std::isnan(Dot(Vec2(0, GetInvalid<Real>()), Vec2(0, 0))));
+    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(),             Vec2(0, 0))));
+    EXPECT_TRUE(IsNan(Dot(Vec2(GetInvalid<Real>(), 0), Vec2(0, 0))));
+    EXPECT_TRUE(IsNan(Dot(Vec2(0, GetInvalid<Real>()), Vec2(0, 0))));
 
-    EXPECT_TRUE(std::isnan(Dot(GetInvalid<Vec2>(), GetInvalid<UnitVec2>())));
-    //EXPECT_TRUE(std::isnan(Dot(Vec2(0, 0),         GetInvalid<UnitVec2>())));
-    EXPECT_TRUE(std::isnan(Dot(GetInvalid<Vec2>(), UnitVec2::GetZero())));
+    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(), GetInvalid<UnitVec2>())));
+    //EXPECT_TRUE(IsNan(Dot(Vec2(0, 0),         GetInvalid<UnitVec2>())));
+    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(), UnitVec2::GetZero())));
 
-    EXPECT_TRUE(std::isnan(Dot(GetInvalid<UnitVec2>(), GetInvalid<Vec2>())));
-    //EXPECT_TRUE(std::isnan(Dot(GetInvalid<UnitVec2>(), Vec2(0, 0))));
-    EXPECT_TRUE(std::isnan(Dot(UnitVec2::GetZero(),    GetInvalid<Vec2>())));
+    EXPECT_TRUE(IsNan(Dot(GetInvalid<UnitVec2>(), GetInvalid<Vec2>())));
+    //EXPECT_TRUE(IsNan(Dot(GetInvalid<UnitVec2>(), Vec2(0, 0))));
+    EXPECT_TRUE(IsNan(Dot(UnitVec2::GetZero(),    GetInvalid<Vec2>())));
 }
 
 TEST(Math, Vec2NegationAndRotationIsOrderIndependent)

--- a/UnitTests/RayCastOutput.cpp
+++ b/UnitTests/RayCastOutput.cpp
@@ -72,7 +72,7 @@ TEST(RayCastOutput, RayCastFreeFunctionHits)
     EXPECT_NEAR(static_cast<double>(output->normal.GetY()),
                 static_cast<double>(UnitVec2::GetRight().GetY()),
                 0.02);
-    EXPECT_NEAR(static_cast<double>(output->fraction), 0.49, 0.01);
+    EXPECT_NEAR(static_cast<double>(output->fraction.get()), 0.49, 0.01);
 }
 
 TEST(RayCastOutput, RayCastLocationFreeFunctionMisses)
@@ -135,7 +135,7 @@ TEST(RayCastOutput, RayCastDistanceProxyFF)
         if (output.has_value())
         {
             EXPECT_EQ(output->normal, UnitVec2::GetLeft());
-            EXPECT_NEAR(static_cast<double>(output->fraction), 0.05, 0.002);
+            EXPECT_NEAR(static_cast<double>(output->fraction.get()), 0.05, 0.002);
         }
     }
     

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -77,7 +77,7 @@ TEST(SeparationFinder, BehavesAsExpected)
     {
         // Prepare input for distance query.
         const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
-        const auto distance = Sqrt(GetLengthSquared(witnessPoints.a - witnessPoints.b));
+        const auto distance = Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
 
         const auto minSeparation = fcn.FindMinSeparation(xfA, xfB);
 

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -21,7 +21,7 @@
 
 using namespace playrho;
 
-TEST(Sweep, ByteSizeIs_36_or_72)
+TEST(Sweep, ByteSize)
 {
     switch (sizeof(Real))
     {

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -20,6 +20,7 @@
 #include <PlayRho/Collision/TimeOfImpact.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/Shapes/PolygonShape.hpp>
+#include <set>
 
 using namespace playrho;
 
@@ -134,6 +135,20 @@ TEST(TOIOutput, InitConstruction)
     //EXPECT_EQ(foo.get_sum_finder_iters(), 0);
     EXPECT_EQ(foo.stats.sum_dist_iters, 5);
     EXPECT_EQ(foo.stats.sum_root_iters, 10);
+}
+
+TEST(TOIOutput, GetName)
+{
+    std::set<std::string> names;
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_unknown)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_overlapped)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_touching)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_separated)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_maxRootIters)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_nextAfter)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_maxToiIters)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_belowMinTarget)).second);
+    EXPECT_TRUE(names.insert(GetName(TOIOutput::e_maxDistIters)).second);
 }
 
 TEST(TimeOfImpact, Overlapped)
@@ -774,6 +789,26 @@ TEST(TimeOfImpact, TryOutDifferentConfs)
     {
         const auto sweepA = Sweep{
             Position{Length2{-5_m, 0_m}, 0_deg},
+            Position{Length2{-0_m, 0_m}, 0_deg}
+        };
+        const auto sweepB = Sweep{
+            Position{Length2{+5_m, 0_m}, 0_deg},
+            Position{Length2{+0_m, 0_m}, 0_deg}
+        };
+        const auto conf = ToiConf{}
+            .UseTargetDepth(0_m)
+            .UseTolerance(0_m)
+            .UseMaxRootIters(0)
+            .UseMaxToiIters(1)
+            .UseMaxDistIters(1)
+            ;
+        const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
+        EXPECT_EQ(output.state, TOIOutput::e_maxRootIters);
+    }
+
+    {
+        const auto sweepA = Sweep{
+            Position{Length2{-5_m, 0_m}, 0_deg},
             Position{Length2{-5_m, 0_m}, 0_deg}
         };
         const auto sweepB = Sweep{
@@ -909,3 +944,4 @@ TEST(TimeOfImpact, TryOutDifferentConfs)
         EXPECT_EQ(output.stats.sum_root_iters, 2);
     }
 }
+

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -23,6 +23,17 @@
 
 using namespace playrho;
 
+TEST(TOIConf, ByteSize)
+{
+    switch (sizeof(Real))
+    {
+        case  4: EXPECT_EQ(sizeof(ToiConf), std::size_t(16)); break;
+        case  8: EXPECT_EQ(sizeof(ToiConf), std::size_t(32)); break;
+        case 16: EXPECT_EQ(sizeof(ToiConf), std::size_t(64)); break;
+        default: FAIL(); break;
+    }
+}
+
 TEST(TOIConf, DefaultConstruction)
 {
     EXPECT_EQ(ToiConf{}.tMax, Real(1));
@@ -32,24 +43,79 @@ TEST(TOIConf, DefaultConstruction)
     EXPECT_EQ(ToiConf{}.tolerance, DefaultLinearSlop / Real{4});
 }
 
+TEST(TOIOutput, StatsByteSize)
+{
+    EXPECT_EQ(sizeof(TOIOutput::Statistics), std::size_t(10));
+}
+
+TEST(TOIOutput, ByteSize)
+{
+    switch (sizeof(Real))
+    {
+        case  4: EXPECT_EQ(sizeof(TOIOutput), std::size_t(16)); break;
+        case  8: EXPECT_EQ(sizeof(TOIOutput), std::size_t(20)); break;
+        case 16: EXPECT_EQ(sizeof(TOIOutput), std::size_t(32)); break;
+        default: FAIL(); break;
+    }
+}
+
+TEST(TOIOutput, StatisticsTraits)
+{
+    EXPECT_TRUE(std::is_default_constructible<TOIOutput::Statistics>::value);
+    EXPECT_TRUE(std::is_nothrow_default_constructible<TOIOutput::Statistics>::value);
+    EXPECT_FALSE(std::is_trivially_default_constructible<TOIOutput::Statistics>::value);
+    
+    EXPECT_TRUE(std::is_copy_constructible<TOIOutput::Statistics>::value);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible<TOIOutput::Statistics>::value);
+    EXPECT_TRUE(std::is_trivially_copy_constructible<TOIOutput::Statistics>::value);
+}
+
+TEST(TOIOutput, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible<TOIOutput>::value);
+    EXPECT_TRUE(std::is_nothrow_default_constructible<TOIOutput>::value);
+    EXPECT_FALSE(std::is_trivially_default_constructible<TOIOutput>::value);
+    
+    EXPECT_TRUE((std::is_constructible<TOIOutput, Real, TOIOutput::Statistics, TOIOutput::State>::value));
+    EXPECT_TRUE((std::is_constructible<TOIOutput>::value));
+    
+    EXPECT_TRUE((std::is_nothrow_constructible<TOIOutput, Real, TOIOutput::Statistics, TOIOutput::State>::value));
+    EXPECT_TRUE((std::is_nothrow_constructible<TOIOutput>::value));
+    
+    EXPECT_FALSE((std::is_trivially_constructible<TOIOutput, Real, TOIOutput::Statistics, TOIOutput::State>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<TOIOutput>::value));
+    
+    EXPECT_TRUE(std::is_copy_constructible<TOIOutput>::value);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible<TOIOutput>::value);
+    EXPECT_TRUE(std::is_trivially_copy_constructible<TOIOutput>::value);
+    
+    EXPECT_TRUE(std::is_copy_assignable<TOIOutput>::value);
+    EXPECT_TRUE(std::is_nothrow_copy_assignable<TOIOutput>::value);
+    EXPECT_TRUE(std::is_trivially_copy_assignable<TOIOutput>::value);
+    
+    EXPECT_TRUE(std::is_destructible<TOIOutput>::value);
+    EXPECT_TRUE(std::is_nothrow_destructible<TOIOutput>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<TOIOutput>::value);
+}
+
 TEST(TOIOutput, Types)
 {
-    EXPECT_GT(sizeof(TOIOutput::dist_sum_type), sizeof(TOIOutput::dist_iter_type));
-    EXPECT_GT(sizeof(TOIOutput::root_sum_type), sizeof(TOIOutput::root_iter_type));
+    EXPECT_GT(sizeof(TOIOutput::Statistics::dist_sum_type), sizeof(TOIOutput::Statistics::dist_iter_type));
+    EXPECT_GT(sizeof(TOIOutput::Statistics::root_sum_type), sizeof(TOIOutput::Statistics::root_iter_type));
 }
 
 TEST(TOIOutput, DefaultConstruction)
 {
     TOIOutput foo;
-    EXPECT_EQ(foo.get_state(), TOIOutput::e_unknown);
+    EXPECT_EQ(foo.state, TOIOutput::e_unknown);
 }
 
 TEST(TOIOutput, InitConstruction)
 {
-    const auto state = TOIOutput::e_failed;
+    const auto state = TOIOutput::e_separated;
     const auto time = Real(0.6);
     
-    TOIOutput::Stats stats;
+    TOIOutput::Statistics stats;
     stats.toi_iters = 3;
     stats.max_dist_iters = 11;
     stats.max_root_iters = 4;
@@ -57,17 +123,17 @@ TEST(TOIOutput, InitConstruction)
     stats.sum_dist_iters = 5;
     stats.sum_root_iters = 10;
 
-    TOIOutput foo{state, time, stats};
+    TOIOutput foo{time, stats, state};
 
-    EXPECT_EQ(foo.get_state(), state);
-    EXPECT_EQ(foo.get_t(), time);
+    EXPECT_EQ(foo.state, state);
+    EXPECT_EQ(foo.time, time);
     
-    EXPECT_EQ(foo.get_toi_iters(), 3);
-    EXPECT_EQ(foo.get_max_dist_iters(), 11);
-    EXPECT_EQ(foo.get_max_root_iters(), 4);
+    EXPECT_EQ(foo.stats.toi_iters, 3);
+    EXPECT_EQ(foo.stats.max_dist_iters, 11);
+    EXPECT_EQ(foo.stats.max_root_iters, 4);
     //EXPECT_EQ(foo.get_sum_finder_iters(), 0);
-    EXPECT_EQ(foo.get_sum_dist_iters(), 5);
-    EXPECT_EQ(foo.get_sum_root_iters(), 10);
+    EXPECT_EQ(foo.stats.sum_dist_iters, 5);
+    EXPECT_EQ(foo.stats.sum_root_iters, 10);
 }
 
 TEST(TimeOfImpact, Overlapped)
@@ -83,9 +149,9 @@ TEST(TimeOfImpact, Overlapped)
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
     const auto sweepB = Sweep{Position{Length2{}, 0_deg}};
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
-    EXPECT_EQ(output.get_state(), TOIOutput::e_overlapped);
-    EXPECT_EQ(output.get_t(), Real(0));
-    EXPECT_EQ(output.get_toi_iters(), 1);
+    EXPECT_EQ(output.state, TOIOutput::e_overlapped);
+    EXPECT_EQ(output.time, Real(0));
+    EXPECT_EQ(output.stats.toi_iters, 1);
 }
 
 TEST(TimeOfImpact, Touching)
@@ -105,9 +171,9 @@ TEST(TimeOfImpact, Touching)
 
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_touching);
-    EXPECT_EQ(output.get_t(), Real(0));
-    EXPECT_EQ(output.get_toi_iters(), 1);
+    EXPECT_EQ(output.state, TOIOutput::e_touching);
+    EXPECT_EQ(output.time, Real(0));
+    EXPECT_EQ(output.stats.toi_iters, 1);
 }
 
 TEST(TimeOfImpact, Separated)
@@ -126,9 +192,9 @@ TEST(TimeOfImpact, Separated)
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_separated);
-    EXPECT_EQ(output.get_t(), Real(1));
-    EXPECT_EQ(output.get_toi_iters(), 1);
+    EXPECT_EQ(output.state, TOIOutput::e_separated);
+    EXPECT_EQ(output.time, Real(1));
+    EXPECT_EQ(output.stats.toi_iters, 1);
 }
 
 TEST(TimeOfImpact, CollideCirclesHorizontally)
@@ -152,9 +218,18 @@ TEST(TimeOfImpact, CollideCirclesHorizontally)
     
     const auto approx_time_of_collision = ((x * Meter - radius) + limits.targetDepth / Real{2}) / (x * Meter);
 
-    EXPECT_EQ(output.get_state(), TOIOutput::e_touching);
-    EXPECT_TRUE(AlmostEqual(output.get_t(), approx_time_of_collision));
-    EXPECT_EQ(output.get_toi_iters(), 2);
+    if (std::is_same<Real, Fixed32>::value)
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_TRUE(AlmostEqual(output.time, approx_time_of_collision));
+        EXPECT_EQ(output.stats.toi_iters, 1);
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_touching);
+        EXPECT_TRUE(AlmostEqual(output.time, approx_time_of_collision));
+        EXPECT_EQ(output.stats.toi_iters, 2);
+    }
 }
 
 TEST(TimeOfImpact, CollideCirclesVertically)
@@ -180,12 +255,21 @@ TEST(TimeOfImpact, CollideCirclesVertically)
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_touching);
-    EXPECT_NEAR(double(output.get_t()), 0.4750375, 0.000001);
-    EXPECT_EQ(output.get_toi_iters(), 2);
+    if (std::is_same<Real, Fixed32>::value)
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_NEAR(double(output.time), 0.474609375, 0.000001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_touching);
+        EXPECT_NEAR(double(output.time), 0.4750375, 0.000001);
+        EXPECT_EQ(output.stats.toi_iters, 2);
+    }
 }
 
-TEST(TimeOfImpact, CirclesPassingParallelSeparatedPathsDontCollide)
+TEST(TimeOfImpact, CirclesPassingParSepPathsDontCollide)
 {
     const auto slop = Real{0.001f};
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(slop * 3_m).UseTolerance((slop / 4) * Meter);
@@ -211,9 +295,18 @@ TEST(TimeOfImpact, CirclesPassingParallelSeparatedPathsDontCollide)
     // Compute the time of impact information now...
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_separated);
-    EXPECT_TRUE(AlmostEqual(output.get_t(), Real(1.0)));
-    EXPECT_EQ(output.get_toi_iters(), 7);
+    if (std::is_same<Real, Fixed<std::int32_t,9>>::value) // Code for Fixed32 basically
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_NEAR(static_cast<double>(output.time), 0.37890625, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_separated);
+        EXPECT_NEAR(static_cast<double>(output.time), 1.0, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 7);
+    }
 }
 
 TEST(TimeOfImpact, RodCircleMissAt360)
@@ -245,9 +338,18 @@ TEST(TimeOfImpact, RodCircleMissAt360)
     // Compute the time of impact information now...
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_separated);
-    EXPECT_TRUE(AlmostEqual(output.get_t(), Real(1.0)));
-    EXPECT_EQ(output.get_toi_iters(), 4);
+    if (std::is_same<Real, Fixed<std::int32_t,9>>::value) // Code for Fixed32 basically
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_NEAR(static_cast<double>(output.time), 0.51171875, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_separated);
+        EXPECT_NEAR(static_cast<double>(output.time), 1.0, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 4);
+    }
 }
 
 TEST(TimeOfImpact, RodCircleHitAt180)
@@ -279,9 +381,18 @@ TEST(TimeOfImpact, RodCircleHitAt180)
     // Compute the time of impact information now...
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_touching);
-    EXPECT_NEAR(double(output.get_t()), 0.4884203672409058, 0.0001);
-    EXPECT_EQ(output.get_toi_iters(), 3);
+    if (std::is_same<Real, Fixed<std::int32_t,9>>::value) // Code for Fixed32 basically
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_NEAR(static_cast<double>(output.time), 0.490234375, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_touching);
+        EXPECT_NEAR(double(output.time), 0.4884203672409058, 0.0001);
+        EXPECT_EQ(output.stats.toi_iters, 3);
+    }
 }
 
 TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_1)
@@ -308,13 +419,26 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_1)
         .UseTolerance((slop / 4) * Meter);
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_touching);
-    EXPECT_NEAR(double(output.get_t()), 0.4975037276744843, 0.0002);
-    EXPECT_EQ(output.get_toi_iters(), 2);
-    EXPECT_EQ(output.get_max_dist_iters(), 1);
-    EXPECT_EQ(output.get_max_root_iters(), 2);
-    EXPECT_EQ(output.get_sum_dist_iters(), 2);
-    EXPECT_EQ(output.get_sum_root_iters(), 2);
+    if (std::is_same<Real, Fixed<std::int32_t,9>>::value) // Code for Fixed32 basically
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_NEAR(static_cast<double>(output.time), 0.49609375, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+        EXPECT_EQ(output.stats.max_dist_iters, 1);
+        EXPECT_EQ(output.stats.max_root_iters, 3);
+        EXPECT_EQ(output.stats.sum_dist_iters, 1);
+        EXPECT_EQ(output.stats.sum_root_iters, 3);
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_touching);
+        EXPECT_NEAR(double(output.time), 0.4975037276744843, 0.0002);
+        EXPECT_EQ(output.stats.toi_iters, 2);
+        EXPECT_EQ(output.stats.max_dist_iters, 1);
+        EXPECT_EQ(output.stats.max_root_iters, 2);
+        EXPECT_EQ(output.stats.sum_dist_iters, 2);
+        EXPECT_EQ(output.stats.sum_root_iters, 2);
+    }
 }
 
 TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
@@ -341,28 +465,43 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
         .UseTolerance((slop / 4) * Meter);
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_touching);
-    EXPECT_NEAR(double(output.get_t()), 0.9975037574768066, 0.002);
-    EXPECT_EQ(output.get_toi_iters(), 2);
-    EXPECT_EQ(output.get_max_dist_iters(), 1);
-    EXPECT_EQ(output.get_max_root_iters(), 2);
-    EXPECT_EQ(output.get_sum_dist_iters(), 2);
-    EXPECT_EQ(output.get_sum_root_iters(), 2);
+    if (std::is_same<Real, Fixed<std::int32_t,9>>::value)
+    {
+        // The results limited to what's possible with this type...
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_NEAR(double(output.time), 0.9975037574768066, 0.002);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+        EXPECT_EQ(output.stats.max_dist_iters, 1);
+        EXPECT_EQ(output.stats.max_root_iters, 3);
+        EXPECT_EQ(output.stats.sum_dist_iters, 1);
+        EXPECT_EQ(output.stats.sum_root_iters, 3);
+    }
+    else
+    {
+        // what the results should be like...
+        EXPECT_EQ(output.state, TOIOutput::e_touching);
+        EXPECT_NEAR(double(output.time), 0.9975037574768066, 0.002);
+        EXPECT_EQ(output.stats.toi_iters, 2);
+        EXPECT_EQ(output.stats.max_dist_iters, 1);
+        EXPECT_EQ(output.stats.max_root_iters, 2);
+        EXPECT_EQ(output.stats.sum_dist_iters, 2);
+        EXPECT_EQ(output.stats.sum_root_iters, 2);
+    }
 
 #if 0
-    ASSERT_EQ(output.get_state(), TOIOutput::e_touching);
+    ASSERT_EQ(output.state, TOIOutput::e_touching);
 
     auto touching = true;
     auto iterations = 0u;
-    for (auto t = output.get_t(); t > 0; t = std::nextafter(t, 0.0f))
+    for (auto t = output.time; t > 0; t = std::nextafter(t, 0.0f))
     {
         const auto conf2 = ToiConf{}.UseMaxToiIters(200).UseMaxRootIters(200).UseTimeMax(t);
         const auto output2 = TimeOfImpact(proxyA, sweepA, proxyB, sweepB, conf2);
         
-        EXPECT_LE(output2.get_t(), t);
+        EXPECT_LE(output2.time, t);
         if (touching)
         {
-            if (output2.get_state() != TOIOutput::e_touching)
+            if (output2.state != TOIOutput::e_touching)
             {
                 std::cout << "lost touch after " << iterations << " iterations at t=" << t << std::endl;
                 touching = false;
@@ -370,7 +509,7 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
         }
         else // !touching
         {
-            if (output2.get_state() == TOIOutput::e_touching)
+            if (output2.state == TOIOutput::e_touching)
             {
                 std::cout << "found additional root at t=" << t << std::endl;
                 touching = true;
@@ -399,14 +538,27 @@ TEST(TimeOfImpact, WithClosingSpeedOf1600)
         .UseTolerance((slop / 4) * Meter);
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
     
-    EXPECT_EQ(output.get_state(), TOIOutput::e_touching);
-    EXPECT_NEAR(double(output.get_t()), 0.4987518787384033, 0.001);
-    //std::cout << std::setprecision(std::numeric_limits<double>::digits10 + 1) << output.get_t() << std::defaultfloat << std::endl;
-    EXPECT_EQ(output.get_toi_iters(), 2);
-    EXPECT_EQ(output.get_max_dist_iters(), 1);
-    EXPECT_EQ(output.get_max_root_iters(), 2);
-    EXPECT_GE(output.get_sum_dist_iters(), output.get_max_dist_iters());
-    EXPECT_GE(output.get_sum_root_iters(), output.get_max_root_iters());
+    if (std::is_same<Real, Fixed<std::int32_t,9>>::value)
+    {
+        // The results limited to what's possible with this type...
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        EXPECT_NEAR(double(output.time), 0.4987518787384033, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+        EXPECT_EQ(output.stats.max_dist_iters, 1);
+        EXPECT_EQ(output.stats.max_root_iters, 2);
+        EXPECT_GE(output.stats.sum_dist_iters, output.stats.max_dist_iters);
+        EXPECT_GE(output.stats.sum_root_iters, output.stats.max_root_iters);
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_touching);
+        EXPECT_NEAR(double(output.time), 0.4987518787384033, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 2);
+        EXPECT_EQ(output.stats.max_dist_iters, 1);
+        EXPECT_EQ(output.stats.max_root_iters, 2);
+        EXPECT_GE(output.stats.sum_dist_iters, output.stats.max_dist_iters);
+        EXPECT_GE(output.stats.sum_root_iters, output.stats.max_root_iters);
+    }
 }
 
 TEST(TimeOfImpact, ForNonCollidingShapesFails)
@@ -440,28 +592,45 @@ TEST(TimeOfImpact, ForNonCollidingShapesFails)
         .UseTargetDepth(Real(3.0f / 10000) * Meter)
         .UseTolerance(Real(1.0f / 40000) * Meter);
     const auto output = GetToiViaSat(dpA, sweepA, dpB, sweepB, conf);
-    
-    EXPECT_TRUE(output.get_state() == TOIOutput::e_failed || output.get_state() == TOIOutput::e_separated);
-    switch (output.get_state())
+
+    if (std::is_same<Real, float>::value)
     {
-        case TOIOutput::e_failed:
-            EXPECT_NEAR(double(output.get_t()), 0.863826394, 0.0001);
-            EXPECT_EQ(output.get_toi_iters(), 1);
-            EXPECT_EQ(output.get_max_dist_iters(), 4);
-            EXPECT_TRUE(output.get_max_root_iters() == 23 || output.get_max_root_iters() == 14);
-            break;
-        case TOIOutput::e_separated:
-            EXPECT_EQ(output.get_t(), Real(1));
-            EXPECT_EQ(output.get_toi_iters(), 2);
-            EXPECT_GE(output.get_max_dist_iters(), 3);
-            EXPECT_LE(output.get_max_dist_iters(), 4);
-            EXPECT_EQ(output.get_max_root_iters(), 6);
-            break;
-        default:
-            break;
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        if (output.state == TOIOutput::e_nextAfter)
+        {
+            EXPECT_NEAR(double(output.time), 0.863826394, 0.0001);
+            EXPECT_EQ(output.stats.toi_iters, 1);
+            EXPECT_EQ(output.stats.max_dist_iters, 4);
+            //EXPECT_TRUE(output.stats.max_root_iters == 23 || output.stats.max_root_iters == 14);
+            EXPECT_EQ(output.stats.max_root_iters, 23);
+        }
     }
-    EXPECT_GE(output.get_sum_dist_iters(), output.get_max_dist_iters());
-    EXPECT_GE(output.get_sum_root_iters(), output.get_max_root_iters());
+    else if (std::is_same<Real, Fixed<std::int32_t,9>>::value)
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_nextAfter);
+        if (output.state == TOIOutput::e_nextAfter)
+        {
+            EXPECT_NEAR(double(output.time), 0.865234375, 0.0001);
+            EXPECT_EQ(output.stats.toi_iters, 1);
+            EXPECT_EQ(output.stats.max_dist_iters, 4);
+            EXPECT_EQ(output.stats.max_root_iters, 4);
+        }
+    }
+    else
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_separated);
+        if (output.state == TOIOutput::e_separated)
+        {
+            EXPECT_EQ(output.time, Real(1));
+            EXPECT_EQ(output.stats.toi_iters, 2);
+            EXPECT_GE(output.stats.max_dist_iters, 3);
+            EXPECT_LE(output.stats.max_dist_iters, 4);
+            EXPECT_EQ(output.stats.max_root_iters, 6);
+        }
+    }
+
+    EXPECT_GE(output.stats.sum_dist_iters, output.stats.max_dist_iters);
+    EXPECT_GE(output.stats.sum_root_iters, output.stats.max_root_iters);
 }
 
 TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
@@ -510,11 +679,75 @@ TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
 
     const auto output = GetToiViaSat(dpA, sweepA, dpB, sweepB, conf);
 
-    EXPECT_TRUE(output.get_state() == TOIOutput::e_separated || output.get_state() == TOIOutput::e_touching);
-    EXPECT_TRUE(AlmostEqual(output.get_t(), Real{1.0f}));
-    EXPECT_TRUE(output.get_toi_iters() == 1 || output.get_toi_iters() == 2);
-    EXPECT_EQ(output.get_max_dist_iters(), 4);
-    EXPECT_EQ(output.get_max_root_iters(), 0);
-    EXPECT_GE(output.get_sum_dist_iters(), output.get_max_dist_iters());
-    EXPECT_GE(output.get_sum_root_iters(), output.get_max_root_iters());
+    if (std::is_same<Real, float>::value)
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_separated);
+        EXPECT_NEAR(static_cast<double>(output.time), 1.0, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 2);
+        EXPECT_EQ(output.stats.max_dist_iters, 4);
+        EXPECT_EQ(output.stats.max_root_iters, 0);
+        EXPECT_GE(output.stats.sum_dist_iters, output.stats.max_dist_iters);
+        EXPECT_GE(output.stats.sum_root_iters, output.stats.max_root_iters);
+    }
+    else if (std::is_same<Real, Fixed<std::int32_t,9>>::value)
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_overlapped);
+        EXPECT_NEAR(static_cast<double>(output.time), 0.0, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+        EXPECT_EQ(output.stats.max_dist_iters, 4);
+        EXPECT_EQ(output.stats.max_root_iters, 0);
+        EXPECT_GE(output.stats.sum_dist_iters, output.stats.max_dist_iters);
+        EXPECT_GE(output.stats.sum_root_iters, output.stats.max_root_iters);
+    }
+#ifndef _WIN32
+    else if (std::is_same<Real, Fixed<std::int64_t,24>>::value)
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_separated);
+        EXPECT_NEAR(static_cast<double>(output.time), 1.0, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 1);
+        EXPECT_EQ(output.stats.max_dist_iters, 4);
+        EXPECT_EQ(output.stats.max_root_iters, 0);
+        EXPECT_GE(output.stats.sum_dist_iters, output.stats.max_dist_iters);
+        EXPECT_GE(output.stats.sum_root_iters, output.stats.max_root_iters);
+    }
+#endif
+    else // if (std::is_same<Real, double>::value)
+    {
+        EXPECT_EQ(output.state, TOIOutput::e_touching);
+        EXPECT_NEAR(static_cast<double>(output.time), 1.0, 0.001);
+        EXPECT_EQ(output.stats.toi_iters, 2);
+        EXPECT_EQ(output.stats.max_dist_iters, 4);
+        EXPECT_EQ(output.stats.max_root_iters, 0);
+        EXPECT_GE(output.stats.sum_dist_iters, output.stats.max_dist_iters);
+        EXPECT_GE(output.stats.sum_root_iters, output.stats.max_root_iters);
+    }
+}
+
+TEST(TimeOfImpact, foo)
+{
+    const auto radius = 1_m;
+    const auto pos = Length2{};
+    const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
+    const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
+
+    const auto sweepA = Sweep{
+        Position{Length2{0.0_m, -0.5_m}, 0_deg},
+        Position{Length2{0.0_m, -0.5_m}, 0_deg}
+    };
+    const auto sweepB = Sweep{
+        Position{Length2{14.3689661_m, 0.500306308_m}, 0.0000139930862_rad},
+        Position{Length2{14.3689451_m, 0.500254989_m}, 0.000260060915_rad}
+    };
+
+    const auto conf = ToiConf{}
+        .UseTargetDepth(0_m)
+        .UseTolerance(0_m)
+        .UseMaxRootIters(0)
+        .UseMaxToiIters(0)
+        .UseMaxDistIters(0)
+        ;
+
+    const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
+    
+    EXPECT_EQ(output.state, TOIOutput::e_maxToiIters);
 }

--- a/UnitTests/UnitVec2.cpp
+++ b/UnitTests/UnitVec2.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include <PlayRho/Common/UnitVec2.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <iostream>
 
 using namespace playrho;
 
@@ -210,4 +211,28 @@ TEST(UnitVec2, Copy)
     auto c = UnitVec2{};
     c = a;
     EXPECT_EQ(a, b);
+}
+
+TEST(UnitVec2, StreamOut)
+{
+    {
+        std::ostringstream os;
+        os << UnitVec2::GetLeft();
+        EXPECT_STREQ(os.str().c_str(), "UnitVec2(-1,0)");
+    }
+    {
+        std::ostringstream os;
+        os << UnitVec2::GetTop();
+        EXPECT_STREQ(os.str().c_str(), "UnitVec2(0,1)");
+    }
+    {
+        std::ostringstream os;
+        os << UnitVec2::GetRight();
+        EXPECT_STREQ(os.str().c_str(), "UnitVec2(1,0)");
+    }
+    {
+        std::ostringstream os;
+        os << UnitVec2::GetBottom();
+        EXPECT_STREQ(os.str().c_str(), "UnitVec2(0,-1)");
+    }
 }

--- a/UnitTests/Vec2.cpp
+++ b/UnitTests/Vec2.cpp
@@ -50,9 +50,11 @@ TEST(Vec2, Traits)
     EXPECT_TRUE((std::is_constructible<Vec2, Real, Real>::value));
     EXPECT_FALSE((std::is_constructible<Vec2, Real>::value));
     EXPECT_TRUE((std::is_constructible<Vec2>::value));
+
     EXPECT_TRUE((std::is_nothrow_constructible<Vec2, Real, Real>::value));
     EXPECT_FALSE((std::is_nothrow_constructible<Vec2, Real>::value));
     EXPECT_TRUE((std::is_nothrow_constructible<Vec2>::value));
+    
     EXPECT_FALSE((std::is_trivially_constructible<Vec2, Real, Real>::value));
     EXPECT_FALSE((std::is_trivially_constructible<Vec2, Real>::value));
     EXPECT_TRUE((std::is_trivially_constructible<Vec2>::value));
@@ -189,11 +191,11 @@ TEST(Vec2, Rotate)
     Vec2 v10{1, 0};
     Vec2 v01{0, 1};
 
-    EXPECT_EQ(Round(v01), Round(Rotate(v10, UnitVec2::GetTop())));
+    EXPECT_EQ(RoundOff(v01), RoundOff(Rotate(v10, UnitVec2::GetTop())));
 
-    EXPECT_EQ(Round(Vec2{22, 30}), Round(Rotate(Vec2{22, 30}, UnitVec2::GetRight())));
-    EXPECT_EQ(Round(Vec2{22, 30}, 1000), Round(Rotate(Vec2{22, 30}, UnitVec2::Get(360_deg)), 1000));
-    EXPECT_EQ(Round(-Vec2{22, 30}, 1000), Round(Rotate(Vec2{22, 30}, UnitVec2::GetLeft()), 1000));
+    EXPECT_EQ(RoundOff(Vec2{22, 30}), RoundOff(Rotate(Vec2{22, 30}, UnitVec2::GetRight())));
+    EXPECT_EQ(RoundOff(Vec2{22, 30}, 1000), RoundOff(Rotate(Vec2{22, 30}, UnitVec2::Get(360_deg)), 1000));
+    EXPECT_EQ(RoundOff(-Vec2{22, 30}, 1000), RoundOff(Rotate(Vec2{22, 30}, UnitVec2::GetLeft()), 1000));
 }
 
 TEST(Vec2, IncrementOperator)

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -772,7 +772,7 @@ TEST(World, DynamicEdgeBodyHasCorrectMass)
     ASSERT_EQ(fixture->GetDensity(), 1_kgpm2);
 
     const auto circleMass = Mass{fixture->GetDensity() * (Pi * Square(shape->GetVertexRadius()))};
-    const auto rectMass = Mass{fixture->GetDensity() * (shape->GetVertexRadius() * Real{2} * GetLength(v2 - v1))};
+    const auto rectMass = Mass{fixture->GetDensity() * (shape->GetVertexRadius() * Real{2} * GetMagnitude(v2 - v1))};
     const auto totalMass = Mass{circleMass + rectMass};
     
     EXPECT_EQ(body->GetType(), BodyType::Dynamic);
@@ -1571,7 +1571,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     ASSERT_EQ(body2->GetLocation(), body_def.location);
     
     auto position_diff = body2pos - body1pos;
-    auto distance = GetLength(position_diff);
+    auto distance = GetMagnitude(position_diff);
 
     const auto angle = GetAngle(position_diff);
     ASSERT_EQ(angle, 0_deg);
@@ -1590,7 +1590,7 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
         world.Step(step);
 
         const auto new_pos_diff = body2->GetLocation() - body1->GetLocation();
-        const auto new_distance = GetLength(new_pos_diff);
+        const auto new_distance = GetMagnitude(new_pos_diff);
         
         if (AlmostEqual(new_distance / Meter, full_separation / Meter) || new_distance > full_separation)
         {
@@ -1743,7 +1743,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     ASSERT_EQ(world.GetContacts().size(), World::Contacts::size_type(0));
 
     auto position_diff = body1pos - body2pos;
-    auto distance = GetLength(position_diff);
+    auto distance = GetMagnitude(position_diff);
     
     auto angle = GetAngle(position_diff);
     EXPECT_TRUE(AlmostEqual(angle / 1_rad, Real{0}));
@@ -1801,7 +1801,7 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
         last_angle_2 = body2->GetAngle();
 
         const auto new_pos_diff = body1->GetLocation() - body2->GetLocation();
-        const auto new_distance = GetLength(new_pos_diff);
+        const auto new_distance = GetMagnitude(new_pos_diff);
         
         if (AlmostEqual(new_distance / Meter, full_separation / Meter) || new_distance > full_separation)
         {
@@ -2876,7 +2876,7 @@ TEST(World, MouseJointWontCauseTunnelling)
             min_y = std::min(Real{GetY(ball_body->GetLocation()) / Meter}, min_y);
 
             const auto linVel = ball_body->GetVelocity().linear;
-            max_velocity = std::max(GetLength(GetVec2(linVel)), max_velocity);
+            max_velocity = std::max(GetMagnitude(GetVec2(linVel)), max_velocity);
 
             if (loops > 50)
             {

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1607,12 +1607,12 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
         }
         else // new_distance > distance
         {
-            if (std::cos(angle / 1_rad) != 0)
+            if (Cos(angle) != 0)
             {
                 EXPECT_LT(GetX(body1->GetLocation()), GetX(lastpos1));
                 EXPECT_GT(GetX(body2->GetLocation()), GetX(lastpos2));
             }
-            if (std::sin(angle / 1_rad) != 0)
+            if (Sin(angle) != 0)
             {
                 EXPECT_LT(GetY(body1->GetLocation()), GetY(lastpos1));
                 EXPECT_GT(GetY(body2->GetLocation()), GetY(lastpos2));
@@ -1810,12 +1810,12 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
         
         if (new_distance == distance)
         {
-            if (std::cos(angle / 1_rad) != 0)
+            if (Cos(angle) != 0)
             {
                 EXPECT_NE(GetX(body1->GetLocation()), GetX(lastpos1));
                 EXPECT_NE(GetX(body2->GetLocation()), GetX(lastpos2));
             }
-            if (std::sin(angle / 1_rad) != 0)
+            if (Sin(angle) != 0)
             {
                 EXPECT_NE(GetY(body1->GetLocation()), GetY(lastpos1));
                 EXPECT_NE(GetY(body2->GetLocation()), GetY(lastpos2));
@@ -1878,9 +1878,10 @@ TEST(World, CollidingDynamicBodies)
     body_def.linearVelocity = LinearVelocity2{+x * 1_mps, 0_mps};
     const auto body_a = world.CreateBody(body_def);
     ASSERT_NE(body_a, nullptr);
-    EXPECT_EQ(body_a->GetType(), BodyType::Dynamic);
-    EXPECT_TRUE(body_a->IsSpeedable());
-    EXPECT_TRUE(body_a->IsAccelerable());
+    ASSERT_EQ(body_a->GetType(), BodyType::Dynamic);
+    ASSERT_TRUE(body_a->IsSpeedable());
+    ASSERT_TRUE(body_a->IsAccelerable());
+    
     const auto fixture1 = body_a->CreateFixture(shape);
     ASSERT_NE(fixture1, nullptr);
 
@@ -1888,11 +1889,12 @@ TEST(World, CollidingDynamicBodies)
     body_def.linearVelocity = LinearVelocity2{-x * 1_mps, 0_mps};
     const auto body_b = world.CreateBody(body_def);
     ASSERT_NE(body_b, nullptr);
+    ASSERT_EQ(body_b->GetType(), BodyType::Dynamic);
+    ASSERT_TRUE(body_b->IsSpeedable());
+    ASSERT_TRUE(body_b->IsAccelerable());
+
     const auto fixture2 = body_b->CreateFixture(shape);
     ASSERT_NE(fixture2, nullptr);
-    EXPECT_EQ(body_b->GetType(), BodyType::Dynamic);
-    EXPECT_TRUE(body_b->IsSpeedable());
-    EXPECT_TRUE(body_b->IsAccelerable());
 
     EXPECT_EQ(GetX(GetLinearVelocity(*body_a)), +x * 1_mps);
     EXPECT_EQ(GetY(GetLinearVelocity(*body_a)), 0_mps);
@@ -2631,8 +2633,8 @@ TEST(World, MouseJointWontCauseTunnelling)
     for (auto i = decltype(numBodies){0}; i < numBodies; ++i)
     {
         const auto angle = i * 2 * Pi / numBodies;
-        const auto x = ball_radius * Real(2.1) * Real(std::cos(angle));
-        const auto y = ball_radius * Real(2.1) * Real(std::sin(angle));
+        const auto x = ball_radius * Real(2.1) * Cos(angle);
+        const auto y = ball_radius * Real(2.1) * Sin(angle);
         body_def.location = Length2{x, y};
         bodies[i] = world.CreateBody(body_def);
         ASSERT_NE(bodies[i], nullptr);
@@ -2772,7 +2774,7 @@ TEST(World, MouseJointWontCauseTunnelling)
                 std::cout << " angl=" << angle;
                 std::cout << " ctoi=" << 0 + contact.GetToiCount();
                 std::cout << " solv=" << 0 + solved;
-                std::cout << " targ=(" << distance * std::cos(angle) << "," << distance * std::sin(angle) << ")";
+                std::cout << " targ=(" << distance * Cos(angle) << "," << distance * Sin(angle) << ")";
                 std::cout << " maxv=" << max_velocity;
                 std::cout << " rang=(" << min_x << "," << min_y << ")-(" << max_x << "," << max_y << ")";
                 std::cout << " bpos=(" << GetX(ball_body->GetLocation()) << "," << GetY(ball_body->GetLocation()) << ")";
@@ -2849,7 +2851,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         auto last_pos = ball_body->GetLocation();
         for (auto loops = unsigned{0};; ++loops)
         {
-            mouse_joint->SetTarget(Length2{distance * std::cos(angle) * Meter, distance * std::sin(angle) * Meter});
+            mouse_joint->SetTarget(Length2{distance * Cos(angle) * Meter, distance * Sin(angle) * Meter});
             angle += anglular_speed;
             distance += distance_speed;
 


### PR DESCRIPTION
#### Description - What's this PR do?
- Reverts Xcode build options to quicker more usable development settings.
- Adds Secant, Bisect, and IsOdd template functions to Math.hpp.
- Refactors code in Fixed.hpp, Math.*, and other files to avoid undefined behavior regarding specializing template functions in-so-far as adhering to applicable C++ standards.
- Refactors the TOIOutput class to more simply being a struct.
- Adds an alternate, caching, implementation of the DistanceProxy for benchmarking and other experimentation.
- Generalizes the GetLengthSquared function to handle any sized input vector.
- Switches to initializing maxValue via std::numeric_limits and infinity.
- Rolls the TOIOutput::e_indifferent state into the TOIOutput::e_nextAfter state thereby eliminating another conditional check.
- Changes the TOI within tolerance check to being <= instead of < so that a tolerance of zero would work as an intolerant condition requiring an exact on target TOI.
- Adds GetDelta convenience function for slightly simplifying the GetToiViaSat code.
- Updates unit tests as needed.
- Renames GetLength and GetLengthSquared functions to GetMagnitude and GetMagnitudeSquared respectively.
- Adds benchmarking of multiply add and fused multiply add for floats and doubles.
