### PR TITLE
Misc changes 20171206

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -80,17 +80,17 @@ static playrho::UnitVec2 GetRandUnitVec2(playrho::Angle lo, playrho::Angle hi)
 static playrho::Transformation
 GetRandTransformation(playrho::Position pos0, playrho::Position pos1)
 {
-    const auto x0 = playrho::Real{GetX(pos0.linear) / playrho::Meter};
-    const auto y0 = playrho::Real{GetY(pos0.linear) / playrho::Meter};
-    const auto a0 = playrho::Real{pos0.angular / playrho::Radian};
+    const auto x0 = static_cast<double>(playrho::Real{GetX(pos0.linear) / playrho::Meter});
+    const auto y0 = static_cast<double>(playrho::Real{GetY(pos0.linear) / playrho::Meter});
+    const auto a0 = static_cast<double>(playrho::Real{pos0.angular / playrho::Radian});
 
-    const auto x1 = playrho::Real{GetX(pos1.linear) / playrho::Meter};
-    const auto y1 = playrho::Real{GetY(pos1.linear) / playrho::Meter};
-    const auto a1 = playrho::Real{pos1.angular / playrho::Radian};
+    const auto x1 = static_cast<double>(playrho::Real{GetX(pos1.linear) / playrho::Meter});
+    const auto y1 = static_cast<double>(playrho::Real{GetY(pos1.linear) / playrho::Meter});
+    const auto a1 = static_cast<double>(playrho::Real{pos1.angular / playrho::Radian});
     
-    const auto x = Rand(x0, x1) * playrho::Meter;
-    const auto y = Rand(y0, y1) * playrho::Meter;
-    const auto a = Rand(a0, a1) * playrho::Radian;
+    const auto x = static_cast<playrho::Real>(Rand(x0, x1)) * playrho::Meter;
+    const auto y = static_cast<playrho::Real>(Rand(y0, y1)) * playrho::Meter;
+    const auto a = static_cast<playrho::Real>(Rand(a0, a1)) * playrho::Radian;
     
     return playrho::Transformation{playrho::Length2{x, y}, playrho::UnitVec2::Get(a)};
 }
@@ -1057,9 +1057,9 @@ static void UnitVectorFromVector(benchmark::State& state)
 static playrho::Vec2 GetUnitVec1(playrho::Vec2 vec, playrho::Vec2 fallback)
 {
     const auto magSquared = playrho::Square(vec[0]) + playrho::Square(vec[1]);
-    if (playrho::IsNormal(magSquared))
+    if (playrho::isnormal(magSquared))
     {
-        const auto mag = playrho::Sqrt(magSquared);
+        const auto mag = playrho::sqrt(magSquared);
         return playrho::Vec2{vec[0] / mag, vec[1] / mag};
     }
     return fallback;
@@ -1068,13 +1068,13 @@ static playrho::Vec2 GetUnitVec1(playrho::Vec2 vec, playrho::Vec2 fallback)
 static playrho::Vec2 GetUnitVec2(playrho::Vec2 vec, playrho::Vec2 fallback)
 {
     const auto magSquared = playrho::Square(vec[0]) + playrho::Square(vec[1]);
-    if (playrho::IsNormal(magSquared))
+    if (playrho::isnormal(magSquared))
     {
-        const auto mag = playrho::Sqrt(magSquared);
+        const auto mag = playrho::sqrt(magSquared);
         return playrho::Vec2{vec[0] / mag, vec[1] / mag};
     }
-    const auto mag = playrho::Hypot(vec[0], vec[1]);
-    if (playrho::IsNormal(mag))
+    const auto mag = playrho::hypot(vec[0], vec[1]);
+    if (playrho::isnormal(mag))
     {
         return playrho::Vec2{vec[0] / mag, vec[1] / mag};
     }

--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -1254,27 +1254,6 @@ static void MaxSepBetweenRelSquaresNoStop(benchmark::State& state)
     }
 }
 
-static void MaxSepBetweenRelSquaresNoStopCached(benchmark::State& state)
-{
-    const auto dim = playrho::Real(2) * playrho::Meter;
-    const auto shape0 = playrho::PolygonShape(dim, dim);
-    const auto shape1 = playrho::PolygonShape(dim, dim);
-    
-    const auto child0 = shape0.GetChild(0);
-    const auto child1 = shape1.GetChild(0);
-    
-    const auto vals = GetTransformationPairs(static_cast<unsigned>(state.range()));
-    for (auto _: state)
-    {
-        for (const auto& val: vals)
-        {
-            const auto xf0 = val.first;
-            const auto xf1 = val.second;
-            benchmark::DoNotOptimize(playrho::GetMaxSeparationCached(child0, xf0, child1, xf1));
-        }
-    }
-}
-
 static void MaxSepBetweenRel4x4(benchmark::State& state)
 {
     const auto dim = playrho::Real(2) * playrho::Meter;
@@ -1941,7 +1920,6 @@ BENCHMARK(AABB2D)->Arg(1000);
 
 // BENCHMARK(MaxSepBetweenAbsSquares);
 BENCHMARK(MaxSepBetweenRel4x4)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);
-BENCHMARK(MaxSepBetweenRelSquaresNoStopCached)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);
 BENCHMARK(MaxSepBetweenRelSquaresNoStop)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);
 BENCHMARK(MaxSepBetweenRelSquares)->Arg(10)->Arg(100)->Arg(1000)->Arg(10000);
 

--- a/PlayRho/Collision/Collision.cpp
+++ b/PlayRho/Collision/Collision.cpp
@@ -93,7 +93,7 @@ ClipList ClipSegmentToLine(const ClipList& vIn, const UnitVec2& normal, Length o
         }
 
         // If we didn't already find two points & the points are on different sides of the plane...
