### PR TITLE
For issue #230: constexpr specifier not abstracted

### DIFF
--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -65,11 +65,11 @@ namespace playrho {
         /// @brief Default constructor.
         /// @details Constructs an "unset" AABB.
         /// @note If an unset AABB is added to another AABB, the result will be the other AABB.
-        constexpr AABB() = default;
+        PLAYRHO_CONSTEXPR inline AABB() = default;
         
         /// @brief Initializing copy constructor.
         template<typename... Tail>
-        constexpr AABB(typename std::enable_if<sizeof...(Tail)+1 == N, LengthInterval>::type head,
+        PLAYRHO_CONSTEXPR inline AABB(typename std::enable_if<sizeof...(Tail)+1 == N, LengthInterval>::type head,
                        Tail... tail) noexcept: ranges{head, LengthInterval(tail)...}
         {
             // Intentionally empty.
@@ -81,7 +81,7 @@ namespace playrho {
         ///   given point's X value.
         /// @post <code>rangeY</code> will have its min and max values both set to the
         ///   given point's Y value.
-        constexpr explicit AABB(const Location p) noexcept
+        PLAYRHO_CONSTEXPR inline explicit AABB(const Location p) noexcept
         {
             for (auto i = decltype(N){0}; i < N; ++i)
             {
@@ -92,7 +92,7 @@ namespace playrho {
         /// @brief Initializing constructor for two points.
         /// @param a Point location "A" to initialize this AABB with.
         /// @param b Point location "B" to initialize this AABB with.
-        constexpr AABB(const Location a, const Location b) noexcept
+        PLAYRHO_CONSTEXPR inline AABB(const Location a, const Location b) noexcept
         {
             for (auto i = decltype(N){0}; i < N; ++i)
             {
@@ -108,7 +108,7 @@ namespace playrho {
     /// @return <code>true</code> if the two values are equal, <code>false</code> otherwise.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
     {
         for (auto i = static_cast<size_t>(0); i < N; ++i)
         {
@@ -124,7 +124,7 @@ namespace playrho {
     /// @return <code>true</code> if the two values are not equal, <code>false</code> otherwise.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr bool operator!= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
     {
         return !(lhs == rhs);
     }
@@ -177,7 +177,7 @@ namespace playrho {
     /// @note This function's complexity is constant.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
+    PLAYRHO_CONSTEXPR inline bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -191,7 +191,7 @@ namespace playrho {
     
     /// @brief Gets the intersecting AABB of the two given AABBs'.
     template <std::size_t N>
-    constexpr AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
+    PLAYRHO_CONSTEXPR inline AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
     {
         auto result = AABB<N>{};
         for (auto i = decltype(N){0}; i < N; ++i)
@@ -204,7 +204,7 @@ namespace playrho {
     /// @brief Gets the center of the AABB.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
+    PLAYRHO_CONSTEXPR inline Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
     {
         auto result = Vector<Length, N>{};
         for (auto i = decltype(N){0}; i < N; ++i)
@@ -217,7 +217,7 @@ namespace playrho {
     /// @brief Gets dimensions of the given AABB.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
+    PLAYRHO_CONSTEXPR inline Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
     {
         auto result = Vector<Length, N>{};
         for (auto i = decltype(N){0}; i < N; ++i)
@@ -230,7 +230,7 @@ namespace playrho {
     /// @brief Gets the extents of the AABB (half-widths).
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
+    PLAYRHO_CONSTEXPR inline Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
     {
         return GetDimensions(aabb) / 2;
     }
@@ -244,7 +244,7 @@ namespace playrho {
     /// @param b AABB to test whether it's contained by the first AABB.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
+    PLAYRHO_CONSTEXPR inline bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -259,7 +259,7 @@ namespace playrho {
     /// @brief Includes the given location into the given AABB.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
+    PLAYRHO_CONSTEXPR inline AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -274,7 +274,7 @@ namespace playrho {
     ///   the other AABB.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
+    PLAYRHO_CONSTEXPR inline AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -285,7 +285,7 @@ namespace playrho {
     
     /// @brief Moves the given AABB by the given value.
     template <std::size_t N>
-    constexpr AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
+    PLAYRHO_CONSTEXPR inline AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -297,7 +297,7 @@ namespace playrho {
     /// @brief Fattens an AABB by the given amount.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
+    PLAYRHO_CONSTEXPR inline AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -310,7 +310,7 @@ namespace playrho {
     ///   displacement amount.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
+    PLAYRHO_CONSTEXPR inline AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -322,7 +322,7 @@ namespace playrho {
     /// @brief Gets the fattened AABB result.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
+    PLAYRHO_CONSTEXPR inline AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
     {
         return Fatten(aabb, amount);
     }
@@ -330,7 +330,7 @@ namespace playrho {
     /// @brief Gets the result of moving the given AABB by the given value.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
+    PLAYRHO_CONSTEXPR inline AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
     {
         return Move(aabb, value);
     }
@@ -338,7 +338,7 @@ namespace playrho {
     /// @brief Gets the AABB that minimally encloses the given AABBs.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
+    PLAYRHO_CONSTEXPR inline AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
     {
         return Include(a, b);
     }
@@ -346,7 +346,7 @@ namespace playrho {
     /// @brief Gets the lower bound.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
+    PLAYRHO_CONSTEXPR inline Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
     {
         auto result = Vector<Length, N>{};
         for (auto i = decltype(N){0}; i < N; ++i)
@@ -359,7 +359,7 @@ namespace playrho {
     /// @brief Gets the upper bound.
     /// @relatedalso AABB
     template <std::size_t N>
-    constexpr Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
+    PLAYRHO_CONSTEXPR inline Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
     {
         auto result = Vector<Length, N>{};
         for (auto i = decltype(N){0}; i < N; ++i)
@@ -398,7 +398,7 @@ namespace playrho {
     /// @brief Gets an invalid AABB value.
     /// @relatedalso AABB
     template <>
-    constexpr AABB2D GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline AABB2D GetInvalid() noexcept
     {
         return AABB2D{LengthInterval{GetInvalid<Length>()}, LengthInterval{GetInvalid<Length>()}};
     }
@@ -408,7 +408,7 @@ namespace playrho {
     /// @return Twice the sum of the width and height.
     /// @relatedalso AABB
     /// @sa https://en.wikipedia.org/wiki/Perimeter
-    constexpr Length GetPerimeter(const AABB2D& aabb) noexcept
+    PLAYRHO_CONSTEXPR inline Length GetPerimeter(const AABB2D& aabb) noexcept
     {
         return (GetSize(aabb.ranges[0]) + GetSize(aabb.ranges[1])) * 2;
     }

--- a/PlayRho/Collision/ContactFeature.hpp
+++ b/PlayRho/Collision/ContactFeature.hpp
@@ -57,7 +57,7 @@ struct ContactFeature
 
 /// @brief Gets the vertex vertex contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
+PLAYRHO_CONSTEXPR inline ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
                                                        ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_vertex, b};
@@ -65,7 +65,7 @@ constexpr ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
 
 /// @brief Gets the vertex face contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
+PLAYRHO_CONSTEXPR inline ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
                                                      ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_face, b};
@@ -73,7 +73,7 @@ constexpr ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
 
 /// @brief Gets the face vertex contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
+PLAYRHO_CONSTEXPR inline ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
                                                      ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_vertex, b};
@@ -81,7 +81,7 @@ constexpr ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
 
 /// @brief Gets the face face contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
+PLAYRHO_CONSTEXPR inline ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
                                                    ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_face, b};
@@ -89,14 +89,14 @@ constexpr ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
 
 /// @brief Flips contact features information.
 /// @relatedalso ContactFeature
-constexpr ContactFeature Flip(ContactFeature val) noexcept
+PLAYRHO_CONSTEXPR inline ContactFeature Flip(ContactFeature val) noexcept
 {
     return ContactFeature{val.typeB, val.indexB, val.typeA, val.indexA};
 }
 
 /// @brief Determines if the given two contact features are equal.
 /// @relatedalso ContactFeature
-constexpr bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
 {
     return (lhs.typeA == rhs.typeA) && (lhs.indexA == rhs.indexA)
         && (lhs.typeB == rhs.typeB) && (lhs.indexB == rhs.indexB);
@@ -104,7 +104,7 @@ constexpr bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
 
 /// @brief Determines if the given two contact features are not equal.
 /// @relatedalso ContactFeature
-constexpr bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -38,7 +38,7 @@ namespace playrho {
     WitnessPoints GetWitnessPoints(const Simplex& simplex) noexcept;
     
     /// @brief Gets the delta of the two points of the given witness points.
-    constexpr Length2 GetDelta(WitnessPoints arg) noexcept
+    PLAYRHO_CONSTEXPR inline Length2 GetDelta(WitnessPoints arg) noexcept
     {
         return arg.a - arg.b;
     }

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -55,7 +55,7 @@ namespace playrho
         using size_type = std::remove_const<decltype(MaxShapeVertices)>::type;
         
         /// @brief Invalid index.
-        static constexpr size_type InvalidIndex = static_cast<size_type>(-1);
+        static PLAYRHO_CONSTEXPR const size_type InvalidIndex = static_cast<size_type>(-1);
         
         /// @brief Constant vertex pointer.
         using ConstVertexPointer = const Length2*;

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -62,7 +62,7 @@ public:
     union VariantData;
     
     /// @brief Gets the invalid size value.
-    static constexpr Size GetInvalidSize() noexcept
+    static PLAYRHO_CONSTEXPR inline Size GetInvalidSize() noexcept
     {
         return static_cast<Size>(-1);
     }
@@ -70,26 +70,29 @@ public:
     /// @brief Strong type for DynamicTree heights.
     using Height = ContactCounter;
     
+    /// @brief Invalid height constant value.
+    static PLAYRHO_CONSTEXPR const auto InvalidHeight = static_cast<Height>(-1);
+
     /// @brief Gets the invalid height value.
-    static constexpr Height GetInvalidHeight() noexcept
+    static PLAYRHO_CONSTEXPR inline Height GetInvalidHeight() noexcept
     {
-        return static_cast<Height>(-1);
+        return InvalidHeight;
     }
     
     /// @brief Gets whether the given height is the height for an "unused" node.
-    static constexpr bool IsUnused(Height value) noexcept
+    static PLAYRHO_CONSTEXPR inline bool IsUnused(Height value) noexcept
     {
         return value == GetInvalidHeight();
     }
     
     /// @brief Gets whether the given height is the height for a "leaf" node.
-    static constexpr bool IsLeaf(Height value) noexcept
+    static PLAYRHO_CONSTEXPR inline bool IsLeaf(Height value) noexcept
     {
         return value == 0;
     }
     
     /// @brief Gets whether the given height is a height for a "branch" node.
-    static constexpr bool IsBranch(Height value) noexcept
+    static PLAYRHO_CONSTEXPR inline bool IsBranch(Height value) noexcept
     {
         return !IsUnused(value) && !IsLeaf(value);
     }
@@ -99,7 +102,7 @@ public:
     using RayCastCallback = std::function<Real(const RayCastInput&, Size)>;
 
     /// @brief Gets the default initial node capacity.
-    static constexpr Size GetDefaultInitialNodeCapacity() noexcept;
+    static PLAYRHO_CONSTEXPR inline Size GetDefaultInitialNodeCapacity() noexcept;
 
     /// @brief Constructing the tree initializes the node pool.
     explicit DynamicTree(Size nodeCapacity = GetDefaultInitialNodeCapacity());
@@ -364,7 +367,7 @@ struct DynamicTree::LeafData
 
 /// @brief Equality operator.
 /// @relatedalso DynamicTree::LeafData
-constexpr inline bool operator== (const DynamicTree::LeafData& lhs,
+PLAYRHO_CONSTEXPR inline bool operator== (const DynamicTree::LeafData& lhs,
                                   const DynamicTree::LeafData& rhs) noexcept
 {
     return lhs.fixture == rhs.fixture && lhs.childIndex == rhs.childIndex;
@@ -372,7 +375,7 @@ constexpr inline bool operator== (const DynamicTree::LeafData& lhs,
 
 /// @brief Inequality operator.
 /// @relatedalso DynamicTree::LeafData
-constexpr inline bool operator!= (const DynamicTree::LeafData& lhs,
+PLAYRHO_CONSTEXPR inline bool operator!= (const DynamicTree::LeafData& lhs,
                                   const DynamicTree::LeafData& rhs) noexcept
 {
     return !(lhs == rhs);
@@ -392,34 +395,34 @@ union DynamicTree::VariantData
     BranchData branch;
     
     /// @brief Default constructor.
-    constexpr VariantData() noexcept: unused{} {}
+    PLAYRHO_CONSTEXPR inline VariantData() noexcept: unused{} {}
 
     /// @brief Initializing constructor.
-    constexpr VariantData(UnusedData value) noexcept: unused{value} {}
+    PLAYRHO_CONSTEXPR inline VariantData(UnusedData value) noexcept: unused{value} {}
     
     /// @brief Initializing constructor.
-    constexpr VariantData(LeafData value) noexcept: leaf{value} {}
+    PLAYRHO_CONSTEXPR inline VariantData(LeafData value) noexcept: leaf{value} {}
     
     /// @brief Initializing constructor.
-    constexpr VariantData(BranchData value) noexcept: branch{value} {}
+    PLAYRHO_CONSTEXPR inline VariantData(BranchData value) noexcept: branch{value} {}
 };
 
 /// @brief Is unused.
 /// @details Determines whether the given DynamicTree node is an unused node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
+PLAYRHO_CONSTEXPR inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is leaf.
 /// @details Determines whether the given DynamicTree node is a leaf node.
 ///   Leaf nodes have a pointer to user data.
 /// @relatedalso DynamicTree::TreeNode
-constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
+PLAYRHO_CONSTEXPR inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is branch.
 /// @details Determines whether the given DynamicTree node is a branch node.
 ///   Branch nodes have 2 indices to child nodes.
 /// @relatedalso DynamicTree::TreeNode
-constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
+PLAYRHO_CONSTEXPR inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief A node in the dynamic tree.
 /// @note Users do not interact with this directly.
@@ -434,20 +437,20 @@ public:
     ~TreeNode() = default;
     
     /// @brief Copy constructor.
-    constexpr TreeNode(const TreeNode& other) = default;
+    PLAYRHO_CONSTEXPR inline TreeNode(const TreeNode& other) = default;
 
     /// @brief Move constructor.
-    constexpr TreeNode(TreeNode&& other) = default;
+    PLAYRHO_CONSTEXPR inline TreeNode(TreeNode&& other) = default;
 
     /// @brief Initializing constructor.
-    constexpr explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
+    PLAYRHO_CONSTEXPR inline explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_other{other}, m_variant{UnusedData{}}
     {
         assert(IsUnused(m_height));
     }
 
     /// @brief Initializing constructor.
-    constexpr TreeNode(const LeafData& value, AABB2D aabb,
+    PLAYRHO_CONSTEXPR inline TreeNode(const LeafData& value, AABB2D aabb,
                        Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{0}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -455,7 +458,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr TreeNode(const BranchData& value, AABB2D aabb, Height height,
+    PLAYRHO_CONSTEXPR inline TreeNode(const BranchData& value, AABB2D aabb, Height height,
                        Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{height}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -470,7 +473,7 @@ public:
         m_aabb = other.m_aabb;
         switch (other.m_height)
         {
-            case DynamicTree::GetInvalidHeight():
+            case DynamicTree::InvalidHeight:
                 m_variant.unused = other.m_variant.unused;
                 break;
             case DynamicTree::Size{0}:
@@ -487,88 +490,88 @@ public:
     TreeNode& operator= (TreeNode&& other) = default;
     
     /// @brief Gets the node "height".
-    constexpr Height GetHeight() const noexcept
+    PLAYRHO_CONSTEXPR inline Height GetHeight() const noexcept
     {
         return m_height;
     }
     
     /// @brief Sets the node "height" to the given value.
-    constexpr TreeNode& SetHeight(Height value) noexcept
+    PLAYRHO_CONSTEXPR inline TreeNode& SetHeight(Height value) noexcept
     {
         m_height = value;
         return *this;
     }
     
     /// @brief Gets the node's "other" index.
-    constexpr Size GetOther() const noexcept
+    PLAYRHO_CONSTEXPR inline Size GetOther() const noexcept
     {
         return m_other;
     }
                 
     /// @brief Sets the node's "other" index to the given value.
-    constexpr TreeNode& SetOther(Size other) noexcept
+    PLAYRHO_CONSTEXPR inline TreeNode& SetOther(Size other) noexcept
     {
         m_other = other;
         return *this;
     }
 
     /// @brief Gets the node's AABB.
-    constexpr AABB2D GetAABB() const noexcept
+    PLAYRHO_CONSTEXPR inline AABB2D GetAABB() const noexcept
     {
         return m_aabb;
     }
 
     /// @brief Sets the node's AABB.
-    constexpr TreeNode& SetAABB(AABB2D value) noexcept
+    PLAYRHO_CONSTEXPR inline TreeNode& SetAABB(AABB2D value) noexcept
     {
         m_aabb = value;
         return *this;
     }
     
     /// @brief Gets the node as an "unused" value.
-    constexpr UnusedData AsUnused() const noexcept
+    PLAYRHO_CONSTEXPR inline UnusedData AsUnused() const noexcept
     {
         assert(IsUnused(m_height));
         return m_variant.unused;
     }
     
     /// @brief Gets the node as a "leaf" value.
-    constexpr LeafData AsLeaf() const noexcept
+    PLAYRHO_CONSTEXPR inline LeafData AsLeaf() const noexcept
     {
         assert(IsLeaf(m_height));
         return m_variant.leaf;
     }
     
     /// @brief Gets the node as a "branch" value.
-    constexpr BranchData AsBranch() const noexcept
+    PLAYRHO_CONSTEXPR inline BranchData AsBranch() const noexcept
     {
         assert(IsBranch(m_height));
         return m_variant.branch;
     }
 
     /// @brief Gets the node as an "unused" value.
-    constexpr UnusedData& AsUnused() noexcept
+    PLAYRHO_CONSTEXPR inline UnusedData& AsUnused() noexcept
     {
         assert(IsUnused(m_height));
         return m_variant.unused;
     }
     
     /// @brief Gets the node as a "leaf" value.
-    constexpr LeafData& AsLeaf() noexcept
+    PLAYRHO_CONSTEXPR inline LeafData& AsLeaf() noexcept
     {
         assert(IsLeaf(m_height));
         return m_variant.leaf;
     }
     
     /// @brief Gets the node as a "branch" value.
-    constexpr BranchData& AsBranch() noexcept
+    PLAYRHO_CONSTEXPR inline BranchData& AsBranch() noexcept
     {
         assert(IsBranch(m_height));
         return m_variant.branch;
     }
 
     /// @brief Assign's the node's value.
-    constexpr TreeNode& Assign(Size height, const UnusedData& value) noexcept
+    PLAYRHO_CONSTEXPR inline TreeNode& Assign(Size height, const UnusedData& value) noexcept
     {
         assert(height == DynamicTree::GetInvalidHeight());
         m_height = height;
@@ -577,7 +580,7 @@ public:
     }
     
     /// @brief Assign's the node's value.
-    constexpr TreeNode& Assign(Size height, const LeafData& value) noexcept
+    PLAYRHO_CONSTEXPR inline TreeNode& Assign(Size height, const LeafData& value) noexcept
     {
         assert(height == 0);
         m_height = height;
@@ -586,7 +589,7 @@ public:
     }
     
     /// @brief Assign's the node's value.
-    constexpr TreeNode& Assign(Size height, const BranchData& value) noexcept
+    PLAYRHO_CONSTEXPR inline TreeNode& Assign(Size height, const BranchData& value) noexcept
     {
         assert(height > 0);
         m_height = height;
@@ -611,7 +614,7 @@ private:
     VariantData m_variant;
 };
 
-constexpr DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
+PLAYRHO_CONSTEXPR inline DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
 {
     return Size{32};
 }
@@ -733,7 +736,7 @@ inline void DynamicTree::SetChild2(Size index, Size value) noexcept
 
 /// @brief Whether this node is free (or allocated).
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
+PLAYRHO_CONSTEXPR inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsUnused(node.GetHeight());
 }
@@ -742,7 +745,7 @@ constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
 /// @note This has constant complexity.
 /// @return <code>true</code> if this is a leaf node, <code>false</code> otherwise.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
+PLAYRHO_CONSTEXPR inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsLeaf(node.GetHeight());
 }
@@ -750,14 +753,14 @@ constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 /// @brief Is branch.
 /// @details Determines whether the given node is a "branch" node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
+PLAYRHO_CONSTEXPR inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsBranch(node.GetHeight());
 }
 
 /// @brief Gets the AABB of the given DynamicTree node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline AABB2D GetAABB(const DynamicTree::TreeNode& node) noexcept
+PLAYRHO_CONSTEXPR inline AABB2D GetAABB(const DynamicTree::TreeNode& node) noexcept
 {
     assert(!IsUnused(node));
     return node.GetAABB();
@@ -766,7 +769,7 @@ constexpr inline AABB2D GetAABB(const DynamicTree::TreeNode& node) noexcept
 /// @brief Gets the next index of the given node.
 /// @warning Behavior is undefined if the given node is not an "unused" node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
+PLAYRHO_CONSTEXPR inline DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
 {
     assert(IsUnused(node));
     return node.GetOther();

--- a/PlayRho/Collision/IndexPair.hpp
+++ b/PlayRho/Collision/IndexPair.hpp
@@ -34,25 +34,27 @@ namespace playrho {
         using size_type = std::remove_const<decltype(MaxShapeVertices)>::type;
         
         /// @brief Invalid index.
-        static constexpr size_type InvalidIndex = static_cast<size_type>(-1);
+        static PLAYRHO_CONSTEXPR const size_type InvalidIndex = static_cast<size_type>(-1);
         
         size_type a; ///< Index of vertex from shape A.
         size_type b; ///< Index of vertex from shape B.
     };
     
     /// @brief Invalid index pair value.
-    constexpr auto InvalidIndexPair = IndexPair{IndexPair::InvalidIndex, IndexPair::InvalidIndex};
+    PLAYRHO_CONSTEXPR const auto InvalidIndexPair = IndexPair{
+        IndexPair::InvalidIndex, IndexPair::InvalidIndex
+    };
     
     /// @brief Determines whether the two given index pairs are equal.
     /// @relatedalso IndexPair
-    constexpr inline bool operator== (IndexPair lhs, IndexPair rhs)
+    PLAYRHO_CONSTEXPR inline bool operator== (IndexPair lhs, IndexPair rhs)
     {
         return (lhs.a == rhs.a) && (lhs.b == rhs.b);
     }
     
     /// @brief Determines whether the two given index pairs are not equal.
     /// @relatedalso IndexPair
-    constexpr inline bool operator!= (IndexPair lhs, IndexPair rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!= (IndexPair lhs, IndexPair rhs)
     {
         return !(lhs == rhs);
     }
@@ -64,7 +66,7 @@ namespace playrho {
     static_assert(MaxSimplexEdges == 3, "Invalid assumption about size of MaxSimplexEdges");
 
     /// @brief Gets the number of valid indices in the given collection of index pairs.
-    constexpr inline std::size_t GetNumIndices(IndexPair3 pairs) noexcept
+    PLAYRHO_CONSTEXPR inline std::size_t GetNumIndices(IndexPair3 pairs) noexcept
     {
         return std::size_t{3}
         - ((std::get<0>(pairs) == InvalidIndexPair)? 1u: 0u)

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -560,7 +560,7 @@ Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
         }
     }
     
-    constexpr auto k_tol = PLAYRHO_MAGIC(DefaultLinearSlop / Real{10});
+    PLAYRHO_CONSTEXPR const auto k_tol = PLAYRHO_MAGIC(DefaultLinearSlop / Real{10});
     return (edgeSepB.separation > (edgeSepA.separation + k_tol))?
     GetFaceManifold(Manifold::e_faceB,
                     shapeB, xfB, edgeSepB.index1,

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -310,7 +310,7 @@ namespace playrho {
         /// @note This must be a constant expression in order to use it in the context
         ///   of the IsValid specialized template function for it.
         ///
-        constexpr Type GetType() const noexcept { return m_type; }
+        PLAYRHO_CONSTEXPR inline Type GetType() const noexcept { return m_type; }
         
         /// Gets the manifold point count.
         ///
@@ -324,10 +324,10 @@ namespace playrho {
         /// @sa AddPoint().
         /// @sa GetPoint().
         ///
-        constexpr size_type GetPointCount() const noexcept { return m_pointCount; }
+        PLAYRHO_CONSTEXPR inline size_type GetPointCount() const noexcept { return m_pointCount; }
         
         /// @brief Gets the contact feature for the given index.
-        constexpr ContactFeature GetContactFeature(size_type index) const noexcept
+        PLAYRHO_CONSTEXPR inline ContactFeature GetContactFeature(size_type index) const noexcept
         {
             assert(index < m_pointCount);
             return m_points[index].contactFeature;
@@ -336,7 +336,7 @@ namespace playrho {
         /// @brief Gets the contact impulses for the given index.
         /// @return Pair of impulses where the first impulse is the "normal impulse"
         ///   and the second impulse is the "tangent impulse".
-        constexpr Momentum2 GetContactImpulses(size_type index) const noexcept
+        PLAYRHO_CONSTEXPR inline Momentum2 GetContactImpulses(size_type index) const noexcept
         {
             assert(index < m_pointCount);
             return Momentum2{m_points[index].normalImpulse, m_points[index].tangentImpulse};
@@ -383,7 +383,7 @@ namespace playrho {
         /// @warning Behavior is undefined for unset (e_unset) type manifolds.
         /// @warning Behavior is undefined for circles (e_circles) type manifolds.
         /// @return Local normal if the manifold type is face A or face B, else invalid value.
-        constexpr UnitVec2 GetLocalNormal() const noexcept
+        PLAYRHO_CONSTEXPR inline UnitVec2 GetLocalNormal() const noexcept
         {
             assert(m_type != e_unset);
             assert(m_type != e_circles);
@@ -398,14 +398,14 @@ namespace playrho {
         /// @note Only valid for circle, face-A, or face-B type manifolds.
         /// @warning Behavior is undefined for unset (e_unset) type manifolds.
         /// @return Local point.
-        constexpr Length2 GetLocalPoint() const noexcept
+        PLAYRHO_CONSTEXPR inline Length2 GetLocalPoint() const noexcept
         {
             assert(m_type != e_unset);
             return m_localPoint;
         }
         
         /// @brief Gets the opposing point.
-        constexpr Length2 GetOpposingPoint(size_type index) const noexcept
+        PLAYRHO_CONSTEXPR inline Length2 GetOpposingPoint(size_type index) const noexcept
         {
             assert((0 <= index) && (index < m_pointCount));
             return m_points[index].localPoint;
@@ -419,10 +419,10 @@ namespace playrho {
             Point elements[MaxManifoldPoints]; ///< Elements.
 
             /// @brief Array indexing operator.
-            constexpr Point& operator[](std::size_t i) { return elements[i]; }
+            PLAYRHO_CONSTEXPR inline Point& operator[](std::size_t i) { return elements[i]; }
             
             /// @brief Array indexing operator.
-            constexpr const Point& operator[](std::size_t i) const { return elements[i]; }
+            PLAYRHO_CONSTEXPR const Point& operator[](std::size_t i) const { return elements[i]; }
         };
     
         /// Constructs manifold with array of points using the given values.
@@ -431,7 +431,7 @@ namespace playrho {
         /// @param lp Local point.
         /// @param n number of points defined in arary.
         /// @param mpa Manifold point array.
-        constexpr Manifold(Type t, UnitVec2 ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
+        PLAYRHO_CONSTEXPR inline Manifold(Type t, UnitVec2 ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
         
         Type m_type = e_unset; ///< Type of collision this manifold is associated with (1-byte).
         size_type m_pointCount = 0; ///< Number of defined manifold points (1-byte).
@@ -471,7 +471,7 @@ namespace playrho {
     
     /// @brief Gets the default manifold configuration.
     /// @relatedalso Manifold::Conf
-    constexpr inline Manifold::Conf GetDefaultManifoldConf() noexcept
+    PLAYRHO_CONSTEXPR inline Manifold::Conf GetDefaultManifoldConf() noexcept
     {
         return Manifold::Conf{};
     }
@@ -495,7 +495,7 @@ namespace playrho {
     /// @relatedalso Manifold
     bool operator!=(const Manifold& lhs, const Manifold& rhs) noexcept;
 
-    constexpr inline Manifold::Manifold(Type t, UnitVec2 ln, Length2 lp, size_type n,
+    PLAYRHO_CONSTEXPR inline Manifold::Manifold(Type t, UnitVec2 ln, Length2 lp, size_type n,
                                               const PointArray& mpa) noexcept:
         m_type{t}, m_pointCount{n}, m_localNormal{ln}, m_localPoint{lp}, m_points{mpa}
     {
@@ -546,7 +546,7 @@ namespace playrho {
     /// @brief Gets whether the given manifold is valid.
     /// @relatedalso Manifold
     template <>
-    constexpr inline bool IsValid(const Manifold& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Manifold& value) noexcept
     {
         return value.GetType() != Manifold::e_unset;
     }

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -54,14 +54,14 @@ namespace playrho {
     
     /// @brief MassData equality operator.
     /// @relatedalso MassData
-    constexpr bool operator== (MassData lhs, MassData rhs)
+    PLAYRHO_CONSTEXPR inline bool operator== (MassData lhs, MassData rhs)
     {
         return lhs.center == rhs.center && lhs.mass == rhs.mass && lhs.I == rhs.I;
     }
     
     /// @brief MassData inequality operator.
     /// @relatedalso MassData
-    constexpr bool operator!= (MassData lhs, MassData rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!= (MassData lhs, MassData rhs)
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Collision/SeparationFinder.hpp
+++ b/PlayRho/Collision/SeparationFinder.hpp
@@ -112,18 +112,18 @@ namespace playrho {
         }
         
         /// @brief Gets the type.
-        constexpr Type GetType() const noexcept;
+        PLAYRHO_CONSTEXPR inline Type GetType() const noexcept;
 
         /// @brief Gets the axis.
-        constexpr UnitVec2 GetAxis() const noexcept;
+        PLAYRHO_CONSTEXPR inline UnitVec2 GetAxis() const noexcept;
         
         /// @brief Gets the local point.
-        constexpr Length2 GetLocalPoint() const noexcept;
+        PLAYRHO_CONSTEXPR inline Length2 GetLocalPoint() const noexcept;
 
     private:
         
         /// @brief Initializing constructor.
-        constexpr SeparationFinder(const DistanceProxy& dpA, const DistanceProxy& dpB,
+        PLAYRHO_CONSTEXPR inline SeparationFinder(const DistanceProxy& dpA, const DistanceProxy& dpB,
                                          const UnitVec2 axis, const Length2 lp, const Type type):
             m_proxyA{dpA}, m_proxyB{dpB}, m_axis{axis}, m_localPoint{lp}, m_type{type}
         {
@@ -155,17 +155,17 @@ namespace playrho {
         const Type m_type; ///< The type of this instance.
     };
 
-    constexpr inline SeparationFinder::Type SeparationFinder::GetType() const noexcept
+    PLAYRHO_CONSTEXPR inline SeparationFinder::Type SeparationFinder::GetType() const noexcept
     {
         return m_type;
     }
     
-    constexpr inline UnitVec2 SeparationFinder::GetAxis() const noexcept
+    PLAYRHO_CONSTEXPR inline UnitVec2 SeparationFinder::GetAxis() const noexcept
     {
         return m_axis;
     }
     
-    constexpr inline Length2 SeparationFinder::GetLocalPoint() const noexcept
+    PLAYRHO_CONSTEXPR inline Length2 SeparationFinder::GetLocalPoint() const noexcept
     {
         return m_localPoint;
     }

--- a/PlayRho/Collision/ShapeSeparation.hpp
+++ b/PlayRho/Collision/ShapeSeparation.hpp
@@ -38,13 +38,13 @@ namespace playrho
         using index_type = std::remove_const<decltype(MaxShapeVertices)>::type;
         
         /// @brief Gets the invalid distance.
-        static constexpr distance_type GetInvalidDistance() noexcept
+        static PLAYRHO_CONSTEXPR inline distance_type GetInvalidDistance() noexcept
         {
             return std::numeric_limits<Length>::max();
         }
 
         /// @brief Index type.
-        static constexpr index_type InvalidIndex = static_cast<index_type>(-1);
+        static PLAYRHO_CONSTEXPR const index_type InvalidIndex = static_cast<index_type>(-1);
         
         distance_type separation = GetInvalidDistance(); ///< Separation.
         index_type index = InvalidIndex; ///< Index.
@@ -62,13 +62,13 @@ namespace playrho
         using index_type = std::remove_const<decltype(MaxShapeVertices)>::type;
         
         /// @brief Gets the invalid distance.
-        static constexpr distance_type GetInvalidDistance() noexcept
+        static PLAYRHO_CONSTEXPR inline distance_type GetInvalidDistance() noexcept
         {
             return std::numeric_limits<Length>::max();
         }
 
         /// @brief Invalid index.
-        static constexpr index_type InvalidIndex = static_cast<index_type>(-1);
+        static PLAYRHO_CONSTEXPR const index_type InvalidIndex = static_cast<index_type>(-1);
         
         distance_type separation = GetInvalidDistance(); ///< Separation.
         index_type index1 = InvalidIndex; ///< Index 1.

--- a/PlayRho/Collision/Shapes/ChainShape.hpp
+++ b/PlayRho/Collision/Shapes/ChainShape.hpp
@@ -48,7 +48,7 @@ class ChainShape: public Shape
 public:
 
     /// @brief Gets the default vertex radius.
-    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return DefaultLinearSlop * Real{2};
     }

--- a/PlayRho/Collision/Shapes/DiskShape.hpp
+++ b/PlayRho/Collision/Shapes/DiskShape.hpp
@@ -41,7 +41,7 @@ class DiskShape : public Shape
 public:
     
     /// @brief Gets the default radius.
-    static constexpr Length GetDefaultRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline Length GetDefaultRadius() noexcept
     {
         return DefaultLinearSlop * 2;
     }
@@ -49,13 +49,13 @@ public:
     /// @brief Configuration data for disk shapes.
     struct Conf: public ShapeDefBuilder<Conf>
     {
-        constexpr Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultRadius())}
+        PLAYRHO_CONSTEXPR inline Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultRadius())}
         {
             // Intentionally empty.
         }
         
         /// @brief Uses the given value as the location.
-        constexpr Conf& UseLocation(Length2 value) noexcept
+        PLAYRHO_CONSTEXPR inline Conf& UseLocation(Length2 value) noexcept
         {
             location = value;
             return *this;
@@ -66,7 +66,7 @@ public:
     };
 
     /// @brief Gets the default configuration.
-    static constexpr Conf GetDefaultConf() noexcept;
+    static PLAYRHO_CONSTEXPR inline Conf GetDefaultConf() noexcept;
 
     /// Initializing constructor.
     explicit DiskShape(const Conf& conf = GetDefaultConf()) noexcept:
@@ -129,7 +129,7 @@ private:
     Length2 m_location = Length2{};
 };
 
-constexpr DiskShape::Conf DiskShape::GetDefaultConf() noexcept
+PLAYRHO_CONSTEXPR inline DiskShape::Conf DiskShape::GetDefaultConf() noexcept
 {
     return Conf{};
 }

--- a/PlayRho/Collision/Shapes/EdgeShape.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShape.hpp
@@ -40,7 +40,7 @@ class EdgeShape : public Shape
 public:
     
     /// @brief Gets the default vertex radius.
-    static constexpr Length GetDefaultVertexRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline Length GetDefaultVertexRadius() noexcept
     {
         return DefaultLinearSlop * Real{2};
     }
@@ -48,20 +48,20 @@ public:
     /// @brief Configuration data for edge shapes.
     struct Conf: public ShapeDefBuilder<Conf>
     {
-        constexpr Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
+        PLAYRHO_CONSTEXPR inline Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
         {
             // Intentionally empty.
         }
         
         /// @brief Uses the given value for vertex 1.
-        constexpr Conf& UseVertex1(Length2 value) noexcept
+        PLAYRHO_CONSTEXPR inline Conf& UseVertex1(Length2 value) noexcept
         {
             vertex1 = value;
             return *this;
         }
 
         /// @brief Uses the given value for vertex 2.
-        constexpr Conf& UseVertex2(Length2 value) noexcept
+        PLAYRHO_CONSTEXPR inline Conf& UseVertex2(Length2 value) noexcept
         {
             vertex2 = value;
             return *this;
@@ -72,7 +72,7 @@ public:
     };
     
     /// @brief Gets the default configuration for an EdgeShape.
-    static constexpr Conf GetDefaultConf() noexcept
+    static PLAYRHO_CONSTEXPR inline Conf GetDefaultConf() noexcept
     {
         return Conf{};
     }

--- a/PlayRho/Collision/Shapes/MultiShape.hpp
+++ b/PlayRho/Collision/Shapes/MultiShape.hpp
@@ -44,10 +44,10 @@ namespace playrho {
         using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
         
         /// @brief Invalid vertex.
-        static constexpr auto InvalidVertex = static_cast<VertexCounter>(-1);
+        static PLAYRHO_CONSTEXPR const auto InvalidVertex = static_cast<VertexCounter>(-1);
         
         /// @brief Gets the default vertex radius for the MultiShape.
-        static constexpr Length GetDefaultVertexRadius() noexcept
+        static PLAYRHO_CONSTEXPR inline Length GetDefaultVertexRadius() noexcept
         {
             return DefaultLinearSlop * Real{2};
         }
@@ -55,14 +55,14 @@ namespace playrho {
         /// @brief Configuration data for multi-shape shapes.
         struct Conf: public ShapeDefBuilder<Conf>
         {
-            constexpr Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
+            PLAYRHO_CONSTEXPR inline Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
             {
                 // Intentionally empty.
             }
         };
         
         /// @brief Gets the default configuration for a MultiShape.
-        static constexpr Conf GetDefaultConf() noexcept
+        static PLAYRHO_CONSTEXPR inline Conf GetDefaultConf() noexcept
         {
             return Conf{};
         }

--- a/PlayRho/Collision/Shapes/PolygonShape.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.hpp
@@ -47,10 +47,10 @@ public:
     using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
 
     /// @brief Invalid vertex.
-    static constexpr auto InvalidVertex = static_cast<VertexCounter>(-1);
+    static PLAYRHO_CONSTEXPR const auto InvalidVertex = static_cast<VertexCounter>(-1);
 
     /// @brief Gets the default vertex radius for the PolygonShape.
-    static constexpr Length GetDefaultVertexRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline Length GetDefaultVertexRadius() noexcept
     {
         return DefaultLinearSlop * Real{2};
     }
@@ -58,14 +58,14 @@ public:
     /// @brief Configuration data for polygon shapes.
     struct Conf: public ShapeDefBuilder<Conf>
     {
-        constexpr Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
+        PLAYRHO_CONSTEXPR inline Conf(): ShapeDefBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
         {
             // Intentionally empty.
         }
     };
     
     /// @brief Gets the default configuration for a PolygonShape.
-    static constexpr Conf GetDefaultConf() noexcept
+    static PLAYRHO_CONSTEXPR inline Conf GetDefaultConf() noexcept
     {
         return Conf{};
     }

--- a/PlayRho/Collision/Shapes/ShapeDef.hpp
+++ b/PlayRho/Collision/Shapes/ShapeDef.hpp
@@ -83,26 +83,26 @@ struct ShapeDefBuilder: ShapeDef
     // Note: don't use 'using ShapeDef::ShapeDef' here as it doesn't work in this context!
     
     /// @brief Default constructor.
-    constexpr ShapeDefBuilder() = default;
+    PLAYRHO_CONSTEXPR inline ShapeDefBuilder() = default;
 
     /// @brief Initializing constructor.
-    constexpr explicit ShapeDefBuilder(const ShapeDef& value) noexcept: ShapeDef{value} {}
+    PLAYRHO_CONSTEXPR inline explicit ShapeDefBuilder(const ShapeDef& value) noexcept: ShapeDef{value} {}
 
     /// @brief Uses the given vertex radius.
-    constexpr ConcreteConf& UseVertexRadius(NonNegative<Length> value) noexcept;
+    PLAYRHO_CONSTEXPR inline ConcreteConf& UseVertexRadius(NonNegative<Length> value) noexcept;
     
     /// @brief Uses the given friction.
-    constexpr ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
+    PLAYRHO_CONSTEXPR inline ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
     
     /// @brief Uses the given restitution.
-    constexpr ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
+    PLAYRHO_CONSTEXPR inline ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
     
     /// @brief Uses the given density.
-    constexpr ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
+    PLAYRHO_CONSTEXPR inline ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
 };
 
 template <typename ConcreteConf>
-constexpr ConcreteConf&
+PLAYRHO_CONSTEXPR inline ConcreteConf&
 ShapeDefBuilder<ConcreteConf>::UseVertexRadius(NonNegative<Length> value) noexcept
 {
     vertexRadius = value;
@@ -110,7 +110,7 @@ ShapeDefBuilder<ConcreteConf>::UseVertexRadius(NonNegative<Length> value) noexce
 }
 
 template <typename ConcreteConf>
-constexpr ConcreteConf&
+PLAYRHO_CONSTEXPR inline ConcreteConf&
 ShapeDefBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
 {
     friction = value;
@@ -118,7 +118,7 @@ ShapeDefBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
 }
 
 template <typename ConcreteConf>
-constexpr ConcreteConf&
+PLAYRHO_CONSTEXPR inline ConcreteConf&
 ShapeDefBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
 {
     restitution = value;
@@ -126,7 +126,7 @@ ShapeDefBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
 }
 
 template <typename ConcreteConf>
-constexpr ConcreteConf&
+PLAYRHO_CONSTEXPR inline ConcreteConf&
 ShapeDefBuilder<ConcreteConf>::UseDensity(NonNegative<AreaDensity> value) noexcept
 {
     density = value;

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -86,7 +86,7 @@ namespace playrho {
             Cache(const Cache& copy) = default;
             
             /// @brief Initializing constructor.
-            constexpr Cache(Real metric, IndexPair3 indices) noexcept;
+            PLAYRHO_CONSTEXPR inline Cache(Real metric, IndexPair3 indices) noexcept;
             
             ~Cache() noexcept = default;
 
@@ -96,16 +96,16 @@ namespace playrho {
             /// @sa SetMetric.
             /// @sa IsMetricSet.
             /// @return Value previously set.
-            constexpr Real GetMetric() const noexcept;
+            PLAYRHO_CONSTEXPR inline Real GetMetric() const noexcept;
             
             /// @brief Is metric set.
-            constexpr bool IsMetricSet() const noexcept;
+            PLAYRHO_CONSTEXPR inline bool IsMetricSet() const noexcept;
             
             /// @brief Gets indices.
-            constexpr IndexPair3 GetIndices() const noexcept;
+            PLAYRHO_CONSTEXPR inline IndexPair3 GetIndices() const noexcept;
             
             /// @brief Gets the index pair for the given index.
-            constexpr IndexPair GetIndexPair(size_type index) const noexcept;
+            PLAYRHO_CONSTEXPR inline IndexPair GetIndexPair(size_type index) const noexcept;
             
         private:
             Real m_metric = GetInvalid<Real>(); ///< Metric. @details This is a length or area value.            
@@ -126,7 +126,7 @@ namespace playrho {
         /// @param simplexEdges A one or two edge list.
         /// @warning Behavior is undefined if the given edge list has zero edges.
         /// @return "search direction" vector.
-        static constexpr Length2 CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept;
+        static PLAYRHO_CONSTEXPR inline Length2 CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept;
         
         /// Gets the given simplex's "metric".
         static inline Real CalcMetric(const SimplexEdges& simplexEdges);
@@ -162,16 +162,16 @@ namespace playrho {
         Simplex() = default;
 
         /// @brief Gets the edges.
-        constexpr SimplexEdges GetEdges() const noexcept;
+        PLAYRHO_CONSTEXPR inline SimplexEdges GetEdges() const noexcept;
 
         /// @brief Gets the give indexed simplex edge.
         const SimplexEdge& GetSimplexEdge(size_type index) const noexcept;
 
         /// @brief Gets the coefficient for the given index.
-        constexpr Real GetCoefficient(size_type index) const noexcept;
+        PLAYRHO_CONSTEXPR inline Real GetCoefficient(size_type index) const noexcept;
 
         /// @brief Gets the size in number of simplex edges that this instance is made up of.
-        constexpr size_type GetSize() const noexcept;
+        PLAYRHO_CONSTEXPR inline size_type GetSize() const noexcept;
 
     private:
         
@@ -194,29 +194,29 @@ namespace playrho {
         Coefficients m_normalizedWeights;
     };
 
-    constexpr inline Simplex::Cache::Cache(Real metric, IndexPair3 indices) noexcept:
+    PLAYRHO_CONSTEXPR inline Simplex::Cache::Cache(Real metric, IndexPair3 indices) noexcept:
         m_metric{metric}, m_indices{indices}
     {
         // Intentionally empty
     }
 
-    constexpr inline Real Simplex::Cache::GetMetric() const noexcept
+    PLAYRHO_CONSTEXPR inline Real Simplex::Cache::GetMetric() const noexcept
     {
         assert(IsMetricSet());
         return m_metric;
     }
     
-    constexpr inline bool Simplex::Cache::IsMetricSet() const noexcept
+    PLAYRHO_CONSTEXPR inline bool Simplex::Cache::IsMetricSet() const noexcept
     {
         return GetNumIndices(m_indices) > std::size_t{0};
     }
     
-    constexpr inline IndexPair3 Simplex::Cache::GetIndices() const noexcept
+    PLAYRHO_CONSTEXPR inline IndexPair3 Simplex::Cache::GetIndices() const noexcept
     {
         return m_indices;
     }
     
-    constexpr inline IndexPair Simplex::Cache::GetIndexPair(size_type index) const noexcept
+    PLAYRHO_CONSTEXPR inline IndexPair Simplex::Cache::GetIndexPair(size_type index) const noexcept
     {
         return m_indices[index];
     }
@@ -238,7 +238,7 @@ namespace playrho {
         return list;
     }
 
-    constexpr inline Length2 Simplex::CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept
+    PLAYRHO_CONSTEXPR inline Length2 Simplex::CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept
     {
         assert((simplexEdges.size() == 1) || (simplexEdges.size() == 2));
         switch (simplexEdges.size())
@@ -297,7 +297,7 @@ namespace playrho {
 #endif
     }
 
-    constexpr inline SimplexEdges Simplex::GetEdges() const noexcept
+    PLAYRHO_CONSTEXPR inline SimplexEdges Simplex::GetEdges() const noexcept
     {
         return m_simplexEdges;
     }
@@ -307,14 +307,14 @@ namespace playrho {
         return m_simplexEdges[index];
     }
     
-    constexpr inline Real Simplex::GetCoefficient(size_type index) const noexcept
+    PLAYRHO_CONSTEXPR inline Real Simplex::GetCoefficient(size_type index) const noexcept
     {
         return m_normalizedWeights[index];
     }
     
     /// @brief Gets the size in number of valid edges of this Simplex.
     /// @return Value between 0 and <code>MaxEdges</code> (inclusive).
-    constexpr inline Simplex::size_type Simplex::GetSize() const noexcept
+    PLAYRHO_CONSTEXPR inline Simplex::size_type Simplex::GetSize() const noexcept
     {
         return m_simplexEdges.size();
     }
@@ -326,7 +326,7 @@ namespace playrho {
     }
 
     /// Gets the "closest point".
-    constexpr inline Length2 GetClosestPoint(const Simplex& simplex)
+    PLAYRHO_CONSTEXPR inline Length2 GetClosestPoint(const Simplex& simplex)
     {
         switch (simplex.GetSize())
         {

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -43,29 +43,29 @@ namespace playrho {
         SimplexEdge() = default;
         
         /// @brief Copy constructor.
-        constexpr SimplexEdge(const SimplexEdge& copy) = default;
+        PLAYRHO_CONSTEXPR inline SimplexEdge(const SimplexEdge& copy) = default;
         
         /// @brief Initializing constructor.
         /// @param pA Point A in world coordinates.
         /// @param iA Index of point A within the shape that it comes from.
         /// @param pB Point B in world coordinates.
         /// @param iB Index of point B within the shape that it comes from.
-        constexpr SimplexEdge(Length2 pA, index_type iA, Length2 pB, index_type iB) noexcept;
+        PLAYRHO_CONSTEXPR inline SimplexEdge(Length2 pA, index_type iA, Length2 pB, index_type iB) noexcept;
         
         /// @brief Gets point A (in world coordinates).
-        constexpr auto GetPointA() const noexcept { return m_wA; }
+        PLAYRHO_CONSTEXPR inline auto GetPointA() const noexcept { return m_wA; }
         
         /// @brief Gets point B (in world coordinates).
-        constexpr auto GetPointB() const noexcept { return m_wB; }
+        PLAYRHO_CONSTEXPR inline auto GetPointB() const noexcept { return m_wB; }
 
         /// @brief Gets index A.
-        constexpr auto GetIndexA() const noexcept { return m_indexPair.a; }
+        PLAYRHO_CONSTEXPR inline auto GetIndexA() const noexcept { return m_indexPair.a; }
         
         /// @brief Gets index B.
-        constexpr auto GetIndexB() const noexcept { return m_indexPair.b; }
+        PLAYRHO_CONSTEXPR inline auto GetIndexB() const noexcept { return m_indexPair.b; }
 
         /// @brief Gets the index pair.
-        constexpr auto GetIndexPair() const noexcept { return m_indexPair; }
+        PLAYRHO_CONSTEXPR inline auto GetIndexPair() const noexcept { return m_indexPair; }
 
     private:
         Length2 m_wA; ///< Point A in world coordinates. This is the support point in proxy A. 8-bytes.
@@ -73,7 +73,7 @@ namespace playrho {
         IndexPair m_indexPair; ///< Index pair. @details Indices of points A and B. 2-bytes.
     };
     
-    constexpr inline SimplexEdge::SimplexEdge(Length2 pA, index_type iA,
+    PLAYRHO_CONSTEXPR inline SimplexEdge::SimplexEdge(Length2 pA, index_type iA,
                                               Length2 pB, index_type iB) noexcept:
         m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
     {
@@ -82,13 +82,13 @@ namespace playrho {
     
     /// @brief Gets "w".
     /// @return 2D vector value of wB minus wA.
-    constexpr inline Length2 GetPointDelta(const SimplexEdge& sv) noexcept
+    PLAYRHO_CONSTEXPR inline Length2 GetPointDelta(const SimplexEdge& sv) noexcept
     {
         return sv.GetPointB() - sv.GetPointA();
     }
     
     /// @brief SimplexEdge equality operator.
-    constexpr inline bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
     {
         return (lhs.GetPointA() == rhs.GetPointA())
             && (lhs.GetPointB() == rhs.GetPointB())
@@ -96,7 +96,7 @@ namespace playrho {
     }
     
     /// @brief SimplexEdge inequality operator.
-    constexpr inline bool operator!= (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -59,22 +59,22 @@ namespace playrho {
         using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
 
         /// @brief Uses the given time max value.
-        constexpr ToiConf& UseTimeMax(Real value) noexcept;
+        PLAYRHO_CONSTEXPR inline ToiConf& UseTimeMax(Real value) noexcept;
 
         /// @brief Uses the given target depth value.
-        constexpr ToiConf& UseTargetDepth(Length value) noexcept;
+        PLAYRHO_CONSTEXPR inline ToiConf& UseTargetDepth(Length value) noexcept;
         
         /// @brief Uses the given tolerance value.
-        constexpr ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
+        PLAYRHO_CONSTEXPR inline ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
         
         /// @brief Uses the given max root iterations value.
-        constexpr ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
+        PLAYRHO_CONSTEXPR inline ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
         
         /// @brief Uses the given max TOI iterations value.
-        constexpr ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
+        PLAYRHO_CONSTEXPR inline ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
         
         /// @brief Uses the given max distance iterations value.
-        constexpr ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
+        PLAYRHO_CONSTEXPR inline ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
 
         /// @brief T-Max.
         Real tMax = 1;
@@ -102,37 +102,37 @@ namespace playrho {
         dist_iter_type maxDistIters = DefaultMaxDistanceIters; ///< Max distance iterations.
     };
 
-    constexpr ToiConf& ToiConf::UseTimeMax(Real value) noexcept
+    PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseTimeMax(Real value) noexcept
     {
         tMax = value;
         return *this;
     }
 
-    constexpr ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
+    PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
     {
         targetDepth = value;
         return *this;
     }
 
-    constexpr ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
+    PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
     {
         tolerance = value;
         return *this;
     }
 
-    constexpr ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
+    PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
     {
         maxRootIters = value;
         return *this;
     }
     
-    constexpr ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
+    PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
     {
         maxToiIters = value;
         return *this;
     }
 
-    constexpr ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
+    PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
     {
         maxDistIters = value;
         return *this;
@@ -140,7 +140,7 @@ namespace playrho {
     
     /// @brief Gets the default time of impact configuration.
     /// @relatedalso ToiConf
-    constexpr auto GetDefaultToiConf()
+    PLAYRHO_CONSTEXPR inline auto GetDefaultToiConf()
     {
         return ToiConf{};
     }

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -76,7 +76,7 @@ namespace playrho {
         WorldManifold() = default;
         
         /// @brief Initializing constructor.
-        constexpr explicit WorldManifold(UnitVec2 normal) noexcept:
+        PLAYRHO_CONSTEXPR inline explicit WorldManifold(UnitVec2 normal) noexcept:
             m_normal{normal}
         {
             assert(IsValid(normal));
@@ -84,7 +84,7 @@ namespace playrho {
         }
         
         /// @brief Initializing constructor.
-        constexpr explicit WorldManifold(UnitVec2 normal, PointData ps0) noexcept:
+        PLAYRHO_CONSTEXPR inline explicit WorldManifold(UnitVec2 normal, PointData ps0) noexcept:
             m_normal{normal},
             m_points{ps0.location, GetInvalid<Length2>()},
             m_impulses{ps0.impulse, Momentum2{}},
@@ -95,7 +95,7 @@ namespace playrho {
         }
         
         /// @brief Initializing constructor.
-        constexpr explicit WorldManifold(UnitVec2 normal, PointData ps0, PointData ps1) noexcept:
+        PLAYRHO_CONSTEXPR inline explicit WorldManifold(UnitVec2 normal, PointData ps0, PointData ps1) noexcept:
             m_normal{normal},
             m_points{ps0.location, ps1.location},
             m_impulses{ps0.impulse, ps1.impulse},

--- a/PlayRho/Common/Acceleration.hpp
+++ b/PlayRho/Common/Acceleration.hpp
@@ -38,28 +38,28 @@ namespace playrho
     /// @brief Determines if the given value is valid.
     /// @relatedalso Acceleration
     template <>
-    constexpr inline bool IsValid(const Acceleration& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Acceleration& value) noexcept
     {
         return IsValid(value.linear) && IsValid(value.angular);
     }
     
     /// @brief Equality operator.
     /// @relatedalso Acceleration
-    constexpr inline bool operator==(const Acceleration& lhs, const Acceleration& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator==(const Acceleration& lhs, const Acceleration& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Acceleration
-    constexpr inline bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Multiplication assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator*= (Acceleration& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration& operator*= (Acceleration& lhs, const Real rhs)
     {
         lhs.linear *= rhs;
         lhs.angular *= rhs;
@@ -68,7 +68,7 @@ namespace playrho
     
     /// @brief Division assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator/= (Acceleration& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration& operator/= (Acceleration& lhs, const Real rhs)
     {
         lhs.linear /= rhs;
         lhs.angular /= rhs;
@@ -77,7 +77,7 @@ namespace playrho
     
     /// @brief Addition assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -86,14 +86,14 @@ namespace playrho
     
     /// @brief Addition operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
     {
         return Acceleration{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -102,42 +102,42 @@ namespace playrho
     
     /// @brief Subtraction operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
     {
         return Acceleration{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Negation operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator- (const Acceleration& value)
+    PLAYRHO_CONSTEXPR inline Acceleration operator- (const Acceleration& value)
     {
         return Acceleration{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator+ (const Acceleration& value)
+    PLAYRHO_CONSTEXPR inline Acceleration operator+ (const Acceleration& value)
     {
         return value;
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator* (const Acceleration& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration operator* (const Acceleration& lhs, const Real rhs)
     {
         return Acceleration{lhs.linear * rhs, lhs.angular * rhs};
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator* (const Real lhs, const Acceleration& rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration operator* (const Real lhs, const Acceleration& rhs)
     {
         return Acceleration{rhs.linear * lhs, rhs.angular * lhs};
     }
     
     /// @brief Division operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator/ (const Acceleration& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Acceleration operator/ (const Acceleration& lhs, const Real rhs)
     {
         /*
          * While it can be argued that division operations shouldn't be supported due to

--- a/PlayRho/Common/AllocatedArray.hpp
+++ b/PlayRho/Common/AllocatedArray.hpp
@@ -67,7 +67,7 @@ public:
     using const_iterator = const_pointer;
 
     /// @brief Initializing constructor.
-    constexpr AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter):
+    PLAYRHO_CONSTEXPR inline AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter):
         m_max_size{max_size}, m_data{data}, m_deleter{deleter}
     {
         assert(data);

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -20,6 +20,8 @@
 #ifndef PLAYRHO_COMMON_ARRAYLIST_HPP
 #define PLAYRHO_COMMON_ARRAYLIST_HPP
 
+#include <PlayRho/Defines.hpp>
+
 #include <array>
 #include <cassert>
 #include <initializer_list>
@@ -50,7 +52,7 @@ namespace playrho
         /// @brief Constant pointer type.
         using const_pointer = const value_type*;
 
-        constexpr ArrayList() noexcept
+        PLAYRHO_CONSTEXPR inline ArrayList() noexcept
         {
             // Intentionally empty.
             // Note that defaulting this method instead of writing it out here,
@@ -58,7 +60,7 @@ namespace playrho
         }
 
         template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t< COPY_MAXSIZE <= MAXSIZE >>
-        constexpr explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
+        PLAYRHO_CONSTEXPR inline explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
             m_size{copy.size()},
             m_elements{copy.data()}
         {
@@ -91,13 +93,13 @@ namespace playrho
             }
         }
         
-        constexpr ArrayList& Append(const value_type& value)
+        PLAYRHO_CONSTEXPR inline ArrayList& Append(const value_type& value)
         {
             push_back(value);
             return *this;
         }
 
-        constexpr void push_back(const value_type& value) noexcept
+        PLAYRHO_CONSTEXPR inline void push_back(const value_type& value) noexcept
         {
             assert(m_size < MAXSIZE);
             m_elements[m_size] = value;
@@ -134,7 +136,7 @@ namespace playrho
             return m_elements[index];
         }
         
-        constexpr const_reference operator[](size_type index) const noexcept
+        PLAYRHO_CONSTEXPR inline const_reference operator[](size_type index) const noexcept
         {
             assert(index < MAXSIZE);
             return m_elements[index];
@@ -144,11 +146,11 @@ namespace playrho
         /// @details This is the number of elements that have been added to this collection.
         /// @return Value between 0 and the maximum size for this collection.
         /// @sa max_size().
-        constexpr size_type size() const noexcept { return m_size; }
+        PLAYRHO_CONSTEXPR inline size_type size() const noexcept { return m_size; }
         
         /// Gets the maximum size that this collection can be.
         /// @details This is the maximum number of elements that can be contained in this collection.
-        constexpr size_type max_size() const noexcept { return MAXSIZE; }
+        PLAYRHO_CONSTEXPR inline size_type max_size() const noexcept { return MAXSIZE; }
 
         auto data() const noexcept { return m_elements.data(); }
 

--- a/PlayRho/Common/BlockAllocator.cpp
+++ b/PlayRho/Common/BlockAllocator.cpp
@@ -26,7 +26,7 @@
 namespace playrho {
 
 /// @brief Array of block sizes.
-static constexpr std::size_t s_blockSizes[BlockAllocator::BlockSizes] =
+static PLAYRHO_CONSTEXPR const std::size_t s_blockSizes[BlockAllocator::BlockSizes] =
 {
     16,        // 0
     32,        // 1
@@ -45,7 +45,7 @@ static constexpr std::size_t s_blockSizes[BlockAllocator::BlockSizes] =
 };
 
 /// @brief Block size lookup array.
-static constexpr std::uint8_t s_blockSizeLookup[BlockAllocator::MaxBlockSize + 1] =
+static PLAYRHO_CONSTEXPR const std::uint8_t s_blockSizeLookup[BlockAllocator::MaxBlockSize + 1] =
 {
     0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 1-16

--- a/PlayRho/Common/BlockAllocator.hpp
+++ b/PlayRho/Common/BlockAllocator.hpp
@@ -39,16 +39,16 @@ namespace playrho {
         using size_type = std::size_t;
         
         /// @brief Chunk size.
-        static constexpr auto ChunkSize = size_type{16 * 1024};
+        static PLAYRHO_CONSTEXPR const auto ChunkSize = size_type{16 * 1024};
         
         /// @brief Max block size (before using external allocator).
-        static constexpr auto MaxBlockSize = size_type{640};
+        static PLAYRHO_CONSTEXPR const auto MaxBlockSize = size_type{640};
 
         /// @brief Block sizes.
-        static constexpr auto BlockSizes = size_type{14};
+        static PLAYRHO_CONSTEXPR const auto BlockSizes = size_type{14};
         
         /// @brief Chunk array increment.
-        static constexpr auto ChunkArrayIncrement = size_type{128};
+        static PLAYRHO_CONSTEXPR const auto ChunkArrayIncrement = size_type{128};
         
         BlockAllocator();
         
@@ -120,7 +120,7 @@ namespace playrho {
         BlockDeallocator() = default;
 
         /// @brief Initializing constructor.
-        constexpr BlockDeallocator(BlockAllocator* a, size_type n) noexcept:
+        PLAYRHO_CONSTEXPR inline BlockDeallocator(BlockAllocator* a, size_type n) noexcept:
             allocator{a}, nelem{n}
         {
             // Intentionally empty.

--- a/PlayRho/Common/BoundedValue.hpp
+++ b/PlayRho/Common/BoundedValue.hpp
@@ -55,10 +55,10 @@ namespace playrho {
     struct ValueCheckHelper
     {
         /// @brief Has one.
-        static constexpr bool has_one = false;
+        static PLAYRHO_CONSTEXPR const bool has_one = false;
         
         /// @brief Gets the "one" value.
-        static constexpr T one() noexcept { return T(0); }
+        static PLAYRHO_CONSTEXPR inline T one() noexcept { return T(0); }
     };
     
     /// @brief Specialization of the value check helper.
@@ -66,15 +66,15 @@ namespace playrho {
     struct ValueCheckHelper<T, typename std::enable_if<std::is_arithmetic<T>::value>::type>
     {
         /// @brief Has one.
-        static constexpr bool has_one = true;
+        static PLAYRHO_CONSTEXPR const bool has_one = true;
 
         /// @brief Gets the "one" value.
-        static constexpr T one() noexcept { return T(1); }
+        static PLAYRHO_CONSTEXPR inline T one() noexcept { return T(1); }
     };
 
     /// @brief Checks if the given value is above negative infinity.
     template <typename T>
-    constexpr void CheckIfAboveNegInf(typename std::enable_if<!std::is_pointer<T>::value, T>::type
+    PLAYRHO_CONSTEXPR inline void CheckIfAboveNegInf(typename std::enable_if<!std::is_pointer<T>::value, T>::type
                                       value)
     {
         if (std::numeric_limits<T>::has_infinity)
@@ -88,7 +88,7 @@ namespace playrho {
     
     /// @brief Checks if the given value is above negative infinity.
     template <typename T>
-    constexpr void CheckIfAboveNegInf(typename std::enable_if<std::is_pointer<T>::value, T>::type
+    PLAYRHO_CONSTEXPR inline void CheckIfAboveNegInf(typename std::enable_if<std::is_pointer<T>::value, T>::type
                                       /*value*/)
     {
         // Intentionally empty.
@@ -114,13 +114,13 @@ namespace playrho {
         using this_type = BoundedValue<value_type, lo, hi>;
 
         /// @brief Gets the lo check.
-        static constexpr LoValueCheck GetLoCheck() { return lo; }
+        static PLAYRHO_CONSTEXPR inline LoValueCheck GetLoCheck() { return lo; }
 
         /// @brief Gets the hi check.
-        static constexpr HiValueCheck GetHiCheck() { return hi; }
+        static PLAYRHO_CONSTEXPR inline HiValueCheck GetHiCheck() { return hi; }
 
         /// @brief Performs the lo check.
-        static constexpr void DoLoCheck(value_type value)
+        static PLAYRHO_CONSTEXPR inline void DoLoCheck(value_type value)
         {
             switch (GetLoCheck())
             {
@@ -151,7 +151,7 @@ namespace playrho {
         }
         
         /// @brief Performs the hi check.
-        static constexpr void DoHiCheck(value_type value)
+        static PLAYRHO_CONSTEXPR inline void DoHiCheck(value_type value)
         {
             switch (GetHiCheck())
             {
@@ -192,17 +192,17 @@ namespace playrho {
         }
 
         /// @brief Initializing constructor.
-        constexpr BoundedValue(value_type value): m_value{value}
+        PLAYRHO_CONSTEXPR inline BoundedValue(value_type value): m_value{value}
         {
             DoLoCheck(value);
             DoHiCheck(value);
         }
         
         /// @brief Copy constructor.
-        constexpr BoundedValue(const this_type& value) = default;
+        PLAYRHO_CONSTEXPR inline BoundedValue(const this_type& value) = default;
 
         /// @brief Move constructor.
-        constexpr BoundedValue(this_type&& value) noexcept:
+        PLAYRHO_CONSTEXPR inline BoundedValue(this_type&& value) noexcept:
             m_value{std::move(value.m_value)}
         {
             // Intentionally empty.
@@ -213,14 +213,14 @@ namespace playrho {
         ~BoundedValue() noexcept = default;
 
         /// @brief Assignment operator.
-        constexpr BoundedValue& operator= (const this_type& other) noexcept
+        PLAYRHO_CONSTEXPR inline BoundedValue& operator= (const this_type& other) noexcept
         {
             m_value = other.m_value;
             return *this;
         }
 
         /// @brief Assignment operator.
-        constexpr BoundedValue& operator= (const T& value)
+        PLAYRHO_CONSTEXPR inline BoundedValue& operator= (const T& value)
         {
             DoLoCheck(value);
             DoHiCheck(value);
@@ -229,7 +229,7 @@ namespace playrho {
         }
 
         /// @brief Move assignment operator.
-        constexpr BoundedValue& operator= (this_type&& value) noexcept
+        PLAYRHO_CONSTEXPR inline BoundedValue& operator= (this_type&& value) noexcept
         {
             // Note that the exception specification of this method
             //   doesn't match the defaulted one (when built with boost units).
@@ -238,27 +238,27 @@ namespace playrho {
         }
 
         /// @brief Gets the underlying value.
-        constexpr value_type get() const noexcept
+        PLAYRHO_CONSTEXPR inline value_type get() const noexcept
         {
             return m_value;
         }
 
         /// @brief Gets the underlying value.
-        constexpr operator value_type () const noexcept
+        PLAYRHO_CONSTEXPR inline operator value_type () const noexcept
         {
             return m_value;
         }
 
         /// @brief Member of pointer operator.
         template <typename U = T>
-        constexpr typename std::enable_if<std::is_pointer<U>::value, U>::type operator-> () const
+        PLAYRHO_CONSTEXPR inline typename std::enable_if<std::is_pointer<U>::value, U>::type operator-> () const
         {
             return m_value;
         }
 
         /// @brief Indirection operator.
         template <typename U = T>
-        constexpr typename std::enable_if<std::is_pointer<U>::value, remove_pointer_type>::type&
+        PLAYRHO_CONSTEXPR inline typename std::enable_if<std::is_pointer<U>::value, remove_pointer_type>::type&
         operator* () const
         {
             return *m_value;
@@ -272,14 +272,14 @@ namespace playrho {
 
     /// @brief BoundedValue equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator== (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator== (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} == T{rhs};
     }
     
     /// @brief BoundedValue inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator!= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} != T{rhs};
     }
@@ -288,56 +288,56 @@ namespace playrho {
 
     /// @brief BoundedValue less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator<= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} <= T{rhs};
     }
     
     /// @brief BoundedValue greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator>= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} >= T{rhs};
     }
     
     /// @brief BoundedValue less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator< (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator< (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} < T{rhs};
     }
     
     /// @brief BoundedValue greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator> (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator> (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} > T{rhs};
     }
     
     /// @brief BoundedValue multiplication operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator* (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator* (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} * T{rhs};
     }
     
     /// @brief BoundedValue division operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator/ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} / T{rhs};
     }
     
     /// @brief BoundedValue addition operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator+ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} + T{rhs};
     }
     
     /// @brief BoundedValue subtraction operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator- (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator- (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} - T{rhs};
     }
@@ -346,14 +346,14 @@ namespace playrho {
 
     /// @brief BoundedValue equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator== (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    PLAYRHO_CONSTEXPR inline bool operator== (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} == rhs;
     }
     
     /// @brief BoundedValue inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator!= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} != rhs;
     }
@@ -362,56 +362,56 @@ namespace playrho {
 
     /// @brief BoundedValue less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator<= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    PLAYRHO_CONSTEXPR inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} <= rhs;
     }
     
     /// @brief BoundedValue greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator>= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    PLAYRHO_CONSTEXPR inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} >= rhs;
     }
     
     /// @brief BoundedValue less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator< (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    PLAYRHO_CONSTEXPR inline bool operator< (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} < rhs;
     }
     
     /// @brief BoundedValue greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator> (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    PLAYRHO_CONSTEXPR inline bool operator> (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} > rhs;
     }
     
     /// @brief BoundedValue multiplication operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator* (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    PLAYRHO_CONSTEXPR inline auto operator* (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} * rhs;
     }
     
     /// @brief BoundedValue division operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator/ (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    PLAYRHO_CONSTEXPR inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} / rhs;
     }
     
     /// @brief BoundedValue addition operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator+ (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    PLAYRHO_CONSTEXPR inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} + rhs;
     }
     
     /// @brief BoundedValue subtraction operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator- (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    PLAYRHO_CONSTEXPR inline auto operator- (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} - T{rhs};
     }
@@ -420,14 +420,14 @@ namespace playrho {
 
     /// @brief BoundedValue equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator== (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator== (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs == T{rhs};
     }
     
     /// @brief BoundedValue inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator!= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs != T{rhs};
     }
@@ -436,56 +436,56 @@ namespace playrho {
 
     /// @brief BoundedValue less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator<= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator<= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs <= T{rhs};
     }
     
     /// @brief BoundedValue greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator>= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator>= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs >= T{rhs};
     }
     
     /// @brief BoundedValue less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator< (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator< (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs < T{rhs};
     }
     
     /// @brief BoundedValue greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr bool operator> (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline bool operator> (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs > T{rhs};
     }
     
     /// @brief BoundedValue multiplication operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator* (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator* (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs * T{rhs};
     }
     
     /// @brief BoundedValue division operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator/ (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator/ (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs / T{rhs};
     }
     
     /// @brief BoundedValue addition operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator+ (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator+ (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs + T{rhs};
     }
     
     /// @brief BoundedValue subtraction operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr auto operator- (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    PLAYRHO_CONSTEXPR inline auto operator- (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs - T{rhs};
     }

--- a/PlayRho/Common/DynamicMemory.hpp
+++ b/PlayRho/Common/DynamicMemory.hpp
@@ -22,6 +22,7 @@
 #ifndef PLAYRHO_COMMON_DYNAMICMEMORY_HPP
 #define PLAYRHO_COMMON_DYNAMICMEMORY_HPP
 
+#include <PlayRho/Defines.hpp>
 #include <cstddef>
 
 namespace playrho

--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -53,16 +53,16 @@ namespace playrho
         using value_type = BASE_TYPE;
         
         /// @brief Total number of bits.
-        static constexpr unsigned int TotalBits = sizeof(BASE_TYPE) * 8;
+        static PLAYRHO_CONSTEXPR const unsigned int TotalBits = sizeof(BASE_TYPE) * 8;
 
         /// @brief Fraction bits.
-        static constexpr unsigned int FractionBits = FRACTION_BITS;
+        static PLAYRHO_CONSTEXPR const unsigned int FractionBits = FRACTION_BITS;
         
         /// @brief Whole value bits.
-        static constexpr unsigned int WholeBits = TotalBits - FractionBits;
+        static PLAYRHO_CONSTEXPR const unsigned int WholeBits = TotalBits - FractionBits;
 
         /// @brief Scale factor.
-        static constexpr value_type ScaleFactor = static_cast<value_type>(1u << FractionBits);
+        static PLAYRHO_CONSTEXPR const value_type ScaleFactor = static_cast<value_type>(1u << FractionBits);
 
         /// @brief Compare result enumeration.
         enum class CmpResult
@@ -74,39 +74,39 @@ namespace playrho
         };
 
         /// @brief Gets the min value this type is capable of expressing.
-        static constexpr Fixed GetMin() noexcept
+        static PLAYRHO_CONSTEXPR inline Fixed GetMin() noexcept
         {
             return Fixed{1, scalar_type{1}};
         }
         
         /// @brief Gets an infinite value for this type.
-        static constexpr Fixed GetInfinity() noexcept
+        static PLAYRHO_CONSTEXPR inline Fixed GetInfinity() noexcept
         {
             return Fixed{numeric_limits::max(), scalar_type{1}};
         }
         
         /// @brief Gets the max value this type is capable of expressing.
-        static constexpr Fixed GetMax() noexcept
+        static PLAYRHO_CONSTEXPR inline Fixed GetMax() noexcept
         {
             // max reserved for +inf
             return Fixed{numeric_limits::max() - 1, scalar_type{1}};
         }
 
         /// @brief Gets a NaN value for this type.
-        static constexpr Fixed GetNaN() noexcept
+        static PLAYRHO_CONSTEXPR inline Fixed GetNaN() noexcept
         {
             return Fixed{numeric_limits::lowest(), scalar_type{1}};
         }
 
         /// @brief Gets the negative infinity value for this type.
-        static constexpr Fixed GetNegativeInfinity() noexcept
+        static PLAYRHO_CONSTEXPR inline Fixed GetNegativeInfinity() noexcept
         {
             // lowest reserved for NaN
             return Fixed{numeric_limits::lowest() + 1, scalar_type{1}};
         }
         
         /// @brief Gets the lowest value this type is capable of expressing.
-        static constexpr Fixed GetLowest() noexcept
+        static PLAYRHO_CONSTEXPR inline Fixed GetLowest() noexcept
         {
             // lowest reserved for NaN
             // lowest + 1 reserved for -inf
@@ -115,7 +115,7 @@ namespace playrho
 
         /// @brief Gets the value from a floating point value.
         template <typename T>
-        static constexpr value_type GetFromFloat(T val) noexcept
+        static PLAYRHO_CONSTEXPR inline value_type GetFromFloat(T val) noexcept
         {
             static_assert(std::is_floating_point<T>::value, "floating point value required");
             // Note: std::isnan(val) *NOT* constant expression, so can't use here!
@@ -127,7 +127,7 @@ namespace playrho
         
         /// @brief Gets the value from a signed integral value.
         template <typename T>
-        static constexpr value_type GetFromSignedInt(T val) noexcept
+        static PLAYRHO_CONSTEXPR inline value_type GetFromSignedInt(T val) noexcept
         {
             static_assert(std::is_integral<T>::value, "integral value required");
             static_assert(std::is_signed<T>::value, "must be signed");
@@ -138,7 +138,7 @@ namespace playrho
         
         /// @brief Gets the value from an unsigned integral value.
         template <typename T>
-        static constexpr value_type GetFromUnsignedInt(T val) noexcept
+        static PLAYRHO_CONSTEXPR inline value_type GetFromUnsignedInt(T val) noexcept
         {
             static_assert(std::is_integral<T>::value, "integral value required");
             static_assert(!std::is_signed<T>::value, "must be unsigned");
@@ -149,77 +149,77 @@ namespace playrho
         Fixed() = default;
         
         /// @brief Initializing constructor.
-        constexpr Fixed(long double val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(long double val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        constexpr Fixed(double val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(double val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
 
         /// @brief Initializing constructor.
-        constexpr Fixed(float val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(float val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        constexpr Fixed(unsigned long long val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(unsigned long long val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        constexpr Fixed(unsigned long val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(unsigned long val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr Fixed(unsigned int val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(unsigned int val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        constexpr Fixed(long long val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(long long val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        constexpr Fixed(long val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(long val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr Fixed(int val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(int val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr Fixed(short val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(short val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr Fixed(value_type val, unsigned int fraction) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(value_type val, unsigned int fraction) noexcept:
             m_value{static_cast<value_type>(static_cast<std::uint32_t>(val * ScaleFactor) | fraction)}
         {
             // Intentionally empty.
@@ -227,7 +227,7 @@ namespace playrho
         
         /// @brief Initializing constructor.
         template <typename BT, unsigned int FB>
-        constexpr Fixed(const Fixed<BT, FB> val) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(const Fixed<BT, FB> val) noexcept:
             Fixed(static_cast<long double>(val))
         {
             // Intentionally empty
@@ -237,7 +237,7 @@ namespace playrho
         
         /// @brief Converts the value to the expressed type.
         template <typename T>
-        constexpr T ConvertTo() const noexcept
+        PLAYRHO_CONSTEXPR inline T ConvertTo() const noexcept
         {
             return isnan()? std::numeric_limits<T>::signaling_NaN():
                 !isfinite()? std::numeric_limits<T>::infinity() * getsign():
@@ -245,7 +245,7 @@ namespace playrho
         }
 
         /// @brief Compares this value to the given one.
-        constexpr CmpResult Compare(const Fixed other) const noexcept
+        PLAYRHO_CONSTEXPR inline CmpResult Compare(const Fixed other) const noexcept
         {
             if (isnan() || other.isnan())
             {
@@ -265,94 +265,94 @@ namespace playrho
         // Unary operations
 
         /// @brief Long double operator.
-        explicit constexpr operator long double() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator long double() const noexcept
         {
             return ConvertTo<long double>();
         }
         
         /// @brief Double operator.
-        explicit constexpr operator double() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator double() const noexcept
         {
             return ConvertTo<double>();
         }
         
         /// @brief Float operator.
-        explicit constexpr operator float() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator float() const noexcept
         {
             return ConvertTo<float>();
         }
     
         /// @brief Long long operator.
-        explicit constexpr operator long long() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator long long() const noexcept
         {
             return m_value / ScaleFactor;
         }
         
         /// @brief Long operator.
-        explicit constexpr operator long() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator long() const noexcept
         {
             return m_value / ScaleFactor;
         }
 
         /// @brief Unsigned long long operator.
-        explicit constexpr operator unsigned long long() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator unsigned long long() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned long long>(m_value / ScaleFactor);
         }
 
         /// @brief Unsigned long operator.
-        explicit constexpr operator unsigned long() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator unsigned long() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned long>(m_value / ScaleFactor);
         }
         
         /// @brief Unsigned int operator.
-        explicit constexpr operator unsigned int() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator unsigned int() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned int>(m_value / ScaleFactor);
         }
 
         /// @brief int operator.
-        explicit constexpr operator int() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator int() const noexcept
         {
             return static_cast<int>(m_value / ScaleFactor);
         }
         
         /// @brief short operator.
-        explicit constexpr operator short() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator short() const noexcept
         {
             return static_cast<short>(m_value / ScaleFactor);
         }
         
         /// @brief Negation operator.
-        constexpr Fixed operator- () const noexcept
+        PLAYRHO_CONSTEXPR inline Fixed operator- () const noexcept
         {
             return (isnan())? *this: Fixed{-m_value, scalar_type{1}};
         }
         
         /// @brief Positive operator.
-        constexpr Fixed operator+ () const noexcept
+        PLAYRHO_CONSTEXPR inline Fixed operator+ () const noexcept
         {
             return *this;
         }
         
         /// @brief bool operator.
-        explicit constexpr operator bool() const noexcept
+        explicit PLAYRHO_CONSTEXPR inline operator bool() const noexcept
         {
             return m_value != 0;
         }
         
         /// @brief Logical not operator.
-        constexpr bool operator! () const noexcept
+        PLAYRHO_CONSTEXPR inline bool operator! () const noexcept
         {
             return m_value == 0;
         }
         
         /// @brief Addition assignment operator.
-        constexpr Fixed& operator+= (Fixed val) noexcept
+        PLAYRHO_CONSTEXPR inline Fixed& operator+= (Fixed val) noexcept
         {
             if (isnan() || val.isnan()
                 || ((m_value == GetInfinity().m_value) && (val.m_value == GetNegativeInfinity().m_value))
@@ -391,7 +391,7 @@ namespace playrho
         }
 
         /// @brief Subtraction assignment operator.
-        constexpr Fixed& operator-= (Fixed val) noexcept
+        PLAYRHO_CONSTEXPR inline Fixed& operator-= (Fixed val) noexcept
         {
             if (isnan() || val.isnan()
                 || ((m_value == GetInfinity().m_value) && (val.m_value == GetInfinity().m_value))
@@ -430,7 +430,7 @@ namespace playrho
         }
 
         /// @brief Multiplication assignment operator.
-        constexpr Fixed& operator*= (Fixed val) noexcept
+        PLAYRHO_CONSTEXPR inline Fixed& operator*= (Fixed val) noexcept
         {
             if (isnan() || val.isnan())
             {
@@ -476,7 +476,7 @@ namespace playrho
         }
 
         /// @brief Division assignment operator.
-        constexpr Fixed& operator/= (Fixed val) noexcept
+        PLAYRHO_CONSTEXPR inline Fixed& operator/= (Fixed val) noexcept
         {
             if (isnan() || val.isnan())
             {
@@ -523,7 +523,7 @@ namespace playrho
         }
         
         /// @brief Modulo operator.
-        constexpr Fixed& operator%= (Fixed val) noexcept
+        PLAYRHO_CONSTEXPR inline Fixed& operator%= (Fixed val) noexcept
         {
             assert(!isnan());
             assert(!val.isnan());
@@ -533,20 +533,20 @@ namespace playrho
         }
         
         /// @brief Is finite.
-        constexpr bool isfinite() const noexcept
+        PLAYRHO_CONSTEXPR inline bool isfinite() const noexcept
         {
             return (m_value > GetNegativeInfinity().m_value)
             && (m_value < GetInfinity().m_value);
         }
         
         /// @brief Is NaN.
-        constexpr bool isnan() const noexcept
+        PLAYRHO_CONSTEXPR inline bool isnan() const noexcept
         {
             return m_value == GetNaN().m_value;
         }
         
         /// @brief Gets this value's sign.
-        constexpr int getsign() const noexcept
+        PLAYRHO_CONSTEXPR inline int getsign() const noexcept
         {
             return (m_value >= 0)? +1: -1;
         }
@@ -569,7 +569,7 @@ namespace playrho
         using numeric_limits = std::numeric_limits<value_type>;
         
         /// @brief Initializing constructor.
-        constexpr Fixed(value_type val, scalar_type scalar) noexcept:
+        PLAYRHO_CONSTEXPR inline Fixed(value_type val, scalar_type scalar) noexcept:
             m_value{val * scalar.value}
         {
             // Intentionally empty.
@@ -580,35 +580,35 @@ namespace playrho
 
     /// @brief Equality operator.
     template <typename BT, unsigned int FB>
-    constexpr bool operator== (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
     template <typename BT, unsigned int FB>
-    constexpr bool operator!= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed<BT, FB>::CmpResult::Equal;
     }
     
     /// @brief Less-than operator.
     template <typename BT, unsigned int FB>
-    constexpr bool operator< (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator< (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::LessThan;
     }
 
     /// @brief Greater-than operator.
     template <typename BT, unsigned int FB>
-    constexpr bool operator> (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator> (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::GreaterThan;
     }
     
     /// @brief Less-than or equal-to operator.
     template <typename BT, unsigned int FB>
-    constexpr bool operator<= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator<= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed<BT, FB>::CmpResult::LessThan ||
@@ -617,7 +617,7 @@ namespace playrho
     
     /// @brief Greater-than or equal-to operator.
     template <typename BT, unsigned int FB>
-    constexpr bool operator>= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator>= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed<BT, FB>::CmpResult::GreaterThan || result == Fixed<BT, FB>::CmpResult::Equal;
@@ -625,7 +625,7 @@ namespace playrho
 
     /// @brief Addition operator.
     template <typename BT, unsigned int FB>
-    constexpr Fixed<BT, FB> operator+ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator+ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs += rhs;
         return lhs;
@@ -633,7 +633,7 @@ namespace playrho
     
     /// @brief Subtraction operator.
     template <typename BT, unsigned int FB>
-    constexpr Fixed<BT, FB> operator- (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator- (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
@@ -641,7 +641,7 @@ namespace playrho
     
     /// @brief Multiplication operator.
     template <typename BT, unsigned int FB>
-    constexpr Fixed<BT, FB> operator* (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator* (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
@@ -649,7 +649,7 @@ namespace playrho
     
     /// @brief Division operator.
     template <typename BT, unsigned int FB>
-    constexpr Fixed<BT, FB> operator/ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator/ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
@@ -657,7 +657,7 @@ namespace playrho
     
     /// @brief Modulo operator.
     template <typename BT, unsigned int FB>
-    constexpr Fixed<BT, FB> operator% (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator% (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
@@ -727,7 +727,7 @@ namespace playrho
     
     /// @brief Gets whether the given value is not-a-number.
     template <typename BT, unsigned int FB>
-    constexpr inline bool IsNan(Fixed<BT, FB> value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsNan(Fixed<BT, FB> value) noexcept
     {
         return value.Compare(0) == Fixed<BT, FB>::CmpResult::Incomparable;
     }
@@ -753,14 +753,14 @@ namespace playrho
     /// odd results like a divide by zero trap occurring.
     /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
     template <typename BT, unsigned int FB>
-    constexpr inline bool AlmostZero(Fixed<BT, FB> value)
+    PLAYRHO_CONSTEXPR inline bool AlmostZero(Fixed<BT, FB> value)
     {
         return value == 0;
     }
 
     /// @brief Determines whether the given two values are "almost equal".
     template <typename BT, unsigned int FB>
-    constexpr inline bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
+    PLAYRHO_CONSTEXPR inline bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
     {
         return Abs(x - y) <= Fixed<BT, FB>{0, static_cast<std::uint32_t>(ulp)};
     }
@@ -768,7 +768,7 @@ namespace playrho
 #ifdef CONFLICT_WITH_GETINVALID
     /// @brief Gets an invalid value.
     template <typename BT, unsigned int FB>
-    constexpr Fixed<BT, FB> GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> GetInvalid() noexcept
     {
         return Fixed<BT, FB>::GetNaN();
     }
@@ -793,81 +793,81 @@ namespace playrho
     
     /// @brief Gets an invalid value.
     template <>
-    constexpr Fixed32 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Fixed32 GetInvalid() noexcept
     {
         return Fixed32::GetNaN();
     }
     
     /// @brief Addition operator.
-    constexpr Fixed32 operator+ (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed32 operator+ (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs += rhs;
         return lhs;
     }
 
     /// @brief Subtraction operator.
-    constexpr Fixed32 operator- (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed32 operator- (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
     }
     
     /// @brief Multiplication operator.
-    constexpr Fixed32 operator* (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed32 operator* (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
     }
     
     /// @brief Division operator.
-    constexpr Fixed32 operator/ (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed32 operator/ (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
     }
     
     /// @brief Modulo operator.
-    constexpr Fixed32 operator% (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed32 operator% (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
     }    
     
     /// @brief Equality operator.
-    constexpr bool operator== (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed32::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
-    constexpr bool operator!= (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed32::CmpResult::Equal;
     }
     
     /// @brief Less-than or equal-to operator.
-    constexpr bool operator <= (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator <= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed32::CmpResult::LessThan) || (result == Fixed32::CmpResult::Equal);
     }
     
     /// @brief Greater-than or equal-to operator.
-    constexpr bool operator >= (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator >= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed32::CmpResult::GreaterThan) || (result == Fixed32::CmpResult::Equal);
     }
     
     /// @brief Less-than operator.
-    constexpr bool operator < (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator < (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed32::CmpResult::LessThan;
     }
     
     /// @brief Greater-than operator.
-    constexpr bool operator > (Fixed32 lhs, Fixed32 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator > (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed32::CmpResult::GreaterThan;
@@ -891,76 +891,76 @@ namespace playrho
     
     /// @brief Gets an invalid value.
     template <>
-    constexpr Fixed64 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Fixed64 GetInvalid() noexcept
     {
         return Fixed64::GetNaN();
     }
 
     /// @brief Addition operator.
-    constexpr Fixed64 operator+ (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed64 operator+ (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs += rhs;
         return lhs;
     }
     
     /// @brief Subtraction operator.
-    constexpr Fixed64 operator- (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed64 operator- (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
     }
     
     /// @brief Multiplication operator.
-    constexpr Fixed64 operator* (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed64 operator* (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
     }
     
     /// @brief Division operator.
-    constexpr Fixed64 operator/ (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed64 operator/ (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
     }
     
-    constexpr Fixed64 operator% (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline Fixed64 operator% (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
     }
     
     /// @brief Equality operator.
-    constexpr bool operator== (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed64::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
-    constexpr bool operator!= (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed64::CmpResult::Equal;
     }
     
-    constexpr bool operator <= (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator <= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed64::CmpResult::LessThan) || (result == Fixed64::CmpResult::Equal);
     }
     
-    constexpr bool operator >= (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator >= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed64::CmpResult::GreaterThan) || (result == Fixed64::CmpResult::Equal);
     }
     
-    constexpr bool operator < (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator < (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed64::CmpResult::LessThan;
     }
     
-    constexpr bool operator > (Fixed64 lhs, Fixed64 rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator > (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed64::CmpResult::GreaterThan;
@@ -1043,76 +1043,76 @@ namespace std
     class numeric_limits<playrho::Fixed<BT,FB>>
     {
     public:
-        static constexpr bool is_specialized = true; ///< Type is specialized.
+        static PLAYRHO_CONSTEXPR const bool is_specialized = true; ///< Type is specialized.
         
         /// @brief Gets the min value available for the type.
-        static constexpr playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
 
         /// @brief Gets the max value available for the type.
-        static constexpr playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
 
         /// @brief Gets the lowest value available for the type.
-        static constexpr playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
         
         /// @brief Number of radix digits that can be represented.
-        static constexpr int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
+        static PLAYRHO_CONSTEXPR const int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
 
         /// @brief Number of decimal digits that can be represented.
-        static constexpr int digits10 = playrho::Fixed<BT,FB>::WholeBits - 1;
+        static PLAYRHO_CONSTEXPR const int digits10 = playrho::Fixed<BT,FB>::WholeBits - 1;
         
         /// @brief Number of decimal digits necessary to differentiate all values.
-        static constexpr int max_digits10 = 5; // TODO(lou): check this
+        static PLAYRHO_CONSTEXPR const int max_digits10 = 5; // TODO(lou): check this
         
-        static constexpr bool is_signed = true; ///< Identifies signed types.
-        static constexpr bool is_integer = false; ///< Identifies integer types.
-        static constexpr bool is_exact = true; ///< Identifies exact type.
-        static constexpr int radix = 0; ///< Radix used by the type.
+        static PLAYRHO_CONSTEXPR const bool is_signed = true; ///< Identifies signed types.
+        static PLAYRHO_CONSTEXPR const bool is_integer = false; ///< Identifies integer types.
+        static PLAYRHO_CONSTEXPR const bool is_exact = true; ///< Identifies exact type.
+        static PLAYRHO_CONSTEXPR const int radix = 0; ///< Radix used by the type.
 
         /// @brief Gets the epsilon value for the type.
-        static constexpr playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
         
         /// @brief Gets the round error value for the type.
-        static constexpr playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
         
         /// @brief One more than smallest negative power of the radix that's a valid
         ///    normalized floating-point value.
-        static constexpr int min_exponent = 0;
+        static PLAYRHO_CONSTEXPR const int min_exponent = 0;
 
         /// @brief Smallest negative power of ten that's a valid normalized floating-point value.
-        static constexpr int min_exponent10 = 0;
+        static PLAYRHO_CONSTEXPR const int min_exponent10 = 0;
         
         /// @brief One more than largest integer power of radix that's a valid finite
         ///   floating-point value.
-        static constexpr int max_exponent = 0;
+        static PLAYRHO_CONSTEXPR const int max_exponent = 0;
         
         /// @brief Largest integer power of 10 that's a valid finite floating-point value.
-        static constexpr int max_exponent10 = 0;
+        static PLAYRHO_CONSTEXPR const int max_exponent10 = 0;
         
-        static constexpr bool has_infinity = true; ///< Whether can represent infinity.
-        static constexpr bool has_quiet_NaN = true; ///< Whether can represent quiet-NaN.
-        static constexpr bool has_signaling_NaN = false; ///< Whether can represent signaling-NaN.
-        static constexpr float_denorm_style has_denorm = denorm_absent; ///< Denorm style used.
-        static constexpr bool has_denorm_loss = false; ///< Has denorm loss amount.
+        static PLAYRHO_CONSTEXPR const bool has_infinity = true; ///< Whether can represent infinity.
+        static PLAYRHO_CONSTEXPR const bool has_quiet_NaN = true; ///< Whether can represent quiet-NaN.
+        static PLAYRHO_CONSTEXPR const bool has_signaling_NaN = false; ///< Whether can represent signaling-NaN.
+        static PLAYRHO_CONSTEXPR const float_denorm_style has_denorm = denorm_absent; ///< Denorm style used.
+        static PLAYRHO_CONSTEXPR const bool has_denorm_loss = false; ///< Has denorm loss amount.
 
         /// @brief Gets the infinite value for the type.
-        static constexpr playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
         
         /// @brief Gets the quiet NaN value for the type.
-        static constexpr playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
 
         /// @brief Gets the signaling NaN value for the type.
-        static constexpr playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
         
         /// @brief Gets the denorm value for the type.
-        static constexpr playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
         
-        static constexpr bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
-        static constexpr bool is_bounded = true; ///< Type bounded: has limited precision.
-        static constexpr bool is_modulo = false; ///< Doesn't modulo arithmetic overflows.
+        static PLAYRHO_CONSTEXPR const bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
+        static PLAYRHO_CONSTEXPR const bool is_bounded = true; ///< Type bounded: has limited precision.
+        static PLAYRHO_CONSTEXPR const bool is_modulo = false; ///< Doesn't modulo arithmetic overflows.
         
-        static constexpr bool traps = false; ///< Doesn't do traps.
-        static constexpr bool tinyness_before = false; ///< Doesn't detect tinyness before rounding.
-        static constexpr float_round_style round_style = round_toward_zero; ///< Rounds down.
+        static PLAYRHO_CONSTEXPR const bool traps = false; ///< Doesn't do traps.
+        static PLAYRHO_CONSTEXPR const bool tinyness_before = false; ///< Doesn't detect tinyness before rounding.
+        static PLAYRHO_CONSTEXPR const float_round_style round_style = round_toward_zero; ///< Rounds down.
     };
     
 } // namespace std

--- a/PlayRho/Common/GrowableStack.hpp
+++ b/PlayRho/Common/GrowableStack.hpp
@@ -42,13 +42,13 @@ public:
     using CountType = std::size_t;
 
     /// @brief Gets the initial capacity.
-    static constexpr auto GetInitialCapacity() noexcept
+    static PLAYRHO_CONSTEXPR inline auto GetInitialCapacity() noexcept
     {
         return CountType(N);
     }
     
     /// @brief Gets the buffer growth rate.
-    static constexpr auto GetBufferGrowthRate() noexcept
+    static PLAYRHO_CONSTEXPR inline auto GetBufferGrowthRate() noexcept
     {
         return CountType{2};
     }
@@ -108,19 +108,19 @@ public:
     }
 
     /// @brief Gets the current size in numbers of elements.
-    constexpr CountType size() const noexcept
+    PLAYRHO_CONSTEXPR inline CountType size() const noexcept
     {
         return m_count;
     }
     
     /// @brief Gets the capacity in number of elements.
-    constexpr CountType capacity() const noexcept
+    PLAYRHO_CONSTEXPR inline CountType capacity() const noexcept
     {
         return m_capacity;
     }
 
     /// @brief Whether this stack is empty.
-    constexpr bool empty() const noexcept
+    PLAYRHO_CONSTEXPR inline bool empty() const noexcept
     {
         return m_count == 0;
     }

--- a/PlayRho/Common/Interval.hpp
+++ b/PlayRho/Common/Interval.hpp
@@ -51,7 +51,7 @@ namespace playrho {
         /// @brief Gets the "lowest" value supported by the <code>value_type</code>.
         /// @return Negative infinity if supported by the value type, limits::lowest()
         ///   otherwise.
-        static constexpr value_type GetLowest() noexcept
+        static PLAYRHO_CONSTEXPR inline value_type GetLowest() noexcept
         {
             return (limits::has_infinity)? -limits::infinity(): limits::lowest();
         }
@@ -59,7 +59,7 @@ namespace playrho {
         /// @brief Gets the "highest" value supported by the <code>value_type</code>.
         /// @return Positive infinity if supported by the value type, limits::max()
         ///   otherwise.
-        static constexpr value_type GetHighest() noexcept
+        static PLAYRHO_CONSTEXPR inline value_type GetHighest() noexcept
         {
             return (limits::has_infinity)? limits::infinity(): limits::max();
         }
@@ -68,36 +68,36 @@ namespace playrho {
         /// @details Constructs an "unset" interval.
         /// @post <code>GetMin()</code> returns the value of <code>GetHighest()</code>.
         /// @post <code>GetMax()</code> returns the value of <code>GetLowest()</code>.
-        constexpr Interval() = default;
+        PLAYRHO_CONSTEXPR inline Interval() = default;
         
         /// @brief Copy constructor.
         /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
         /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-        constexpr Interval(const Interval& other) = default;
+        PLAYRHO_CONSTEXPR inline Interval(const Interval& other) = default;
 
         /// @brief Move constructor.
         /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
         /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-        constexpr Interval(Interval&& other) = default;
+        PLAYRHO_CONSTEXPR inline Interval(Interval&& other) = default;
         
         /// @brief Initializing constructor.
         /// @post <code>GetMin()</code> returns the value of <code>v</code>.
         /// @post <code>GetMax()</code> returns the value of <code>v</code>.
-        constexpr explicit Interval(const value_type& v) noexcept:
+        PLAYRHO_CONSTEXPR inline explicit Interval(const value_type& v) noexcept:
             Interval(pair_type{v, v})
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr Interval(const value_type& a, const value_type& b) noexcept:
+        PLAYRHO_CONSTEXPR inline Interval(const value_type& a, const value_type& b) noexcept:
             Interval(std::minmax(a, b))
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr Interval(const std::initializer_list<T> ilist) noexcept:
+        PLAYRHO_CONSTEXPR inline Interval(const std::initializer_list<T> ilist) noexcept:
             Interval(std::minmax(ilist))
         {
             // Intentionally empty.
@@ -118,7 +118,7 @@ namespace playrho {
         /// @brief Moves the interval by the given amount.
         /// @warning Behavior is undefined if incrementing the min or max value by
         ///   the given amount overflows the finite range of the <code>value_type</code>,
-        constexpr Interval& Move(const value_type& v) noexcept
+        PLAYRHO_CONSTEXPR inline Interval& Move(const value_type& v) noexcept
         {
             m_min += v;
             m_max += v;
@@ -126,13 +126,13 @@ namespace playrho {
         }
 
         /// @brief Gets the minimum value of this range.
-        constexpr value_type GetMin() const noexcept
+        PLAYRHO_CONSTEXPR inline value_type GetMin() const noexcept
         {
             return m_min;
         }
 
         /// @brief Gets the maximum value of this range.
-        constexpr value_type GetMax() const noexcept
+        PLAYRHO_CONSTEXPR inline value_type GetMax() const noexcept
         {
             return m_max;
         }
@@ -142,7 +142,7 @@ namespace playrho {
         ///   will be the given value.
         /// @param v Value to "include" into this value.
         /// @post This value's "min" is the minimum of the given value and this value's "min".
-        constexpr Interval& Include(const value_type& v) noexcept
+        PLAYRHO_CONSTEXPR inline Interval& Include(const value_type& v) noexcept
         {
             m_min = std::min(v, GetMin());
             m_max = std::max(v, GetMax());
@@ -155,7 +155,7 @@ namespace playrho {
         /// @param v Value to "include" into this value.
         /// @post This value's "min" is the minimum of the given value's "min" and
         ///   this value's "min".
-        constexpr Interval& Include(const Interval& v) noexcept
+        PLAYRHO_CONSTEXPR inline Interval& Include(const Interval& v) noexcept
         {
             m_min = std::min(v.GetMin(), GetMin());
             m_max = std::max(v.GetMax(), GetMax());
@@ -163,7 +163,7 @@ namespace playrho {
         }
         
         /// @brief Intersects this interval with the given interval.
-        constexpr Interval& Intersect(const Interval& v) noexcept
+        PLAYRHO_CONSTEXPR inline Interval& Intersect(const Interval& v) noexcept
         {
             const auto min = std::max(v.GetMin(), GetMin());
             const auto max = std::min(v.GetMax(), GetMax());
@@ -178,7 +178,7 @@ namespace playrho {
         /// @param v Amount to expand this interval by.
         /// @warning Behavior is undefined if expanding the range by
         ///   the given amount overflows the range of the <code>value_type</code>,
-        constexpr Interval& Expand(const value_type& v) noexcept
+        PLAYRHO_CONSTEXPR inline Interval& Expand(const value_type& v) noexcept
         {
             if (v < value_type{})
             {
@@ -198,7 +198,7 @@ namespace playrho {
         /// @param v Amount to expand both ends of this interval by.
         /// @warning Behavior is undefined if expanding the range by
         ///   the given amount overflows the range of the <code>value_type</code>,
-        constexpr Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
+        PLAYRHO_CONSTEXPR inline Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
         {
             const auto amount = value_type{v};
             m_min -= amount;
@@ -211,7 +211,7 @@ namespace playrho {
         using pair_type = std::pair<value_type, value_type>;
         
         /// @brief Internal pair type accepting constructor.
-        constexpr explicit Interval(pair_type pair) noexcept:
+        PLAYRHO_CONSTEXPR inline explicit Interval(pair_type pair) noexcept:
             m_min{pair.first}, m_max{pair.second}
         {
             // Intentionally empty.
@@ -227,7 +227,7 @@ namespace playrho {
     ///   max and min values overflows the range of the <code>Interval::value_type</code>.
     /// @return Non-negative value unless the given interval is "unset" or invalid.
     template <typename T>
-    constexpr T GetSize(const Interval<T>& v) noexcept
+    PLAYRHO_CONSTEXPR inline T GetSize(const Interval<T>& v) noexcept
     {
         return v.GetMax() - v.GetMin();
     }
@@ -237,7 +237,7 @@ namespace playrho {
     ///   max and min values overflows the range of the <code>Interval::value_type</code>.
     /// @relatedalso Interval
     template <typename T>
-    constexpr T GetCenter(const Interval<T>& v) noexcept
+    PLAYRHO_CONSTEXPR inline T GetCenter(const Interval<T>& v) noexcept
     {
         // Rounding may cause issues...
         return (v.GetMin() + v.GetMax()) / 2;
@@ -246,7 +246,7 @@ namespace playrho {
     /// @brief Checks whether two value ranges have any intersection/overlap at all.
     /// @relatedalso Interval
     template <typename T>
-    constexpr bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
     {
         const auto maxOfMins = std::max(a.GetMin(), b.GetMin());
         const auto minOfMaxs = std::min(a.GetMax(), b.GetMax());
@@ -256,28 +256,28 @@ namespace playrho {
     /// @brief Gets the intersecting interval of two given ranges.
     /// @relatedalso Interval
     template <typename T>
-    constexpr Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
+    PLAYRHO_CONSTEXPR inline Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
     {
         return a.Intersect(b);
     }
     
     /// @brief Determines whether the first range is entirely before the second range.
     template <typename T>
-    constexpr bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
+    PLAYRHO_CONSTEXPR inline bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
     {
         return a.GetMax() < b.GetMin();
     }
     
     /// @brief Determines whether the first range is entirely after the second range.
     template <typename T>
-    constexpr bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
+    PLAYRHO_CONSTEXPR inline bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
     {
         return a.GetMin() > b.GetMax();
     }
     
     /// @brief Determines whether the first range entirely encloses the second.
     template <typename T>
-    constexpr bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
+    PLAYRHO_CONSTEXPR inline bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
     {
         return a.GetMin() <= b.GetMin() && a.GetMax() >= b.GetMax();
     }
@@ -287,7 +287,7 @@ namespace playrho {
     /// @relatedalso Interval
     /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
     template <typename T>
-    constexpr bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
     {
         return (a.GetMin() == b.GetMin()) && (a.GetMax() == b.GetMax());
     }
@@ -297,7 +297,7 @@ namespace playrho {
     /// @relatedalso Interval
     /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
     template <typename T>
-    constexpr bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
     {
         return !(a == b);
     }
@@ -313,7 +313,7 @@ namespace playrho {
     /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
     /// @sa http://en.cppreference.com/w/cpp/concept/LessThanComparable
     template <typename T>
-    constexpr bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
     {
         return (lhs.GetMin() < rhs.GetMin()) ||
             (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() < rhs.GetMax());
@@ -325,7 +325,7 @@ namespace playrho {
     /// @relatedalso Interval
     /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
     template <typename T>
-    constexpr bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
     {
         return (lhs.GetMin() < rhs.GetMin()) ||
             (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() <= rhs.GetMax());
@@ -337,7 +337,7 @@ namespace playrho {
     /// @relatedalso Interval
     /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
     template <typename T>
-    constexpr bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
     {
         return (lhs.GetMin() > rhs.GetMin()) ||
             (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() > rhs.GetMax());
@@ -349,7 +349,7 @@ namespace playrho {
     /// @relatedalso Interval
     /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
     template <typename T>
-    constexpr bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
     {
         return (lhs.GetMin() > rhs.GetMin()) ||
             (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() >= rhs.GetMax());

--- a/PlayRho/Common/InvalidArgument.hpp
+++ b/PlayRho/Common/InvalidArgument.hpp
@@ -21,6 +21,7 @@
 #ifndef PLAYRHO_COMMON_INVALIDARGUMENT_HPP
 #define PLAYRHO_COMMON_INVALIDARGUMENT_HPP
 
+#include <PlayRho/Defines.hpp>
 #include <stdexcept>
 
 namespace playrho {

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -44,49 +44,49 @@ namespace playrho
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-constexpr auto& GetX(T& value)
+PLAYRHO_CONSTEXPR inline auto& GetX(T& value)
 {
     return Get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-constexpr auto& GetY(T& value)
+PLAYRHO_CONSTEXPR inline auto& GetY(T& value)
 {
     return Get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-constexpr auto& GetZ(T& value)
+PLAYRHO_CONSTEXPR inline auto& GetZ(T& value)
 {
     return Get<2>(value);
 }
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-constexpr inline auto GetX(const T& value)
+PLAYRHO_CONSTEXPR inline auto GetX(const T& value)
 {
     return Get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-constexpr inline auto GetY(const T& value)
+PLAYRHO_CONSTEXPR inline auto GetY(const T& value)
 {
     return Get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-constexpr inline auto GetZ(const T& value)
+PLAYRHO_CONSTEXPR inline auto GetZ(const T& value)
 {
     return Get<2>(value);
 }
 
 /// @brief Strips the unit from the given value.
 template <typename T, LoValueCheck lo, HiValueCheck hi>
-constexpr inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
+PLAYRHO_CONSTEXPR inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
 {
     return StripUnit(v.get());
 }
@@ -100,7 +100,7 @@ constexpr inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
 /// @brief Secant method.
 /// @sa https://en.wikipedia.org/wiki/Secant_method
 template <typename T, typename U>
-constexpr inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
+PLAYRHO_CONSTEXPR inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
 {
     static_assert(IsArithmetic<T>::value && IsArithmetic<U>::value, "Arithmetic types required.");
     return (a1 + (target - s1) * (a2 - a1) / (s2 - s1));
@@ -109,7 +109,7 @@ constexpr inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
 /// @brief Bisection method.
 /// @sa https://en.wikipedia.org/wiki/Bisection_method
 template <typename T>
-constexpr inline T Bisect(T a1, T a2) noexcept
+PLAYRHO_CONSTEXPR inline T Bisect(T a1, T a2) noexcept
 {
     return (a1 + a2) / 2;
 }
@@ -117,7 +117,7 @@ constexpr inline T Bisect(T a1, T a2) noexcept
 /// @brief Is-odd.
 /// @details Determines whether the given integral value is odd (as opposed to being even).
 template <typename T>
-constexpr inline bool IsOdd(T val) noexcept
+PLAYRHO_CONSTEXPR inline bool IsOdd(T val) noexcept
 {
     static_assert(std::is_integral<T>::value, "Integral type required.");
     return val % 2;
@@ -125,7 +125,7 @@ constexpr inline bool IsOdd(T val) noexcept
 
 /// @brief Squares the given value.
 template<class TYPE>
-constexpr inline auto Square(TYPE t) noexcept { return t * t; }
+PLAYRHO_CONSTEXPR inline auto Square(TYPE t) noexcept { return t * t; }
 
 /// @brief Square root's the given value.
 template<typename T>
@@ -244,7 +244,7 @@ inline auto Average(Span<const T> span)
 
     // Relies on C++11 zero initialization to zero initialize value_type.
     // See: http://en.cppreference.com/w/cpp/language/zero_initialization
-    constexpr auto zero = value_type{};
+    PLAYRHO_CONSTEXPR const auto zero = value_type{};
     assert(zero * Real{2} == zero);
     
     // For C++17, switch from using std::accumulate to using std::reduce.
@@ -269,7 +269,7 @@ inline Vec2 RoundOff(Vec2 value, std::uint32_t precision = 100000)
 }
 
 /// @brief Gets a Vec2 representation of the given value.
-constexpr inline Vec2 GetVec2(const UnitVec2 value)
+PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const UnitVec2 value)
 {
     return Vec2{Get<0>(value), Get<1>(value)};
 }
@@ -279,7 +279,7 @@ constexpr inline Vec2 GetVec2(const UnitVec2 value)
 /// odd results like a divide by zero trap occurring.
 /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
 template <typename T>
-constexpr typename std::enable_if<std::is_arithmetic<T>::value, bool>::type
+PLAYRHO_CONSTEXPR inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type
 AlmostZero(T value)
 {
     return Abs(value) < std::numeric_limits<T>::min();
@@ -287,7 +287,7 @@ AlmostZero(T value)
 
 /// @brief Determines whether the given two values are "almost equal".
 template <typename T>
-constexpr inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+PLAYRHO_CONSTEXPR inline typename std::enable_if<std::is_floating_point<T>::value, bool>::type
 AlmostEqual(T x, T y, int ulp = 2)
 {
     // From http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon :
@@ -327,7 +327,7 @@ inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
 /// @sa Atan2
 inline Angle GetNormalized(Angle value) noexcept
 {
-    constexpr auto oneRotationInRadians = Real{2 * Pi};
+    PLAYRHO_CONSTEXPR const auto oneRotationInRadians = Real{2 * Pi};
     auto angleInRadians = Real{value / Radian};
 #if defined(NORMALIZE_ANGLE_VIA_FMOD)
     // Note: std::fmod appears slower than std::trunc.
@@ -391,7 +391,7 @@ inline Angle GetAngle(const Vector2<T> value)
 /// @note For performance, use this instead of GetMagnitude(T value) (if possible).
 /// @return Non-negative value.
 template <typename T>
-constexpr inline auto GetMagnitudeSquared(T value) noexcept
+PLAYRHO_CONSTEXPR inline auto GetMagnitudeSquared(T value) noexcept
 {
     using VT = typename T::value_type;
     using OT = decltype(VT{} * VT{});
@@ -436,9 +436,11 @@ inline auto GetMagnitude(T value)
 /// @return Dot product of the vectors (0 means the two vectors are perpendicular).
 ///
 template <typename T1, typename T2>
-constexpr auto Dot(const T1 a, const T2 b) noexcept
+PLAYRHO_CONSTEXPR inline auto Dot(const T1 a, const T2 b) noexcept
 {
-    static_assert(a.size() == b.size(), "Dot only for same sized values");
+    //static_assert(a.size() == b.size(), "Dot only for same sized values");
+    assert(a.size() == b.size());
+    
     using VT1 = typename T1::value_type;
     using VT2 = typename T2::value_type;
     using OT = decltype(VT1{} * VT2{});
@@ -483,7 +485,7 @@ constexpr auto Dot(const T1 a, const T2 b) noexcept
 ///
 template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
-constexpr auto Cross(T1 a, T2 b) noexcept
+PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
 {
     assert(IsFinite(StripUnit(Get<0>(a))));
     assert(IsFinite(StripUnit(Get<1>(a))));
@@ -515,7 +517,7 @@ constexpr auto Cross(T1 a, T2 b) noexcept
 /// @return Cross product of the two values.
 template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 3 && std::tuple_size<T2>::value == 3, int> = 0>
-constexpr auto Cross(T1 a, T2 b) noexcept
+PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
 {
     assert(IsFinite(Get<0>(a)));
     assert(IsFinite(Get<1>(a)));
@@ -535,7 +537,7 @@ constexpr auto Cross(T1 a, T2 b) noexcept
 /// @brief Solves A * x = b, where b is a column vector.
 /// @note This is more efficient than computing the inverse in one-shot cases.
 template <typename T, typename U>
-constexpr auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
+PLAYRHO_CONSTEXPR inline auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
 {
     const auto cp = Cross(Get<0>(mat), Get<1>(mat));
     using OutType = decltype((U{} * T{}) / cp);
@@ -548,7 +550,7 @@ constexpr auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
 
 /// @brief Inverts the given value.
 template <class IN_TYPE>
-constexpr auto Invert(const Matrix22<IN_TYPE> value) noexcept
+PLAYRHO_CONSTEXPR inline auto Invert(const Matrix22<IN_TYPE> value) noexcept
 {
     const auto cp = Cross(Get<0>(value), Get<1>(value));
     using OutType = decltype(Get<0>(value)[0] / cp);
@@ -562,7 +564,7 @@ constexpr auto Invert(const Matrix22<IN_TYPE> value) noexcept
 
 /// @brief Solves A * x = b, where b is a column vector.
 /// @note This is more efficient than computing the inverse in one-shot cases.
-constexpr Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
+PLAYRHO_CONSTEXPR inline Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
 {
     const auto dp = Dot(GetX(mat), Cross(GetY(mat), GetZ(mat)));
     const auto det = (dp != 0)? 1 / dp: dp;
@@ -576,7 +578,7 @@ constexpr Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
 /// @note This is more efficient than computing the inverse in one-shot cases.
 /// @note Solves only the upper 2-by-2 matrix equation.
 template <typename T>
-constexpr T Solve22(const Mat33& mat, const T b) noexcept
+PLAYRHO_CONSTEXPR inline T Solve22(const Mat33& mat, const T b) noexcept
 {
     const auto cp = GetX(GetX(mat)) * GetY(GetY(mat)) - GetX(GetY(mat)) * GetY(GetX(mat));
     const auto det = (cp != 0)? 1 / cp: cp;
@@ -587,7 +589,7 @@ constexpr T Solve22(const Mat33& mat, const T b) noexcept
 
 /// @brief Gets the inverse of the given matrix as a 2-by-2.
 /// @return Zero matrix if singular.
-constexpr inline Mat33 GetInverse22(const Mat33& value) noexcept
+PLAYRHO_CONSTEXPR inline Mat33 GetInverse22(const Mat33& value) noexcept
 {
     const auto a = GetX(GetX(value)), b = GetX(GetY(value)), c = GetY(GetX(value)), d = GetY(GetY(value));
     auto det = (a * d) - (b * c);
@@ -600,7 +602,7 @@ constexpr inline Mat33 GetInverse22(const Mat33& value) noexcept
     
 /// @brief Gets the symmetric inverse of this matrix as a 3-by-3.
 /// @return Zero matrix if singular.
-constexpr inline Mat33 GetSymInverse33(const Mat33& value) noexcept
+PLAYRHO_CONSTEXPR inline Mat33 GetSymInverse33(const Mat33& value) noexcept
 {
     auto det = Dot(GetX(value), Cross(GetY(value), GetZ(value)));
     if (det != Real{0})
@@ -629,7 +631,7 @@ constexpr inline Mat33 GetSymInverse33(const Mat33& value) noexcept
 /// @return A counter-clockwise 90-degree rotation of the given vector.
 /// @sa GetFwdPerpendicular.
 template <class T>
-constexpr inline auto GetRevPerpendicular(const T vector) noexcept
+PLAYRHO_CONSTEXPR inline auto GetRevPerpendicular(const T vector) noexcept
 {
     // See http://mathworld.wolfram.com/PerpendicularVector.html
     return T{-GetY(vector), GetX(vector)};
@@ -641,7 +643,7 @@ constexpr inline auto GetRevPerpendicular(const T vector) noexcept
 /// @return A clockwise 90-degree rotation of the given vector.
 /// @sa GetRevPerpendicular.
 template <class T>
-constexpr inline auto GetFwdPerpendicular(const T vector) noexcept
+PLAYRHO_CONSTEXPR inline auto GetFwdPerpendicular(const T vector) noexcept
 {
     // See http://mathworld.wolfram.com/PerpendicularVector.html
     return T{GetY(vector), -GetX(vector)};
@@ -649,7 +651,7 @@ constexpr inline auto GetFwdPerpendicular(const T vector) noexcept
 
 /// Multiply a matrix times a vector. If a rotation matrix is provided,
 /// then this transforms the vector from one frame to another.
-constexpr inline Vec2 Transform(const Vec2 v, const Mat22& A) noexcept
+PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat22& A) noexcept
 {
     return Vec2{
         Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
@@ -658,7 +660,7 @@ constexpr inline Vec2 Transform(const Vec2 v, const Mat22& A) noexcept
 }
 
 #ifdef USE_BOOST_UNITS
-constexpr inline auto Transform(const LinearVelocity2 v, const Mass22& A) noexcept
+PLAYRHO_CONSTEXPR inline auto Transform(const LinearVelocity2 v, const Mass22& A) noexcept
 {
     return Momentum2{
         Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
@@ -666,7 +668,7 @@ constexpr inline auto Transform(const LinearVelocity2 v, const Mass22& A) noexce
     };
 }
 
-constexpr inline auto Transform(const Momentum2 v, const InvMass22 A) noexcept
+PLAYRHO_CONSTEXPR inline auto Transform(const Momentum2 v, const InvMass22 A) noexcept
 {
     return LinearVelocity2{
         Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
@@ -677,53 +679,53 @@ constexpr inline auto Transform(const Momentum2 v, const InvMass22 A) noexcept
 
 /// Multiply a matrix transpose times a vector. If a rotation matrix is provided,
 /// then this transforms the vector from one frame to another (inverse transform).
-constexpr inline Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
+PLAYRHO_CONSTEXPR inline Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
 {
     return Vec2{Dot(v, GetX(A)), Dot(v, GetY(A))};
 }
 
 /// @brief Multiplication operator.
 template <class T, LoValueCheck lo, HiValueCheck hi>
-constexpr inline Vector2<T> operator* (BoundedValue<T, lo, hi> s, UnitVec2 u) noexcept
+PLAYRHO_CONSTEXPR inline Vector2<T> operator* (BoundedValue<T, lo, hi> s, UnitVec2 u) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * T{s}};
 }
 
 /// @brief Multiplication operator.
 template <class T>
-constexpr inline Vector2<T> operator* (const T s, const UnitVec2 u) noexcept
+PLAYRHO_CONSTEXPR inline Vector2<T> operator* (const T s, const UnitVec2 u) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * s};
 }
 
 /// @brief Multiplication operator.
 template <class T, LoValueCheck lo, HiValueCheck hi>
-constexpr inline Vector2<T> operator* (UnitVec2 u, BoundedValue<T, lo, hi> s) noexcept
+PLAYRHO_CONSTEXPR inline Vector2<T> operator* (UnitVec2 u, BoundedValue<T, lo, hi> s) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * T{s}};
 }
 
 /// @brief Multiplication operator.
 template <class T>
-constexpr inline Vector2<T> operator* (const UnitVec2 u, const T s) noexcept
+PLAYRHO_CONSTEXPR inline Vector2<T> operator* (const UnitVec2 u, const T s) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * s};
 }
 
 /// @brief Division operator.
-constexpr inline Vec2 operator/ (const UnitVec2 u, const UnitVec2::value_type s) noexcept
+PLAYRHO_CONSTEXPR inline Vec2 operator/ (const UnitVec2 u, const UnitVec2::value_type s) noexcept
 {
     return Vec2{GetX(u) / s, GetY(u) / s};
 }
 
 /// @brief Computes A * B.
-constexpr inline Mat22 Mul(const Mat22& A, const Mat22& B) noexcept
+PLAYRHO_CONSTEXPR inline Mat22 Mul(const Mat22& A, const Mat22& B) noexcept
 {
     return Mat22{Transform(GetX(B), A), Transform(GetY(B), A)};
 }
 
 /// @brief Computes A^T * B.
-constexpr inline Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
+PLAYRHO_CONSTEXPR inline Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
 {
     const auto c1 = Vec2{Dot(GetX(A), GetX(B)), Dot(GetY(A), GetX(B))};
     const auto c2 = Vec2{Dot(GetX(A), GetY(B)), Dot(GetY(A), GetY(B))};
@@ -731,13 +733,13 @@ constexpr inline Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
 }
 
 /// @brief Multiplies a matrix by a vector.
-constexpr inline Vec3 Transform(const Vec3& v, const Mat33& A) noexcept
+PLAYRHO_CONSTEXPR inline Vec3 Transform(const Vec3& v, const Mat33& A) noexcept
 {
     return (GetX(v) * GetX(A)) + (GetY(v) * GetY(A)) + (GetZ(v) * GetZ(A));
 }
 
 /// @brief Multiplies a matrix by a vector.
-constexpr inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
+PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 {
     return Vec2{
         GetX(GetX(A)) * v[0] + GetX(GetY(A)) * v[1],
@@ -751,7 +753,7 @@ constexpr inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 /// @param angle Expresses the angle to forward rotate the given vector by.
 /// @sa InverseRotate.
 template <class T>
-constexpr inline auto Rotate(const Vector2<T> vector, const UnitVec2& angle) noexcept
+PLAYRHO_CONSTEXPR inline auto Rotate(const Vector2<T> vector, const UnitVec2& angle) noexcept
 {
     const auto newX = (angle.cos() * GetX(vector)) - (angle.sin() * GetY(vector));
     const auto newY = (angle.sin() * GetX(vector)) + (angle.cos() * GetY(vector));
@@ -766,7 +768,7 @@ constexpr inline auto Rotate(const Vector2<T> vector, const UnitVec2& angle) noe
 /// @param angle Expresses the angle to reverse rotate the given vector by.
 /// @sa Rotate.
 template <class T>
-constexpr inline auto InverseRotate(const Vector2<T> vector, const UnitVec2& angle) noexcept
+PLAYRHO_CONSTEXPR inline auto InverseRotate(const Vector2<T> vector, const UnitVec2& angle) noexcept
 {
     const auto newX = (angle.cos() * GetX(vector)) + (angle.sin() * GetY(vector));
     const auto newY = (angle.cos() * GetY(vector)) - (angle.sin() * GetX(vector));
@@ -784,7 +786,7 @@ constexpr inline auto InverseRotate(const Vector2<T> vector, const UnitVec2& ang
 /// @param v 2-D position to transform (to rotate and then translate).
 /// @param xfm Transformation (a translation and rotation) to apply to the given vector.
 /// @return Rotated and translated vector.
-constexpr inline Length2 Transform(const Length2 v, const Transformation xfm) noexcept
+PLAYRHO_CONSTEXPR inline Length2 Transform(const Length2 v, const Transformation xfm) noexcept
 {
     return Rotate(v, xfm.q) + xfm.p;
 }
@@ -799,7 +801,7 @@ constexpr inline Length2 Transform(const Length2 v, const Transformation xfm) no
 /// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
 /// @param T Transformation (a translation and rotation) to inversely apply to the given vector.
 /// @return Inverse transformed vector.
-constexpr inline Length2 InverseTransform(const Length2 v, const Transformation T) noexcept
+PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transformation T) noexcept
 {
     const auto v2 = v - T.p;
     return InverseRotate(v2, T.q);
@@ -808,7 +810,7 @@ constexpr inline Length2 InverseTransform(const Length2 v, const Transformation 
 /// @brief Multiplies a given transformation by another given transformation.
 /// @note v2 = A.q.Rot(B.q.Rot(v1) + B.p) + A.p
 ///          = (A.q * B.q).Rot(v1) + A.q.Rot(B.p) + A.p
-constexpr inline Transformation Mul(const Transformation& A, const Transformation& B) noexcept
+PLAYRHO_CONSTEXPR inline Transformation Mul(const Transformation& A, const Transformation& B) noexcept
 {
     return Transformation{A.p + Rotate(B.p, A.q), A.q.Rotate(B.q)};
 }
@@ -816,7 +818,7 @@ constexpr inline Transformation Mul(const Transformation& A, const Transformatio
 /// @brief Inverse multiplies a given transformation by another given transformation.
 /// @note v2 = A.q' * (B.q * v1 + B.p - A.p)
 ///          = A.q' * B.q * v1 + A.q' * (B.p - A.p)
-constexpr inline Transformation MulT(const Transformation& A, const Transformation& B) noexcept
+PLAYRHO_CONSTEXPR inline Transformation MulT(const Transformation& A, const Transformation& B) noexcept
 {
     const auto dp = B.p - A.p;
     return Transformation{InverseRotate(dp, A.q), B.q.Rotate(A.q.FlipY())};
@@ -847,7 +849,7 @@ inline Mat22 Abs(const Mat22& A)
 /// @param low Lowest value to return or NaN to keep the low-end unbounded.
 /// @param high Highest value to return or NaN to keep the high-end unbounded.
 template <typename T>
-constexpr inline T Clamp(T value, T low, T high) noexcept
+PLAYRHO_CONSTEXPR inline T Clamp(T value, T low, T high) noexcept
 {
     const auto tmp = (value > high)? high: value; // std::isnan(high)? a: Min(a, high);
     return (tmp < low)? low: tmp; // std::isnan(low)? b: Max(b, low);
@@ -871,7 +873,7 @@ inline std::uint64_t NextPowerOfTwo(std::uint64_t x)
 }
 
 /// @brief Gets the transformation for the given values.
-constexpr inline Transformation GetTransformation(const Length2 ctr, const UnitVec2 rot,
+PLAYRHO_CONSTEXPR inline Transformation GetTransformation(const Length2 ctr, const UnitVec2 rot,
                                                   const Length2 localCtr) noexcept
 {
     assert(IsValid(rot));
@@ -975,7 +977,7 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices);
 
 /// @brief Gets the modulo next value.
 template <typename T>
-constexpr inline T GetModuloNext(T value, T count) noexcept
+PLAYRHO_CONSTEXPR inline T GetModuloNext(T value, T count) noexcept
 {
     assert(value < count);
     return (value + 1) % count;
@@ -983,7 +985,7 @@ constexpr inline T GetModuloNext(T value, T count) noexcept
 
 /// @brief Gets the modulo previous value.
 template <typename T>
-constexpr inline T GetModuloPrev(T value, T count) noexcept
+PLAYRHO_CONSTEXPR inline T GetModuloPrev(T value, T count) noexcept
 {
     assert(value < count);
     return (value? value: count) - 1;
@@ -998,7 +1000,7 @@ Angle GetDelta(Angle a1, Angle a2) noexcept;
 
 /// Gets the reverse (counter) clockwise rotational angle to go from angle 1 to angle 2.
 /// @return Angular rotation in the counter clockwise direction to go from angle 1 to angle 2.
-constexpr inline Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
+PLAYRHO_CONSTEXPR inline Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
 {
     return (a1 > a2)? 360_deg - (a1 - a2): a2 - a1;
 }

--- a/PlayRho/Common/Matrix.hpp
+++ b/PlayRho/Common/Matrix.hpp
@@ -56,14 +56,14 @@ namespace playrho {
     
     /// @brief Determines if the given value is valid.
     template <>
-    constexpr inline bool IsValid(const Mat22& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Mat22& value) noexcept
     {
         return IsValid(Get<0>(value)) && IsValid(Get<1>(value));
     }
     
     /// @brief Gets an invalid value for a Mat22.
     template <>
-    constexpr inline Mat22 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Mat22 GetInvalid() noexcept
     {
         return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
     }

--- a/PlayRho/Common/OptionalValue.hpp
+++ b/PlayRho/Common/OptionalValue.hpp
@@ -21,6 +21,7 @@
 #ifndef PLAYRHO_COMMON_OPTIONALVALUE_HPP
 #define PLAYRHO_COMMON_OPTIONALVALUE_HPP
 
+#include <PlayRho/Defines.hpp>
 #include <cassert>
 #include <utility>
 
@@ -38,13 +39,13 @@ namespace playrho {
         /// @brief Value type.
         using value_type = T;
         
-        constexpr OptionalValue() = default;
+        PLAYRHO_CONSTEXPR inline OptionalValue() = default;
         
         /// @brief Copy constructor.
-        constexpr OptionalValue(const OptionalValue& other) = default;
+        PLAYRHO_CONSTEXPR inline OptionalValue(const OptionalValue& other) = default;
 
         /// @brief Move constructor.
-        constexpr OptionalValue(OptionalValue&& other) noexcept:
+        PLAYRHO_CONSTEXPR inline OptionalValue(OptionalValue&& other) noexcept:
             m_value{std::move(other.m_value)}, m_set{other.m_set}
         {
             // Intentionally empty.
@@ -53,27 +54,27 @@ namespace playrho {
         }
 
         /// @brief Initializing constructor.
-        constexpr explicit OptionalValue(T v);
+        PLAYRHO_CONSTEXPR inline explicit OptionalValue(T v);
 
         ~OptionalValue() = default;
 
         /// @brief Indirection operator.
-        constexpr const T& operator* () const;
+        PLAYRHO_CONSTEXPR const T& operator* () const;
 
         /// @brief Indirection operator.
-        constexpr T& operator* ();
+        PLAYRHO_CONSTEXPR inline T& operator* ();
         
         /// @brief Member of pointer operator.
-        constexpr const T* operator-> () const;
+        PLAYRHO_CONSTEXPR const T* operator-> () const;
         
         /// @brief Member of pointer operator.
-        constexpr T* operator-> ();
+        PLAYRHO_CONSTEXPR inline T* operator-> ();
 
         /// @brief bool operator.
-        constexpr explicit operator bool() const noexcept;
+        PLAYRHO_CONSTEXPR inline explicit operator bool() const noexcept;
 
         /// @brief Whether this optional value has a value.
-        constexpr bool has_value() const noexcept;
+        PLAYRHO_CONSTEXPR inline bool has_value() const noexcept;
         
         /// @brief Assignment operator.
         OptionalValue& operator= (const OptionalValue& other) = default;
@@ -92,13 +93,13 @@ namespace playrho {
         OptionalValue& operator= (T v);
 
         /// @brief Accesses the value.
-        constexpr T& value();
+        PLAYRHO_CONSTEXPR inline T& value();
 
         /// @brief Accesses the value.
-        constexpr const T& value() const;
+        PLAYRHO_CONSTEXPR const T& value() const;
         
         /// @brief Gets the value or provides the alternate given value instead.
-        constexpr T value_or(const T& alt) const;
+        PLAYRHO_CONSTEXPR inline T value_or(const T& alt) const;
         
         /// @brief Resets the optional value back to its default constructed state.
         void reset() noexcept
@@ -113,16 +114,16 @@ namespace playrho {
     };
     
     template<typename T>
-    constexpr OptionalValue<T>::OptionalValue(T v): m_value{v}, m_set{true} {}
+    PLAYRHO_CONSTEXPR inline OptionalValue<T>::OptionalValue(T v): m_value{v}, m_set{true} {}
     
     template<typename T>
-    constexpr bool OptionalValue<T>::has_value() const noexcept
+    PLAYRHO_CONSTEXPR inline bool OptionalValue<T>::has_value() const noexcept
     {
         return m_set;
     }
     
     template<typename T>
-    constexpr OptionalValue<T>::operator bool() const noexcept
+    PLAYRHO_CONSTEXPR inline OptionalValue<T>::operator bool() const noexcept
     {
         return m_set;
     }
@@ -136,47 +137,47 @@ namespace playrho {
     }
     
     template<typename T>
-    constexpr const T* OptionalValue<T>::operator->() const
+    PLAYRHO_CONSTEXPR const T* OptionalValue<T>::operator->() const
     {
         assert(m_set);
         return &m_value;
     }
     
     template<typename T>
-    constexpr T* OptionalValue<T>::operator->()
+    PLAYRHO_CONSTEXPR inline T* OptionalValue<T>::operator->()
     {
         assert(m_set);
         return &m_value;
     }
 
     template<typename T>
-    constexpr const T& OptionalValue<T>::operator*() const
+    PLAYRHO_CONSTEXPR const T& OptionalValue<T>::operator*() const
     {
         assert(m_set);
         return m_value;
     }
     
     template<typename T>
-    constexpr T& OptionalValue<T>::operator*()
+    PLAYRHO_CONSTEXPR inline T& OptionalValue<T>::operator*()
     {
         assert(m_set);
         return m_value;
     }
 
     template<typename T>
-    constexpr T& OptionalValue<T>::value()
+    PLAYRHO_CONSTEXPR inline T& OptionalValue<T>::value()
     {
         return m_value;
     }
     
     template<typename T>
-    constexpr const T& OptionalValue<T>::value() const
+    PLAYRHO_CONSTEXPR const T& OptionalValue<T>::value() const
     {
         return m_value;
     }
 
     template<typename T>
-    constexpr T OptionalValue<T>::value_or(const T& alt) const
+    PLAYRHO_CONSTEXPR inline T OptionalValue<T>::value_or(const T& alt) const
     {
         return m_set? m_value: alt;
     }

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -40,42 +40,42 @@ namespace playrho
     /// @brief Determines if the given value is valid.
     /// @relatedalso Position
     template <>
-    constexpr inline bool IsValid(const Position& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Position& value) noexcept
     {
         return IsValid(value.linear) && IsValid(value.angular);
     }
     
     /// @brief Equality operator.
     /// @relatedalso Position
-    constexpr inline bool operator==(const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator==(const Position& lhs, const Position& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Position
-    constexpr inline bool operator!=(const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!=(const Position& lhs, const Position& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Negation operator.
     /// @relatedalso Position
-    constexpr inline Position operator- (const Position& value)
+    PLAYRHO_CONSTEXPR inline Position operator- (const Position& value)
     {
         return Position{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
     /// @relatedalso Position
-    constexpr inline Position operator+ (const Position& value)
+    PLAYRHO_CONSTEXPR inline Position operator+ (const Position& value)
     {
         return value;
     }
     
     /// @brief Addition assignment operator.
     /// @relatedalso Position
-    constexpr inline Position& operator+= (Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position& operator+= (Position& lhs, const Position& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -84,14 +84,14 @@ namespace playrho
     
     /// @brief Addition operator.
     /// @relatedalso Position
-    constexpr inline Position operator+ (const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position operator+ (const Position& lhs, const Position& rhs)
     {
         return Position{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
     /// @relatedalso Position
-    constexpr inline Position& operator-= (Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position& operator-= (Position& lhs, const Position& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -100,20 +100,20 @@ namespace playrho
     
     /// @brief Subtraction operator.
     /// @relatedalso Position
-    constexpr inline Position operator- (const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position operator- (const Position& lhs, const Position& rhs)
     {
         return Position{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Multiplication operator.
-    constexpr inline Position operator* (const Position& pos, const Real scalar)
+    PLAYRHO_CONSTEXPR inline Position operator* (const Position& pos, const Real scalar)
     {
         return Position{pos.linear * scalar, pos.angular * scalar};
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Position
-    constexpr inline Position operator* (const Real scalar, const Position& pos)
+    PLAYRHO_CONSTEXPR inline Position operator* (const Real scalar, const Position& pos)
     {
         return Position{pos.linear * scalar, pos.angular * scalar};
     }
@@ -125,7 +125,7 @@ namespace playrho
     /// @return pos0 if pos0 == pos1 or beta == 0, pos1 if beta == 1, or at the given
     ///   unit interval value between pos0 and pos1.
     /// @relatedalso Position
-    constexpr Position GetPosition(const Position pos0, const Position pos1,
+    PLAYRHO_CONSTEXPR inline Position GetPosition(const Position pos0, const Position pos1,
                                    const Real beta) noexcept
     {
         assert(IsValid(pos0));

--- a/PlayRho/Common/Range.hpp
+++ b/PlayRho/Common/Range.hpp
@@ -36,7 +36,7 @@ namespace playrho
         using iterator_type = IT;
 
         /// @brief Initializing constructor.
-        constexpr Range(iterator_type iter_begin, iterator_type iter_end) noexcept:
+        PLAYRHO_CONSTEXPR inline Range(iterator_type iter_begin, iterator_type iter_end) noexcept:
         	m_begin{iter_begin}, m_end{iter_end}
         {
             // Intentionally empty.
@@ -74,7 +74,7 @@ namespace playrho
         using size_type = std::size_t;
 
         /// @brief Initializing constructor.
-        constexpr SizedRange(typename Range<IT>::iterator_type iter_begin,
+        PLAYRHO_CONSTEXPR inline SizedRange(typename Range<IT>::iterator_type iter_begin,
                              typename Range<IT>::iterator_type iter_end,
                              size_type size) noexcept:
         	Range<IT>{iter_begin, iter_end}, m_size{size}

--- a/PlayRho/Common/RealConstants.hpp
+++ b/PlayRho/Common/RealConstants.hpp
@@ -50,13 +50,13 @@ namespace playrho {
 ///
 /// @sa https://en.wikipedia.org/wiki/Pi
 ///
-constexpr auto Pi = Real(3.14159265358979323846264338327950288);
+PLAYRHO_CONSTEXPR const auto Pi = Real(3.14159265358979323846264338327950288);
 
 /// @brief Square root of two.
 ///
 /// @sa https://en.wikipedia.org/wiki/Square_root_of_2
 ///
-constexpr auto SquareRootTwo =
+PLAYRHO_CONSTEXPR const auto SquareRootTwo =
     Real(1.414213562373095048801688724209698078569671875376948073176679737990732478462);
 
 /// @defgroup DecimalUnitPrefices Decimal Unit Prefices
@@ -69,23 +69,23 @@ constexpr auto SquareRootTwo =
 
 /// @brief Centi (1 x 10^-2).
 /// @sa https://en.wikipedia.org/wiki/Centi-
-constexpr auto Centi = Real(1e-2);
+PLAYRHO_CONSTEXPR const auto Centi = Real(1e-2);
 
 /// @brief Deci (1 x 10^-1).
 /// @sa https://en.wikipedia.org/wiki/Deci-
-constexpr auto Deci = Real(1e-1);
+PLAYRHO_CONSTEXPR const auto Deci = Real(1e-1);
 
 /// @brief Kilo (1 x 10^3).
 /// @sa https://en.wikipedia.org/wiki/Kilo-
-constexpr auto Kilo = Real(1e3);
+PLAYRHO_CONSTEXPR const auto Kilo = Real(1e3);
 
 /// @brief Giga (1 x 10^9).
 /// @sa https://en.wikipedia.org/wiki/Giga-
-constexpr auto Giga = Real(1e9);
+PLAYRHO_CONSTEXPR const auto Giga = Real(1e9);
 
 /// @brief Yotta (1 x 10^24).
 /// @sa https://en.wikipedia.org/wiki/Yotta-
-constexpr auto Yotta = Real(1e24);
+PLAYRHO_CONSTEXPR const auto Yotta = Real(1e24);
 
 /// @}
 

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -52,14 +52,14 @@ template <typename T>
 struct Defaults
 {
     /// @brief Gets the linear slop.
-    static constexpr auto GetLinearSlop() noexcept
+    static PLAYRHO_CONSTEXPR inline auto GetLinearSlop() noexcept
     {
         // Return the value used by Box2D 2.3.2 b2_linearSlop define....
         return 0.005_m;
     }
     
     /// @brief Gets the max vertex radius.
-    static constexpr auto GetMaxVertexRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline auto GetMaxVertexRadius() noexcept
     {
         // DefaultLinearSlop * Real{2 * 1024 * 1024};
         // linearSlop * 2550000
@@ -71,9 +71,8 @@ struct Defaults
 template <unsigned int FRACTION_BITS>
 struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
 {
-    
     /// @brief Gets the linear slop.
-    static constexpr auto GetLinearSlop() noexcept
+    static PLAYRHO_CONSTEXPR inline auto GetLinearSlop() noexcept
     {
         // Needs to be big enough that the step tolerance doesn't go to zero.
         // ex: FRACTION_BITS==10, then divisor==256
@@ -81,7 +80,7 @@ struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
     }
     
     /// @brief Gets the max vertex radius.
-    static constexpr auto GetMaxVertexRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline auto GetMaxVertexRadius() noexcept
     {
         // linearSlop * 2550000
         return Length{Real(1u << (28 - FRACTION_BITS)) * 1_m};
@@ -91,10 +90,10 @@ struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
 } // namespace details
 
 /// @brief Maximum number of supportable edges in a simplex.
-constexpr auto MaxSimplexEdges = std::uint8_t{3};
+PLAYRHO_CONSTEXPR const auto MaxSimplexEdges = std::uint8_t{3};
 
 /// @brief Max child count.
-constexpr auto MaxChildCount = std::numeric_limits<std::uint32_t>::max() >> 6;
+PLAYRHO_CONSTEXPR const auto MaxChildCount = std::numeric_limits<std::uint32_t>::max() >> 6;
 
 /// @brief Child counter type.
 /// @details Relating to "children" of shape where each child is a convex shape possibly
@@ -107,7 +106,7 @@ using ChildCounter = std::remove_const<decltype(MaxChildCount)>::type;
 using TimestepIters = std::uint8_t;
 
 /// @brief Maximum float value.
-constexpr auto MaxFloat = std::numeric_limits<Real>::max(); // FLT_MAX
+PLAYRHO_CONSTEXPR const auto MaxFloat = std::numeric_limits<Real>::max(); // FLT_MAX
 
 // Collision
 
@@ -115,11 +114,11 @@ constexpr auto MaxFloat = std::numeric_limits<Real>::max(); // FLT_MAX
 /// This is the maximum number of contact points between two convex shapes.
 /// Do not change this value.
 /// @note For memory efficiency, uses the smallest integral type that can hold the value. 
-constexpr auto MaxManifoldPoints = std::uint8_t{2};
+PLAYRHO_CONSTEXPR const auto MaxManifoldPoints = std::uint8_t{2};
 
 /// Maximum number of vertices for any shape type.
 /// @note For memory efficiency, uses the smallest integral type that can hold the value.
-constexpr auto MaxShapeVertices = std::uint8_t{254};
+PLAYRHO_CONSTEXPR const auto MaxShapeVertices = std::uint8_t{254};
 
 /// @brief Default linear slop.
 /// @details Length used as a collision and constraint tolerance.
@@ -128,53 +127,53 @@ constexpr auto MaxShapeVertices = std::uint8_t{254};
 ///   between bodies at rest.
 /// @note Smaller values relative to sizes of bodies increases the time it takes
 ///   for bodies to come to rest.
-constexpr auto DefaultLinearSlop = details::Defaults<Real>::GetLinearSlop();
+PLAYRHO_CONSTEXPR const auto DefaultLinearSlop = details::Defaults<Real>::GetLinearSlop();
 
 /// @brief Default minimum vertex radius.
-constexpr auto DefaultMinVertexRadius = DefaultLinearSlop * Real{2};
+PLAYRHO_CONSTEXPR const auto DefaultMinVertexRadius = DefaultLinearSlop * Real{2};
 
 /// @brief Default maximum vertex radius.
-constexpr auto DefaultMaxVertexRadius = details::Defaults<Real>::GetMaxVertexRadius();
+PLAYRHO_CONSTEXPR const auto DefaultMaxVertexRadius = details::Defaults<Real>::GetMaxVertexRadius();
 
 /// @brief Default AABB extension amount.
-constexpr auto DefaultAabbExtension = DefaultLinearSlop * Real{20};
+PLAYRHO_CONSTEXPR const auto DefaultAabbExtension = DefaultLinearSlop * Real{20};
 
 /// @brief Default distance multiplier.
-constexpr auto DefaultDistanceMultiplier = Real{2};
+PLAYRHO_CONSTEXPR const auto DefaultDistanceMultiplier = Real{2};
 
 /// @brief Default angular slop.
 /// @details
 /// A small angle used as a collision and constraint tolerance. Usually it is
 /// chosen to be numerically significant, but visually insignificant.
-constexpr auto DefaultAngularSlop = (Pi * 2_rad) / Real{180};
+PLAYRHO_CONSTEXPR const auto DefaultAngularSlop = (Pi * 2_rad) / Real{180};
 
 /// @brief Default maximum linear correction.
 /// @details The maximum linear position correction used when solving constraints.
 ///   This helps to prevent overshoot.
 /// @note This value should be greater than the linear slop value.
-constexpr auto DefaultMaxLinearCorrection = 0.2_m;
+PLAYRHO_CONSTEXPR const auto DefaultMaxLinearCorrection = 0.2_m;
 
 /// @brief Default maximum angular correction.
 /// @note This value should be greater than the angular slop value.
-constexpr auto DefaultMaxAngularCorrection = Real(8.0f / 180.0f) * Pi * 1_rad;
+PLAYRHO_CONSTEXPR const auto DefaultMaxAngularCorrection = Real(8.0f / 180.0f) * Pi * 1_rad;
 
 /// @brief Default maximum translation amount.
-constexpr auto DefaultMaxTranslation = 2_m;
+PLAYRHO_CONSTEXPR const auto DefaultMaxTranslation = 2_m;
 
 /// @brief Default maximum rotation per world step.
 /// @warning This value should be less than Pi * Radian.
 /// @note This limit is meant to prevent numerical problems. Adjusting this value isn't advised.
 /// @sa StepConf::maxRotation.
-constexpr auto DefaultMaxRotation = Angle{Pi * 1_rad / Real(2)};
+PLAYRHO_CONSTEXPR const auto DefaultMaxRotation = Angle{Pi * 1_rad / Real(2)};
 
 /// @brief Default maximum time of impact iterations.
-constexpr auto DefaultMaxToiIters = std::uint8_t{20};
+PLAYRHO_CONSTEXPR const auto DefaultMaxToiIters = std::uint8_t{20};
 
 /// Default maximum time of impact root iterator count.
-constexpr auto DefaultMaxToiRootIters = std::uint8_t{30};
+PLAYRHO_CONSTEXPR const auto DefaultMaxToiRootIters = std::uint8_t{30};
 
 /// Default max number of distance iterations.
-constexpr auto DefaultMaxDistanceIters = std::uint8_t{20};
+PLAYRHO_CONSTEXPR const auto DefaultMaxDistanceIters = std::uint8_t{20};
 
 /// Default maximum number of sub steps.
 /// @details
@@ -182,22 +181,22 @@ constexpr auto DefaultMaxDistanceIters = std::uint8_t{20};
 /// In other words, this is the default maximum number of times in a world step that a contact will
 /// have continuous collision resolution done for it.
 /// @note Used in the TOI phase of step processing.
-constexpr auto DefaultMaxSubSteps = std::uint8_t{8};
+PLAYRHO_CONSTEXPR const auto DefaultMaxSubSteps = std::uint8_t{8};
     
 // Dynamics
 
 /// @brief Default velocity threshold.
-constexpr auto DefaultVelocityThreshold = 1_mps;
+PLAYRHO_CONSTEXPR const auto DefaultVelocityThreshold = 1_mps;
 
 /// @brief Default regular-phase minimum momentum.
-constexpr auto DefaultRegMinMomentum = Momentum{0_Ns / 100};
+PLAYRHO_CONSTEXPR const auto DefaultRegMinMomentum = Momentum{0_Ns / 100};
 
 /// @brief Default TOI-phase minimum momentum.
-constexpr auto DefaultToiMinMomentum = Momentum{0_Ns / 100};
+PLAYRHO_CONSTEXPR const auto DefaultToiMinMomentum = Momentum{0_Ns / 100};
 
 /// @brief Maximum number of bodies in a world.
 /// @note This is 65534 based off std::uint16_t and eliminating one value for invalid.
-constexpr auto MaxBodies = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
+PLAYRHO_CONSTEXPR const auto MaxBodies = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
                                                       std::uint16_t{1});
 
 /// @brief Body count type.
@@ -209,16 +208,16 @@ using BodyCounter = std::remove_const<decltype(MaxBodies)>::type;
 using ContactCounter = Wider<BodyCounter>::type;
 
 /// @brief Invalid contact index.
-constexpr auto InvalidContactIndex = static_cast<ContactCounter>(-1);
+PLAYRHO_CONSTEXPR const auto InvalidContactIndex = static_cast<ContactCounter>(-1);
 
 /// @brief Maximum number of contacts in a world (2147319811).
 /// @details Uses the formula for the maximum number of edges in an unidirectional graph of MaxBodies nodes. 
 /// This occurs when every possible body is connected to every other body.
-constexpr auto MaxContacts = ContactCounter{MaxBodies} * ContactCounter{MaxBodies - 1} / ContactCounter{2};
+PLAYRHO_CONSTEXPR const auto MaxContacts = ContactCounter{MaxBodies} * ContactCounter{MaxBodies - 1} / ContactCounter{2};
 
 /// @brief Maximum number of joints in a world.
 /// @note This is 65534 based off std::uint16_t and eliminating one value for invalid.
-constexpr auto MaxJoints = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
+PLAYRHO_CONSTEXPR const auto MaxJoints = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
                                                       std::uint16_t{1});
 
 /// @brief Joint count type.
@@ -226,29 +225,29 @@ constexpr auto MaxJoints = static_cast<std::uint16_t>(std::numeric_limits<std::u
 using JointCounter = std::remove_const<decltype(MaxJoints)>::type;
 
 /// @brief Default step time.
-constexpr auto DefaultStepTime = Time{1_s / 60};
+PLAYRHO_CONSTEXPR const auto DefaultStepTime = Time{1_s / 60};
 
 /// @brief Default step frequency.
-constexpr auto DefaultStepFrequency = 60_Hz;
+PLAYRHO_CONSTEXPR const auto DefaultStepFrequency = 60_Hz;
 
 // Sleep
 
 /// Default minimum still time to sleep.
 /// @details The default minimum time bodies must be still for bodies to be put to sleep.
-constexpr auto DefaultMinStillTimeToSleep = Time{1_s / 2}; // aka 0.5 secs
+PLAYRHO_CONSTEXPR const auto DefaultMinStillTimeToSleep = Time{1_s / 2}; // aka 0.5 secs
 
 /// Default linear sleep tolerance.
 /// @details A body cannot sleep if the magnitude of its linear velocity is above this amount.
-constexpr auto DefaultLinearSleepTolerance = 0.01_mps; // aka 0.01
+PLAYRHO_CONSTEXPR const auto DefaultLinearSleepTolerance = 0.01_mps; // aka 0.01
 
 /// Default angular sleep tolerance.
 /// @details A body cannot sleep if its angular velocity is above this amount.
-constexpr auto DefaultAngularSleepTolerance = Real{(Pi * 2) / 180} * RadianPerSecond;
+PLAYRHO_CONSTEXPR const auto DefaultAngularSleepTolerance = Real{(Pi * 2) / 180} * RadianPerSecond;
 
 /// Default circles ratio.
 /// @details Ratio used for switching between rounded-corner collisions and closest-face
 ///   biased normal collisions.
-constexpr auto DefaultCirclesRatio = Real{10};
+PLAYRHO_CONSTEXPR const auto DefaultCirclesRatio = Real{10};
 
 } // namespace playrho
 

--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -19,6 +19,8 @@
 #ifndef PLAYRHO_COMMON_SPAN_HPP
 #define PLAYRHO_COMMON_SPAN_HPP
 
+#include <PlayRho/Defines.hpp>
+
 #include <cstddef>
 #include <cassert>
 #include <type_traits>
@@ -55,13 +57,13 @@ namespace playrho {
         Span(const Span& copy) = default;
         
         /// @brief Initializing constructor.
-        constexpr Span(pointer array, size_type size) noexcept:
+        PLAYRHO_CONSTEXPR inline Span(pointer array, size_type size) noexcept:
             m_array{array}, m_size{size}
         {
         }
         
         /// @brief Initializing constructor.
-        constexpr Span(pointer first, pointer last) noexcept:
+        PLAYRHO_CONSTEXPR inline Span(pointer first, pointer last) noexcept:
             m_array{first}, m_size{static_cast<size_type>(std::distance(first, last))}
         {
             assert(first <= last);
@@ -69,21 +71,21 @@ namespace playrho {
         
         /// @brief Initializing constructor.
         template <std::size_t SIZE>
-        constexpr Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
+        PLAYRHO_CONSTEXPR inline Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
         
         /// @brief Initializing constructor.
         template <typename U, typename = std::enable_if_t< !std::is_array<U>::value > >
-        constexpr Span(U& value) noexcept: m_array{value.begin()}, m_size{value.size()} {}
+        PLAYRHO_CONSTEXPR inline Span(U& value) noexcept: m_array{value.begin()}, m_size{value.size()} {}
         
         /// @brief Initializing constructor.
         template <typename U, typename = std::enable_if_t< !std::is_array<U>::value > >
-        constexpr Span(const U& value) noexcept: m_array{value.begin()}, m_size{value.size()} {}
+        PLAYRHO_CONSTEXPR inline Span(const U& value) noexcept: m_array{value.begin()}, m_size{value.size()} {}
 
         /// @brief Initializing constructor.
-        constexpr Span(std::vector<T>& value) noexcept: m_array{value.data()}, m_size{value.size()} {}
+        PLAYRHO_CONSTEXPR inline Span(std::vector<T>& value) noexcept: m_array{value.data()}, m_size{value.size()} {}
 
         /// @brief Initializing constructor.
-        constexpr Span(std::initializer_list<T> list) noexcept:
+        PLAYRHO_CONSTEXPR inline Span(std::initializer_list<T> list) noexcept:
             m_array{list.begin()}, m_size{list.size()} {}
         
         /// @brief Gets the "begin" iterator value.

--- a/PlayRho/Common/StackAllocator.cpp
+++ b/PlayRho/Common/StackAllocator.cpp
@@ -29,7 +29,7 @@ namespace {
 
 inline std::size_t alignment_size(std::size_t size)
 {
-    constexpr auto one = static_cast<std::size_t>(1);
+    PLAYRHO_CONSTEXPR const auto one = static_cast<std::size_t>(1);
     return (size < one)? one: (size < sizeof(std::max_align_t))?
     static_cast<std::size_t>(NextPowerOfTwo(size - one)): alignof(std::max_align_t);
 };

--- a/PlayRho/Common/StackAllocator.hpp
+++ b/PlayRho/Common/StackAllocator.hpp
@@ -46,7 +46,7 @@ public:
     };
 
     /// @brief Gets the default configuration.
-    static constexpr Configuration GetDefaultConfiguration()
+    static PLAYRHO_CONSTEXPR inline Configuration GetDefaultConfiguration()
     {
         return Configuration{};
     }

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -46,10 +46,10 @@ namespace playrho
         Sweep() = default;
         
         /// @brief Copy constructor.
-        constexpr Sweep(const Sweep& copy) = default;
+        PLAYRHO_CONSTEXPR inline Sweep(const Sweep& copy) = default;
         
         /// @brief Initializing constructor.
-        constexpr Sweep(const Position p0, const Position p1,
+        PLAYRHO_CONSTEXPR inline Sweep(const Position p0, const Position p1,
                         const Length2 lc = Length2{0_m, 0_m},
                         Real a0 = 0) noexcept:
         	pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
@@ -59,7 +59,7 @@ namespace playrho
         }
         
         /// @brief Initializing constructor.
-        constexpr explicit Sweep(const Position p,
+        PLAYRHO_CONSTEXPR inline explicit Sweep(const Position p,
                                  const Length2 lc = Length2{0_m, 0_m}):
         	Sweep{p, p, lc, 0}
         {
@@ -129,7 +129,7 @@ namespace playrho
     /// @brief Determines if the given value is valid.
     /// @relatedalso Transformation
     template <>
-    constexpr inline bool IsValid(const Sweep& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Sweep& value) noexcept
     {
         return IsValid(value.pos0) && IsValid(value.pos1)
             && IsValid(value.GetLocalCenter()) && IsValid(value.GetAlpha0());

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -21,9 +21,12 @@
 #ifndef PLAYRHO_COMMON_TEMPLATES_HPP
 #define PLAYRHO_COMMON_TEMPLATES_HPP
 
+#include <PlayRho/Defines.hpp>
+
 #include <limits>
 #include <typeinfo>
 #include <type_traits>
+#include <tuple>
 
 namespace playrho
 {
@@ -33,16 +36,16 @@ namespace playrho
 
     /// @brief Gets an invalid value for the type.
     template <typename T>
-    constexpr T GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline T GetInvalid() noexcept
     {
         static_assert(sizeof(T) == 0, "No available specialization");
     }
 
     /// @brief Determines if the given value is valid.
     template <typename T>
-    constexpr bool IsValid(const T& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const T& value) noexcept
     {
-        // Note: This is not necessarily a no-op!! But it is a "constexpr".
+        // Note: This is not necessarily a no-op!! But it is a "PLAYRHO_CONSTEXPR inline".
         //
         // From http://en.cppreference.com/w/cpp/numeric/math/isnan:
         //   "Another way to test if a floating-point value is NaN is
@@ -59,28 +62,28 @@ namespace playrho
     
     /// @brief Gets an invalid value for the float type.
     template <>
-    constexpr float GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline float GetInvalid() noexcept
     {
         return std::numeric_limits<float>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the double type.
     template <>
-    constexpr double GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline double GetInvalid() noexcept
     {
         return std::numeric_limits<double>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the long double type.
     template <>
-    constexpr long double GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline long double GetInvalid() noexcept
     {
         return std::numeric_limits<long double>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the std::size_t type.
     template <>
-    constexpr std::size_t GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline std::size_t GetInvalid() noexcept
     {
         return static_cast<std::size_t>(-1);
     }
@@ -89,7 +92,7 @@ namespace playrho
     
     /// @brief Determines if the given value is valid.
     template <>
-    constexpr inline bool IsValid(const std::size_t& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const std::size_t& value) noexcept
     {
         return value != GetInvalid<std::size_t>();
     }
@@ -98,56 +101,56 @@ namespace playrho
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    constexpr const T* GetPtr(const T* value) noexcept
+    PLAYRHO_CONSTEXPR const T* GetPtr(const T* value) noexcept
     {
         return value;
     }
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    constexpr T* GetPtr(T* value) noexcept
+    PLAYRHO_CONSTEXPR inline T* GetPtr(T* value) noexcept
     {
         return value;
     }
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    constexpr const T* GetPtr(const T& value) noexcept
+    PLAYRHO_CONSTEXPR const T* GetPtr(const T& value) noexcept
     {
         return &value;
     }
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    constexpr T* GetPtr(T& value) noexcept
+    PLAYRHO_CONSTEXPR inline T* GetPtr(T& value) noexcept
     {
         return &value;
     }
 
     /// @brief Gets a reference for the given variable.
     template <class T>
-    constexpr const T& GetRef(const T* value) noexcept
+    PLAYRHO_CONSTEXPR const T& GetRef(const T* value) noexcept
     {
         return *value;
     }
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    constexpr T& GetRef(T* value) noexcept
+    PLAYRHO_CONSTEXPR inline T& GetRef(T* value) noexcept
     {
         return *value;
     }
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    constexpr const T& GetRef(const T& value) noexcept
+    PLAYRHO_CONSTEXPR const T& GetRef(const T& value) noexcept
     {
         return value;
     }
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    constexpr T& GetRef(T& value) noexcept
+    PLAYRHO_CONSTEXPR inline T& GetRef(T& value) noexcept
     {
         return value;
     }
@@ -206,9 +209,45 @@ namespace playrho
         decltype(T{} + T{}), decltype(T{} - T{}), decltype(T{} * T{}), decltype(T{} / T{})
     > >: std::true_type {};
     
+    /// @brief Has-type trait template class.
+    /// @note This is from Piotr Skotnicki's answer on StackOverflow to the question of
+    ///   "How do I find out if a tuple contains a type?".
+    /// @sa https://stackoverflow.com/a/25958302/7410358
+    template <typename T, typename Tuple>
+    struct HasType;
+    
+    /// @brief Has-type trait template class specialized for std::tuple classes.
+    /// @note This is from Piotr Skotnicki's answer on StackOverflow to the question of
+    ///   "How do I find out if a tuple contains a type?".
+    /// @sa https://stackoverflow.com/a/25958302/7410358
+    template <typename T>
+    struct HasType<T, std::tuple<>> : std::false_type {};
+    
+    /// @brief Has-type trait true class.
+    /// @note This is from Piotr Skotnicki's answer on StackOverflow to the question of
+    ///   "How do I find out if a tuple contains a type?".
+    /// @sa https://stackoverflow.com/a/25958302/7410358
+    template <typename T, typename... Ts>
+    struct HasType<T, std::tuple<T, Ts...>> : std::true_type {};
+    
+    /// @brief Has-type trait template super class.
+    /// @note This is from Piotr Skotnicki's answer on StackOverflow to the question of
+    ///   "How do I find out if a tuple contains a type?".
+    /// @sa https://stackoverflow.com/a/25958302/7410358
+    template <typename T, typename U, typename... Ts>
+    struct HasType<T, std::tuple<U, Ts...>> : HasType<T, std::tuple<Ts...>> {};
+
+    /// @brief Tuple contains type alias.
+    /// @details Alias in case the trait itself should be std::true_type or std::false_type.
+    /// @note This is from Piotr Skotnicki's answer on StackOverflow to the question of
+    ///   "How do I find out if a tuple contains a type?".
+    /// @sa https://stackoverflow.com/a/25958302/7410358
+    template <typename T, typename Tuple>
+    using TupleContainsType = typename HasType<T, Tuple>::type;
+    
     /// @brief Computes the absolute value of the given value.
     template <typename T>
-    constexpr inline T Abs(T a)
+    PLAYRHO_CONSTEXPR inline T Abs(T a)
     {
         return (a >= T{0}) ? a : -a;
     }

--- a/PlayRho/Common/Transformation.hpp
+++ b/PlayRho/Common/Transformation.hpp
@@ -45,26 +45,26 @@ namespace playrho
     };
     
     /// @brief Identity transformation value.
-    constexpr auto Transform_identity = Transformation{Length2{0_m, 0_m}, UnitVec2::GetRight()};
+    PLAYRHO_CONSTEXPR const auto Transform_identity = Transformation{Length2{0_m, 0_m}, UnitVec2::GetRight()};
     
     /// @brief Determines if the given value is valid.
     /// @relatedalso Transformation
     template <>
-    constexpr inline bool IsValid(const Transformation& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Transformation& value) noexcept
     {
         return IsValid(value.p) && IsValid(value.q);
     }
     
     /// @brief Equality operator.
     /// @relatedalso Transformation
-    constexpr inline bool operator== (Transformation lhs, Transformation rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (Transformation lhs, Transformation rhs) noexcept
     {
         return (lhs.p == rhs.p) && (lhs.q == rhs.q);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Transformation
-    constexpr inline bool operator!= (Transformation lhs, Transformation rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (Transformation lhs, Transformation rhs) noexcept
     {
         return (lhs.p != rhs.p) || (lhs.q != rhs.q);
     }

--- a/PlayRho/Common/UnitVec2.hpp
+++ b/PlayRho/Common/UnitVec2.hpp
@@ -58,32 +58,32 @@ public:
     /// @note This is the value for the 0/4 turned (0 angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the bottom oriented vector.
     /// @note This is the forward perpendicular unit vector of the top oriented vector.
-    static constexpr UnitVec2 GetRight() noexcept { return UnitVec2{1, 0}; }
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetRight() noexcept { return UnitVec2{1, 0}; }
 
     /// @brief Gets the top-ward oriented unit vector.
     /// @note This is the actual value for the 1/4 turned (90 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the right oriented vector.
     /// @note This is the forward perpendicular unit vector of the left oriented vector.
-    static constexpr UnitVec2 GetTop() noexcept { return UnitVec2{0, 1}; }
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetTop() noexcept { return UnitVec2{0, 1}; }
 
     /// @brief Gets the left-ward oriented unit vector.
     /// @note This is the actual value for the 2/4 turned (180 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the top oriented vector.
     /// @note This is the forward perpendicular unit vector of the bottom oriented vector.
-    static constexpr UnitVec2 GetLeft() noexcept { return UnitVec2{-1, 0}; }
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetLeft() noexcept { return UnitVec2{-1, 0}; }
 
     /// @brief Gets the bottom-ward oriented unit vector.
     /// @note This is the actual value for the 3/4 turned (270 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the left oriented vector.
     /// @note This is the forward perpendicular unit vector of the right oriented vector.
-    static constexpr UnitVec2 GetBottom() noexcept { return UnitVec2{0, -1}; }
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetBottom() noexcept { return UnitVec2{0, -1}; }
 
     /// @brief Gets the non-oriented unit vector.
-    static constexpr UnitVec2 GetZero() noexcept { return UnitVec2{0, 0}; }
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetZero() noexcept { return UnitVec2{0, 0}; }
 
     /// @brief Gets the 45 degree unit vector.
     /// @details This is the unit vector in the positive X and Y quadrant where X == Y.
-    static constexpr UnitVec2 GetTopRight() noexcept
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetTopRight() noexcept
     {
         return UnitVec2{+SquareRootTwo/Real(2), +SquareRootTwo/Real(2)};
     }
@@ -91,13 +91,13 @@ public:
     /// @brief Gets the -45 degree unit vector.
     /// @details This is the unit vector in the positive X and negative Y quadrant
     ///   where |X| == |Y|.
-    static constexpr UnitVec2 GetBottomRight() noexcept
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetBottomRight() noexcept
     {
         return UnitVec2{+SquareRootTwo/Real(2), -SquareRootTwo/Real(2)};
     }
     
     /// @brief Gets the default fallback.
-    static constexpr UnitVec2 GetDefaultFallback() noexcept { return UnitVec2{}; }
+    static PLAYRHO_CONSTEXPR inline UnitVec2 GetDefaultFallback() noexcept { return UnitVec2{}; }
 
     /// @brief Polar coordinate.
     /// @details This is a direction and magnitude pair defined by the unit vector class.
@@ -117,17 +117,17 @@ public:
     ///
     static UnitVec2 Get(const Angle angle) noexcept;
 
-    constexpr UnitVec2() noexcept = default;
+    PLAYRHO_CONSTEXPR inline UnitVec2() noexcept = default;
     
     /// @brief Gets the max size.
-    constexpr size_type max_size() const noexcept { return size_type{2}; }
+    PLAYRHO_CONSTEXPR inline size_type max_size() const noexcept { return size_type{2}; }
     
     /// @brief Gets the size.
-    constexpr size_type size() const noexcept { return size_type{2}; }
+    PLAYRHO_CONSTEXPR inline size_type size() const noexcept { return size_type{2}; }
     
     /// @brief Whether empty.
     /// @note Always false for N > 0.
-    constexpr bool empty() const noexcept { return false; }
+    PLAYRHO_CONSTEXPR inline bool empty() const noexcept { return false; }
     
     /// @brief Gets a "begin" iterator.
     const_iterator begin() const noexcept { return const_iterator(m_elems); }
@@ -168,7 +168,7 @@ public:
     /// @brief Gets a constant reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr const_reference operator[](size_type pos) const noexcept
+    PLAYRHO_CONSTEXPR inline const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
         return m_elems[pos];
@@ -176,7 +176,7 @@ public:
     
     /// @brief Gets a constant reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    constexpr const_reference at(size_type pos) const
+    PLAYRHO_CONSTEXPR inline const_reference at(size_type pos) const
     {
         if (pos >= size())
         {
@@ -186,31 +186,31 @@ public:
     }
     
     /// @brief Direct access to data.
-    constexpr const_pointer data() const noexcept
+    PLAYRHO_CONSTEXPR inline const_pointer data() const noexcept
     {
         return m_elems;
     }
     
     /// @brief Gets the "X" value.
-    constexpr auto GetX() const noexcept { return m_elems[0]; }
+    PLAYRHO_CONSTEXPR inline auto GetX() const noexcept { return m_elems[0]; }
 
     /// @brief Gets the "Y" value.
-    constexpr auto GetY() const noexcept { return m_elems[1]; }
+    PLAYRHO_CONSTEXPR inline auto GetY() const noexcept { return m_elems[1]; }
 
     /// @brief Gets the cosine value.
-    constexpr auto cos() const noexcept { return m_elems[0]; }
+    PLAYRHO_CONSTEXPR inline auto cos() const noexcept { return m_elems[0]; }
 
     /// @brief Gets the sine value.
-    constexpr auto sin() const noexcept { return m_elems[1]; }
+    PLAYRHO_CONSTEXPR inline auto sin() const noexcept { return m_elems[1]; }
 
     /// @brief Flips the X and Y values.
-    constexpr inline UnitVec2 FlipXY() const noexcept { return UnitVec2{-GetX(), -GetY()}; }
+    PLAYRHO_CONSTEXPR inline UnitVec2 FlipXY() const noexcept { return UnitVec2{-GetX(), -GetY()}; }
 
     /// @brief Flips the X value.
-    constexpr inline UnitVec2 FlipX() const noexcept { return UnitVec2{-GetX(), GetY()}; }
+    PLAYRHO_CONSTEXPR inline UnitVec2 FlipX() const noexcept { return UnitVec2{-GetX(), GetY()}; }
 
     /// @brief Flips the Y value.
-    constexpr inline UnitVec2 FlipY() const noexcept { return UnitVec2{GetX(), -GetY()}; }
+    PLAYRHO_CONSTEXPR inline UnitVec2 FlipY() const noexcept { return UnitVec2{GetX(), -GetY()}; }
 
     /// @brief Rotates the unit vector by the given amount.
     ///
@@ -219,7 +219,7 @@ public:
     ///
     /// @return Result of rotating this unit vector by the given amount.
     ///
-    constexpr inline UnitVec2 Rotate(UnitVec2 amount) const noexcept
+    PLAYRHO_CONSTEXPR inline UnitVec2 Rotate(UnitVec2 amount) const noexcept
     {
         return UnitVec2{GetX() * amount.GetX() - GetY() * amount.GetY(),
                         GetY() * amount.GetX() + GetX() * amount.GetY()};
@@ -229,7 +229,7 @@ public:
     /// @details This returns the unit vector (-y, x).
     /// @return A counter-clockwise 90-degree rotation of this vector.
     /// @sa GetFwdPerpendicular.
-    constexpr inline UnitVec2 GetRevPerpendicular() const noexcept
+    PLAYRHO_CONSTEXPR inline UnitVec2 GetRevPerpendicular() const noexcept
     {
         // See http://mathworld.wolfram.com/PerpendicularVector.html
         return UnitVec2{-GetY(), GetX()};
@@ -239,20 +239,20 @@ public:
     /// @details This returns the unit vector (y, -x).
     /// @return A clockwise 90-degree rotation of this vector.
     /// @sa GetRevPerpendicular.
-    constexpr inline UnitVec2 GetFwdPerpendicular() const noexcept
+    PLAYRHO_CONSTEXPR inline UnitVec2 GetFwdPerpendicular() const noexcept
     {
         // See http://mathworld.wolfram.com/PerpendicularVector.html
         return UnitVec2{GetY(), -GetX()};
     }
 
     /// @brief Negation operator.
-    constexpr inline UnitVec2 operator-() const noexcept { return UnitVec2{-GetX(), -GetY()}; }
+    PLAYRHO_CONSTEXPR inline UnitVec2 operator-() const noexcept { return UnitVec2{-GetX(), -GetY()}; }
 
     /// @brief Positive operator.
-    constexpr inline UnitVec2 operator+() const noexcept { return UnitVec2{+GetX(), +GetY()}; }
+    PLAYRHO_CONSTEXPR inline UnitVec2 operator+() const noexcept { return UnitVec2{+GetX(), +GetY()}; }
 
     /// @brief Gets the absolute value.
-    constexpr inline UnitVec2 Absolute() const noexcept
+    PLAYRHO_CONSTEXPR inline UnitVec2 Absolute() const noexcept
     {
         return UnitVec2{Abs(GetX()), Abs(GetY())};
     }
@@ -260,7 +260,7 @@ public:
 private:
     
     /// @brief Initializing constructor.
-    constexpr UnitVec2(value_type x, value_type y) noexcept : m_elems{x, y}
+    PLAYRHO_CONSTEXPR inline UnitVec2(value_type x, value_type y) noexcept : m_elems{x, y}
     {
         // Intentionally empty.
     }
@@ -269,20 +269,20 @@ private:
 };
 
 /// @brief Gets the "X-axis".
-constexpr inline UnitVec2 GetXAxis(UnitVec2 rot) noexcept { return rot; }
+PLAYRHO_CONSTEXPR inline UnitVec2 GetXAxis(UnitVec2 rot) noexcept { return rot; }
 
 /// @brief Gets the "Y-axis".
 /// @note This is the reverse perpendicular vector of the given unit vector.
-constexpr inline UnitVec2 GetYAxis(UnitVec2 rot) noexcept { return rot.GetRevPerpendicular(); }
+PLAYRHO_CONSTEXPR inline UnitVec2 GetYAxis(UnitVec2 rot) noexcept { return rot.GetRevPerpendicular(); }
 
 /// @brief Equality operator.
-constexpr inline bool operator==(const UnitVec2 a, const UnitVec2 b) noexcept
+PLAYRHO_CONSTEXPR inline bool operator==(const UnitVec2 a, const UnitVec2 b) noexcept
 {
     return (a.GetX() == b.GetX()) && (a.GetY() == b.GetY());
 }
 
 /// @brief Inequality operator.
-constexpr inline bool operator!=(const UnitVec2 a, const UnitVec2 b) noexcept
+PLAYRHO_CONSTEXPR inline bool operator!=(const UnitVec2 a, const UnitVec2 b) noexcept
 {
     return (a.GetX() != b.GetX()) || (a.GetY() != b.GetY());
 }
@@ -293,7 +293,7 @@ constexpr inline bool operator!=(const UnitVec2 a, const UnitVec2 b) noexcept
 /// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
 /// @return A counter-clockwise 90-degree rotation of the given vector.
 /// @sa GetFwdPerpendicular.
-constexpr inline UnitVec2 GetRevPerpendicular(const UnitVec2 vector) noexcept
+PLAYRHO_CONSTEXPR inline UnitVec2 GetRevPerpendicular(const UnitVec2 vector) noexcept
 {
     return vector.GetRevPerpendicular();
 }
@@ -303,7 +303,7 @@ constexpr inline UnitVec2 GetRevPerpendicular(const UnitVec2 vector) noexcept
 /// @param vector Vector to return a clockwise perpendicular equivalent for.
 /// @return A clockwise 90-degree rotation of the given vector.
 /// @sa GetRevPerpendicular.
-constexpr inline UnitVec2 GetFwdPerpendicular(const UnitVec2 vector) noexcept
+PLAYRHO_CONSTEXPR inline UnitVec2 GetFwdPerpendicular(const UnitVec2 vector) noexcept
 {
     return vector.GetFwdPerpendicular();
 }
@@ -311,29 +311,29 @@ constexpr inline UnitVec2 GetFwdPerpendicular(const UnitVec2 vector) noexcept
 /// @brief Rotates a unit vector by the angle expressed by the second unit vector.
 /// @return Unit vector for the angle that's the sum of the two angles expressed by
 ///   the input unit vectors.
-constexpr inline UnitVec2 Rotate(const UnitVec2 vector, const UnitVec2& angle) noexcept
+PLAYRHO_CONSTEXPR inline UnitVec2 Rotate(const UnitVec2 vector, const UnitVec2& angle) noexcept
 {
     return vector.Rotate(angle);
 }
 
 /// @brief Inverse rotates a vector.
-constexpr inline UnitVec2 InverseRotate(const UnitVec2 vector, const UnitVec2& angle) noexcept
+PLAYRHO_CONSTEXPR inline UnitVec2 InverseRotate(const UnitVec2 vector, const UnitVec2& angle) noexcept
 {
     return vector.Rotate(angle.FlipY());
 }
     
 /// @brief Gets an invalid value for the UnitVec2 type.
-template <> constexpr UnitVec2 GetInvalid() noexcept { return UnitVec2{}; }
+template <> PLAYRHO_CONSTEXPR inline UnitVec2 GetInvalid() noexcept { return UnitVec2{}; }
 
 /// @brief Determines if the given value is valid.
-template <> constexpr inline bool IsValid(const UnitVec2& value) noexcept
+template <> PLAYRHO_CONSTEXPR inline bool IsValid(const UnitVec2& value) noexcept
 {
     return IsValid(value.GetX()) && IsValid(value.GetY()) && (value != UnitVec2::GetZero());
 }
 
 /// @brief Gets the I'th element of the given collection.
 template <size_t I>
-constexpr UnitVec2::value_type Get(UnitVec2 v) noexcept
+PLAYRHO_CONSTEXPR inline UnitVec2::value_type Get(UnitVec2 v) noexcept
 {
     static_assert(I < 2, "Index out of bounds in playrho::Get<> (playrho::UnitVec2)");
     switch (I)
@@ -345,14 +345,14 @@ constexpr UnitVec2::value_type Get(UnitVec2 v) noexcept
 
 /// @brief Gets the 0'th element of the given collection.
 template <>
-constexpr UnitVec2::value_type Get<0>(UnitVec2 v) noexcept
+PLAYRHO_CONSTEXPR inline UnitVec2::value_type Get<0>(UnitVec2 v) noexcept
 {
     return v.GetX();
 }
 
 /// @brief Gets the 1'st element of the given collection.
 template <>
-constexpr UnitVec2::value_type Get<1>(UnitVec2 v) noexcept
+PLAYRHO_CONSTEXPR inline UnitVec2::value_type Get<1>(UnitVec2 v) noexcept
 {
     return v.GetY();
 }

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -300,100 +300,100 @@ namespace playrho
 
     /// @brief Second unit of Time.
     /// @sa Time.
-    constexpr auto Second = PLAYRHO_UNIT(Time, boost::units::si::second);
+    PLAYRHO_CONSTEXPR const auto Second = PLAYRHO_UNIT(Time, boost::units::si::second);
 
     /// @brief Square second unit.
     /// @sa Second
-    constexpr auto SquareSecond = Second * Second;
+    PLAYRHO_CONSTEXPR const auto SquareSecond = Second * Second;
 
     /// @brief Hertz unit of Frequency.
     /// @details Represents the hertz unit of Frequency (Hz).
     /// @sa Frequency.
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    constexpr auto Hertz = PLAYRHO_UNIT(Frequency, boost::units::si::hertz);
+    PLAYRHO_CONSTEXPR const auto Hertz = PLAYRHO_UNIT(Frequency, boost::units::si::hertz);
 
     /// @brief Meter unit of Length.
     /// @details A unit of the Length quantity.
     /// @sa Length.
-    constexpr auto Meter = PLAYRHO_UNIT(Length, boost::units::si::meter);
+    PLAYRHO_CONSTEXPR const auto Meter = PLAYRHO_UNIT(Length, boost::units::si::meter);
 
     /// @brief Meter per second unit of LinearVelocity.
     /// @sa LinearVelocity.
-    constexpr auto MeterPerSecond = PLAYRHO_UNIT(LinearVelocity,
+    PLAYRHO_CONSTEXPR const auto MeterPerSecond = PLAYRHO_UNIT(LinearVelocity,
         boost::units::si::meter_per_second);
 
     /// @brief Meter per square second unit of LinearAcceleration.
     /// @sa LinearAcceleration.
-    constexpr auto MeterPerSquareSecond = PLAYRHO_UNIT(LinearAcceleration,
+    PLAYRHO_CONSTEXPR const auto MeterPerSquareSecond = PLAYRHO_UNIT(LinearAcceleration,
         boost::units::si::meter_per_second_squared);
 
     /// @brief Kilogram unit of Mass.
     /// @sa Mass.
-    constexpr auto Kilogram = PLAYRHO_UNIT(Mass, boost::units::si::kilogram);
+    PLAYRHO_CONSTEXPR const auto Kilogram = PLAYRHO_UNIT(Mass, boost::units::si::kilogram);
 
     /// @brief Square meter unit of Area.
     /// @sa Area.
-    constexpr auto SquareMeter = PLAYRHO_UNIT(Area, boost::units::si::square_meter);
+    PLAYRHO_CONSTEXPR const auto SquareMeter = PLAYRHO_UNIT(Area, boost::units::si::square_meter);
 
     /// @brief Cubic meter unit of Volume.
-    constexpr auto CubicMeter = Meter * Meter * Meter;
+    PLAYRHO_CONSTEXPR const auto CubicMeter = Meter * Meter * Meter;
 
     /// @brief Kilogram per square meter unit of AreaDensity.
     /// @sa AreaDensity.
-    constexpr auto KilogramPerSquareMeter = PLAYRHO_UNIT(AreaDensity,
+    PLAYRHO_CONSTEXPR const auto KilogramPerSquareMeter = PLAYRHO_UNIT(AreaDensity,
         boost::units::si::kilogram_per_square_meter);
 
     /// @brief Radian unit of Angle.
     /// @sa Angle.
     /// @sa Degree.
-    constexpr auto Radian = PLAYRHO_UNIT(Angle, boost::units::si::radian);
+    PLAYRHO_CONSTEXPR const auto Radian = PLAYRHO_UNIT(Angle, boost::units::si::radian);
     
     /// @brief Degree unit of Angle quantity.
     /// @sa Angle.
     /// @sa Radian.
-    constexpr auto Degree = Angle{Radian * Pi / Real{180}};
+    PLAYRHO_CONSTEXPR const auto Degree = Angle{Radian * Pi / Real{180}};
     
     /// @brief Square radian unit type.
     /// @sa Angle.
     /// @sa Radian.
-    constexpr auto SquareRadian = Radian * Radian;
+    PLAYRHO_CONSTEXPR const auto SquareRadian = Radian * Radian;
 
     /// @brief Radian per second unit of AngularVelocity.
     /// @sa AngularVelocity.
-    constexpr auto RadianPerSecond = PLAYRHO_UNIT(AngularVelocity,
+    PLAYRHO_CONSTEXPR const auto RadianPerSecond = PLAYRHO_UNIT(AngularVelocity,
         boost::units::si::radian_per_second);
     
     /// @brief Degree per second unit of AngularVelocity.
     /// @sa AngularVelocity.
-    constexpr auto DegreePerSecond = AngularVelocity{RadianPerSecond * Degree / Radian};
+    PLAYRHO_CONSTEXPR const auto DegreePerSecond = AngularVelocity{RadianPerSecond * Degree / Radian};
 
     /// @brief Radian per square second unit of AngularAcceleration.
     /// @sa AngularAcceleration.
-    constexpr auto RadianPerSquareSecond = Radian / (Second * Second);
+    PLAYRHO_CONSTEXPR const auto RadianPerSquareSecond = Radian / (Second * Second);
 
     /// @brief Degree per square second unit of AngularAcceleration.
     /// @sa AngularAcceleration.
-    constexpr auto DegreePerSquareSecond = Degree / (Second * Second);
+    PLAYRHO_CONSTEXPR const auto DegreePerSquareSecond = Degree / (Second * Second);
 
     /// @brief Newton unit of Force.
     /// @sa Force.
-    constexpr auto Newton = PLAYRHO_UNIT(Force, boost::units::si::newton);
+    PLAYRHO_CONSTEXPR const auto Newton = PLAYRHO_UNIT(Force, boost::units::si::newton);
 
     /// @brief Newton meter unit of Torque.
     /// @sa Torque.
-    constexpr auto NewtonMeter = PLAYRHO_UNIT(Torque, boost::units::si::newton_meter);
+    PLAYRHO_CONSTEXPR const auto NewtonMeter = PLAYRHO_UNIT(Torque, boost::units::si::newton_meter);
 
     /// @brief Newton second unit of Momentum.
     /// @sa Momentum.
-    constexpr auto NewtonSecond = Newton * Second;
+    PLAYRHO_CONSTEXPR const auto NewtonSecond = Newton * Second;
     
     /// @brief Newton meter second unit of AngularMomentum.
     /// @sa AngularMomentum.
-    constexpr auto NewtonMeterSecond = NewtonMeter * Second;
+    PLAYRHO_CONSTEXPR const auto NewtonMeterSecond = NewtonMeter * Second;
     
     /// @brief Revolutions per minute units of AngularVelocity.
     /// @sa AngularVelocity
-    constexpr auto RevolutionsPerMinute = 2 * Pi * Radian / (Real{60} * Second);
+    PLAYRHO_CONSTEXPR const auto RevolutionsPerMinute = 2 * Pi * Radian / (Real{60} * Second);
     
     /// @}
     
@@ -406,14 +406,14 @@ namespace playrho
 
     /// @brief SI unit symbol for a gram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Gram
-    constexpr Mass operator"" _g(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Mass operator"" _g(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * (Kilogram / Kilo);
     }
     
     /// @brief SI unit symbol for a gram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Gram
-    constexpr Mass operator"" _g(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Mass operator"" _g(long double v) noexcept
     {
         return static_cast<Real>(v) * (Kilogram / Kilo);
     }
@@ -421,7 +421,7 @@ namespace playrho
     /// @brief SI unit symbol for a kilogram unit of Mass.
     /// @sa Kilogram
     /// @sa https://en.wikipedia.org/wiki/Kilogram
-    constexpr Mass operator"" _kg(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Mass operator"" _kg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilogram;
     }
@@ -429,21 +429,21 @@ namespace playrho
     /// @brief SI unit symbol for a kilogram unit of Mass.
     /// @sa Kilogram
     /// @sa https://en.wikipedia.org/wiki/Kilogram
-    constexpr Mass operator"" _kg(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Mass operator"" _kg(long double v) noexcept
     {
         return static_cast<Real>(v) * Kilogram;
     }
     
     /// @brief SI unit symbol for a yottagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    constexpr Mass operator"" _Yg(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Mass operator"" _Yg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
     
     /// @brief SI unit symbol for a yottagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    constexpr Mass operator"" _Yg(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Mass operator"" _Yg(long double v) noexcept
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
@@ -451,7 +451,7 @@ namespace playrho
     /// @brief SI unit symbol for a meter of Length.
     /// @sa Meter
     /// @sa https://en.wikipedia.org/wiki/Metre
-    constexpr Length operator"" _m(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _m(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Meter;
     }
@@ -459,63 +459,63 @@ namespace playrho
     /// @brief SI unit symbol for a meter of Length.
     /// @sa Meter
     /// @sa https://en.wikipedia.org/wiki/Metre
-    constexpr Length operator"" _m(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _m(long double v) noexcept
     {
         return static_cast<Real>(v) * Meter;
     }
     
     /// @brief SI unit symbol for a decimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Decimetre
-    constexpr Length operator"" _dm(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _dm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
     
     /// @brief SI unit symbol for a decimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Decimetre
-    constexpr Length operator"" _dm(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _dm(long double v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
     
     /// @brief SI unit symbol for a centimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Centimetre
-    constexpr Length operator"" _cm(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _cm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
     
     /// @brief SI unit symbol for a centimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Centimetre
-    constexpr Length operator"" _cm(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _cm(long double v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
     
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Gigametre
-    constexpr Length operator"" _Gm (unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _Gm (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
     
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Gigametre
-    constexpr Length operator"" _Gm (long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _Gm (long double v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
     
     /// @brief SI symbol for a kilometer unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Kilometre
-    constexpr Length operator"" _km (unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _km (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
     
     /// @brief SI symbol for a kilometer unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Kilometre
-    constexpr Length operator"" _km (long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Length operator"" _km (long double v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
@@ -523,7 +523,7 @@ namespace playrho
     /// @brief SI symbol for a second unit of Time.
     /// @sa Second
     /// @sa https://en.wikipedia.org/wiki/Second
-    constexpr Time operator"" _s(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _s(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Second;
     }
@@ -531,49 +531,49 @@ namespace playrho
     /// @brief SI symbol for a second unit of Time.
     /// @sa Second
     /// @sa https://en.wikipedia.org/wiki/Second
-    constexpr Time operator"" _s(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _s(long double v) noexcept
     {
         return static_cast<Real>(v) * Second;
     }
     
     /// @brief SI symbol for a minute unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Minute
-    constexpr Time operator"" _min(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _min(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
     
     /// @brief SI symbol for a minute unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Minute
-    constexpr Time operator"" _min(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _min(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
     
     /// @brief Symbol for an hour unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Hour
-    constexpr Time operator"" _h(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _h(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
     
     /// @brief Symbol for an hour unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Hour
-    constexpr Time operator"" _h(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _h(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
     
     /// @brief Symbol for a day unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Day
-    constexpr Time operator"" _d(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _d(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * 24 * Second;
     }
     
     /// @brief Symbol for a day unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Day
-    constexpr Time operator"" _d(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Time operator"" _d(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * 24 * Second;
     }
@@ -581,7 +581,7 @@ namespace playrho
     /// @brief SI symbol for a radian unit of Angle.
     /// @sa Radian.
     /// @sa https://en.wikipedia.org/wiki/Radian
-    constexpr Angle operator"" _rad(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Angle operator"" _rad(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Radian;
     }
@@ -589,7 +589,7 @@ namespace playrho
     /// @brief SI symbol for a radian unit of Angle.
     /// @sa Radian.
     /// @sa https://en.wikipedia.org/wiki/Radian
-    constexpr Angle operator"" _rad(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Angle operator"" _rad(long double v) noexcept
     {
         return static_cast<Real>(v) * Radian;
     }
@@ -597,7 +597,7 @@ namespace playrho
     /// @brief Abbreviation for a degree unit of Angle.
     /// @sa Degree.
     /// @sa https://en.wikipedia.org/wiki/Degree_(angle)
-    constexpr Angle operator"" _deg(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Angle operator"" _deg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Degree;
     }
@@ -605,7 +605,7 @@ namespace playrho
     /// @brief Abbreviation for a degree unit of Angle.
     /// @sa Degree.
     /// @sa https://en.wikipedia.org/wiki/Degree_(angle)
-    constexpr Angle operator"" _deg(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Angle operator"" _deg(long double v) noexcept
     {
         return static_cast<Real>(v) * Degree;
     }
@@ -613,7 +613,7 @@ namespace playrho
     /// @brief SI symbol for a newton unit of Force.
     /// @sa Newton
     /// @sa https://en.wikipedia.org/wiki/Newton_(unit)
-    constexpr Force operator"" _N(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Force operator"" _N(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Newton;
     }
@@ -621,7 +621,7 @@ namespace playrho
     /// @brief SI symbol for a newton unit of Force.
     /// @sa Newton
     /// @sa https://en.wikipedia.org/wiki/Newton_(unit)
-    constexpr Force operator"" _N(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Force operator"" _N(long double v) noexcept
     {
         return static_cast<Real>(v) * Newton;
     }
@@ -631,7 +631,7 @@ namespace playrho
     /// @sa Meter
     /// @sa Second
     /// @sa MeterPerSecond
-    constexpr LinearVelocity operator"" _mps(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _mps(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSecond;
     }
@@ -641,7 +641,7 @@ namespace playrho
     /// @sa Meter
     /// @sa Second
     /// @sa MeterPerSecond
-    constexpr LinearVelocity operator"" _mps(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _mps(long double v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSecond;
     }
@@ -649,7 +649,7 @@ namespace playrho
     /// @brief Abbreviation for kilometer per second.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second
     /// @sa Second
-    constexpr LinearVelocity operator"" _kps(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _kps(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
@@ -657,7 +657,7 @@ namespace playrho
     /// @brief Abbreviation for kilometer per second.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second
     /// @sa Second
-    constexpr LinearVelocity operator"" _kps(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _kps(long double v) noexcept
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
@@ -665,7 +665,7 @@ namespace playrho
     /// @brief Abbreviation for meter per second squared.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @sa MeterPerSquareSecond
-    constexpr LinearAcceleration operator"" _mps2(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline LinearAcceleration operator"" _mps2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
@@ -673,7 +673,7 @@ namespace playrho
     /// @brief Abbreviation for meter per second squared.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @sa MeterPerSquareSecond
-    constexpr LinearAcceleration operator"" _mps2(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline LinearAcceleration operator"" _mps2(long double v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
@@ -681,7 +681,7 @@ namespace playrho
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @sa Hertz
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    constexpr Frequency operator"" _Hz(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Frequency operator"" _Hz(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Hertz;
     }
@@ -689,7 +689,7 @@ namespace playrho
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @sa Hertz
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    constexpr Frequency operator"" _Hz(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Frequency operator"" _Hz(long double v) noexcept
     {
         return static_cast<Real>(v) * Hertz;
     }
@@ -697,7 +697,7 @@ namespace playrho
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @sa NewtonMeter
     /// @sa https://en.wikipedia.org/wiki/Newton_metre
-    constexpr Torque operator"" _Nm(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Torque operator"" _Nm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
@@ -705,7 +705,7 @@ namespace playrho
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @sa NewtonMeter
     /// @sa https://en.wikipedia.org/wiki/Newton_metre
-    constexpr Torque operator"" _Nm(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Torque operator"" _Nm(long double v) noexcept
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
@@ -713,7 +713,7 @@ namespace playrho
     /// @brief SI symbol for a newton second of impulse.
     /// @sa NewtonSecond
     /// @sa https://en.wikipedia.org/wiki/Newton_second
-    constexpr Momentum operator"" _Ns(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline Momentum operator"" _Ns(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
@@ -721,33 +721,33 @@ namespace playrho
     /// @brief SI symbol for a newton second of impulse.
     /// @sa NewtonSecond
     /// @sa https://en.wikipedia.org/wiki/Newton_second
-    constexpr Momentum operator"" _Ns(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline Momentum operator"" _Ns(long double v) noexcept
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    constexpr AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    constexpr AreaDensity operator"" _kgpm2(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline AreaDensity operator"" _kgpm2(long double v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
 
     /// @brief Abbreviation for revolutions per minute.
     /// @sa RevolutionsPerMinute
-    constexpr AngularVelocity operator"" _rpm(unsigned long long int v) noexcept
+    PLAYRHO_CONSTEXPR inline AngularVelocity operator"" _rpm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * RevolutionsPerMinute;
     }
 
     /// @brief Abbreviation for revolutions per minute.
     /// @sa RevolutionsPerMinute
-    constexpr AngularVelocity operator"" _rpm(long double v) noexcept
+    PLAYRHO_CONSTEXPR inline AngularVelocity operator"" _rpm(long double v) noexcept
     {
         return static_cast<Real>(v) * RevolutionsPerMinute;
     }
@@ -755,7 +755,7 @@ namespace playrho
     /// @}
     
     /// @brief Strips the units off of the given value.
-    constexpr inline Real StripUnit(const Real value)
+    PLAYRHO_CONSTEXPR inline Real StripUnit(const Real value)
     {
         return value;
     }
@@ -771,12 +771,12 @@ namespace playrho
     ///   the Earth due to the Earth's gravity.
     /// @note This constant is only appropriate for use for objects of low mass and close
     ///   distance relative to the Earth.
-    constexpr auto EarthlyLinearAcceleration = Real{-9.8f} * MeterPerSquareSecond;
+    PLAYRHO_CONSTEXPR const auto EarthlyLinearAcceleration = Real{-9.8f} * MeterPerSquareSecond;
     
     /// @brief Big "G".
     /// @details Gravitational constant used in calculating the attractive force on a mass
     ///   to another mass at a given distance due to gravity.
-    constexpr auto BigG = Real{6.67408e-11f} * CubicMeter / (Kilogram * SquareSecond);
+    PLAYRHO_CONSTEXPR const auto BigG = Real{6.67408e-11f} * CubicMeter / (Kilogram * SquareSecond);
     
     /// @}
 
@@ -805,105 +805,105 @@ namespace playrho
 
     /// @brief Strips the units off of the given value.
     template<typename Y>
-    inline constexpr auto StripUnit(const boost::units::quantity<Y, Real> source)
+    PLAYRHO_CONSTEXPR inline auto StripUnit(const boost::units::quantity<Y, Real> source)
     {
         return source.value();
     }
 
     /// @brief Gets an invalid value for the Angle type.
     template <>
-    constexpr Angle GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Angle GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Radian;
     }
     
     /// @brief Gets an invalid value for the Frequency type.
     template <>
-    constexpr Frequency GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Frequency GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Hertz;
     }
     
     /// @brief Gets an invalid value for the AngularVelocity type.
     template <>
-    constexpr AngularVelocity GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline AngularVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSecond;
     }
     
     /// @brief Gets an invalid value for the Time type.
     template <>
-    constexpr Time GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Time GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Second;
     }
     
     /// @brief Gets an invalid value for the Length type.
     template <>
-    constexpr Length GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Length GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Meter;
     }
     
     /// @brief Gets an invalid value for the Mass type.
     template <>
-    constexpr Mass GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Mass GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram;
     }
     
     /// @brief Gets an invalid value for the InvMass type.
     template <>
-    constexpr InvMass GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline InvMass GetInvalid() noexcept
     {
         return GetInvalid<Real>() / Kilogram;
     }
     
     /// @brief Gets an invalid value for the Momentum type.
     template <>
-    constexpr Momentum GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Momentum GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram * MeterPerSecond;
     }
     
     /// @brief Gets an invalid value for the Force type.
     template <>
-    constexpr Force GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Force GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Newton;
     }
     
     /// @brief Gets an invalid value for the Torque type.
     template <>
-    constexpr Torque GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Torque GetInvalid() noexcept
     {
         return GetInvalid<Real>() * NewtonMeter;
     }
     
     /// @brief Gets an invalid value for the LinearVelocity type.
     template <>
-    constexpr LinearVelocity GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline LinearVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSecond;
     }
     
     /// @brief Gets an invalid value for the LinearAcceleration type.
     template <>
-    constexpr LinearAcceleration GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline LinearAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSquareSecond;
     }
     
     /// @brief Gets an invalid value for the AngularAcceleration type.
     template <>
-    constexpr AngularAcceleration GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline AngularAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSquareSecond;
     }
     
     /// @brief Gets an invalid value for the RotInertia type.
     template <>
-    constexpr RotInertia GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline RotInertia GetInvalid() noexcept
     {
         // RotInertia is L^2  M    QP^-2
         return GetInvalid<Real>() * SquareMeter * Kilogram / SquareRadian;
@@ -938,7 +938,7 @@ template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} / X{}), playrho::Real>::value >
 >
-constexpr auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
+PLAYRHO_CONSTEXPR inline auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
 {
     return lhs / playrho::Real(rhs);
 }
@@ -947,7 +947,7 @@ template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(X{} / playrho::Real{}), playrho::Real>::value >
 >
-constexpr auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
+PLAYRHO_CONSTEXPR inline auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
 {
     return playrho::Real(lhs) / rhs;
 }
@@ -963,7 +963,7 @@ constexpr auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
 template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-constexpr auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
+PLAYRHO_CONSTEXPR inline auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
 {
     return lhs * playrho::Real(rhs);
 }
@@ -979,7 +979,7 @@ constexpr auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
 template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-constexpr auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
+PLAYRHO_CONSTEXPR inline auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
 {
     return playrho::Real(lhs) * rhs;
 }

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -37,7 +37,7 @@ namespace playrho
 {
 
 /// @brief Vector.
-/// @details This is a <code>constexpr</code> and constructor enhanced
+/// @details This is a <code>PLAYRHO_CONSTEXPR inline</code> and constructor enhanced
 ///   <code>std::array</code>-like template class for types supporting the +, -, *, /
 ///   arithmetic operators ("arithmetic types" as defined by the <code>IsArithmetic</code>
 ///   type trait) that itself comes with non-member arithmetic operator support making
@@ -87,25 +87,25 @@ struct Vector
     /// @brief Default constructor.
     /// @note Defaulted explicitly.
     /// @note This constructor performs no action.
-    constexpr Vector() = default;
+    PLAYRHO_CONSTEXPR inline Vector() = default;
     
     /// @brief Initializing constructor.
     template<typename... Tail>
-    constexpr explicit Vector(typename std::enable_if<sizeof...(Tail)+1 == N, T>::type
+    PLAYRHO_CONSTEXPR inline explicit Vector(typename std::enable_if<sizeof...(Tail)+1 == N, T>::type
                      head, Tail... tail) noexcept: elements{head, T(tail)...}
     {
         // Intentionally empty.
     }
 
     /// @brief Gets the max size.
-    constexpr size_type max_size() const noexcept { return N; }
+    PLAYRHO_CONSTEXPR inline size_type max_size() const noexcept { return N; }
     
     /// @brief Gets the size.
-    constexpr size_type size() const noexcept { return N; }
+    PLAYRHO_CONSTEXPR inline size_type size() const noexcept { return N; }
     
     /// @brief Whether empty.
     /// @note Always false for N > 0.
-    constexpr bool empty() const noexcept { return N == 0; }
+    PLAYRHO_CONSTEXPR inline bool empty() const noexcept { return N == 0; }
     
     /// @brief Gets a "begin" iterator.
     iterator begin() noexcept { return iterator(elements); }
@@ -158,7 +158,7 @@ struct Vector
     /// @brief Gets a reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr reference operator[](size_type pos) noexcept
+    PLAYRHO_CONSTEXPR inline reference operator[](size_type pos) noexcept
     {
         assert(pos < size());
         return elements[pos];
@@ -167,7 +167,7 @@ struct Vector
     /// @brief Gets a constant reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr const_reference operator[](size_type pos) const noexcept
+    PLAYRHO_CONSTEXPR inline const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
         return elements[pos];
@@ -175,7 +175,7 @@ struct Vector
     
     /// @brief Gets a reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    constexpr reference at(size_type pos)
+    PLAYRHO_CONSTEXPR inline reference at(size_type pos)
     {
         if (pos >= size())
         {
@@ -186,7 +186,7 @@ struct Vector
     
     /// @brief Gets a constant reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    constexpr const_reference at(size_type pos) const
+    PLAYRHO_CONSTEXPR inline const_reference at(size_type pos) const
     {
         if (pos >= size())
         {
@@ -196,13 +196,13 @@ struct Vector
     }
     
     /// @brief Direct access to data.
-    constexpr pointer data() noexcept
+    PLAYRHO_CONSTEXPR inline pointer data() noexcept
     {
         return elements;
     }
     
     /// @brief Direct access to data.
-    constexpr const_pointer data() const noexcept
+    PLAYRHO_CONSTEXPR inline const_pointer data() const noexcept
     {
         return elements;
     }
@@ -217,7 +217,7 @@ struct Vector
 /// @brief Equality operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -232,7 +232,7 @@ constexpr bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noe
 /// @brief Inequality operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     return !(lhs == rhs);
 }
@@ -240,7 +240,7 @@ constexpr bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noe
 /// @brief Unary plus operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto operator+ (Vector<T, N> v) noexcept
+PLAYRHO_CONSTEXPR inline auto operator+ (Vector<T, N> v) noexcept
 {
     return v;
 }
@@ -248,7 +248,7 @@ constexpr auto operator+ (Vector<T, N> v) noexcept
 /// @brief Unary negation operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto operator- (Vector<T, N> v) noexcept
+PLAYRHO_CONSTEXPR inline auto operator- (Vector<T, N> v) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -260,7 +260,7 @@ constexpr auto operator- (Vector<T, N> v) noexcept
 /// @brief Increments the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto& operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto& operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -272,7 +272,7 @@ constexpr auto& operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 /// @brief Decrements the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto& operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto& operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -284,7 +284,7 @@ constexpr auto& operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 /// @brief Adds two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
     return lhs += rhs;
 }
@@ -292,7 +292,7 @@ constexpr auto operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 /// @brief Subtracts two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
     return lhs -= rhs;
 }
@@ -300,7 +300,7 @@ constexpr auto operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 /// @brief Multiplication assignment operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto& operator*= (Vector<T, N>& lhs, const Real rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto& operator*= (Vector<T, N>& lhs, const Real rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -312,7 +312,7 @@ constexpr auto& operator*= (Vector<T, N>& lhs, const Real rhs) noexcept
 /// @brief Division assignment operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr auto& operator/= (Vector<T, N>& lhs, const Real rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto& operator/= (Vector<T, N>& lhs, const Real rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -324,7 +324,7 @@ constexpr auto& operator/= (Vector<T, N>& lhs, const Real rhs) noexcept
 /// @brief Multiplication operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-constexpr auto operator* (const T1 s, const Vector<T2, N>& a) noexcept
+PLAYRHO_CONSTEXPR inline auto operator* (const T1 s, const Vector<T2, N>& a) noexcept
 {
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<size_t>(0); i < N; ++i)
@@ -337,7 +337,7 @@ constexpr auto operator* (const T1 s, const Vector<T2, N>& a) noexcept
 /// @brief Multiplication operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-constexpr auto operator* (const Vector<T1, N>& a, const T2 s) noexcept
+PLAYRHO_CONSTEXPR inline auto operator* (const Vector<T1, N>& a, const T2 s) noexcept
 {
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<size_t>(0); i < N; ++i)
@@ -350,7 +350,7 @@ constexpr auto operator* (const Vector<T1, N>& a, const T2 s) noexcept
 /// @brief Division operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} / T2{})>
-constexpr auto operator/ (const Vector<T1, N>& a, const T2 s) noexcept
+PLAYRHO_CONSTEXPR inline auto operator/ (const Vector<T1, N>& a, const T2 s) noexcept
 {
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<size_t>(0); i < N; ++i)
@@ -363,7 +363,7 @@ constexpr auto operator/ (const Vector<T1, N>& a, const T2 s) noexcept
 /// @brief Multiplication operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-constexpr auto operator* (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto operator* (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) noexcept
 {
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<size_t>(0); i < N; ++i)
@@ -376,7 +376,7 @@ constexpr auto operator* (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) no
 /// @brief Division operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} / T2{})>
-constexpr auto operator/ (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline auto operator/ (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) noexcept
 {
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<size_t>(0); i < N; ++i)
@@ -389,7 +389,7 @@ constexpr auto operator/ (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) no
 /// @brief Lexicographical less-than operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr bool operator< (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator< (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     return std::lexicographical_compare(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
                                         std::less<T>{});
@@ -398,7 +398,7 @@ constexpr bool operator< (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noex
 /// @brief Lexicographical less-than or equal-to operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr bool operator<= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator<= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     const auto lhsEnd = std::cend(lhs);
     const auto rhsEnd = std::cend(rhs);
@@ -409,7 +409,7 @@ constexpr bool operator<= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noe
 /// @brief Lexicographical greater-than operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr bool operator> (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator> (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     return std::lexicographical_compare(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
                                         std::greater<T>{});
@@ -418,7 +418,7 @@ constexpr bool operator> (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noex
 /// @brief Lexicographical greater-than or equal-to operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr bool operator>= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator>= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     const auto lhsEnd = std::cend(lhs);
     const auto rhsEnd = std::cend(rhs);
@@ -429,7 +429,7 @@ constexpr bool operator>= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noe
 /// @brief Gets the I'th element of the given collection.
 /// @relatedalso Vector
 template <size_t I, size_t N, typename T>
-constexpr auto& Get(Vector<T, N>& v) noexcept
+PLAYRHO_CONSTEXPR inline auto& Get(Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::Get<> (playrho::Vector)");
     return v[I];
@@ -437,7 +437,7 @@ constexpr auto& Get(Vector<T, N>& v) noexcept
 
 /// @brief Gets the I'th element of the given collection.
 template <size_t I, size_t N, typename T>
-constexpr auto Get(const Vector<T, N>& v) noexcept
+PLAYRHO_CONSTEXPR inline auto Get(const Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::Get<> (playrho::Vector)");
     return v[I];

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -67,24 +67,24 @@ namespace playrho
     /// @brief Earthly gravity in 2-dimensions.
     /// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
     /// @sa EarthlyLinearAcceleration
-    constexpr auto EarthlyGravity2D = LinearAcceleration2{0_mps2, EarthlyLinearAcceleration};
+    PLAYRHO_CONSTEXPR const auto EarthlyGravity2D = LinearAcceleration2{0_mps2, EarthlyLinearAcceleration};
 
     /// @brief Gets the given value as a Vec2.
-    constexpr inline Vec2 GetVec2(const Vector2<Real> value)
+    PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Vector2<Real> value)
     {
         return {value};
     }
 
     /// @brief Gets an invalid value for the Vec2 type.
     template <>
-    constexpr inline Vec2 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Vec2 GetInvalid() noexcept
     {
         return Vec2{GetInvalid<Vec2::value_type>(), GetInvalid<Vec2::value_type>()};
     }
 
     /// @brief Determines whether the given vector contains finite coordinates.
     template <typename TYPE>
-    constexpr inline bool IsValid(const Vector2<TYPE>& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Vector2<TYPE>& value) noexcept
     {
         return IsValid(Get<0>(value)) && IsValid(Get<1>(value));
     }
@@ -92,33 +92,33 @@ namespace playrho
 #ifdef USE_BOOST_UNITS
     /// @brief Gets an invalid value for the Length2 type.
     template <>
-    constexpr Length2 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Length2 GetInvalid() noexcept
     {
         return Length2{GetInvalid<Length>(), GetInvalid<Length>()};
     }
     
     /// @brief Gets an invalid value for the LinearVelocity2 type.
     template <>
-    constexpr LinearVelocity2 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline LinearVelocity2 GetInvalid() noexcept
     {
         return LinearVelocity2{GetInvalid<LinearVelocity>(), GetInvalid<LinearVelocity>()};
     }
     
     /// @brief Gets an invalid value for the Force2 type.
     template <>
-    constexpr Force2 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Force2 GetInvalid() noexcept
     {
         return Force2{GetInvalid<Force>(), GetInvalid<Force>()};
     }
     
     /// @brief Gets an invalid value for the Momentum2 type.
     template <>
-    constexpr Momentum2 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Momentum2 GetInvalid() noexcept
     {
         return Momentum2{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
     }
     
-    constexpr inline Vec2 GetVec2(const Length2 value)
+    PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Length2 value)
     {
         return Vec2{
             Get<0>(value) / Meter,
@@ -126,7 +126,7 @@ namespace playrho
         };
     }
     
-    constexpr inline Vec2 GetVec2(const LinearVelocity2 value)
+    PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const LinearVelocity2 value)
     {
         return Vec2{
             Get<0>(value) / MeterPerSecond,
@@ -134,7 +134,7 @@ namespace playrho
         };
     }
     
-    constexpr inline Vec2 GetVec2(const Momentum2 value)
+    PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Momentum2 value)
     {
         return Vec2{
             Get<0>(value) / (Kilogram * MeterPerSecond),
@@ -142,7 +142,7 @@ namespace playrho
         };
     }
     
-    constexpr inline Vec2 GetVec2(const Force2 value)
+    PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Force2 value)
     {
         return Vec2{
             Get<0>(value) / Newton,

--- a/PlayRho/Common/Vector3.hpp
+++ b/PlayRho/Common/Vector3.hpp
@@ -45,14 +45,14 @@ namespace playrho
     
     /// @brief Gets an invalid value for the Vec3 type.
     template <>
-    constexpr inline Vec3 GetInvalid() noexcept
+    PLAYRHO_CONSTEXPR inline Vec3 GetInvalid() noexcept
     {
         return Vec3{GetInvalid<Real>(), GetInvalid<Real>(), GetInvalid<Real>()};
     }
     
     /// @brief Determines whether the given vector contains finite coordinates.
     template <>
-    constexpr inline bool IsValid(const Vec3& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Vec3& value) noexcept
     {
         return IsValid(Get<0>(value)) && IsValid(Get<1>(value)) && IsValid(Get<2>(value));
     }

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -38,28 +38,28 @@ namespace playrho
     /// @brief Determines if the given value is valid.
     /// @relatedalso Velocity
     template <>
-    constexpr inline bool IsValid(const Velocity& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Velocity& value) noexcept
     {
         return IsValid(value.linear) && IsValid(value.angular);
     }
     
     /// @brief Equality operator.
     /// @relatedalso Velocity
-    constexpr inline bool operator==(const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator==(const Velocity& lhs, const Velocity& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Velocity
-    constexpr inline bool operator!=(const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!=(const Velocity& lhs, const Velocity& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Multiplication assignment operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity& operator*= (Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity& operator*= (Velocity& lhs, const Real rhs)
     {
         lhs.linear *= rhs;
         lhs.angular *= rhs;
@@ -68,7 +68,7 @@ namespace playrho
     
     /// @brief Division assignment operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity& operator/= (Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity& operator/= (Velocity& lhs, const Real rhs)
     {
         lhs.linear /= rhs;
         lhs.angular /= rhs;
@@ -77,7 +77,7 @@ namespace playrho
     
     /// @brief Addition assignment operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -86,14 +86,14 @@ namespace playrho
     
     /// @brief Addition operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
     {
         return Velocity{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -102,42 +102,42 @@ namespace playrho
     
     /// @brief Subtraction operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity operator- (const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity operator- (const Velocity& lhs, const Velocity& rhs)
     {
         return Velocity{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Negation operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity operator- (const Velocity& value)
+    PLAYRHO_CONSTEXPR inline Velocity operator- (const Velocity& value)
     {
         return Velocity{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity operator+ (const Velocity& value)
+    PLAYRHO_CONSTEXPR inline Velocity operator+ (const Velocity& value)
     {
         return value;
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity operator* (const Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity operator* (const Velocity& lhs, const Real rhs)
     {
         return Velocity{lhs.linear * rhs, lhs.angular * rhs};
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity operator* (const Real lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity operator* (const Real lhs, const Velocity& rhs)
     {
         return Velocity{rhs.linear * lhs, rhs.angular * lhs};
     }
     
     /// @brief Division operator.
     /// @relatedalso Velocity
-    constexpr inline Velocity operator/ (const Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity operator/ (const Velocity& lhs, const Real rhs)
     {
         /*
          * While it can be argued that division operations shouldn't be supported due to

--- a/PlayRho/Common/Version.hpp
+++ b/PlayRho/Common/Version.hpp
@@ -22,6 +22,8 @@
 #ifndef PLAYRHO_COMMON_VERSION_HPP
 #define PLAYRHO_COMMON_VERSION_HPP
 
+#include <PlayRho/Defines.hpp>
+
 #include <cstdint>
 #include <string>
 
@@ -59,13 +61,13 @@ namespace playrho {
     };
     
     /// @brief Equality operator.
-    constexpr inline bool operator== (Version lhs, Version rhs)
+    PLAYRHO_CONSTEXPR inline bool operator== (Version lhs, Version rhs)
     {
         return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.revision == rhs.revision;
     }
     
     /// @brief Inequality operator.
-    constexpr inline bool operator!= (Version lhs, Version rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!= (Version lhs, Version rhs)
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Defines.hpp
+++ b/PlayRho/Defines.hpp
@@ -42,4 +42,8 @@
 #define PLAYRHO_UNREACHABLE std::abort()
 #endif
 
+// Macro for constant expressions.
+// Value of this macro should either be 'constexpr' or empty.
+#define PLAYRHO_CONSTEXPR constexpr
+
 #endif /* PLAYRHO_DEFINES_HPP */

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -85,7 +85,7 @@ public:
     using Contacts = std::vector<KeyedContactPtr>;
 
     /// @brief Invalid island index.
-    static constexpr auto InvalidIslandIndex = static_cast<BodyCounter>(-1);
+    static PLAYRHO_CONSTEXPR const auto InvalidIslandIndex = static_cast<BodyCounter>(-1);
 
     /// @brief Flags type.
     /// @note For internal use. Made public to facilitate unit testing.

--- a/PlayRho/Dynamics/BodyDef.hpp
+++ b/PlayRho/Dynamics/BodyDef.hpp
@@ -48,52 +48,52 @@ namespace playrho {
         // Builder-styled methods...
 
         /// @brief Use the given type.
-        constexpr BodyDef& UseType(BodyType t) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseType(BodyType t) noexcept;
 
         /// @brief Use the given location.
-        constexpr BodyDef& UseLocation(Length2 l) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseLocation(Length2 l) noexcept;
         
         /// @brief Use the given angle.
-        constexpr BodyDef& UseAngle(Angle a) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseAngle(Angle a) noexcept;
         
         /// @brief Use the given linear velocity.
-        constexpr BodyDef& UseLinearVelocity(LinearVelocity2 v) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseLinearVelocity(LinearVelocity2 v) noexcept;
         
         /// @brief Use the given angular velocity.
-        constexpr BodyDef& UseAngularVelocity(AngularVelocity v) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseAngularVelocity(AngularVelocity v) noexcept;
         
         /// @brief Use the given linear acceleration.
-        constexpr BodyDef& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
         
         /// @brief Use the given angular acceleration.
-        constexpr BodyDef& UseAngularAcceleration(AngularAcceleration v) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseAngularAcceleration(AngularAcceleration v) noexcept;
         
         /// @brief Use the given linear damping.
-        constexpr BodyDef& UseLinearDamping(NonNegative<Frequency> v) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseLinearDamping(NonNegative<Frequency> v) noexcept;
         
         /// @brief Use the given angular damping.
-        constexpr BodyDef& UseAngularDamping(NonNegative<Frequency> v) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseAngularDamping(NonNegative<Frequency> v) noexcept;
         
         /// @brief Use the given under active time.
-        constexpr BodyDef& UseUnderActiveTime(Time v) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseUnderActiveTime(Time v) noexcept;
         
         /// @brief Use the given allow sleep value.
-        constexpr BodyDef& UseAllowSleep(bool value) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseAllowSleep(bool value) noexcept;
         
         /// @brief Use the given awake value.
-        constexpr BodyDef& UseAwake(bool value) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseAwake(bool value) noexcept;
         
         /// @brief Use the given fixed rotation state.
-        constexpr BodyDef& UseFixedRotation(bool value) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseFixedRotation(bool value) noexcept;
         
         /// @brief Use the given bullet state.
-        constexpr BodyDef& UseBullet(bool value) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseBullet(bool value) noexcept;
         
         /// @brief Use the given enabled state.
-        constexpr BodyDef& UseEnabled(bool value) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseEnabled(bool value) noexcept;
         
         /// @brief Use the given user data.
-        constexpr BodyDef& UseUserData(void* value) noexcept;
+        PLAYRHO_CONSTEXPR inline BodyDef& UseUserData(void* value) noexcept;
         
         // Public member variables...
         
@@ -159,97 +159,97 @@ namespace playrho {
         void* userData = nullptr;
     };
     
-    constexpr inline BodyDef& BodyDef::UseType(BodyType t) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseType(BodyType t) noexcept
     {
         type = t;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseLocation(Length2 l) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseLocation(Length2 l) noexcept
     {
         location = l;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseAngle(Angle a) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseAngle(Angle a) noexcept
     {
         angle = a;
         return *this;
     }
     
-    constexpr BodyDef& BodyDef::UseLinearVelocity(LinearVelocity2 v) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseLinearVelocity(LinearVelocity2 v) noexcept
     {
         linearVelocity = v;
         return *this;
     }
     
-    constexpr BodyDef& BodyDef::UseLinearAcceleration(LinearAcceleration2 v) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseLinearAcceleration(LinearAcceleration2 v) noexcept
     {
         linearAcceleration = v;
         return *this;
     }
     
-    constexpr BodyDef& BodyDef::UseAngularVelocity(AngularVelocity v) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseAngularVelocity(AngularVelocity v) noexcept
     {
         angularVelocity = v;
         return *this;
     }
     
-    constexpr BodyDef& BodyDef::UseAngularAcceleration(AngularAcceleration v) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseAngularAcceleration(AngularAcceleration v) noexcept
     {
         angularAcceleration = v;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseLinearDamping(NonNegative<Frequency> v) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseLinearDamping(NonNegative<Frequency> v) noexcept
     {
         linearDamping = v;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseAngularDamping(NonNegative<Frequency> v) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseAngularDamping(NonNegative<Frequency> v) noexcept
     {
         angularDamping = v;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseUnderActiveTime(Time v) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseUnderActiveTime(Time v) noexcept
     {
         underActiveTime = v;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseAllowSleep(bool value) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseAllowSleep(bool value) noexcept
     {
         allowSleep = value;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseAwake(bool value) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseAwake(bool value) noexcept
     {
         awake = value;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseFixedRotation(bool value) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseFixedRotation(bool value) noexcept
     {
         fixedRotation = value;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseBullet(bool value) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseBullet(bool value) noexcept
     {
         bullet = value;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseEnabled(bool value) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseEnabled(bool value) noexcept
     {
         enabled = value;
         return *this;
     }
     
-    constexpr inline BodyDef& BodyDef::UseUserData(void* value) noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef& BodyDef::UseUserData(void* value) noexcept
     {
         userData = value;
         return *this;
@@ -257,7 +257,7 @@ namespace playrho {
     
     /// @brief Gets the default body definition.
     /// @relatedalso BodyDef
-    constexpr BodyDef GetDefaultBodyDef() noexcept
+    PLAYRHO_CONSTEXPR inline BodyDef GetDefaultBodyDef() noexcept
     {
         return BodyDef{};
     }

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -42,7 +42,7 @@ namespace playrho {
         BodyConstraint() = default;
         
         /// @brief Initializing constructor.
-        constexpr BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
+        PLAYRHO_CONSTEXPR inline BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
                                  Position position, Velocity velocity) noexcept:
             m_position{position},
             m_velocity{velocity},

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -43,26 +43,26 @@ namespace playrho
         /// @brief Index type.
         using Index = ContactCounter;
         
-        constexpr ContactKey() noexcept
+        PLAYRHO_CONSTEXPR inline ContactKey() noexcept
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        constexpr ContactKey(Index fp1, Index fp2) noexcept:
+        PLAYRHO_CONSTEXPR inline ContactKey(Index fp1, Index fp2) noexcept:
             m_ids{std::minmax(fp1, fp2)}
         {
             // Intentionally empty
         }
 
         /// @brief Gets the minimum index value.
-        constexpr Index GetMin() const noexcept
+        PLAYRHO_CONSTEXPR inline Index GetMin() const noexcept
         {
             return m_ids.first;
         }
         
         /// @brief Gets the maximum index value.
-        constexpr Index GetMax() const noexcept
+        PLAYRHO_CONSTEXPR inline Index GetMax() const noexcept
         {
             return m_ids.second;
         }
@@ -73,40 +73,40 @@ namespace playrho
     };
 
     /// @brief Equality operator.
-    constexpr bool operator== (const ContactKey lhs, const ContactKey rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (const ContactKey lhs, const ContactKey rhs) noexcept
     {
         return lhs.GetMin() == rhs.GetMin() && lhs.GetMax() == rhs.GetMax();
     }
     
     /// @brief Inequality operator.
-    constexpr bool operator!= (const ContactKey lhs, const ContactKey rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (const ContactKey lhs, const ContactKey rhs) noexcept
     {
         return !(lhs == rhs);
     }
 
     /// @brief Less-than operator.
-    constexpr bool operator< (const ContactKey lhs, const ContactKey rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator< (const ContactKey lhs, const ContactKey rhs) noexcept
     {
         return (lhs.GetMin() < rhs.GetMin())
             || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() < rhs.GetMax()));
     }
     
     /// @brief Less-than or equal-to operator.
-    constexpr bool operator<= (const ContactKey lhs, const ContactKey rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator<= (const ContactKey lhs, const ContactKey rhs) noexcept
     {
         return (lhs.GetMin() < rhs.GetMin())
         || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() <= rhs.GetMax()));
     }
     
     /// @brief Greater-than operator.
-    constexpr bool operator> (const ContactKey lhs, const ContactKey rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator> (const ContactKey lhs, const ContactKey rhs) noexcept
     {
         return (lhs.GetMin() > rhs.GetMin())
             || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() > rhs.GetMax()));
     }
     
     /// @brief Greater-than or equal-to operator.
-    constexpr bool operator>= (const ContactKey lhs, const ContactKey rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator>= (const ContactKey lhs, const ContactKey rhs) noexcept
     {
         return (lhs.GetMin() > rhs.GetMin())
         || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() >= rhs.GetMax()));
@@ -143,7 +143,7 @@ namespace std
         using result_type = std::size_t;
 
         /// @brief Function object operator.
-        constexpr std::size_t operator()(const playrho::ContactKey& key) const
+        PLAYRHO_CONSTEXPR inline std::size_t operator()(const playrho::ContactKey& key) const
         {
             // Use simple and fast Knuth multiplicative hash...
             const auto a = std::size_t{key.GetMin()} * 2654435761u;

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -38,7 +38,7 @@ namespace playrho {
 namespace {
 
 #if defined(B2_DEBUG_SOLVER)
-static constexpr auto k_errorTol = 1e-3_mps; ///< error tolerance
+static PLAYRHO_CONSTEXPR inline auto k_errorTol = 1e-3_mps; ///< error tolerance
 #endif
 
 struct VelocityPair

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
@@ -105,7 +105,7 @@ VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
         const auto k00_times_k11 = Get<0>(k) * Get<1>(k);
         const auto k01_squared = Square(Get<2>(k));
         const auto k_diff = k00_times_k11 - k01_squared;
-        constexpr auto maxCondNum = PLAYRHO_MAGIC(Real(1000.0f));
+        PLAYRHO_CONSTEXPR const auto maxCondNum = PLAYRHO_MAGIC(Real(1000.0f));
         if (k00_squared < maxCondNum * k_diff)
         {
             // K is safe to invert.

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -54,7 +54,7 @@ namespace playrho {
         };
         
         /// @brief Gets the default configuration for a VelocityConstraint.
-        static constexpr Conf GetDefaultConf() noexcept
+        static PLAYRHO_CONSTEXPR inline Conf GetDefaultConf() noexcept
         {
             return Conf{};
         }

--- a/PlayRho/Dynamics/Filter.hpp
+++ b/PlayRho/Dynamics/Filter.hpp
@@ -23,6 +23,7 @@
 /// @file
 /// Declarations of the Filter struct and any free functions associated with it.
 
+#include <PlayRho/Defines.hpp>
 #include <cstdint>
 
 namespace playrho {
@@ -61,7 +62,7 @@ namespace playrho {
     
     /// @brief Equality operator.
     /// @relatedalso Filter
-    constexpr bool operator== (const Filter lhs, const Filter rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator== (const Filter lhs, const Filter rhs) noexcept
     {
         return lhs.categoryBits == rhs.categoryBits
             && lhs.maskBits == rhs.maskBits
@@ -70,7 +71,7 @@ namespace playrho {
 
     /// @brief Inequality operator.
     /// @relatedalso Filter
-    constexpr bool operator!= (const Filter lhs, const Filter rhs) noexcept
+    PLAYRHO_CONSTEXPR inline bool operator!= (const Filter lhs, const Filter rhs) noexcept
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Dynamics/FixtureDef.hpp
+++ b/PlayRho/Dynamics/FixtureDef.hpp
@@ -40,13 +40,13 @@ namespace playrho {
     {
         
         /// @brief Uses the given user data.
-        constexpr FixtureDef& UseUserData(void* value) noexcept;
+        PLAYRHO_CONSTEXPR inline FixtureDef& UseUserData(void* value) noexcept;
 
         /// @brief Uses the given sensor state value.
-        constexpr FixtureDef& UseIsSensor(bool value) noexcept;
+        PLAYRHO_CONSTEXPR inline FixtureDef& UseIsSensor(bool value) noexcept;
         
         /// @brief Uses the given filter value.
-        constexpr FixtureDef& UseFilter(Filter value) noexcept;
+        PLAYRHO_CONSTEXPR inline FixtureDef& UseFilter(Filter value) noexcept;
         
         /// Use this to store application specific fixture data.
         void* userData = nullptr;
@@ -59,19 +59,19 @@ namespace playrho {
         Filter filter;
     };
     
-    constexpr inline FixtureDef& FixtureDef::UseUserData(void* value) noexcept
+    PLAYRHO_CONSTEXPR inline FixtureDef& FixtureDef::UseUserData(void* value) noexcept
     {
         userData = value;
         return *this;
     }
     
-    constexpr inline FixtureDef& FixtureDef::UseIsSensor(bool value) noexcept
+    PLAYRHO_CONSTEXPR inline FixtureDef& FixtureDef::UseIsSensor(bool value) noexcept
     {
         isSensor = value;
         return *this;
     }
     
-    constexpr inline FixtureDef& FixtureDef::UseFilter(Filter value) noexcept
+    PLAYRHO_CONSTEXPR inline FixtureDef& FixtureDef::UseFilter(Filter value) noexcept
     {
         filter = value;
         return *this;
@@ -79,7 +79,7 @@ namespace playrho {
 
     /// @brief Gets the default fixture definition.
     /// @relatedalso FixtureDef
-    constexpr FixtureDef GetDefaultFixtureDef() noexcept
+    PLAYRHO_CONSTEXPR inline FixtureDef GetDefaultFixtureDef() noexcept
     {
         return FixtureDef{};
     }

--- a/PlayRho/Dynamics/FixtureProxy.hpp
+++ b/PlayRho/Dynamics/FixtureProxy.hpp
@@ -44,14 +44,14 @@ struct FixtureProxy
 
 /// @brief Equality operator
 /// @relatedalso FixtureProxy
-constexpr bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
 {
     return lhs.treeId == rhs.treeId;
 }
 
 /// @brief Inequality operator
 /// @relatedalso FixtureProxy
-constexpr bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+PLAYRHO_CONSTEXPR inline bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
 {
     return !(lhs.treeId == rhs.treeId);
 }

--- a/PlayRho/Dynamics/Joints/DistanceJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointDef.hpp
@@ -43,7 +43,7 @@ struct DistanceJointDef : public JointBuilder<DistanceJointDef>
     /// @brief Super type.
     using super = JointBuilder<DistanceJointDef>;
     
-    constexpr DistanceJointDef() noexcept: super{JointType::Distance} {}
+    PLAYRHO_CONSTEXPR inline DistanceJointDef() noexcept: super{JointType::Distance} {}
     
     /// @brief Copy constructor.
     DistanceJointDef(const DistanceJointDef& copy) = default;
@@ -55,13 +55,13 @@ struct DistanceJointDef : public JointBuilder<DistanceJointDef>
                      Length2 anchorB = Length2{}) noexcept;
     
     /// @brief Uses the given length.
-    constexpr DistanceJointDef& UseLength(Length v) noexcept;
+    PLAYRHO_CONSTEXPR inline DistanceJointDef& UseLength(Length v) noexcept;
     
     /// @brief Uses the given frequency.
-    constexpr DistanceJointDef& UseFrequency(NonNegative<Frequency> v) noexcept;
+    PLAYRHO_CONSTEXPR inline DistanceJointDef& UseFrequency(NonNegative<Frequency> v) noexcept;
     
     /// @brief Uses the given damping ratio.
-    constexpr DistanceJointDef& UseDampingRatio(Real v) noexcept;
+    PLAYRHO_CONSTEXPR inline DistanceJointDef& UseDampingRatio(Real v) noexcept;
     
     /// @brief Local anchor point relative to bodyA's origin.
     Length2 localAnchorA = Length2{};
@@ -81,19 +81,19 @@ struct DistanceJointDef : public JointBuilder<DistanceJointDef>
     Real dampingRatio = 0;
 };
 
-constexpr DistanceJointDef& DistanceJointDef::UseLength(Length v) noexcept
+PLAYRHO_CONSTEXPR inline DistanceJointDef& DistanceJointDef::UseLength(Length v) noexcept
 {
     length = v;
     return *this;
 }
 
-constexpr DistanceJointDef& DistanceJointDef::UseFrequency(NonNegative<Frequency> v) noexcept
+PLAYRHO_CONSTEXPR inline DistanceJointDef& DistanceJointDef::UseFrequency(NonNegative<Frequency> v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr DistanceJointDef& DistanceJointDef::UseDampingRatio(Real v) noexcept
+PLAYRHO_CONSTEXPR inline DistanceJointDef& DistanceJointDef::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/FrictionJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointDef.hpp
@@ -38,7 +38,7 @@ struct FrictionJointDef : public JointBuilder<FrictionJointDef>
     /// @brief Super type.
     using super = JointBuilder<FrictionJointDef>;
     
-    constexpr FrictionJointDef() noexcept: super{JointType::Friction} {}
+    PLAYRHO_CONSTEXPR inline FrictionJointDef() noexcept: super{JointType::Friction} {}
     
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, axis, and reference angle using the world
@@ -46,10 +46,10 @@ struct FrictionJointDef : public JointBuilder<FrictionJointDef>
     FrictionJointDef(Body* bodyA, Body* bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given maximum force value.
-    constexpr FrictionJointDef& UseMaxForce(NonNegative<Force> v) noexcept;
+    PLAYRHO_CONSTEXPR inline FrictionJointDef& UseMaxForce(NonNegative<Force> v) noexcept;
     
     /// @brief Uses the given maximum torque value.
-    constexpr FrictionJointDef& UseMaxTorque(NonNegative<Torque> v) noexcept;
+    PLAYRHO_CONSTEXPR inline FrictionJointDef& UseMaxTorque(NonNegative<Torque> v) noexcept;
     
     /// @brief Local anchor point relative to bodyA's origin.
     Length2 localAnchorA = Length2{};
@@ -64,13 +64,13 @@ struct FrictionJointDef : public JointBuilder<FrictionJointDef>
     NonNegative<Torque> maxTorque = NonNegative<Torque>{0};
 };
 
-constexpr FrictionJointDef& FrictionJointDef::UseMaxForce(NonNegative<Force> v) noexcept
+PLAYRHO_CONSTEXPR inline FrictionJointDef& FrictionJointDef::UseMaxForce(NonNegative<Force> v) noexcept
 {
     maxForce = v;
     return *this;
 }
 
-constexpr FrictionJointDef& FrictionJointDef::UseMaxTorque(NonNegative<Torque> v) noexcept
+PLAYRHO_CONSTEXPR inline FrictionJointDef& FrictionJointDef::UseMaxTorque(NonNegative<Torque> v) noexcept
 {
     maxTorque = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/JointDef.hpp
+++ b/PlayRho/Dynamics/Joints/JointDef.hpp
@@ -40,7 +40,7 @@ struct JointDef
     JointDef() = delete; // deleted to prevent direct instantiation.
     
     /// @brief Initializing constructor.
-    constexpr explicit JointDef(JointType t) noexcept : type{t}
+    PLAYRHO_CONSTEXPR inline explicit JointDef(JointType t) noexcept : type{t}
     {
         // Intentionally empty.
     }
@@ -81,34 +81,34 @@ struct JointBuilder : JointDef
     using reference = value_type&;
     
     /// @brief Initializing constructor.
-    constexpr explicit JointBuilder(JointType t) noexcept : JointDef{t}
+    PLAYRHO_CONSTEXPR inline explicit JointBuilder(JointType t) noexcept : JointDef{t}
     {
         // Intentionally empty.
     }
     
     /// @brief Use value for body A setting.
-    constexpr reference UseBodyA(Body* b) noexcept
+    PLAYRHO_CONSTEXPR inline reference UseBodyA(Body* b) noexcept
     {
         bodyA = b;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for body B setting.
-    constexpr reference UseBodyB(Body* b) noexcept
+    PLAYRHO_CONSTEXPR inline reference UseBodyB(Body* b) noexcept
     {
         bodyB = b;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for collide connected setting.
-    constexpr reference UseCollideConnected(bool v) noexcept
+    PLAYRHO_CONSTEXPR inline reference UseCollideConnected(bool v) noexcept
     {
         collideConnected = v;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for user data setting.
-    constexpr reference UseUserData(void* v) noexcept
+    PLAYRHO_CONSTEXPR inline reference UseUserData(void* v) noexcept
     {
         userData = v;
         return static_cast<reference>(*this);

--- a/PlayRho/Dynamics/Joints/JointKey.hpp
+++ b/PlayRho/Dynamics/Joints/JointKey.hpp
@@ -39,26 +39,26 @@ namespace playrho {
     public:
         
         /// @brief Gets the JointKey for the given bodies.
-        static constexpr JointKey Get(const Body* bodyA, const Body* bodyB) noexcept
+        static PLAYRHO_CONSTEXPR inline JointKey Get(const Body* bodyA, const Body* bodyB) noexcept
         {
             return (bodyA < bodyB)? JointKey{bodyA, bodyB}: JointKey{bodyB, bodyA};
         }
         
         /// @brief Gets body 1.
-        constexpr const Body* GetBody1() const noexcept
+        PLAYRHO_CONSTEXPR const Body* GetBody1() const noexcept
         {
             return m_body1;
         }
         
         /// @brief Gets body 2.
-        constexpr const Body* GetBody2() const
+        PLAYRHO_CONSTEXPR const Body* GetBody2() const
         {
             return m_body2;
         }
 
     private:
         /// @brief Initializing constructor.
-        constexpr JointKey(const Body* body1, const Body* body2):
+        PLAYRHO_CONSTEXPR inline JointKey(const Body* body1, const Body* body2):
         	m_body1(body1), m_body2(body2)
         {
             // Intentionally empty.
@@ -77,7 +77,7 @@ namespace playrho {
     JointKey GetJointKey(const Joint& joint) noexcept;
 
     /// @brief Compares the given joint keys.
-    constexpr int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
+    PLAYRHO_CONSTEXPR inline int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
     {
         if (lhs.GetBody1() < rhs.GetBody1())
         {
@@ -100,7 +100,7 @@ namespace playrho {
     
     /// @brief Determines whether the given key is for the given body.
     /// @relatedalso JointKey
-    constexpr bool IsFor(const JointKey key, const Body* body) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsFor(const JointKey key, const Body* body) noexcept
     {
         return body == key.GetBody1() || body == key.GetBody2();
     }
@@ -120,7 +120,7 @@ namespace std
     struct less<playrho::JointKey>
     {
         /// @brief Function object operator.
-        constexpr bool operator()(const playrho::JointKey& lhs,
+        PLAYRHO_CONSTEXPR inline bool operator()(const playrho::JointKey& lhs,
                                   const playrho::JointKey& rhs) const
         {
             return playrho::Compare(lhs, rhs) < 0;
@@ -133,7 +133,7 @@ namespace std
     {
         
         /// @brief Function object operator.
-        constexpr bool operator()( const playrho::JointKey& lhs, const playrho::JointKey& rhs ) const
+        PLAYRHO_CONSTEXPR inline bool operator()( const playrho::JointKey& lhs, const playrho::JointKey& rhs ) const
         {
             return playrho::Compare(lhs, rhs) == 0;
         }

--- a/PlayRho/Dynamics/Joints/JointType.hpp
+++ b/PlayRho/Dynamics/Joints/JointType.hpp
@@ -22,6 +22,8 @@
 #ifndef PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP
 #define PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP
 
+#include <PlayRho/Defines.hpp>
+
 #include <cstdint>
 
 namespace playrho {

--- a/PlayRho/Dynamics/Joints/MotorJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointDef.hpp
@@ -37,7 +37,7 @@ struct MotorJointDef : public JointBuilder<MotorJointDef>
     /// @brief Super type.
     using super = JointBuilder<MotorJointDef>;
     
-    constexpr MotorJointDef() noexcept: super{JointType::Motor} {}
+    PLAYRHO_CONSTEXPR inline MotorJointDef() noexcept: super{JointType::Motor} {}
     
     /// @brief Initialize the bodies and offsets using the current transforms.
     MotorJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB) noexcept;

--- a/PlayRho/Dynamics/Joints/MouseJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/MouseJointDef.hpp
@@ -38,25 +38,25 @@ struct MouseJointDef : public JointBuilder<MouseJointDef>
     /// @brief Super type.
     using super = JointBuilder<MouseJointDef>;
     
-    constexpr MouseJointDef() noexcept: super{JointType::Mouse} {}
+    PLAYRHO_CONSTEXPR inline MouseJointDef() noexcept: super{JointType::Mouse} {}
 
     /// @brief Initializing constructor.
-    constexpr MouseJointDef(NonNull<Body*> b) noexcept: super{super{JointType::Mouse}.UseBodyB(b)}
+    PLAYRHO_CONSTEXPR inline MouseJointDef(NonNull<Body*> b) noexcept: super{super{JointType::Mouse}.UseBodyB(b)}
     {
         // Intentionally empty.
     }
     
     /// @brief Use value for target.
-    constexpr MouseJointDef& UseTarget(Length2 v) noexcept;
+    PLAYRHO_CONSTEXPR inline MouseJointDef& UseTarget(Length2 v) noexcept;
 
     /// @brief Use value for max force.
-    constexpr MouseJointDef& UseMaxForce(NonNegative<Force> v) noexcept;
+    PLAYRHO_CONSTEXPR inline MouseJointDef& UseMaxForce(NonNegative<Force> v) noexcept;
 
     /// @brief Use value for frequency.
-    constexpr MouseJointDef& UseFrequency(NonNegative<Frequency> v) noexcept;
+    PLAYRHO_CONSTEXPR inline MouseJointDef& UseFrequency(NonNegative<Frequency> v) noexcept;
 
     /// @brief Use value for damping ratio.
-    constexpr MouseJointDef& UseDampingRatio(NonNegative<Real> v) noexcept;
+    PLAYRHO_CONSTEXPR inline MouseJointDef& UseDampingRatio(NonNegative<Real> v) noexcept;
 
     /// The initial world target point. This is assumed
     /// to coincide with the body anchor initially.
@@ -79,25 +79,25 @@ struct MouseJointDef : public JointBuilder<MouseJointDef>
     NonNegative<Real> dampingRatio = NonNegative<Real>(0.7f);
 };
 
-constexpr MouseJointDef& MouseJointDef::UseTarget(Length2 v) noexcept
+PLAYRHO_CONSTEXPR inline MouseJointDef& MouseJointDef::UseTarget(Length2 v) noexcept
 {
     target = v;
     return *this;
 }
 
-constexpr MouseJointDef& MouseJointDef::UseMaxForce(NonNegative<Force> v) noexcept
+PLAYRHO_CONSTEXPR inline MouseJointDef& MouseJointDef::UseMaxForce(NonNegative<Force> v) noexcept
 {
     maxForce = v;
     return *this;
 }
 
-constexpr MouseJointDef& MouseJointDef::UseFrequency(NonNegative<Frequency> v) noexcept
+PLAYRHO_CONSTEXPR inline MouseJointDef& MouseJointDef::UseFrequency(NonNegative<Frequency> v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr MouseJointDef& MouseJointDef::UseDampingRatio(NonNegative<Real> v) noexcept
+PLAYRHO_CONSTEXPR inline MouseJointDef& MouseJointDef::UseDampingRatio(NonNegative<Real> v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/PrismaticJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointDef.hpp
@@ -42,7 +42,7 @@ struct PrismaticJointDef : public JointBuilder<PrismaticJointDef>
     /// @brief Super type.
     using super = JointBuilder<PrismaticJointDef>;
     
-    constexpr PrismaticJointDef() noexcept: super{JointType::Prismatic} {}
+    PLAYRHO_CONSTEXPR inline PrismaticJointDef() noexcept: super{JointType::Prismatic} {}
     
     /// @brief Copy constructor.
     PrismaticJointDef(const PrismaticJointDef& copy) = default;

--- a/PlayRho/Dynamics/Joints/RevoluteJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointDef.hpp
@@ -47,22 +47,22 @@ struct RevoluteJointDef : public JointBuilder<RevoluteJointDef>
     /// @brief Super type.
     using super = JointBuilder<RevoluteJointDef>;
     
-    constexpr RevoluteJointDef() noexcept: super{JointType::Revolute} {}
+    PLAYRHO_CONSTEXPR inline RevoluteJointDef() noexcept: super{JointType::Revolute} {}
     
     /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
     RevoluteJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given enable limit state value.
-    constexpr RevoluteJointDef& UseEnableLimit(bool v) noexcept;
+    PLAYRHO_CONSTEXPR inline RevoluteJointDef& UseEnableLimit(bool v) noexcept;
     
     /// @brief Uses the given lower angle value.
-    constexpr RevoluteJointDef& UseLowerAngle(Angle v) noexcept;
+    PLAYRHO_CONSTEXPR inline RevoluteJointDef& UseLowerAngle(Angle v) noexcept;
     
     /// @brief Uses the given upper angle value.
-    constexpr RevoluteJointDef& UseUpperAngle(Angle v) noexcept;
+    PLAYRHO_CONSTEXPR inline RevoluteJointDef& UseUpperAngle(Angle v) noexcept;
     
     /// @brief Uses the given enable motor state value.
-    constexpr RevoluteJointDef& UseEnableMotor(bool v) noexcept;
+    PLAYRHO_CONSTEXPR inline RevoluteJointDef& UseEnableMotor(bool v) noexcept;
 
     /// @brief Local anchor point relative to bodyA's origin.
     Length2 localAnchorA = Length2{};
@@ -93,25 +93,25 @@ struct RevoluteJointDef : public JointBuilder<RevoluteJointDef>
     Torque maxMotorTorque = 0;
 };
 
-constexpr RevoluteJointDef& RevoluteJointDef::UseEnableLimit(bool v) noexcept
+PLAYRHO_CONSTEXPR inline RevoluteJointDef& RevoluteJointDef::UseEnableLimit(bool v) noexcept
 {
     enableLimit = v;
     return *this;
 }
 
-constexpr RevoluteJointDef& RevoluteJointDef::UseLowerAngle(Angle v) noexcept
+PLAYRHO_CONSTEXPR inline RevoluteJointDef& RevoluteJointDef::UseLowerAngle(Angle v) noexcept
 {
     lowerAngle = v;
     return *this;
 }
 
-constexpr RevoluteJointDef& RevoluteJointDef::UseUpperAngle(Angle v) noexcept
+PLAYRHO_CONSTEXPR inline RevoluteJointDef& RevoluteJointDef::UseUpperAngle(Angle v) noexcept
 {
     upperAngle = v;
     return *this;
 }
 
-constexpr RevoluteJointDef& RevoluteJointDef::UseEnableMotor(bool v) noexcept
+PLAYRHO_CONSTEXPR inline RevoluteJointDef& RevoluteJointDef::UseEnableMotor(bool v) noexcept
 {
     enableMotor = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/RopeJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointDef.hpp
@@ -39,17 +39,17 @@ struct RopeJointDef : public JointBuilder<RopeJointDef>
     /// @brief Super type.
     using super = JointBuilder<RopeJointDef>;
     
-    constexpr RopeJointDef() noexcept: super{JointType::Rope} {}
+    PLAYRHO_CONSTEXPR inline RopeJointDef() noexcept: super{JointType::Rope} {}
     
     /// @brief Initializing constructor.
-    constexpr RopeJointDef(Body* bodyA, Body* bodyB) noexcept:
+    PLAYRHO_CONSTEXPR inline RopeJointDef(Body* bodyA, Body* bodyB) noexcept:
         super{super{JointType::Rope}.UseBodyA(bodyA).UseBodyB(bodyB)}
     {
         // Intentionally empty.
     }
     
     /// @brief Uses the given max length value.
-    constexpr RopeJointDef& UseMaxLength(Length v) noexcept;
+    PLAYRHO_CONSTEXPR inline RopeJointDef& UseMaxLength(Length v) noexcept;
     
     /// The local anchor point relative to bodyA's origin.
     Length2 localAnchorA = Length2{-1_m, 0_m};
@@ -61,7 +61,7 @@ struct RopeJointDef : public JointBuilder<RopeJointDef>
     Length maxLength = 0_m;
 };
 
-constexpr RopeJointDef& RopeJointDef::UseMaxLength(Length v) noexcept
+PLAYRHO_CONSTEXPR inline RopeJointDef& RopeJointDef::UseMaxLength(Length v) noexcept
 {
     maxLength = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/WeldJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointDef.hpp
@@ -42,7 +42,7 @@ struct WeldJointDef : public JointBuilder<WeldJointDef>
     /// @brief Super type.
     using super = JointBuilder<WeldJointDef>;
     
-    constexpr WeldJointDef() noexcept: super{JointType::Weld} {}
+    PLAYRHO_CONSTEXPR inline WeldJointDef() noexcept: super{JointType::Weld} {}
     
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, and reference angle using a world
@@ -53,10 +53,10 @@ struct WeldJointDef : public JointBuilder<WeldJointDef>
     WeldJointDef(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given frequency value.
-    constexpr WeldJointDef& UseFrequency(Frequency v) noexcept;
+    PLAYRHO_CONSTEXPR inline WeldJointDef& UseFrequency(Frequency v) noexcept;
     
     /// @brief Uses the given damping ratio.
-    constexpr WeldJointDef& UseDampingRatio(Real v) noexcept;
+    PLAYRHO_CONSTEXPR inline WeldJointDef& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to bodyA's origin.
     Length2 localAnchorA = Length2{};
@@ -77,13 +77,13 @@ struct WeldJointDef : public JointBuilder<WeldJointDef>
     Real dampingRatio = 0;
 };
 
-constexpr WeldJointDef& WeldJointDef::UseFrequency(Frequency v) noexcept
+PLAYRHO_CONSTEXPR inline WeldJointDef& WeldJointDef::UseFrequency(Frequency v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr WeldJointDef& WeldJointDef::UseDampingRatio(Real v) noexcept
+PLAYRHO_CONSTEXPR inline WeldJointDef& WeldJointDef::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/WheelJointDef.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointDef.hpp
@@ -42,7 +42,7 @@ struct WheelJointDef : public JointBuilder<WheelJointDef>
     /// @brief Super type.
     using super = JointBuilder<WheelJointDef>;
     
-    constexpr WheelJointDef() noexcept: super{JointType::Wheel} {}
+    PLAYRHO_CONSTEXPR inline WheelJointDef() noexcept: super{JointType::Wheel} {}
     
     /// Initialize the bodies, anchors, axis, and reference angle using the world
     /// anchor and world axis.
@@ -50,19 +50,19 @@ struct WheelJointDef : public JointBuilder<WheelJointDef>
                   const UnitVec2 axis) noexcept;
     
     /// @brief Uses the given enable motor state value.
-    constexpr WheelJointDef& UseEnableMotor(bool v) noexcept;
+    PLAYRHO_CONSTEXPR inline WheelJointDef& UseEnableMotor(bool v) noexcept;
     
     /// @brief Uses the given max motor toque value.
-    constexpr WheelJointDef& UseMaxMotorTorque(Torque v) noexcept;
+    PLAYRHO_CONSTEXPR inline WheelJointDef& UseMaxMotorTorque(Torque v) noexcept;
     
     /// @brief Uses the given motor speed value.
-    constexpr WheelJointDef& UseMotorSpeed(AngularVelocity v) noexcept;
+    PLAYRHO_CONSTEXPR inline WheelJointDef& UseMotorSpeed(AngularVelocity v) noexcept;
     
     /// @brief Uses the given frequency value.
-    constexpr WheelJointDef& UseFrequency(Frequency v) noexcept;
+    PLAYRHO_CONSTEXPR inline WheelJointDef& UseFrequency(Frequency v) noexcept;
     
     /// @brief Uses the given damping ratio value.
-    constexpr WheelJointDef& UseDampingRatio(Real v) noexcept;
+    PLAYRHO_CONSTEXPR inline WheelJointDef& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to bodyA's origin.
     Length2 localAnchorA = Length2{};
@@ -89,31 +89,31 @@ struct WheelJointDef : public JointBuilder<WheelJointDef>
     Real dampingRatio = 0.7f;
 };
 
-constexpr WheelJointDef& WheelJointDef::UseEnableMotor(bool v) noexcept
+PLAYRHO_CONSTEXPR inline WheelJointDef& WheelJointDef::UseEnableMotor(bool v) noexcept
 {
     enableMotor = v;
     return *this;
 }
 
-constexpr WheelJointDef& WheelJointDef::UseMaxMotorTorque(Torque v) noexcept
+PLAYRHO_CONSTEXPR inline WheelJointDef& WheelJointDef::UseMaxMotorTorque(Torque v) noexcept
 {
     maxMotorTorque = v;
     return *this;
 }
 
-constexpr WheelJointDef& WheelJointDef::UseMotorSpeed(AngularVelocity v) noexcept
+PLAYRHO_CONSTEXPR inline WheelJointDef& WheelJointDef::UseMotorSpeed(AngularVelocity v) noexcept
 {
     motorSpeed = v;
     return *this;
 }
 
-constexpr WheelJointDef& WheelJointDef::UseFrequency(Frequency v) noexcept
+PLAYRHO_CONSTEXPR inline WheelJointDef& WheelJointDef::UseFrequency(Frequency v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr WheelJointDef& WheelJointDef::UseDampingRatio(Real v) noexcept
+PLAYRHO_CONSTEXPR inline WheelJointDef& WheelJointDef::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -45,7 +45,7 @@ public:
     using iteration_type = TimestepIters;
 
     /// @brief Invalid iteration value.
-    static constexpr auto InvalidIteration = static_cast<iteration_type>(-1);
+    static PLAYRHO_CONSTEXPR const auto InvalidIteration = static_cast<iteration_type>(-1);
 
     /// @brief Gets the delta time (time amount for this time step).
     /// @sa SetTime(Real).
@@ -64,7 +64,7 @@ public:
     /// @sa GetTime().
     /// @sa GetInvTime().
     /// @param value Elapsed time amount.
-    constexpr StepConf& SetTime(Time value) noexcept
+    PLAYRHO_CONSTEXPR inline StepConf& SetTime(Time value) noexcept
     {
         time = value;
         invTime = (value != Time{0})? Real{1} / value: 0_Hz;
@@ -78,7 +78,7 @@ public:
     /// @sa GetTime().
     /// @sa GetInvTime().
     /// @param value Inverse time amount.
-    constexpr StepConf& SetInvTime(Frequency value) noexcept
+    PLAYRHO_CONSTEXPR inline StepConf& SetInvTime(Frequency value) noexcept
     {
         invTime = value;
         time = (value != 0_Hz)? Time{Real{1} / value}: Time{0};

--- a/PlayRho/Dynamics/WorldDef.hpp
+++ b/PlayRho/Dynamics/WorldDef.hpp
@@ -32,16 +32,16 @@ namespace playrho {
     struct WorldDef
     {
         /// @brief Uses the given gravity value.
-        constexpr WorldDef& UseGravity(LinearAcceleration2 value) noexcept;
+        PLAYRHO_CONSTEXPR inline WorldDef& UseGravity(LinearAcceleration2 value) noexcept;
 
         /// @brief Uses the given min vertex radius value.
-        constexpr WorldDef& UseMinVertexRadius(Positive<Length> value) noexcept;
+        PLAYRHO_CONSTEXPR inline WorldDef& UseMinVertexRadius(Positive<Length> value) noexcept;
         
         /// @brief Uses the given max vertex radius value.
-        constexpr WorldDef& UseMaxVertexRadius(Positive<Length> value) noexcept;
+        PLAYRHO_CONSTEXPR inline WorldDef& UseMaxVertexRadius(Positive<Length> value) noexcept;
         
         /// @brief Uses the given value as the initial dynamic tree size.
-        constexpr WorldDef& UseInitialTreeSize(ContactCounter value) noexcept;
+        PLAYRHO_CONSTEXPR inline WorldDef& UseInitialTreeSize(ContactCounter value) noexcept;
 
         /// @brief Gravity.
         /// @details The acceleration all dynamic bodies are subject to.
@@ -71,25 +71,25 @@ namespace playrho {
         ContactCounter initialTreeSize = 4096;
     };
     
-    constexpr inline WorldDef& WorldDef::UseGravity(LinearAcceleration2 value) noexcept
+    PLAYRHO_CONSTEXPR inline WorldDef& WorldDef::UseGravity(LinearAcceleration2 value) noexcept
     {
         gravity = value;
         return *this;
     }
     
-    constexpr inline WorldDef& WorldDef::UseMinVertexRadius(Positive<Length> value) noexcept
+    PLAYRHO_CONSTEXPR inline WorldDef& WorldDef::UseMinVertexRadius(Positive<Length> value) noexcept
     {
         minVertexRadius = value;
         return *this;
     }
     
-    constexpr inline WorldDef& WorldDef::UseMaxVertexRadius(Positive<Length> value) noexcept
+    PLAYRHO_CONSTEXPR inline WorldDef& WorldDef::UseMaxVertexRadius(Positive<Length> value) noexcept
     {
         maxVertexRadius = value;
         return *this;
     }
     
-    constexpr inline WorldDef& WorldDef::UseInitialTreeSize(ContactCounter value) noexcept
+    PLAYRHO_CONSTEXPR inline WorldDef& WorldDef::UseInitialTreeSize(ContactCounter value) noexcept
     {
         initialTreeSize = value;
         return *this;
@@ -101,7 +101,7 @@ namespace playrho {
     ///     "cannot use defaulted constructor of 'Def' within 'World' outside of member functions
     ///      because 'gravity' has an initializer"
     /// @relatedalso WorldDef
-    constexpr WorldDef GetDefaultWorldDef() noexcept
+    PLAYRHO_CONSTEXPR inline WorldDef GetDefaultWorldDef() noexcept
     {
         return WorldDef{};
     }

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -210,7 +210,7 @@ struct GLRenderPoints
 {
     GLRenderPoints()
     {
-        static constexpr char vs[] = \
+        static PLAYRHO_CONSTEXPR const char vs[] = \
         "#version 330\n"
         "uniform mat4 projectionMatrix;\n"
         "layout(location = 0) in vec2 v_position;\n"
@@ -224,7 +224,7 @@ struct GLRenderPoints
         "    gl_PointSize = v_size;\n"
         "}\n";
         
-        static constexpr char fs[] = \
+        static PLAYRHO_CONSTEXPR const char fs[] = \
         "#version 330\n"
         "in vec4 f_color;\n"
         "out vec4 color;\n"

--- a/Testbed/Framework/Drawer.hpp
+++ b/Testbed/Framework/Drawer.hpp
@@ -30,7 +30,7 @@ struct Color
 {
     Color() = default;
     
-    constexpr Color(float ri, float gi, float bi, float ai = 1):
+    PLAYRHO_CONSTEXPR inline Color(float ri, float gi, float bi, float ai = 1):
         r(Clamp(ri, 0.0f, 1.0f)),
         g(Clamp(gi, 0.0f, 1.0f)),
         b(Clamp(bi, 0.0f, 1.0f)),
@@ -39,7 +39,7 @@ struct Color
         // Intentionally empty.
     }
 
-    constexpr Color(Color copy, float new_a):
+    PLAYRHO_CONSTEXPR inline Color(Color copy, float new_a):
         Color{copy.r, copy.g, copy.b, new_a}
     {
         // Intentionally empty.

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -1266,7 +1266,7 @@ void Test::RegisterForKey(KeyID key, KeyAction action, KeyMods mods, KeyHandlerI
     m_handledKeys.push_back(std::make_pair(KeyActionMods{key, action, mods}, id));
 }
 
-constexpr auto RAND_LIMIT = 32767;
+PLAYRHO_CONSTEXPR const auto RAND_LIMIT = 32767;
 
 Real playrho::RandomFloat()
 {

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -270,8 +270,8 @@ protected:
     
     using PointCount = int;
     using TextLinePos = int;
-    static constexpr auto k_maxContactPoints = PointCount{2048};
-    static constexpr auto DRAW_STRING_NEW_LINE = TextLinePos{16};
+    static PLAYRHO_CONSTEXPR const auto k_maxContactPoints = PointCount{2048};
+    static PLAYRHO_CONSTEXPR const auto DRAW_STRING_NEW_LINE = TextLinePos{16};
 
     virtual void PreStep(const Settings& settings, Drawer& drawer)
     {

--- a/Testbed/Tests/BagOfDisks.hpp
+++ b/Testbed/Tests/BagOfDisks.hpp
@@ -29,7 +29,7 @@ namespace playrho {
     class BagOfDisks: public Test
     {
     public:
-        static constexpr auto Count = 180;
+        static PLAYRHO_CONSTEXPR const auto Count = 180;
 
         static Test::Conf GetTestConf()
         {

--- a/Testbed/Tests/Bridge.hpp
+++ b/Testbed/Tests/Bridge.hpp
@@ -28,7 +28,7 @@ class Bridge : public Test
 {
 public:
 
-    static constexpr auto Count = 30;
+    static PLAYRHO_CONSTEXPR const auto Count = 30;
 
     Bridge()
     {

--- a/Testbed/Tests/DynamicTreeTest.hpp
+++ b/Testbed/Tests/DynamicTreeTest.hpp
@@ -28,7 +28,7 @@ class DynamicTreeTest : public Test
 {
 public:
 
-    static constexpr auto e_actorCount = 128;
+    static PLAYRHO_CONSTEXPR const auto e_actorCount = 128;
 
     DynamicTreeTest()
     {

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -202,7 +202,7 @@ public:
         ShapeDrawer shapeDrawer;
         shapeDrawer.g_debugDraw = &drawer;
 
-        constexpr int e_maxCount = 4;
+        PLAYRHO_CONSTEXPR const int e_maxCount = 4;
         int count = 0;
         const auto aabb = ComputeAABB(circle, transform);
         m_world.QueryAABB(aabb, [&](Fixture* f, const ChildCounter) {

--- a/Testbed/Tests/SolarSystem.hpp
+++ b/Testbed/Tests/SolarSystem.hpp
@@ -38,7 +38,7 @@ struct SolarSystemObject
     Time rotationalPeriod; ///< Rotational period.
 };
 
-static constexpr SolarSystemObject SolarSystemBodies[] = {
+static PLAYRHO_CONSTEXPR const SolarSystemObject SolarSystemBodies[] = {
     { "The Sun", 696342_km, 1988550000.0_Yg,     0.000_d,    0_Gm,   25.050_d },
     { "Mercury",   2439_km,        330.2_Yg,    87.969_d,   57_Gm,   58.646_d },
     { "Venus",     6051_km,       4868.5_Yg,   224.701_d,  108_Gm, -243.025_d },

--- a/Testbed/Tests/Tumbler.hpp
+++ b/Testbed/Tests/Tumbler.hpp
@@ -27,7 +27,7 @@ namespace playrho {
 class Tumbler : public Test
 {
 public:
-    static constexpr auto Count = 800;
+    static PLAYRHO_CONSTEXPR const auto Count = 800;
     
     Tumbler()
     {

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -173,7 +173,7 @@ public:
         
         //angular velocity
         const auto rotInertia = GetRotInertia(*m_body);
-        constexpr auto Tenth = Real{1} / Real{10};
+        PLAYRHO_CONSTEXPR const auto Tenth = Real{1} / Real{10};
         ApplyAngularImpulse(*m_body, m_currentTraction * Tenth * rotInertia * -GetAngularVelocity(*m_body));
         
         //forward linear velocity

--- a/UnitTests/ArrayList.cpp
+++ b/UnitTests/ArrayList.cpp
@@ -26,7 +26,7 @@ using namespace playrho;
 TEST(ArrayList, DefaultConstruction)
 {
     {
-        constexpr unsigned max_size = 4;
+        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
         ArrayList<int, max_size> list;
         EXPECT_EQ(list.size(), decltype(list.size()){0});
         EXPECT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -38,9 +38,9 @@ TEST(ArrayList, DefaultConstruction)
 TEST(ArrayList, ArrayConstruction)
 {
     {
-        constexpr auto array_size = 2;
+        PLAYRHO_CONSTEXPR const auto array_size = 2;
         int array[array_size];
-        constexpr unsigned max_size = 4;
+        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
         ArrayList<int, max_size> list(array);
         EXPECT_EQ(list.size(), decltype(list.size()){array_size});
         EXPECT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -48,9 +48,9 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(std::distance(list.begin(), list.end()), array_size);
     }
     {
-        constexpr auto array_size = 6;
+        PLAYRHO_CONSTEXPR const auto array_size = 6;
         float array[array_size];
-        constexpr unsigned max_size = 6;
+        PLAYRHO_CONSTEXPR const unsigned max_size = 6;
         ArrayList<float, max_size> list(array);
         EXPECT_EQ(list.size(), decltype(list.size()){array_size});
         EXPECT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -58,14 +58,14 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(std::distance(list.begin(), list.end()), array_size);
     }
     {
-        constexpr auto maxsize = std::size_t{10};
+        PLAYRHO_CONSTEXPR const auto maxsize = std::size_t{10};
         ArrayList<int, maxsize> list = { 1, 2, 3 };
         EXPECT_EQ(list.size(), decltype(list.size()){3});
         EXPECT_EQ(list.max_size(), maxsize);
     }
     {
-        constexpr auto maxsize = std::size_t{10};
-        constexpr auto list = std::array<int, maxsize>{{5, 4, 3}};
+        PLAYRHO_CONSTEXPR const auto maxsize = std::size_t{10};
+        PLAYRHO_CONSTEXPR const auto list = std::array<int, maxsize>{{5, 4, 3}};
         EXPECT_EQ(list.size(), decltype(list.size()){maxsize});
         EXPECT_EQ(list.max_size(), maxsize);
         EXPECT_EQ(list[0], 5);
@@ -73,9 +73,9 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(list[2], 3);
     }
     {
-        constexpr auto maxsize = std::size_t{10};
+        PLAYRHO_CONSTEXPR const auto maxsize = std::size_t{10};
         
-        // Note: list cannot be constexpr.
+        // Note: list cannot be PLAYRHO_CONSTEXPR const.
         const auto list = ArrayList<int, maxsize>{1, 2, 3};
 
         EXPECT_EQ(list.size(), decltype(list.size()){3});
@@ -85,7 +85,7 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(list[2], 3);
     }
     {
-        constexpr auto list = Vector<int, 3>{1, 2, 3};
+        PLAYRHO_CONSTEXPR const auto list = Vector<int, 3>{1, 2, 3};
         EXPECT_EQ(list.size(), decltype(list.size()){3});
         EXPECT_EQ(list[0], 1);
         EXPECT_EQ(list[1], 2);
@@ -96,7 +96,7 @@ TEST(ArrayList, ArrayConstruction)
 TEST(ArrayList, add)
 {
     {
-        constexpr unsigned max_size = 4;
+        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
         ArrayList<int, max_size> list;
         ASSERT_EQ(list.size(), decltype(list.size()){0});
         ASSERT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -116,7 +116,7 @@ TEST(ArrayList, add)
 TEST(ArrayList, clear)
 {
     {
-        constexpr unsigned max_size = 4;
+        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
         ArrayList<int, max_size> list;
         ASSERT_EQ(list.size(), decltype(list.size()){0});
         ASSERT_EQ(list.max_size(), decltype(list.size()){max_size});

--- a/UnitTests/BoundedValue.cpp
+++ b/UnitTests/BoundedValue.cpp
@@ -254,8 +254,8 @@ namespace playrho
 template <typename T>
 struct ValueCheckHelper<T, Fixed32>
 {
-    static constexpr bool has_one = true;
-    static constexpr T one() noexcept { return T(1); }
+    static PLAYRHO_CONSTEXPR inline bool has_one = true;
+    static PLAYRHO_CONSTEXPR inline T one() noexcept { return T(1); }
 };
 }
 

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -26,7 +26,7 @@
 
 using namespace playrho;
 
-static constexpr auto Baumgarte = Real{2} / Real{10};
+static PLAYRHO_CONSTEXPR const auto Baumgarte = Real{2} / Real{10};
 
 TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 {

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -92,7 +92,7 @@ TEST(DynamicTree, ZeroCapacityConstructionThrows)
 
 TEST(DynamicTree, InitializingConstruction)
 {
-    constexpr auto initCapacity = DynamicTree::GetDefaultInitialNodeCapacity() * 2;
+    PLAYRHO_CONSTEXPR const auto initCapacity = DynamicTree::GetDefaultInitialNodeCapacity() * 2;
     DynamicTree foo{initCapacity};
     EXPECT_EQ(foo.GetNodeCapacity(), initCapacity);
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -368,10 +368,10 @@ TEST(Fixed32, Max)
     switch (Fixed32::FractionBits)
     {
         case  9:
-            EXPECT_NEAR(static_cast<long double>(Fixed32::GetMax()), 4.1943e+06, 4.0);
+            EXPECT_NEAR(static_cast<double>(Fixed32::GetMax()), 4.1943e+06, 4.0);
             break;
         case 14:
-            EXPECT_EQ(static_cast<long double>(Fixed32::GetMax()), 131071.9998779296875L);
+            EXPECT_EQ(static_cast<double>(Fixed32::GetMax()), 131071.9998779296875);
             break;
     }
 
@@ -388,10 +388,10 @@ TEST(Fixed32, Min)
     switch (Fixed32::FractionBits)
     {
         case  9:
-            EXPECT_NEAR(static_cast<long double>(Fixed32::GetMin()), 0.00195312, 0.0000001);
+            EXPECT_NEAR(static_cast<double>(Fixed32::GetMin()), 0.00195312, 0.0000001);
             break;
         case 14:
-            EXPECT_EQ(static_cast<long double>(Fixed32::GetMin()), 0.00006103515625000000L);
+            EXPECT_EQ(static_cast<double>(Fixed32::GetMin()), 0.00006103515625000000);
             break;
     }
 
@@ -413,10 +413,10 @@ TEST(Fixed32, Lowest)
     switch (Fixed32::FractionBits)
     {
         case  9:
-            EXPECT_NEAR(static_cast<long double>(Fixed32::GetLowest()), -4.1943e+06, 4.0);
+            EXPECT_NEAR(static_cast<double>(Fixed32::GetLowest()), -4.1943e+06, 4.0);
             break;
         case 14:
-            EXPECT_EQ(static_cast<long double>(Fixed32::GetLowest()), -131071.9998779296875L);
+            EXPECT_EQ(static_cast<double>(Fixed32::GetLowest()), -131071.9998779296875);
             break;
     }
     EXPECT_LT(Fixed32::GetLowest(), Fixed32(0));

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -373,16 +373,6 @@ TEST(Math, ComputeCentroidCenteredR1)
     EXPECT_EQ(average, center);
 }
 
-template <typename T>
-struct Results {
-    constexpr static auto expected_ctr = Vec2{0,0};
-};
-
-template <>
-struct Results<Fixed32> {
-    constexpr static auto expected_ctr = Vec2{0,0};
-};
-
 TEST(Math, ComputeCentroidCentered0R1000)
 {
     const auto hx = Real(1000);
@@ -536,7 +526,7 @@ TEST(Math, NextPowerOfTwo)
     EXPECT_EQ(NextPowerOfTwo(15u), 16u);
     EXPECT_EQ(NextPowerOfTwo(16u), 32u);
 
-    constexpr auto max = std::numeric_limits<std::uint32_t>::max() / 512;
+    PLAYRHO_CONSTEXPR const auto max = std::numeric_limits<std::uint32_t>::max() / 512;
     for (auto i = decltype(max){0}; i < max; ++i)
     {
         const auto next = std::pow(2, std::ceil(std::log(i + 1)/std::log(2)));
@@ -651,7 +641,7 @@ struct Coords {
 #if 0
 TEST(Math, LengthFasterThanHypot)
 {
-    constexpr auto iterations = unsigned(5000000);
+    PLAYRHO_CONSTEXPR inline auto iterations = unsigned(5000000);
     
     std::chrono::duration<double> elapsed_secs_length;
     std::chrono::duration<double> elapsed_secs_hypot;

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1208,9 +1208,9 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
 
 TEST(World, HeavyOnLight)
 {
-    constexpr auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
-    constexpr auto LargerLinearSlop = playrho::Meter / playrho::Real(200);
-    constexpr auto SmallerLinearSlop = playrho::Meter / playrho::Real(1000);
+    PLAYRHO_CONSTEXPR const auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
+    PLAYRHO_CONSTEXPR const auto LargerLinearSlop = playrho::Meter / playrho::Real(200);
+    PLAYRHO_CONSTEXPR const auto SmallerLinearSlop = playrho::Meter / playrho::Real(1000);
 
     const auto bd = BodyDef{}.UseType(BodyType::Dynamic);
     const auto upperBodyDef = BodyDef(bd).UseLocation(Vec2(0.0f, 6.0f) * Meter);
@@ -2002,13 +2002,13 @@ TEST(World, CollidingDynamicBodies)
 
 TEST(World, TilesComesToRest)
 {
-    constexpr auto LinearSlop = Meter / 1000;
-    constexpr auto AngularSlop = (Pi * 2 * 1_rad) / 180;
-    constexpr auto VertexRadius = LinearSlop * 2;
+    PLAYRHO_CONSTEXPR const auto LinearSlop = Meter / 1000;
+    PLAYRHO_CONSTEXPR const auto AngularSlop = (Pi * 2 * 1_rad) / 180;
+    PLAYRHO_CONSTEXPR const auto VertexRadius = LinearSlop * 2;
     const auto conf = PolygonShape::Conf{}.UseVertexRadius(VertexRadius);
     const auto m_world = std::make_unique<World>(WorldDef{}.UseMinVertexRadius(VertexRadius));
     
-    constexpr auto e_count = 36;
+    PLAYRHO_CONSTEXPR const auto e_count = 36;
     
     {
         const auto a = Real{0.5f};
@@ -2364,9 +2364,9 @@ TEST(World, TilesComesToRest)
 
 TEST(World, SpeedingBulletBallWontTunnel)
 {
-    constexpr auto LinearSlop = playrho::Meter / playrho::Real(1000);
-    constexpr auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
-    constexpr auto VertexRadius = playrho::Length{LinearSlop * playrho::Real(2)};
+    PLAYRHO_CONSTEXPR const auto LinearSlop = playrho::Meter / playrho::Real(1000);
+    PLAYRHO_CONSTEXPR const auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
+    PLAYRHO_CONSTEXPR const auto VertexRadius = playrho::Length{LinearSlop * playrho::Real(2)};
     
     World world{WorldDef{}.UseGravity(LinearAcceleration2{}).UseMinVertexRadius(VertexRadius)};
 
@@ -2636,7 +2636,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         ASSERT_NE(ball_fixture, nullptr);
     }
 
-    constexpr unsigned numBodies = 1;
+    PLAYRHO_CONSTEXPR const unsigned numBodies = 1;
     Length2 last_opos[numBodies];
     Body *bodies[numBodies];
     for (auto i = decltype(numBodies){0}; i < numBodies; ++i)


### PR DESCRIPTION
#### Description - What's this PR do?
- Adds a macro named `PLAYRHO_CONSTEXPR`.
- Replaces all uses of `constexpr` specifier with use of `PLAYRHO_CONSTEXPR` macro.
- Adds `const` after `PLAYRHO_CONSTEXPR` for all constant expression variables.
- Adds `inline` after `PLAYRHO_CONSTEXPR` for all constant expression functions.
- Also adds some trait types I was using to experiment with detecting whether a tuple has a type.

#### Related Issues
- Issue #230.
