### PR TITLE
For issue #241

### DIFF
--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -919,7 +919,7 @@ namespace playrho
         return "Fixed32";
     }
 
-#ifndef _WIN32
+#ifdef PLAYRHO_INT128
     // Fixed64 free functions.
 
     /// @brief 64-bit fixed precision type.
@@ -1017,7 +1017,7 @@ namespace playrho
         return "Fixed64";
     }
 
-#endif /* !_WIN32 */
+#endif /* PLAYRHO_INT128 */
 
 } // namespace playrho
 

--- a/PlayRho/Common/Wider.hpp
+++ b/PlayRho/Common/Wider.hpp
@@ -21,6 +21,7 @@
 #ifndef PLAYRHO_COMMON_WIDER_HPP
 #define PLAYRHO_COMMON_WIDER_HPP
 
+#include <PlayRho/Defines.hpp>
 #include <cstdint>
 #include <type_traits>
 
@@ -75,32 +76,31 @@ template <> struct Wider<double> {
     using type = long double; ///< Wider type.
 };
 
-#ifndef _WIN32
-// Note: __int128_t not defined for Windows!
-    
+#ifdef PLAYRHO_INT128
 /// @brief Specialization of the Wider trait for signed 64-bit integers.
 template <> struct Wider<std::int64_t> {
-    using type = __int128_t; ///< Wider type.
+    using type = PLAYRHO_INT128; ///< Wider type.
 };
+#endif
 
+#ifdef PLAYRHO_UINT128
 /// @brief Specialization of the Wider trait for unsigned 64-bit integers.
 template <> struct Wider<std::uint64_t> {
-    using type = __uint128_t; ///< Wider type.
+    using type = PLAYRHO_UINT128; ///< Wider type.
 };
-
 #endif
 
 } // namespace playrho
 
 namespace std {
 
-#ifndef _WIN32
+#if defined(PLAYRHO_INT128) && defined(PLAYRHO_UINT128)
 // This might already be defined by the standard library header, but
 // define it here explicitly in case it's not.
 
 /// @brief Make unsigned specialization for the __int128_t type.
-template <> struct make_unsigned<__int128_t> {
-    using type = __uint128_t; ///< Wider type.
+template <> struct make_unsigned<PLAYRHO_INT128> {
+    using type = PLAYRHO_UINT128; ///< Wider type.
 };
 #endif
 

--- a/PlayRho/Defines.hpp
+++ b/PlayRho/Defines.hpp
@@ -46,4 +46,12 @@
 // Value of this macro should either be 'constexpr' or empty.
 #define PLAYRHO_CONSTEXPR constexpr
 
+// Checks if platform supports 128-bit integer types and defines macros for them if so.
+// Note that these could use any LiteralType type that has full operator and common
+// mathemtical function support.
+#ifdef __SIZEOF_INT128__
+#define PLAYRHO_INT128 __int128_t
+#define PLAYRHO_UINT128 __uint128_t
+#endif
+
 #endif /* PLAYRHO_DEFINES_HPP */


### PR DESCRIPTION
#### Description - What's this PR do?
Uses the definition of `__SIZEOF_INT128__` instead of `_WIN32` to determine whether the platform supports 128-bit integers. This define is used by clang and gcc and presumably only defined when 128-bit integers are in fact supported. So while this isn't perfect either, it's preferred over presuming 128-bit integer support exists unless _WIN32 is defined.

#### Related Issues
- Issue #241.