-        if (vOut.size() < 2 && SignBit(StripUnit(distance0)) != SignBit(StripUnit(distance1)))
+        if (vOut.size() < 2 && signbit(StripUnit(distance0)) != signbit(StripUnit(distance1)))
         {
             // Neither distance0 nor distance1 is 0 and either one or the other is negative (but not both).
             // Find intersection point of edge and plane

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -25,7 +25,7 @@ namespace playrho {
 
 namespace {
 
-    inline bool Find(IndexPair3 pairs, IndexPair key)
+    inline bool HasKey(IndexPair3 pairs, IndexPair key)
     {
         return pairs[0] == key || pairs[1] == key || pairs[2] == key;
     }
@@ -184,12 +184,12 @@ DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& trans
         }
 
         // Compute a tentative new simplex edge using support points.
-        const auto indexA = GetSupportIndex(proxyA, GetVec2(InverseRotate(-d, transformA.q)));
-        const auto indexB = GetSupportIndex(proxyB, GetVec2(InverseRotate(d, transformB.q)));
+        const auto indexA = GetSupportIndex(proxyA, InverseRotate(-d, transformA.q));
+        const auto indexB = GetSupportIndex(proxyB, InverseRotate(d, transformB.q));
 
         // Check for duplicate support points. This is the main termination criteria.
         // If there's a duplicate support point, code must exit loop to avoid cycling.
-        if (Find(savedIndices, IndexPair{indexA, indexB}))
+        if (HasKey(savedIndices, IndexPair{indexA, indexB}))
         {
             state = DistanceOutput::DuplicateIndexPair;
             break;

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -32,10 +32,10 @@ namespace {
 
     inline SimplexEdge GetSimplexEdge(const DistanceProxy& proxyA,
                                       const Transformation& xfA,
-                                      DistanceProxy::size_type idxA,
+                                      VertexCounter idxA,
                                       const DistanceProxy& proxyB,
                                       const Transformation& xfB,
-                                      DistanceProxy::size_type idxB)
+                                      VertexCounter idxB)
     {
         const auto wA = Transform(proxyA.GetVertex(idxA), xfA);
         const auto wB = Transform(proxyB.GetVertex(idxB), xfB);
@@ -54,16 +54,16 @@ namespace {
         switch (count)
         {
             case 3:
-                simplexEdges[2] = GetSimplexEdge(proxyA, xfA, indexPairs[2].a,
-                                                 proxyB, xfB, indexPairs[2].b);
+                simplexEdges[2] = GetSimplexEdge(proxyA, xfA, indexPairs[2].first,
+                                                 proxyB, xfB, indexPairs[2].second);
                 // [[fallthrough]]
             case 2:
-                simplexEdges[1] = GetSimplexEdge(proxyA, xfA, indexPairs[1].a,
-                                                 proxyB, xfB, indexPairs[1].b);
+                simplexEdges[1] = GetSimplexEdge(proxyA, xfA, indexPairs[1].first,
+                                                 proxyB, xfB, indexPairs[1].second);
                 // [[fallthrough]]
             case 1:
-                simplexEdges[0] = GetSimplexEdge(proxyA, xfA, indexPairs[0].a,
-                                                 proxyB, xfB, indexPairs[0].b);
+                simplexEdges[0] = GetSimplexEdge(proxyA, xfA, indexPairs[0].first,
+                                                 proxyB, xfB, indexPairs[0].second);
                 // [[fallthrough]]
         }
         simplexEdges.size(static_cast<size_type>(count));
@@ -72,7 +72,7 @@ namespace {
 
 } // namespace
 
-WitnessPoints GetWitnessPoints(const Simplex& simplex) noexcept
+PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept
 {
     auto pointA = Length2{};
     auto pointB = Length2{};
@@ -95,7 +95,7 @@ WitnessPoints GetWitnessPoints(const Simplex& simplex) noexcept
         std::cout << std::endl;
     }
 #endif
-    return WitnessPoints{pointA, pointB};
+    return PairLength2{pointA, pointB};
 }
 
 DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& transformA,

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -27,20 +27,16 @@ namespace playrho {
 
     class DistanceProxy;
 
-    /// @brief Witness Points.
-    struct WitnessPoints
-    {
-        Length2 a; ///< Point A.
-        Length2 b; ///< Point B.
-    };
+    /// @brief Pair of Length2 values.
+    using PairLength2 = std::pair<Length2, Length2>;
     
     /// @brief Gets the witness points of the given simplex.
-    WitnessPoints GetWitnessPoints(const Simplex& simplex) noexcept;
+    PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept;
     
     /// @brief Gets the delta of the two points of the given witness points.
-    PLAYRHO_CONSTEXPR inline Length2 GetDelta(WitnessPoints arg) noexcept
+    PLAYRHO_CONSTEXPR inline Length2 GetDelta(PairLength2 arg) noexcept
     {
-        return arg.a - arg.b;
+        return arg.first - arg.second;
     }
     
     /// @brief Distance Configuration.

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -37,24 +37,6 @@ bool operator== (const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept
     return std::equal(std::cbegin(lhr), std::cend(lhr), std::cbegin(rhr), std::cend(rhr));
 }
 
-VertexCounter GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept
-{
-    auto index = InvalidVertex; ///< Index of vertex that when dotted with d has the max value.
-    auto maxValue = -std::numeric_limits<Length>::infinity(); ///< Max dot value.
-    auto i = VertexCounter{0};
-    for (const auto& vertex: proxy.GetVertices())
-    {
-        const auto value = Dot(vertex, d);
-        if (maxValue < value)
-        {
-            maxValue = value;
-            index = i;
-        }
-        ++i;
-    }
-    return index;
-}
-
 std::size_t FindLowestRightMostVertex(Span<const Length2> vertices)
 {
     const auto size = vertices.size();

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -37,11 +37,11 @@ bool operator== (const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept
     return std::equal(std::cbegin(lhr), std::cend(lhr), std::cbegin(rhr), std::cend(rhr));
 }
 
-DistanceProxy::size_type GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept
+VertexCounter GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept
 {
-    auto index = DistanceProxy::InvalidIndex; ///< Index of vertex that when dotted with d has the max value.
+    auto index = InvalidVertex; ///< Index of vertex that when dotted with d has the max value.
     auto maxValue = -std::numeric_limits<Length>::infinity(); ///< Max dot value.
-    auto i = DistanceProxy::size_type{0};
+    auto i = VertexCounter{0};
     for (const auto& vertex: proxy.GetVertices())
     {
         const auto value = Dot(vertex, d);

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -50,13 +50,6 @@ namespace playrho
     class DistanceProxy
     {
     public:
-        /// @brief Size type.
-        /// @details Must be big enough to hold max posible count of vertices.
-        using size_type = std::remove_const<decltype(MaxShapeVertices)>::type;
-        
-        /// @brief Invalid index.
-        static PLAYRHO_CONSTEXPR const size_type InvalidIndex = static_cast<size_type>(-1);
-        
         /// @brief Constant vertex pointer.
         using ConstVertexPointer = const Length2*;
         
@@ -96,8 +89,12 @@ namespace playrho
         ///    <code>MaxShapeVertices</code> elements.
         /// @warning Behavior is undefined if the vertices collection has less than one element or
         ///   more than <code>MaxShapeVertices</code> elements.
+        /// @warning Behavior is undefined if the vertices are not in counter-clockwise order.
+        /// @warning Behavior is undefined if the shape defined by the vertices is not convex.
+        /// @warning Behavior is undefined if the normals aren't normals for adjacent vertices.
+        /// @warning Behavior is undefined if any normal is not unique.
         ///
-        DistanceProxy(const NonNegative<Length> vertexRadius, const size_type count,
+        DistanceProxy(const NonNegative<Length> vertexRadius, const VertexCounter count,
                       const Length2* vertices, const UnitVec2* normals) noexcept:
 #ifndef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
             m_vertices{vertices},
@@ -144,23 +141,23 @@ namespace playrho
         ///
         /// @warning Behavior is undefined if the index given is not less than the count of vertices
         ///   represented by this proxy.
-        /// @warning Behavior is undefined if InvalidIndex is given as the index value.
+        /// @warning Behavior is undefined if InvalidVertex is given as the index value.
         ///
         /// @return Vertex linear position (relative to the shape's origin) at the given index.
         ///
         /// @sa Distance.
         ///
-        auto GetVertex(size_type index) const noexcept
+        auto GetVertex(VertexCounter index) const noexcept
         {
-            assert(index != InvalidIndex);
+            assert(index != InvalidVertex);
             assert(index < m_count);
             return *(m_vertices + index);
         }
         
         /// @brief Gets the normal for the given index.
-        auto GetNormal(size_type index) const noexcept
+        auto GetNormal(VertexCounter index) const noexcept
         {
-            assert(index != InvalidIndex);
+            assert(index != InvalidVertex);
             assert(index < m_count);
             return *(m_normals + index);
         }
@@ -173,7 +170,7 @@ namespace playrho
         const Length2* m_vertices = nullptr; ///< Vertices.
         const UnitVec2* m_normals = nullptr; ///< Normals.
 #endif
-        size_type m_count = 0; ///< Count of valid elements of m_vertices.
+        VertexCounter m_count = 0; ///< Count of valid elements of m_vertices.
         NonNegative<Length> m_vertexRadius = 0_m; ///< Radius of the vertices of the associated shape.
     };
     
@@ -194,11 +191,11 @@ namespace playrho
     /// @note 0 is returned for a given zero length direction vector.
     /// @param proxy Distance proxy object to find index in if a valid index exists for it.
     /// @param d Direction vector to find index for.
-    /// @return InvalidIndex if d is invalid or the count of vertices is zero, otherwise a
+    /// @return InvalidVertex if d is invalid or the count of vertices is zero, otherwise a
     ///   value from 0 to one less than count.
     /// @sa GetVertexCount().
     /// @relatedalso DistanceProxy
-    DistanceProxy::size_type GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept;
+    VertexCounter GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept;
 
     /// @brief Finds the lowest right most vertex in the given collection.
     std::size_t FindLowestRightMostVertex(Span<const Length2> vertices);

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -195,7 +195,27 @@ namespace playrho
     ///   value from 0 to one less than count.
     /// @sa GetVertexCount().
     /// @relatedalso DistanceProxy
-    VertexCounter GetSupportIndex(const DistanceProxy& proxy, Vec2 d) noexcept;
+    template <class T>
+    inline VertexCounter GetSupportIndex(const DistanceProxy& proxy, T d) noexcept
+    {
+        using VT = typename T::value_type;
+        using OT = decltype(VT{} * 0_m);
+
+        auto index = InvalidVertex; ///< Index of vertex that when dotted with d has the max value.
+        auto maxValue = -std::numeric_limits<OT>::infinity(); ///< Max dot value.
+        auto i = VertexCounter{0};
+        for (const auto& vertex: proxy.GetVertices())
+        {
+            const auto value = Dot(vertex, d);
+            if (maxValue < value)
+            {
+                maxValue = value;
+                index = i;
+            }
+            ++i;
+        }
+        return index;
+    }
 
     /// @brief Finds the lowest right most vertex in the given collection.
     std::size_t FindLowestRightMostVertex(Span<const Length2> vertices);

--- a/PlayRho/Collision/IndexPair.hpp
+++ b/PlayRho/Collision/IndexPair.hpp
@@ -3,17 +3,19 @@
  * Modified work Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
@@ -22,42 +24,18 @@
 
 #include <PlayRho/Common/Settings.hpp>
 #include <array>
+#include <utility>
 
 namespace playrho {
     
     /// Index pair.
     /// @note This data structure is at least 2-bytes large.
-    struct IndexPair
-    {
-        /// Size type.
-        /// @details Must be big enough to hold max posible count of vertices.
-        using size_type = std::remove_const<decltype(MaxShapeVertices)>::type;
-        
-        /// @brief Invalid index.
-        static PLAYRHO_CONSTEXPR const size_type InvalidIndex = static_cast<size_type>(-1);
-        
-        size_type a; ///< Index of vertex from shape A.
-        size_type b; ///< Index of vertex from shape B.
-    };
+    using IndexPair = std::pair<VertexCounter, VertexCounter>;
     
     /// @brief Invalid index pair value.
     PLAYRHO_CONSTEXPR const auto InvalidIndexPair = IndexPair{
-        IndexPair::InvalidIndex, IndexPair::InvalidIndex
+        InvalidVertex, InvalidVertex
     };
-    
-    /// @brief Determines whether the two given index pairs are equal.
-    /// @relatedalso IndexPair
-    PLAYRHO_CONSTEXPR inline bool operator== (IndexPair lhs, IndexPair rhs)
-    {
-        return (lhs.a == rhs.a) && (lhs.b == rhs.b);
-    }
-    
-    /// @brief Determines whether the two given index pairs are not equal.
-    /// @relatedalso IndexPair
-    PLAYRHO_CONSTEXPR inline bool operator!= (IndexPair lhs, IndexPair rhs)
-    {
-        return !(lhs == rhs);
-    }
     
     /// @brief Index pairs.
     /// @note This data type is 6-bytes large (on at least one 64-bit platform).
@@ -73,7 +51,15 @@ namespace playrho {
         - ((std::get<1>(pairs) == InvalidIndexPair)? 1u: 0u)
         - ((std::get<2>(pairs) == InvalidIndexPair)? 1u: 0u);
     }
-
+    
+    /// Index pair distance.
+    /// @details This structure is used to keep track of the best separating axis.
+    struct IndexPairDistance
+    {
+        Length distance = GetInvalid<Length>(); ///< Separation.
+        IndexPair indices = InvalidIndexPair; ///< Index pair.
+    };
+    
 } // namespace playrho
 
 #endif // PLAYRHO_COLLISION_INDEXPAIR_HPP

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -579,7 +579,7 @@ Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transfor
     const auto totalRadius = proxyA.GetVertexRadius() + proxyB.GetVertexRadius();
     const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
 
-    const auto distance = Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
+    const auto distance = sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
     if (distance > totalRadius)
     {
         // no collision

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -50,7 +50,7 @@ RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input
     }
     
     // Find the point of intersection of the line with the circle.
-    const auto a = -(c + Sqrt(sigma) * SquareMeter);
+    const auto a = -(c + sqrt(sigma) * SquareMeter);
     const auto fraction = Real{a / rr};
 
     // Is the intersection point on the segment?
@@ -171,7 +171,7 @@ RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
     const auto ray0 = transformedInput.p1;
     const auto ray = transformedInput.p2 - transformedInput.p1; // Ray delta (p2 - p1)
     
-    auto minT = NextAfter(Real{input.maxFraction}, Real(2));
+    auto minT = nextafter(Real{input.maxFraction}, Real(2));
     auto normalFound = GetInvalid<UnitVec2>();
     
     for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)

--- a/PlayRho/Collision/SeparationFinder.cpp
+++ b/PlayRho/Collision/SeparationFinder.cpp
@@ -31,15 +31,15 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
     assert(proxyB.GetVertexCount() > 0);
     
     const auto numIndices = GetNumIndices(indices);
-    const auto type = (numIndices == 1)? e_points: ((indices[0].a == indices[1].a)? e_faceB: e_faceA);
+    const auto type = (numIndices == 1)? e_points: ((indices[0].first == indices[1].first)? e_faceB: e_faceA);
     
     switch (type)
     {
         case e_points:
         {
             const auto ip0 = indices[0];
-            const auto localPointA = proxyA.GetVertex(ip0.a);
-            const auto localPointB = proxyB.GetVertex(ip0.b);
+            const auto localPointA = proxyA.GetVertex(ip0.first);
+            const auto localPointB = proxyB.GetVertex(ip0.second);
             const auto pointA = Transform(localPointA, xfA);
             const auto pointB = Transform(localPointB, xfB);
             const auto axis = GetUnitVector(pointB - pointA, UnitVec2::GetZero());
@@ -51,8 +51,8 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
             const auto ip1 = indices[1];
             
             // Two points on B and one on A.
-            const auto localPointB1 = proxyB.GetVertex(ip0.b);
-            const auto localPointB2 = proxyB.GetVertex(ip1.b);
+            const auto localPointB1 = proxyB.GetVertex(ip0.second);
+            const auto localPointB2 = proxyB.GetVertex(ip1.second);
             const auto lpDelta = localPointB2 - localPointB1;
             
             const auto axis = GetUnitVector(GetFwdPerpendicular(lpDelta),
@@ -62,7 +62,7 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
             const auto localPoint = (localPointB1 + localPointB2) / Real(2);
             const auto pointB = Transform(localPoint, xfB);
             
-            const auto localPointA = proxyA.GetVertex(ip0.a);
+            const auto localPointA = proxyA.GetVertex(ip0.first);
             const auto pointA = Transform(localPointA, xfA);
             
             const auto deltaPoint = pointA - pointB;
@@ -78,8 +78,8 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
             const auto ip1 = indices[1];
             
             // Two points on A and one or two points on B.
-            const auto localPointA1 = proxyA.GetVertex(ip0.a);
-            const auto localPointA2 = proxyA.GetVertex(ip1.a);
+            const auto localPointA1 = proxyA.GetVertex(ip0.first);
+            const auto localPointA2 = proxyA.GetVertex(ip1.first);
             const auto delta = localPointA2 - localPointA1;
             
             const auto axis = GetUnitVector(GetFwdPerpendicular(delta), UnitVec2::GetZero());
@@ -88,7 +88,7 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
             const auto localPoint = (localPointA1 + localPointA2) / Real(2);
             const auto pointA = Transform(localPoint, xfA);
             
-            const auto localPointB = proxyB.GetVertex(ip0.b);
+            const auto localPointB = proxyB.GetVertex(ip0.second);
             const auto pointB = Transform(localPointB, xfB);
             
             const auto deltaPoint = pointB - pointA;
@@ -105,7 +105,9 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
     return SeparationFinder{proxyA, proxyB, UnitVec2{}, GetInvalid<Length2>(), type};
 }
 
-SeparationFinder::Data SeparationFinder::FindMinSeparationForPoints(const Transformation& xfA, const Transformation& xfB) const
+IndexPairDistance
+SeparationFinder::FindMinSeparationForPoints(const Transformation& xfA,
+                                             const Transformation& xfB) const
 {
     const auto dirA = InverseRotate(+m_axis, xfA.q);
     const auto dirB = InverseRotate(-m_axis, xfB.q);
@@ -114,55 +116,62 @@ SeparationFinder::Data SeparationFinder::FindMinSeparationForPoints(const Transf
     const auto pointA = Transform(m_proxyA.GetVertex(indexA), xfA);
     const auto pointB = Transform(m_proxyB.GetVertex(indexB), xfB);
     const auto delta = pointB - pointA;
-    return Data{IndexPair{indexA, indexB}, Dot(delta, m_axis)};
+    return IndexPairDistance{Dot(delta, m_axis), IndexPair{indexA, indexB}};
 }
 
-SeparationFinder::Data SeparationFinder::FindMinSeparationForFaceA(const Transformation& xfA, const Transformation& xfB) const
+IndexPairDistance
+SeparationFinder::FindMinSeparationForFaceA(const Transformation& xfA,
+                                            const Transformation& xfB) const
 {
     const auto normal = Rotate(m_axis, xfA.q);
-    const auto indexA = IndexPair::InvalidIndex;
+    const auto indexA = InvalidVertex;
     const auto pointA = Transform(m_localPoint, xfA);
     const auto dir = InverseRotate(-normal, xfB.q);
     const auto indexB = GetSupportIndex(m_proxyB, GetVec2(dir));
     const auto pointB = Transform(m_proxyB.GetVertex(indexB), xfB);
     const auto delta = pointB - pointA;
-    return Data{IndexPair{indexA, indexB}, Dot(delta, normal)};
+    return IndexPairDistance{Dot(delta, normal), IndexPair{indexA, indexB}};
 }
 
-SeparationFinder::Data SeparationFinder::FindMinSeparationForFaceB(const Transformation& xfA, const Transformation& xfB) const
+IndexPairDistance
+SeparationFinder::FindMinSeparationForFaceB(const Transformation& xfA,
+                                            const Transformation& xfB) const
 {
     const auto normal = Rotate(m_axis, xfB.q);
     const auto dir = InverseRotate(-normal, xfA.q);
     const auto indexA = GetSupportIndex(m_proxyA, GetVec2(dir));
     const auto pointA = Transform(m_proxyA.GetVertex(indexA), xfA);
-    const auto indexB = IndexPair::InvalidIndex;
+    const auto indexB = InvalidVertex;
     const auto pointB = Transform(m_localPoint, xfB);
     const auto delta = pointA - pointB;
-    return Data{IndexPair{indexA, indexB}, Dot(delta, normal)};
+    return IndexPairDistance{Dot(delta, normal), IndexPair{indexA, indexB}};
 }
 
-Length SeparationFinder::EvaluateForPoints(IndexPair indexPair, const Transformation& xfA, const Transformation& xfB) const
+Length SeparationFinder::EvaluateForPoints(const Transformation& xfA, const Transformation& xfB,
+                                           IndexPair indexPair) const
 {
-    const auto pointA = Transform(m_proxyA.GetVertex(indexPair.a), xfA);
-    const auto pointB = Transform(m_proxyB.GetVertex(indexPair.b), xfB);
+    const auto pointA = Transform(m_proxyA.GetVertex(indexPair.first), xfA);
+    const auto pointB = Transform(m_proxyB.GetVertex(indexPair.second), xfB);
     const auto delta = pointB - pointA;
     return Dot(delta, m_axis);
 }
 
-Length SeparationFinder::EvaluateForFaceA(IndexPair indexPair, const Transformation& xfA, const Transformation& xfB) const
+Length SeparationFinder::EvaluateForFaceA(const Transformation& xfA, const Transformation& xfB,
+                                          IndexPair indexPair) const
 {
     const auto normal = Rotate(m_axis, xfA.q);
     const auto pointA = Transform(m_localPoint, xfA);
-    const auto pointB = Transform(m_proxyB.GetVertex(indexPair.b), xfB);
+    const auto pointB = Transform(m_proxyB.GetVertex(indexPair.second), xfB);
     const auto delta = pointB - pointA;
     return Dot(delta, normal);
 }
 
-Length SeparationFinder::EvaluateForFaceB(IndexPair indexPair, const Transformation& xfA, const Transformation& xfB) const
+Length SeparationFinder::EvaluateForFaceB(const Transformation& xfA, const Transformation& xfB,
+                                          IndexPair indexPair) const
 {
     const auto normal = Rotate(m_axis, xfB.q);
     const auto pointB = Transform(m_localPoint, xfB);
-    const auto pointA = Transform(m_proxyA.GetVertex(indexPair.a), xfA);
+    const auto pointA = Transform(m_proxyA.GetVertex(indexPair.first), xfA);
     const auto delta = pointA - pointB;
     return Dot(delta, normal);
 }

--- a/PlayRho/Collision/SeparationFinder.cpp
+++ b/PlayRho/Collision/SeparationFinder.cpp
@@ -111,8 +111,8 @@ SeparationFinder::FindMinSeparationForPoints(const Transformation& xfA,
 {
     const auto dirA = InverseRotate(+m_axis, xfA.q);
     const auto dirB = InverseRotate(-m_axis, xfB.q);
-    const auto indexA = GetSupportIndex(m_proxyA, GetVec2(dirA));
-    const auto indexB = GetSupportIndex(m_proxyB, GetVec2(dirB));
+    const auto indexA = GetSupportIndex(m_proxyA, dirA);
+    const auto indexB = GetSupportIndex(m_proxyB, dirB);
     const auto pointA = Transform(m_proxyA.GetVertex(indexA), xfA);
     const auto pointB = Transform(m_proxyB.GetVertex(indexB), xfB);
     const auto delta = pointB - pointA;
@@ -127,7 +127,7 @@ SeparationFinder::FindMinSeparationForFaceA(const Transformation& xfA,
     const auto indexA = InvalidVertex;
     const auto pointA = Transform(m_localPoint, xfA);
     const auto dir = InverseRotate(-normal, xfB.q);
-    const auto indexB = GetSupportIndex(m_proxyB, GetVec2(dir));
+    const auto indexB = GetSupportIndex(m_proxyB, dir);
     const auto pointB = Transform(m_proxyB.GetVertex(indexB), xfB);
     const auto delta = pointB - pointA;
     return IndexPairDistance{Dot(delta, normal), IndexPair{indexA, indexB}};
@@ -139,7 +139,7 @@ SeparationFinder::FindMinSeparationForFaceB(const Transformation& xfA,
 {
     const auto normal = Rotate(m_axis, xfB.q);
     const auto dir = InverseRotate(-normal, xfA.q);
-    const auto indexA = GetSupportIndex(m_proxyA, GetVec2(dir));
+    const auto indexA = GetSupportIndex(m_proxyA, dir);
     const auto pointA = Transform(m_proxyA.GetVertex(indexA), xfA);
     const auto indexB = InvalidVertex;
     const auto pointB = Transform(m_localPoint, xfB);

--- a/PlayRho/Collision/SeparationFinder.hpp
+++ b/PlayRho/Collision/SeparationFinder.hpp
@@ -41,22 +41,6 @@ namespace playrho {
             e_faceB
         };
         
-        /// Separation finder data.
-        struct Data
-        {
-            /// Index pair.
-            /// @details Pair of indices of vertices for which distance is being returned for.
-            /// @note The <code>a</code> index in this pair will be <code>InvalidIndex</code> for
-            ///   face-A type separarion finders.
-            /// @note The <code>b</code> index in this pair will be <code>InvalidIndex</code> for
-            ///   face-B type separarion finders.
-            IndexPair indexPair;
-
-            /// Distance.
-            /// @details Distance of separation between vertices indexed by the index-pair.
-            Length distance;
-        };
-        
         /// Gets a separation finder for the given inputs.
         ///
         /// @warning Behavior is undefined if given less than one index pair or more than three.
@@ -75,7 +59,8 @@ namespace playrho {
         /// Finds the minimum separation.
         /// @return indexes of proxy A's and proxy B's vertices that have the minimum
         ///    distance between them and what that distance is.
-        Data FindMinSeparation(const Transformation& xfA, const Transformation& xfB) const
+        IndexPairDistance FindMinSeparation(const Transformation& xfA,
+                                            const Transformation& xfB) const
         {
             switch (m_type)
             {
@@ -86,7 +71,7 @@ namespace playrho {
             
             // Should never be reached
             assert(false);
-            return Data{IndexPair{IndexPair::InvalidIndex, IndexPair::InvalidIndex}, 0};
+            return IndexPairDistance{0, InvalidIndexPair};
         }
         
         /// Evaluates the separation of the identified proxy vertices at the given time factor.
@@ -98,13 +83,14 @@ namespace playrho {
         /// @return Separation distance which will be negative when the given transforms put the
         ///    vertices on the opposite sides of the separating axis.
         ///
-        Length Evaluate(IndexPair indexPair, const Transformation& xfA, const Transformation& xfB) const
+        Length Evaluate(const Transformation& xfA, const Transformation& xfB,
+                        IndexPair indexPair) const
         {
             switch (m_type)
             {
-                case e_points: return EvaluateForPoints(indexPair, xfA, xfB);
-                case e_faceA: return EvaluateForFaceA(indexPair, xfA, xfB);
-                case e_faceB: return EvaluateForFaceB(indexPair, xfA, xfB);
+                case e_points: return EvaluateForPoints(xfA, xfB, indexPair);
+                case e_faceA: return EvaluateForFaceA(xfA, xfB, indexPair);
+                case e_faceB: return EvaluateForFaceB(xfA, xfB, indexPair);
                 default: break;
             }
             assert(false);
@@ -131,22 +117,28 @@ namespace playrho {
         }
         
         /// @brief Finds the minimum separation for points.
-        Data FindMinSeparationForPoints(const Transformation& xfA, const Transformation& xfB) const;
+        IndexPairDistance FindMinSeparationForPoints(const Transformation& xfA,
+                                                     const Transformation& xfB) const;
         
         /// @brief Finds the minimum separation for face A.
-        Data FindMinSeparationForFaceA(const Transformation& xfA, const Transformation& xfB) const;
+        IndexPairDistance FindMinSeparationForFaceA(const Transformation& xfA,
+                                                    const Transformation& xfB) const;
         
         /// @brief Finds the minimum separation for face B.
-        Data FindMinSeparationForFaceB(const Transformation& xfA, const Transformation& xfB) const;
+        IndexPairDistance FindMinSeparationForFaceB(const Transformation& xfA,
+                                                    const Transformation& xfB) const;
         
         /// @brief Evaluates for points.
-        Length EvaluateForPoints(IndexPair indexPair, const Transformation& xfA, const Transformation& xfB) const;
+        Length EvaluateForPoints(const Transformation& xfA, const Transformation& xfB,
+                                 IndexPair indexPair) const;
         
         /// @brief Evaluates for face A.
-        Length EvaluateForFaceA(IndexPair indexPair, const Transformation& xfA, const Transformation& xfB) const;
+        Length EvaluateForFaceA(const Transformation& xfA, const Transformation& xfB,
+                                IndexPair indexPair) const;
         
         /// @brief Evaluates for face B.
-        Length EvaluateForFaceB(IndexPair indexPair, const Transformation& xfA, const Transformation& xfB) const;
+        Length EvaluateForFaceB(const Transformation& xfA, const Transformation& xfB,
+                                IndexPair indexPair) const;
         
         const DistanceProxy& m_proxyA; ///< Distance proxy A.
         const DistanceProxy& m_proxyB; ///< Distance proxy B.

--- a/PlayRho/Collision/ShapeSeparation.hpp
+++ b/PlayRho/Collision/ShapeSeparation.hpp
@@ -36,11 +36,7 @@ namespace playrho
     ///   distance from each other in the direction of that normal), and the maximal distance.
     IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
                                        const DistanceProxy& proxy2, Transformation xf2);
-
-    /// @brief Gets the max separation information via pre-caching some info.
-    IndexPairDistance GetMaxSeparationCached(const DistanceProxy& proxy1, Transformation xf1,
-                                             const DistanceProxy& proxy2, Transformation xf2);
-
+    
     /// @brief Gets the max separation information.
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation

--- a/PlayRho/Collision/ShapeSeparation.hpp
+++ b/PlayRho/Collision/ShapeSeparation.hpp
@@ -21,59 +21,11 @@
 #define PLAYRHO_COLLISION_SHAPESEPARATION_HPP
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Collision/IndexPair.hpp>
 
 namespace playrho
 {
     class DistanceProxy;
-
-    /// Index separation.
-    /// @details This structure is used to keep track of the best separating axis.
-    struct IndexSeparation
-    {
-        
-        /// @brief Distance type.
-        using distance_type = Length;
-
-        /// @brief Index type.
-        using index_type = std::remove_const<decltype(MaxShapeVertices)>::type;
-        
-        /// @brief Gets the invalid distance.
-        static PLAYRHO_CONSTEXPR inline distance_type GetInvalidDistance() noexcept
-        {
-            return std::numeric_limits<Length>::max();
-        }
-
-        /// @brief Index type.
-        static PLAYRHO_CONSTEXPR const index_type InvalidIndex = static_cast<index_type>(-1);
-        
-        distance_type separation = GetInvalidDistance(); ///< Separation.
-        index_type index = InvalidIndex; ///< Index.
-    };
-    
-    /// Index pair separation.
-    /// @details This structure is used to keep track of the best separating axis.
-    struct IndexPairSeparation
-    {
-        
-        /// @brief Distance type.
-        using distance_type = Length;
-        
-        /// @brief Index type.
-        using index_type = std::remove_const<decltype(MaxShapeVertices)>::type;
-        
-        /// @brief Gets the invalid distance.
-        static PLAYRHO_CONSTEXPR inline distance_type GetInvalidDistance() noexcept
-        {
-            return std::numeric_limits<Length>::max();
-        }
-
-        /// @brief Invalid index.
-        static PLAYRHO_CONSTEXPR const index_type InvalidIndex = static_cast<index_type>(-1);
-        
-        distance_type separation = GetInvalidDistance(); ///< Separation.
-        index_type index1 = InvalidIndex; ///< Index 1.
-        index_type index2 = InvalidIndex; ///< Index 2.
-    };
     
     /// @brief Gets the max separation information.
     /// @note Prefer using this function - over the <code>GetMaxSeparation</code>
@@ -82,16 +34,20 @@ namespace playrho
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairSeparation GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                         const DistanceProxy& proxy2, Transformation xf2);
+    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
+                                       const DistanceProxy& proxy2, Transformation xf2);
+
+    /// @brief Gets the max separation information via pre-caching some info.
+    IndexPairDistance GetMaxSeparationCached(const DistanceProxy& proxy1, Transformation xf1,
+                                             const DistanceProxy& proxy2, Transformation xf2);
 
     /// @brief Gets the max separation information.
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairSeparation GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                         const DistanceProxy& proxy2, Transformation xf2,
-                                         Length stop);
+    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
+                                       const DistanceProxy& proxy2, Transformation xf2,
+                                       Length stop);
     
     /// @brief Gets the max separation information for the first four vertices of the two
     ///   given shapes.
@@ -100,16 +56,16 @@ namespace playrho
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairSeparation GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
-                                            const DistanceProxy& proxy2, Transformation xf2);
+    IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
+                                          const DistanceProxy& proxy2, Transformation xf2);
 
     /// @brief Gets the max separation information.
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairSeparation GetMaxSeparation(const DistanceProxy& proxy1,
-                                         const DistanceProxy& proxy2,
-                                         Length stop = MaxFloat * Meter);
+    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1,
+                                       const DistanceProxy& proxy2,
+                                       Length stop = MaxFloat * Meter);
     
 } // namespace playrho
 

--- a/PlayRho/Collision/Shapes/ChainShape.cpp
+++ b/PlayRho/Collision/Shapes/ChainShape.cpp
@@ -33,7 +33,7 @@ namespace {
             const auto delta = vertices[i-1] - vertices[i];
             
             // XXX not quite right unit-wise but this works well enough.
-            if (GetMagnitudeSquared(GetVec2(delta)) * Meter <= DefaultLinearSlop)
+            if (GetMagnitudeSquared(delta) <= DefaultLinearSlop)
             {
                 return false;
             }

--- a/PlayRho/Collision/Shapes/MultiShape.hpp
+++ b/PlayRho/Collision/Shapes/MultiShape.hpp
@@ -36,16 +36,6 @@ namespace playrho {
     {
     public:
         
-        /// @brief Vertex count type.
-        ///
-        /// @note This type must not support more than 255 vertices as that would conflict
-        ///   with the <code>ContactFeature::Index</code> type.
-        ///
-        using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
-        
-        /// @brief Invalid vertex.
-        static PLAYRHO_CONSTEXPR const auto InvalidVertex = static_cast<VertexCounter>(-1);
-        
         /// @brief Gets the default vertex radius for the MultiShape.
         static PLAYRHO_CONSTEXPR inline Length GetDefaultVertexRadius() noexcept
         {
@@ -129,7 +119,7 @@ namespace playrho {
         }
         const auto& child = m_children.at(index);
         return DistanceProxy{
-            GetVertexRadius(), static_cast<DistanceProxy::size_type>(child.vertices.size()),
+            GetVertexRadius(), static_cast<VertexCounter>(child.vertices.size()),
             child.vertices.data(), child.normals.data()
         };
     }

--- a/PlayRho/Collision/Shapes/PolygonShape.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.cpp
@@ -138,7 +138,7 @@ void PolygonShape::Accept(ShapeVisitor& visitor) const
     visitor.Visit(*this);
 }
 
-Length2 GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index)
+Length2 GetEdge(const PolygonShape& shape, VertexCounter index)
 {
     assert(shape.GetVertexCount() > 1);
 

--- a/PlayRho/Collision/Shapes/PolygonShape.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShape.hpp
@@ -30,7 +30,7 @@ namespace playrho {
 
 /// @brief Polygon shape.
 /// @details A convex polygon. The interior of the polygon is to the left of each edge.
-///   Polygons have a maximum number of vertices equal to MaxShapeVertices.
+///   Polygons maximum number of vertices is defined by <code>MaxShapeVertices</code>.
 ///   In most cases you should not need many vertices for a convex polygon.
 /// @image html convex_concave.gif
 /// @note This data structure is 64-bytes large (with 4-byte Real).
@@ -38,16 +38,6 @@ namespace playrho {
 class PolygonShape : public Shape
 {
 public:
-
-    /// Vertex count type.
-    ///
-    /// @note This type must not support more than 255 vertices as that would conflict
-    ///   with the <code>ContactFeature::Index</code> type.
-    ///
-    using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
-
-    /// @brief Invalid vertex.
-    static PLAYRHO_CONSTEXPR const auto InvalidVertex = static_cast<VertexCounter>(-1);
 
     /// @brief Gets the default vertex radius for the PolygonShape.
     static PLAYRHO_CONSTEXPR inline Length GetDefaultVertexRadius() noexcept
@@ -92,8 +82,8 @@ public:
     /// @param conf Configuration data for the shape.
     explicit PolygonShape(Length hx, Length hy, const Conf& conf = GetDefaultConf()) noexcept;
     
-    /// Creates a convex hull from the given array of local points.
-    /// The size of the span must be in the range [1, MaxShapeVertices].
+    /// @brief Creates a convex hull from the given array of local points.
+    /// @note The size of the span must be in the range [1, MaxShapeVertices].
     /// @warning the points may be re-ordered, even if they form a convex polygon
     /// @warning collinear points are handled but not removed. Collinear points
     /// may lead to poor stacking behavior.
@@ -197,11 +187,11 @@ inline DistanceProxy PolygonShape::GetChild(ChildCounter index) const
         throw InvalidArgument("only index of 0 is supported");
     }
     return DistanceProxy{GetVertexRadius(),
-        static_cast<DistanceProxy::size_type>(m_vertices.size()), m_vertices.data(),
+        static_cast<VertexCounter>(m_vertices.size()), m_vertices.data(),
         m_normals.data()};
 }
 
-inline PolygonShape::VertexCounter PolygonShape::GetVertexCount() const noexcept
+inline VertexCounter PolygonShape::GetVertexCount() const noexcept
 {
     return static_cast<VertexCounter>(m_vertices.size());
 }
@@ -224,7 +214,7 @@ inline UnitVec2 PolygonShape::GetNormal(VertexCounter index) const
 /// @note This must not be called for shapes with less than 2 vertices.
 /// @warning Behavior is undefined if called for a shape with less than 2 vertices.
 /// @relatedalso PolygonShape
-Length2 GetEdge(const PolygonShape& shape, PolygonShape::VertexCounter index);
+Length2 GetEdge(const PolygonShape& shape, VertexCounter index);
 
 /// Validate convexity of the given shape.
 /// @note This is a time consuming operation.

--- a/PlayRho/Collision/Simplex.cpp
+++ b/PlayRho/Collision/Simplex.cpp
@@ -54,13 +54,13 @@ Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1) noexcept
     // a1 = d12_1 / d12_sum
     // a2 = d12_2 / d12_sum
 
-    const auto w1 = GetVec2(GetPointDelta(s0));
-    const auto w2 = GetVec2(GetPointDelta(s1));
+    const auto w1 = GetPointDelta(s0);
+    const auto w2 = GetPointDelta(s1);
     const auto e12 = w2 - w1;
     
     // w1 region
     const auto d12_2 = -Dot(w1, e12);
-    if (d12_2 <= 0)
+    if (d12_2 <= 0_m2)
     {
         // a2 <= 0, so we clamp it to 0
         return Simplex{{s0}, {1}};
@@ -68,7 +68,7 @@ Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1) noexcept
     
     // w2 region
     const auto d12_1 = Dot(w2, e12);
-    if (d12_1 <= 0)
+    if (d12_1 <= 0_m2)
     {
         // a1 <= 0, so we clamp it to 0
         return Simplex{{s1}, {1}};
@@ -89,9 +89,9 @@ Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1, const Simplex
     // - edge points[1]-points[2]
     // - inside the triangle
 
-    const auto w1 = GetVec2(GetPointDelta(s0));
-    const auto w2 = GetVec2(GetPointDelta(s1));
-    const auto w3 = GetVec2(GetPointDelta(s2));
+    const auto w1 = GetPointDelta(s0);
+    const auto w2 = GetPointDelta(s1);
+    const auto w3 = GetPointDelta(s2);
     
     // Edge12
     // [1      1     ][a1] = [1]
@@ -118,19 +118,19 @@ Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1, const Simplex
     const auto d23_2 = -Dot(w2, e23);
     
     // w1 region
-    if ((d12_2 <= 0) && (d13_2 <= 0))
+    if ((d12_2 <= 0_m2) && (d13_2 <= 0_m2))
     {
         return Simplex{{s0}, {1}};
     }
     
     // w2 region
-    if ((d12_1 <= 0) && (d23_2 <= 0))
+    if ((d12_1 <= 0_m2) && (d23_2 <= 0_m2))
     {
         return Simplex{{s1}, {1}};
     }
     
     // w3 region
-    if ((d13_1 <= 0) && (d23_1 <= 0))
+    if ((d13_1 <= 0_m2) && (d23_1 <= 0_m2))
     {
         return Simplex{{s2}, {1}};
     }
@@ -141,7 +141,7 @@ Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1, const Simplex
     // e12
     const auto cp_w1_w2 = Cross(w1, w2);
     const auto d123_3 = n123 * cp_w1_w2;
-    if ((d12_1 > 0) && (d12_2 > 0) && (d123_3 <= 0))
+    if ((d12_1 > 0_m2) && (d12_2 > 0_m2) && (d123_3 <= 0 * SquareMeter * SquareMeter))
     {
         const auto d12_sum = d12_1 + d12_2;
         return Simplex{{s0, s1}, {d12_1 / d12_sum, d12_2 / d12_sum}};
@@ -150,7 +150,7 @@ Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1, const Simplex
     // e13
     const auto cp_w3_w1 = Cross(w3, w1);
     const auto d123_2 = n123 * cp_w3_w1;
-    if ((d13_1 > 0) && (d13_2 > 0) && (d123_2 <= 0))
+    if ((d13_1 > 0_m2) && (d13_2 > 0_m2) && (d123_2 <= 0 * SquareMeter * SquareMeter))
     {
         const auto d13_sum = d13_1 + d13_2;
         return Simplex{{s0, s2}, {d13_1 / d13_sum, d13_2 / d13_sum}};
@@ -159,7 +159,7 @@ Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1, const Simplex
     // e23
     const auto cp_w2_w3 = Cross(w2, w3);
     const auto d123_1 = n123 * cp_w2_w3;
-    if ((d23_1 > 0) && (d23_2 > 0) && (d123_1 <= 0))
+    if ((d23_1 > 0_m2) && (d23_2 > 0_m2) && (d123_1 <= 0 * SquareMeter * SquareMeter))
     {
         const auto d23_sum = d23_1 + d23_2;
         return Simplex{{s2, s1}, {d23_2 / d23_sum, d23_1 / d23_sum}};

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -254,7 +254,7 @@ namespace playrho {
                 const auto e0 = GetPointDelta(simplexEdges[0]);
                 const auto sgn = Cross(e12, -e0);
                 // If sgn > 0, then origin is left of e12, else origin is right of e12.
-                return (sgn > Real{0} * SquareMeter)? GetRevPerpendicular(e12): GetFwdPerpendicular(e12);
+                return (sgn > 0_m2)? GetRevPerpendicular(e12): GetFwdPerpendicular(e12);
             }
                 
             default:

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -272,7 +272,7 @@ namespace playrho {
             case 2:
             {
                 const auto delta = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
-                return StripUnit(Sqrt(GetMagnitudeSquared(delta)));
+                return StripUnit(sqrt(GetMagnitudeSquared(delta)));
             }
             case 3:
             {

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -272,13 +272,13 @@ namespace playrho {
             case 2:
             {
                 const auto delta = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
-                return Sqrt(GetMagnitudeSquared(GetVec2(delta)));
+                return StripUnit(Sqrt(GetMagnitudeSquared(delta)));
             }
             case 3:
             {
                 const auto delta10 = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
                 const auto delta20 = GetPointDelta(simplexEdges[2]) - GetPointDelta(simplexEdges[0]);
-                return Cross(GetVec2(delta10), GetVec2(delta20));
+                return StripUnit(Cross(delta10, delta20));
             }
             default: break; // should not be reached
         }

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -35,10 +35,6 @@ namespace playrho {
     class SimplexEdge
     {
     public:
-        
-        /// @brief Index type.
-        using index_type = IndexPair::size_type;
-        
         /// @brief Default constructor.
         SimplexEdge() = default;
         
@@ -50,7 +46,8 @@ namespace playrho {
         /// @param iA Index of point A within the shape that it comes from.
         /// @param pB Point B in world coordinates.
         /// @param iB Index of point B within the shape that it comes from.
-        PLAYRHO_CONSTEXPR inline SimplexEdge(Length2 pA, index_type iA, Length2 pB, index_type iB) noexcept;
+        PLAYRHO_CONSTEXPR inline SimplexEdge(Length2 pA, VertexCounter iA,
+                                             Length2 pB, VertexCounter iB) noexcept;
         
         /// @brief Gets point A (in world coordinates).
         PLAYRHO_CONSTEXPR inline auto GetPointA() const noexcept { return m_wA; }
@@ -59,10 +56,10 @@ namespace playrho {
         PLAYRHO_CONSTEXPR inline auto GetPointB() const noexcept { return m_wB; }
 
         /// @brief Gets index A.
-        PLAYRHO_CONSTEXPR inline auto GetIndexA() const noexcept { return m_indexPair.a; }
+        PLAYRHO_CONSTEXPR inline auto GetIndexA() const noexcept { return m_indexPair.first; }
         
         /// @brief Gets index B.
-        PLAYRHO_CONSTEXPR inline auto GetIndexB() const noexcept { return m_indexPair.b; }
+        PLAYRHO_CONSTEXPR inline auto GetIndexB() const noexcept { return m_indexPair.second; }
 
         /// @brief Gets the index pair.
         PLAYRHO_CONSTEXPR inline auto GetIndexPair() const noexcept { return m_indexPair; }
@@ -73,8 +70,8 @@ namespace playrho {
         IndexPair m_indexPair; ///< Index pair. @details Indices of points A and B. 2-bytes.
     };
     
-    PLAYRHO_CONSTEXPR inline SimplexEdge::SimplexEdge(Length2 pA, index_type iA,
-                                              Length2 pB, index_type iB) noexcept:
+    PLAYRHO_CONSTEXPR inline SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
+                                                      Length2 pB, VertexCounter iB) noexcept:
         m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
     {
         // Intentionally empty.

--- a/PlayRho/Collision/TimeOfImpact.cpp
+++ b/PlayRho/Collision/TimeOfImpact.cpp
@@ -43,10 +43,10 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
     assert(IsValid(sweepA));
     assert(IsValid(sweepB));
     assert(sweepA.GetAlpha0() == sweepB.GetAlpha0());
-    //assert(IsFinite(GetMagnitudeSquared(sweepA.pos0.linear - sweepB.pos0.linear)));
-    //assert(IsFinite(GetMagnitudeSquared(sweepA.pos0.linear - sweepB.pos1.linear)));
-    //assert(IsFinite(GetMagnitudeSquared(sweepA.pos1.linear - sweepB.pos0.linear)));
-    //assert(IsFinite(GetMagnitudeSquared(sweepA.pos1.linear - sweepB.pos1.linear)));
+    //assert(isfinite(GetMagnitudeSquared(sweepA.pos0.linear - sweepB.pos0.linear)));
+    //assert(isfinite(GetMagnitudeSquared(sweepA.pos0.linear - sweepB.pos1.linear)));
+    //assert(isfinite(GetMagnitudeSquared(sweepA.pos1.linear - sweepB.pos0.linear)));
+    //assert(isfinite(GetMagnitudeSquared(sweepA.pos1.linear - sweepB.pos1.linear)));
     assert(conf.tMax >= 0 && conf.tMax <=1);
 
     // CCD via the local separating axis method. This seeks progression
@@ -75,13 +75,13 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
     //assert(minTarget > 0_m && !AlmostZero(minTarget / Meter));
     
     const auto minTargetSquared = Square(minTarget);
-    if (!IsFinite(minTargetSquared) && IsFinite(minTarget))
+    if (!isfinite(minTargetSquared) && isfinite(minTarget))
     {
         return TOIOutput{0, stats, TOIOutput::e_minTargetSquaredOverflow};
     }
 
     const auto maxTargetSquared = Square(maxTarget);
-    if (!IsFinite(maxTargetSquared) && IsFinite(maxTarget))
+    if (!isfinite(maxTargetSquared) && isfinite(maxTarget))
     {
         return TOIOutput{0, stats, TOIOutput::e_maxTargetSquaredOverflow};
     }
@@ -116,7 +116,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
         // Get the real distance squared between shapes at the time of t1.
         const auto distSquared = GetMagnitudeSquared(GetDelta(GetWitnessPoints(dinfo.simplex)));
 #if 0
-        if (!IsFinite(distSquared))
+        if (!isfinite(distSquared))
         {
             return TOIOutput{t1, stats, TOIOutput::e_notFinite};
         }
@@ -234,7 +234,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
                 {
                     state = TOIOutput::e_maxRootIters;
                 }
-                else if (std::nextafter(a1, a2) >= a2)
+                else if (nextafter(a1, a2) >= a2)
                 {
                     state = TOIOutput::e_nextAfter;
                 }

--- a/PlayRho/Collision/TimeOfImpact.cpp
+++ b/PlayRho/Collision/TimeOfImpact.cpp
@@ -196,7 +196,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
             // From here on t2MinSeparation.distance is < minTarget; i.e. at t2, shapes too close.
 
             // Compute the initial separation of the witness points.
-            const auto t1EvaluatedDistance = fcn.Evaluate(t2MinSeparation.indexPair, t1xfA, t1xfB);
+            const auto t1EvaluatedDistance = fcn.Evaluate(t1xfA, t1xfB, t2MinSeparation.indices);
 
             // Check for initial overlap. This might happen if the root finder
             // runs out of iterations.
@@ -262,7 +262,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
 
                 const auto txfA = GetTransformation(sweepA, t);
                 const auto txfB = GetTransformation(sweepB, t);
-                const auto s = fcn.Evaluate(t2MinSeparation.indexPair, txfA, txfB);
+                const auto s = fcn.Evaluate(txfA, txfB, t2MinSeparation.indices);
 
                 if (Abs(s - target) <= conf.tolerance) // Root finding succeeded!
                 {

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -115,7 +115,7 @@ NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices)
 {
     // Uses the "Shoelace formula".
     // See: https://en.wikipedia.org/wiki/Shoelace_formula
-    auto sum = Real(0) * SquareMeter;
+    auto sum = 0_m2;
     const auto count = vertices.size();
     for (auto i = decltype(count){0}; i < count; ++i)
     {

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -85,8 +85,8 @@ std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle sta
         while (i < slices)
         {
             const auto angleInRadians = Real{(start + (Real(i) * deltaAngle)) / Radian};
-            const auto x = radius * Cos(angleInRadians);
-            const auto y = radius * Sin(angleInRadians);
+            const auto x = radius * cos(angleInRadians);
+            const auto y = radius * sin(angleInRadians);
             vertices.emplace_back(x, y);
             ++i;
         }
@@ -98,8 +98,8 @@ std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle sta
         else
         {
             const auto angleInRadians = Real{(start + (Real(i) * deltaAngle)) / Radian};
-            const auto x = radius * Cos(angleInRadians);
-            const auto y = radius * Sin(angleInRadians);
+            const auto x = radius * cos(angleInRadians);
+            const auto y = radius * sin(angleInRadians);
             vertices.emplace_back(x, y);
         }
     }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -438,9 +438,8 @@ inline auto GetMagnitude(T value)
 template <typename T1, typename T2>
 PLAYRHO_CONSTEXPR inline auto Dot(const T1 a, const T2 b) noexcept
 {
-    //static_assert(a.size() == b.size(), "Dot only for same sized values");
-    assert(a.size() == b.size());
-    
+    static_assert(std::tuple_size<T1>::value == std::tuple_size<T2>::value,
+                  "Dot only for same tuple-like sized types");
     using VT1 = typename T1::value_type;
     using VT2 = typename T2::value_type;
     using OT = decltype(VT1{} * VT2{});

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -127,103 +127,38 @@ PLAYRHO_CONSTEXPR inline bool IsOdd(T val) noexcept
 template<class TYPE>
 PLAYRHO_CONSTEXPR inline auto Square(TYPE t) noexcept { return t * t; }
 
-/// @brief Square root's the given value.
-template<typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Sqrt(T t)
-{
-    // Note that std::sqrt is not declared noexcept at cppreference.com.
-    // See: http://en.cppreference.com/w/cpp/numeric/math/sqrt
-    return std::sqrt(t);
-}
-
-/// @brief Computes the square root of the sum of the squares.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Hypot(T x, T y)
-{
-    return std::hypot(x, y);
-}
-
-/// @brief Determines if the given argument is normal.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type IsNormal(T arg)
-{
-    return std::isnormal(arg);
-}
-
-/// @brief Gets whether the given value is not-a-number.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type IsNan(T arg)
-{
-    return std::isnan(arg);
-}
-
-/// @brief Gets whether the given value is finite.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type IsFinite(T arg)
-{
-    return std::isfinite(arg);
-}
-
-/// @brief Rounds the given value.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Round(T arg)
-{
-    return std::round(arg);
-}
-
-/// @brief Truncates the given value.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Trunc(T arg)
-{
-    return std::trunc(arg);
-}
-
-/// @brief Determines whether the given value is negative.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, bool>::type SignBit(T value) noexcept
-{
-    return std::signbit(value);
-}
-
-/// @brief Gets the next representable value after the given from value and going towards
-///   the to value.
-template <typename T>
-inline T NextAfter(T from, T to)
-{
-    return static_cast<T>(std::nextafter(from, to));
-}
-
-/// @brief Computes the cosine of the argument.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Cos(T arg)
-{
-    return std::cos(arg);
-}
-
-/// @brief Computes the sine of the argument.
-template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type Sin(T arg)
-{
-    return std::sin(arg);
-}
+using std::signbit;
+using std::nextafter;
+using std::trunc;
+using std::fmod;
+using std::isfinite;
+using std::round;
+using std::isnormal;
+using std::isnan;
+using std::hypot;
+using std::cos;
+using std::sin;
+using std::atan2;
+using std::sqrt;
+using std::pow;
 
 #ifdef USE_BOOST_UNITS
 /// @brief Square roots the given area.
-inline auto Sqrt(Area t)
+inline auto sqrt(Area t)
 {
-    return Sqrt(StripUnit(t)) * Meter;
+    return sqrt(StripUnit(t)) * Meter;
 }
 
 /// @brief Computes the cosine of the argument.
-inline Real Cos(Angle a)
+inline Real cos(Angle a)
 {
-    return Cos(Real{a / Radian});
+    return cos(Real{a / Radian});
 }
 
 /// @brief Computes the sine of the argument.
-inline Real Sin(Angle a)
+inline Real sin(Angle a)
 {
-    return Sin(Real{a / Radian});
+    return sin(Real{a / Radian});
 }
 #endif
 
@@ -233,7 +168,7 @@ inline Real Sin(Angle a)
 template<typename T>
 inline auto Atan2(T y, T x)
 {
-    return Angle{static_cast<Real>(std::atan2(StripUnit(y), StripUnit(x))) * Radian};
+    return Angle{static_cast<Real>(atan2(StripUnit(y), StripUnit(x))) * Radian};
 }
 
 /// @brief Computes the average of the given values.
@@ -303,11 +238,10 @@ AlmostEqual(T x, T y, int ulp = 2)
 /// @note Modulo via std::fmod appears slower than via std::trunc.
 /// @sa ModuloViaTrunc
 template <typename T>
-inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
-ModuloViaFmod(T dividend, T divisor) noexcept
+inline auto ModuloViaFmod(T dividend, T divisor) noexcept
 {
     // Note: modulo via std::fmod appears slower than via std::trunc.
-    return static_cast<T>(std::fmod(dividend, divisor));
+    return static_cast<T>(fmod(dividend, divisor));
 }
 
 /// @brief Modulo operation using std::trunc.
@@ -317,7 +251,7 @@ template <typename T>
 inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
 {
     const auto quotient = dividend / divisor;
-    const auto integer = static_cast<T>(Trunc(quotient));
+    const auto integer = static_cast<T>(trunc(quotient));
     const auto remainder = quotient - integer;
     return remainder * divisor;
 }
@@ -408,7 +342,7 @@ PLAYRHO_CONSTEXPR inline auto GetMagnitudeSquared(T value) noexcept
 template <typename T>
 inline auto GetMagnitude(T value)
 {
-    return Sqrt(GetMagnitudeSquared(value));
+    return sqrt(GetMagnitudeSquared(value));
 }
 
 /// @brief Performs the dot product on two vectors (A and B).
@@ -486,10 +420,10 @@ template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
 PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
 {
-    assert(IsFinite(StripUnit(Get<0>(a))));
-    assert(IsFinite(StripUnit(Get<1>(a))));
-    assert(IsFinite(StripUnit(Get<0>(b))));
-    assert(IsFinite(StripUnit(Get<1>(b))));
+    assert(isfinite(StripUnit(Get<0>(a))));
+    assert(isfinite(StripUnit(Get<1>(a))));
+    assert(isfinite(StripUnit(Get<0>(b))));
+    assert(isfinite(StripUnit(Get<1>(b))));
 
     // Both vectors of same direction...
     // If a = Vec2{1, 2} and b = Vec2{1, 2} then: a x b = 1 * 2 - 2 * 1 = 0.
@@ -503,8 +437,8 @@ PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
     // If a = Vec2{1, 2} and b = Vec2{-1, 2} then: a x b = 1 * 2 - 2 * (-1) = 2 + 2 = 4.
     const auto minuend = Get<0>(a) * Get<1>(b);
     const auto subtrahend = Get<1>(a) * Get<0>(b);
-    assert(IsFinite(StripUnit(minuend)));
-    assert(IsFinite(StripUnit(subtrahend)));
+    assert(isfinite(StripUnit(minuend)));
+    assert(isfinite(StripUnit(subtrahend)));
     return minuend - subtrahend;
 }
 
@@ -518,12 +452,12 @@ template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 3 && std::tuple_size<T2>::value == 3, int> = 0>
 PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
 {
-    assert(IsFinite(Get<0>(a)));
-    assert(IsFinite(Get<1>(a)));
-    assert(IsFinite(Get<2>(a)));
-    assert(IsFinite(Get<0>(b)));
-    assert(IsFinite(Get<1>(b)));
-    assert(IsFinite(Get<2>(b)));
+    assert(isfinite(Get<0>(a)));
+    assert(isfinite(Get<1>(a)));
+    assert(isfinite(Get<2>(a)));
+    assert(isfinite(Get<0>(b)));
+    assert(isfinite(Get<1>(b)));
+    assert(isfinite(Get<2>(b)));
 
     using OT = decltype(Get<0>(a) * Get<0>(b));
     return Vector<OT, 3>{
@@ -754,8 +688,8 @@ PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 template <class T>
 PLAYRHO_CONSTEXPR inline auto Rotate(const Vector2<T> vector, const UnitVec2& angle) noexcept
 {
-    const auto newX = (angle.cos() * GetX(vector)) - (angle.sin() * GetY(vector));
-    const auto newY = (angle.sin() * GetX(vector)) + (angle.cos() * GetY(vector));
+    const auto newX = (GetX(angle) * GetX(vector)) - (GetY(angle) * GetY(vector));
+    const auto newY = (GetY(angle) * GetX(vector)) + (GetX(angle) * GetY(vector));
     return Vector2<T>{newX, newY};
 }
 
@@ -769,8 +703,8 @@ PLAYRHO_CONSTEXPR inline auto Rotate(const Vector2<T> vector, const UnitVec2& an
 template <class T>
 PLAYRHO_CONSTEXPR inline auto InverseRotate(const Vector2<T> vector, const UnitVec2& angle) noexcept
 {
-    const auto newX = (angle.cos() * GetX(vector)) + (angle.sin() * GetY(vector));
-    const auto newY = (angle.cos() * GetY(vector)) - (angle.sin() * GetX(vector));
+    const auto newX = (GetX(angle) * GetX(vector)) + (GetY(angle) * GetY(vector));
+    const auto newY = (GetX(angle) * GetY(vector)) - (GetY(angle) * GetX(vector));
     return Vector2<T>{newX, newY};
 }
 

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -116,9 +116,18 @@ PLAYRHO_CONSTEXPR const auto MaxFloat = std::numeric_limits<Real>::max(); // FLT
 /// @note For memory efficiency, uses the smallest integral type that can hold the value. 
 PLAYRHO_CONSTEXPR const auto MaxManifoldPoints = std::uint8_t{2};
 
-/// Maximum number of vertices for any shape type.
-/// @note For memory efficiency, uses the smallest integral type that can hold the value.
+/// @brief Maximum number of vertices for any shape type.
+/// @note For memory efficiency, uses the smallest integral type that can hold the value minus
+///   one that's left out as a sentinal value.
 PLAYRHO_CONSTEXPR const auto MaxShapeVertices = std::uint8_t{254};
+
+/// @brief Vertex count type.
+/// @note This type must not support more than 255 vertices as that would conflict
+///   with the <code>ContactFeature::Index</code> type.
+using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
+
+/// @brief Invalid vertex index.
+PLAYRHO_CONSTEXPR const auto InvalidVertex = static_cast<VertexCounter>(-1);
 
 /// @brief Default linear slop.
 /// @details Length used as a collision and constraint tolerance.

--- a/PlayRho/Common/UnitVec2.cpp
+++ b/PlayRho/Common/UnitVec2.cpp
@@ -27,15 +27,15 @@ UnitVec2::PolarCoord UnitVec2::Get(const Real x, const Real y, const UnitVec2 fa
 {
     // Try the faster way first...
     const auto magnitudeSquared = x * x + y * y;
-    if (IsNormal(magnitudeSquared))
+    if (isnormal(magnitudeSquared))
     {
-        const auto magnitude = Sqrt(magnitudeSquared);
+        const auto magnitude = sqrt(magnitudeSquared);
         return std::make_pair(UnitVec2{x / magnitude, y / magnitude}, magnitude);
     }
     
     // Failed the faster way, try the more accurate and robust way...
-    const auto magnitude = Hypot(x, y);
-    if (IsNormal(magnitude))
+    const auto magnitude = hypot(x, y);
+    if (isnormal(magnitude))
     {
         return std::make_pair(UnitVec2{x / magnitude, y / magnitude}, magnitude);
     }
@@ -46,7 +46,7 @@ UnitVec2::PolarCoord UnitVec2::Get(const Real x, const Real y, const UnitVec2 fa
 
 UnitVec2 UnitVec2::Get(const Angle angle) noexcept
 {
-    return UnitVec2{Cos(angle), Sin(angle)};
+    return UnitVec2{cos(angle), sin(angle)};
 }
 
 } // namespace playrho

--- a/PlayRho/Common/UnitVec2.hpp
+++ b/PlayRho/Common/UnitVec2.hpp
@@ -196,13 +196,7 @@ public:
 
     /// @brief Gets the "Y" value.
     PLAYRHO_CONSTEXPR inline auto GetY() const noexcept { return m_elems[1]; }
-
-    /// @brief Gets the cosine value.
-    PLAYRHO_CONSTEXPR inline auto cos() const noexcept { return m_elems[0]; }
-
-    /// @brief Gets the sine value.
-    PLAYRHO_CONSTEXPR inline auto sin() const noexcept { return m_elems[1]; }
-
+    
     /// @brief Flips the X and Y values.
     PLAYRHO_CONSTEXPR inline UnitVec2 FlipXY() const noexcept { return UnitVec2{-GetX(), -GetY()}; }
 

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -626,6 +626,20 @@ namespace playrho
         return static_cast<Real>(v) * Newton;
     }
     
+    /// @brief Abbreviation for meter squared unit of Area.
+    /// @sa SquareMeter
+    PLAYRHO_CONSTEXPR inline Area operator"" _m2(unsigned long long int v) noexcept
+    {
+        return static_cast<Real>(v) * SquareMeter;
+    }
+    
+    /// @brief Abbreviation for meter squared unit of Area.
+    /// @sa SquareMeter
+    PLAYRHO_CONSTEXPR inline Area operator"" _m2(long double v) noexcept
+    {
+        return static_cast<Real>(v) * SquareMeter;
+    }
+    
     /// @brief Abbreviation for meter per second.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second
     /// @sa Meter

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -796,19 +796,8 @@ namespace playrho
 
 #if defined(USE_BOOST_UNITS)
     
-    /// @brief Is finite.
-    template <class Y>
-    inline auto IsFinite(const boost::units::quantity<Y, Real> v)
-    {
-        return boost::units::isfinite(v);
-    }
-    
-    /// @brief Is normal.
-    template <class Y>
-    inline auto IsNormal(const boost::units::quantity<Y, Real> v)
-    {
-        return boost::units::isnormal(v);
-    }
+    using boost::units::isfinite;
+    using boost::units::isnormal;
     
     /// @brief Almost zero.
     template <class Y>

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -72,7 +72,7 @@ namespace playrho
     /// @brief Gets the given value as a Vec2.
     PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Vector2<Real> value)
     {
-        return {value};
+        return value;
     }
 
     /// @brief Gets an invalid value for the Vec2 type.

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -24,6 +24,7 @@
 
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Vector2.hpp>
+#include <utility>
 
 namespace playrho
 {
@@ -151,6 +152,9 @@ namespace playrho
          */
         return Velocity{lhs.linear / rhs, lhs.angular / rhs};
     }
+    
+    /// @brief Velocity pair.
+    using VelocityPair = std::pair<Velocity, Velocity>;
     
 } // namespace playrho
 

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -41,7 +41,7 @@ namespace playrho {
         /// @brief Gets the default minimum separation squared value.
         static Area GetDefaultMinSeparationSquared()
         {
-            return Sqrt(std::numeric_limits<Vec2::value_type>::min()) * SquareMeter;
+            return sqrt(std::numeric_limits<Vec2::value_type>::min()) * SquareMeter;
         }
         
         /// @brief Initializing constructor.

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -466,7 +466,7 @@ Velocity GetVelocity(const Body& body, Time h, MovementConf conf) noexcept
     if (lsquared > Square(conf.maxTranslation))
     {
         // Scale back linear velocity so max translation not exceeded.
-        const auto ratio = conf.maxTranslation / Sqrt(lsquared);
+        const auto ratio = conf.maxTranslation / sqrt(lsquared);
         velocity.linear *= ratio;
     }
     
@@ -491,8 +491,8 @@ void RotateAboutWorldPoint(Body& body, Angle amount, Length2 worldPoint)
 {
     const auto xfm = body.GetTransformation();
     const auto p = xfm.p - worldPoint;
-    const auto c = Cos(amount);
-    const auto s = Sin(amount);
+    const auto c = cos(amount);
+    const auto s = sin(amount);
     const auto x = GetX(p) * c - GetY(p) * s;
     const auto y = GetX(p) * s + GetY(p) * c;
     const auto pos = Length2{x, y} + worldPoint;

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -49,7 +49,7 @@ class StepConf;
 inline Real MixFriction(Real friction1, Real friction2)
 {
     assert(friction1 >= Real(0) && friction2 >= Real(0));
-    return Sqrt(friction1 * friction2);
+    return sqrt(friction1 * friction2);
 }
 
 /// @brief Mixes restitution.

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -41,12 +41,6 @@ namespace {
 static PLAYRHO_CONSTEXPR inline auto k_errorTol = 1e-3_mps; ///< error tolerance
 #endif
 
-struct VelocityPair
-{
-    Velocity vel_a;
-    Velocity vel_b;
-};
-
 /// Impulse change.
 ///
 /// @details
@@ -99,8 +93,8 @@ VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impu
 Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2 newImpulses)
 {
     const auto delta_v = GetVelocityDelta(vc, newImpulses - GetNormalImpulses(vc));
-    vc.GetBodyA()->SetVelocity(vc.GetBodyA()->GetVelocity() + delta_v.vel_a);
-    vc.GetBodyB()->SetVelocity(vc.GetBodyB()->GetVelocity() + delta_v.vel_b);
+    vc.GetBodyA()->SetVelocity(vc.GetBodyA()->GetVelocity() + delta_v.first);
+    vc.GetBodyB()->SetVelocity(vc.GetBodyB()->GetVelocity() + delta_v.second);
     SetNormalImpulses(vc, newImpulses);
     return std::max(Abs(newImpulses[0]), Abs(newImpulses[1]));
 }

--- a/PlayRho/Dynamics/StepConf.cpp
+++ b/PlayRho/Dynamics/StepConf.cpp
@@ -24,7 +24,7 @@ namespace playrho {
 
 bool IsMaxTranslationWithinTolerance(const StepConf& conf) noexcept
 {
-    const auto delta = Real(1) - std::nextafter(Real(1), Real(0));
+    const auto delta = Real(1) - nextafter(Real(1), Real(0));
     return (conf.maxTranslation * delta) < Length{conf.tolerance};
 }
 

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -71,6 +71,7 @@
 #include <vector>
 #include <unordered_map>
 #include <algorithm>
+
 #ifdef DO_PAR_UNSEQ
 #include <atomic>
 #endif
@@ -201,12 +202,6 @@ namespace {
 #endif
     }
     
-    struct VelocityPair
-    {
-        Velocity a;
-        Velocity b;
-    };
-    
     inline VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc)
     {
         auto vp = VelocityPair{
@@ -237,8 +232,8 @@ namespace {
             const auto P = vcp.normalImpulse * normal + vcp.tangentImpulse * tangent;
             const auto LA = Cross(vcp.relA, P) / Radian;
             const auto LB = Cross(vcp.relB, P) / Radian;
-            vp.a -= Velocity{invMassA * P, invRotInertiaA * LA};
-            vp.b += Velocity{invMassB * P, invRotInertiaB * LB};
+            vp.first -= Velocity{invMassA * P, invRotInertiaA * LA};
+            vp.second += Velocity{invMassB * P, invRotInertiaB * LB};
         }
         return vp;
     }
@@ -250,8 +245,8 @@ namespace {
             const auto vp = CalcWarmStartVelocityDeltas(vc);
             const auto bodyA = vc.GetBodyA();
             const auto bodyB = vc.GetBodyB();
-            bodyA->SetVelocity(bodyA->GetVelocity() + vp.a);
-            bodyB->SetVelocity(bodyB->GetVelocity() + vp.b);
+            bodyA->SetVelocity(bodyA->GetVelocity() + vp.first);
+            bodyB->SetVelocity(bodyB->GetVelocity() + vp.second);
         });
     }
 

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -1404,7 +1404,7 @@ World::UpdateContactsData World::UpdateContactTOIs(const StepConf& conf)
     
 World::ContactToiData World::GetSoonestContacts(size_t reserveSize)
 {
-    auto minToi = NextAfter(Real{1}, Real{0});
+    auto minToi = nextafter(Real{1}, Real{0});
     auto minContacts = std::vector<Contact*>();
     minContacts.reserve(reserveSize);
     for (auto&& contact: m_contacts)

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -603,8 +603,8 @@ struct GLRenderTriangles
 
 DebugDraw::DebugDraw(Camera& camera):
     m_camera(camera),
-    m_cosInc{Cos((2 * Pi) / m_circleParts)},
-    m_sinInc{Sin((2 * Pi) / m_circleParts)}
+    m_cosInc{cos((2 * Pi) / m_circleParts)},
+    m_sinInc{sin((2 * Pi) / m_circleParts)}
 {
     m_points = new GLRenderPoints;
     m_lines = new GLRenderLines;

--- a/Testbed/Tests/ApplyForce.hpp
+++ b/Testbed/Tests/ApplyForce.hpp
@@ -135,7 +135,7 @@ public:
 
                 // For a circle: I = 0.5 * m * r * r ==> r = sqrt(2 * I / m)
                 const auto radiusSquaredUnitless = 2 * I * invMass * SquareRadian / SquareMeter;
-                const auto radius = Length{Sqrt(Real{radiusSquaredUnitless}) * 1_m};
+                const auto radius = Length{sqrt(Real{radiusSquaredUnitless}) * 1_m};
 
                 FrictionJointDef jd;
                 jd.localAnchorA = Length2{};

--- a/Testbed/Tests/Car.hpp
+++ b/Testbed/Tests/Car.hpp
@@ -126,7 +126,7 @@ public:
             m_world.CreateJoint(jd);
 
             // AngularMomentum is L^2 M T^-1 QP^-1.
-            ApplyAngularImpulse(*body, 100 * SquareMeter * 1_kg / (1_s * 1_rad));
+            ApplyAngularImpulse(*body, 100_m2 * 1_kg / (1_s * 1_rad));
         }
 
         // Bridge

--- a/Testbed/Tests/CharacterCollision.hpp
+++ b/Testbed/Tests/CharacterCollision.hpp
@@ -201,7 +201,7 @@ public:
             Length2 vertices[6];
             for (auto i = 0; i < 6; ++i)
             {
-                vertices[i] = Vec2(0.5f * Cos(angle), 0.5f * Sin(angle)) * 1_m;
+                vertices[i] = Vec2(0.5f * cos(angle), 0.5f * sin(angle)) * 1_m;
                 angle += delta;
             }
 

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -168,7 +168,7 @@ public:
                 };
                 const auto angle_from_center = GetAngle(centerPos);
                 const auto direction = angle_from_center + Pi * 1_rad;
-                const auto magnitude = Sqrt(Square(StripUnit(wall_length)) * 2) *
+                const auto magnitude = sqrt(Square(StripUnit(wall_length)) * 2) *
                 	GetMass(b) * 20_mps;
                 const auto impulse = Momentum2{magnitude * UnitVec2::Get(direction)};
                 ApplyLinearImpulse(b, impulse, b.GetWorldCenter());

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -260,7 +260,7 @@ public:
         const auto output = Distance(proxyA, xfmA, proxyB, xfmB, distanceConf);
         distanceConf.cache = Simplex::GetCache(output.simplex.GetEdges());
         const auto witnessPoints = GetWitnessPoints(output.simplex);
-        const auto outputDistance = Sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second));
+        const auto outputDistance = sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second));
         
         const auto rA = proxyA.GetVertexRadius();
         const auto rB = proxyB.GetVertexRadius();

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -260,7 +260,7 @@ public:
         const auto output = Distance(proxyA, xfmA, proxyB, xfmB, distanceConf);
         distanceConf.cache = Simplex::GetCache(output.simplex.GetEdges());
         const auto witnessPoints = GetWitnessPoints(output.simplex);
-        const auto outputDistance = Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
+        const auto outputDistance = Sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second));
         
         const auto rA = proxyA.GetVertexRadius();
         const auto rB = proxyB.GetVertexRadius();
@@ -273,17 +273,17 @@ public:
             // Shapes are still not overlapped.
             // Move the witness points to the outer surface.
             adjustedDistance -= totalRadius;
-            const auto normal = GetUnitVector(witnessPoints.b - witnessPoints.a);
-            adjustedWitnessPoints.a += rA * normal;
-            adjustedWitnessPoints.b -= rB * normal;
+            const auto normal = GetUnitVector(witnessPoints.second - witnessPoints.first);
+            adjustedWitnessPoints.first += rA * normal;
+            adjustedWitnessPoints.second -= rB * normal;
         }
         else
         {
             // Shapes are overlapped when radii are considered.
             // Move the witness points to the middle.
-            const auto p = (witnessPoints.a + witnessPoints.b) / Real{2};
-            adjustedWitnessPoints.a = p;
-            adjustedWitnessPoints.b = p;
+            const auto p = (witnessPoints.first + witnessPoints.second) / Real{2};
+            adjustedWitnessPoints.first = p;
+            adjustedWitnessPoints.second = p;
             adjustedDistance = 0;
         }
         
@@ -302,22 +302,22 @@ public:
         os << ".\n\n";
 
         os << "Max separation:\n";
-        os << "  " << static_cast<double>(Real{maxIndicesAB.separation / 1_m});
-        os << " for a-face[" << unsigned{maxIndicesAB.index1} << "]";
-        os << " b-vert[" << unsigned{maxIndicesAB.index2} << "].\n";
-        os << "  " << static_cast<double>(Real{maxIndicesBA.separation / 1_m});
-        os << " for b-face[" << unsigned{maxIndicesBA.index1} << "]";
-        os << " a-vert[" << unsigned{maxIndicesBA.index2} << "].\n\n";
+        os << "  " << static_cast<double>(Real{maxIndicesAB.distance / 1_m});
+        os << " for a-face[" << unsigned{maxIndicesAB.indices.first} << "]";
+        os << " b-vert[" << unsigned{maxIndicesAB.indices.second} << "].\n";
+        os << "  " << static_cast<double>(Real{maxIndicesBA.distance / 1_m});
+        os << " for b-face[" << unsigned{maxIndicesBA.indices.first} << "]";
+        os << " a-vert[" << unsigned{maxIndicesBA.indices.second} << "].\n\n";
 
-        if (AlmostEqual(static_cast<double>(Real{maxIndicesAB.separation / 1_m}),
-                         static_cast<double>(Real{maxIndicesBA.separation / 1_m})))
+        if (AlmostEqual(static_cast<double>(Real{maxIndicesAB.distance / 1_m}),
+                         static_cast<double>(Real{maxIndicesBA.distance / 1_m})))
         {
             //assert(maxIndicesAB.index1 == maxIndicesBA.index2);
             //assert(maxIndicesAB.index2 == maxIndicesBA.index1);
-            const auto ifaceA = maxIndicesAB.index1;
+            const auto ifaceA = maxIndicesAB.indices.first;
             const auto nA = InverseRotate(Rotate(shapeA->GetNormal(ifaceA), xfmA.q), xfmB.q);
             // shapeA face maxIndicesAB.index1 is coplanar to an edge intersecting shapeB vertex maxIndicesAB.index2
-            const auto i1 = maxIndicesAB.index2;
+            const auto i1 = maxIndicesAB.indices.second;
             const auto i0 = GetModuloPrev(i1, shapeB->GetVertexCount());
             const auto n0 = shapeB->GetNormal(i0);
             const auto n1 = shapeB->GetNormal(i1);
@@ -334,7 +334,7 @@ public:
                 i1;
 #endif
         }
-        else if (maxIndicesAB.separation > maxIndicesBA.separation)
+        else if (maxIndicesAB.distance > maxIndicesBA.distance)
         {
             // shape A face maxIndicesAB.index1 is least separated from shape B vertex maxIndicesAB.index2
             // Circles or Face-A manifold type.
@@ -352,13 +352,13 @@ public:
         {
             const auto size = output.simplex.GetSize();
             os << "Simplex info: size=" << unsigned{size} << ", wpt-a={";
-            os << static_cast<double>(Real{GetX(witnessPoints.a) / 1_m});
+            os << static_cast<double>(Real{GetX(witnessPoints.first) / 1_m});
             os << ",";
-            os << static_cast<double>(Real{GetY(witnessPoints.a) / 1_m});
+            os << static_cast<double>(Real{GetY(witnessPoints.first) / 1_m});
             os << "}, wpt-b={";
-            os << static_cast<double>(Real{GetX(witnessPoints.b) / 1_m});
+            os << static_cast<double>(Real{GetX(witnessPoints.second) / 1_m});
             os << ",";
-            os << static_cast<double>(Real{GetY(witnessPoints.b) / 1_m});
+            os << static_cast<double>(Real{GetY(witnessPoints.second) / 1_m});
             os << "}:\n";
             for (auto i = decltype(size){0}; i < size; ++i)
             {
@@ -453,18 +453,18 @@ public:
                 drawer.DrawSegment(edge.GetPointA(), edge.GetPointB(), simplexSegmentColor);
             }
 
-            if (adjustedWitnessPoints.a != adjustedWitnessPoints.b)
+            if (adjustedWitnessPoints.first != adjustedWitnessPoints.second)
             {
-                drawer.DrawPoint(adjustedWitnessPoints.a, 4.0f, adjustedPointColor);
-                drawer.DrawPoint(adjustedWitnessPoints.b, 4.0f, adjustedPointColor);
+                drawer.DrawPoint(adjustedWitnessPoints.first, 4.0f, adjustedPointColor);
+                drawer.DrawPoint(adjustedWitnessPoints.second, 4.0f, adjustedPointColor);
             }
             else
             {
-                drawer.DrawPoint(adjustedWitnessPoints.a, 4.0f, matchingPointColor);
+                drawer.DrawPoint(adjustedWitnessPoints.first, 4.0f, matchingPointColor);
             }
 
-            drawer.DrawPoint(witnessPoints.a, 4.0f, witnessPointColor);
-            drawer.DrawPoint(witnessPoints.b, 4.0f, witnessPointColor);
+            drawer.DrawPoint(witnessPoints.first, 4.0f, witnessPointColor);
+            drawer.DrawPoint(witnessPoints.second, 4.0f, witnessPointColor);
             
             for (auto&& edge: output.simplex.GetEdges())
             {

--- a/Testbed/Tests/EdgeShapes.hpp
+++ b/Testbed/Tests/EdgeShapes.hpp
@@ -75,8 +75,8 @@ public:
 
         {
             const auto w = 1.0f;
-            const auto b = w / (2.0f + Sqrt(2.0f));
-            const auto s = Sqrt(2.0f) * b;
+            const auto b = w / (2.0f + sqrt(2.0f));
+            const auto s = sqrt(2.0f) * b;
 
             m_polygons[2]->Set({
                 Vec2(0.5f * s, 0.0f) * 1_m,
@@ -169,7 +169,7 @@ public:
     {
         const auto L = Real(25);
         const auto point1 = Vec2(0.0f, 10.0f) * 1_m;
-        const auto d = Vec2(L * Cos(m_angle), -L * Abs(Sin(m_angle))) * 1_m;
+        const auto d = Vec2(L * cos(m_angle), -L * Abs(sin(m_angle))) * 1_m;
         const auto point2 = point1 + d;
 
         auto fixture = static_cast<Fixture*>(nullptr);

--- a/Testbed/Tests/MotorJoint.hpp
+++ b/Testbed/Tests/MotorJoint.hpp
@@ -71,7 +71,7 @@ public:
             m_time += settings.dt;
         }
 
-        const auto linearOffset = Vec2{6 * Sin(2 * m_time), 8 + 4 * Sin(m_time)} * 1_m;
+        const auto linearOffset = Vec2{6 * sin(2 * m_time), 8 + 4 * sin(m_time)} * 1_m;
 
         m_joint->SetLinearOffset(linearOffset);
         m_joint->SetAngularOffset(4_rad * m_time);

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -91,8 +91,8 @@ public:
 
         {
             const auto w = Real(1);
-            const auto b = w / (2.0f + Sqrt(2.0f));
-            const auto s = Sqrt(2.0f) * b;
+            const auto b = w / (2.0f + sqrt(2.0f));
+            const auto s = sqrt(2.0f) * b;
 
             m_polygons[2]->Set({
                 Vec2(0.5f * s, 0.0f) * 1_m,

--- a/Testbed/Tests/RayCast.hpp
+++ b/Testbed/Tests/RayCast.hpp
@@ -75,8 +75,8 @@ public:
 
         {
             const auto w = 1.0f;
-            const auto b = w / (2.0f + Sqrt(2.0f));
-            const auto s = Sqrt(2.0f) * b;
+            const auto b = w / (2.0f + sqrt(2.0f));
+            const auto s = sqrt(2.0f) * b;
 
             m_polygons[2]->Set({
                 Vec2(0.5f * s, 0.0f) * 1_m,
@@ -204,7 +204,7 @@ public:
 
         const auto L = 11.0f;
         const auto point1 = Vec2(0.0f, 10.0f) * 1_m;
-        const auto d = Vec2(L * Cos(m_angle), L * Sin(m_angle)) * 1_m;
+        const auto d = Vec2(L * cos(m_angle), L * sin(m_angle)) * 1_m;
         const auto point2 = point1 + d;
 
         if (m_mode == Mode::e_closest)

--- a/Testbed/Tests/iforce2d_Trajectories.hpp
+++ b/Testbed/Tests/iforce2d_Trajectories.hpp
@@ -220,8 +220,8 @@ public:
         const auto b = 0.5f;
         const auto c = desiredHeight;
         
-        const auto quadraticSolution1 = ( -b - Sqrt( b*b - 4*a*c ) ) / (2*a);
-        const auto quadraticSolution2 = ( -b + Sqrt( b*b - 4*a*c ) ) / (2*a);
+        const auto quadraticSolution1 = ( -b - sqrt( b*b - 4*a*c ) ) / (2*a);
+        const auto quadraticSolution2 = ( -b + sqrt( b*b - 4*a*c ) ) / (2*a);
         
         auto v = quadraticSolution1;
         if ( v < decltype(v){} )

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -159,37 +159,37 @@ TEST(AABB2D, InitializingConstruction)
         const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto pa = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         const auto pb = Length2{GetInvalid<Length>(), 0_m};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_FALSE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_FALSE(isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto pa = Length2{GetInvalid<Length>(), 0_m};
         const auto pb = Length2{GetInvalid<Length>(), GetInvalid<Length>()};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_FALSE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_FALSE(isnan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto pa = Length2{GetInvalid<Length>(), 0_m};
         const auto pb = Length2{GetInvalid<Length>(), 0_m};
         AABB2D foo{pa, pb};
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetLowerBound(foo)))));
-        EXPECT_FALSE(IsNan(StripUnit(GetY(GetLowerBound(foo)))));
-        EXPECT_TRUE(IsNan(StripUnit(GetX(GetUpperBound(foo)))));
-        EXPECT_FALSE(IsNan(StripUnit(GetY(GetUpperBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetLowerBound(foo)))));
+        EXPECT_FALSE(isnan(StripUnit(GetY(GetLowerBound(foo)))));
+        EXPECT_TRUE(isnan(StripUnit(GetX(GetUpperBound(foo)))));
+        EXPECT_FALSE(isnan(StripUnit(GetY(GetUpperBound(foo)))));
     }
     {
         const auto rangeX = Interval<Length>{-2_m, +3_m};
@@ -221,7 +221,7 @@ TEST(AABB2D, GetPerimeterOfPoint)
     EXPECT_EQ(GetPerimeter(AABB2D{Length2{}}), 0_m);
     EXPECT_EQ(GetPerimeter(AABB2D{Length2{-1_m, -2_m}}), 0_m);
     EXPECT_EQ(GetPerimeter(AABB2D{Length2{+99_m, +3_m}}), 0_m);
-    EXPECT_TRUE(IsNan(StripUnit(GetPerimeter(AABB2D{
+    EXPECT_TRUE(isnan(StripUnit(GetPerimeter(AABB2D{
         Length2{
             Real(+std::numeric_limits<Real>::infinity()) * Meter,
             Real(+std::numeric_limits<Real>::infinity()) * Meter

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -558,39 +558,39 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction1)
     switch (sizeof(Real))
     {
         case 4:
-            EXPECT_EQ(maxSep01_4x4.index1, decltype(maxSep01_4x4.index1){0}); // v0 of shape0
-            EXPECT_EQ(maxSep01_NxN.index1, decltype(maxSep01_NxN.index1){0}); // v0 of shape0
-            EXPECT_EQ(maxSep01_nos.index1, decltype(maxSep01_nos.index1){0}); // v0 of shape0
-            EXPECT_EQ(maxSep01_4x4.index2, decltype(maxSep01_4x4.index2){3}); // v3 of shape1
-            EXPECT_EQ(maxSep01_NxN.index2, decltype(maxSep01_NxN.index2){3}); // v3 of shape1
-            EXPECT_EQ(maxSep01_nos.index2, decltype(maxSep01_nos.index2){3}); // v3 of shape1
+            EXPECT_EQ(maxSep01_4x4.indices.first, decltype(maxSep01_4x4.indices.first){0}); // v0 of shape0
+            EXPECT_EQ(maxSep01_NxN.indices.first, decltype(maxSep01_NxN.indices.first){0}); // v0 of shape0
+            EXPECT_EQ(maxSep01_nos.indices.first, decltype(maxSep01_nos.indices.first){0}); // v0 of shape0
+            EXPECT_EQ(maxSep01_4x4.indices.second, decltype(maxSep01_4x4.indices.second){3}); // v3 of shape1
+            EXPECT_EQ(maxSep01_NxN.indices.second, decltype(maxSep01_NxN.indices.second){3}); // v3 of shape1
+            EXPECT_EQ(maxSep01_nos.indices.second, decltype(maxSep01_nos.indices.second){3}); // v3 of shape1
             break;
         case 8:
-            EXPECT_EQ(maxSep01_4x4.index1, decltype(maxSep01_4x4.index1){1}); // v1 of shape0
-            EXPECT_EQ(maxSep01_NxN.index1, decltype(maxSep01_NxN.index1){1}); // v1 of shape0
-            EXPECT_EQ(maxSep01_nos.index1, decltype(maxSep01_nos.index1){1}); // v1 of shape0
-            EXPECT_EQ(maxSep01_4x4.index2, decltype(maxSep01_4x4.index1){0}); // v0 of shape1
-            EXPECT_EQ(maxSep01_NxN.index2, decltype(maxSep01_NxN.index1){0}); // v0 of shape1
-            EXPECT_EQ(maxSep01_nos.index2, decltype(maxSep01_nos.index2){0}); // v0 of shape1
+            EXPECT_EQ(maxSep01_4x4.indices.first, decltype(maxSep01_4x4.indices.first){1}); // v1 of shape0
+            EXPECT_EQ(maxSep01_NxN.indices.first, decltype(maxSep01_NxN.indices.first){1}); // v1 of shape0
+            EXPECT_EQ(maxSep01_nos.indices.first, decltype(maxSep01_nos.indices.first){1}); // v1 of shape0
+            EXPECT_EQ(maxSep01_4x4.indices.second, decltype(maxSep01_4x4.indices.first){0}); // v0 of shape1
+            EXPECT_EQ(maxSep01_NxN.indices.second, decltype(maxSep01_NxN.indices.first){0}); // v0 of shape1
+            EXPECT_EQ(maxSep01_nos.indices.second, decltype(maxSep01_nos.indices.second){0}); // v0 of shape1
             break;
     }
     
-    EXPECT_EQ(maxSep10_4x4.index1, decltype(maxSep10_4x4.index1){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_NxN.index1, decltype(maxSep10_NxN.index1){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_nos.index1, decltype(maxSep10_nos.index1){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_4x4.index2, decltype(maxSep10_4x4.index1){1}); // v1 of shape0
-    EXPECT_EQ(maxSep10_NxN.index2, decltype(maxSep10_NxN.index1){1}); // v1 of shape0
-    EXPECT_EQ(maxSep10_nos.index2, decltype(maxSep10_nos.index2){1}); // v1 of shape0
+    EXPECT_EQ(maxSep10_4x4.indices.first, decltype(maxSep10_4x4.indices.first){3}); // v3 of shape1
+    EXPECT_EQ(maxSep10_NxN.indices.first, decltype(maxSep10_NxN.indices.first){3}); // v3 of shape1
+    EXPECT_EQ(maxSep10_nos.indices.first, decltype(maxSep10_nos.indices.first){3}); // v3 of shape1
+    EXPECT_EQ(maxSep10_4x4.indices.second, decltype(maxSep10_4x4.indices.first){1}); // v1 of shape0
+    EXPECT_EQ(maxSep10_NxN.indices.second, decltype(maxSep10_NxN.indices.first){1}); // v1 of shape0
+    EXPECT_EQ(maxSep10_nos.indices.second, decltype(maxSep10_nos.indices.second){1}); // v1 of shape0
     
-    EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.separation / Meter)), -2.0, std::abs(-2.0) / 100);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep01_NxN.separation / Meter)), -2.0, std::abs(-2.0) / 100);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep01_nos.separation / Meter)), -2.0, std::abs(-2.0) / 100);
+    EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)), -2.0, std::abs(-2.0) / 100);
+    EXPECT_NEAR(static_cast<double>(Real(maxSep01_NxN.distance / Meter)), -2.0, std::abs(-2.0) / 100);
+    EXPECT_NEAR(static_cast<double>(Real(maxSep01_nos.distance / Meter)), -2.0, std::abs(-2.0) / 100);
 
-    EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.separation / Meter)),
+    EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.distance / Meter)),
                 -0.82842707633972168, std::abs(-0.82842707633972168) / 100);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep10_NxN.separation / Meter)),
+    EXPECT_NEAR(static_cast<double>(Real(maxSep10_NxN.distance / Meter)),
                 -0.82842707633972168, std::abs(-0.82842707633972168) / 100);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep10_nos.separation / Meter)),
+    EXPECT_NEAR(static_cast<double>(Real(maxSep10_nos.distance / Meter)),
                 -0.82842707633972168, std::abs(-0.82842707633972168) / 100);
 }
 
@@ -614,25 +614,25 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction2)
     const auto maxSep10_NxN = GetMaxSeparation(child0, xfm1, child0, xfm0, totalRadius);
     
     
-    EXPECT_EQ(maxSep01_4x4.index1, decltype(maxSep01_4x4.index1){1}); // v0 of shape0
-    EXPECT_EQ(maxSep01_4x4.index1, maxSep01_NxN.index1);
-    EXPECT_EQ(maxSep01_4x4.index2, decltype(maxSep01_4x4.index1){0}); // v3 of shape1
-    EXPECT_EQ(maxSep01_4x4.index2, maxSep01_NxN.index2);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.separation / Meter)),
+    EXPECT_EQ(maxSep01_4x4.indices.first, decltype(maxSep01_4x4.indices.first){1}); // v0 of shape0
+    EXPECT_EQ(maxSep01_4x4.indices.first, maxSep01_NxN.indices.first);
+    EXPECT_EQ(maxSep01_4x4.indices.second, decltype(maxSep01_4x4.indices.first){0}); // v3 of shape1
+    EXPECT_EQ(maxSep01_4x4.indices.second, maxSep01_NxN.indices.second);
+    EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)),
                 -2.0, 0.0);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.separation / Meter)),
-                static_cast<double>(Real(maxSep01_NxN.separation / Meter)),
-                std::abs(static_cast<double>(Real(maxSep01_4x4.separation / Meter)) / 1000000.0));
+    EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)),
+                static_cast<double>(Real(maxSep01_NxN.distance / Meter)),
+                std::abs(static_cast<double>(Real(maxSep01_4x4.distance / Meter)) / 1000000.0));
     
-    EXPECT_EQ(maxSep10_4x4.index1, decltype(maxSep10_4x4.index1){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_4x4.index1, maxSep10_NxN.index1);
-    EXPECT_EQ(maxSep10_4x4.index2, decltype(maxSep10_4x4.index1){1}); // v1 of shape0
-    EXPECT_EQ(maxSep10_4x4.index2, maxSep10_NxN.index2);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.separation / Meter)),
+    EXPECT_EQ(maxSep10_4x4.indices.first, decltype(maxSep10_4x4.indices.first){3}); // v3 of shape1
+    EXPECT_EQ(maxSep10_4x4.indices.first, maxSep10_NxN.indices.first);
+    EXPECT_EQ(maxSep10_4x4.indices.second, decltype(maxSep10_4x4.indices.first){1}); // v1 of shape0
+    EXPECT_EQ(maxSep10_4x4.indices.second, maxSep10_NxN.indices.second);
+    EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.distance / Meter)),
                 -2.0, 0.0);
-    EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.separation / Meter)),
-                static_cast<double>(Real(maxSep10_NxN.separation / Meter)),
-                std::abs(static_cast<double>(Real(maxSep10_4x4.separation / Meter)) / 1000000.0));
+    EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.distance / Meter)),
+                static_cast<double>(Real(maxSep10_NxN.distance / Meter)),
+                std::abs(static_cast<double>(Real(maxSep10_4x4.distance / Meter)) / 1000000.0));
 }
 
 TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -435,7 +435,7 @@ TEST(Distance, VerEdgeSquareTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_NEAR(static_cast<double>(Real{Sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second)) / Meter}),
+    EXPECT_NEAR(static_cast<double>(Real{sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second)) / Meter}),
                 1.0, 0.000001);
     EXPECT_EQ(GetX(witnessPoints.first), 3_m);
     EXPECT_EQ(GetY(witnessPoints.first), 2_m);

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -47,13 +47,13 @@ TEST(Distance, MatchingCircles)
 
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(witnessPoints.a, pos1);
-    EXPECT_EQ(witnessPoints.b, pos1);
+    EXPECT_EQ(witnessPoints.first, pos1);
+    EXPECT_EQ(witnessPoints.second, pos1);
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
 
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -74,19 +74,19 @@ TEST(Distance, OpposingCircles)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.a), GetY(pos1));
+    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
+    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
 
-    EXPECT_EQ(GetX(witnessPoints.b), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.b), GetY(pos2));
+    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
+    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
 
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -110,19 +110,19 @@ TEST(Distance, HorTouchingCircles)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.a), GetY(pos1));
+    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
+    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.b), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.b), GetY(pos2));
+    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
+    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -143,19 +143,19 @@ TEST(Distance, OverlappingCirclesPN)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.a), GetY(pos1));
+    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
+    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.b), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.b), GetY(pos2));
+    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
+    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -176,19 +176,19 @@ TEST(Distance, OverlappingCirclesNP)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.a), GetY(pos1));
+    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
+    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.b), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.b), GetY(pos2));
+    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
+    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -210,19 +210,19 @@ TEST(Distance, SeparatedCircles)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.a), GetY(pos1));
+    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
+    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.b), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.b), GetY(pos2));
+    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
+    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -249,23 +249,23 @@ TEST(Distance, EdgeCircleOverlapping)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.a), GetY(pos3));
+    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos3));
+    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos3));
 
-    EXPECT_EQ(GetX(witnessPoints.b), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.b), GetY(pos3));
+    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos3));
+    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos3));
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip0.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip0.first, VertexCounter{0});
+    EXPECT_EQ(ip0.second, VertexCounter{0});
 
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.a, IndexPair::size_type{1});
-    EXPECT_EQ(ip1.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip1.first, VertexCounter{1});
+    EXPECT_EQ(ip1.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
@@ -291,23 +291,23 @@ TEST(Distance, EdgeCircleOverlapping2)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.a), GetY(pos3));
+    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos3));
+    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos3));
     
-    EXPECT_EQ(GetX(witnessPoints.b), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.b), GetY(pos3));
+    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos3));
+    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos3));
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip0.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip0.first, VertexCounter{0});
+    EXPECT_EQ(ip0.second, VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.a, IndexPair::size_type{1});
-    EXPECT_EQ(ip1.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip1.first, VertexCounter{1});
+    EXPECT_EQ(ip1.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{10});
@@ -333,23 +333,23 @@ TEST(Distance, EdgeCircleTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.a), 3_m);
+    EXPECT_EQ(GetX(witnessPoints.first), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.first), 3_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.b), 1_m);
+    EXPECT_EQ(GetX(witnessPoints.second), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.second), 1_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip0.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip0.first, VertexCounter{0});
+    EXPECT_EQ(ip0.second, VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.a, IndexPair::size_type{1});
-    EXPECT_EQ(ip1.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip1.first, VertexCounter{1});
+    EXPECT_EQ(ip1.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
@@ -384,23 +384,23 @@ TEST(Distance, HorEdgeSquareTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), 1_m);
-    EXPECT_EQ(GetY(witnessPoints.a), 1_m);
+    EXPECT_EQ(GetX(witnessPoints.first), 1_m);
+    EXPECT_EQ(GetY(witnessPoints.first), 1_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), 1_m);
-    EXPECT_EQ(GetY(witnessPoints.b), 0_m);
+    EXPECT_EQ(GetX(witnessPoints.second), 1_m);
+    EXPECT_EQ(GetY(witnessPoints.second), 0_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip0.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip0.first, VertexCounter{0});
+    EXPECT_EQ(ip0.second, VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip1.b, IndexPair::size_type{1});
+    EXPECT_EQ(ip1.first, VertexCounter{0});
+    EXPECT_EQ(ip1.second, VertexCounter{1});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 8.0, 0.000001);
@@ -435,25 +435,25 @@ TEST(Distance, VerEdgeSquareTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_NEAR(static_cast<double>(Real{Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b)) / Meter}),
+    EXPECT_NEAR(static_cast<double>(Real{Sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second)) / Meter}),
                 1.0, 0.000001);
-    EXPECT_EQ(GetX(witnessPoints.a), 3_m);
-    EXPECT_EQ(GetY(witnessPoints.a), 2_m);
+    EXPECT_EQ(GetX(witnessPoints.first), 3_m);
+    EXPECT_EQ(GetY(witnessPoints.first), 2_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), 4_m);
-    EXPECT_EQ(GetY(witnessPoints.b), 2_m);
+    EXPECT_EQ(GetX(witnessPoints.second), 4_m);
+    EXPECT_EQ(GetY(witnessPoints.second), 2_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.a, IndexPair::size_type{2});
-    EXPECT_EQ(ip0.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip0.first, VertexCounter{2});
+    EXPECT_EQ(ip0.second, VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.a, IndexPair::size_type{3});
-    EXPECT_EQ(ip1.b, IndexPair::size_type{1});
+    EXPECT_EQ(ip1.first, VertexCounter{3});
+    EXPECT_EQ(ip1.second, VertexCounter{1});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{10});
@@ -480,19 +480,19 @@ TEST(Distance, SquareTwice)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.a), 2_m);
+    EXPECT_EQ(GetX(witnessPoints.first), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.first), 2_m);
 
-    EXPECT_EQ(GetX(witnessPoints.b), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.b), 2_m);
+    EXPECT_EQ(GetX(witnessPoints.second), 2_m);
+    EXPECT_EQ(GetY(witnessPoints.second), 2_m);
 
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -532,19 +532,19 @@ TEST(Distance, SquareSquareTouchingVertically)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), 4_m);
-    EXPECT_EQ(GetY(witnessPoints.a), 3_m);
+    EXPECT_EQ(GetX(witnessPoints.first), 4_m);
+    EXPECT_EQ(GetY(witnessPoints.first), 3_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), 4_m);
-    EXPECT_EQ(GetY(witnessPoints.b), 3_m);
+    EXPECT_EQ(GetX(witnessPoints.second), 4_m);
+    EXPECT_EQ(GetY(witnessPoints.second), 3_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{3});
-    EXPECT_EQ(ip.b, IndexPair::size_type{1});
+    EXPECT_EQ(ip.first, VertexCounter{3});
+    EXPECT_EQ(ip.second, VertexCounter{1});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
@@ -583,19 +583,19 @@ TEST(Distance, SquareSquareDiagonally)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), -1_m);
-    EXPECT_EQ(GetY(witnessPoints.a), -1_m);
+    EXPECT_EQ(GetX(witnessPoints.first), -1_m);
+    EXPECT_EQ(GetY(witnessPoints.first), -1_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), 1_m);
-    EXPECT_EQ(GetY(witnessPoints.b), 1_m);
+    EXPECT_EQ(GetX(witnessPoints.second), 1_m);
+    EXPECT_EQ(GetY(witnessPoints.second), 1_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{2});
-    EXPECT_EQ(ip.b, IndexPair::size_type{3});
+    EXPECT_EQ(ip.first, VertexCounter{2});
+    EXPECT_EQ(ip.second, VertexCounter{3});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -658,19 +658,19 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.a), 0_m);
-    EXPECT_EQ(GetY(witnessPoints.a), 0.5_m);
+    EXPECT_EQ(GetX(witnessPoints.first), 0_m);
+    EXPECT_EQ(GetY(witnessPoints.first), 0.5_m);
     
-    EXPECT_EQ(GetX(witnessPoints.b), 0_m);
-    EXPECT_EQ(GetY(witnessPoints.b), 0.5_m);
+    EXPECT_EQ(GetX(witnessPoints.second), 0_m);
+    EXPECT_EQ(GetY(witnessPoints.second), 0.5_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{3});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.a, IndexPair::size_type{0});
-    EXPECT_EQ(ip.b, IndexPair::size_type{0});
+    EXPECT_EQ(ip.first, VertexCounter{0});
+    EXPECT_EQ(ip.second, VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{-64});

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -112,7 +112,7 @@ TEST(DistanceProxy, TwoVecSupportIndex)
 TEST(DistanceProxy, ThreeVertices)
 {
     const auto radius = 33_m;
-    const auto count = DistanceProxy::size_type(3);
+    const auto count = VertexCounter(3);
     const auto v0 = Length2{1_m, 2_m};
     const auto v1 = Length2{-3_m, -4_m};
     const auto v2 = Length2{-6_m, 5_m};
@@ -203,13 +203,13 @@ TEST(DistanceProxy, GetMaxSeparationFromWorld)
     
     const auto result1 = GetMaxSeparation(squareDp, circleDp);
     
-    EXPECT_NEAR(static_cast<double>(Real(result1.separation / Meter)), 3.0, 0.0001);
-    EXPECT_EQ(result1.index1, static_cast<decltype(result1.index1)>(2));
-    EXPECT_EQ(result1.index2, static_cast<decltype(result1.index2)>(0));
+    EXPECT_NEAR(static_cast<double>(Real(result1.distance / Meter)), 3.0, 0.0001);
+    EXPECT_EQ(result1.indices.first, static_cast<decltype(result1.indices.first)>(2));
+    EXPECT_EQ(result1.indices.second, static_cast<decltype(result1.indices.second)>(0));
     
     const auto result2 = GetMaxSeparation(squareDp, circleDp, 0_m);
     
-    EXPECT_NEAR(static_cast<double>(Real(result2.separation / Meter)), 3.0, 0.0001);
-    EXPECT_EQ(result2.index1, static_cast<decltype(result2.index1)>(2));
-    EXPECT_EQ(result2.index2, static_cast<decltype(result2.index2)>(0));
+    EXPECT_NEAR(static_cast<double>(Real(result2.distance / Meter)), 3.0, 0.0001);
+    EXPECT_EQ(result2.indices.first, static_cast<decltype(result2.indices.first)>(2));
+    EXPECT_EQ(result2.indices.second, static_cast<decltype(result2.indices.second)>(0));
 }

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -125,10 +125,10 @@ DECL_INT_CONSTRUCTION_AND_COMPARE_TEST(Fixed64)
 #define DECL_ISFINITE_TEST(type) \
 TEST(type, isfinite) \
 { \
-    EXPECT_TRUE(IsFinite(type(0))); \
-    EXPECT_FALSE(IsFinite( type::GetInfinity())); \
-    EXPECT_FALSE(IsFinite(-type::GetInfinity())); \
-    EXPECT_FALSE(IsFinite(type::GetNaN())); \
+    EXPECT_TRUE(isfinite(type(0))); \
+    EXPECT_FALSE(isfinite( type::GetInfinity())); \
+    EXPECT_FALSE(isfinite(-type::GetInfinity())); \
+    EXPECT_FALSE(isfinite(type::GetNaN())); \
 }
 
 DECL_ISFINITE_TEST(Fixed32)
@@ -136,24 +136,24 @@ DECL_ISFINITE_TEST(Fixed32)
 DECL_ISFINITE_TEST(Fixed64)
 #endif
 
-// Tests of IsNan(Fixed<T>)
+// Tests of isnan(Fixed<T>)
 
 #define DECL_ISNAN_TEST(type) \
 TEST(type, isnan) \
 { \
-    EXPECT_FALSE(IsNan(type( 0))); \
-    EXPECT_FALSE(IsNan(type( 1))); \
-    EXPECT_FALSE(IsNan(type(-1))); \
-    EXPECT_FALSE(IsNan( type::GetInfinity())); \
-    EXPECT_FALSE(IsNan(-type::GetInfinity())); \
-    EXPECT_FALSE(IsNan( type::GetNegativeInfinity())); \
-    EXPECT_TRUE(IsNan(type::GetNaN())); \
-    EXPECT_TRUE(IsNan(type(std::numeric_limits<float>::quiet_NaN()))); \
-    EXPECT_TRUE(IsNan(type(std::numeric_limits<float>::signaling_NaN()))); \
-    EXPECT_TRUE(IsNan(type(std::numeric_limits<double>::quiet_NaN()))); \
-    EXPECT_TRUE(IsNan(type(std::numeric_limits<double>::signaling_NaN()))); \
-    EXPECT_TRUE(IsNan(type(std::numeric_limits<long double>::quiet_NaN()))); \
-    EXPECT_TRUE(IsNan(type(std::numeric_limits<long double>::signaling_NaN()))); \
+    EXPECT_FALSE(isnan(type( 0))); \
+    EXPECT_FALSE(isnan(type( 1))); \
+    EXPECT_FALSE(isnan(type(-1))); \
+    EXPECT_FALSE(isnan( type::GetInfinity())); \
+    EXPECT_FALSE(isnan(-type::GetInfinity())); \
+    EXPECT_FALSE(isnan( type::GetNegativeInfinity())); \
+    EXPECT_TRUE(isnan(type::GetNaN())); \
+    EXPECT_TRUE(isnan(type(std::numeric_limits<float>::quiet_NaN()))); \
+    EXPECT_TRUE(isnan(type(std::numeric_limits<float>::signaling_NaN()))); \
+    EXPECT_TRUE(isnan(type(std::numeric_limits<double>::quiet_NaN()))); \
+    EXPECT_TRUE(isnan(type(std::numeric_limits<double>::signaling_NaN()))); \
+    EXPECT_TRUE(isnan(type(std::numeric_limits<long double>::quiet_NaN()))); \
+    EXPECT_TRUE(isnan(type(std::numeric_limits<long double>::signaling_NaN()))); \
 }
 
 DECL_ISNAN_TEST(Fixed32)
@@ -224,8 +224,8 @@ TEST(Fixed32, FloatConstruction)
     EXPECT_EQ(Fixed32(std::numeric_limits<float>::infinity()), Fixed32::GetInfinity());
     EXPECT_EQ(Fixed32(-std::numeric_limits<float>::infinity()), -Fixed32::GetInfinity());
     EXPECT_EQ(Fixed32(-std::numeric_limits<float>::infinity()), Fixed32::GetNegativeInfinity());
-    EXPECT_TRUE(IsNan(Fixed32(std::numeric_limits<float>::quiet_NaN())));
-    EXPECT_TRUE(IsNan(Fixed32(std::numeric_limits<float>::signaling_NaN())));
+    EXPECT_TRUE(isnan(Fixed32(std::numeric_limits<float>::quiet_NaN())));
+    EXPECT_TRUE(isnan(Fixed32(std::numeric_limits<float>::signaling_NaN())));
 
     const auto range = 30000;
     for (auto i = -range; i < range; ++i)
@@ -339,21 +339,21 @@ TEST(Fixed32, Division)
     EXPECT_EQ(3 / Fixed32(2), Fixed32(1.5));
 }
 
-TEST(Fixed32, Sin)
+TEST(Fixed32, sin)
 {
-    EXPECT_FLOAT_EQ(static_cast<float>(Sin(Fixed32(0))), 0.0f);
-    EXPECT_NEAR(static_cast<double>(Sin(Fixed32(1))), std::sin(1.0), 0.002);
-    EXPECT_NEAR(static_cast<double>(Sin(Fixed32(2))), std::sin(2.0), 0.002);
-    EXPECT_NEAR(static_cast<double>(Sin(Fixed32(Pi/2))), 1.0, 0.002);
+    EXPECT_FLOAT_EQ(static_cast<float>(sin(Fixed32(0))), 0.0f);
+    EXPECT_NEAR(static_cast<double>(sin(Fixed32(1))), std::sin(1.0), 0.002);
+    EXPECT_NEAR(static_cast<double>(sin(Fixed32(2))), std::sin(2.0), 0.002);
+    EXPECT_NEAR(static_cast<double>(sin(Fixed32(Pi/2))), 1.0, 0.002);
 }
 
-TEST(Fixed32, Cos)
+TEST(Fixed32, cos)
 {
-    EXPECT_FLOAT_EQ(static_cast<float>(Cos(Fixed32(0))), float(1));
-    EXPECT_NEAR(static_cast<double>(Cos(Fixed32(1))), std::cos(1.0), 0.002);
-    EXPECT_NEAR(static_cast<double>(Cos(Fixed32(2))), std::cos(2.0), 0.002);
-    EXPECT_LT(static_cast<float>(Cos(Fixed32(Pi/2))), +0.001f);
-    EXPECT_GT(static_cast<float>(Cos(Fixed32(Pi/2))), -0.001f);
+    EXPECT_FLOAT_EQ(static_cast<float>(cos(Fixed32(0))), float(1));
+    EXPECT_NEAR(static_cast<double>(cos(Fixed32(1))), std::cos(1.0), 0.002);
+    EXPECT_NEAR(static_cast<double>(cos(Fixed32(2))), std::cos(2.0), 0.002);
+    EXPECT_LT(static_cast<float>(cos(Fixed32(Pi/2))), +0.001f);
+    EXPECT_GT(static_cast<float>(cos(Fixed32(Pi/2))), -0.001f);
 }
 
 TEST(Fixed32, Max)
@@ -463,7 +463,7 @@ TEST(Fixed32, InifnityDividedByPositiveIsInfinity)
 
 TEST(Fixed32, InfinityDividedByInfinityIsNaN)
 {
-    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
+    EXPECT_TRUE(isnan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
 }
 
 TEST(Fixed32, InifnityTimesNegativeIsNegativeInfinity)
@@ -492,25 +492,25 @@ TEST(Fixed32, NegativeInfinityMinusInfinityIsNegativeInfinity)
 
 TEST(Fixed32, NaN)
 {
-    EXPECT_TRUE(IsNan(Fixed32::GetNaN()));
-    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
-    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() - Fixed32::GetInfinity()));
-    EXPECT_TRUE(IsNan(-Fixed32::GetInfinity() - -Fixed32::GetInfinity()));
-    EXPECT_TRUE(IsNan(-Fixed32::GetInfinity() + Fixed32::GetInfinity()));
+    EXPECT_TRUE(isnan(Fixed32::GetNaN()));
+    EXPECT_TRUE(isnan(Fixed32::GetInfinity() / Fixed32::GetInfinity()));
+    EXPECT_TRUE(isnan(Fixed32::GetInfinity() - Fixed32::GetInfinity()));
+    EXPECT_TRUE(isnan(-Fixed32::GetInfinity() - -Fixed32::GetInfinity()));
+    EXPECT_TRUE(isnan(-Fixed32::GetInfinity() + Fixed32::GetInfinity()));
 
-    EXPECT_FALSE(IsNan(Fixed32{0}));
-    EXPECT_FALSE(IsNan(Fixed32{10.0f}));
-    EXPECT_FALSE(IsNan(Fixed32{-10.0f}));
-    EXPECT_FALSE(IsNan(Fixed32::GetInfinity()));
-    EXPECT_FALSE(IsNan(Fixed32::GetNegativeInfinity()));
-    EXPECT_FALSE(IsNan(Fixed32::GetMax()));
-    EXPECT_FALSE(IsNan(Fixed32::GetMin()));
-    EXPECT_FALSE(IsNan(Fixed32::GetLowest()));
+    EXPECT_FALSE(isnan(Fixed32{0}));
+    EXPECT_FALSE(isnan(Fixed32{10.0f}));
+    EXPECT_FALSE(isnan(Fixed32{-10.0f}));
+    EXPECT_FALSE(isnan(Fixed32::GetInfinity()));
+    EXPECT_FALSE(isnan(Fixed32::GetNegativeInfinity()));
+    EXPECT_FALSE(isnan(Fixed32::GetMax()));
+    EXPECT_FALSE(isnan(Fixed32::GetMin()));
+    EXPECT_FALSE(isnan(Fixed32::GetLowest()));
 }
 
 TEST(Fixed32, InfinityTimesZeroIsNaN)
 {
-    EXPECT_TRUE(IsNan(Fixed32::GetInfinity() * 0));
+    EXPECT_TRUE(isnan(Fixed32::GetInfinity() * 0));
 }
 
 TEST(Fixed32, Comparators)
@@ -531,7 +531,7 @@ TEST(Fixed32, BiggerValsIdenticallyInaccurate)
     const auto max = sizeof(Fixed32) * 8 - Fixed32::FractionBits - 1;
     for (auto i = decltype(max){0}; i < max; ++i)
     {
-        const auto next = std::nextafter(val, std::numeric_limits<Fixed32>::max());
+        const auto next = nextafter(val, std::numeric_limits<Fixed32>::max());
         const auto delta = static_cast<float>(next - val);
         ASSERT_EQ(val + (delta / 2.0f), val);
 #if 0
@@ -681,17 +681,17 @@ TEST(Fixed, LessThan)
 TEST(Fixed, nextafter)
 {
     using fixed_32_0 = Fixed<std::int32_t, 0>;
-    EXPECT_EQ(std::nextafter(fixed_32_0(0), fixed_32_0( 0)),  0.0);
-    EXPECT_EQ(std::nextafter(fixed_32_0(0), fixed_32_0(+1)), +1.0);
-    EXPECT_EQ(std::nextafter(fixed_32_0(0), fixed_32_0(-1)), -1.0);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_0(0), fixed_32_0( 0))),  0.0);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_0(0), fixed_32_0(+1))), +1.0);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_0(0), fixed_32_0(-1))), -1.0);
 
     using fixed_32_1 = Fixed<std::int32_t, 1>;
-    EXPECT_EQ(std::nextafter(fixed_32_1(0), fixed_32_1( 0)),  0.0);
-    EXPECT_EQ(std::nextafter(fixed_32_1(0), fixed_32_1(+1)), +0.5);
-    EXPECT_EQ(std::nextafter(fixed_32_1(0), fixed_32_1(-1)), -0.5);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_1(0), fixed_32_1( 0))),  0.0);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_1(0), fixed_32_1(+1))), +0.5);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_1(0), fixed_32_1(-1))), -0.5);
 
     using fixed_32_2 = Fixed<std::int32_t, 2>;
-    EXPECT_EQ(std::nextafter(fixed_32_2(0), fixed_32_2( 0)),  0.0);
-    EXPECT_EQ(std::nextafter(fixed_32_2(0), fixed_32_2(+1)), +0.25);
-    EXPECT_EQ(std::nextafter(fixed_32_2(0), fixed_32_2(-1)), -0.25);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_2(0), fixed_32_2( 0))),  0.0);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_2(0), fixed_32_2(+1))), +0.25);
+    EXPECT_EQ(static_cast<double>(nextafter(fixed_32_2(0), fixed_32_2(-1))), -0.25);
 }

--- a/UnitTests/IndexPair.cpp
+++ b/UnitTests/IndexPair.cpp
@@ -24,8 +24,8 @@ using namespace playrho;
 TEST(IndexPair, Init)
 {
     IndexPair ip{1, 2};
-    EXPECT_EQ(ip.a, 1);
-    EXPECT_EQ(ip.b, 2);
+    EXPECT_EQ(ip.first, 1);
+    EXPECT_EQ(ip.second, 2);
 }
 
 TEST(IndexPair, Equality)
@@ -48,8 +48,8 @@ TEST(IndexPair, Inequality)
 
 TEST(IndexPair, InvalidIndex)
 {
-    const auto invalid_index = IndexPair::InvalidIndex;
+    const auto invalid_index = InvalidVertex;
     IndexPair ip{invalid_index, 2};    
-    EXPECT_EQ(invalid_index, ip.a);
-    EXPECT_NE(invalid_index, ip.b);
+    EXPECT_EQ(invalid_index, ip.first);
+    EXPECT_NE(invalid_index, ip.second);
 }

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -24,12 +24,12 @@
 
 using namespace playrho;
 
-TEST(Math, Sqrt)
+TEST(Math, sqrt)
 {
-    EXPECT_EQ(Sqrt(Real{0}), Real{0});
-    EXPECT_EQ(Sqrt(Real{4}), Real{2});
-    EXPECT_EQ(Sqrt(Real{25}), Real{5});
-    EXPECT_NE(Sqrt(std::numeric_limits<Real>::min()), Real(0));
+    EXPECT_EQ(sqrt(Real{0}), Real{0});
+    EXPECT_EQ(sqrt(Real{4}), Real{2});
+    EXPECT_EQ(sqrt(Real{25}), Real{5});
+    EXPECT_NE(sqrt(std::numeric_limits<Real>::min()), Real(0));
 
     EXPECT_NE(std::sqrt(std::numeric_limits<double>::min()), double(0));
     EXPECT_EQ(Square(std::sqrt(std::numeric_limits<double>::min())), std::numeric_limits<double>::min());
@@ -95,25 +95,25 @@ TEST(Math, Square)
     EXPECT_EQ(high, float(2.646978275714050648e-23));
 
     ASSERT_NE(Square(high), float(0));
-    ASSERT_EQ(Sqrt(Square(float(1))), float(1));
+    ASSERT_EQ(sqrt(Square(float(1))), float(1));
 #if 0
-    std::cout << "Sqrt(min) is: ";
+    std::cout << "sqrt(min) is: ";
     std::cout << std::setprecision(std::numeric_limits<long double>::digits10 + 1);
-    std::cout << Sqrt(std::numeric_limits<float>::min());
+    std::cout << sqrt(std::numeric_limits<float>::min());
     std::cout << " aka ";
     std::cout << std::hexfloat;
-    std::cout << Sqrt(std::numeric_limits<float>::min());
+    std::cout << sqrt(std::numeric_limits<float>::min());
     std::cout << std::endl;
-    EXPECT_EQ(Sqrt(std::numeric_limits<float>::min()), float(0x1p-63)); // float(1.084202172485504434e-19)
+    EXPECT_EQ(sqrt(std::numeric_limits<float>::min()), float(0x1p-63)); // float(1.084202172485504434e-19)
 #endif
     
     // What is the smallest float a for which:
     // AlmostEqual(sqrt(square(a)), a) and AlmostEqual(square(sqrt(a)), a)
     // hold true?
     
-    const auto a = Sqrt(std::numeric_limits<float>::min());
-    EXPECT_TRUE(AlmostEqual(Square(Sqrt(a)), a));
-    EXPECT_TRUE(AlmostEqual(Sqrt(Square(a)), a));
+    const auto a = sqrt(std::numeric_limits<float>::min());
+    EXPECT_TRUE(AlmostEqual(Square(sqrt(a)), a));
+    EXPECT_TRUE(AlmostEqual(sqrt(Square(a)), a));
 }
 
 TEST(Math, Atan2)
@@ -227,23 +227,23 @@ TEST(Math, CrossProductOfTwoVecTwoIsAntiCommutative)
 
 TEST(Math, DotProductOfInvalidIsInvalid)
 {
-    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(), GetInvalid<Vec2>())));
+    EXPECT_TRUE(isnan(Dot(GetInvalid<Vec2>(), GetInvalid<Vec2>())));
 
-    EXPECT_TRUE(IsNan(Dot(Vec2(0, 0), GetInvalid<Vec2>())));
-    EXPECT_TRUE(IsNan(Dot(Vec2(0, 0), Vec2(GetInvalid<Real>(), 0))));
-    EXPECT_TRUE(IsNan(Dot(Vec2(0, 0), Vec2(0, GetInvalid<Real>()))));
+    EXPECT_TRUE(isnan(Dot(Vec2(0, 0), GetInvalid<Vec2>())));
+    EXPECT_TRUE(isnan(Dot(Vec2(0, 0), Vec2(GetInvalid<Real>(), 0))));
+    EXPECT_TRUE(isnan(Dot(Vec2(0, 0), Vec2(0, GetInvalid<Real>()))));
     
-    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(),             Vec2(0, 0))));
-    EXPECT_TRUE(IsNan(Dot(Vec2(GetInvalid<Real>(), 0), Vec2(0, 0))));
-    EXPECT_TRUE(IsNan(Dot(Vec2(0, GetInvalid<Real>()), Vec2(0, 0))));
+    EXPECT_TRUE(isnan(Dot(GetInvalid<Vec2>(),             Vec2(0, 0))));
+    EXPECT_TRUE(isnan(Dot(Vec2(GetInvalid<Real>(), 0), Vec2(0, 0))));
+    EXPECT_TRUE(isnan(Dot(Vec2(0, GetInvalid<Real>()), Vec2(0, 0))));
 
-    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(), GetInvalid<UnitVec2>())));
-    //EXPECT_TRUE(IsNan(Dot(Vec2(0, 0),         GetInvalid<UnitVec2>())));
-    EXPECT_TRUE(IsNan(Dot(GetInvalid<Vec2>(), UnitVec2::GetZero())));
+    EXPECT_TRUE(isnan(Dot(GetInvalid<Vec2>(), GetInvalid<UnitVec2>())));
+    //EXPECT_TRUE(isnan(Dot(Vec2(0, 0),         GetInvalid<UnitVec2>())));
+    EXPECT_TRUE(isnan(Dot(GetInvalid<Vec2>(), UnitVec2::GetZero())));
 
-    EXPECT_TRUE(IsNan(Dot(GetInvalid<UnitVec2>(), GetInvalid<Vec2>())));
-    //EXPECT_TRUE(IsNan(Dot(GetInvalid<UnitVec2>(), Vec2(0, 0))));
-    EXPECT_TRUE(IsNan(Dot(UnitVec2::GetZero(),    GetInvalid<Vec2>())));
+    EXPECT_TRUE(isnan(Dot(GetInvalid<UnitVec2>(), GetInvalid<Vec2>())));
+    //EXPECT_TRUE(isnan(Dot(GetInvalid<UnitVec2>(), Vec2(0, 0))));
+    EXPECT_TRUE(isnan(Dot(UnitVec2::GetZero(),    GetInvalid<Vec2>())));
 }
 
 TEST(Math, Vec2NegationAndRotationIsOrderIndependent)

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -132,7 +132,7 @@ TEST(MultiShape, AddConvexHullWithOnePointSameAsDisk)
     EXPECT_EQ(foo.GetChildCount(), ChildCounter{1});
 
     const auto child = foo.GetChild(0);
-    EXPECT_EQ(child.GetVertexCount(), DistanceProxy::size_type(1));
+    EXPECT_EQ(child.GetVertexCount(), VertexCounter(1));
     
     const auto massData = foo.GetMassData();
     EXPECT_NE(massData, defaultMassData);
@@ -168,7 +168,7 @@ TEST(MultiShape, AddConvexHullWithTwoPointsSameAsEdge)
     EXPECT_EQ(foo.GetChildCount(), ChildCounter{1});
     
     const auto child = foo.GetChild(0);
-    EXPECT_EQ(child.GetVertexCount(), DistanceProxy::size_type(2));
+    EXPECT_EQ(child.GetVertexCount(), VertexCounter(2));
     
     const auto massData = foo.GetMassData();
     EXPECT_NE(massData, defaultMassData);
@@ -212,7 +212,7 @@ TEST(MultiShape, AddTwoConvexHullWithOnePoint)
     EXPECT_EQ(foo.GetChildCount(), ChildCounter{1});
 
     const auto child0 = foo.GetChild(0);
-    EXPECT_EQ(child0.GetVertexCount(), DistanceProxy::size_type(1));
+    EXPECT_EQ(child0.GetVertexCount(), VertexCounter(1));
     EXPECT_EQ(child0.GetVertex(0), p0);
     
     pointSet.clear();
@@ -224,7 +224,7 @@ TEST(MultiShape, AddTwoConvexHullWithOnePoint)
     EXPECT_EQ(foo.GetChildCount(), ChildCounter{2});
     
     const auto child1 = foo.GetChild(1);
-    EXPECT_EQ(child1.GetVertexCount(), DistanceProxy::size_type(1));
+    EXPECT_EQ(child1.GetVertexCount(), VertexCounter(1));
     EXPECT_EQ(child1.GetVertex(0), p1);
 
     const auto massData = foo.GetMassData();

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -123,7 +123,7 @@ TEST(PolygonShape, BoxConstruction)
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
 
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
 
@@ -149,7 +149,7 @@ TEST(PolygonShape, Copy)
     ASSERT_EQ(shape.GetCentroid(), (Length2{}));
     ASSERT_EQ(shape.GetChildCount(), ChildCounter(1));
     ASSERT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     ASSERT_EQ(shape.GetVertex(0), Length2(hx, -hy)); // bottom right
@@ -169,7 +169,7 @@ TEST(PolygonShape, Copy)
     EXPECT_EQ(copy.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(copy), PolygonShape::GetDefaultVertexRadius());
     
-    ASSERT_EQ(copy.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(copy.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
@@ -193,7 +193,7 @@ TEST(PolygonShape, Translate)
     ASSERT_EQ(shape.GetCentroid(), (Length2{}));
     ASSERT_EQ(shape.GetChildCount(), ChildCounter(1));
     ASSERT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     ASSERT_EQ(shape.GetVertex(0), Length2(hx, -hy)); // bottom right
@@ -213,7 +213,7 @@ TEST(PolygonShape, Translate)
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
 
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
 
     EXPECT_EQ(shape.GetVertex(0), Length2(hx, -hy) + new_ctr); // bottom right
     EXPECT_EQ(shape.GetVertex(1), Length2(hx, hy) + new_ctr); // top right
@@ -236,7 +236,7 @@ TEST(PolygonShape, SetAsBox)
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
@@ -261,7 +261,7 @@ TEST(PolygonShape, SetAsZeroCenteredRotatedBox)
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
@@ -288,7 +288,7 @@ TEST(PolygonShape, SetAsCenteredBox)
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise from lowest right-most (and normals follow their edges)...
     
@@ -316,7 +316,7 @@ TEST(PolygonShape, SetAsBoxAngledDegrees90)
     EXPECT_EQ(shape.GetChildCount(), ChildCounter(1));
     EXPECT_EQ(GetVertexRadius(shape), PolygonShape::GetDefaultVertexRadius());
     
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(4));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(4));
     
     // vertices go counter-clockwise (and normals follow their edges)...
     
@@ -354,7 +354,7 @@ TEST(PolygonShape, SetPoints)
     };
     shape.Set(points);
     
-    ASSERT_EQ(shape.GetVertexCount(), PolygonShape::VertexCounter(5));
+    ASSERT_EQ(shape.GetVertexCount(), VertexCounter(5));
 
     // vertices go counter-clockwise from lowest right-most...
 
@@ -377,7 +377,7 @@ TEST(PolygonShape, CanSetTwoPoints)
     PolygonShape shape;
     shape.SetVertexRadius(vertexRadius);
     shape.Set(points);
-    EXPECT_EQ(shape.GetVertexCount(), static_cast<PolygonShape::VertexCounter>(points.size()));
+    EXPECT_EQ(shape.GetVertexCount(), static_cast<VertexCounter>(points.size()));
     EXPECT_EQ(shape.GetVertex(0), points[1]);
     EXPECT_EQ(shape.GetVertex(1), points[0]);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(shape.GetNormal(0)))),
@@ -401,7 +401,7 @@ TEST(PolygonShape, CanSetOnePoint)
     PolygonShape shape;
     shape.SetVertexRadius(vertexRadius);
     shape.Set(points);
-    EXPECT_EQ(shape.GetVertexCount(), static_cast<PolygonShape::VertexCounter>(points.size()));
+    EXPECT_EQ(shape.GetVertexCount(), static_cast<VertexCounter>(points.size()));
     EXPECT_EQ(shape.GetVertex(0), points[0]);
     EXPECT_FALSE(IsValid(shape.GetNormal(0)));
     EXPECT_EQ(shape.GetCentroid(), points[0]);

--- a/UnitTests/Real.cpp
+++ b/UnitTests/Real.cpp
@@ -101,7 +101,7 @@ TEST(Real, beta0)
 {
     Real zero{0};
     Real one{1};
-    const auto beta = std::nextafter(zero, one);
+    const auto beta = nextafter(zero, one);
     const auto coefficient0 = 1 - beta;
     const auto coefficient1 = beta;
     EXPECT_EQ(coefficient0 + coefficient1, one);
@@ -111,7 +111,7 @@ TEST(Real, beta1)
 {
     Real zero{0};
     Real one{1};
-    const auto beta = std::nextafter(one, zero);
+    const auto beta = nextafter(one, zero);
     const auto coefficient0 = 1 - beta;
     const auto coefficient1 = beta;
     EXPECT_EQ(coefficient0 + coefficient1, one);

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -77,11 +77,11 @@ TEST(SeparationFinder, BehavesAsExpected)
     {
         // Prepare input for distance query.
         const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
-        const auto distance = Sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
+        const auto distance = Sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second));
 
         const auto minSeparation = fcn.FindMinSeparation(xfA, xfB);
 
-        EXPECT_EQ(minSeparation.indexPair, (IndexPair{IndexPair::InvalidIndex, 2}));
+        EXPECT_EQ(minSeparation.indices, (IndexPair{InvalidVertex, 2}));
         EXPECT_LT(minSeparation.distance, last_s);
         if (minSeparation.distance > 0_m)
         {
@@ -99,7 +99,7 @@ TEST(SeparationFinder, BehavesAsExpected)
         }
         last_min_sep = minSeparation.distance;
         
-        const auto s = fcn.Evaluate(minSeparation.indexPair, xfA, xfB);
+        const auto s = fcn.Evaluate(xfA, xfB, minSeparation.indices);
         EXPECT_EQ(s, minSeparation.distance);
         if (s >= 0_m)
         {

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -77,7 +77,7 @@ TEST(SeparationFinder, BehavesAsExpected)
     {
         // Prepare input for distance query.
         const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
-        const auto distance = Sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second));
+        const auto distance = sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second));
 
         const auto minSeparation = fcn.FindMinSeparation(xfA, xfB);
 

--- a/UnitTests/Simplex.cpp
+++ b/UnitTests/Simplex.cpp
@@ -164,8 +164,8 @@ TEST(Simplex, Get1)
 {
     const auto va = Length2{-4_m, 33_m};
     const auto vb = Length2{901.5_m, 0.06_m};
-    const auto ia = SimplexEdge::index_type{2};
-    const auto ib = SimplexEdge::index_type{7};
+    const auto ia = VertexCounter{2};
+    const auto ib = VertexCounter{7};
     const auto sv = SimplexEdge{va, ia, vb, ib};
     
     const auto simplex = Simplex::Get(sv);
@@ -186,8 +186,8 @@ TEST(Simplex, Get2_of_same)
 {
     const auto va = Length2{-4_m, 33_m};
     const auto vb = Length2{901.5_m, 0.06_m};
-    const auto ia = SimplexEdge::index_type{2};
-    const auto ib = SimplexEdge::index_type{7};
+    const auto ia = VertexCounter{2};
+    const auto ib = VertexCounter{7};
     const auto sv = SimplexEdge{va, ia, vb, ib};
     
     const auto simplex = Simplex::Get(sv, sv);
@@ -209,14 +209,14 @@ TEST(Simplex, Get2_fwd_perp)
 {
     const auto va0 = Length2{-4_m, 33_m};
     const auto vb0 = Length2{901.5_m, 0.06_m};
-    const auto ia0 = SimplexEdge::index_type{2};
-    const auto ib0 = SimplexEdge::index_type{7};
+    const auto ia0 = VertexCounter{2};
+    const auto ib0 = VertexCounter{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
 
     const auto va1 = GetFwdPerpendicular(va0);
     const auto vb1 = GetFwdPerpendicular(vb0);
-    const auto ia1 = SimplexEdge::index_type{4};
-    const auto ib1 = SimplexEdge::index_type{1};
+    const auto ia1 = VertexCounter{4};
+    const auto ib1 = VertexCounter{1};
     const auto sv1 = SimplexEdge{va1, ia1, vb1, ib1};
     
     const auto simplex = Simplex::Get(sv0, sv1);
@@ -249,14 +249,14 @@ TEST(Simplex, Get2_rev_perp)
 {
     const auto va0 = Length2{-4_m, 33_m};
     const auto vb0 = Length2{901.5_m, 0.06_m};
-    const auto ia0 = SimplexEdge::index_type{2};
-    const auto ib0 = SimplexEdge::index_type{7};
+    const auto ia0 = VertexCounter{2};
+    const auto ib0 = VertexCounter{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
     
     const auto va1 = GetRevPerpendicular(va0);
     const auto vb1 = GetRevPerpendicular(vb0);
-    const auto ia1 = SimplexEdge::index_type{4};
-    const auto ib1 = SimplexEdge::index_type{1};
+    const auto ia1 = VertexCounter{4};
+    const auto ib1 = VertexCounter{1};
     const auto sv1 = SimplexEdge{va1, ia1, vb1, ib1};
     
     const auto simplex = Simplex::Get(sv0, sv1);
@@ -289,14 +289,14 @@ TEST(Simplex, Get2_rot_plus_45)
 {
     const auto va0 = Length2{-4_m, 33_m};
     const auto vb0 = Length2{901.5_m, 0.06_m};
-    const auto ia0 = SimplexEdge::index_type{2};
-    const auto ib0 = SimplexEdge::index_type{7};
+    const auto ia0 = VertexCounter{2};
+    const auto ib0 = VertexCounter{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
     
     const auto va1 = Rotate(va0, UnitVec2::Get(45_deg));
     const auto vb1 = Rotate(vb0, UnitVec2::Get(45_deg));
-    const auto ia1 = SimplexEdge::index_type{4};
-    const auto ib1 = SimplexEdge::index_type{1};
+    const auto ia1 = VertexCounter{4};
+    const auto ib1 = VertexCounter{1};
     const auto sv1 = SimplexEdge{va1, ia1, vb1, ib1};
     
     const auto simplex = Simplex::Get(sv0, sv1);
@@ -329,8 +329,8 @@ TEST(Simplex, Get2_rot45_half)
 {
     const auto va0 = Length2{-4_m, 33_m}; // upper left
     const auto vb0 = Length2{901_m, 6_m}; // lower right
-    const auto ia0 = SimplexEdge::index_type{2};
-    const auto ib0 = SimplexEdge::index_type{7};
+    const auto ia0 = VertexCounter{2};
+    const auto ib0 = VertexCounter{7};
     const auto sv0 = SimplexEdge{va0, ia0, vb0, ib0};
     
     const auto va1 = Rotate(va0, UnitVec2::Get(45_deg)) / 2; // Vec2{-13.081475, 10.253049}
@@ -339,8 +339,8 @@ TEST(Simplex, Get2_rot45_half)
     EXPECT_NEAR(double(Real{GetY(va1) / Meter}),  10.253049, 0.001);
     EXPECT_NEAR(double(Real{GetX(vb1) / Meter}), 316.4303,   0.001);
     EXPECT_NEAR(double(Real{GetY(vb1) / Meter}), 320.67291,  0.001);
-    const auto ia1 = SimplexEdge::index_type{4};
-    const auto ib1 = SimplexEdge::index_type{1};
+    const auto ia1 = VertexCounter{4};
+    const auto ib1 = VertexCounter{1};
     const auto sv1 = SimplexEdge{va1, ia1, vb1, ib1};
 
     const auto w1 = vb0 - va0; // Vec2{901, 6} - Vec2{-4, 33} = Vec2{905, -27}

--- a/UnitTests/SimplexEdge.cpp
+++ b/UnitTests/SimplexEdge.cpp
@@ -34,8 +34,8 @@ TEST(SimplexEdge, ByteSize)
 
 TEST(SimplexEdge, InitializingConstructor)
 {
-    const auto iA = SimplexEdge::index_type{1};
-    const auto iB = SimplexEdge::index_type{2};
+    const auto iA = VertexCounter{1};
+    const auto iB = VertexCounter{2};
     const auto pA = Length2{2.2_m, -3.1_m};
     const auto pB = Length2{-9.2_m, 0.003_m};
 

--- a/UnitTests/StepConf.cpp
+++ b/UnitTests/StepConf.cpp
@@ -57,7 +57,7 @@ TEST(StepConf, CopyConstruction)
 TEST(StepConf, maxTranslation)
 {
     const auto v = Real(1);
-    const auto n = std::nextafter(v, Real(0));
+    const auto n = nextafter(v, Real(0));
     const auto inc = v - n;
     ASSERT_GT(inc, Real(0));
     ASSERT_LT(inc, Real(1));
@@ -90,7 +90,7 @@ TEST(StepConf, maxTranslation)
 TEST(StepConf, maxRotation)
 {
     const auto v = Real(1);
-    const auto n = std::nextafter(v, Real(0));
+    const auto n = nextafter(v, Real(0));
     const auto inc = v - n;
     ASSERT_GT(inc, Real(0));
     ASSERT_LT(inc, Real(1));

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -87,8 +87,8 @@ TEST(Transformation, Mul)
     EXPECT_EQ(GetX(xfm2.p), GetX(newP));
     EXPECT_EQ(GetY(xfm2.p), GetY(newP));
     
-    EXPECT_NEAR(double(xfm2.q.cos()), double(rotation2.cos()), 0.0001);
-    EXPECT_NEAR(double(xfm2.q.sin()), double(rotation2.sin()), 0.0001);
+    EXPECT_NEAR(double(GetX(xfm2.q)), double(GetX(rotation2)), 0.0001);
+    EXPECT_NEAR(double(GetY(xfm2.q)), double(GetY(rotation2)), 0.0001);
 }
 
 TEST(Transformation, MulSameAsTransformTwice)

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -89,7 +89,7 @@ TEST(World, Def)
     const auto stepConf = StepConf{};
 
     const auto v = Real(1);
-    const auto n = std::nextafter(v, Real(0));
+    const auto n = nextafter(v, Real(0));
     const auto time_inc = (v - n) * 1_s;
     ASSERT_GT(time_inc, 0_s);
     ASSERT_LT(time_inc, 1_s);
@@ -1173,7 +1173,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     conf.regVelocityIterations = 0;
     conf.toiPositionIterations = 0;
     conf.toiVelocityIterations = 0;
-    conf.tolerance = std::nextafter(StripUnit(conf.targetDepth), Real{0}) * Meter;
+    conf.tolerance = nextafter(StripUnit(conf.targetDepth), Real{0}) * Meter;
 
     auto steps = unsigned{0};
     while (GetX(pos_a) < (x * Meter) && GetX(pos_b) > (-x * Meter))
@@ -1614,12 +1614,12 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
         }
         else // new_distance > distance
         {
-            if (Cos(angle) != 0)
+            if (cos(angle) != 0)
             {
                 EXPECT_LT(GetX(body1->GetLocation()), GetX(lastpos1));
                 EXPECT_GT(GetX(body2->GetLocation()), GetX(lastpos2));
             }
-            if (Sin(angle) != 0)
+            if (sin(angle) != 0)
             {
                 EXPECT_LT(GetY(body1->GetLocation()), GetY(lastpos1));
                 EXPECT_GT(GetY(body2->GetLocation()), GetY(lastpos2));
@@ -1817,12 +1817,12 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
         
         if (new_distance == distance)
         {
-            if (Cos(angle) != 0)
+            if (cos(angle) != 0)
             {
                 EXPECT_NE(GetX(body1->GetLocation()), GetX(lastpos1));
                 EXPECT_NE(GetX(body2->GetLocation()), GetX(lastpos2));
             }
-            if (Sin(angle) != 0)
+            if (sin(angle) != 0)
             {
                 EXPECT_NE(GetY(body1->GetLocation()), GetY(lastpos1));
                 EXPECT_NE(GetY(body2->GetLocation()), GetY(lastpos2));
@@ -2642,8 +2642,8 @@ TEST(World, MouseJointWontCauseTunnelling)
     for (auto i = decltype(numBodies){0}; i < numBodies; ++i)
     {
         const auto angle = i * 2 * Pi / numBodies;
-        const auto x = ball_radius * Real(2.1) * Cos(angle);
-        const auto y = ball_radius * Real(2.1) * Sin(angle);
+        const auto x = ball_radius * Real(2.1) * cos(angle);
+        const auto y = ball_radius * Real(2.1) * sin(angle);
         body_def.location = Length2{x, y};
         bodies[i] = world.CreateBody(body_def);
         ASSERT_NE(bodies[i], nullptr);
@@ -2783,7 +2783,7 @@ TEST(World, MouseJointWontCauseTunnelling)
                 std::cout << " angl=" << angle;
                 std::cout << " ctoi=" << 0 + contact.GetToiCount();
                 std::cout << " solv=" << 0 + solved;
-                std::cout << " targ=(" << distance * Cos(angle) << "," << distance * Sin(angle) << ")";
+                std::cout << " targ=(" << distance * cos(angle) << "," << distance * sin(angle) << ")";
                 std::cout << " maxv=" << max_velocity;
                 std::cout << " rang=(" << min_x << "," << min_y << ")-(" << max_x << "," << max_y << ")";
                 std::cout << " bpos=(" << GetX(ball_body->GetLocation()) << "," << GetY(ball_body->GetLocation()) << ")";
@@ -2860,7 +2860,7 @@ TEST(World, MouseJointWontCauseTunnelling)
         auto last_pos = ball_body->GetLocation();
         for (auto loops = unsigned{0};; ++loops)
         {
-            mouse_joint->SetTarget(Length2{distance * Cos(angle) * Meter, distance * Sin(angle) * Meter});
+            mouse_joint->SetTarget(Length2{distance * cos(angle) * Meter, distance * sin(angle) * Meter});
             angle += anglular_speed;
             distance += distance_speed;
 


### PR DESCRIPTION
#### Description - What's this PR do?
Miscellaneous changes:
- Replaces common mathematical function definitions with using std within playrho namespace.
- Replaces some uses of GetVec2 with StripUnit.
- Adds _m2 user defined literal for meters squared.
- Generalizes GetSupportIndex.
- Removes GetMaxSeparationCached.
- Removes some uses of GetVec2.
- Updates Dot code to again be static assertable.
- Promotes VertexCounter to global usage and permeates its usage throughout.
- Replaces IndexPair code with an alias to std::pair<VertexCounter, VertexCounter>.
- Renames IndexPairSeparation to IndexPairDistance.
- Replaces SeparationFinder::Data with use of IndexPairDistance instead.
- Replaces embedded VelocityPair code with alias using std::pair.

#### Related Issues
- Issue #217.