### PR TITLE
For issue 178

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -78,7 +78,7 @@ static playrho::UnitVec2 GetRandUnitVec2(playrho::Angle lo, playrho::Angle hi)
 }
 
 static playrho::Transformation
-GetRandTransformation(playrho::Position pos0, playrho::Position pos1)
+GetRandTransformation(playrho::Position2D pos0, playrho::Position2D pos1)
 {
     const auto x0 = static_cast<double>(playrho::Real{GetX(pos0.linear) / playrho::Meter});
     const auto y0 = static_cast<double>(playrho::Real{GetY(pos0.linear) / playrho::Meter});
@@ -138,7 +138,7 @@ GetRandUnitVec2Pair(playrho::Angle lo, playrho::Angle hi)
 }
 
 static std::pair<playrho::Transformation, playrho::Transformation>
-GetRandTransformationPair(playrho::Position pos0, playrho::Position pos1)
+GetRandTransformationPair(playrho::Position2D pos0, playrho::Position2D pos1)
 {
     return std::make_pair(GetRandTransformation(pos0, pos1), GetRandTransformation(pos0, pos1));
 }
@@ -216,7 +216,7 @@ GetRandUnitVec2Pairs(unsigned count, playrho::Angle lo, playrho::Angle hi)
 }
 
 static std::vector<std::pair<playrho::Transformation, playrho::Transformation>>
-GetRandTransformationPairs(unsigned count, playrho::Position pos0, playrho::Position pos1)
+GetRandTransformationPairs(unsigned count, playrho::Position2D pos0, playrho::Position2D pos1)
 {
     auto rands = std::vector<std::pair<playrho::Transformation, playrho::Transformation>>{};
     rands.reserve(count);
@@ -1213,12 +1213,12 @@ static TransformationPairs GetTransformationPairs(unsigned count)
 {
     static std::map<unsigned,TransformationPairs> xfms;
 
-    constexpr auto pos0 = playrho::Position{
+    constexpr auto pos0 = playrho::Position2D{
         playrho::Vec2{0, -2} * (playrho::Real(1) * playrho::Meter),
         playrho::Angle{playrho::Real{  0.0f} * playrho::Degree}
     }; // bottom
     
-    constexpr auto pos1 = playrho::Position{
+    constexpr auto pos1 = playrho::Position2D{
         playrho::Vec2{0, +2} * (playrho::Real(1) * playrho::Meter),
         playrho::Angle{playrho::Real{360.0f} * playrho::Degree}
     }; // top
@@ -1431,14 +1431,14 @@ static void ConstructAndAssignVC(benchmark::State& state)
     const auto worldManifold = playrho::WorldManifold{normal, ps0};
     
     const auto locA = playrho::Length2{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
-    const auto posA = playrho::Position{locA, playrho::Angle(0)};
+    const auto posA = playrho::Position2D{locA, playrho::Angle(0)};
     const auto velA = playrho::Velocity{
         playrho::LinearVelocity2{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
     
     const auto locB = playrho::Length2{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
-    const auto posB = playrho::Position{locB, playrho::Angle(0)};
+    const auto posB = playrho::Position2D{locB, playrho::Angle(0)};
     const auto velB = playrho::Velocity{
         playrho::LinearVelocity2{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
@@ -1512,14 +1512,14 @@ static void SolveVC(benchmark::State& state)
     const auto worldManifold = playrho::WorldManifold{normal, ps0};
     
     const auto locA = playrho::Length2{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
-    const auto posA = playrho::Position{locA, playrho::Angle(0)};
+    const auto posA = playrho::Position2D{locA, playrho::Angle(0)};
     const auto velA = playrho::Velocity{
         playrho::LinearVelocity2{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
 
     const auto locB = playrho::Length2{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
-    const auto posB = playrho::Position{locB, playrho::Angle(0)};
+    const auto posB = playrho::Position2D{locB, playrho::Angle(0)};
     const auto velB = playrho::Velocity{
         playrho::LinearVelocity2{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}

--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -1432,14 +1432,14 @@ static void ConstructAndAssignVC(benchmark::State& state)
     
     const auto locA = playrho::Length2{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posA = playrho::Position2D{locA, playrho::Angle(0)};
-    const auto velA = playrho::Velocity{
+    const auto velA = playrho::Velocity2D{
         playrho::LinearVelocity2{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
     
     const auto locB = playrho::Length2{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posB = playrho::Position2D{locB, playrho::Angle(0)};
-    const auto velB = playrho::Velocity{
+    const auto velB = playrho::Velocity2D{
         playrho::LinearVelocity2{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
@@ -1513,14 +1513,14 @@ static void SolveVC(benchmark::State& state)
     
     const auto locA = playrho::Length2{playrho::Real(+1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posA = playrho::Position2D{locA, playrho::Angle(0)};
-    const auto velA = playrho::Velocity{
+    const auto velA = playrho::Velocity2D{
         playrho::LinearVelocity2{playrho::Real(-0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };
 
     const auto locB = playrho::Length2{playrho::Real(-1) * playrho::Meter, playrho::Real(0) * playrho::Meter};
     const auto posB = playrho::Position2D{locB, playrho::Angle(0)};
-    const auto velB = playrho::Velocity{
+    const auto velB = playrho::Velocity2D{
         playrho::LinearVelocity2{playrho::Real(+0.5) * playrho::MeterPerSecond, playrho::Real(0) * playrho::MeterPerSecond},
         playrho::AngularVelocity{playrho::Real(0) * playrho::RadianPerSecond}
     };

--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -77,7 +77,7 @@ static playrho::UnitVec2 GetRandUnitVec2(playrho::Angle lo, playrho::Angle hi)
     return playrho::UnitVec2::Get(playrho::Real{a} * playrho::Radian);
 }
 
-static playrho::Transformation
+static playrho::Transformation2D
 GetRandTransformation(playrho::Position2D pos0, playrho::Position2D pos1)
 {
     const auto x0 = static_cast<double>(playrho::Real{GetX(pos0.linear) / playrho::Meter});
@@ -92,7 +92,7 @@ GetRandTransformation(playrho::Position2D pos0, playrho::Position2D pos1)
     const auto y = static_cast<playrho::Real>(Rand(y0, y1)) * playrho::Meter;
     const auto a = static_cast<playrho::Real>(Rand(a0, a1)) * playrho::Radian;
     
-    return playrho::Transformation{playrho::Length2{x, y}, playrho::UnitVec2::Get(a)};
+    return playrho::Transformation2D{playrho::Length2{x, y}, playrho::UnitVec2::Get(a)};
 }
 
 static std::vector<float> Rands(unsigned count, float lo, float hi)
@@ -137,7 +137,7 @@ GetRandUnitVec2Pair(playrho::Angle lo, playrho::Angle hi)
     return std::make_pair(GetRandUnitVec2(lo, hi), GetRandUnitVec2(lo, hi));
 }
 
-static std::pair<playrho::Transformation, playrho::Transformation>
+static std::pair<playrho::Transformation2D, playrho::Transformation2D>
 GetRandTransformationPair(playrho::Position2D pos0, playrho::Position2D pos1)
 {
     return std::make_pair(GetRandTransformation(pos0, pos1), GetRandTransformation(pos0, pos1));
@@ -215,10 +215,10 @@ GetRandUnitVec2Pairs(unsigned count, playrho::Angle lo, playrho::Angle hi)
     return rands;
 }
 
-static std::vector<std::pair<playrho::Transformation, playrho::Transformation>>
+static std::vector<std::pair<playrho::Transformation2D, playrho::Transformation2D>>
 GetRandTransformationPairs(unsigned count, playrho::Position2D pos0, playrho::Position2D pos1)
 {
-    auto rands = std::vector<std::pair<playrho::Transformation, playrho::Transformation>>{};
+    auto rands = std::vector<std::pair<playrho::Transformation2D, playrho::Transformation2D>>{};
     rands.reserve(count);
     for (auto i = decltype(count){0}; i < count; ++i)
     {
@@ -1206,7 +1206,7 @@ static void AABB2D(benchmark::State& state)
 
 // ----
 
-using TransformationPair = std::pair<playrho::Transformation, playrho::Transformation>;
+using TransformationPair = std::pair<playrho::Transformation2D, playrho::Transformation2D>;
 using TransformationPairs = std::vector<TransformationPair>;
 
 static TransformationPairs GetTransformationPairs(unsigned count)
@@ -1348,8 +1348,8 @@ static void ManifoldForTwoSquares1(benchmark::State& state)
     const auto shape = playrho::PolygonShapeConf(dim, dim);
     
     const auto rot0 = playrho::Angle{playrho::Real{45.0f} * playrho::Degree};
-    const auto xfm0 = playrho::Transformation{playrho::Vec2{0, -2} * (playrho::Real(1) * playrho::Meter), playrho::UnitVec2::Get(rot0)}; // bottom
-    const auto xfm1 = playrho::Transformation{playrho::Vec2{0, +2} * (playrho::Real(1) * playrho::Meter), playrho::UnitVec2::GetRight()}; // top
+    const auto xfm0 = playrho::Transformation2D{playrho::Vec2{0, -2} * (playrho::Real(1) * playrho::Meter), playrho::UnitVec2::Get(rot0)}; // bottom
+    const auto xfm1 = playrho::Transformation2D{playrho::Vec2{0, +2} * (playrho::Real(1) * playrho::Meter), playrho::UnitVec2::GetRight()}; // top
     
     // Rotate square A and put it below square B.
     // In ASCII art terms:
@@ -1387,11 +1387,11 @@ static void ManifoldForTwoSquares2(benchmark::State& state)
     // Shape B: wide rectangle
     const auto shape1 = playrho::PolygonShapeConf(playrho::Real{3} * playrho::Meter, playrho::Real{1.5f} * playrho::Meter);
     
-    const auto xfm0 = playrho::Transformation{
+    const auto xfm0 = playrho::Transformation2D{
         playrho::Vec2{-2, 0} * (playrho::Real(1) * playrho::Meter),
         playrho::UnitVec2::GetRight()
     }; // left
-    const auto xfm1 = playrho::Transformation{
+    const auto xfm1 = playrho::Transformation2D{
         playrho::Vec2{+2, 0} * (playrho::Real(1) * playrho::Meter),
         playrho::UnitVec2::GetRight()
     }; // right

--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -50,11 +50,8 @@ int main()
                                        .UseLocation(Length2{0_m, 4_m})
                                        .UseType(BodyType::Dynamic));
 
-    // Define a disk shape for the ball body.
-    const auto disk = DiskShapeConf{}.UseRadius(1_m);
-
-    // Add the disk shape to the ball body.
-    ball->CreateFixture(disk);
+    // Define a disk shape for the ball body and create a fixture to add it.
+    ball->CreateFixture(DiskShapeConf{}.UseRadius(1_m));
 
     // Prepare for simulation. Typically code uses a time step of 1/60 of a second
     // (60Hz). The defaults are setup for that and to generally provide a high

--- a/PlayRho/Collision/AABB.cpp
+++ b/PlayRho/Collision/AABB.cpp
@@ -29,7 +29,7 @@
 
 namespace playrho {
 
-AABB2D ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept
+AABB2D ComputeAABB(const DistanceProxy& proxy, const Transformation2D& xf) noexcept
 {
     assert(IsValid(xf));
     auto result = AABB2D{};
@@ -41,7 +41,7 @@ AABB2D ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcep
 }
 
 AABB2D ComputeAABB(const DistanceProxy& proxy,
-                   const Transformation& xfm0, const Transformation& xfm1) noexcept
+                   const Transformation2D& xfm0, const Transformation2D& xfm1) noexcept
 {
     assert(IsValid(xfm0));
     assert(IsValid(xfm1));
@@ -54,7 +54,7 @@ AABB2D ComputeAABB(const DistanceProxy& proxy,
     return GetFattenedAABB(result, proxy.GetVertexRadius());
 }
 
-AABB2D ComputeAABB(const Shape& shape, const Transformation& xf) noexcept
+AABB2D ComputeAABB(const Shape& shape, const Transformation2D& xf) noexcept
 {
     auto sum = AABB2D{};
     const auto childCount = GetChildCount(shape);

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -39,7 +39,7 @@ namespace playrho {
     class Body;
     class Contact;
     class DistanceProxy;
-    struct Transformation;
+    struct Transformation2D;
     
     /// @brief N-dimensional Axis Aligned Bounding Box.
     ///
@@ -421,7 +421,7 @@ namespace playrho {
     /// @param xf World transform of the shape.
     /// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
     /// @relatedalso DistanceProxy
-    AABB2D ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept;
+    AABB2D ComputeAABB(const DistanceProxy& proxy, const Transformation2D& xf) noexcept;
     
     /// @brief Computes the AABB.
     /// @details Computes the Axis Aligned Bounding Box (AABB) for the given child shape
@@ -433,11 +433,11 @@ namespace playrho {
     /// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
     /// @relatedalso DistanceProxy
     AABB2D ComputeAABB(const DistanceProxy& proxy,
-                     const Transformation& xfm0, const Transformation& xfm1) noexcept;
+                     const Transformation2D& xfm0, const Transformation2D& xfm1) noexcept;
     
     /// @brief Computes the AABB for the given shape with the given transformation.
     /// @relatedalso Shape
-    AABB2D ComputeAABB(const Shape& shape, const Transformation& xf) noexcept;
+    AABB2D ComputeAABB(const Shape& shape, const Transformation2D& xf) noexcept;
     
     /// @brief Computes the AABB for the given fixture.
     /// @details This is the AABB of the entire shape of the given fixture at the body's

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -31,10 +31,10 @@ namespace {
     }
 
     inline SimplexEdge GetSimplexEdge(const DistanceProxy& proxyA,
-                                      const Transformation& xfA,
+                                      const Transformation2D& xfA,
                                       VertexCounter idxA,
                                       const DistanceProxy& proxyB,
-                                      const Transformation& xfB,
+                                      const Transformation2D& xfB,
                                       VertexCounter idxB)
     {
         const auto wA = Transform(proxyA.GetVertex(idxA), xfA);
@@ -43,8 +43,8 @@ namespace {
     }
     
     inline SimplexEdges GetSimplexEdges(const IndexPair3 indexPairs,
-                                          const DistanceProxy& proxyA, const Transformation& xfA,
-                                          const DistanceProxy& proxyB, const Transformation& xfB)
+                                          const DistanceProxy& proxyA, const Transformation2D& xfA,
+                                          const DistanceProxy& proxyB, const Transformation2D& xfB)
     {
         /// @brief Size type.
         using size_type = std::remove_const<decltype(MaxSimplexEdges)>::type;
@@ -98,8 +98,8 @@ PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept
     return PairLength2{pointA, pointB};
 }
 
-DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& transformA,
-                        const DistanceProxy& proxyB, const Transformation& transformB,
+DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation2D& transformA,
+                        const DistanceProxy& proxyB, const Transformation2D& transformB,
                         DistanceConf conf)
 {
     assert(proxyA.GetVertexCount() > 0);
@@ -204,8 +204,8 @@ DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& trans
     return DistanceOutput{simplex, iter, state};
 }
 
-Area TestOverlap(const DistanceProxy& proxyA, const Transformation& xfA,
-                 const DistanceProxy& proxyB, const Transformation& xfB,
+Area TestOverlap(const DistanceProxy& proxyA, const Transformation2D& xfA,
+                 const DistanceProxy& proxyB, const Transformation2D& xfB,
                  DistanceConf conf)
 {
     const auto distanceInfo = Distance(proxyA, xfA, proxyB, xfB, conf);

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -82,8 +82,8 @@ namespace playrho {
     /// @return Closest points between the two shapes and the count of iterations it took to
     ///   determine them. The iteration count will always be greater than zero unless
     ///   <code>DefaultMaxDistanceIters</code> is zero.
-    DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& transformA,
-                            const DistanceProxy& proxyB, const Transformation& transformB,
+    DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation2D& transformA,
+                            const DistanceProxy& proxyB, const Transformation2D& transformB,
                             DistanceConf conf = DistanceConf{});
  
     /// @brief Determine if two generic shapes overlap.
@@ -92,8 +92,8 @@ namespace playrho {
     ///   the CollideShapes function. This is not always the case however especially when the
     ///   separation or overlap distance is closer to zero.
     ///
-    Area TestOverlap(const DistanceProxy& proxyA, const Transformation& xfA,
-                     const DistanceProxy& proxyB, const Transformation& xfB,
+    Area TestOverlap(const DistanceProxy& proxyA, const Transformation2D& xfA,
+                     const DistanceProxy& proxyB, const Transformation2D& xfB,
                      DistanceConf conf = DistanceConf{});
 
 } // namespace playrho

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -57,9 +57,9 @@ inline index_type GetEdgeIndex(VertexCounter i1, VertexCounter i2, VertexCounter
 /// @param idx1 Index 1. This is the index of the vertex of shape1 that had the maximal separation distance
 ///     from the edge of shape0 identified by idx0.
 Manifold GetFaceManifold(const Manifold::Type type,
-                         const DistanceProxy& shape0, const Transformation& xf0,
+                         const DistanceProxy& shape0, const Transformation2D& xf0,
                          const VertexCounter idx0,
-                         const DistanceProxy& shape1, const Transformation& xf1,
+                         const DistanceProxy& shape1, const Transformation2D& xf1,
                          const VertexCounter idx1,
                          const Manifold::Conf conf)
 {
@@ -276,8 +276,8 @@ Manifold GetFaceManifold(const Manifold::Type type,
 }
 
 Manifold CollideShapes(Manifold::Type type, Length totalRadius,
-                       const DistanceProxy& shape, const Transformation& sxf,
-                       Length2 point, const Transformation& xfm)
+                       const DistanceProxy& shape, const Transformation2D& sxf,
+                       Length2 point, const Transformation2D& xfm)
 {
     // Computes the center of the circle in the frame of the polygon.
     const auto cLocal = InverseTransform(Transform(point, xfm), sxf); ///< Center of circle in frame of polygon.
@@ -388,8 +388,8 @@ Manifold CollideShapes(Manifold::Type type, Length totalRadius,
     return Manifold{};
 }
 
-inline Manifold CollideShapes(Length2 locationA, const Transformation& xfA,
-                              Length2 locationB, const Transformation& xfB,
+inline Manifold CollideShapes(Length2 locationA, const Transformation2D& xfA,
+                              Length2 locationB, const Transformation2D& xfB,
                               Length totalRadius) noexcept
 {
     const auto pA = Transform(locationA, xfA);
@@ -407,8 +407,8 @@ inline Manifold CollideShapes(Length2 locationA, const Transformation& xfA,
  * All CollideShapes functions return a Manifold object.
  */
 
-Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA,
-                       const DistanceProxy& shapeB, const Transformation& xfB,
+Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation2D& xfA,
+                       const DistanceProxy& shapeB, const Transformation2D& xfB,
                        Manifold::Conf conf)
 {
     // Assumes called after detecting AABB overlap.

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -26,7 +26,7 @@
 namespace playrho {
 
     class DistanceProxy;
-    struct Transformation;
+    struct Transformation2D;
     
     /// @brief A collision description for the collision two convex shapes.
     ///
@@ -559,8 +559,8 @@ namespace playrho {
     ///
     /// @relatedalso Manifold
     ///
-    Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA,
-                           const DistanceProxy& shapeB, const Transformation& xfB,
+    Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation2D& xfA,
+                           const DistanceProxy& shapeB, const Transformation2D& xfB,
                            Manifold::Conf conf = GetDefaultManifoldConf());
 #if 0
     Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -35,11 +35,11 @@ namespace playrho {
 
     /// @brief Mass data.
     /// @details This holds the mass data computed for a shape.
-    /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
+    template <std::size_t N>
     struct MassData
     {
         /// @brief Position of the shape's centroid relative to the shape's origin.
-        Length2 center = Length2{};
+        Vector<Length, N> center = Vector<Length, N>{};
         
         /// @brief Mass of the shape in kilograms.
         NonNegative<Mass> mass = NonNegative<Mass>{0};
@@ -50,18 +50,24 @@ namespace playrho {
         NonNegative<RotInertia> I = NonNegative<RotInertia>{0};
     };
     
+    /// @brief Mass data alias for 2-D objects.
+    /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
+    using MassData2D = MassData<2>;
+    
     // Free functions...
     
     /// @brief MassData equality operator.
     /// @relatedalso MassData
-    PLAYRHO_CONSTEXPR inline bool operator== (MassData lhs, MassData rhs)
+    template <std::size_t N>
+    PLAYRHO_CONSTEXPR inline bool operator== (MassData<N> lhs, MassData<N> rhs)
     {
         return lhs.center == rhs.center && lhs.mass == rhs.mass && lhs.I == rhs.I;
     }
     
     /// @brief MassData inequality operator.
     /// @relatedalso MassData
-    PLAYRHO_CONSTEXPR inline bool operator!= (MassData lhs, MassData rhs)
+    template <std::size_t N>
+    PLAYRHO_CONSTEXPR inline bool operator!= (MassData<N> lhs, MassData<N> rhs)
     {
         return !(lhs == rhs);
     }
@@ -74,7 +80,7 @@ namespace playrho {
     ///
     /// @relatedalso MassData
     ///
-    MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location);
+    MassData2D GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location);
 
     /// @brief Computes the mass data for a linear shape.
     ///
@@ -85,12 +91,12 @@ namespace playrho {
     ///
     /// @relatedalso MassData
     ///
-    MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1);
+    MassData2D GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1);
 
     /// @brief Gets the mass data for the given collection of vertices with the given
     ///    properties.
     /// @relatedalso MassData
-    MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
+    MassData2D GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
                          Span<const Length2> vertices);
     
     /// @brief Computes the mass data for the given fixture.
@@ -104,7 +110,7 @@ namespace playrho {
     ///
     /// @relatedalso Fixture
     ///
-    MassData GetMassData(const Fixture& f);
+    MassData2D GetMassData(const Fixture& f);
     
     /// @brief Computes the body's mass data.
     /// @details This basically accumulates the mass data over all fixtures.
@@ -112,13 +118,13 @@ namespace playrho {
     ///   mass to get the averaged center.
     /// @return accumalated mass data for all fixtures associated with the given body.
     /// @relatedalso Body
-    MassData ComputeMassData(const Body& body) noexcept;
+    MassData2D ComputeMassData(const Body& body) noexcept;
     
     
     /// @brief Gets the mass data of the body.
     /// @return a struct containing the mass, inertia and center of the body.
     /// @relatedalso Body
-    MassData GetMassData(const Body& body) noexcept;
+    MassData2D GetMassData(const Body& body) noexcept;
     
 } // namespace playrho
 

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -134,7 +134,7 @@ RayCastOutput RayCast(const AABB2D& aabb, const RayCastInput& input) noexcept
 }
 
 RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
-                      const Transformation& transform) noexcept
+                      const Transformation2D& transform) noexcept
 {
     const auto vertexCount = proxy.GetVertexCount();
     assert(vertexCount > 0);
@@ -230,7 +230,7 @@ RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
 }
 
 RayCastOutput RayCast(const Shape& shape, ChildCounter childIndex,
-                      const RayCastInput& input, const Transformation& transform) noexcept
+                      const RayCastInput& input, const Transformation2D& transform) noexcept
 {
     return RayCast(GetChild(shape, childIndex), input, transform);
 }

--- a/PlayRho/Collision/RayCastOutput.hpp
+++ b/PlayRho/Collision/RayCastOutput.hpp
@@ -74,7 +74,7 @@ namespace playrho
     /// @param transform Transform to be applied to the distance-proxy to get world coordinates.
     /// @relatedalso DistanceProxy
     RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
-                          const Transformation& transform) noexcept;
+                          const Transformation2D& transform) noexcept;
     
     /// @brief Cast a ray against the child of the given shape.
     /// @note This is a convenience function for calling the raycast against a distance-proxy.
@@ -84,7 +84,7 @@ namespace playrho
     /// @param transform Transform to be applied to the child of the shape.
     /// @relatedalso Shape
     RayCastOutput RayCast(const Shape& shape, ChildCounter childIndex,
-                          const RayCastInput& input, const Transformation& transform) noexcept;
+                          const RayCastInput& input, const Transformation2D& transform) noexcept;
 
     /// @}
 

--- a/PlayRho/Collision/SeparationFinder.cpp
+++ b/PlayRho/Collision/SeparationFinder.cpp
@@ -23,8 +23,8 @@
 namespace playrho {
 
 SeparationFinder SeparationFinder::Get(IndexPair3 indices,
-                                       const DistanceProxy& proxyA, const Transformation& xfA,
-                                       const DistanceProxy& proxyB, const Transformation& xfB)
+                                       const DistanceProxy& proxyA, const Transformation2D& xfA,
+                                       const DistanceProxy& proxyB, const Transformation2D& xfB)
 {
     assert(GetNumIndices(indices) > 0);
     assert(proxyA.GetVertexCount() > 0);
@@ -106,8 +106,8 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
 }
 
 IndexPairDistance
-SeparationFinder::FindMinSeparationForPoints(const Transformation& xfA,
-                                             const Transformation& xfB) const
+SeparationFinder::FindMinSeparationForPoints(const Transformation2D& xfA,
+                                             const Transformation2D& xfB) const
 {
     const auto dirA = InverseRotate(+m_axis, xfA.q);
     const auto dirB = InverseRotate(-m_axis, xfB.q);
@@ -120,8 +120,8 @@ SeparationFinder::FindMinSeparationForPoints(const Transformation& xfA,
 }
 
 IndexPairDistance
-SeparationFinder::FindMinSeparationForFaceA(const Transformation& xfA,
-                                            const Transformation& xfB) const
+SeparationFinder::FindMinSeparationForFaceA(const Transformation2D& xfA,
+                                            const Transformation2D& xfB) const
 {
     const auto normal = Rotate(m_axis, xfA.q);
     const auto indexA = InvalidVertex;
@@ -134,8 +134,8 @@ SeparationFinder::FindMinSeparationForFaceA(const Transformation& xfA,
 }
 
 IndexPairDistance
-SeparationFinder::FindMinSeparationForFaceB(const Transformation& xfA,
-                                            const Transformation& xfB) const
+SeparationFinder::FindMinSeparationForFaceB(const Transformation2D& xfA,
+                                            const Transformation2D& xfB) const
 {
     const auto normal = Rotate(m_axis, xfB.q);
     const auto dir = InverseRotate(-normal, xfA.q);
@@ -147,7 +147,7 @@ SeparationFinder::FindMinSeparationForFaceB(const Transformation& xfA,
     return IndexPairDistance{Dot(delta, normal), IndexPair{indexA, indexB}};
 }
 
-Length SeparationFinder::EvaluateForPoints(const Transformation& xfA, const Transformation& xfB,
+Length SeparationFinder::EvaluateForPoints(const Transformation2D& xfA, const Transformation2D& xfB,
                                            IndexPair indexPair) const
 {
     const auto pointA = Transform(m_proxyA.GetVertex(indexPair.first), xfA);
@@ -156,7 +156,7 @@ Length SeparationFinder::EvaluateForPoints(const Transformation& xfA, const Tran
     return Dot(delta, m_axis);
 }
 
-Length SeparationFinder::EvaluateForFaceA(const Transformation& xfA, const Transformation& xfB,
+Length SeparationFinder::EvaluateForFaceA(const Transformation2D& xfA, const Transformation2D& xfB,
                                           IndexPair indexPair) const
 {
     const auto normal = Rotate(m_axis, xfA.q);
@@ -166,7 +166,7 @@ Length SeparationFinder::EvaluateForFaceA(const Transformation& xfA, const Trans
     return Dot(delta, normal);
 }
 
-Length SeparationFinder::EvaluateForFaceB(const Transformation& xfA, const Transformation& xfB,
+Length SeparationFinder::EvaluateForFaceB(const Transformation2D& xfA, const Transformation2D& xfB,
                                           IndexPair indexPair) const
 {
     const auto normal = Rotate(m_axis, xfB.q);

--- a/PlayRho/Collision/SeparationFinder.hpp
+++ b/PlayRho/Collision/SeparationFinder.hpp
@@ -26,7 +26,7 @@
 namespace playrho {
 
     class DistanceProxy;
-    struct Transformation;
+    struct Transformation2D;
         
     /// Separation finder.
     class SeparationFinder
@@ -53,14 +53,14 @@ namespace playrho {
         /// @param xfB Transformation B.
         ///
         static SeparationFinder Get(IndexPair3 indices,
-                                    const DistanceProxy& proxyA, const Transformation& xfA,
-                                    const DistanceProxy& proxyB, const Transformation& xfB);
+                                    const DistanceProxy& proxyA, const Transformation2D& xfA,
+                                    const DistanceProxy& proxyB, const Transformation2D& xfB);
         
         /// Finds the minimum separation.
         /// @return indexes of proxy A's and proxy B's vertices that have the minimum
         ///    distance between them and what that distance is.
-        IndexPairDistance FindMinSeparation(const Transformation& xfA,
-                                            const Transformation& xfB) const
+        IndexPairDistance FindMinSeparation(const Transformation2D& xfA,
+                                            const Transformation2D& xfB) const
         {
             switch (m_type)
             {
@@ -83,7 +83,7 @@ namespace playrho {
         /// @return Separation distance which will be negative when the given transforms put the
         ///    vertices on the opposite sides of the separating axis.
         ///
-        Length Evaluate(const Transformation& xfA, const Transformation& xfB,
+        Length Evaluate(const Transformation2D& xfA, const Transformation2D& xfB,
                         IndexPair indexPair) const
         {
             switch (m_type)
@@ -117,27 +117,27 @@ namespace playrho {
         }
         
         /// @brief Finds the minimum separation for points.
-        IndexPairDistance FindMinSeparationForPoints(const Transformation& xfA,
-                                                     const Transformation& xfB) const;
+        IndexPairDistance FindMinSeparationForPoints(const Transformation2D& xfA,
+                                                     const Transformation2D& xfB) const;
         
         /// @brief Finds the minimum separation for face A.
-        IndexPairDistance FindMinSeparationForFaceA(const Transformation& xfA,
-                                                    const Transformation& xfB) const;
+        IndexPairDistance FindMinSeparationForFaceA(const Transformation2D& xfA,
+                                                    const Transformation2D& xfB) const;
         
         /// @brief Finds the minimum separation for face B.
-        IndexPairDistance FindMinSeparationForFaceB(const Transformation& xfA,
-                                                    const Transformation& xfB) const;
+        IndexPairDistance FindMinSeparationForFaceB(const Transformation2D& xfA,
+                                                    const Transformation2D& xfB) const;
         
         /// @brief Evaluates for points.
-        Length EvaluateForPoints(const Transformation& xfA, const Transformation& xfB,
+        Length EvaluateForPoints(const Transformation2D& xfA, const Transformation2D& xfB,
                                  IndexPair indexPair) const;
         
         /// @brief Evaluates for face A.
-        Length EvaluateForFaceA(const Transformation& xfA, const Transformation& xfB,
+        Length EvaluateForFaceA(const Transformation2D& xfA, const Transformation2D& xfB,
                                 IndexPair indexPair) const;
         
         /// @brief Evaluates for face B.
-        Length EvaluateForFaceB(const Transformation& xfA, const Transformation& xfB,
+        Length EvaluateForFaceB(const Transformation2D& xfA, const Transformation2D& xfB,
                                 IndexPair indexPair) const;
         
         const DistanceProxy& m_proxyA; ///< Distance proxy A.

--- a/PlayRho/Collision/ShapeSeparation.cpp
+++ b/PlayRho/Collision/ShapeSeparation.cpp
@@ -60,8 +60,8 @@ IndexPairDistance GetMinIndexSeparation(Range<DistanceProxy::ConstVertexIterator
 
 } // anonymous namespace
 
-IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
-                                      const DistanceProxy& proxy2, Transformation xf2)
+IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation2D xf1,
+                                      const DistanceProxy& proxy2, Transformation2D xf2)
 {
     // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
     auto separation = -std::numeric_limits<Length>::infinity();
@@ -101,8 +101,8 @@ IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformatio
     return IndexPairDistance{separation, indexPair};
 }
 
-IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                   const DistanceProxy& proxy2, Transformation xf2)
+IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
+                                   const DistanceProxy& proxy2, Transformation2D xf2)
 {
     // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
     auto separation = -std::numeric_limits<Length>::infinity();
@@ -126,8 +126,8 @@ IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation x
     return IndexPairDistance{separation, indexPair};
 }
 
-IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                   const DistanceProxy& proxy2, Transformation xf2,
+IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
+                                   const DistanceProxy& proxy2, Transformation2D xf2,
                                    Length stop)
 {
     // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.

--- a/PlayRho/Collision/ShapeSeparation.hpp
+++ b/PlayRho/Collision/ShapeSeparation.hpp
@@ -34,15 +34,15 @@ namespace playrho
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                       const DistanceProxy& proxy2, Transformation xf2);
+    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
+                                       const DistanceProxy& proxy2, Transformation2D xf2);
     
     /// @brief Gets the max separation information.
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                       const DistanceProxy& proxy2, Transformation xf2,
+    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
+                                       const DistanceProxy& proxy2, Transformation2D xf2,
                                        Length stop);
     
     /// @brief Gets the max separation information for the first four vertices of the two
@@ -52,8 +52,8 @@ namespace playrho
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
-                                          const DistanceProxy& proxy2, Transformation xf2);
+    IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation2D xf1,
+                                          const DistanceProxy& proxy2, Transformation2D xf2);
 
     /// @brief Gets the max separation information.
     /// @return Index of the vertex and normal from <code>proxy1</code>,

--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -61,7 +61,7 @@ ChainShapeConf& ChainShapeConf::Set(std::vector<Length2> vertices)
     {
         auto vprev = Length2{};
         auto first = true;
-        for (const auto v: m_vertices)
+        for (const auto& v: m_vertices)
         {
             if (!first)
             {
@@ -98,7 +98,7 @@ ChainShapeConf& ChainShapeConf::Add(Length2 vertex)
     return *this;
 }
 
-MassData ChainShapeConf::GetMassData() const noexcept
+MassData2D ChainShapeConf::GetMassData() const noexcept
 {
     const auto density = this->density;
     if (density > AreaDensity(0))
@@ -130,14 +130,14 @@ MassData ChainShapeConf::GetMassData() const noexcept
                 vprev = v;
             }
             center /= StripUnit(area);
-            return MassData{center, mass, I};
+            return MassData2D{center, mass, I};
         }
         if (vertexCount == 1)
         {
             return playrho::GetMassData(vertexRadius, density, GetVertex(0));
         }
     }
-    return MassData{};
+    return MassData2D{};
 }
 
 DistanceProxy ChainShapeConf::GetChild(ChildCounter index) const

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -73,7 +73,7 @@ public:
     DistanceProxy GetChild(ChildCounter index) const;
     
     /// @brief Gets the mass data.
-    MassData GetMassData() const noexcept;
+    MassData2D GetMassData() const noexcept;
     
     /// @brief Gets the vertex count.
     ChildCounter GetVertexCount() const noexcept
@@ -130,7 +130,7 @@ inline DistanceProxy GetChild(const ChainShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the mass data for a given chain shape configuration.
-inline MassData GetMassData(const ChainShapeConf& arg) noexcept
+inline MassData2D GetMassData(const ChainShapeConf& arg) noexcept
 {
     return arg.GetMassData();
 }

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -120,7 +120,7 @@ inline DistanceProxy GetChild(const DiskShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the mass data of the given disk shape configuration.
-inline MassData GetMassData(const DiskShapeConf& arg) noexcept
+inline MassData2D GetMassData(const DiskShapeConf& arg) noexcept
 {
     return playrho::GetMassData(arg.vertexRadius, arg.density, arg.location);
 }

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -117,7 +117,7 @@ inline DistanceProxy GetChild(const EdgeShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the mass data for the given shape configuration.
-inline MassData GetMassData(const EdgeShapeConf& arg) noexcept
+inline MassData2D GetMassData(const EdgeShapeConf& arg) noexcept
 {
     return playrho::GetMassData(arg.vertexRadius, arg.density,
                                 arg.GetVertexA(), arg.GetVertexB());

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -27,7 +27,7 @@ namespace playrho {
 /// Computes the mass properties of this shape using its dimensions and density.
 /// The inertia tensor is computed about the local origin.
 /// @return Mass data for this shape.
-MassData GetMassData(const MultiShapeConf& arg) noexcept
+MassData2D GetMassData(const MultiShapeConf& arg) noexcept
 {
     auto mass = 0_kg;
     const auto origin = Length2{};
@@ -47,7 +47,7 @@ MassData GetMassData(const MultiShapeConf& arg) noexcept
     });
 
     const auto center = (mass > 0_kg)? weightedCenter / mass: origin;
-    return MassData{center, mass, I};
+    return MassData2D{center, mass, I};
 }
 
 ConvexHull ConvexHull::Get(const VertexSet& pointSet)

--- a/PlayRho/Collision/Shapes/MultiShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.hpp
@@ -144,7 +144,7 @@ namespace playrho {
     }
     
     /// @brief Gets the mass data for the given shape configuration.
-    MassData GetMassData(const MultiShapeConf& arg) noexcept;
+    MassData2D GetMassData(const MultiShapeConf& arg) noexcept;
     
 } // namespace playrho
 

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -78,11 +78,11 @@ PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy,
                                                  Length2 center, Angle angle) noexcept
 {
     SetAsBox(hx, hy);
-    Transform(Transformation{center, UnitVec2::Get(angle)});
+    Transform(Transformation2D{center, UnitVec2::Get(angle)});
     return *this;
 }
 
-PolygonShapeConf& PolygonShapeConf::Transform(Transformation xfm) noexcept
+PolygonShapeConf& PolygonShapeConf::Transform(Transformation2D xfm) noexcept
 {
     for (auto i = decltype(GetVertexCount()){0}; i < GetVertexCount(); ++i)
     {

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -92,7 +92,7 @@ public:
     PolygonShapeConf& Set(const VertexSet& points) noexcept;
     
     /// @brief Transforms the set vertices.
-    PolygonShapeConf& Transform(Transformation xfm) noexcept;
+    PolygonShapeConf& Transform(Transformation2D xfm) noexcept;
     
     /// @brief Equality operator.
     friend bool operator== (const PolygonShapeConf& lhs, const PolygonShapeConf& rhs) noexcept

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -188,7 +188,7 @@ inline DistanceProxy GetChild(const PolygonShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the mass data for the given shape configuration.
-inline MassData GetMassData(const PolygonShapeConf& arg) noexcept
+inline MassData2D GetMassData(const PolygonShapeConf& arg) noexcept
 {
     return playrho::GetMassData(arg.vertexRadius, arg.density, arg.GetVertices());
 }

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -112,7 +112,7 @@ public:
     
     /// @brief Gets the mass properties of this shape using its dimensions and density.
     /// @return Mass data for this shape.
-    friend MassData GetMassData(const Shape& shape) noexcept
+    friend MassData2D GetMassData(const Shape& shape) noexcept
     {
         return shape.m_self->GetMassData_();
     }
@@ -204,7 +204,7 @@ private:
         virtual DistanceProxy GetChild_(ChildCounter index) const = 0;
         
         /// @brief Gets the mass data.
-        virtual MassData GetMassData_() const noexcept = 0;
+        virtual MassData2D GetMassData_() const noexcept = 0;
         
         /// @brief Gets the vertex radius.
         virtual NonNegative<Length> GetVertexRadius_() const noexcept = 0;
@@ -261,7 +261,7 @@ private:
             return GetChild(data, index);
         }
 
-        MassData GetMassData_() const noexcept override
+        MassData2D GetMassData_() const noexcept override
         {
             return GetMassData(data);
         }

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -30,7 +30,7 @@ namespace playrho {
     /// @details This is the locations (in world coordinates) and indices of a pair of vertices
     /// from two shapes (shape A and shape B).
     ///
-    /// @note This data structure is 28-bytes large (on at least one 64-bit platform).
+    /// @note This data structure is 20-bytes large (on at least one 64-bit platform).
     ///
     class SimplexEdge
     {

--- a/PlayRho/Collision/TimeOfImpact.cpp
+++ b/PlayRho/Collision/TimeOfImpact.cpp
@@ -36,8 +36,8 @@ inline DistanceConf GetDistanceConf(const ToiConf& conf)
 
 } // anonymous namespace
 
-TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
-                       const DistanceProxy& proxyB, const Sweep& sweepB,
+TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep2D& sweepA,
+                       const DistanceProxy& proxyB, const Sweep2D& sweepB,
                        ToiConf conf)
 {
     assert(IsValid(sweepA));

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -281,8 +281,8 @@ namespace playrho {
     ///
     /// @relatedalso TOIOutput
     ///
-    TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
-                           const DistanceProxy& proxyB, const Sweep& sweepB,
+    TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep2D& sweepA,
+                           const DistanceProxy& proxyB, const Sweep2D& sweepB,
                            ToiConf conf = GetDefaultToiConf());
     
     

--- a/PlayRho/Collision/WorldManifold.cpp
+++ b/PlayRho/Collision/WorldManifold.cpp
@@ -28,8 +28,8 @@ namespace playrho {
 namespace {
 
 inline WorldManifold GetForCircles(const Manifold& manifold,
-                                   const Transformation xfA, const Length radiusA,
-                                   const Transformation xfB, const Length radiusB)
+                                   const Transformation2D xfA, const Length radiusA,
+                                   const Transformation2D xfB, const Length radiusB)
 {
     assert(manifold.GetPointCount() == 1);
 
@@ -45,8 +45,8 @@ inline WorldManifold GetForCircles(const Manifold& manifold,
 }
 
 inline WorldManifold GetForFaceA(const Manifold& manifold,
-                                 const Transformation xfA, const Length radiusA,
-                                 const Transformation xfB, const Length radiusB)
+                                 const Transformation2D xfA, const Length radiusA,
+                                 const Transformation2D xfB, const Length radiusB)
 {
     const auto normal = Rotate(manifold.GetLocalNormal(), xfA.q);
     const auto planePoint = Transform(manifold.GetLocalPoint(), xfA);
@@ -72,8 +72,8 @@ inline WorldManifold GetForFaceA(const Manifold& manifold,
 }
 
 inline WorldManifold GetForFaceB(const Manifold& manifold,
-                                 const Transformation xfA, const Length radiusA,
-                                 const Transformation xfB, const Length radiusB)
+                                 const Transformation2D xfA, const Length radiusA,
+                                 const Transformation2D xfB, const Length radiusB)
 {
     const auto normal = Rotate(manifold.GetLocalNormal(), xfB.q);
     const auto planePoint = Transform(manifold.GetLocalPoint(), xfB);
@@ -102,8 +102,8 @@ inline WorldManifold GetForFaceB(const Manifold& manifold,
 } // anonymous namespace
 
 WorldManifold GetWorldManifold(const Manifold& manifold,
-                               Transformation xfA, Length radiusA,
-                               Transformation xfB, Length radiusB)
+                               Transformation2D xfA, Length radiusA,
+                               Transformation2D xfB, Length radiusB)
 {
     const auto type = manifold.GetType();
 

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -182,8 +182,8 @@ namespace playrho {
     /// @relatedalso Manifold
     ///
     WorldManifold GetWorldManifold(const Manifold& manifold,
-                                   Transformation xfA, Length radiusA,
-                                   Transformation xfB, Length radiusB);
+                                   Transformation2D xfA, Length radiusA,
+                                   Transformation2D xfB, Length radiusB);
     
     /// Gets the world manifold for the given data.
     ///

--- a/PlayRho/Common/Acceleration.hpp
+++ b/PlayRho/Common/Acceleration.hpp
@@ -29,37 +29,37 @@ namespace playrho
 {
     /// @brief Acceleration related data structure.
     /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
-    struct Acceleration
+    struct Acceleration2D
     {
         LinearAcceleration2 linear; ///< Linear acceleration.
         AngularAcceleration angular; ///< Angular acceleration.
     };
     
     /// @brief Determines if the given value is valid.
-    /// @relatedalso Acceleration
+    /// @relatedalso Acceleration2D
     template <>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const Acceleration& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Acceleration2D& value) noexcept
     {
         return IsValid(value.linear) && IsValid(value.angular);
     }
     
     /// @brief Equality operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline bool operator==(const Acceleration& lhs, const Acceleration& rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline bool operator==(const Acceleration2D& lhs, const Acceleration2D& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline bool operator!=(const Acceleration2D& lhs, const Acceleration2D& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Multiplication assignment operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator*= (Acceleration& lhs, const Real rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D& operator*= (Acceleration2D& lhs, const Real rhs)
     {
         lhs.linear *= rhs;
         lhs.angular *= rhs;
@@ -67,8 +67,8 @@ namespace playrho
     }
     
     /// @brief Division assignment operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator/= (Acceleration& lhs, const Real rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D& operator/= (Acceleration2D& lhs, const Real rhs)
     {
         lhs.linear /= rhs;
         lhs.angular /= rhs;
@@ -76,8 +76,8 @@ namespace playrho
     }
     
     /// @brief Addition assignment operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D& operator+= (Acceleration2D& lhs, const Acceleration2D& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -85,15 +85,15 @@ namespace playrho
     }
     
     /// @brief Addition operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D operator+ (const Acceleration2D& lhs, const Acceleration2D& rhs)
     {
-        return Acceleration{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
+        return Acceleration2D{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D& operator-= (Acceleration2D& lhs, const Acceleration2D& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -101,43 +101,43 @@ namespace playrho
     }
     
     /// @brief Subtraction operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D operator- (const Acceleration2D& lhs, const Acceleration2D& rhs)
     {
-        return Acceleration{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
+        return Acceleration2D{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Negation operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator- (const Acceleration& value)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D operator- (const Acceleration2D& value)
     {
-        return Acceleration{-value.linear, -value.angular};
+        return Acceleration2D{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator+ (const Acceleration& value)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D operator+ (const Acceleration2D& value)
     {
         return value;
     }
     
     /// @brief Multiplication operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator* (const Acceleration& lhs, const Real rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D operator* (const Acceleration2D& lhs, const Real rhs)
     {
-        return Acceleration{lhs.linear * rhs, lhs.angular * rhs};
+        return Acceleration2D{lhs.linear * rhs, lhs.angular * rhs};
     }
     
     /// @brief Multiplication operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator* (const Real lhs, const Acceleration& rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D operator* (const Real lhs, const Acceleration2D& rhs)
     {
-        return Acceleration{rhs.linear * lhs, rhs.angular * lhs};
+        return Acceleration2D{rhs.linear * lhs, rhs.angular * lhs};
     }
     
     /// @brief Division operator.
-    /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator/ (const Acceleration& lhs, const Real rhs)
+    /// @relatedalso Acceleration2D
+    PLAYRHO_CONSTEXPR inline Acceleration2D operator/ (const Acceleration2D& lhs, const Real rhs)
     {
         /*
          * While it can be argued that division operations shouldn't be supported due to
@@ -149,7 +149,7 @@ namespace playrho
          * on down to the Vec2 and Angle types (rather than manually rewriting the divisions
          * as multiplications).
          */
-        return Acceleration{lhs.linear / rhs, lhs.angular / rhs};
+        return Acceleration2D{lhs.linear / rhs, lhs.angular / rhs};
     }
     
 } // namespace playrho

--- a/PlayRho/Common/Acceleration.hpp
+++ b/PlayRho/Common/Acceleration.hpp
@@ -27,7 +27,7 @@
 
 namespace playrho
 {
-    /// @brief Acceleration related data structure.
+    /// @brief 2-D acceleration related data structure.
     /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
     struct Acceleration2D
     {

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -298,7 +298,7 @@ inline Position2D GetNormalized(const Position2D& val) noexcept
 /// @return Sweep with its pos0 angle to be between -2 pi and 2 pi
 ///    and its pos1 angle reduced by the amount pos0's angle was reduced by.
 /// @relatedalso Sweep
-inline Sweep GetNormalized(Sweep sweep) noexcept
+inline Sweep2D GetNormalized(Sweep2D sweep) noexcept
 {
     const auto pos0a = GetNormalized(sweep.pos0.angular);
     const auto d = sweep.pos0.angular - pos0a;
@@ -825,7 +825,7 @@ inline Transformation GetTransformation(const Position2D pos, const Length2 loca
 /// @param sweep Sweep data to get the transform from.
 /// @param beta Time factor in [0,1], where 0 indicates alpha0.
 /// @return Transformation of the given sweep at the specified time.
-inline Transformation GetTransformation(const Sweep& sweep, const Real beta) noexcept
+inline Transformation GetTransformation(const Sweep2D& sweep, const Real beta) noexcept
 {
     assert(beta >= 0);
     assert(beta <= 1);
@@ -837,7 +837,7 @@ inline Transformation GetTransformation(const Sweep& sweep, const Real beta) noe
 /// @sa GetTransformation(const Sweep& sweep, Real beta).
 /// @param sweep Sweep data to get the transform from.
 /// @return Transformation of the given sweep at time zero.
-inline Transformation GetTransform0(const Sweep& sweep) noexcept
+inline Transformation GetTransform0(const Sweep2D& sweep) noexcept
 {
     return GetTransformation(sweep.pos0, sweep.GetLocalCenter());
 }
@@ -847,7 +847,7 @@ inline Transformation GetTransform0(const Sweep& sweep) noexcept
 /// @sa GetTransformation(const Sweep& sweep, Real beta).
 /// @param sweep Sweep data to get the transform from.
 /// @return Transformation of the given sweep at time one.
-inline Transformation GetTransform1(const Sweep& sweep) noexcept
+inline Transformation GetTransform1(const Sweep2D& sweep) noexcept
 {
     return GetTransformation(sweep.pos1, sweep.GetLocalCenter());
 }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -719,7 +719,7 @@ PLAYRHO_CONSTEXPR inline auto InverseRotate(const Vector2<T> vector, const UnitV
 /// @param v 2-D position to transform (to rotate and then translate).
 /// @param xfm Transformation (a translation and rotation) to apply to the given vector.
 /// @return Rotated and translated vector.
-PLAYRHO_CONSTEXPR inline Length2 Transform(const Length2 v, const Transformation xfm) noexcept
+PLAYRHO_CONSTEXPR inline Length2 Transform(const Length2 v, const Transformation2D xfm) noexcept
 {
     return Rotate(v, xfm.q) + xfm.p;
 }
@@ -734,7 +734,7 @@ PLAYRHO_CONSTEXPR inline Length2 Transform(const Length2 v, const Transformation
 /// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
 /// @param T Transformation (a translation and rotation) to inversely apply to the given vector.
 /// @return Inverse transformed vector.
-PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transformation T) noexcept
+PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transformation2D T) noexcept
 {
     const auto v2 = v - T.p;
     return InverseRotate(v2, T.q);
@@ -743,18 +743,18 @@ PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transfo
 /// @brief Multiplies a given transformation by another given transformation.
 /// @note v2 = A.q.Rot(B.q.Rot(v1) + B.p) + A.p
 ///          = (A.q * B.q).Rot(v1) + A.q.Rot(B.p) + A.p
-PLAYRHO_CONSTEXPR inline Transformation Mul(const Transformation& A, const Transformation& B) noexcept
+PLAYRHO_CONSTEXPR inline Transformation2D Mul(const Transformation2D& A, const Transformation2D& B) noexcept
 {
-    return Transformation{A.p + Rotate(B.p, A.q), A.q.Rotate(B.q)};
+    return Transformation2D{A.p + Rotate(B.p, A.q), A.q.Rotate(B.q)};
 }
 
 /// @brief Inverse multiplies a given transformation by another given transformation.
 /// @note v2 = A.q' * (B.q * v1 + B.p - A.p)
 ///          = A.q' * B.q * v1 + A.q' * (B.p - A.p)
-PLAYRHO_CONSTEXPR inline Transformation MulT(const Transformation& A, const Transformation& B) noexcept
+PLAYRHO_CONSTEXPR inline Transformation2D MulT(const Transformation2D& A, const Transformation2D& B) noexcept
 {
     const auto dp = B.p - A.p;
-    return Transformation{InverseRotate(dp, A.q), B.q.Rotate(A.q.FlipY())};
+    return Transformation2D{InverseRotate(dp, A.q), B.q.Rotate(A.q.FlipY())};
 }
 
 /// @brief Gets the absolute value of the given value.
@@ -806,15 +806,15 @@ inline std::uint64_t NextPowerOfTwo(std::uint64_t x)
 }
 
 /// @brief Gets the transformation for the given values.
-PLAYRHO_CONSTEXPR inline Transformation GetTransformation(const Length2 ctr, const UnitVec2 rot,
+PLAYRHO_CONSTEXPR inline Transformation2D GetTransformation(const Length2 ctr, const UnitVec2 rot,
                                                   const Length2 localCtr) noexcept
 {
     assert(IsValid(rot));
-    return Transformation{ctr - (Rotate(localCtr, rot)), rot};
+    return Transformation2D{ctr - (Rotate(localCtr, rot)), rot};
 }
 
 /// @brief Gets the transformation for the given values.
-inline Transformation GetTransformation(const Position2D pos, const Length2 local_ctr) noexcept
+inline Transformation2D GetTransformation(const Position2D pos, const Length2 local_ctr) noexcept
 {
     assert(IsValid(pos));
     assert(IsValid(local_ctr));
@@ -825,7 +825,7 @@ inline Transformation GetTransformation(const Position2D pos, const Length2 loca
 /// @param sweep Sweep data to get the transform from.
 /// @param beta Time factor in [0,1], where 0 indicates alpha0.
 /// @return Transformation of the given sweep at the specified time.
-inline Transformation GetTransformation(const Sweep2D& sweep, const Real beta) noexcept
+inline Transformation2D GetTransformation(const Sweep2D& sweep, const Real beta) noexcept
 {
     assert(beta >= 0);
     assert(beta <= 1);
@@ -837,7 +837,7 @@ inline Transformation GetTransformation(const Sweep2D& sweep, const Real beta) n
 /// @sa GetTransformation(const Sweep& sweep, Real beta).
 /// @param sweep Sweep data to get the transform from.
 /// @return Transformation of the given sweep at time zero.
-inline Transformation GetTransform0(const Sweep2D& sweep) noexcept
+inline Transformation2D GetTransform0(const Sweep2D& sweep) noexcept
 {
     return GetTransformation(sweep.pos0, sweep.GetLocalCenter());
 }
@@ -847,7 +847,7 @@ inline Transformation GetTransform0(const Sweep2D& sweep) noexcept
 /// @sa GetTransformation(const Sweep& sweep, Real beta).
 /// @param sweep Sweep data to get the transform from.
 /// @return Transformation of the given sweep at time one.
-inline Transformation GetTransform1(const Sweep2D& sweep) noexcept
+inline Transformation2D GetTransform1(const Sweep2D& sweep) noexcept
 {
     return GetTransformation(sweep.pos1, sweep.GetLocalCenter());
 }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -870,8 +870,8 @@ inline Real Normalize(Vec2& vector)
 /// @note If relA and relB are the zero vectors, the resulting value is simply
 ///    velB.linear - velA.linear.
 inline LinearVelocity2
-GetContactRelVelocity(const Velocity velA, const Length2 relA,
-                      const Velocity velB, const Length2 relB) noexcept
+GetContactRelVelocity(const Velocity2D velA, const Length2 relA,
+                      const Velocity2D velB, const Length2 relB) noexcept
 {
 #if 0 // Using std::fma appears to be slower!
     const auto revPerpRelB = GetRevPerpendicular(relB);
@@ -974,7 +974,7 @@ SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices);
 /// @}
 
 /// @brief Gets whether the given velocity is "under active" based on the given tolerances.
-inline bool IsUnderActive(Velocity velocity,
+inline bool IsUnderActive(Velocity2D velocity,
                           LinearVelocity linSleepTol, AngularVelocity angSleepTol) noexcept
 {
     const auto linVelSquared = GetMagnitudeSquared(velocity.linear);

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -297,7 +297,7 @@ inline Position2D GetNormalized(const Position2D& val) noexcept
 /// @param sweep Sweep to return with its angles normalized.
 /// @return Sweep with its pos0 angle to be between -2 pi and 2 pi
 ///    and its pos1 angle reduced by the amount pos0's angle was reduced by.
-/// @relatedalso Sweep
+/// @relatedalso Sweep2D
 inline Sweep2D GetNormalized(Sweep2D sweep) noexcept
 {
     const auto pos0a = GetNormalized(sweep.pos0.angular);

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -288,9 +288,9 @@ inline Angle GetNormalized(Angle value) noexcept
 /// @brief Gets the "normalized" position.
 /// @details Enforces a wrap-around of one rotation on the angular position.
 /// @note Use to prevent unbounded angles in positions.
-inline Position GetNormalized(const Position& val) noexcept
+inline Position2D GetNormalized(const Position2D& val) noexcept
 {
-    return Position{val.linear, GetNormalized(val.angular)};
+    return Position2D{val.linear, GetNormalized(val.angular)};
 }
 
 /// @brief Gets a sweep with the given sweeps's angles normalized.
@@ -814,7 +814,7 @@ PLAYRHO_CONSTEXPR inline Transformation GetTransformation(const Length2 ctr, con
 }
 
 /// @brief Gets the transformation for the given values.
-inline Transformation GetTransformation(const Position pos, const Length2 local_ctr) noexcept
+inline Transformation GetTransformation(const Position2D pos, const Length2 local_ctr) noexcept
 {
     assert(IsValid(pos));
     assert(IsValid(local_ctr));

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -26,12 +26,13 @@
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Vector2.hpp>
 
-namespace playrho
-{
+namespace playrho {
     
-    /// @brief Positional data structure.
+    /// @brief 2-D positional data structure.
+    /// @details A 2-element length and angle pair suitable for representing a linear and
+    ///   angular position in 2-D.
     /// @note This structure is likely to be 12-bytes large (at least on 64-bit platforms).
-    struct Position
+    struct Position2D
     {
         Length2 linear; ///< Linear position.
         Angle angular; ///< Angular position.
@@ -40,42 +41,42 @@ namespace playrho
     /// @brief Determines if the given value is valid.
     /// @relatedalso Position
     template <>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const Position& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Position2D& value) noexcept
     {
         return IsValid(value.linear) && IsValid(value.angular);
     }
     
     /// @brief Equality operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline bool operator==(const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator==(const Position2D& lhs, const Position2D& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline bool operator!=(const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!=(const Position2D& lhs, const Position2D& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Negation operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position operator- (const Position& value)
+    PLAYRHO_CONSTEXPR inline Position2D operator- (const Position2D& value)
     {
-        return Position{-value.linear, -value.angular};
+        return Position2D{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position operator+ (const Position& value)
+    PLAYRHO_CONSTEXPR inline Position2D operator+ (const Position2D& value)
     {
         return value;
     }
     
     /// @brief Addition assignment operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position& operator+= (Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position2D& operator+= (Position2D& lhs, const Position2D& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -84,14 +85,14 @@ namespace playrho
     
     /// @brief Addition operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position operator+ (const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position2D operator+ (const Position2D& lhs, const Position2D& rhs)
     {
-        return Position{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
+        return Position2D{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position& operator-= (Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position2D& operator-= (Position2D& lhs, const Position2D& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -100,22 +101,22 @@ namespace playrho
     
     /// @brief Subtraction operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position operator- (const Position& lhs, const Position& rhs)
+    PLAYRHO_CONSTEXPR inline Position2D operator- (const Position2D& lhs, const Position2D& rhs)
     {
-        return Position{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
+        return Position2D{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Multiplication operator.
-    PLAYRHO_CONSTEXPR inline Position operator* (const Position& pos, const Real scalar)
+    PLAYRHO_CONSTEXPR inline Position2D operator* (const Position2D& pos, const Real scalar)
     {
-        return Position{pos.linear * scalar, pos.angular * scalar};
+        return Position2D{pos.linear * scalar, pos.angular * scalar};
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position operator* (const Real scalar, const Position& pos)
+    PLAYRHO_CONSTEXPR inline Position2D operator* (const Real scalar, const Position2D& pos)
     {
-        return Position{pos.linear * scalar, pos.angular * scalar};
+        return Position2D{pos.linear * scalar, pos.angular * scalar};
     }
     
     /// Gets the position between two positions at a given unit interval.
@@ -125,7 +126,7 @@ namespace playrho
     /// @return pos0 if pos0 == pos1 or beta == 0, pos1 if beta == 1, or at the given
     ///   unit interval value between pos0 and pos1.
     /// @relatedalso Position
-    PLAYRHO_CONSTEXPR inline Position GetPosition(const Position pos0, const Position pos1,
+    PLAYRHO_CONSTEXPR inline Position2D GetPosition(const Position2D pos0, const Position2D pos1,
                                    const Real beta) noexcept
     {
         assert(IsValid(pos0));

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -39,7 +39,7 @@ namespace playrho {
     };
     
     /// @brief Determines if the given value is valid.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     template <>
     PLAYRHO_CONSTEXPR inline bool IsValid(const Position2D& value) noexcept
     {
@@ -47,35 +47,35 @@ namespace playrho {
     }
     
     /// @brief Equality operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline bool operator==(const Position2D& lhs, const Position2D& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline bool operator!=(const Position2D& lhs, const Position2D& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Negation operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D operator- (const Position2D& value)
     {
         return Position2D{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D operator+ (const Position2D& value)
     {
         return value;
     }
     
     /// @brief Addition assignment operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D& operator+= (Position2D& lhs, const Position2D& rhs)
     {
         lhs.linear += rhs.linear;
@@ -84,14 +84,14 @@ namespace playrho {
     }
     
     /// @brief Addition operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D operator+ (const Position2D& lhs, const Position2D& rhs)
     {
         return Position2D{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D& operator-= (Position2D& lhs, const Position2D& rhs)
     {
         lhs.linear -= rhs.linear;
@@ -100,7 +100,7 @@ namespace playrho {
     }
     
     /// @brief Subtraction operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D operator- (const Position2D& lhs, const Position2D& rhs)
     {
         return Position2D{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
@@ -113,7 +113,7 @@ namespace playrho {
     }
     
     /// @brief Multiplication operator.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D operator* (const Real scalar, const Position2D& pos)
     {
         return Position2D{pos.linear * scalar, pos.angular * scalar};
@@ -125,7 +125,7 @@ namespace playrho {
     /// @param beta Unit interval (value between 0 and 1) of travel between pos0 and pos1.
     /// @return pos0 if pos0 == pos1 or beta == 0, pos1 if beta == 1, or at the given
     ///   unit interval value between pos0 and pos1.
-    /// @relatedalso Position
+    /// @relatedalso Position2D
     PLAYRHO_CONSTEXPR inline Position2D GetPosition(const Position2D pos0, const Position2D pos1,
                                    const Real beta) noexcept
     {

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -29,7 +29,7 @@
 namespace playrho
 {
     
-    /// @brief Description of a "sweep" of motion.
+    /// @brief Description of a "sweep" of motion in 2-D space.
     ///
     /// @details This describes the motion of a body/shape for TOI computation.
     ///   Shapes are defined with respect to the body origin, which may
@@ -38,18 +38,18 @@ namespace playrho
     ///
     /// @note This data structure is likely 36-bytes (at least on 64-bit platforms).
     ///
-    class Sweep
+    class Sweep2D
     {
     public:
 
         /// @brief Default constructor.
-        Sweep() = default;
+        Sweep2D() = default;
         
         /// @brief Copy constructor.
-        PLAYRHO_CONSTEXPR inline Sweep(const Sweep& copy) = default;
+        PLAYRHO_CONSTEXPR inline Sweep2D(const Sweep2D& copy) = default;
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Sweep(const Position2D p0, const Position2D p1,
+        PLAYRHO_CONSTEXPR inline Sweep2D(const Position2D p0, const Position2D p1,
                         const Length2 lc = Length2{0_m, 0_m},
                         Real a0 = 0) noexcept:
         	pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
@@ -59,9 +59,9 @@ namespace playrho
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline explicit Sweep(const Position2D p,
+        PLAYRHO_CONSTEXPR inline explicit Sweep2D(const Position2D p,
                                  const Length2 lc = Length2{0_m, 0_m}):
-        	Sweep{p, p, lc, 0}
+        	Sweep2D{p, p, lc, 0}
         {
             // Intentionally empty.
         }
@@ -107,7 +107,7 @@ namespace playrho
         Real alpha0 = 0;
     };
     
-    inline void Sweep::Advance0(const Real alpha) noexcept
+    inline void Sweep2D::Advance0(const Real alpha) noexcept
     {
         assert(IsValid(alpha));
         assert(alpha >= 0);
@@ -119,7 +119,7 @@ namespace playrho
         alpha0 = alpha;
     }
     
-    inline void Sweep::ResetAlpha0() noexcept
+    inline void Sweep2D::ResetAlpha0() noexcept
     {
         alpha0 = 0;
     }
@@ -129,7 +129,7 @@ namespace playrho
     /// @brief Determines if the given value is valid.
     /// @relatedalso Transformation
     template <>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const Sweep& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Sweep2D& value) noexcept
     {
         return IsValid(value.pos0) && IsValid(value.pos1)
             && IsValid(value.GetLocalCenter()) && IsValid(value.GetAlpha0());

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -49,7 +49,7 @@ namespace playrho
         PLAYRHO_CONSTEXPR inline Sweep(const Sweep& copy) = default;
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Sweep(const Position p0, const Position p1,
+        PLAYRHO_CONSTEXPR inline Sweep(const Position2D p0, const Position2D p1,
                         const Length2 lc = Length2{0_m, 0_m},
                         Real a0 = 0) noexcept:
         	pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
@@ -59,7 +59,7 @@ namespace playrho
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline explicit Sweep(const Position p,
+        PLAYRHO_CONSTEXPR inline explicit Sweep(const Position2D p,
                                  const Length2 lc = Length2{0_m, 0_m}):
         	Sweep{p, p, lc, 0}
         {
@@ -91,10 +91,10 @@ namespace playrho
         void ResetAlpha0() noexcept;
         
         /// @brief Center world position and world angle at time "0".
-        Position pos0;
+        Position2D pos0;
 
         /// @brief Center world position and world angle at time "1".
-        Position pos1;
+        Position2D pos1;
         
     private:
         /// @brief Local center of mass position.

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -127,7 +127,7 @@ namespace playrho
     // Free functions...
     
     /// @brief Determines if the given value is valid.
-    /// @relatedalso Transformation
+    /// @relatedalso Transformation2D
     template <>
     PLAYRHO_CONSTEXPR inline bool IsValid(const Sweep2D& value) noexcept
     {

--- a/PlayRho/Common/Transformation.hpp
+++ b/PlayRho/Common/Transformation.hpp
@@ -29,8 +29,7 @@
 /// @file
 /// Definition of the Transformation class and free functions directly associated with it.
 
-namespace playrho
-{
+namespace playrho {
     
     /// @brief Describes a geometric transformation.
     /// @details A transform contains translation and rotation. It is used to represent
@@ -38,33 +37,33 @@ namespace playrho
     /// @note The default transformation is the identity transformation - the transformation
     ///   which neither translates nor rotates a location.
     /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
-    struct Transformation
+    struct Transformation2D
     {
         Length2 p = Length2{}; ///< Translational portion of the transformation. 8-bytes.
         UnitVec2 q = UnitVec2::GetRight(); ///< Rotational portion of the transformation. 8-bytes.
     };
     
     /// @brief Identity transformation value.
-    PLAYRHO_CONSTEXPR const auto Transform_identity = Transformation{Length2{0_m, 0_m}, UnitVec2::GetRight()};
+    PLAYRHO_CONSTEXPR const auto Transform_identity = Transformation2D{Length2{0_m, 0_m}, UnitVec2::GetRight()};
     
     /// @brief Determines if the given value is valid.
-    /// @relatedalso Transformation
+    /// @relatedalso Transformation2D
     template <>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const Transformation& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Transformation2D& value) noexcept
     {
         return IsValid(value.p) && IsValid(value.q);
     }
     
     /// @brief Equality operator.
-    /// @relatedalso Transformation
-    PLAYRHO_CONSTEXPR inline bool operator== (Transformation lhs, Transformation rhs) noexcept
+    /// @relatedalso Transformation2D
+    PLAYRHO_CONSTEXPR inline bool operator== (Transformation2D lhs, Transformation2D rhs) noexcept
     {
         return (lhs.p == rhs.p) && (lhs.q == rhs.q);
     }
     
     /// @brief Inequality operator.
-    /// @relatedalso Transformation
-    PLAYRHO_CONSTEXPR inline bool operator!= (Transformation lhs, Transformation rhs) noexcept
+    /// @relatedalso Transformation2D
+    PLAYRHO_CONSTEXPR inline bool operator!= (Transformation2D lhs, Transformation2D rhs) noexcept
     {
         return (lhs.p != rhs.p) || (lhs.q != rhs.q);
     }

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -37,7 +37,7 @@ namespace playrho
     };
     
     /// @brief Determines if the given value is valid.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     template <>
     PLAYRHO_CONSTEXPR inline bool IsValid(const Velocity2D& value) noexcept
     {
@@ -45,21 +45,21 @@ namespace playrho
     }
     
     /// @brief Equality operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline bool operator==(const Velocity2D& lhs, const Velocity2D& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline bool operator!=(const Velocity2D& lhs, const Velocity2D& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Multiplication assignment operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D& operator*= (Velocity2D& lhs, const Real rhs)
     {
         lhs.linear *= rhs;
@@ -68,7 +68,7 @@ namespace playrho
     }
     
     /// @brief Division assignment operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D& operator/= (Velocity2D& lhs, const Real rhs)
     {
         lhs.linear /= rhs;
@@ -77,7 +77,7 @@ namespace playrho
     }
     
     /// @brief Addition assignment operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D& operator+= (Velocity2D& lhs, const Velocity2D& rhs)
     {
         lhs.linear += rhs.linear;
@@ -86,14 +86,14 @@ namespace playrho
     }
     
     /// @brief Addition operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D operator+ (const Velocity2D& lhs, const Velocity2D& rhs)
     {
         return Velocity2D{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D& operator-= (Velocity2D& lhs, const Velocity2D& rhs)
     {
         lhs.linear -= rhs.linear;
@@ -102,42 +102,42 @@ namespace playrho
     }
     
     /// @brief Subtraction operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D operator- (const Velocity2D& lhs, const Velocity2D& rhs)
     {
         return Velocity2D{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Negation operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D operator- (const Velocity2D& value)
     {
         return Velocity2D{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D operator+ (const Velocity2D& value)
     {
         return value;
     }
     
     /// @brief Multiplication operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D operator* (const Velocity2D& lhs, const Real rhs)
     {
         return Velocity2D{lhs.linear * rhs, lhs.angular * rhs};
     }
     
     /// @brief Multiplication operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D operator* (const Real lhs, const Velocity2D& rhs)
     {
         return Velocity2D{rhs.linear * lhs, rhs.angular * lhs};
     }
     
     /// @brief Division operator.
-    /// @relatedalso Velocity
+    /// @relatedalso Velocity2D
     PLAYRHO_CONSTEXPR inline Velocity2D operator/ (const Velocity2D& lhs, const Real rhs)
     {
         /*

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -28,9 +28,9 @@
 
 namespace playrho
 {
-    /// @brief Velocity related data structure.
+    /// @brief 2-D velocity related data structure.
     /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
-    struct Velocity
+    struct Velocity2D
     {
         LinearVelocity2 linear; ///< Linear velocity.
         AngularVelocity angular; ///< Angular velocity.
@@ -39,28 +39,28 @@ namespace playrho
     /// @brief Determines if the given value is valid.
     /// @relatedalso Velocity
     template <>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const Velocity& value) noexcept
+    PLAYRHO_CONSTEXPR inline bool IsValid(const Velocity2D& value) noexcept
     {
         return IsValid(value.linear) && IsValid(value.angular);
     }
     
     /// @brief Equality operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline bool operator==(const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator==(const Velocity2D& lhs, const Velocity2D& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline bool operator!=(const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline bool operator!=(const Velocity2D& lhs, const Velocity2D& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Multiplication assignment operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity& operator*= (Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D& operator*= (Velocity2D& lhs, const Real rhs)
     {
         lhs.linear *= rhs;
         lhs.angular *= rhs;
@@ -69,7 +69,7 @@ namespace playrho
     
     /// @brief Division assignment operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity& operator/= (Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D& operator/= (Velocity2D& lhs, const Real rhs)
     {
         lhs.linear /= rhs;
         lhs.angular /= rhs;
@@ -78,7 +78,7 @@ namespace playrho
     
     /// @brief Addition assignment operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D& operator+= (Velocity2D& lhs, const Velocity2D& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -87,14 +87,14 @@ namespace playrho
     
     /// @brief Addition operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D operator+ (const Velocity2D& lhs, const Velocity2D& rhs)
     {
-        return Velocity{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
+        return Velocity2D{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D& operator-= (Velocity2D& lhs, const Velocity2D& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -103,42 +103,42 @@ namespace playrho
     
     /// @brief Subtraction operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity operator- (const Velocity& lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D operator- (const Velocity2D& lhs, const Velocity2D& rhs)
     {
-        return Velocity{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
+        return Velocity2D{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Negation operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity operator- (const Velocity& value)
+    PLAYRHO_CONSTEXPR inline Velocity2D operator- (const Velocity2D& value)
     {
-        return Velocity{-value.linear, -value.angular};
+        return Velocity2D{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity operator+ (const Velocity& value)
+    PLAYRHO_CONSTEXPR inline Velocity2D operator+ (const Velocity2D& value)
     {
         return value;
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity operator* (const Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D operator* (const Velocity2D& lhs, const Real rhs)
     {
-        return Velocity{lhs.linear * rhs, lhs.angular * rhs};
+        return Velocity2D{lhs.linear * rhs, lhs.angular * rhs};
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity operator* (const Real lhs, const Velocity& rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D operator* (const Real lhs, const Velocity2D& rhs)
     {
-        return Velocity{rhs.linear * lhs, rhs.angular * lhs};
+        return Velocity2D{rhs.linear * lhs, rhs.angular * lhs};
     }
     
     /// @brief Division operator.
     /// @relatedalso Velocity
-    PLAYRHO_CONSTEXPR inline Velocity operator/ (const Velocity& lhs, const Real rhs)
+    PLAYRHO_CONSTEXPR inline Velocity2D operator/ (const Velocity2D& lhs, const Real rhs)
     {
         /*
          * While it can be argued that division operations shouldn't be supported due to
@@ -150,11 +150,11 @@ namespace playrho
          * on down to the Vec2 and Angle types (rather than manually rewriting the divisions
          * as multiplications).
          */
-        return Velocity{lhs.linear / rhs, lhs.angular / rhs};
+        return Velocity2D{lhs.linear / rhs, lhs.angular / rhs};
     }
     
     /// @brief Velocity pair.
-    using VelocityPair = std::pair<Velocity, Velocity>;
+    using VelocityPair = std::pair<Velocity2D, Velocity2D>;
     
 } // namespace playrho
 

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -184,7 +184,7 @@ void Body::ResetMassData()
     UnsetMassDataDirty();
 }
 
-void Body::SetMassData(const MassData& massData)
+void Body::SetMassData(const MassData2D& massData)
 {
     if (m_world->IsLocked())
     {

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -94,7 +94,7 @@ Body::Body(World* world, const BodyDef& bd):
     assert(IsValid(bd.angularVelocity));
     assert(IsValid(m_xf));
 
-    SetVelocity(Velocity{bd.linearVelocity, bd.angularVelocity});
+    SetVelocity(Velocity2D{bd.linearVelocity, bd.angularVelocity});
     SetAcceleration(bd.linearAcceleration, bd.angularAcceleration);
     SetUnderActiveTime(bd.underActiveTime);
 }
@@ -227,7 +227,7 @@ void Body::SetMassData(const MassData& massData)
     UnsetMassDataDirty();
 }
 
-void Body::SetVelocity(const Velocity& velocity) noexcept
+void Body::SetVelocity(const Velocity2D& velocity) noexcept
 {
     if ((velocity.linear != LinearVelocity2{}) || (velocity.angular != 0_rpm))
     {
@@ -438,7 +438,7 @@ BodyCounter GetWorldIndex(const Body* body) noexcept
     return BodyCounter(-1);
 }
 
-Velocity GetVelocity(const Body& body, Time h, MovementConf conf) noexcept
+Velocity2D GetVelocity(const Body& body, Time h, MovementConf conf) noexcept
 {
     // Integrate velocity and apply damping.
     auto velocity = body.GetVelocity();

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -80,7 +80,7 @@ Body::FlagsType Body::GetFlags(const BodyDef& bd) noexcept
 
 Body::Body(World* world, const BodyDef& bd):
     m_xf{bd.location, UnitVec2::Get(bd.angle)},
-    m_sweep{Position{bd.location, bd.angle}},
+    m_sweep{Position2D{bd.location, bd.angle}},
     m_flags{GetFlags(bd)},
     m_world{world},
     m_userData{bd.userData},
@@ -145,7 +145,7 @@ void Body::ResetMassData()
     {
         m_invMass = 0;
         m_invRotI = 0;
-        m_sweep = Sweep{Position{GetLocation(), GetAngle()}};
+        m_sweep = Sweep{Position2D{GetLocation(), GetAngle()}};
         UnsetMassDataDirty();
         return;
     }
@@ -174,7 +174,7 @@ void Body::ResetMassData()
 
     // Move center of mass.
     const auto oldCenter = GetWorldCenter();
-    m_sweep = Sweep{Position{Transform(localCenter, GetTransformation()), GetAngle()}, localCenter};
+    m_sweep = Sweep{Position2D{Transform(localCenter, GetTransformation()), GetAngle()}, localCenter};
     const auto newCenter = GetWorldCenter();
 
     // Update center of mass velocity.
@@ -215,7 +215,7 @@ void Body::SetMassData(const MassData& massData)
     // Move center of mass.
     const auto oldCenter = GetWorldCenter();
     m_sweep = Sweep{
-        Position{Transform(massData.center, GetTransformation()), GetAngle()},
+        Position2D{Transform(massData.center, GetTransformation()), GetAngle()},
         massData.center
     };
 
@@ -284,7 +284,7 @@ void Body::SetTransform(Length2 location, Angle angle)
     const auto xfm = Transformation{location, UnitVec2::Get(angle)};
     SetTransformation(xfm);
 
-    m_sweep = Sweep{Position{Transform(GetLocalCenter(), xfm), angle}, GetLocalCenter()};
+    m_sweep = Sweep{Position2D{Transform(GetLocalCenter(), xfm), angle}, GetLocalCenter()};
     
     GetWorld()->RegisterForProxies(this);
 }

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -145,7 +145,7 @@ void Body::ResetMassData()
     {
         m_invMass = 0;
         m_invRotI = 0;
-        m_sweep = Sweep{Position2D{GetLocation(), GetAngle()}};
+        m_sweep = Sweep2D{Position2D{GetLocation(), GetAngle()}};
         UnsetMassDataDirty();
         return;
     }
@@ -174,7 +174,7 @@ void Body::ResetMassData()
 
     // Move center of mass.
     const auto oldCenter = GetWorldCenter();
-    m_sweep = Sweep{Position2D{Transform(localCenter, GetTransformation()), GetAngle()}, localCenter};
+    m_sweep = Sweep2D{Position2D{Transform(localCenter, GetTransformation()), GetAngle()}, localCenter};
     const auto newCenter = GetWorldCenter();
 
     // Update center of mass velocity.
@@ -214,7 +214,7 @@ void Body::SetMassData(const MassData& massData)
 
     // Move center of mass.
     const auto oldCenter = GetWorldCenter();
-    m_sweep = Sweep{
+    m_sweep = Sweep2D{
         Position2D{Transform(massData.center, GetTransformation()), GetAngle()},
         massData.center
     };
@@ -284,7 +284,7 @@ void Body::SetTransform(Length2 location, Angle angle)
     const auto xfm = Transformation{location, UnitVec2::Get(angle)};
     SetTransformation(xfm);
 
-    m_sweep = Sweep{Position2D{Transform(GetLocalCenter(), xfm), angle}, GetLocalCenter()};
+    m_sweep = Sweep2D{Position2D{Transform(GetLocalCenter(), xfm), angle}, GetLocalCenter()};
     
     GetWorld()->RegisterForProxies(this);
 }

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -521,7 +521,7 @@ Force2 GetCentripetalForce(const Body& body, Length2 axis)
     return Force2{dir * mass * Square(magnitudeOfVelocity) / radius};
 }
 
-Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
+Acceleration2D CalcGravitationalAcceleration(const Body& body) noexcept
 {
     const auto m1 = GetMass(body);
     if (m1 != 0_kg)
@@ -546,9 +546,9 @@ Acceleration CalcGravitationalAcceleration(const Body& body) noexcept
             sumForce += f * dir;
         }
         // F = m a... i.e.  a = F / m.
-        return Acceleration{sumForce / m1, 0 * RadianPerSquareSecond};
+        return Acceleration2D{sumForce / m1, 0 * RadianPerSquareSecond};
     }
-    return Acceleration{};
+    return Acceleration2D{};
 }
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -259,7 +259,7 @@ void Body::SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angul
     m_angularAcceleration = angular;
 }
 
-void Body::SetTransformation(Transformation value) noexcept
+void Body::SetTransformation(Transformation2D value) noexcept
 {
     assert(IsValid(value));
     if (m_xf != value)
@@ -281,7 +281,7 @@ void Body::SetTransform(Length2 location, Angle angle)
         throw WrongState("Body::SetTransform: world is locked");
     }
 
-    const auto xfm = Transformation{location, UnitVec2::Get(angle)};
+    const auto xfm = Transformation2D{location, UnitVec2::Get(angle)};
     SetTransformation(xfm);
 
     m_sweep = Sweep2D{Position2D{Transform(GetLocalCenter(), xfm), angle}, GetLocalCenter()};

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -33,6 +33,7 @@
 #include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
 #include <PlayRho/Dynamics/Joints/JointKey.hpp>
 #include <PlayRho/Dynamics/MovementConf.hpp>
+#include <PlayRho/Collision/MassData.hpp>
 
 #include <vector>
 #include <memory>
@@ -46,7 +47,6 @@ class World;
 struct FixtureDef;
 class Shape;
 struct BodyDef;
-struct MassData;
 
 /// @brief Physical entity that exists within a World.
 ///
@@ -277,7 +277,7 @@ public:
     /// @note Creating or destroying fixtures can also alter the mass.
     /// @note This function has no effect if the body isn't dynamic.
     /// @param massData the mass properties.
-    void SetMassData(const MassData& massData);
+    void SetMassData(const MassData2D& massData);
 
     /// @brief Resets the mass data properties.
     /// @details This resets the mass data to the sum of the mass properties of the fixtures.

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -221,7 +221,7 @@ public:
     Length2 GetLocation() const noexcept;
 
     /// @brief Gets the body's sweep.
-    const Sweep& GetSweep() const noexcept;
+    const Sweep2D& GetSweep() const noexcept;
 
     /// @brief Get the angle.
     /// @return the current world rotation angle.
@@ -510,7 +510,7 @@ private:
     /// This is essentially the cached result of <code>GetTransform1(m_sweep)</code>. 16-bytes.
     Transformation m_xf;
 
-    Sweep m_sweep; ///< Sweep motion for CCD. 36-bytes.
+    Sweep2D m_sweep; ///< Sweep motion for CCD. 36-bytes.
 
     Velocity2D m_velocity; ///< Velocity (linear and angular). 12-bytes.
     FlagsType m_flags = 0; ///< Flags. 2-bytes.
@@ -584,7 +584,7 @@ inline Length2 Body::GetLocation() const noexcept
     return GetTransformation().p;
 }
 
-inline const Sweep& Body::GetSweep() const noexcept
+inline const Sweep2D& Body::GetSweep() const noexcept
 {
     return m_sweep;
 }

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -913,7 +913,7 @@ bool ShouldCollide(const Body& lhs, const Body& rhs) noexcept;
 
 /// @brief Gets the "position 1" Position information for the given body.
 /// @relatedalso Body
-inline Position GetPosition1(const Body& body) noexcept
+inline Position2D GetPosition1(const Body& body) noexcept
 {
     return body.GetSweep().pos1;
 }

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -234,13 +234,13 @@ public:
     Length2 GetLocalCenter() const noexcept;
 
     /// @brief Gets the velocity.
-    Velocity GetVelocity() const noexcept;
+    Velocity2D GetVelocity() const noexcept;
 
     /// @brief Sets the body's velocity (linear and angular velocity).
     /// @note This method does nothing if this body is not speedable.
     /// @note A non-zero velocity will awaken this body.
     /// @sa SetAwake, SetUnderActiveTime.
-    void SetVelocity(const Velocity& velocity) noexcept;
+    void SetVelocity(const Velocity2D& velocity) noexcept;
 
     /// @brief Sets the linear and rotational accelerations on this body.
     /// @note This has no effect on non-accelerable bodies.
@@ -512,7 +512,7 @@ private:
 
     Sweep m_sweep; ///< Sweep motion for CCD. 36-bytes.
 
-    Velocity m_velocity; ///< Velocity (linear and angular). 12-bytes.
+    Velocity2D m_velocity; ///< Velocity (linear and angular). 12-bytes.
     FlagsType m_flags = 0; ///< Flags. 2-bytes.
 
     /// @brief Linear acceleration.
@@ -604,7 +604,7 @@ inline Length2 Body::GetLocalCenter() const noexcept
     return GetSweep().GetLocalCenter();
 }
 
-inline Velocity Body::GetVelocity() const noexcept
+inline Velocity2D Body::GetVelocity() const noexcept
 {
     return m_velocity;
 }
@@ -687,7 +687,7 @@ inline void Body::UnsetAwake() noexcept
     {
         UnsetAwakeFlag();
         m_underActiveTime = 0;
-        m_velocity = Velocity{LinearVelocity2{}, 0_rpm};
+        m_velocity = Velocity2D{LinearVelocity2{}, 0_rpm};
     }
 }
 
@@ -1097,7 +1097,7 @@ inline AngularVelocity GetAngularVelocity(const Body& body) noexcept
 /// @relatedalso Body
 inline void SetLinearVelocity(Body& body, const LinearVelocity2 v) noexcept
 {
-    body.SetVelocity(Velocity{v, GetAngularVelocity(body)});
+    body.SetVelocity(Velocity2D{v, GetAngularVelocity(body)});
 }
 
 /// @brief Sets the angular velocity.
@@ -1106,7 +1106,7 @@ inline void SetLinearVelocity(Body& body, const LinearVelocity2 v) noexcept
 /// @relatedalso Body
 inline void SetAngularVelocity(Body& body, AngularVelocity omega) noexcept
 {
-    body.SetVelocity(Velocity{GetLinearVelocity(body), omega});
+    body.SetVelocity(Velocity2D{GetLinearVelocity(body), omega});
 }
 
 /// @brief Gets the world coordinates of a point given in coordinates relative to the body's origin.
@@ -1203,7 +1203,7 @@ inline Torque GetTorque(const Body& body) noexcept
 /// @param h Time elapsed to get velocity for. Behavior is undefined if this value is invalid.
 /// @param conf Movement configuration. This defines caps on linear and angular speeds.
 /// @relatedalso Body
-Velocity GetVelocity(const Body& body, Time h, MovementConf conf) noexcept;
+Velocity2D GetVelocity(const Body& body, Time h, MovementConf conf) noexcept;
 
 /// @brief Gets the world index for the given body.
 /// @relatedalso Body

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -859,18 +859,18 @@ inline void Body::UnsetIslandedFlag() noexcept
 /// @brief Gets the given body's acceleration.
 /// @param body Body whose acceleration should be returned.
 /// @relatedalso Body
-inline Acceleration GetAcceleration(const Body& body) noexcept
+inline Acceleration2D GetAcceleration(const Body& body) noexcept
 {
-    return Acceleration{body.GetLinearAcceleration(), body.GetAngularAcceleration()};
+    return Acceleration2D{body.GetLinearAcceleration(), body.GetAngularAcceleration()};
 }
 
 /// @brief Sets the accelerations on the given body.
 /// @note This has no effect on non-accelerable bodies.
 /// @note A non-zero acceleration will also awaken the body.
 /// @param body Body whose acceleration should be set.
-/// @param value Acceleration value to set.
+/// @param value Acceleration2D value to set.
 /// @relatedalso Body
-inline void SetAcceleration(Body& body, Acceleration value) noexcept
+inline void SetAcceleration(Body& body, Acceleration2D value) noexcept
 {
     body.SetAcceleration(value.linear, value.angular);
 }
@@ -880,7 +880,7 @@ inline void SetAcceleration(Body& body, Acceleration value) noexcept
 /// @relatedalso Body
 /// @return Zero acceleration if given body is has no mass, else the acceleration of
 ///    the body due to the gravitational attraction to the other bodies.
-Acceleration CalcGravitationalAcceleration(const Body& body) noexcept;
+Acceleration2D CalcGravitationalAcceleration(const Body& body) noexcept;
     
 /// @brief Awakens the body if it's asleep.
 /// @relatedalso Body

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -205,7 +205,7 @@ public:
     /// @brief Gets the body transform for the body's origin.
     /// @return the world transform of the body's origin.
     /// @sa GetLocation.
-    Transformation GetTransformation() const noexcept;
+    Transformation2D GetTransformation() const noexcept;
 
     /// @brief Gets the world body origin location.
     /// @details This is the location of the body's origin relative to its world.
@@ -499,7 +499,7 @@ private:
     ///   method updates the current transformation and flags each associated contact
     ///   for updating.
     /// @warning Behavior is undefined if value is invalid.
-    void SetTransformation(Transformation value) noexcept;
+    void SetTransformation(Transformation2D value) noexcept;
 
     //
     // Member variables. Try to keep total size small.
@@ -508,7 +508,7 @@ private:
     /// Transformation for body origin.
     /// @details
     /// This is essentially the cached result of <code>GetTransform1(m_sweep)</code>. 16-bytes.
-    Transformation m_xf;
+    Transformation2D m_xf;
 
     Sweep2D m_sweep; ///< Sweep motion for CCD. 36-bytes.
 
@@ -574,7 +574,7 @@ inline BodyType Body::GetType() const noexcept
     return BodyType::Static;
 }
 
-inline Transformation Body::GetTransformation() const noexcept
+inline Transformation2D Body::GetTransformation() const noexcept
 {
     return m_xf;
 }

--- a/PlayRho/Dynamics/BodyAtty.hpp
+++ b/PlayRho/Dynamics/BodyAtty.hpp
@@ -97,7 +97,7 @@ private:
             case BodyType::Static:
                 b.UnsetAwakeFlag();
                 b.m_underActiveTime = 0;
-                b.m_velocity = Velocity{LinearVelocity2{}, 0_rpm};
+                b.m_velocity = Velocity2D{LinearVelocity2{}, 0_rpm};
                 b.m_sweep.pos0 = b.m_sweep.pos1;
                 break;
         }
@@ -198,7 +198,7 @@ private:
     
     /// Sets the body's velocity.
     /// @note This sets what Body::GetVelocity returns.
-    static void SetVelocity(Body& b, Velocity value) noexcept
+    static void SetVelocity(Body& b, Velocity2D value) noexcept
     {
         b.m_velocity = value;
     }

--- a/PlayRho/Dynamics/BodyAtty.hpp
+++ b/PlayRho/Dynamics/BodyAtty.hpp
@@ -183,7 +183,7 @@ private:
     }
     
     /// @brief Sets the sweep value of the given body.
-    static void SetSweep(Body& b, const Sweep value) noexcept
+    static void SetSweep(Body& b, const Sweep2D value) noexcept
     {
         assert(b.IsSpeedable() || value.pos0 == value.pos1);
         b.m_sweep = value;
@@ -224,7 +224,7 @@ private:
     }
     
     /// @brief Restores the given body's sweep to the given sweep value.
-    static void Restore(Body& b, const Sweep value) noexcept
+    static void Restore(Body& b, const Sweep2D value) noexcept
     {
         BodyAtty::SetSweep(b, value);
         BodyAtty::SetTransformation(b, GetTransform1(value));

--- a/PlayRho/Dynamics/BodyAtty.hpp
+++ b/PlayRho/Dynamics/BodyAtty.hpp
@@ -191,7 +191,7 @@ private:
     
     /// Sets the body's transformation.
     /// @note This sets what Body::GetLocation returns.
-    static void SetTransformation(Body& b, const Transformation value) noexcept
+    static void SetTransformation(Body& b, const Transformation2D value) noexcept
     {
         b.SetTransformation(value);
     }

--- a/PlayRho/Dynamics/BodyAtty.hpp
+++ b/PlayRho/Dynamics/BodyAtty.hpp
@@ -162,7 +162,7 @@ private:
     }
     
     /// @brief Sets the position0 value of the given body to the given position.
-    static void SetPosition0(Body& b, const Position value) noexcept
+    static void SetPosition0(Body& b, const Position2D value) noexcept
     {
         assert(b.IsSpeedable() || b.m_sweep.pos0 == value);
         b.m_sweep.pos0 = value;
@@ -170,7 +170,7 @@ private:
     
     /// Sets the body sweep's position 1 value.
     /// @note This sets what Body::GetWorldCenter returns.
-    static void SetPosition1(Body& b, const Position value) noexcept
+    static void SetPosition1(Body& b, const Position2D value) noexcept
     {
         assert(b.IsSpeedable() || b.m_sweep.pos1 == value);
         b.m_sweep.pos1 = value;

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -43,7 +43,7 @@ namespace playrho {
         
         /// @brief Initializing constructor.
         PLAYRHO_CONSTEXPR inline BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
-                                 Position2D position, Velocity velocity) noexcept:
+                                 Position2D position, Velocity2D velocity) noexcept:
             m_position{position},
             m_velocity{velocity},
             m_localCenter{localCenter},
@@ -72,7 +72,7 @@ namespace playrho {
         Position2D GetPosition() const noexcept;
         
         /// @brief Gets the velocity of the body.
-        Velocity GetVelocity() const noexcept;
+        Velocity2D GetVelocity() const noexcept;
         
         /// @brief Sets the position of the body.
         /// @param value A valid position value to set for the represented body.
@@ -82,11 +82,11 @@ namespace playrho {
         /// @brief Sets the velocity of the body.
         /// @param value A valid velocity value to set for the represented body.
         /// @warning Behavior is undefined if the given value is not valid.
-        BodyConstraint& SetVelocity(Velocity value) noexcept;
+        BodyConstraint& SetVelocity(Velocity2D value) noexcept;
         
     private:
         Position2D m_position; ///< Body position data.
-        Velocity m_velocity; ///< Body velocity data.
+        Velocity2D m_velocity; ///< Body velocity data.
         Length2 m_localCenter; ///< Local center of the associated body's sweep.
         InvMass m_invMass; ///< Inverse mass of associated body (a non-negative value).
 
@@ -115,7 +115,7 @@ namespace playrho {
         return m_position;
     }
     
-    inline Velocity BodyConstraint::GetVelocity() const noexcept
+    inline Velocity2D BodyConstraint::GetVelocity() const noexcept
     {
         return m_velocity;
     }
@@ -127,7 +127,7 @@ namespace playrho {
         return *this;
     }
     
-    inline BodyConstraint& BodyConstraint::SetVelocity(Velocity value) noexcept
+    inline BodyConstraint& BodyConstraint::SetVelocity(Velocity2D value) noexcept
     {
         assert(IsValid(value));
         m_velocity = value;

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -43,7 +43,7 @@ namespace playrho {
         
         /// @brief Initializing constructor.
         PLAYRHO_CONSTEXPR inline BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
-                                 Position position, Velocity velocity) noexcept:
+                                 Position2D position, Velocity velocity) noexcept:
             m_position{position},
             m_velocity{velocity},
             m_localCenter{localCenter},
@@ -69,7 +69,7 @@ namespace playrho {
         Length2 GetLocalCenter() const noexcept;
         
         /// @brief Gets the position of the body.
-        Position GetPosition() const noexcept;
+        Position2D GetPosition() const noexcept;
         
         /// @brief Gets the velocity of the body.
         Velocity GetVelocity() const noexcept;
@@ -77,7 +77,7 @@ namespace playrho {
         /// @brief Sets the position of the body.
         /// @param value A valid position value to set for the represented body.
         /// @warning Behavior is undefined if the given value is not valid.
-        BodyConstraint& SetPosition(Position value) noexcept;
+        BodyConstraint& SetPosition(Position2D value) noexcept;
         
         /// @brief Sets the velocity of the body.
         /// @param value A valid velocity value to set for the represented body.
@@ -85,7 +85,7 @@ namespace playrho {
         BodyConstraint& SetVelocity(Velocity value) noexcept;
         
     private:
-        Position m_position; ///< Body position data.
+        Position2D m_position; ///< Body position data.
         Velocity m_velocity; ///< Body velocity data.
         Length2 m_localCenter; ///< Local center of the associated body's sweep.
         InvMass m_invMass; ///< Inverse mass of associated body (a non-negative value).
@@ -110,7 +110,7 @@ namespace playrho {
         return m_localCenter;
     }
     
-    inline Position BodyConstraint::GetPosition() const noexcept
+    inline Position2D BodyConstraint::GetPosition() const noexcept
     {
         return m_position;
     }
@@ -120,7 +120,7 @@ namespace playrho {
         return m_velocity;
     }
     
-    inline BodyConstraint& BodyConstraint::SetPosition(Position value) noexcept
+    inline BodyConstraint& BodyConstraint::SetPosition(Position2D value) noexcept
     {
         assert(IsValid(value));
         m_position = value;

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -47,10 +47,10 @@ static PLAYRHO_CONSTEXPR inline auto k_errorTol = 1e-3_mps; ///< error tolerance
 /// This describes the change in impulse necessary for a solution.
 /// To apply this: let P = magnitude * direction, then
 ///   the change to body A's velocity is
-///   -Velocity{vc.GetBodyA()->GetInvMass() * P,
+///   -Velocity2D{vc.GetBodyA()->GetInvMass() * P,
 ///       Radian * vc.GetBodyA()->GetInvRotInertia() * Cross(vcp.relA, P)}
 ///   the change to body B's velocity is
-///   +Velocity{vc.GetBodyB()->GetInvMass() * P,
+///   +Velocity2D{vc.GetBodyB()->GetInvMass() * P,
 ///       Radian * vc.GetBodyB()->GetInvRotInertia() * Cross(vcp.relB, P)}
 ///   and the new impulse = oldImpulse + magnitude.
 ///
@@ -85,8 +85,8 @@ VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impu
         (Cross(GetPointRelPosB(vc, 0), P0) + Cross(GetPointRelPosB(vc, 1), P1)) / Radian
     };
     return VelocityPair{
-        -Velocity{invMassA * P, invRotInertiaA * LA},
-        +Velocity{invMassB * P, invRotInertiaB * LB}
+        -Velocity2D{invMassA * P, invRotInertiaA * LA},
+        +Velocity2D{invMassB * P, invRotInertiaB * LB}
     };
 }
 
@@ -352,8 +352,8 @@ inline Momentum SeqSolveNormalConstraint(VelocityConstraint& vc)
         const auto P = incImpulse * direction;
         const auto LA = AngularMomentum{Cross(vcp.relA, P) / Radian};
         const auto LB = AngularMomentum{Cross(vcp.relB, P) / Radian};
-        newVelA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        newVelB += Velocity{invMassB * P, invRotInertiaB * LB};
+        newVelA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        newVelB += Velocity2D{invMassB * P, invRotInertiaB * LB};
         maxIncImpulse = std::max(maxIncImpulse, Abs(incImpulse));
 
         // Note: using newImpulse, instead of oldImpulse + incImpulse, results in
@@ -412,8 +412,8 @@ inline Momentum SolveTangentConstraint(VelocityConstraint& vc)
         const auto P = incImpulse * direction;
         const auto LA = AngularMomentum{Cross(vcp.relA, P) / Radian};
         const auto LB = AngularMomentum{Cross(vcp.relB, P) / Radian};
-        newVelA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        newVelB += Velocity{invMassB * P, invRotInertiaB * LB};
+        newVelA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        newVelB += Velocity2D{invMassB * P, invRotInertiaB * LB};
         maxIncImpulse = std::max(maxIncImpulse, Abs(incImpulse));
         
         // Note: using newImpulse, instead of oldImpulse + incImpulse, results in

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -530,8 +530,8 @@ PositionSolution SolvePositionConstraint(const PositionConstraint& pc,
         // Product of InvMass * P is: L
         // Product of InvRotInertia * L{A,B} is: QP
         return PositionSolution{
-            -Position{invMassA * P, invRotInertiaA * LA},
-            +Position{invMassB * P, invRotInertiaB * LB},
+            -Position2D{invMassA * P, invRotInertiaA * LA},
+            +Position2D{invMassB * P, invRotInertiaB * LB},
             separation
         };
     };

--- a/PlayRho/Dynamics/Contacts/ContactSolver.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.hpp
@@ -31,8 +31,8 @@ namespace playrho {
     /// @brief Solution for position constraint.
     struct PositionSolution
     {
-        Position pos_a; ///< Position A.
-        Position pos_b; ///< Position B.
+        Position2D pos_a; ///< Position A.
+        Position2D pos_b; ///< Position B.
         Length min_separation; ///< Min separation.
     };
 

--- a/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
+++ b/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
@@ -30,8 +30,8 @@ namespace {
 /// @param plp Point's local point. Location of shape B in local coordinates.
 /// @note The returned separation is the magnitude of the positional difference of the two points.
 ///   This is always a non-negative amount.
-inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2 lp,
-                                            const Transformation& xfB, Length2 plp)
+inline PositionSolverManifold GetForCircles(const Transformation2D& xfA, Length2 lp,
+                                            const Transformation2D& xfB, Length2 plp)
 {
     const auto pointA = Transform(lp, xfA);
     const auto pointB = Transform(plp, xfB);
@@ -51,8 +51,8 @@ inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2 l
 /// @param plp Point's local point. Location for shape B in local coordinates.
 /// @return Separation is the dot-product of the positional difference between the two points in
 ///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2 lp, UnitVec2 ln,
-                                          const Transformation& xfB, Length2 plp)
+inline PositionSolverManifold GetForFaceA(const Transformation2D& xfA, Length2 lp, UnitVec2 ln,
+                                          const Transformation2D& xfB, Length2 plp)
 {
     const auto planePoint = Transform(lp, xfA);
     const auto normal = Rotate(ln, xfA.q);
@@ -70,8 +70,8 @@ inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2 lp,
 /// @param plp Point's local point. Location for shape A in local coordinates.
 /// @return Separation is the dot-product of the positional difference between the two points in
 ///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceB(const Transformation& xfB, Length2 lp, UnitVec2 ln,
-                                          const Transformation& xfA, Length2 plp)
+inline PositionSolverManifold GetForFaceB(const Transformation2D& xfB, Length2 lp, UnitVec2 ln,
+                                          const Transformation2D& xfA, Length2 plp)
 {
     const auto planePoint = Transform(lp, xfB);
     const auto normal = Rotate(ln, xfB.q);
@@ -84,7 +84,7 @@ inline PositionSolverManifold GetForFaceB(const Transformation& xfB, Length2 lp,
 } // unnamed namespace
 
 PositionSolverManifold GetPSM(const Manifold& manifold, Manifold::size_type index,
-                              const Transformation& xfA, const Transformation& xfB)
+                              const Transformation2D& xfA, const Transformation2D& xfB)
 {
     assert(manifold.GetType() != Manifold::e_unset);
     assert(manifold.GetPointCount() > 0);

--- a/PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp
+++ b/PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp
@@ -56,7 +56,7 @@ namespace playrho {
     ///   the separation between the points of the manifold. To account for the vertex radiuses,
     ///   the total vertex radius must be subtracted from this separation distance.
     PositionSolverManifold GetPSM(const Manifold& manifold, Manifold::size_type index,
-                                  const Transformation& xfA, const Transformation& xfB);
+                                  const Transformation2D& xfA, const Transformation2D& xfB);
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/Fixture.cpp
+++ b/PlayRho/Dynamics/Fixture.cpp
@@ -115,7 +115,7 @@ void SetAwake(const Fixture& f) noexcept
     f.GetBody()->SetAwake();
 }
 
-Transformation GetTransformation(const Fixture& f) noexcept
+Transformation2D GetTransformation(const Fixture& f) noexcept
 {
     assert(static_cast<Body*>(f.GetBody()) != nullptr);
 

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -309,7 +309,7 @@ void SetAwake(const Fixture& f) noexcept;
 /// @warning Behavior is undefined if the fixture doesn't have an associated body - i.e.
 ///   behavior is undefined if the fixture has <code>nullptr</code> as its associated body.
 /// @relatedalso Fixture
-Transformation GetTransformation(const Fixture& f) noexcept;
+Transformation2D GetTransformation(const Fixture& f) noexcept;
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/Joints/DistanceJoint.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.cpp
@@ -153,8 +153,8 @@ void DistanceJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         // Product is: L^-2 M^-1 QP^2 M L^2 T^-1 = QP^2 T^-1
         const auto LA = Cross(m_rA, P) / Radian;
         const auto LB = Cross(m_rB, P) / Radian;
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -189,8 +189,8 @@ bool DistanceJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
     const auto P = impulse * m_u;
     const auto LA = Cross(m_rA, P) / Radian;
     const auto LB = Cross(m_rB, P) / Radian;
-    velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-    velB += Velocity{invMassB * P, invRotInertiaB * LB};
+    velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+    velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
 
     bodyConstraintA->SetVelocity(velA);
     bodyConstraintB->SetVelocity(velB);

--- a/PlayRho/Dynamics/Joints/DistanceJoint.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.cpp
@@ -234,8 +234,8 @@ bool DistanceJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     const auto impulse = -m_mass * C;
     const auto P = impulse * u;
 
-    posA -= Position{invMassA * P, invRotInertiaA * Cross(rA, P) / Radian};
-    posB += Position{invMassB * P, invRotInertiaB * Cross(rB, P) / Radian};
+    posA -= Position2D{invMassA * P, invRotInertiaA * Cross(rA, P) / Radian};
+    posB += Position2D{invMassB * P, invRotInertiaB * Cross(rB, P) / Radian};
 
     bodyConstraintA->SetPosition(posA);
     bodyConstraintB->SetPosition(posB);

--- a/PlayRho/Dynamics/Joints/FrictionJoint.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.cpp
@@ -124,8 +124,8 @@ void FrictionJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const St
         const auto crossAP = AngularMomentum{Cross(m_rA, P) / Radian};
         const auto crossBP = AngularMomentum{Cross(m_rB, P) / Radian}; // L * M * L T^-1 is: L^2 M T^-1
         
-        velA -= Velocity{invMassA * P, invRotInertiaA * (crossAP + m_angularImpulse)};
-        velB += Velocity{invMassB * P, invRotInertiaB * (crossBP + m_angularImpulse)};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * (crossAP + m_angularImpulse)};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * (crossBP + m_angularImpulse)};
     }
     else
     {
@@ -197,8 +197,8 @@ bool FrictionJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
             solved = false;
         }
 
-        velA -= Velocity{bodyConstraintA->GetInvMass() * incImpulse, invRotInertiaA * angImpulseA};
-        velB += Velocity{bodyConstraintB->GetInvMass() * incImpulse, invRotInertiaB * angImpulseB};
+        velA -= Velocity2D{bodyConstraintA->GetInvMass() * incImpulse, invRotInertiaA * angImpulseA};
+        velB += Velocity2D{bodyConstraintB->GetInvMass() * incImpulse, invRotInertiaB * angImpulseB};
     }
 
     bodyConstraintA->SetVelocity(velA);

--- a/PlayRho/Dynamics/Joints/GearJoint.cpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.cpp
@@ -398,19 +398,19 @@ bool GearJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
 
     const auto impulse = ((invMass > 0)? -C / invMass: 0) * Kilogram * Meter;
 
-    posA += Position{
+    posA += Position2D{
         bodyConstraintA->GetInvMass() * impulse * JvAC,
         bodyConstraintA->GetInvRotInertia() * impulse * JwA * Meter / Radian
     };
-    posB += Position{
+    posB += Position2D{
         bodyConstraintB->GetInvMass() * impulse * JvBD,
         bodyConstraintB->GetInvRotInertia() * impulse * JwB * Meter / Radian
     };
-    posC -= Position{
+    posC -= Position2D{
         bodyConstraintC->GetInvMass() * impulse * JvAC,
         bodyConstraintC->GetInvRotInertia() * impulse * JwC * Meter / Radian
     };
-    posD -= Position{
+    posD -= Position2D{
         bodyConstraintD->GetInvMass() * impulse * JvBD,
         bodyConstraintD->GetInvRotInertia() * impulse * JwD * Meter / Radian
     };

--- a/PlayRho/Dynamics/Joints/GearJoint.cpp
+++ b/PlayRho/Dynamics/Joints/GearJoint.cpp
@@ -240,19 +240,19 @@ void GearJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepCo
 
     if (step.doWarmStart)
     {
-        velA += Velocity{
+        velA += Velocity2D{
             (bodyConstraintA->GetInvMass() * m_impulse) * m_JvAC,
             bodyConstraintA->GetInvRotInertia() * m_impulse * m_JwA / Radian
         };
-        velB += Velocity{
+        velB += Velocity2D{
             (bodyConstraintB->GetInvMass() * m_impulse) * m_JvBD,
             bodyConstraintB->GetInvRotInertia() * m_impulse * m_JwB / Radian
         };
-        velC -= Velocity{
+        velC -= Velocity2D{
             (bodyConstraintC->GetInvMass() * m_impulse) * m_JvAC,
             bodyConstraintC->GetInvRotInertia() * m_impulse * m_JwC / Radian
         };
-        velD -= Velocity{
+        velD -= Velocity2D{
             (bodyConstraintD->GetInvMass() * m_impulse) * m_JvBD,
             bodyConstraintD->GetInvRotInertia() * m_impulse * m_JwD / Radian
         };
@@ -289,19 +289,19 @@ bool GearJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
     const auto impulse = Momentum{-m_mass * Kilogram * Cdot};
     m_impulse += impulse;
 
-    velA += Velocity{
+    velA += Velocity2D{
         (bodyConstraintA->GetInvMass() * impulse) * m_JvAC,
         bodyConstraintA->GetInvRotInertia() * impulse * m_JwA / Radian
     };
-    velB += Velocity{
+    velB += Velocity2D{
         (bodyConstraintB->GetInvMass() * impulse) * m_JvBD,
         bodyConstraintB->GetInvRotInertia() * impulse * m_JwB / Radian
     };
-    velC -= Velocity{
+    velC -= Velocity2D{
         (bodyConstraintC->GetInvMass() * impulse) * m_JvAC,
         bodyConstraintC->GetInvRotInertia() * impulse * m_JwC / Radian
     };
-    velD -= Velocity{
+    velD -= Velocity2D{
         (bodyConstraintD->GetInvMass() * impulse) * m_JvBD,
         bodyConstraintD->GetInvRotInertia() * impulse * m_JwD / Radian
     };

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -33,7 +33,7 @@ namespace playrho {
 
 class Body;
 class StepConf;
-struct Velocity;
+struct Velocity2D;
 struct ConstraintSolverConf;
 class BodyConstraint;
 class JointVisitor;

--- a/PlayRho/Dynamics/Joints/MotorJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.cpp
@@ -132,8 +132,8 @@ void MotorJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         const auto crossAP = AngularMomentum{Cross(m_rA, P) / Radian};
         const auto crossBP = AngularMomentum{Cross(m_rB, P) / Radian}; // L * M * L T^-1 is: L^2 M T^-1
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * (crossAP + m_angularImpulse)};
-        velB += Velocity{invMassB * P, invRotInertiaB * (crossBP + m_angularImpulse)};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * (crossAP + m_angularImpulse)};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * (crossBP + m_angularImpulse)};
     }
     else
     {
@@ -208,8 +208,8 @@ bool MotorJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
             solved = false;
         }
 
-        velA -= Velocity{invMassA * incImpulse, invRotInertiaA * angImpulseA};
-        velB += Velocity{invMassB * incImpulse, invRotInertiaB * angImpulseB};
+        velA -= Velocity2D{invMassA * incImpulse, invRotInertiaA * angImpulseA};
+        velB += Velocity2D{invMassB * incImpulse, invRotInertiaB * angImpulseB};
     }
 
     bodyConstraintA->SetVelocity(velA);

--- a/PlayRho/Dynamics/Joints/MouseJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MouseJoint.cpp
@@ -153,7 +153,7 @@ void MouseJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         m_impulse *= step.dtRatio;
         const auto P = m_impulse;
         const auto crossBP = AngularMomentum{Cross(m_rB, P) / Radian}; // L * M * L T^-1 is: L^2 M T^-1
-        velB += Velocity{bodyConstraintB->GetInvMass() * P, bodyConstraintB->GetInvRotInertia() * crossBP};
+        velB += Velocity2D{bodyConstraintB->GetInvMass() * P, bodyConstraintB->GetInvRotInertia() * crossBP};
     }
     else
     {
@@ -185,7 +185,7 @@ bool MouseJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
     const auto incImpulse = (m_impulse - oldImpulse);
     const auto angImpulseB = AngularMomentum{Cross(m_rB, incImpulse) / Radian};
 
-    velB += Velocity{
+    velB += Velocity2D{
         bodyConstraintB->GetInvMass() * incImpulse,
         bodyConstraintB->GetInvRotInertia() * angImpulseB
     };

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
@@ -509,8 +509,8 @@ bool PrismaticJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const 
     const auto LA = (GetX(impulse) * s1 + GetY(impulse) * Meter + GetZ(impulse) * a1) * Kilogram * Meter / Radian;
     const auto LB = (GetX(impulse) * s2 + GetY(impulse) * Meter + GetZ(impulse) * a2) * Kilogram * Meter / Radian;
 
-    posA -= Position{Length2{invMassA * P}, invRotInertiaA * LA};
-    posB += Position{invMassB * P, invRotInertiaB * LB};
+    posA -= Position2D{Length2{invMassA * P}, invRotInertiaA * LA};
+    posB += Position2D{invMassB * P, invRotInertiaB * LB};
 
     bodyConstraintA->SetPosition(posA);
     bodyConstraintB->SetPosition(posB);

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
@@ -242,8 +242,8 @@ void PrismaticJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         const auto LB = L + (Pxs2 * Meter + PzLength * m_a2) / Radian;
 
         // InvRotInertia is L^-2 M^-1 QP^2
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -287,8 +287,8 @@ bool PrismaticJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const 
         const auto LA = impulse * m_a1 / Radian;
         const auto LB = impulse * m_a2 / Radian;
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
 
     const auto velDelta = velB.linear - velA.linear;
@@ -335,8 +335,8 @@ bool PrismaticJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const 
             (GetX(df) * m_s2 + GetY(df) * Meter + GetZ(df) * m_a2) * NewtonSecond / Radian
         };
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -356,8 +356,8 @@ bool PrismaticJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const 
             (GetX(df) * m_s2 + GetY(df) * Meter) * NewtonSecond / Radian
         };
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
 
     if ((velA != oldVelA) || (velB != oldVelB))

--- a/PlayRho/Dynamics/Joints/PulleyJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.cpp
@@ -114,8 +114,8 @@ void PulleyJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         const auto PA = -(m_impulse) * m_uA;
         const auto PB = (-m_ratio * m_impulse) * m_uB;
 
-        velA += Velocity{invMassA * PA, invRotInertiaA * Cross(m_rA, PA) / Radian};
-        velB += Velocity{invMassB * PB, invRotInertiaB * Cross(m_rB, PB) / Radian};
+        velA += Velocity2D{invMassA * PA, invRotInertiaA * Cross(m_rA, PA) / Radian};
+        velB += Velocity2D{invMassB * PB, invRotInertiaB * Cross(m_rB, PB) / Radian};
     }
     else
     {
@@ -148,8 +148,8 @@ bool PulleyJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Ste
 
     const auto PA = -impulse * m_uA;
     const auto PB = -m_ratio * impulse * m_uB;
-    velA += Velocity{invMassA * PA, invRotInertiaA * Cross(m_rA, PA) / Radian};
-    velB += Velocity{invMassB * PB, invRotInertiaB * Cross(m_rB, PB) / Radian};
+    velA += Velocity2D{invMassA * PA, invRotInertiaA * Cross(m_rA, PA) / Radian};
+    velB += Velocity2D{invMassB * PB, invRotInertiaB * Cross(m_rB, PB) / Radian};
 
     bodyConstraintA->SetVelocity(velA);
     bodyConstraintB->SetVelocity(velB);

--- a/PlayRho/Dynamics/Joints/PulleyJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.cpp
@@ -205,8 +205,8 @@ bool PulleyJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     const auto PA = -impulse * uA;
     const auto PB = -m_ratio * impulse * uB;
 
-    posA += Position{invMassA * PA, invRotInertiaA * Cross(rA, PA) / Radian};
-    posB += Position{invMassB * PB, invRotInertiaB * Cross(rB, PB) / Radian};
+    posA += Position2D{invMassA * PA, invRotInertiaA * Cross(rA, PA) / Radian};
+    posB += Position2D{invMassB * PB, invRotInertiaB * Cross(rB, PB) / Radian};
 
     bodyConstraintA->SetPosition(posA);
     bodyConstraintB->SetPosition(posB);

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -188,8 +188,8 @@ void RevoluteJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         const auto LA = AngularMomentum{Cross(m_rA, P) / Radian} + L;
         const auto LB = AngularMomentum{Cross(m_rB, P) / Radian} + L;
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -293,8 +293,8 @@ bool RevoluteJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
         const auto LA = AngularMomentum{Cross(m_rA, P) / Radian} + L;
         const auto LB = AngularMomentum{Cross(m_rB, P) / Radian} + L;
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -310,8 +310,8 @@ bool RevoluteJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
         const auto LA = AngularMomentum{Cross(m_rA, P) / Radian};
         const auto LB = AngularMomentum{Cross(m_rB, P) / Radian};
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
 
     if ((velA != oldVelA) || (velB != oldVelB))

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -411,8 +411,8 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
         GetY(GetY(K)) = eyy;
         const auto P = -Solve(K, C);
 
-        posA -= Position{invMassA * P, invRotInertiaA * Cross(rA, P) / Radian};
-        posB += Position{invMassB * P, invRotInertiaB * Cross(rB, P) / Radian};
+        posA -= Position2D{invMassA * P, invRotInertiaA * Cross(rA, P) / Radian};
+        posB += Position2D{invMassB * P, invRotInertiaB * Cross(rB, P) / Radian};
     }
 
     bodyConstraintA->SetPosition(posA);

--- a/PlayRho/Dynamics/Joints/RopeJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.cpp
@@ -117,8 +117,8 @@ void RopeJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
         const auto crossAP = AngularMomentum{Cross(m_rA, P) / Radian};
         const auto crossBP = AngularMomentum{Cross(m_rB, P) / Radian}; // L * M * L T^-1 is: L^2 M T^-1
 
-        velA -= Velocity{bodyConstraintA->GetInvMass() * P, invRotInertiaA * crossAP};
-        velB += Velocity{bodyConstraintB->GetInvMass() * P, invRotInertiaB * crossBP};
+        velA -= Velocity2D{bodyConstraintA->GetInvMass() * P, invRotInertiaA * crossAP};
+        velB += Velocity2D{bodyConstraintB->GetInvMass() * P, invRotInertiaB * crossBP};
     }
     else
     {
@@ -158,8 +158,8 @@ bool RopeJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
     const auto crossAP = AngularMomentum{Cross(m_rA, P) / Radian};
     const auto crossBP = AngularMomentum{Cross(m_rB, P) / Radian}; // L * M * L T^-1 is: L^2 M T^-1
 
-    velA -= Velocity{bodyConstraintA->GetInvMass() * P, bodyConstraintA->GetInvRotInertia() * crossAP};
-    velB += Velocity{bodyConstraintB->GetInvMass() * P, bodyConstraintB->GetInvRotInertia() * crossBP};
+    velA -= Velocity2D{bodyConstraintA->GetInvMass() * P, bodyConstraintA->GetInvRotInertia() * crossAP};
+    velB += Velocity2D{bodyConstraintB->GetInvMass() * P, bodyConstraintB->GetInvRotInertia() * crossBP};
 
     bodyConstraintA->SetVelocity(velA);
     bodyConstraintB->SetVelocity(velB);

--- a/PlayRho/Dynamics/Joints/RopeJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.cpp
@@ -194,8 +194,8 @@ bool RopeJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     const auto angImpulseA = Cross(rA, linImpulse) / Radian;
     const auto angImpulseB = Cross(rB, linImpulse) / Radian;
 
-    posA -= Position{bodyConstraintA->GetInvMass() * linImpulse, bodyConstraintA->GetInvRotInertia() * angImpulseA};
-    posB += Position{bodyConstraintB->GetInvMass() * linImpulse, bodyConstraintB->GetInvRotInertia() * angImpulseB};
+    posA -= Position2D{bodyConstraintA->GetInvMass() * linImpulse, bodyConstraintA->GetInvRotInertia() * angImpulseA};
+    posB += Position2D{bodyConstraintB->GetInvMass() * linImpulse, bodyConstraintB->GetInvRotInertia() * angImpulseB};
 
     bodyConstraintA->SetPosition(posA);
     bodyConstraintB->SetPosition(posB);

--- a/PlayRho/Dynamics/Joints/WeldJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.cpp
@@ -334,8 +334,8 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
         const auto LA = Cross(rA, P) / Radian;
         const auto LB = Cross(rB, P) / Radian;
 
-        posA -= Position{invMassA * P, invRotInertiaA * LA};
-        posB += Position{invMassB * P, invRotInertiaB * LB};
+        posA -= Position2D{invMassA * P, invRotInertiaA * LA};
+        posB += Position2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -363,8 +363,8 @@ bool WeldJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
         const auto LA = L + Cross(rA, P) / Radian;
         const auto LB = L + Cross(rB, P) / Radian;
 
-        posA -= Position{invMassA * P, invRotInertiaA * LA};
-        posB += Position{invMassB * P, invRotInertiaB * LB};
+        posA -= Position2D{invMassA * P, invRotInertiaA * LA};
+        posB += Position2D{invMassB * P, invRotInertiaB * LB};
     }
 
     bodyConstraintA->SetPosition(posA);

--- a/PlayRho/Dynamics/Joints/WeldJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJoint.cpp
@@ -179,8 +179,8 @@ void WeldJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepCo
         const auto LA = L + AngularMomentum{Cross(m_rA, P) / Radian};
         const auto LB = L + AngularMomentum{Cross(m_rB, P) / Radian};
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -233,8 +233,8 @@ bool WeldJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         const auto LA = AngularMomentum{Cross(m_rA, P) / Radian};
         const auto LB = AngularMomentum{Cross(m_rB, P) / Radian};
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -255,8 +255,8 @@ bool WeldJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         const auto LA = L + AngularMomentum{Cross(m_rA, P) / Radian};
         const auto LB = L + AngularMomentum{Cross(m_rB, P) / Radian};
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
 
     if ((velA != oldVelA) || (velB != oldVelB))

--- a/PlayRho/Dynamics/Joints/WheelJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.cpp
@@ -301,8 +301,8 @@ bool WheelJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Cons
     const auto LA = impulse * sAy / Radian;
     const auto LB = impulse * sBy / Radian;
 
-    posA -= Position{invMassA * P, invRotInertiaA * LA};
-    posB += Position{invMassB * P, invRotInertiaB * LB};
+    posA -= Position2D{invMassA * P, invRotInertiaA * LA};
+    posB += Position2D{invMassB * P, invRotInertiaB * LB};
 
     bodyConstraintA->SetPosition(posA);
     bodyConstraintB->SetPosition(posB);

--- a/PlayRho/Dynamics/Joints/WheelJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.cpp
@@ -180,8 +180,8 @@ void WheelJoint::InitVelocityConstraints(BodyConstraintsMap& bodies, const StepC
         const auto LA = AngularMomentum{(m_impulse * m_sAy + m_springImpulse * m_sAx) / Radian + m_motorImpulse};
         const auto LB = AngularMomentum{(m_impulse * m_sBy + m_springImpulse * m_sBx) / Radian + m_motorImpulse};
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
     else
     {
@@ -221,8 +221,8 @@ bool WheelJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
         const auto LA = AngularMomentum{impulse * m_sAx / Radian};
         const auto LB = AngularMomentum{impulse * m_sBx / Radian};
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
 
     // Solve rotational motor constraint
@@ -250,8 +250,8 @@ bool WheelJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
         const auto LA = AngularMomentum{impulse * m_sAy / Radian};
         const auto LB = AngularMomentum{impulse * m_sBy / Radian};
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
+        velA -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+        velB += Velocity2D{invMassB * P, invRotInertiaB * LB};
     }
 
     if ((velA != oldVelA) || (velB != oldVelB))

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -205,8 +205,8 @@ namespace {
     inline VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc)
     {
         auto vp = VelocityPair{
-            Velocity{LinearVelocity2{}, 0_rpm},
-            Velocity{LinearVelocity2{}, 0_rpm}
+            Velocity2D{LinearVelocity2{}, 0_rpm},
+            Velocity2D{LinearVelocity2{}, 0_rpm}
         };
         
         const auto normal = vc.GetNormal();
@@ -232,8 +232,8 @@ namespace {
             const auto P = vcp.normalImpulse * normal + vcp.tangentImpulse * tangent;
             const auto LA = Cross(vcp.relA, P) / Radian;
             const auto LB = Cross(vcp.relB, P) / Radian;
-            vp.first -= Velocity{invMassA * P, invRotInertiaA * LA};
-            vp.second += Velocity{invMassB * P, invRotInertiaB * LB};
+            vp.first -= Velocity2D{invMassA * P, invRotInertiaA * LA};
+            vp.second += Velocity2D{invMassB * P, invRotInertiaB * LB};
         }
         return vp;
     }
@@ -1668,7 +1668,7 @@ World::IslandSolverResults World::SolveToi(const StepConf& conf, Contact& contac
     return results;
 }
 
-void World::UpdateBody(Body& body, const Position2D& pos, const Velocity& vel)
+void World::UpdateBody(Body& body, const Position2D& pos, const Velocity2D& vel)
 {
     assert(IsValid(pos));
     assert(IsValid(vel));

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2836,14 +2836,14 @@ BodyCounter Awaken(World& world) noexcept
     return awoken;
 }
 
-void SetAccelerations(World& world, std::function<Acceleration(const Body& b)> fn) noexcept
+void SetAccelerations(World& world, std::function<Acceleration2D(const Body& b)> fn) noexcept
 {
     for_each(begin(world.GetBodies()), end(world.GetBodies()), [&](World::Bodies::value_type &b) {
         SetAcceleration(GetRef(b), fn(GetRef(b)));
     });
 }
 
-void SetAccelerations(World& world, Acceleration acceleration) noexcept
+void SetAccelerations(World& world, Acceleration2D acceleration) noexcept
 {
     for_each(begin(world.GetBodies()), end(world.GetBodies()), [&](World::Bodies::value_type &b) {
         SetAcceleration(GetRef(b), acceleration);

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -149,7 +149,7 @@ namespace {
             const auto velocity = bc.GetVelocity();
             const auto translation = h * velocity.linear;
             const auto rotation = h * velocity.angular;
-            bc.SetPosition(bc.GetPosition() + Position{translation, rotation});
+            bc.SetPosition(bc.GetPosition() + Position2D{translation, rotation});
         });
     }
     
@@ -1668,7 +1668,7 @@ World::IslandSolverResults World::SolveToi(const StepConf& conf, Contact& contac
     return results;
 }
 
-void World::UpdateBody(Body& body, const Position& pos, const Velocity& vel)
+void World::UpdateBody(Body& body, const Position2D& pos, const Velocity& vel)
 {
     assert(IsValid(pos));
     assert(IsValid(vel));

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2722,7 +2722,7 @@ void World::InternalTouchProxies(Fixture& fixture) noexcept
 }
 
 ContactCounter World::Synchronize(Body& body,
-                                  Transformation xfm1, Transformation xfm2,
+                                  Transformation2D xfm1, Transformation2D xfm2,
                                   Real multiplier, Length extension)
 {
     assert(::playrho::IsValid(xfm1));
@@ -2738,7 +2738,7 @@ ContactCounter World::Synchronize(Body& body,
 }
 
 ContactCounter World::Synchronize(Fixture& fixture,
-                                  Transformation xfm1, Transformation xfm2,
+                                  Transformation2D xfm1, Transformation2D xfm2,
                                   Length2 displacement, Length extension)
 {
     assert(::playrho::IsValid(xfm1));

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -525,7 +525,7 @@ private:
     /// @param body Body to update.
     /// @param pos New position to set the given body to.
     /// @param vel New velocity to set the given body to.
-    static void UpdateBody(Body& body, const Position2D& pos, const Velocity& vel);
+    static void UpdateBody(Body& body, const Position2D& pos, const Velocity2D& vel);
 
     /// @brief Reset bodies for solve TOI.
     void ResetBodiesForSolveTOI();

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -1110,18 +1110,18 @@ BodyCounter Awaken(World& world) noexcept;
 
 /// @brief Sets the accelerations of all the world's bodies.
 /// @relatedalso World
-void SetAccelerations(World& world, std::function<Acceleration(const Body& b)> fn) noexcept;
+void SetAccelerations(World& world, std::function<Acceleration2D(const Body& b)> fn) noexcept;
 
 /// @brief Sets the accelerations of all the world's bodies to the given value.
 /// @relatedalso World
-void SetAccelerations(World& world, Acceleration acceleration) noexcept;
+void SetAccelerations(World& world, Acceleration2D acceleration) noexcept;
 
 /// @brief Clears forces.
 /// @details Manually clear the force buffer on all bodies.
 /// @relatedalso World
 inline void ClearForces(World& world) noexcept
 {
-    SetAccelerations(world, Acceleration{world.GetGravity(), 0 * RadianPerSquareSecond});
+    SetAccelerations(world, Acceleration2D{world.GetGravity(), 0 * RadianPerSquareSecond});
 }
 
 /// @brief Creates a rectanglular enclosure.

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -715,14 +715,14 @@ private:
     /// @details This updates the broad phase dynamic tree data for all of the given
     ///   body's fixtures.
     ContactCounter Synchronize(Body& body,
-                               Transformation xfm1, Transformation xfm2,
+                               Transformation2D xfm1, Transformation2D xfm2,
                                Real multiplier, Length extension);
 
     /// @brief Synchronizes the given fixture.
     /// @details This updates the broad phase dynamic tree data for all of the given
     ///   fixture shape's children.
     ContactCounter Synchronize(Fixture& fixture,
-                               Transformation xfm1, Transformation xfm2,
+                               Transformation2D xfm1, Transformation2D xfm2,
                                Length2 displacement, Length extension);
     
     /// @brief Creates and destroys proxies.

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -525,7 +525,7 @@ private:
     /// @param body Body to update.
     /// @param pos New position to set the given body to.
     /// @param vel New velocity to set the given body to.
-    static void UpdateBody(Body& body, const Position& pos, const Velocity& vel);
+    static void UpdateBody(Body& body, const Position2D& pos, const Velocity& vel);
 
     /// @brief Reset bodies for solve TOI.
     void ResetBodiesForSolveTOI();

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -50,7 +50,7 @@ static void DrawCorner(Drawer& drawer, Length2 p, Length r, Angle a0, Angle a1, 
 class ShapeDrawer
 {
 public:
-    ShapeDrawer(Drawer& d, Color c, bool s, Transformation t):
+    ShapeDrawer(Drawer& d, Color c, bool s, Transformation2D t):
         drawer{d}, color{c}, skins{s}, xf{t}
     {
         // Intentionally empty.
@@ -91,7 +91,7 @@ public:
     Drawer& drawer;
     Color color;
     bool skins;
-    Transformation xf;
+    Transformation2D xf;
 };
 
 void ShapeDrawer::Visit(const DiskShapeConf& shape)

--- a/Testbed/Tests/ApplyForce.hpp
+++ b/Testbed/Tests/ApplyForce.hpp
@@ -75,7 +75,7 @@ public:
         }
 
         {
-            Transformation xf1;
+            Transformation2D xf1;
             xf1.q = UnitVec2::Get(0.3524_rad * Pi);
             xf1.p = GetVec2(GetXAxis(xf1.q)) * 1_m;
 
@@ -89,7 +89,7 @@ public:
             conf.density = 4_kgpm2;
             const auto poly1 = PolygonShapeConf(Span<const Length2>(vertices, 3), conf);
 
-            Transformation xf2;
+            Transformation2D xf2;
             xf2.q = UnitVec2::Get(-0.3524_rad * Pi);
             xf2.p = GetVec2(-GetXAxis(xf2.q)) * 1_m;
 

--- a/Testbed/Tests/BodyTypes.hpp
+++ b/Testbed/Tests/BodyTypes.hpp
@@ -40,7 +40,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_K, GLFW_PRESS, 0, "Kinematic", [&](KeyActionMods) {
             m_platform->SetType(BodyType::Kinematic);
-            m_platform->SetVelocity(Velocity{Vec2(-m_speed, 0) * 1_mps, 0_rpm});
+            m_platform->SetVelocity(Velocity2D{Vec2(-m_speed, 0) * 1_mps, 0_rpm});
         });
 
         // Define attachment
@@ -97,7 +97,7 @@ public:
             if ((GetX(p) < -10_m && GetX(velocity.linear) < 0_mps) ||
                 (GetX(p) > +10_m && GetX(velocity.linear) > 0_mps))
             {
-                m_platform->SetVelocity(Velocity{
+                m_platform->SetVelocity(Velocity2D{
                     LinearVelocity2{-GetX(velocity.linear), GetY(velocity.linear)},
                     velocity.angular
                 });

--- a/Testbed/Tests/Breakable.hpp
+++ b/Testbed/Tests/Breakable.hpp
@@ -113,8 +113,8 @@ public:
         const auto velocity1 = m_velocity + GetRevPerpendicular(center1 - center) * m_angularVelocity / 1_rad;
         const auto velocity2 = m_velocity + GetRevPerpendicular(center2 - center) * m_angularVelocity / 1_rad;
 
-        body1->SetVelocity(Velocity{velocity1, m_angularVelocity});
-        body2->SetVelocity(Velocity{velocity2, m_angularVelocity});
+        body1->SetVelocity(Velocity2D{velocity1, m_angularVelocity});
+        body2->SetVelocity(Velocity2D{velocity2, m_angularVelocity});
     }
 
     void PreStep(const Settings&, Drawer&) override

--- a/Testbed/Tests/BulletTest.hpp
+++ b/Testbed/Tests/BulletTest.hpp
@@ -61,18 +61,18 @@ public:
             m_bullet = m_world.CreateBody(bd);
             m_bullet->CreateFixture(Shape{conf});
 
-            m_bullet->SetVelocity(Velocity{Vec2{0.0f, -50.0f} * 1_mps, 0_rpm});
+            m_bullet->SetVelocity(Velocity2D{Vec2{0.0f, -50.0f} * 1_mps, 0_rpm});
         }
     }
 
     void Launch()
     {
         m_body->SetTransform(Vec2(0.0f, 4.0f) * 1_m, 0_rad);
-        m_body->SetVelocity(Velocity{LinearVelocity2{}, 0_rpm});
+        m_body->SetVelocity(Velocity2D{LinearVelocity2{}, 0_rpm});
 
         m_x = RandomFloat(-1.0f, 1.0f);
         m_bullet->SetTransform(Vec2(m_x, 10.0f) * 1_m, 0_rad);
-        m_bullet->SetVelocity(Velocity{Vec2(0.0f, -50.0f) * 1_mps, 0_rpm});
+        m_bullet->SetVelocity(Velocity2D{Vec2(0.0f, -50.0f) * 1_mps, 0_rpm});
     }
 
     void PostStep(const Settings&, Drawer&) override

--- a/Testbed/Tests/CompoundShapes.hpp
+++ b/Testbed/Tests/CompoundShapes.hpp
@@ -75,7 +75,7 @@ public:
         }
 
         {
-            Transformation xf1;
+            Transformation2D xf1;
             xf1.q = UnitVec2::Get(0.3524_rad * Pi);
             xf1.p = GetVec2(GetXAxis(xf1.q)) * 1_m;
 
@@ -88,7 +88,7 @@ public:
             triangleConf1.UseDensity(2_kgpm2);
             const auto triangle1 = Shape(triangleConf1);
 
-            Transformation xf2;
+            Transformation2D xf2;
             xf2.q = UnitVec2::Get(-0.3524_rad * Pi);
             xf2.p = -GetVec2(GetXAxis(xf2.q)) * 1_m;
 

--- a/Testbed/Tests/ContinuousTest.hpp
+++ b/Testbed/Tests/ContinuousTest.hpp
@@ -46,7 +46,7 @@ public:
             m_body->CreateFixture(PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(2_m, 0.1_m));
             m_angularVelocity = RandomFloat(-50.0f, 50.0f) * 1_rad / 1_s;
             //m_angularVelocity = 46.661274f;
-            m_body->SetVelocity(Velocity{Vec2(0.0f, -100.0f) * 1_mps, m_angularVelocity});
+            m_body->SetVelocity(Velocity2D{Vec2(0.0f, -100.0f) * 1_mps, m_angularVelocity});
         }
     }
 
@@ -54,7 +54,7 @@ public:
     {
         m_body->SetTransform(Vec2(0.0f, 20.0f) * 1_m, 0_rad);
         m_angularVelocity = RandomFloat(-50.0f, 50.0f) * 1_rad / 1_s;
-        m_body->SetVelocity(Velocity{Vec2(0.0f, -100.0f) * 1_mps, m_angularVelocity});
+        m_body->SetVelocity(Velocity2D{Vec2(0.0f, -100.0f) * 1_mps, m_angularVelocity});
     }
 
     void PostStep(const Settings&, Drawer&) override

--- a/Testbed/Tests/OneSidedPlatform.hpp
+++ b/Testbed/Tests/OneSidedPlatform.hpp
@@ -60,7 +60,7 @@ public:
             conf.vertexRadius = m_radius;
             conf.density = 20_kgpm2;
             m_character = body->CreateFixture(Shape(conf));
-            body->SetVelocity(Velocity{Vec2(0.0f, -50.0f) * 1_mps, 0_rpm});
+            body->SetVelocity(Velocity2D{Vec2(0.0f, -50.0f) * 1_mps, 0_rpm});
         }
     }
 

--- a/Testbed/Tests/Orbiter.hpp
+++ b/Testbed/Tests/Orbiter.hpp
@@ -44,7 +44,7 @@ namespace testbed {
             m_orbiter = m_world.CreateBody(bd);
             m_orbiter->CreateFixture(DiskShapeConf{}.UseRadius(0.5_m).UseDensity(1_kgpm2));
             
-            const auto velocity = Velocity{
+            const auto velocity = Velocity2D{
                 Vec2{Pi * radius / 2, 0} * 1_mps,
                 360_deg / 1_s
             };

--- a/Testbed/Tests/PolyCollision.hpp
+++ b/Testbed/Tests/PolyCollision.hpp
@@ -30,34 +30,34 @@ class PolyCollision : public Test
 public:
     PolyCollision()
     {
-        m_transformA = Transformation{Length2{}, UnitVec2::GetRight()};
+        m_transformA = Transformation2D{Length2{}, UnitVec2::GetRight()};
         m_positionB = Vec2(19.345284f, 1.5632932f) * 1_m;
         m_angleB = 1.9160721_rad;
-        m_transformB = Transformation{m_positionB, UnitVec2::Get(m_angleB)};
+        m_transformB = Transformation2D{m_positionB, UnitVec2::Get(m_angleB)};
         
         RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Move Left", [&](KeyActionMods) {
             GetX(m_positionB) -= 0.1_m;
-            m_transformB = Transformation{m_positionB, UnitVec2::Get(m_angleB)};
+            m_transformB = Transformation2D{m_positionB, UnitVec2::Get(m_angleB)};
         });
         RegisterForKey(GLFW_KEY_D, GLFW_PRESS, 0, "Move Right", [&](KeyActionMods) {
             GetX(m_positionB) += 0.1_m;
-            m_transformB = Transformation{m_positionB, UnitVec2::Get(m_angleB)};
+            m_transformB = Transformation2D{m_positionB, UnitVec2::Get(m_angleB)};
         });
         RegisterForKey(GLFW_KEY_S, GLFW_PRESS, 0, "Move Down", [&](KeyActionMods) {
             GetY(m_positionB) -= 0.1_m;
-            m_transformB = Transformation{m_positionB, UnitVec2::Get(m_angleB)};
+            m_transformB = Transformation2D{m_positionB, UnitVec2::Get(m_angleB)};
         });
         RegisterForKey(GLFW_KEY_W, GLFW_PRESS, 0, "Move Up", [&](KeyActionMods) {
             GetY(m_positionB) += 0.1_m;
-            m_transformB = Transformation{m_positionB, UnitVec2::Get(m_angleB)};
+            m_transformB = Transformation2D{m_positionB, UnitVec2::Get(m_angleB)};
         });
         RegisterForKey(GLFW_KEY_Q, GLFW_PRESS, 0, "Rotate Counter Clockwise", [&](KeyActionMods) {
             m_angleB += 0.1_rad * Pi;
-            m_transformB = Transformation{m_positionB, UnitVec2::Get(m_angleB)};
+            m_transformB = Transformation2D{m_positionB, UnitVec2::Get(m_angleB)};
         });
         RegisterForKey(GLFW_KEY_E, GLFW_PRESS, 0, "Rotate Clockwise", [&](KeyActionMods) {
             m_angleB -= 0.1_rad * Pi;
-            m_transformB = Transformation{m_positionB, UnitVec2::Get(m_angleB)};
+            m_transformB = Transformation2D{m_positionB, UnitVec2::Get(m_angleB)};
         });
     }
 
@@ -110,8 +110,8 @@ public:
     PolygonShapeConf m_polygonA{PolygonShapeConf{}.SetAsBox(0.2_m, 0.4_m)};
     PolygonShapeConf m_polygonB{PolygonShapeConf{}.SetAsBox(0.5_m, 0.5_m)};
 
-    Transformation m_transformA;
-    Transformation m_transformB;
+    Transformation2D m_transformA;
+    Transformation2D m_transformB;
 
     Length2 m_positionB;
     Angle m_angleB;

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -67,7 +67,7 @@ public:
     }
     
     Color m_color = Color(0.95f, 0.95f, 0.6f);
-    Transformation m_xf;
+    Transformation2D m_xf;
     Drawer* g_debugDraw;
 };
 

--- a/Testbed/Tests/Revolute.hpp
+++ b/Testbed/Tests/Revolute.hpp
@@ -44,7 +44,7 @@ public:
             body->CreateFixture(Shape(circleConf));
 
             const auto w = 100.0f;
-            body->SetVelocity(Velocity{
+            body->SetVelocity(Velocity2D{
                 Vec2(-8.0f * w, 0.0f) * 1_mps, w * 1_rad / 1_s
             });
             

--- a/Testbed/Tests/SolarSystem.hpp
+++ b/Testbed/Tests/SolarSystem.hpp
@@ -126,7 +126,7 @@ public:
             // Use () instead of {} to avoid MSVC++ doing const preserving copy elision.
             const auto b = m_world.CreateBody(BodyDef(DynamicBD).UseLocation(l));
             const auto a = 2 * Pi * 1_rad / sso.rotationalPeriod;
-            b->SetVelocity(Velocity{LinearVelocity2{0_mps, v}, a});
+            b->SetVelocity(Velocity2D{LinearVelocity2{0_mps, v}, a});
             const auto d = sso.mass / (Pi * Square(sso.radius));
             const auto sconf = DiskShapeConf{}.UseRadius(sso.radius).UseDensity(d);
             const auto shape = Shape(sconf);

--- a/Testbed/Tests/SphereStack.hpp
+++ b/Testbed/Tests/SphereStack.hpp
@@ -44,7 +44,7 @@ public:
             bd.location = Vec2(0, 4.0f + 3.0f * i) * 1_m;
             m_bodies[i] = m_world.CreateBody(bd);
             m_bodies[i]->CreateFixture(shape);
-            m_bodies[i]->SetVelocity(Velocity{Vec2(0.0f, -50.0f) * 1_mps, 0_rpm});
+            m_bodies[i]->SetVelocity(Velocity2D{Vec2(0.0f, -50.0f) * 1_mps, 0_rpm});
         }
     }
 

--- a/Testbed/Tests/TimeOfImpact.hpp
+++ b/Testbed/Tests/TimeOfImpact.hpp
@@ -36,11 +36,11 @@ public:
     {
         const auto offset = Vec2{Real(-35), Real(70)} * 1_m;
         const auto sweepA = Sweep{
-            Position{Vec2(24.0f, -60.0f) * 1_m + offset, 2.95_rad}
+            Position2D{Vec2(24.0f, -60.0f) * 1_m + offset, 2.95_rad}
         };
         const auto sweepB = Sweep{
-            Position{Vec2(53.474274f, -50.252514f) * 1_m + offset, 513.36676_rad},
-            Position{Vec2(54.595478f, -51.083473f) * 1_m + offset, 513.62781_rad}
+            Position2D{Vec2(53.474274f, -50.252514f) * 1_m + offset, 513.36676_rad},
+            Position2D{Vec2(54.595478f, -51.083473f) * 1_m + offset, 513.62781_rad}
         };
 
         const auto output = GetToiViaSat(GetChild(m_shapeA, 0), sweepA,

--- a/Testbed/Tests/TimeOfImpact.hpp
+++ b/Testbed/Tests/TimeOfImpact.hpp
@@ -35,10 +35,10 @@ public:
     void PostStep(const Settings&, Drawer& drawer) override
     {
         const auto offset = Vec2{Real(-35), Real(70)} * 1_m;
-        const auto sweepA = Sweep{
+        const auto sweepA = Sweep2D{
             Position2D{Vec2(24.0f, -60.0f) * 1_m + offset, 2.95_rad}
         };
-        const auto sweepB = Sweep{
+        const auto sweepB = Sweep2D{
             Position2D{Vec2(53.474274f, -50.252514f) * 1_m + offset, 513.36676_rad},
             Position2D{Vec2(54.595478f, -51.083473f) * 1_m + offset, 513.62781_rad}
         };

--- a/Testbed/Tests/VerticalStack.hpp
+++ b/Testbed/Tests/VerticalStack.hpp
@@ -83,7 +83,7 @@ public:
                 
                 m_bullet = m_world.CreateBody(bd);
                 m_bullet->CreateFixture(m_bulletshape);
-                m_bullet->SetVelocity(Velocity{Vec2(400.0f, 0.0f) * 1_mps, 0_rpm});
+                m_bullet->SetVelocity(Velocity2D{Vec2(400.0f, 0.0f) * 1_mps, 0_rpm});
             }
         });
     }

--- a/Testbed/Tests/iforce2d_Trajectories.hpp
+++ b/Testbed/Tests/iforce2d_Trajectories.hpp
@@ -116,7 +116,7 @@ public:
         
         m_firing2 = false;
         m_littleBox2->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
-        m_littleBox2->SetVelocity(Velocity{});
+        m_littleBox2->SetVelocity(Velocity2D{});
 
         SetMouseWorld(Vec2(11,22) * 1_m);//sometimes is not set
         
@@ -124,7 +124,7 @@ public:
             const auto launchSpeed = LinearVelocity2(m_launchSpeed, 0_mps);
             m_littleBox->SetAwake();
             m_littleBox->SetAcceleration(Gravity, AngularAcceleration{});
-            m_littleBox->SetVelocity(Velocity{});
+            m_littleBox->SetVelocity(Velocity2D{});
             m_littleBox->SetTransform(GetWorldPoint(*m_launcherBody, Vec2(3,0) * 1_m),
                                       m_launcherBody->GetAngle());
             const auto rotVec = GetWorldVector(*m_launcherBody, UnitVec2::GetRight());
@@ -134,7 +134,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_W, GLFW_PRESS, 0, "Reset projectile.", [&](KeyActionMods) {
             m_littleBox->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
-            m_littleBox->SetVelocity(Velocity{});
+            m_littleBox->SetVelocity(Velocity2D{});
             m_firing = false;
         });
         RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Increase launch speed.", [&](KeyActionMods) {
@@ -146,7 +146,7 @@ public:
         RegisterForKey(GLFW_KEY_D, GLFW_PRESS, 0, "Launch computer controlled projectile.", [&](KeyActionMods) {
             m_littleBox2->SetAwake();
             m_littleBox2->SetAcceleration(Gravity, AngularAcceleration{});
-            m_littleBox2->SetVelocity(Velocity{});
+            m_littleBox2->SetVelocity(Velocity2D{});
             const auto launchVel = getComputerLaunchVelocity();
             const auto computerStartingPosition = Vec2(15,5) * 1_m;
             m_littleBox2->SetTransform(computerStartingPosition, 0_rad);
@@ -155,7 +155,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_F, GLFW_PRESS, 0, "Reset computer controlled projectile.", [&](KeyActionMods) {
             m_littleBox2->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
-            m_littleBox2->SetVelocity(Velocity{});
+            m_littleBox2->SetVelocity(Velocity2D{});
             m_firing2 = false;
         });
         RegisterForKey(GLFW_KEY_M, GLFW_PRESS, 0, "Hold down & use left mouse button to move the computer's target", [&](KeyActionMods) {

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -417,7 +417,7 @@ TEST(AABB2D, StreamOutputOperator)
 TEST(AABB2D, ComputeAabbForFixtureAtBodyOrigin)
 {
     const auto shape = DiskShapeConf{};
-    const auto shapeAabb = ComputeAABB(Shape(shape), Transformation{});
+    const auto shapeAabb = ComputeAABB(Shape(shape), Transformation2D{});
 
     World world;
     const auto body = world.CreateBody();
@@ -431,7 +431,7 @@ TEST(AABB2D, ComputeAabbForFixtureAtBodyOrigin)
 TEST(AABB2D, ComputeAabbForFixtureOffFromBodyOrigin)
 {
     const auto shape = DiskShapeConf{};
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(shape, Transformation2D{});
     
     const auto bodyLocation = Length2{2_m, 3_m};
     World world;
@@ -447,7 +447,7 @@ TEST(AABB2D, ComputeAabbForFixtureOffFromBodyOrigin)
 TEST(AABB2D, ComputeIntersectingAABBForSameFixture)
 {
     const auto shape = DiskShapeConf{};
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(shape, Transformation2D{});
     
     World world;
     const auto body = world.CreateBody();
@@ -466,7 +466,7 @@ TEST(AABB2D, ComputeIntersectingAABBForTwoFixtures)
     const auto shapeInterval = LengthInterval{-2_m, +2_m};
 
     const auto shape = DiskShapeConf{}.UseRadius(2_m);
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(shape, Transformation2D{});
     ASSERT_EQ(shapeAabb, (AABB2D{shapeInterval, shapeInterval}));
 
     const auto bodyLocation0 = Length2{+1_m, 0_m};
@@ -495,7 +495,7 @@ TEST(AABB2D, ComputeIntersectingAABBForContact)
     const auto shapeInterval = LengthInterval{-2_m, +2_m};
     
     const auto shape = DiskShapeConf{}.UseRadius(2_m);
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(shape, Transformation2D{});
     ASSERT_EQ(shapeAabb, (AABB2D{shapeInterval, shapeInterval}));
     
     const auto bodyLocation0 = Length2{+1_m, 0_m};

--- a/UnitTests/Acceleration.cpp
+++ b/UnitTests/Acceleration.cpp
@@ -27,26 +27,26 @@ TEST(Acceleration, ByteSize)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(Acceleration), std::size_t(12)); break;
-        case  8: EXPECT_EQ(sizeof(Acceleration), std::size_t(24)); break;
-        case 16: EXPECT_EQ(sizeof(Acceleration), std::size_t(48)); break;
+        case  4: EXPECT_EQ(sizeof(Acceleration2D), std::size_t(12)); break;
+        case  8: EXPECT_EQ(sizeof(Acceleration2D), std::size_t(24)); break;
+        case 16: EXPECT_EQ(sizeof(Acceleration2D), std::size_t(48)); break;
         default: FAIL(); break;
     }
 }
 
 TEST(Acceleration, Addition)
 {
-    EXPECT_EQ(Acceleration{} + Acceleration{}, Acceleration{});
-    EXPECT_EQ((Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
-            + (Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
-              (Acceleration{LinearAcceleration2{2_mps2, 2_mps2}, 2 * RadianPerSquareSecond}));
+    EXPECT_EQ(Acceleration2D{} + Acceleration2D{}, Acceleration2D{});
+    EXPECT_EQ((Acceleration2D{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
+            + (Acceleration2D{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
+              (Acceleration2D{LinearAcceleration2{2_mps2, 2_mps2}, 2 * RadianPerSquareSecond}));
 }
 
 TEST(Acceleration, Subtraction)
 {
-    EXPECT_EQ(Acceleration{} - Acceleration{}, Acceleration{});
-    EXPECT_EQ((Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
-            - (Acceleration{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
-              (Acceleration{LinearAcceleration2{0_mps2, 0_mps2}, 0 * RadianPerSquareSecond}));
+    EXPECT_EQ(Acceleration2D{} - Acceleration2D{}, Acceleration2D{});
+    EXPECT_EQ((Acceleration2D{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond})
+            - (Acceleration2D{LinearAcceleration2{1_mps2, 1_mps2}, 1 * RadianPerSquareSecond}),
+              (Acceleration2D{LinearAcceleration2{0_mps2, 0_mps2}, 0 * RadianPerSquareSecond}));
 }
 

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -554,7 +554,7 @@ TEST(Body, GetAccelerationFF)
     ASSERT_EQ(body->GetLinearAcceleration(), LinearAcceleration2{});
     ASSERT_EQ(body->GetAngularAcceleration(), AngularAcceleration{});
     
-    EXPECT_EQ(GetAcceleration(*body), Acceleration{});
+    EXPECT_EQ(GetAcceleration(*body), Acceleration2D{});
 }
 
 TEST(Body, SetAccelerationFF)
@@ -566,7 +566,7 @@ TEST(Body, SetAccelerationFF)
     ASSERT_EQ(body->GetLinearAcceleration(), LinearAcceleration2{});
     ASSERT_EQ(body->GetAngularAcceleration(), AngularAcceleration{});
  
-    const auto newAccel = Acceleration{
+    const auto newAccel = Acceleration2D{
         LinearAcceleration2{2_mps2, 3_mps2}, AngularAcceleration{1.2f * RadianPerSquareSecond}
     };
     SetAcceleration(*body, newAccel);
@@ -584,7 +584,7 @@ TEST(Body, CalcGravitationalAcceleration)
     
     const auto b1 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(l1));
     b1->CreateFixture(shape);
-    EXPECT_EQ(CalcGravitationalAcceleration(*b1), Acceleration{});
+    EXPECT_EQ(CalcGravitationalAcceleration(*b1), Acceleration2D{});
     
     const auto b2 = world.CreateBody(BodyDef{}.UseType(BodyType::Dynamic).UseLocation(l2));
     b2->CreateFixture(shape);
@@ -595,7 +595,7 @@ TEST(Body, CalcGravitationalAcceleration)
     EXPECT_EQ(accel.angular, 0 * RadianPerSquareSecond);
     
     const auto b3 = world.CreateBody(BodyDef{}.UseType(BodyType::Static).UseLocation(l3));
-    EXPECT_EQ(CalcGravitationalAcceleration(*b3), Acceleration{});
+    EXPECT_EQ(CalcGravitationalAcceleration(*b3), Acceleration2D{});
 }
 
 TEST(Body, RotateAboutWorldPointFF)

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -225,7 +225,7 @@ TEST(Body, WorldCreated)
 
 TEST(Body, SetVelocityDoesNothingToStatic)
 {
-    const auto zeroVelocity = Velocity{
+    const auto zeroVelocity = Velocity2D{
         LinearVelocity2{0_mps, 0_mps},
         AngularVelocity{Real(0) * RadianPerSecond}
     };
@@ -239,7 +239,7 @@ TEST(Body, SetVelocityDoesNothingToStatic)
     ASSERT_FALSE(body->IsAccelerable());
     ASSERT_EQ(body->GetVelocity(), zeroVelocity);
     
-    const auto velocity = Velocity{
+    const auto velocity = Velocity2D{
         LinearVelocity2{1.1_mps, 1.1_mps},
         AngularVelocity{Real(1.1) * RadianPerSecond}
     };

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -423,9 +423,9 @@ TEST(Body, SetTransform)
     bd.type = BodyType::Dynamic;
     World world;
     const auto body = world.CreateBody(bd);
-    const auto xfm1 = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfm1 = Transformation2D{Length2{}, UnitVec2::GetRight()};
     ASSERT_EQ(body->GetTransformation(), xfm1);
-    const auto xfm2 = Transformation{Vec2(10, -12) * 1_m, UnitVec2::GetLeft()};
+    const auto xfm2 = Transformation2D{Vec2(10, -12) * 1_m, UnitVec2::GetLeft()};
     body->SetTransform(xfm2.p, GetAngle(xfm2.q));
     EXPECT_EQ(body->GetTransformation().p, xfm2.p);
     EXPECT_NEAR(static_cast<double>(GetX(body->GetTransformation().q)),

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -55,7 +55,7 @@ TEST(ChainShapeConf, ByteSize)
 TEST(ChainShapeConf, DefaultConstruction)
 {
     const auto foo = ChainShapeConf{};
-    const auto defaultMassData = MassData{};
+    const auto defaultMassData = MassData2D{};
     const auto defaultConf = ChainShapeConf{};
     
     EXPECT_EQ(typeid(foo), typeid(ChainShapeConf));

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -31,7 +31,7 @@ TEST(CollideShapes, IdenticalOverlappingCircles)
     const auto radius = 1_m;
     const auto shape = DiskShapeConf{}.UseRadius(radius);
     const auto position = Vec2{11, -4} * Meter;
-    const auto xfm = Transformation{position, UnitVec2::GetRight()};
+    const auto xfm = Transformation2D{position, UnitVec2::GetRight()};
     
     // put shape 1 to left of shape 2
     const auto manifold = CollideShapes(GetChild(shape, 0), xfm, GetChild(shape, 0), xfm);
@@ -58,8 +58,8 @@ TEST(CollideShapes, CircleCircleOrientedHorizontally)
     const auto s2 = DiskShapeConf{}.UseRadius(r2);
     const auto p1 = Vec2{11, -4} * Meter;
     const auto p2 = Vec2{13, -4} * Meter;
-    const auto t1 = Transformation{p1, UnitVec2::GetRight()};
-    const auto t2 = Transformation{p2, UnitVec2::GetRight()};
+    const auto t1 = Transformation2D{p1, UnitVec2::GetRight()};
+    const auto t2 = Transformation2D{p2, UnitVec2::GetRight()};
     
     // put shape 1 to left of shape 2
     const auto manifold = CollideShapes(GetChild(s1, 0), t1, GetChild(s2, 0), t2);
@@ -88,8 +88,8 @@ TEST(CollideShapes, CircleCircleOrientedVertically)
     const auto p2 = Vec2{7, -1} * Meter;
     
     // Rotations don't matter so long as circle shapes' centers are at (0, 0).
-    const auto t1 = Transformation{p1, UnitVec2::Get(45_deg)};
-    const auto t2 = Transformation{p2, UnitVec2::Get(-21_deg)};
+    const auto t1 = Transformation2D{p1, UnitVec2::Get(45_deg)};
+    const auto t2 = Transformation2D{p2, UnitVec2::Get(-21_deg)};
     
     // put shape 1 to left of shape 2
     const auto manifold = CollideShapes(GetChild(s1, 0), t1, GetChild(s2, 0), t2);
@@ -113,11 +113,11 @@ TEST(CollideShapes, CircleTouchingTrianglePointBelow)
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
     const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShapeConf{}.Set({triangleLeftPt, triangleRightPt, triangleTopPt});
-    const auto triangleXfm = Transformation{
+    const auto triangleXfm = Transformation2D{
         Length2{},
         UnitVec2::GetRight()
     };
-    const auto circleXfm = Transformation{
+    const auto circleXfm = Transformation2D{
         triangleTopPt + UnitVec2::GetTop() * circleRadius,
         UnitVec2::GetRight()
     };
@@ -143,11 +143,11 @@ TEST(CollideShapes, CircleTouchingTrianglePointLeft)
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
     const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShapeConf{}.Set({triangleLeftPt, triangleRightPt, triangleTopPt});
-    const auto circleXfm = Transformation{
+    const auto circleXfm = Transformation2D{
         triangleLeftPt + UnitVec2::Get(225_deg) * circleRadius,
         UnitVec2::GetRight()
     };
-    const auto triangleXfm = Transformation{
+    const auto triangleXfm = Transformation2D{
         Length2{},
         UnitVec2::GetRight()
     };
@@ -173,11 +173,11 @@ TEST(CollideShapes, CircleTouchingTrianglePointRight)
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
     const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShapeConf({triangleLeftPt, triangleRightPt, triangleTopPt});
-    const auto circleXfm = Transformation{
+    const auto circleXfm = Transformation2D{
         triangleRightPt + UnitVec2::Get(-45_deg) * circleRadius,
         UnitVec2::GetRight()
     };
-    const auto triangleXfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto triangleXfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(triangle, 0), triangleXfm, GetChild(circle, 0), circleXfm);
     
@@ -202,11 +202,11 @@ TEST(CollideShapes, CircleJustPastTrianglePointRightDoesntCollide)
     auto triangle = PolygonShapeConf{}
             .UseVertexRadius(Real{0.0001f * 2} * Meter)
             .Set({triangleLeftPt, triangleRightPt, triangleTopPt});
-    const auto circleXfm = Transformation{
+    const auto circleXfm = Transformation2D{
         triangleRightPt + UnitVec2::Get(-45_deg) * circleRadius * Real(1.01),
         UnitVec2::GetRight()
     };
-    const auto triangleXfm = Transformation{
+    const auto triangleXfm = Transformation2D{
         Length2{},
         UnitVec2::GetRight()
     };
@@ -225,11 +225,11 @@ TEST(CollideShapes, CircleOverRightFaceOfTriangle)
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
     const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto triangle = PolygonShapeConf({triangleLeftPt, triangleRightPt, triangleTopPt});
-    const auto circleXfm = Transformation{
+    const auto circleXfm = Transformation2D{
         Vec2{1, 1} * Meter,
         UnitVec2::GetRight()
     };
-    const auto triangleXfm = Transformation{
+    const auto triangleXfm = Transformation2D{
         Length2{},
         UnitVec2::GetRight()
     };
@@ -258,11 +258,11 @@ TEST(CollideShapes, CircleOverLeftFaceOfTriangle)
     const auto circleRadius = 1_m;
     const auto circle = DiskShapeConf(circleRadius);
     const auto triangle = PolygonShapeConf({Vec2{-1, -1} * Meter, Vec2{+1, -1} * Meter, Vec2{0, +1} * Meter});
-    const auto circleXfm = Transformation{
+    const auto circleXfm = Transformation2D{
         Vec2{-1, 1} * Meter,
         UnitVec2::GetRight()
     };
-    const auto triangleXfm = Transformation{
+    const auto triangleXfm = Transformation2D{
         Length2{},
         UnitVec2::GetRight()
     };
@@ -302,8 +302,8 @@ TEST(CollideShapes, TallRectangleLeftCircleRight)
     
     const auto p1 = Vec2{-1, 0} * Meter;
     const auto p2 = Vec2{3, 0} * Meter;
-    const auto t1 = Transformation{p1, UnitVec2::Get(45_deg)};
-    const auto t2 = Transformation{p2, UnitVec2::GetRight()};
+    const auto t1 = Transformation2D{p1, UnitVec2::Get(45_deg)};
+    const auto t2 = Transformation2D{p2, UnitVec2::GetRight()};
     
     // rotate rectangle 45 degrees and put it on the left of the circle
     const auto manifold = CollideShapes(GetChild(s1, 0), t1, GetChild(s2, 0), t2);
@@ -335,7 +335,7 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim1)
     ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * Meter)); // top left
     ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * Meter)); // bottom left
     
-    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfm, GetChild(shape, 0), xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
@@ -376,7 +376,7 @@ TEST(CollideShapes, IdenticalOverlappingSquaresDim2)
     ASSERT_EQ(shape.GetVertex(2), (Vec2{-dim, +dim} * Meter)); // top left
     ASSERT_EQ(shape.GetVertex(3), (Vec2{-dim, -dim} * Meter)); // bottom left
     
-    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfm, GetChild(shape, 0), xfm);
     
     EXPECT_EQ(manifold.GetType(), Manifold::e_faceA);
@@ -417,11 +417,11 @@ TEST(CollideShapes, IdenticalVerticalTouchingSquares)
     ASSERT_EQ(shape.GetVertex(2), (Vec2{-2, +2} * Meter)); // top left
     ASSERT_EQ(shape.GetVertex(3), (Vec2{-2, -2} * Meter)); // bottom left
 
-    const auto xfm0 = Transformation{
+    const auto xfm0 = Transformation2D{
         Vec2{0, -1} * Meter,
         UnitVec2::GetRight()
     }; // bottom
-    const auto xfm1 = Transformation{
+    const auto xfm1 = Transformation2D{
         Vec2{0, +1} * Meter,
         UnitVec2::GetRight()
     }; // top
@@ -465,11 +465,11 @@ TEST(CollideShapes, IdenticalHorizontalTouchingSquares)
     ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * Meter); // top left
     ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * Meter); // bottom left
 
-    const auto xfm0 = Transformation{
+    const auto xfm0 = Transformation2D{
         Vec2{-2, 0} * Meter,
         UnitVec2::GetRight()
     }; // left
-    const auto xfm1 = Transformation{
+    const auto xfm1 = Transformation2D{
         Vec2{+2, 0} * Meter,
         UnitVec2::GetRight()
     }; // right
@@ -507,8 +507,8 @@ TEST(CollideShapes, IdenticalHorizontalTouchingSquares)
 TEST(CollideShapes, GetMaxSeparationFreeFunction1)
 {
     const auto rot0 = 45_deg;
-    const auto xfm0 = Transformation{Vec2{0, -2} * Meter, UnitVec2::Get(rot0)}; // bottom
-    const auto xfm1 = Transformation{Vec2{0, +2} * Meter, UnitVec2::GetRight()}; // top
+    const auto xfm0 = Transformation2D{Vec2{0, -2} * Meter, UnitVec2::Get(rot0)}; // bottom
+    const auto xfm1 = Transformation2D{Vec2{0, +2} * Meter, UnitVec2::GetRight()}; // top
     
     const auto dim = 2_m;
     const auto shape0 = PolygonShapeConf(dim, dim);
@@ -600,8 +600,8 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction2)
     ASSERT_EQ(shape.GetVertex(2), Vec2(-2, +2) * Meter); // top left
     ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * Meter); // bottom left
 
-    const auto xfm0 = Transformation{Vec2{0, -1} * Meter, UnitVec2::GetRight()}; // bottom
-    const auto xfm1 = Transformation{Vec2{0, +1} * Meter, UnitVec2::GetRight()}; // top
+    const auto xfm0 = Transformation2D{Vec2{0, -1} * Meter, UnitVec2::GetRight()}; // bottom
+    const auto xfm1 = Transformation2D{Vec2{0, +1} * Meter, UnitVec2::GetRight()}; // top
     const auto totalRadius = GetVertexRadius(shape) * Real(2);
 
     const auto child0 = GetChild(shape, 0);
@@ -643,8 +643,8 @@ TEST(CollideShapes, SquareCornerTouchingSquareFaceAbove)
     ASSERT_EQ(shape.GetVertex(3), Vec2(-2, -2) * Meter); // bottom left
     
     const auto rot0 = 45_deg;
-    const auto xfm0 = Transformation{Vec2{0, -2} * Meter, UnitVec2::Get(rot0)}; // bottom
-    const auto xfm1 = Transformation{Vec2{0, +2} * Meter, UnitVec2::GetRight()}; // top
+    const auto xfm0 = Transformation2D{Vec2{0, -2} * Meter, UnitVec2::Get(rot0)}; // bottom
+    const auto xfm1 = Transformation2D{Vec2{0, +2} * Meter, UnitVec2::GetRight()}; // top
     
     // Rotate square A and put it below square B.
     // In ASCII art terms:
@@ -731,11 +731,11 @@ TEST(CollideShapes, HorizontalOverlappingRects1)
     ASSERT_EQ(shape1.GetVertex(2), Length2(-3.0_m, +1.5_m)); // top left
     ASSERT_EQ(shape1.GetVertex(3), Length2(-3.0_m, -1.5_m)); // bottom left
 
-    const auto xfm0 = Transformation{
+    const auto xfm0 = Transformation2D{
         Vec2{-2, 0} * Meter,
         UnitVec2::GetRight()
     }; // left
-    const auto xfm1 = Transformation{
+    const auto xfm1 = Transformation2D{
         Vec2{+2, 0} * Meter,
         UnitVec2::GetRight()
     }; // right
@@ -817,11 +817,11 @@ TEST(CollideShapes, HorizontalOverlappingRects2)
     ASSERT_EQ(shape1.GetVertex(2), Length2(-2_m,+2_m)); // top left
     ASSERT_EQ(shape1.GetVertex(3), Length2(-2_m,-2_m)); // bottom left
     
-    const auto xfm0 = Transformation{
+    const auto xfm0 = Transformation2D{
         Vec2{-2, 0} * Meter,
         UnitVec2::GetRight()
     }; // left
-    const auto xfm1 = Transformation{
+    const auto xfm1 = Transformation2D{
         Vec2{+2, 0} * Meter,
         UnitVec2::GetRight()
     }; // right
@@ -881,7 +881,7 @@ TEST(CollideShapes, EdgeBelowPolygon)
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{
+    const auto edge_xfm = Transformation2D{
         Vec2{0, -1} * Meter,
         UnitVec2::GetRight()
     };
@@ -889,7 +889,7 @@ TEST(CollideShapes, EdgeBelowPolygon)
     const auto hx = 1_m;
     const auto hy = 1_m;
     const auto polygon_shape = PolygonShapeConf(hx, hy);
-    const auto polygon_xfm = Transformation{
+    const auto polygon_xfm = Transformation2D{
         Length2{},
         UnitVec2::GetRight()
     };
@@ -930,12 +930,12 @@ TEST(CollideShapes, EdgeAbovePolygon)
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Vec2{0, +1} * Meter, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation2D{Vec2{0, +1} * Meter, UnitVec2::GetRight()};
     
     const auto hx = 1_m;
     const auto hy = 1_m;
     const auto polygon_shape = PolygonShapeConf(hx, hy);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -973,12 +973,12 @@ TEST(CollideShapes, EdgeLeftOfPolygon)
     const auto p1 = Vec2(0, -1) * Meter;
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Vec2{-1, 0} * Meter, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation2D{Vec2{-1, 0} * Meter, UnitVec2::GetRight()};
     
     const auto hx = 1_m;
     const auto hy = 1_m;
     const auto polygon_shape = PolygonShapeConf(hx, hy);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -998,12 +998,12 @@ TEST(CollideShapes, EdgeRightOfPolygon)
     const auto p1 = Vec2(0, -1) * Meter;
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation2D{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
     
     const auto hx = 1_m;
     const auto hy = 1_m;
     const auto polygon_shape = PolygonShapeConf(hx, hy);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -1023,10 +1023,10 @@ TEST(CollideShapes, EdgeInsideSquare)
     const auto p1 = Vec2(0, -1) * Meter;
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto s = 1_m;
     const auto polygon_shape = PolygonShapeConf(s, s);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -1048,10 +1048,10 @@ TEST(CollideShapes, EdgeTwiceInsideSquare)
     const auto p1 = Vec2(0, -2) * Meter;
     const auto p2 = Vec2(0, +2) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto s = 1_m;
     const auto polygon_shape = PolygonShapeConf(s, s);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -1073,10 +1073,10 @@ TEST(CollideShapes, EdgeHalfInsideSquare)
     const auto p1 = Vec2(0, -0.5) * Meter;
     const auto p2 = Vec2(0, +0.5) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto edge_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto s = 1_m;
     const auto polygon_shape = PolygonShapeConf(s, s);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -1098,10 +1098,10 @@ TEST(CollideShapes, EdgeR90InsideSquare)
     const auto p1 = Vec2(0, -1) * Meter;
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetTop()};
+    const auto edge_xfm = Transformation2D{Length2{}, UnitVec2::GetTop()};
     const auto s = 1_m;
     const auto polygon_shape = PolygonShapeConf(s, s);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     // Sets up a collision between a line segment (A) and a square (B) where the line segment is
     // fully inside the square and bisects the square into an upper and low rectangular area like
@@ -1154,10 +1154,10 @@ TEST(CollideShapes, EdgeR45InsideSquare)
     const auto p1 = Vec2(0, -1) * Meter;
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Length2{}, UnitVec2::Get(45_deg)};
+    const auto edge_xfm = Transformation2D{Length2{}, UnitVec2::Get(45_deg)};
     const auto s = 1_m;
     const auto polygon_shape = PolygonShapeConf(s, s);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -1197,10 +1197,10 @@ TEST(CollideShapes, EdgeR180InsideSquare)
     const auto p1 = Vec2(0, -1) * Meter;
     const auto p2 = Vec2(0, +1) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{Length2{}, UnitVec2::GetLeft()};
+    const auto edge_xfm = Transformation2D{Length2{}, UnitVec2::GetLeft()};
     const auto s = 1_m;
     const auto polygon_shape = PolygonShapeConf(s, s);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -1257,13 +1257,13 @@ TEST(CollideShapes, EdgeTwiceR180Square)
     const auto p1 = Vec2(0, -2) * Meter;
     const auto p2 = Vec2(0, +2) * Meter;
     const auto edge_shape = EdgeShapeConf(p1, p2);
-    const auto edge_xfm = Transformation{
+    const auto edge_xfm = Transformation2D{
         Vec2{0, 1} * Meter,
         UnitVec2::GetLeft()
     };
     const auto s = 1_m;
     const auto polygon_shape = PolygonShapeConf(s, s);
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(polygon_shape, 0), polygon_xfm);
     
@@ -1320,12 +1320,12 @@ TEST(CollideShapes, EdgeFooTriangle)
     const auto p2 = Vec2(-2, +2) * Meter;
     const auto edge_shape = EdgeShapeConf(p2, p1,
                                       EdgeShapeConf{}.UseVertexRadius(0_m));
-    const auto edge_xfm = Transformation{Vec2(0, 0.5) * Meter, UnitVec2::Get(-5_deg)};
+    const auto edge_xfm = Transformation2D{Vec2(0, 0.5) * Meter, UnitVec2::Get(-5_deg)};
     const auto triangleTopPt = Vec2{0, +1} * Meter;
     const auto triangleLeftPt = Vec2{-1, -1} * Meter;
     const auto triangleRightPt = Vec2{+1, -1} * Meter;
     const auto polygon_shape = PolygonShapeConf{}.UseVertexRadius(0_m).Set({triangleLeftPt, triangleRightPt, triangleTopPt});
-    const auto polygon_xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto polygon_xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm,
                                         GetChild(polygon_shape, 0), polygon_xfm);
@@ -1344,7 +1344,7 @@ TEST(CollideShapes, EdgePolygonFaceB1)
     auto conf = EdgeShapeConf{};
     conf.vertexRadius = 0;
     const auto edge_shape = EdgeShapeConf(Vec2(6, 8) * Meter, Vec2(7, 8) * Meter, conf);
-    const auto edge_xfm = Transformation{Length2{}, GetUnitVector(Vec2(Real(0.707106769), Real(0.707106769)))};
+    const auto edge_xfm = Transformation2D{Length2{}, GetUnitVector(Vec2(Real(0.707106769), Real(0.707106769)))};
     const auto poly_shape = PolygonShapeConf({
         Vec2(0.5, 0) * Meter,
         Vec2(0.249999985f, 0.433012724f) * Meter,
@@ -1353,7 +1353,7 @@ TEST(CollideShapes, EdgePolygonFaceB1)
         Vec2(-0.249999955f, -0.433012724f) * Meter,
         Vec2(0.249999955f, -0.433012724f) * Meter
     });
-    const auto poly_xfm = Transformation{Vec2(-0.797443091f, 11.0397148f) * Meter, GetUnitVector(Vec2(1, 0))};
+    const auto poly_xfm = Transformation2D{Vec2(-0.797443091f, 11.0397148f) * Meter, GetUnitVector(Vec2(1, 0))};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(poly_shape, 0), poly_xfm);
     
@@ -1376,14 +1376,14 @@ TEST(CollideShapes, EdgePolygonFaceB2)
     auto conf = EdgeShapeConf{};
     conf.vertexRadius = 0.000199999995_m;
     const auto edge_shape = EdgeShapeConf(Vec2(-6, 2) * Meter, Vec2(-6, 0) * Meter, conf);
-    const auto edge_xfm = Transformation{Vec2(-9.99999904f, 4.0f) * Meter, GetUnitVector(Vec2(Real(1), Real(0)))};
+    const auto edge_xfm = Transformation2D{Vec2(-9.99999904f, 4.0f) * Meter, GetUnitVector(Vec2(Real(1), Real(0)))};
     const auto poly_shape = PolygonShapeConf({
         Vec2(0.5f, -0.5f) * Meter,
         Vec2(0.5f, 0.5f) * Meter,
         Vec2(-0.5f, 0.5f) * Meter,
         Length2{}
     });
-    const auto poly_xfm = Transformation{Vec2(-16.0989342f, 3.49960017f) * Meter, GetUnitVector(Vec2(1, 0))};
+    const auto poly_xfm = Transformation2D{Vec2(-16.0989342f, 3.49960017f) * Meter, GetUnitVector(Vec2(1, 0))};
     
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), edge_xfm, GetChild(poly_shape, 0), poly_xfm);
     
@@ -1418,8 +1418,8 @@ TEST(CollideShapes, R0EdgeCollinearAndTouchingR0Edge)
 {
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
-    const auto xfm1 = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{+3, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm1 = Transformation2D{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation2D{Vec2{+3, 0} * Meter, UnitVec2::GetRight()};
     const auto edge_shape = EdgeShapeConf(EdgeShapeConf{}.UseVertexRadius(0_m).Set(p1, p2));
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), xfm1, GetChild(edge_shape, 0), xfm2);
     
@@ -1438,8 +1438,8 @@ TEST(CollideShapes, R1EdgeCollinearAndTouchingR1Edge)
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
     const auto edge_shape = EdgeShapeConf(EdgeShapeConf{}.UseVertexRadius(1_m).Set(p1, p2));
-    const auto xfm1 = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{+5, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm1 = Transformation2D{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation2D{Vec2{+5, 0} * Meter, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), xfm1, GetChild(edge_shape, 0), xfm2);
 
     ASSERT_NE(manifold.GetType(), Manifold::e_unset);
@@ -1451,8 +1451,8 @@ TEST(CollideShapes, R0EdgeCollinearAndSeparateFromR0Edge)
 {
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
-    const auto xfm1 = Transformation{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{+4, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm1 = Transformation2D{Vec2{+1, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation2D{Vec2{+4, 0} * Meter, UnitVec2::GetRight()};
     const auto edge_shape = EdgeShapeConf(EdgeShapeConf{}.UseVertexRadius(0_m).Set(p1, p2));
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), xfm1, GetChild(edge_shape, 0), xfm2);
     
@@ -1463,8 +1463,8 @@ TEST(CollideShapes, R0EdgeParallelAndSeparateFromR0Edge)
 {
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
-    const auto xfm1 = Transformation{Vec2{-4, 1} * Meter, UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Vec2{-4, 0} * Meter, UnitVec2::GetRight()};
+    const auto xfm1 = Transformation2D{Vec2{-4, 1} * Meter, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation2D{Vec2{-4, 0} * Meter, UnitVec2::GetRight()};
     const auto edge_shape = EdgeShapeConf(EdgeShapeConf{}.UseVertexRadius(0_m).Set(p1, p2));
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), xfm1, GetChild(edge_shape, 0), xfm2);
     
@@ -1476,8 +1476,8 @@ TEST(CollideShapes, R0EdgePerpendicularCrossingFromR0Edge)
     const auto p1 = Vec2(-1, 0) * Meter;
     const auto p2 = Vec2(+1, 0) * Meter;
     const auto edge_shape = EdgeShapeConf(EdgeShapeConf{}.UseVertexRadius(0_m).Set(p1, p2));
-    const auto xfm1 = Transformation{Length2{}, UnitVec2::GetRight()};
-    const auto xfm2 = Transformation{Length2{}, UnitVec2::GetTop()};
+    const auto xfm1 = Transformation2D{Length2{}, UnitVec2::GetRight()};
+    const auto xfm2 = Transformation2D{Length2{}, UnitVec2::GetTop()};
     const auto manifold = CollideShapes(GetChild(edge_shape, 0), xfm1, GetChild(edge_shape, 0), xfm2);
     
     ASSERT_NE(manifold.GetType(), Manifold::e_unset);

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -32,8 +32,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 {
     const auto old_pA = Position2D{Vec2{-2, 0} * Meter, 0_deg};
     const auto old_pB = Position2D{Vec2{+2, 0} * Meter, 0_deg};
-    const auto old_vA = Velocity{LinearVelocity2{}, 0_deg / 1_s};
-    const auto old_vB = Velocity{LinearVelocity2{}, 0_deg / 1_s};
+    const auto old_vA = Velocity2D{LinearVelocity2{}, 0_deg / 1_s};
+    const auto old_vB = Velocity2D{LinearVelocity2{}, 0_deg / 1_s};
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
@@ -75,8 +75,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerTouchingDoesntMove)
 {
     const auto old_pA = Position2D{Vec2{0, -2} * Meter, 0_deg};
     const auto old_pB = Position2D{Vec2{0, +2} * Meter, 0_deg};
-    const auto old_vA = Velocity{};
-    const auto old_vB = Velocity{};
+    const auto old_vA = Velocity2D{};
+    const auto old_vB = Velocity2D{};
     
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
@@ -128,8 +128,8 @@ TEST(ContactSolver, SolvePosConstraintsForOverlappingZeroRateDoesntMove)
     const auto lcB = Length2{};
     const auto old_pA = Position2D{Length2{}, 0_deg};
     const auto old_pB = Position2D{Length2{}, 0_deg};
-    const auto old_vA = Velocity{};
-    const auto old_vB = Velocity{};
+    const auto old_vA = Velocity2D{};
+    const auto old_vB = Velocity2D{};
     auto bA = BodyConstraint{
         Real(1) / 1_kg,
         InvRotInertia{Real{1} * SquareRadian / (SquareMeter * 1_kg)},
@@ -167,8 +167,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly1)
     const auto old_pA = Position2D{Vec2{ctr_x - 1, 0} * Meter, 0_deg};
     const auto old_pB = Position2D{Vec2{ctr_x + 1, 0} * Meter, 0_deg};
 
-    const auto old_vA = Velocity{};
-    const auto old_vB = Velocity{};
+    const auto old_vA = Velocity2D{};
+    const auto old_vB = Velocity2D{};
     
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
@@ -221,8 +221,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly2)
     // square A is right of square B
     const auto old_pA = Position2D{Vec2{ctr_x + 1, 0} * Meter, 0_deg};
     const auto old_pB = Position2D{Vec2{ctr_x - 1, 0} * Meter, 0_deg};
-    const auto old_vA = Velocity{};
-    const auto old_vB = Velocity{};
+    const auto old_vA = Velocity2D{};
+    const auto old_vB = Velocity2D{};
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
@@ -275,8 +275,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly1)
     // square A is below square B
     const auto old_pA = Position2D{Vec2{0, ctr_y - 1} * Meter, 0_deg};
     const auto old_pB = Position2D{Vec2{0, ctr_y + 1} * Meter, 0_deg};
-    const auto old_vA = Velocity{};
-    const auto old_vB = Velocity{};
+    const auto old_vA = Velocity2D{};
+    const auto old_vB = Velocity2D{};
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
@@ -341,8 +341,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
     // square A is above square B
     const auto old_pA = Position2D{Vec2{0, ctr_y + 1} * Meter, 0_deg};
     const auto old_pB = Position2D{Vec2{0, ctr_y - 1} * Meter, 0_deg};
-    const auto old_vA = Velocity{};
-    const auto old_vB = Velocity{};
+    const auto old_vA = Velocity2D{};
+    const auto old_vB = Velocity2D{};
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
@@ -413,8 +413,8 @@ TEST(ContactSolver, SolvePosConstraintsForPerfectlyOverlappingSquares)
 
     const auto old_pA = Position2D{Length2{}, 0_deg};
     const auto old_pB = Position2D{Length2{}, 0_deg};
-    const auto old_vA = Velocity{};
-    const auto old_vB = Velocity{};
+    const auto old_vA = Velocity2D{};
+    const auto old_vB = Velocity2D{};
 
     const auto lcA = Length2{};
     const auto lcB = Length2{};

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -30,8 +30,8 @@ static PLAYRHO_CONSTEXPR const auto Baumgarte = Real{2} / Real{10};
 
 TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 {
-    const auto old_pA = Position{Vec2{-2, 0} * Meter, 0_deg};
-    const auto old_pB = Position{Vec2{+2, 0} * Meter, 0_deg};
+    const auto old_pA = Position2D{Vec2{-2, 0} * Meter, 0_deg};
+    const auto old_pB = Position2D{Vec2{+2, 0} * Meter, 0_deg};
     const auto old_vA = Velocity{LinearVelocity2{}, 0_deg / 1_s};
     const auto old_vB = Velocity{LinearVelocity2{}, 0_deg / 1_s};
 
@@ -73,8 +73,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 
 TEST(ContactSolver, SolvePosConstraintsForVerTouchingDoesntMove)
 {
-    const auto old_pA = Position{Vec2{0, -2} * Meter, 0_deg};
-    const auto old_pB = Position{Vec2{0, +2} * Meter, 0_deg};
+    const auto old_pA = Position2D{Vec2{0, -2} * Meter, 0_deg};
+    const auto old_pB = Position2D{Vec2{0, +2} * Meter, 0_deg};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
     
@@ -126,8 +126,8 @@ TEST(ContactSolver, SolvePosConstraintsForOverlappingZeroRateDoesntMove)
     
     const auto lcA = Length2{};
     const auto lcB = Length2{};
-    const auto old_pA = Position{Length2{}, 0_deg};
-    const auto old_pB = Position{Length2{}, 0_deg};
+    const auto old_pA = Position2D{Length2{}, 0_deg};
+    const auto old_pB = Position2D{Length2{}, 0_deg};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
     auto bA = BodyConstraint{
@@ -164,8 +164,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly1)
     const auto ctr_x = Real(100);
     
     // square A is left of square B
-    const auto old_pA = Position{Vec2{ctr_x - 1, 0} * Meter, 0_deg};
-    const auto old_pB = Position{Vec2{ctr_x + 1, 0} * Meter, 0_deg};
+    const auto old_pA = Position2D{Vec2{ctr_x - 1, 0} * Meter, 0_deg};
+    const auto old_pB = Position2D{Vec2{ctr_x + 1, 0} * Meter, 0_deg};
 
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
@@ -219,8 +219,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly2)
     const auto ctr_x = Real(100);
     
     // square A is right of square B
-    const auto old_pA = Position{Vec2{ctr_x + 1, 0} * Meter, 0_deg};
-    const auto old_pB = Position{Vec2{ctr_x - 1, 0} * Meter, 0_deg};
+    const auto old_pA = Position2D{Vec2{ctr_x + 1, 0} * Meter, 0_deg};
+    const auto old_pB = Position2D{Vec2{ctr_x - 1, 0} * Meter, 0_deg};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
@@ -273,8 +273,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly1)
     const auto ctr_y = Real(100);
     
     // square A is below square B
-    const auto old_pA = Position{Vec2{0, ctr_y - 1} * Meter, 0_deg};
-    const auto old_pB = Position{Vec2{0, ctr_y + 1} * Meter, 0_deg};
+    const auto old_pA = Position2D{Vec2{0, ctr_y - 1} * Meter, 0_deg};
+    const auto old_pB = Position2D{Vec2{0, ctr_y + 1} * Meter, 0_deg};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
@@ -339,8 +339,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
     const auto ctr_y = Real(100);
 
     // square A is above square B
-    const auto old_pA = Position{Vec2{0, ctr_y + 1} * Meter, 0_deg};
-    const auto old_pB = Position{Vec2{0, ctr_y - 1} * Meter, 0_deg};
+    const auto old_pA = Position2D{Vec2{0, ctr_y + 1} * Meter, 0_deg};
+    const auto old_pB = Position2D{Vec2{0, ctr_y - 1} * Meter, 0_deg};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 
@@ -411,8 +411,8 @@ TEST(ContactSolver, SolvePosConstraintsForPerfectlyOverlappingSquares)
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
 
-    const auto old_pA = Position{Length2{}, 0_deg};
-    const auto old_pB = Position{Length2{}, 0_deg};
+    const auto old_pA = Position2D{Length2{}, 0_deg};
+    const auto old_pB = Position2D{Length2{}, 0_deg};
     const auto old_vA = Velocity{};
     const auto old_vB = Velocity{};
 

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -456,10 +456,10 @@ TEST(ContactSolver, SolveVelocityConstraint1)
     const auto linear_velocity = Vec2{1, 1};
     const auto angular_velocity = 0_deg;
 
-    const auto old_pA = Position{Vec2{0, 0}, 0_deg};
-    const auto old_pB = Position{Vec2{0, 0}, 0_deg};
-    const auto vel_a = Velocity{linear_velocity, angular_velocity};
-    const auto vel_b = Velocity{linear_velocity, angular_velocity};
+    const auto old_pA = Position2D{Vec2{0, 0}, 0_deg};
+    const auto old_pB = Position2D{Vec2{0, 0}, 0_deg};
+    const auto vel_a = Velocity2D{linear_velocity, angular_velocity};
+    const auto vel_b = Velocity2D{linear_velocity, angular_velocity};
     const auto lcA = Vec2{};
     const auto lcB = Vec2{};
 
@@ -519,11 +519,11 @@ TEST(ContactSolver, SolveVelocityConstraint2)
     const auto linear_velocity = Vec2{1, 1};
     const auto angular_velocity = 0_deg;
     
-    const auto old_pA = Position{Vec2{0, 0}, 0_deg};
-    const auto old_pB = Position{Vec2{0, 0}, 0_deg};
+    const auto old_pA = Position2D{Vec2{0, 0}, 0_deg};
+    const auto old_pB = Position2D{Vec2{0, 0}, 0_deg};
     
-    auto vel_a = Velocity{linear_velocity, angular_velocity};
-    auto vel_b = Velocity{linear_velocity, angular_velocity};
+    auto vel_a = Velocity2D{linear_velocity, angular_velocity};
+    auto vel_b = Velocity2D{linear_velocity, angular_velocity};
     
     const auto lcA = Vec2{};
     const auto lcB = Vec2{};

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -37,8 +37,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
-    const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
+    const auto xfmA = Transformation2D{old_pA.linear, UnitVec2::Get(old_pA.angular)};
+    const auto xfmB = Transformation2D{old_pB.linear, UnitVec2::Get(old_pB.angular)};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
@@ -80,8 +80,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerTouchingDoesntMove)
     
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
-    const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
+    const auto xfmA = Transformation2D{old_pA.linear, UnitVec2::Get(old_pA.angular)};
+    const auto xfmB = Transformation2D{old_pB.linear, UnitVec2::Get(old_pB.angular)};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
@@ -118,8 +118,8 @@ TEST(ContactSolver, SolvePosConstraintsForOverlappingZeroRateDoesntMove)
 {
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{Length2{}, UnitVec2::GetRight()};
-    const auto xfmB = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfmA = Transformation2D{Length2{}, UnitVec2::GetRight()};
+    const auto xfmB = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);
@@ -172,8 +172,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly1)
     
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
-    const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
+    const auto xfmA = Transformation2D{old_pA.linear, UnitVec2::Get(old_pA.angular)};
+    const auto xfmB = Transformation2D{old_pB.linear, UnitVec2::Get(old_pB.angular)};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))), +1.0, 0.00001);
@@ -226,8 +226,8 @@ TEST(ContactSolver, SolvePosConstraintsForHorOverlappingMovesHorOnly2)
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
-    const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
+    const auto xfmA = Transformation2D{old_pA.linear, UnitVec2::Get(old_pA.angular)};
+    const auto xfmB = Transformation2D{old_pB.linear, UnitVec2::Get(old_pB.angular)};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))), -1.0, 0.00001);
@@ -280,8 +280,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly1)
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
-    const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
+    const auto xfmA = Transformation2D{old_pA.linear, UnitVec2::Get(old_pA.angular)};
+    const auto xfmB = Transformation2D{old_pB.linear, UnitVec2::Get(old_pB.angular)};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_NEAR(static_cast<double>(GetX(GetVec2(manifold.GetLocalNormal()))), +0.0, 0.00001);
@@ -346,8 +346,8 @@ TEST(ContactSolver, SolvePosConstraintsForVerOverlappingMovesVerOnly2)
 
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{old_pA.linear, UnitVec2::Get(old_pA.angular)};
-    const auto xfmB = Transformation{old_pB.linear, UnitVec2::Get(old_pB.angular)};
+    const auto xfmA = Transformation2D{old_pA.linear, UnitVec2::Get(old_pA.angular)};
+    const auto xfmB = Transformation2D{old_pB.linear, UnitVec2::Get(old_pB.angular)};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
@@ -405,8 +405,8 @@ TEST(ContactSolver, SolvePosConstraintsForPerfectlyOverlappingSquares)
 {
     const auto dim = 2_m;
     const auto shape = PolygonShapeConf(dim, dim);
-    const auto xfmA = Transformation{Length2{}, UnitVec2::GetRight()};
-    const auto xfmB = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfmA = Transformation2D{Length2{}, UnitVec2::GetRight()};
+    const auto xfmB = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto manifold = CollideShapes(GetChild(shape, 0), xfmA, GetChild(shape, 0), xfmB);
     ASSERT_EQ(manifold.GetType(), Manifold::e_faceA);
     ASSERT_EQ(manifold.GetPointCount(), 2);

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -25,8 +25,8 @@ using namespace playrho;
 TEST(Distance, MatchingCircles)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     const auto pos1 = Length2{2_m, 2_m};
     const auto pos2 = Length2{2_m, 2_m};
     const auto normal = UnitVec2{};
@@ -62,8 +62,8 @@ TEST(Distance, MatchingCircles)
 TEST(Distance, OpposingCircles)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     const auto pos1 = Length2{2_m, 2_m};
     const auto pos2 = Length2{-2_m, -2_m};
     const auto normal = UnitVec2{};
@@ -101,8 +101,8 @@ TEST(Distance, HorTouchingCircles)
     const auto normal = UnitVec2{};
 
     const auto output = [&]() {
-        Transformation xf1 = Transform_identity;
-        Transformation xf2 = Transform_identity;
+        Transformation2D xf1 = Transform_identity;
+        Transformation2D xf2 = Transform_identity;
         DistanceProxy dp1{2_m, 1, &pos1, &normal};
         DistanceProxy dp2{2_m, 1, &pos2, &normal};
         return Distance(dp1, xf1, dp2, xf2, conf);
@@ -131,8 +131,8 @@ TEST(Distance, HorTouchingCircles)
 TEST(Distance, OverlappingCirclesPN)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     const auto pos1 = Length2{1_m, 1_m};
     const auto pos2 = Length2{-1_m, -1_m};
     const auto normal = UnitVec2{};
@@ -164,8 +164,8 @@ TEST(Distance, OverlappingCirclesPN)
 TEST(Distance, OverlappingCirclesNP)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     const auto pos1 = Length2{-1_m, -1_m};
     const auto pos2 = Length2{1_m, 1_m};
     const auto normal = UnitVec2{};
@@ -198,8 +198,8 @@ TEST(Distance, OverlappingCirclesNP)
 TEST(Distance, SeparatedCircles)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     const auto pos1 = Length2{2_m, 2_m};
     const auto pos2 = Length2{-2_m, -2_m};
     const auto normal = UnitVec2{};
@@ -231,8 +231,8 @@ TEST(Distance, SeparatedCircles)
 TEST(Distance, EdgeCircleOverlapping)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
 
     const auto pos1 = Length2{0_m, 2_m};
     const auto pos2 = Length2{4_m, 2_m};
@@ -274,8 +274,8 @@ TEST(Distance, EdgeCircleOverlapping)
 TEST(Distance, EdgeCircleOverlapping2)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     
     const auto pos1 = Length2{-3_m, 2_m};
     const auto pos2 = Length2{7_m, 2_m};
@@ -316,8 +316,8 @@ TEST(Distance, EdgeCircleOverlapping2)
 TEST(Distance, EdgeCircleTouching)
 {
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     
     const auto pos1 = Length2{0_m, 3_m};
     const auto pos2 = Length2{4_m, 3_m};
@@ -377,8 +377,8 @@ TEST(Distance, HorEdgeSquareTouching)
     DistanceProxy dp2{0.5_m, 2, vertices, normals};
     
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
 
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -428,8 +428,8 @@ TEST(Distance, VerEdgeSquareTouching)
     DistanceProxy dp2{0.5_m, 2, vertices, normals};
     
     DistanceConf conf;
-    Transformation xf1 = Transform_identity;
-    Transformation xf2 = Transform_identity;
+    Transformation2D xf1 = Transform_identity;
+    Transformation2D xf2 = Transform_identity;
     
     const auto output = Distance(dp1, xf1, dp2, xf2, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -474,7 +474,7 @@ TEST(Distance, SquareTwice)
     DistanceProxy dp1{0.05_m, 4, square, squareNormals};
 
     DistanceConf conf;
-    Transformation xfm = Transform_identity;
+    Transformation2D xfm = Transform_identity;
     
     const auto output = Distance(dp1, xfm, dp1, xfm, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -526,7 +526,7 @@ TEST(Distance, SquareSquareTouchingVertically)
     DistanceProxy dp2{0.05_m, 4, square2, normals2};
 
     DistanceConf conf;
-    Transformation xfm = Transform_identity;
+    Transformation2D xfm = Transform_identity;
     
     const auto output = Distance(dp1, xfm, dp2, xfm, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -577,7 +577,7 @@ TEST(Distance, SquareSquareDiagonally)
     DistanceProxy dp2{0.05_m, 4, square2, normals2};
     
     DistanceConf conf;
-    Transformation xfm = Transform_identity;
+    Transformation2D xfm = Transform_identity;
     
     const auto output = Distance(dp1, xfm, dp2, xfm, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
@@ -652,7 +652,7 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
     DistanceProxy dp2{NonNegative<Length>{0}, 4, square2, normals2};
     
     DistanceConf conf;
-    Transformation xfm = Transform_identity;
+    Transformation2D xfm = Transform_identity;
     
     const auto output = Distance(dp1, xfm, dp2, xfm, conf);
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -195,8 +195,8 @@ TEST(DistanceProxy, GetMaxSeparationStopping)
     const auto radius = 1_m;
     const auto dp = DistanceProxy{radius, 4, vertices, normals};
     
-    const auto xfm1 = Transformation{Length2{-1_m, 0_m}, UnitVec2::Get(190_deg)};
-    const auto xfm2 = Transformation{Length2{+1_m, 0_m}, UnitVec2::Get( 95_deg)};
+    const auto xfm1 = Transformation2D{Length2{-1_m, 0_m}, UnitVec2::Get(190_deg)};
+    const auto xfm2 = Transformation2D{Length2{+1_m, 0_m}, UnitVec2::Get( 95_deg)};
     const auto resultRegular = GetMaxSeparation(dp, xfm1, dp, xfm2);
     const auto resultStopped = GetMaxSeparation(dp, xfm1, dp, xfm2, -3_m);
     

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -28,16 +28,16 @@ TEST(MassData, ByteSize)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(MassData), std::size_t(16)); break;
-        case  8: EXPECT_EQ(sizeof(MassData), std::size_t(32)); break;
-        case 16: EXPECT_EQ(sizeof(MassData), std::size_t(64)); break;
+        case  4: EXPECT_EQ(sizeof(MassData2D), std::size_t(16)); break;
+        case  8: EXPECT_EQ(sizeof(MassData2D), std::size_t(32)); break;
+        case 16: EXPECT_EQ(sizeof(MassData2D), std::size_t(64)); break;
         default: FAIL(); break;
     }
 }
 
 TEST(MassData, DefaultConstruct)
 {
-    MassData foo;
+    MassData2D foo;
     EXPECT_EQ(foo.center, (Length2{}));
     EXPECT_EQ(foo.mass, 0_kg);
     EXPECT_EQ(foo.I, RotInertia(0));
@@ -45,36 +45,36 @@ TEST(MassData, DefaultConstruct)
 
 TEST(MassData, Traits)
 {
-    EXPECT_TRUE(std::is_default_constructible<MassData>::value);
-    // EXPECT_FALSE(std::is_nothrow_default_constructible<MassData>::value); // clang-3.7 and 4.0
-    // EXPECT_TRUE(std::is_nothrow_default_constructible<MassData>::value); // gcc 6.3
-    EXPECT_FALSE(std::is_trivially_default_constructible<MassData>::value);
+    EXPECT_TRUE(std::is_default_constructible<MassData2D>::value);
+    // EXPECT_FALSE(std::is_nothrow_default_constructible<MassData2D>::value); // clang-3.7 and 4.0
+    // EXPECT_TRUE(std::is_nothrow_default_constructible<MassData2D>::value); // gcc 6.3
+    EXPECT_FALSE(std::is_trivially_default_constructible<MassData2D>::value);
     
-    EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass, RotInertia>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2, NonNegative<Mass>, NonNegative<RotInertia>>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2, NonNegative<Mass>>::value));
-    EXPECT_FALSE((std::is_constructible<MassData, Length2>::value));
-    EXPECT_TRUE((std::is_constructible<MassData>::value));
-    // EXPECT_FALSE(std::is_nothrow_constructible<MassData>::value); // clang 3.7 and 4.0
-    // EXPECT_TRUE(std::is_nothrow_constructible<MassData>::value); // gcc 6.3
-    EXPECT_FALSE((std::is_trivially_constructible<MassData, Length2, Mass, RotInertia>::value));
+    EXPECT_FALSE((std::is_constructible<MassData2D, Length2, Mass, RotInertia>::value));
+    EXPECT_FALSE((std::is_constructible<MassData2D, Length2, Mass>::value));
+    EXPECT_FALSE((std::is_constructible<MassData2D, Length2>::value));
+    EXPECT_FALSE((std::is_constructible<MassData2D, Length2, NonNegative<Mass>, NonNegative<RotInertia>>::value));
+    EXPECT_FALSE((std::is_constructible<MassData2D, Length2, NonNegative<Mass>>::value));
+    EXPECT_FALSE((std::is_constructible<MassData2D, Length2>::value));
+    EXPECT_TRUE((std::is_constructible<MassData2D>::value));
+    // EXPECT_FALSE(std::is_nothrow_constructible<MassData2D>::value); // clang 3.7 and 4.0
+    // EXPECT_TRUE(std::is_nothrow_constructible<MassData2D>::value); // gcc 6.3
+    EXPECT_FALSE((std::is_trivially_constructible<MassData2D, Length2, Mass, RotInertia>::value));
     
-    EXPECT_TRUE(std::is_copy_constructible<MassData>::value);
-    // EXPECT_TRUE(std::is_nothrow_copy_constructible<MassData>::value); // with clang-4.0 gcc 6.3
-    // EXPECT_FALSE(std::is_nothrow_copy_constructible<MassData>::value); // with clang-3.7
-    // EXPECT_TRUE(std::is_trivially_copy_constructible<MassData>::value); // with clang-4.0
-    // EXPECT_FALSE(std::is_trivially_copy_constructible<MassData>::value); // with clang-3.7
+    EXPECT_TRUE(std::is_copy_constructible<MassData2D>::value);
+    // EXPECT_TRUE(std::is_nothrow_copy_constructible<MassData2D>::value); // with clang-4.0 gcc 6.3
+    // EXPECT_FALSE(std::is_nothrow_copy_constructible<MassData2D>::value); // with clang-3.7
+    // EXPECT_TRUE(std::is_trivially_copy_constructible<MassData2D>::value); // with clang-4.0
+    // EXPECT_FALSE(std::is_trivially_copy_constructible<MassData2D>::value); // with clang-3.7
     
-    EXPECT_TRUE(std::is_copy_assignable<MassData>::value);
-    // EXPECT_TRUE(std::is_nothrow_copy_assignable<MassData>::value); // with clang-4.0 gcc 6.3
-    // EXPECT_FALSE(std::is_nothrow_copy_assignable<MassData>::value); // with clang-3.7
-    EXPECT_FALSE(std::is_trivially_copy_assignable<MassData>::value);
+    EXPECT_TRUE(std::is_copy_assignable<MassData2D>::value);
+    // EXPECT_TRUE(std::is_nothrow_copy_assignable<MassData2D>::value); // with clang-4.0 gcc 6.3
+    // EXPECT_FALSE(std::is_nothrow_copy_assignable<MassData2D>::value); // with clang-3.7
+    EXPECT_FALSE(std::is_trivially_copy_assignable<MassData2D>::value);
     
-    EXPECT_TRUE(std::is_destructible<MassData>::value);
-    EXPECT_TRUE(std::is_nothrow_destructible<MassData>::value);
-    EXPECT_TRUE(std::is_trivially_destructible<MassData>::value);
+    EXPECT_TRUE(std::is_destructible<MassData2D>::value);
+    EXPECT_TRUE(std::is_nothrow_destructible<MassData2D>::value);
+    EXPECT_TRUE(std::is_trivially_destructible<MassData2D>::value);
 }
 
 TEST(MassData, GetAreaOfPolygon)
@@ -233,7 +233,7 @@ TEST(MassData, GetForZeroVertexRadiusRectangle)
     ASSERT_EQ(GetY(shape.GetCentroid()), 0_m);
     const auto mass_data = GetMassData(shape);
     EXPECT_TRUE(AlmostEqual(Real(Mass{mass_data.mass} / 1_kg),
-                             Real((density / KilogramPerSquareMeter) * (8 * 2))));
+                             Real((density / 1_kgpm2) * (8 * 2))));
     EXPECT_NEAR(double(StripUnit(mass_data.I)),
                 90.666664 * double(StripUnit(density)),
                 0.008);
@@ -362,13 +362,13 @@ TEST(MassData, GetForCenteredEdge)
 
 TEST(MassData, Equals)
 {
-    const auto foo = MassData{};
+    const auto foo = MassData2D{};
     EXPECT_TRUE(foo == foo);
     
-    const auto boo = MassData{};
+    const auto boo = MassData2D{};
     EXPECT_TRUE(foo == boo);
     
-    const auto poo = MassData{
+    const auto poo = MassData2D{
         Length2(1_m, 1_m), 4_kg, RotInertia{2_kg * SquareMeter / SquareRadian}
     };
     EXPECT_FALSE(foo == poo);
@@ -376,13 +376,13 @@ TEST(MassData, Equals)
 
 TEST(MassData, NotEquals)
 {
-    const auto foo = MassData{};
+    const auto foo = MassData2D{};
     EXPECT_FALSE(foo != foo);
     
-    const auto boo = MassData{};
+    const auto boo = MassData2D{};
     EXPECT_FALSE(foo != boo);
     
-    const auto poo = MassData{
+    const auto poo = MassData2D{
         Length2(1_m, 1_m), 4_kg, RotInertia{2_kg * SquareMeter / SquareRadian}
     };
     EXPECT_TRUE(foo != poo);

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -301,7 +301,7 @@ TEST(Math, TransformIsRotatePlusTranslate)
     const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
-    const auto transformation = Transformation{translation, rotation};
+    const auto transformation = Transformation2D{translation, rotation};
     
     const auto transformed_vector = Transform(vector, transformation);
     const auto alt = Rotate(vector, rotation) + translation;
@@ -314,7 +314,7 @@ TEST(Math, InverseTransformIsUntranslateAndInverseRotate)
     const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
-    const auto transformation = Transformation{translation, rotation};
+    const auto transformation = Transformation2D{translation, rotation};
     
     const auto inv_vector = InverseTransform(vector, transformation);
     const auto alt = InverseRotate(vector - translation, rotation);
@@ -327,7 +327,7 @@ TEST(Math, InverseTransformTransformedIsOriginal)
     const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
-    const auto transformation = Transformation{translation, rotation};
+    const auto transformation = Transformation2D{translation, rotation};
 
     const auto transformed_vector = Transform(vector, transformation);
     const auto inverse_transformed_vector = InverseTransform(transformed_vector, transformation);
@@ -343,7 +343,7 @@ TEST(Math, TransformInverseTransformedIsOriginal)
     const auto vector = Length2{19_m, -0.5_m};
     const auto translation = Length2{-3_m, +5_m};
     const auto rotation = UnitVec2::GetTop();
-    const auto transformation = Transformation{translation, rotation};
+    const auto transformation = Transformation2D{translation, rotation};
 
     const auto inverse_transformed_vector = InverseTransform(vector, transformation);
     const auto transformed_inverse_vector = Transform(inverse_transformed_vector, transformation);

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -497,8 +497,8 @@ TEST(Math, ComputeCentroidOfHexagonalVertices)
 
 TEST(Math, GetContactRelVelocity)
 {
-    const auto velA = Velocity{LinearVelocity2(+1_mps, +4_mps), 3.2f * RadianPerSecond};
-    const auto velB = Velocity{LinearVelocity2(+3_mps, +1_mps), 0.4f * RadianPerSecond};
+    const auto velA = Velocity2D{LinearVelocity2(+1_mps, +4_mps), 3.2f * RadianPerSecond};
+    const auto velB = Velocity2D{LinearVelocity2(+3_mps, +1_mps), 0.4f * RadianPerSecond};
     const auto relA = Length2{};
     const auto relB = Length2{};
     const auto result = GetContactRelVelocity(velA, relA, velB, relB);

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -608,7 +608,7 @@ TEST(Math, GetPosition)
     const auto y = Real{5.515012264251709e+00f};
     const auto value = Real{0.0866042823f};
 
-    const auto oldPos = Position{Vec2{x, y} * Meter, 0_rad};
+    const auto oldPos = Position2D{Vec2{x, y} * Meter, 0_rad};
     const auto newPos = GetPosition(oldPos, oldPos, value);
     
     EXPECT_EQ(oldPos.linear, newPos.linear);

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -56,7 +56,7 @@ TEST(MultiShapeConf, ByteSize)
 TEST(MultiShapeConf, DefaultConstruction)
 {
     const auto foo = MultiShapeConf{};
-    const auto defaultMassData = MassData{};
+    const auto defaultMassData = MassData2D{};
     const auto defaultConf = MultiShapeConf{};
     
     EXPECT_EQ(typeid(foo), typeid(MultiShapeConf));
@@ -108,7 +108,7 @@ TEST(MultiShapeConf, BaseVisitorForDiskShape)
 #endif
 TEST(MultiShapeConf, AddConvexHullWithOnePointSameAsDisk)
 {
-    const auto defaultMassData = MassData{};
+    const auto defaultMassData = MassData2D{};
     const auto center = Length2(1_m, -4_m);
 
     auto pointSet = VertexSet{};
@@ -143,7 +143,7 @@ TEST(MultiShapeConf, AddConvexHullWithOnePointSameAsDisk)
 
 TEST(MultiShapeConf, AddConvexHullWithTwoPointsSameAsEdge)
 {
-    const auto defaultMassData = MassData{};
+    const auto defaultMassData = MassData2D{};
     const auto p0 = Length2(1_m, -4_m);
     const auto p1 = Length2(1_m, +4_m);
     
@@ -186,7 +186,7 @@ TEST(MultiShapeConf, AddConvexHullWithTwoPointsSameAsEdge)
 
 TEST(MultiShapeConf, AddTwoConvexHullWithOnePoint)
 {
-    const auto defaultMassData = MassData{};
+    const auto defaultMassData = MassData2D{};
     const auto p0 = Length2(1_m, -4_m);
     const auto p1 = Length2(1_m, +4_m);
 

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -196,7 +196,7 @@ TEST(PolygonShapeConf, Translate)
     
     const auto new_ctr = Length2{-3_m, 67_m};
     shape = PolygonShapeConf{
-        PolygonShapeConf{}.SetAsBox(hx, hy).Transform(Transformation{new_ctr, UnitVec2::GetRight()})
+        PolygonShapeConf{}.SetAsBox(hx, hy).Transform(Transformation2D{new_ctr, UnitVec2::GetRight()})
     };
 
     EXPECT_NEAR(static_cast<double>(Real{GetX(shape.GetCentroid())/Meter}),

--- a/UnitTests/PositionSolverManifold.cpp
+++ b/UnitTests/PositionSolverManifold.cpp
@@ -72,8 +72,8 @@ TEST(PositionSolverManifold, GetPSM)
     ASSERT_EQ(GetX(shape1.GetVertex(3)), -2_m); // left
     ASSERT_EQ(GetY(shape1.GetVertex(3)), -2_m); // bottom
     
-    const auto xfm0 = Transformation{Length2{-2_m, 0_m}, UnitVec2::GetRight()}; // left
-    const auto xfm1 = Transformation{Length2{+2_m, 0_m}, UnitVec2::GetRight()}; // right
+    const auto xfm0 = Transformation2D{Length2{-2_m, 0_m}, UnitVec2::GetRight()}; // left
+    const auto xfm1 = Transformation2D{Length2{+2_m, 0_m}, UnitVec2::GetRight()}; // right
     
     // put wide rectangle on left, square on right
     const auto manifold = CollideShapes(GetChild(shape0, 0), xfm0, GetChild(shape1, 0), xfm1);

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -50,12 +50,12 @@ TEST(SeparationFinder, BehavesAsExpected)
 
     const auto x = Real(100);
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, 0_m}, 0_deg},
-        Position{Length2{+x * Meter, 0_m}, 0_deg}
+        Position2D{Length2{-x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{+x * Meter, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, 0_m}, 0_deg},
-        Position{Length2{-x * Meter, 0_m}, 0_deg}
+        Position2D{Length2{+x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };
     
     auto t = Real{0}; // Will be set to value of t2

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -49,11 +49,11 @@ TEST(SeparationFinder, BehavesAsExpected)
     const auto distproxy = GetChild(shape, 0);
 
     const auto x = Real(100);
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-x * Meter, 0_m}, 0_deg},
         Position2D{Length2{+x * Meter, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+x * Meter, 0_m}, 0_deg},
         Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -47,7 +47,7 @@ TEST(Shape, ByteSize)
 TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)
 {
     const auto shape = DiskShapeConf{2_m};
-    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto child = GetChild(shape, 0);
 
     const auto maxloops = 1000000u;
@@ -94,7 +94,7 @@ TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)
 TEST(Shape, TestOverlapFasterThanCollideShapesForPolygons)
 {
     const auto shape = PolygonShapeConf{2_m, 2_m};
-    const auto xfm = Transformation{Length2{}, UnitVec2::GetRight()};
+    const auto xfm = Transformation2D{Length2{}, UnitVec2::GetRight()};
     const auto child = GetChild(shape, 0);
 
     const auto maxloops = 1000000u;

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -33,14 +33,14 @@ TEST(Sweep, ByteSize)
 }
 
 TEST(Sweep, ConstructorSetsPos0and1) {
-    const auto pos = Position{Length2{-0.4_m, 2.34_m}, 3.14_rad};
+    const auto pos = Position2D{Length2{-0.4_m, 2.34_m}, 3.14_rad};
     Sweep sweep{pos};
     EXPECT_EQ(pos, sweep.pos0);
     EXPECT_EQ(pos, sweep.pos1);
 }
 
 TEST(Sweep, ResetSetsAlpha0to0) {
-    const auto pos = Position{Length2{-0.4_m, 2.34_m}, 3.14_rad};
+    const auto pos = Position2D{Length2{-0.4_m, 2.34_m}, 3.14_rad};
     Sweep sweep{pos, pos, Length2{}, Real(0.6)};
     EXPECT_NE(Real{0}, sweep.GetAlpha0());
     sweep.ResetAlpha0();
@@ -48,16 +48,16 @@ TEST(Sweep, ResetSetsAlpha0to0) {
 }
 
 TEST(Sweep, GetPosition) {
-    const auto pos0 = Position{Length2{-0.4_m, +2.34_m}, 3.14_rad};
-    const auto pos1 = Position{Length2{+0.4_m, -2.34_m}, -3.14_rad};
+    const auto pos0 = Position2D{Length2{-0.4_m, +2.34_m}, 3.14_rad};
+    const auto pos1 = Position2D{Length2{+0.4_m, -2.34_m}, -3.14_rad};
     Sweep sweep{pos0, pos1, Length2{}, Real(0.6)};
     EXPECT_EQ(pos0, GetPosition(sweep.pos0, sweep.pos1, 0));
     EXPECT_EQ(pos1, GetPosition(sweep.pos0, sweep.pos1, 1));
 }
 
 TEST(Sweep, Advance) {
-    const auto pos0 = Position{Length2{-0.4_m, +2.34_m}, 3.14_rad};
-    const auto pos1 = Position{Length2{+0.4_m, -2.34_m}, -3.14_rad};
+    const auto pos0 = Position2D{Length2{-0.4_m, +2.34_m}, 3.14_rad};
+    const auto pos1 = Position2D{Length2{+0.4_m, -2.34_m}, -3.14_rad};
     
     Sweep sweep{pos0, pos1, Length2{}, 0};
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());
@@ -70,7 +70,7 @@ TEST(Sweep, Advance) {
     sweep.Advance0(Real{1}/Real{2});
     EXPECT_EQ(Real{1}/Real{2}, sweep.GetAlpha0());
     EXPECT_EQ(pos1, sweep.pos1);
-    EXPECT_EQ((Position{Length2{}, 0_deg}), sweep.pos0);
+    EXPECT_EQ((Position2D{Length2{}, 0_deg}), sweep.pos0);
 
     sweep.Advance0(0);
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());
@@ -81,47 +81,47 @@ TEST(Sweep, Advance) {
 TEST(Sweep, GetNormalized)
 {
     const auto sweep0 = Sweep{
-        Position{Length2{}, 0_deg},
-        Position{Length2{}, 0_deg}
+        Position2D{Length2{}, 0_deg},
+        Position2D{Length2{}, 0_deg}
     };
     EXPECT_EQ(GetNormalized(sweep0).pos0.angular, 0_deg);
     EXPECT_EQ(GetNormalized(sweep0).pos1.angular, 0_deg);
 
-    const auto sweep1 = Sweep{Position{Length2{}, 90_deg}, Position{Length2{}, 90_deg}};
+    const auto sweep1 = Sweep{Position2D{Length2{}, 90_deg}, Position2D{Length2{}, 90_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep1).pos0.angular / Degree}),
                 double( 90), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep1).pos1.angular / Degree}),
                 double( 90), 0.03);
 
-    const auto sweep2 = Sweep{Position{Length2{}, 180_deg}, Position{Length2{}, 180_deg}};
+    const auto sweep2 = Sweep{Position2D{Length2{}, 180_deg}, Position2D{Length2{}, 180_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep2).pos0.angular / Degree}),
                 double(180), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep2).pos1.angular / Degree}),
                 double(180), 0.03);
 
-    const auto sweep3 = Sweep{Position{Length2{}, 270_deg}, Position{Length2{}, 270_deg}};
+    const auto sweep3 = Sweep{Position2D{Length2{}, 270_deg}, Position2D{Length2{}, 270_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep3).pos0.angular / Degree}), -90.0, 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep3).pos1.angular / Degree}), -90.0, 0.03);
 
-    const auto sweep4 = Sweep{Position{Length2{}, 361_deg}, Position{Length2{}, 361_deg}};
+    const auto sweep4 = Sweep{Position2D{Length2{}, 361_deg}, Position2D{Length2{}, 361_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep4).pos0.angular / Degree}),
                 double(1), 0.001);
     EXPECT_NEAR(double(Real{GetNormalized(sweep4).pos1.angular / Degree}),
                 double(1), 0.001);
 
-    const auto sweep5 = Sweep{Position{Length2{}, 722_deg}, Position{Length2{}, 722_deg}};
+    const auto sweep5 = Sweep{Position2D{Length2{}, 722_deg}, Position2D{Length2{}, 722_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep5).pos0.angular / Degree}),
                 double(2), 0.002);
     EXPECT_NEAR(double(Real{GetNormalized(sweep5).pos1.angular / Degree}),
                 double(2), 0.002);
 
-    const auto sweep6 = Sweep{Position{Length2{}, 726_deg}, Position{Length2{}, 90_deg}};
+    const auto sweep6 = Sweep{Position2D{Length2{}, 726_deg}, Position2D{Length2{}, 90_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep6).pos0.angular / Degree}),
                 double(6), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep6).pos1.angular / Degree}),
                 double(-630), 0.03);
     
-    const auto sweep7 = Sweep{Position{Length2{}, -90_deg}, Position{Length2{}, -90_deg}};
+    const auto sweep7 = Sweep{Position2D{Length2{}, -90_deg}, Position2D{Length2{}, -90_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep7).pos0.angular / Degree}),
                 double( -90), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep7).pos1.angular / Degree}),

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -25,23 +25,23 @@ TEST(Sweep, ByteSize)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(Sweep), std::size_t(36)); break;
-        case  8: EXPECT_EQ(sizeof(Sweep), std::size_t(72)); break;
-        case 16: EXPECT_EQ(sizeof(Sweep), std::size_t(144)); break;
+        case  4: EXPECT_EQ(sizeof(Sweep2D), std::size_t(36)); break;
+        case  8: EXPECT_EQ(sizeof(Sweep2D), std::size_t(72)); break;
+        case 16: EXPECT_EQ(sizeof(Sweep2D), std::size_t(144)); break;
         default: FAIL(); break;
     }
 }
 
 TEST(Sweep, ConstructorSetsPos0and1) {
     const auto pos = Position2D{Length2{-0.4_m, 2.34_m}, 3.14_rad};
-    Sweep sweep{pos};
+    Sweep2D sweep{pos};
     EXPECT_EQ(pos, sweep.pos0);
     EXPECT_EQ(pos, sweep.pos1);
 }
 
 TEST(Sweep, ResetSetsAlpha0to0) {
     const auto pos = Position2D{Length2{-0.4_m, 2.34_m}, 3.14_rad};
-    Sweep sweep{pos, pos, Length2{}, Real(0.6)};
+    Sweep2D sweep{pos, pos, Length2{}, Real(0.6)};
     EXPECT_NE(Real{0}, sweep.GetAlpha0());
     sweep.ResetAlpha0();
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());    
@@ -50,7 +50,7 @@ TEST(Sweep, ResetSetsAlpha0to0) {
 TEST(Sweep, GetPosition) {
     const auto pos0 = Position2D{Length2{-0.4_m, +2.34_m}, 3.14_rad};
     const auto pos1 = Position2D{Length2{+0.4_m, -2.34_m}, -3.14_rad};
-    Sweep sweep{pos0, pos1, Length2{}, Real(0.6)};
+    Sweep2D sweep{pos0, pos1, Length2{}, Real(0.6)};
     EXPECT_EQ(pos0, GetPosition(sweep.pos0, sweep.pos1, 0));
     EXPECT_EQ(pos1, GetPosition(sweep.pos0, sweep.pos1, 1));
 }
@@ -59,7 +59,7 @@ TEST(Sweep, Advance) {
     const auto pos0 = Position2D{Length2{-0.4_m, +2.34_m}, 3.14_rad};
     const auto pos1 = Position2D{Length2{+0.4_m, -2.34_m}, -3.14_rad};
     
-    Sweep sweep{pos0, pos1, Length2{}, 0};
+    Sweep2D sweep{pos0, pos1, Length2{}, 0};
     EXPECT_EQ(Real{0}, sweep.GetAlpha0());
     
     sweep.Advance0(0);
@@ -80,48 +80,48 @@ TEST(Sweep, Advance) {
 
 TEST(Sweep, GetNormalized)
 {
-    const auto sweep0 = Sweep{
+    const auto sweep0 = Sweep2D{
         Position2D{Length2{}, 0_deg},
         Position2D{Length2{}, 0_deg}
     };
     EXPECT_EQ(GetNormalized(sweep0).pos0.angular, 0_deg);
     EXPECT_EQ(GetNormalized(sweep0).pos1.angular, 0_deg);
 
-    const auto sweep1 = Sweep{Position2D{Length2{}, 90_deg}, Position2D{Length2{}, 90_deg}};
+    const auto sweep1 = Sweep2D{Position2D{Length2{}, 90_deg}, Position2D{Length2{}, 90_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep1).pos0.angular / Degree}),
                 double( 90), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep1).pos1.angular / Degree}),
                 double( 90), 0.03);
 
-    const auto sweep2 = Sweep{Position2D{Length2{}, 180_deg}, Position2D{Length2{}, 180_deg}};
+    const auto sweep2 = Sweep2D{Position2D{Length2{}, 180_deg}, Position2D{Length2{}, 180_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep2).pos0.angular / Degree}),
                 double(180), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep2).pos1.angular / Degree}),
                 double(180), 0.03);
 
-    const auto sweep3 = Sweep{Position2D{Length2{}, 270_deg}, Position2D{Length2{}, 270_deg}};
+    const auto sweep3 = Sweep2D{Position2D{Length2{}, 270_deg}, Position2D{Length2{}, 270_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep3).pos0.angular / Degree}), -90.0, 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep3).pos1.angular / Degree}), -90.0, 0.03);
 
-    const auto sweep4 = Sweep{Position2D{Length2{}, 361_deg}, Position2D{Length2{}, 361_deg}};
+    const auto sweep4 = Sweep2D{Position2D{Length2{}, 361_deg}, Position2D{Length2{}, 361_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep4).pos0.angular / Degree}),
                 double(1), 0.001);
     EXPECT_NEAR(double(Real{GetNormalized(sweep4).pos1.angular / Degree}),
                 double(1), 0.001);
 
-    const auto sweep5 = Sweep{Position2D{Length2{}, 722_deg}, Position2D{Length2{}, 722_deg}};
+    const auto sweep5 = Sweep2D{Position2D{Length2{}, 722_deg}, Position2D{Length2{}, 722_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep5).pos0.angular / Degree}),
                 double(2), 0.002);
     EXPECT_NEAR(double(Real{GetNormalized(sweep5).pos1.angular / Degree}),
                 double(2), 0.002);
 
-    const auto sweep6 = Sweep{Position2D{Length2{}, 726_deg}, Position2D{Length2{}, 90_deg}};
+    const auto sweep6 = Sweep2D{Position2D{Length2{}, 726_deg}, Position2D{Length2{}, 90_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep6).pos0.angular / Degree}),
                 double(6), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep6).pos1.angular / Degree}),
                 double(-630), 0.03);
     
-    const auto sweep7 = Sweep{Position2D{Length2{}, -90_deg}, Position2D{Length2{}, -90_deg}};
+    const auto sweep7 = Sweep2D{Position2D{Length2{}, -90_deg}, Position2D{Length2{}, -90_deg}};
     EXPECT_NEAR(double(Real{GetNormalized(sweep7).pos0.angular / Degree}),
                 double( -90), 0.03);
     EXPECT_NEAR(double(Real{GetNormalized(sweep7).pos1.angular / Degree}),

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -164,10 +164,10 @@ TEST(TimeOfImpact, Overlapped)
     const auto radius = 1_m;
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position2D{Length2{}, 0_deg}};
+    const auto sweepA = Sweep2D{Position2D{Length2{}, 0_deg}};
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position2D{Length2{}, 0_deg}};
+    const auto sweepB = Sweep2D{Position2D{Length2{}, 0_deg}};
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     EXPECT_EQ(output.state, TOIOutput::e_overlapped);
     EXPECT_EQ(output.time, Real(0));
@@ -183,11 +183,11 @@ TEST(TimeOfImpact, Touching)
 
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position2D{Length2{}, 0_deg}};
+    const auto sweepA = Sweep2D{Position2D{Length2{}, 0_deg}};
     
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position2D{Length2{2_m, 0_m}, 0_deg}};
+    const auto sweepB = Sweep2D{Position2D{Length2{2_m, 0_m}, 0_deg}};
 
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -204,11 +204,11 @@ TEST(TimeOfImpact, Separated)
     
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position2D{Length2{}, 0_deg}};
+    const auto sweepA = Sweep2D{Position2D{Length2{}, 0_deg}};
     
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position2D{Length2{4_m, 0_m}, 0_deg}};
+    const auto sweepB = Sweep2D{Position2D{Length2{4_m, 0_m}, 0_deg}};
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -228,10 +228,10 @@ TEST(TimeOfImpact, CollideCirclesHorizontally)
     const auto x = Real(2);
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position2D{Length2{-x * Meter, 0_m}, 0_deg}, Position2D{Length2{}, 0_deg}};
+    const auto sweepA = Sweep2D{Position2D{Length2{-x * Meter, 0_m}, 0_deg}, Position2D{Length2{}, 0_deg}};
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position2D{Length2{+x * Meter, 0_m}, 0_deg}, Position2D{Length2{}, 0_deg}};
+    const auto sweepB = Sweep2D{Position2D{Length2{+x * Meter, 0_m}, 0_deg}, Position2D{Length2{}, 0_deg}};
     
     // Compute the time of impact information now...
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
@@ -262,13 +262,13 @@ TEST(TimeOfImpact, CollideCirclesVertically)
     const auto pos = Length2{};
 
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{0_m, -y * Meter}, 0_deg},
         Position2D{Length2{0_m, +y * Meter}, 0_deg}
     };
     
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{0_m, +y * Meter}, 0_deg},
         Position2D{Length2{0_m, -y * Meter}, 0_deg}
     };
@@ -302,12 +302,12 @@ TEST(TimeOfImpact, CirclesPassingParSepPathsDontCollide)
     const auto x = Real(3);
     const auto y = Real(1);
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-x * Meter, +y * Meter}, 0_deg},
         Position2D{Length2{+x * Meter, +y * Meter}, 0_deg}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+x * Meter, -y * Meter}, 0_deg},
         Position2D{Length2{-x * Meter, -y * Meter}, 0_deg}
     };
@@ -337,10 +337,10 @@ TEST(TimeOfImpact, CirclesExactlyTouchingAtStart)
     const UnitVec2 circleNormals[] = {UnitVec2{}};
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
-    const auto circleSweep0 = Sweep{
+    const auto circleSweep0 = Sweep2D{
         Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
-    const auto circleSweep1 = Sweep{
+    const auto circleSweep1 = Sweep2D{
         Position2D{Length2{+1_m, 0_m}, 0_deg}
     };
     
@@ -369,10 +369,10 @@ TEST(TimeOfImpact, EdgeCircleExactlyTouchingAtStart)
     const UnitVec2 circleNormals[] = {UnitVec2{}};
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
-    const auto edgeSweep = Sweep{
+    const auto edgeSweep = Sweep2D{
         Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
-    const auto circleSweep = Sweep{
+    const auto circleSweep = Sweep2D{
         Position2D{Length2{radius * 2, 0_m}, 0_deg}
     };
     
@@ -402,10 +402,10 @@ TEST(TimeOfImpact, EdgeCircleTolerantTouchingAsRounded)
     const UnitVec2 circleNormals[] = {UnitVec2{}};
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
-    const auto edgeSweep = Sweep{
+    const auto edgeSweep = Sweep2D{
         Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
-    const auto circleSweep = Sweep{
+    const auto circleSweep = Sweep2D{
         Position2D{Length2{2_m, 1_m}, 0_deg},
         Position2D{Length2{1.5_m, 1_m}, 0_deg}
     };
@@ -431,10 +431,10 @@ TEST(TimeOfImpact, EdgeEdgeTolerantTouchingAsRounded)
     const UnitVec2 edgeNormals[] = {n0, n1};
     const auto edge = DistanceProxy{radius, 2, edgeVertices, edgeNormals};
     
-    const auto edgeSweep0 = Sweep{
+    const auto edgeSweep0 = Sweep2D{
         Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
-    const auto edgeSweep1 = Sweep{
+    const auto edgeSweep1 = Sweep2D{
         Position2D{Length2{3_m, 1_m}, 0_deg},
         Position2D{Length2{2.5_m, 1_m}, 0_deg}
     };
@@ -464,10 +464,10 @@ TEST(TimeOfImpact, EdgeCircleSeparated)
     const UnitVec2 circleNormals[] = {UnitVec2{}};
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
-    const auto edgeSweep = Sweep{
+    const auto edgeSweep = Sweep2D{
         Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
-    const auto circleSweep = Sweep{
+    const auto circleSweep = Sweep2D{
         Position2D{Length2{radius * 2, 0.5_m}, 0_deg}
     };
     
@@ -495,13 +495,13 @@ TEST(TimeOfImpact, RodCircleMissAt360)
     const auto nA0 = GetUnitVector(vA1 - vA0);
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-x * Meter, 4_m}, 0_deg},
         Position2D{Length2{+x * Meter, 4_m}, 360_deg}
     };
     const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+x * Meter, 0_m}, 0_deg},
         Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };
@@ -538,13 +538,13 @@ TEST(TimeOfImpact, RodCircleHitAt180)
     const auto nA0 = GetUnitVector(vA1 - vA0);
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-x * Meter, 4_m}, 0_deg},
         Position2D{Length2{+x * Meter, 4_m}, Angle{Real{180.0f} * 1_deg}}
     };
     const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+x * Meter, 0_m}, 0_deg},
         Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };
@@ -573,12 +573,12 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_1)
     const auto x = Real(200);
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-x * Meter, 0_m}, 0_deg},
         Position2D{Length2{+x * Meter, 0_m}, 0_deg}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+x * Meter, 0_m}, 0_deg},
         Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };
@@ -619,12 +619,12 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
     const auto x = Real(400);
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-x * Meter, 0_m}, 0_deg},
         Position2D{Length2{}, 0_deg}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+x * Meter, 0_m}, 0_deg},
         Position2D{Length2{}, 0_deg}
     };
@@ -698,9 +698,9 @@ TEST(TimeOfImpact, WithClosingSpeedOf1600)
     const auto x = Real(400);
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{Position2D{Length2{-x * Meter, 0_m}, 0_deg}, Position2D{Length2{+x * Meter, 0_m}, 0_deg}};
+    const auto sweepA = Sweep2D{Position2D{Length2{-x * Meter, 0_m}, 0_deg}, Position2D{Length2{+x * Meter, 0_m}, 0_deg}};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{Position2D{Length2{+x * Meter, 0_m}, 0_deg}, Position2D{Length2{-x * Meter, 0_m}, 0_deg}};
+    const auto sweepB = Sweep2D{Position2D{Length2{+x * Meter, 0_m}, 0_deg}, Position2D{Length2{-x * Meter, 0_m}, 0_deg}};
     
     const auto conf = ToiConf{}
         .UseMaxToiIters(200)
@@ -747,11 +747,11 @@ TEST(TimeOfImpact, ForNonCollidingShapesFails)
     const auto dpA = GetChild(shapeA, 0);
     const auto dpB = GetChild(shapeB, 0);
 
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-11_m, 10_m}, 2.95000005_rad},
         Position2D{Length2{-11_m, 10_m}, 2.95000005_rad}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{18.4742737_m, 19.7474861_m}, 513.36676_rad},
         Position2D{Length2{19.5954781_m, 18.9165268_m}, 513.627808_rad}
     };
@@ -809,11 +809,11 @@ TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
     // This setup causes the TimeOfImpact function to get into the state where
     // separation has reached tolerance but t2 already equals t1.
 
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{0.0_m, -0.5_m}, 0_deg},
         Position2D{Length2{0.0_m, -0.5_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{14.3689661_m, 0.500306308_m}, 0.0000139930862_rad},
         Position2D{Length2{14.3689451_m, 0.500254989_m}, 0.000260060915_rad}
     };
@@ -902,11 +902,11 @@ TEST(TimeOfImpact, MaxToiIters)
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
 
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-5_m, 0_m}, 0_deg},
         Position2D{Length2{-5_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+5_m, 0_m}, 0_deg},
         Position2D{Length2{+5_m, 0_m}, 0_deg}
     };
@@ -928,11 +928,11 @@ TEST(TimeOfImpact, MaxDistIters)
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
 
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-5_m, 0_m}, 0_deg},
         Position2D{Length2{-5_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+5_m, 0_m}, 0_deg},
         Position2D{Length2{+5_m, 0_m}, 0_deg}
     };
@@ -954,11 +954,11 @@ TEST(TimeOfImpact, MaxRootIters)
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
 
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-5_m, 0_m}, 0_deg},
         Position2D{Length2{-0_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+5_m, 0_m}, 0_deg},
         Position2D{Length2{+0_m, 0_m}, 0_deg}
     };
@@ -985,11 +985,11 @@ TEST(TimeOfImpact, NextAfter)
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-2e18_m, 0_m}, 0_deg},
         Position2D{Length2{+1e16_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+2e18_m, 0_m}, 0_deg},
         Position2D{Length2{+0_m, 0_m}, 0_deg}
     };
@@ -1055,11 +1055,11 @@ TEST(TimeOfImpact, TargetDepthExceedsTotalRadius)
         .UseTolerance(0_m)
         ;
     
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-200_m, 0_m}, 0_deg},
         Position2D{Length2{+100_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+200_m, 0_m}, 0_deg},
         Position2D{Length2{-10_m, 0_m}, 0_deg}
     };
@@ -1090,11 +1090,11 @@ TEST(TimeOfImpact, MinTargetSquaredOverflow)
         .UseTolerance(0_m)
         ;
     
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-200_m, 0_m}, 0_deg},
         Position2D{Length2{+100_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+200_m, 0_m}, 0_deg},
         Position2D{Length2{-10_m, 0_m}, 0_deg}
     };
@@ -1125,11 +1125,11 @@ TEST(TimeOfImpact, MaxTargetSquaredOverflow)
         .UseTolerance(NonNegative<Length>{std::numeric_limits<Length>::max()})
         ;
 
-    const auto sweepA = Sweep{
+    const auto sweepA = Sweep2D{
         Position2D{Length2{-200_m, 0_m}, 0_deg},
         Position2D{Length2{+100_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
+    const auto sweepB = Sweep2D{
         Position2D{Length2{+200_m, 0_m}, 0_deg},
         Position2D{Length2{-10_m, 0_m}, 0_deg}
     };
@@ -1195,11 +1195,11 @@ TEST(TimeOfImpact, TryOutDifferentConfs)
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     
     {
-        const auto sweepA = Sweep{
+        const auto sweepA = Sweep2D{
             Position2D{Length2{-2e16_m, 0_m}, 0_deg},
             Position2D{Length2{+1e16_m, 0_m}, 0_deg}
         };
-        const auto sweepB = Sweep{
+        const auto sweepB = Sweep2D{
             Position2D{Length2{+2e16_m, 0_m}, 0_deg},
             Position2D{Length2{0_m, 0_m}, 0_deg}
         };

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -1153,13 +1153,13 @@ TEST(TimeOfImpact, BelowMinTarget)
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
 
-    const auto sweepA = Sweep{
-        Position{Length2{-2e18_m, 0_m}, 0_deg},
-        Position{Length2{+0_m, 0_m}, 0_deg}
+    const auto sweepA = Sweep2D{
+        Position2D{Length2{-2e18_m, 0_m}, 0_deg},
+        Position2D{Length2{+0_m, 0_m}, 0_deg}
     };
-    const auto sweepB = Sweep{
-        Position{Length2{+2e18_m, 0_m}, 0_deg},
-        Position{Length2{+0_m, 0_m}, 0_deg}
+    const auto sweepB = Sweep2D{
+        Position2D{Length2{+2e18_m, 0_m}, 0_deg},
+        Position2D{Length2{+0_m, 0_m}, 0_deg}
     };
     const auto conf = ToiConf{}
         .UseTargetDepth(0.002_m)

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -164,10 +164,10 @@ TEST(TimeOfImpact, Overlapped)
     const auto radius = 1_m;
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2{}, 0_deg}};
+    const auto sweepA = Sweep{Position2D{Length2{}, 0_deg}};
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2{}, 0_deg}};
+    const auto sweepB = Sweep{Position2D{Length2{}, 0_deg}};
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     EXPECT_EQ(output.state, TOIOutput::e_overlapped);
     EXPECT_EQ(output.time, Real(0));
@@ -183,11 +183,11 @@ TEST(TimeOfImpact, Touching)
 
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2{}, 0_deg}};
+    const auto sweepA = Sweep{Position2D{Length2{}, 0_deg}};
     
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2{2_m, 0_m}, 0_deg}};
+    const auto sweepB = Sweep{Position2D{Length2{2_m, 0_m}, 0_deg}};
 
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -204,11 +204,11 @@ TEST(TimeOfImpact, Separated)
     
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2{}, 0_deg}};
+    const auto sweepA = Sweep{Position2D{Length2{}, 0_deg}};
     
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2{4_m, 0_m}, 0_deg}};
+    const auto sweepB = Sweep{Position2D{Length2{4_m, 0_m}, 0_deg}};
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
     
@@ -228,10 +228,10 @@ TEST(TimeOfImpact, CollideCirclesHorizontally)
     const auto x = Real(2);
     const auto pA = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pA, nullptr};
-    const auto sweepA = Sweep{Position{Length2{-x * Meter, 0_m}, 0_deg}, Position{Length2{}, 0_deg}};
+    const auto sweepA = Sweep{Position2D{Length2{-x * Meter, 0_m}, 0_deg}, Position2D{Length2{}, 0_deg}};
     const auto pB = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pB, nullptr};
-    const auto sweepB = Sweep{Position{Length2{+x * Meter, 0_m}, 0_deg}, Position{Length2{}, 0_deg}};
+    const auto sweepB = Sweep{Position2D{Length2{+x * Meter, 0_m}, 0_deg}, Position2D{Length2{}, 0_deg}};
     
     // Compute the time of impact information now...
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
@@ -263,14 +263,14 @@ TEST(TimeOfImpact, CollideCirclesVertically)
 
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{0_m, -y * Meter}, 0_deg},
-        Position{Length2{0_m, +y * Meter}, 0_deg}
+        Position2D{Length2{0_m, -y * Meter}, 0_deg},
+        Position2D{Length2{0_m, +y * Meter}, 0_deg}
     };
     
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{0_m, +y * Meter}, 0_deg},
-        Position{Length2{0_m, -y * Meter}, 0_deg}
+        Position2D{Length2{0_m, +y * Meter}, 0_deg},
+        Position2D{Length2{0_m, -y * Meter}, 0_deg}
     };
     
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, limits);
@@ -303,13 +303,13 @@ TEST(TimeOfImpact, CirclesPassingParSepPathsDontCollide)
     const auto y = Real(1);
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, +y * Meter}, 0_deg},
-        Position{Length2{+x * Meter, +y * Meter}, 0_deg}
+        Position2D{Length2{-x * Meter, +y * Meter}, 0_deg},
+        Position2D{Length2{+x * Meter, +y * Meter}, 0_deg}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, -y * Meter}, 0_deg},
-        Position{Length2{-x * Meter, -y * Meter}, 0_deg}
+        Position2D{Length2{+x * Meter, -y * Meter}, 0_deg},
+        Position2D{Length2{-x * Meter, -y * Meter}, 0_deg}
     };
     
     // Compute the time of impact information now...
@@ -338,10 +338,10 @@ TEST(TimeOfImpact, CirclesExactlyTouchingAtStart)
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
     const auto circleSweep0 = Sweep{
-        Position{Length2{-1_m, 0_m}, 0_deg}
+        Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
     const auto circleSweep1 = Sweep{
-        Position{Length2{+1_m, 0_m}, 0_deg}
+        Position2D{Length2{+1_m, 0_m}, 0_deg}
     };
     
     const auto slop = 0_m;
@@ -370,10 +370,10 @@ TEST(TimeOfImpact, EdgeCircleExactlyTouchingAtStart)
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
     const auto edgeSweep = Sweep{
-        Position{Length2{-1_m, 0_m}, 0_deg}
+        Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
     const auto circleSweep = Sweep{
-        Position{Length2{radius * 2, 0_m}, 0_deg}
+        Position2D{Length2{radius * 2, 0_m}, 0_deg}
     };
     
     const auto slop = 0_m;
@@ -403,11 +403,11 @@ TEST(TimeOfImpact, EdgeCircleTolerantTouchingAsRounded)
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
     const auto edgeSweep = Sweep{
-        Position{Length2{-1_m, 0_m}, 0_deg}
+        Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
     const auto circleSweep = Sweep{
-        Position{Length2{2_m, 1_m}, 0_deg},
-        Position{Length2{1.5_m, 1_m}, 0_deg}
+        Position2D{Length2{2_m, 1_m}, 0_deg},
+        Position2D{Length2{1.5_m, 1_m}, 0_deg}
     };
     
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(0_m).UseTolerance(0.001_m);
@@ -432,11 +432,11 @@ TEST(TimeOfImpact, EdgeEdgeTolerantTouchingAsRounded)
     const auto edge = DistanceProxy{radius, 2, edgeVertices, edgeNormals};
     
     const auto edgeSweep0 = Sweep{
-        Position{Length2{-1_m, 0_m}, 0_deg}
+        Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
     const auto edgeSweep1 = Sweep{
-        Position{Length2{3_m, 1_m}, 0_deg},
-        Position{Length2{2.5_m, 1_m}, 0_deg}
+        Position2D{Length2{3_m, 1_m}, 0_deg},
+        Position2D{Length2{2.5_m, 1_m}, 0_deg}
     };
     
     const auto limits = ToiConf{}.UseTimeMax(1).UseTargetDepth(0_m).UseTolerance(0.001_m);
@@ -465,10 +465,10 @@ TEST(TimeOfImpact, EdgeCircleSeparated)
     const auto circle = DistanceProxy{radius, 1, circleVertices, circleNormals};
     
     const auto edgeSweep = Sweep{
-        Position{Length2{-1_m, 0_m}, 0_deg}
+        Position2D{Length2{-1_m, 0_m}, 0_deg}
     };
     const auto circleSweep = Sweep{
-        Position{Length2{radius * 2, 0.5_m}, 0_deg}
+        Position2D{Length2{radius * 2, 0.5_m}, 0_deg}
     };
     
     const auto slop = 0_m;
@@ -496,14 +496,14 @@ TEST(TimeOfImpact, RodCircleMissAt360)
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, 4_m}, 0_deg},
-        Position{Length2{+x * Meter, 4_m}, 360_deg}
+        Position2D{Length2{-x * Meter, 4_m}, 0_deg},
+        Position2D{Length2{+x * Meter, 4_m}, 360_deg}
     };
     const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, 0_m}, 0_deg},
-        Position{Length2{-x * Meter, 0_m}, 0_deg}
+        Position2D{Length2{+x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };
     
     // Compute the time of impact information now...
@@ -539,14 +539,14 @@ TEST(TimeOfImpact, RodCircleHitAt180)
     const UnitVec2 normals[] = {nA0, -nA0};
     const auto proxyA = DistanceProxy{radius, 2, vertices, normals};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, 4_m}, 0_deg},
-        Position{Length2{+x * Meter, 4_m}, Angle{Real{180.0f} * 1_deg}}
+        Position2D{Length2{-x * Meter, 4_m}, 0_deg},
+        Position2D{Length2{+x * Meter, 4_m}, Angle{Real{180.0f} * 1_deg}}
     };
     const auto pos = Length2{};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, 0_m}, 0_deg},
-        Position{Length2{-x * Meter, 0_m}, 0_deg}
+        Position2D{Length2{+x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };
     
     // Compute the time of impact information now...
@@ -574,13 +574,13 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_1)
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, 0_m}, 0_deg},
-        Position{Length2{+x * Meter, 0_m}, 0_deg}
+        Position2D{Length2{-x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{+x * Meter, 0_m}, 0_deg}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, 0_m}, 0_deg},
-        Position{Length2{-x * Meter, 0_m}, 0_deg}
+        Position2D{Length2{+x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{-x * Meter, 0_m}, 0_deg}
     };
     
     const auto conf = ToiConf{}
@@ -620,13 +620,13 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{-x * Meter, 0_m}, 0_deg},
-        Position{Length2{}, 0_deg}
+        Position2D{Length2{-x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{}, 0_deg}
     };
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepB = Sweep{
-        Position{Length2{+x * Meter, 0_m}, 0_deg},
-        Position{Length2{}, 0_deg}
+        Position2D{Length2{+x * Meter, 0_m}, 0_deg},
+        Position2D{Length2{}, 0_deg}
     };
     
     const auto conf = ToiConf{}
@@ -698,9 +698,9 @@ TEST(TimeOfImpact, WithClosingSpeedOf1600)
     const auto x = Real(400);
     const auto pos = Length2{};
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepA = Sweep{Position{Length2{-x * Meter, 0_m}, 0_deg}, Position{Length2{+x * Meter, 0_m}, 0_deg}};
+    const auto sweepA = Sweep{Position2D{Length2{-x * Meter, 0_m}, 0_deg}, Position2D{Length2{+x * Meter, 0_m}, 0_deg}};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
-    const auto sweepB = Sweep{Position{Length2{+x * Meter, 0_m}, 0_deg}, Position{Length2{-x * Meter, 0_m}, 0_deg}};
+    const auto sweepB = Sweep{Position2D{Length2{+x * Meter, 0_m}, 0_deg}, Position2D{Length2{-x * Meter, 0_m}, 0_deg}};
     
     const auto conf = ToiConf{}
         .UseMaxToiIters(200)
@@ -748,12 +748,12 @@ TEST(TimeOfImpact, ForNonCollidingShapesFails)
     const auto dpB = GetChild(shapeB, 0);
 
     const auto sweepA = Sweep{
-        Position{Length2{-11_m, 10_m}, 2.95000005_rad},
-        Position{Length2{-11_m, 10_m}, 2.95000005_rad}
+        Position2D{Length2{-11_m, 10_m}, 2.95000005_rad},
+        Position2D{Length2{-11_m, 10_m}, 2.95000005_rad}
     };
     const auto sweepB = Sweep{
-        Position{Length2{18.4742737_m, 19.7474861_m}, 513.36676_rad},
-        Position{Length2{19.5954781_m, 18.9165268_m}, 513.627808_rad}
+        Position2D{Length2{18.4742737_m, 19.7474861_m}, 513.36676_rad},
+        Position2D{Length2{19.5954781_m, 18.9165268_m}, 513.627808_rad}
     };
     
     const auto conf = ToiConf{}
@@ -810,12 +810,12 @@ TEST(TimeOfImpact, ToleranceReachedWithT1Of1)
     // separation has reached tolerance but t2 already equals t1.
 
     const auto sweepA = Sweep{
-        Position{Length2{0.0_m, -0.5_m}, 0_deg},
-        Position{Length2{0.0_m, -0.5_m}, 0_deg}
+        Position2D{Length2{0.0_m, -0.5_m}, 0_deg},
+        Position2D{Length2{0.0_m, -0.5_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{14.3689661_m, 0.500306308_m}, 0.0000139930862_rad},
-        Position{Length2{14.3689451_m, 0.500254989_m}, 0.000260060915_rad}
+        Position2D{Length2{14.3689661_m, 0.500306308_m}, 0.0000139930862_rad},
+        Position2D{Length2{14.3689451_m, 0.500254989_m}, 0.000260060915_rad}
     };
 
     // Note that these vertices are interpretted by code using the DistanceProxy as
@@ -903,12 +903,12 @@ TEST(TimeOfImpact, MaxToiIters)
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
 
     const auto sweepA = Sweep{
-        Position{Length2{-5_m, 0_m}, 0_deg},
-        Position{Length2{-5_m, 0_m}, 0_deg}
+        Position2D{Length2{-5_m, 0_m}, 0_deg},
+        Position2D{Length2{-5_m, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+5_m, 0_m}, 0_deg},
-        Position{Length2{+5_m, 0_m}, 0_deg}
+        Position2D{Length2{+5_m, 0_m}, 0_deg},
+        Position2D{Length2{+5_m, 0_m}, 0_deg}
     };
     const auto conf = ToiConf{}
         .UseTargetDepth(0_m)
@@ -929,12 +929,12 @@ TEST(TimeOfImpact, MaxDistIters)
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
 
     const auto sweepA = Sweep{
-        Position{Length2{-5_m, 0_m}, 0_deg},
-        Position{Length2{-5_m, 0_m}, 0_deg}
+        Position2D{Length2{-5_m, 0_m}, 0_deg},
+        Position2D{Length2{-5_m, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+5_m, 0_m}, 0_deg},
-        Position{Length2{+5_m, 0_m}, 0_deg}
+        Position2D{Length2{+5_m, 0_m}, 0_deg},
+        Position2D{Length2{+5_m, 0_m}, 0_deg}
     };
     const auto conf = ToiConf{}
         .UseTargetDepth(0_m)
@@ -955,12 +955,12 @@ TEST(TimeOfImpact, MaxRootIters)
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
 
     const auto sweepA = Sweep{
-        Position{Length2{-5_m, 0_m}, 0_deg},
-        Position{Length2{-0_m, 0_m}, 0_deg}
+        Position2D{Length2{-5_m, 0_m}, 0_deg},
+        Position2D{Length2{-0_m, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+5_m, 0_m}, 0_deg},
-        Position{Length2{+0_m, 0_m}, 0_deg}
+        Position2D{Length2{+5_m, 0_m}, 0_deg},
+        Position2D{Length2{+0_m, 0_m}, 0_deg}
     };
     const auto conf = ToiConf{}
         .UseTargetDepth(0_m)
@@ -986,12 +986,12 @@ TEST(TimeOfImpact, NextAfter)
     const auto proxyA = DistanceProxy{radius, 1, &pos, nullptr};
     const auto proxyB = DistanceProxy{radius, 1, &pos, nullptr};
     const auto sweepA = Sweep{
-        Position{Length2{-2e18_m, 0_m}, 0_deg},
-        Position{Length2{+1e16_m, 0_m}, 0_deg}
+        Position2D{Length2{-2e18_m, 0_m}, 0_deg},
+        Position2D{Length2{+1e16_m, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+2e18_m, 0_m}, 0_deg},
-        Position{Length2{+0_m, 0_m}, 0_deg}
+        Position2D{Length2{+2e18_m, 0_m}, 0_deg},
+        Position2D{Length2{+0_m, 0_m}, 0_deg}
     };
 
     // Negative tolerance results in a TOIOutput::e_nextAfter result no matter how
@@ -1056,12 +1056,12 @@ TEST(TimeOfImpact, TargetDepthExceedsTotalRadius)
         ;
     
     const auto sweepA = Sweep{
-        Position{Length2{-200_m, 0_m}, 0_deg},
-        Position{Length2{+100_m, 0_m}, 0_deg}
+        Position2D{Length2{-200_m, 0_m}, 0_deg},
+        Position2D{Length2{+100_m, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+200_m, 0_m}, 0_deg},
-        Position{Length2{-10_m, 0_m}, 0_deg}
+        Position2D{Length2{+200_m, 0_m}, 0_deg},
+        Position2D{Length2{-10_m, 0_m}, 0_deg}
     };
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
     
@@ -1091,12 +1091,12 @@ TEST(TimeOfImpact, MinTargetSquaredOverflow)
         ;
     
     const auto sweepA = Sweep{
-        Position{Length2{-200_m, 0_m}, 0_deg},
-        Position{Length2{+100_m, 0_m}, 0_deg}
+        Position2D{Length2{-200_m, 0_m}, 0_deg},
+        Position2D{Length2{+100_m, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+200_m, 0_m}, 0_deg},
-        Position{Length2{-10_m, 0_m}, 0_deg}
+        Position2D{Length2{+200_m, 0_m}, 0_deg},
+        Position2D{Length2{-10_m, 0_m}, 0_deg}
     };
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
     
@@ -1126,12 +1126,12 @@ TEST(TimeOfImpact, MaxTargetSquaredOverflow)
         ;
 
     const auto sweepA = Sweep{
-        Position{Length2{-200_m, 0_m}, 0_deg},
-        Position{Length2{+100_m, 0_m}, 0_deg}
+        Position2D{Length2{-200_m, 0_m}, 0_deg},
+        Position2D{Length2{+100_m, 0_m}, 0_deg}
     };
     const auto sweepB = Sweep{
-        Position{Length2{+200_m, 0_m}, 0_deg},
-        Position{Length2{-10_m, 0_m}, 0_deg}
+        Position2D{Length2{+200_m, 0_m}, 0_deg},
+        Position2D{Length2{-10_m, 0_m}, 0_deg}
     };
     const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, conf);
     
@@ -1196,12 +1196,12 @@ TEST(TimeOfImpact, TryOutDifferentConfs)
     
     {
         const auto sweepA = Sweep{
-            Position{Length2{-2e16_m, 0_m}, 0_deg},
-            Position{Length2{+1e16_m, 0_m}, 0_deg}
+            Position2D{Length2{-2e16_m, 0_m}, 0_deg},
+            Position2D{Length2{+1e16_m, 0_m}, 0_deg}
         };
         const auto sweepB = Sweep{
-            Position{Length2{+2e16_m, 0_m}, 0_deg},
-            Position{Length2{0_m, 0_m}, 0_deg}
+            Position2D{Length2{+2e16_m, 0_m}, 0_deg},
+            Position2D{Length2{0_m, 0_m}, 0_deg}
         };
         const auto conf = ToiConf{}
             .UseTargetDepth(0.002_m)

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -25,16 +25,16 @@ TEST(Transformation, ByteSizeIs_16_32_or_64)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(Transformation), std::size_t(16)); break;
-        case  8: EXPECT_EQ(sizeof(Transformation), std::size_t(32)); break;
-        case 16: EXPECT_EQ(sizeof(Transformation), std::size_t(64)); break;
+        case  4: EXPECT_EQ(sizeof(Transformation2D), std::size_t(16)); break;
+        case  8: EXPECT_EQ(sizeof(Transformation2D), std::size_t(32)); break;
+        case 16: EXPECT_EQ(sizeof(Transformation2D), std::size_t(64)); break;
         default: FAIL(); break;
     }
 }
 
 TEST(Transformation, DefaultConstruct)
 {
-    const Transformation xfm;
+    const Transformation2D xfm;
     EXPECT_EQ(xfm.p, Length2{});
     EXPECT_EQ(xfm.q, UnitVec2::GetRight());
 }
@@ -43,7 +43,7 @@ TEST(Transformation, Initialize)
 {
     const auto translation = Length2{2_m, 4_m};
     const auto rotation = UnitVec2::Get(1_rad * Real{Pi / 2});
-    const Transformation xfm{translation, rotation};
+    const Transformation2D xfm{translation, rotation};
     EXPECT_EQ(translation, xfm.p);
     EXPECT_EQ(rotation, xfm.q);
 }
@@ -52,7 +52,7 @@ TEST(Transformation, Equality)
 {
     const auto translation = Length2{2_m, 4_m};
     const auto rotation = UnitVec2::Get(1_rad * Real{Pi / 2});
-    const Transformation xfm{translation, rotation};
+    const Transformation2D xfm{translation, rotation};
     EXPECT_EQ(xfm, xfm);
 }
 
@@ -60,11 +60,11 @@ TEST(Transformation, Inequality)
 {
     const auto translation1 = Length2{2_m, 4_m};
     const auto rotation1 = UnitVec2::Get(1_rad * Pi * Real{0.7f});
-    const Transformation xfm1{translation1, rotation1};
+    const Transformation2D xfm1{translation1, rotation1};
 
     const auto translation2 = Length2{-3_m, 37_m};
     const auto rotation2 = UnitVec2::Get(1_rad * Pi * Real{0.002f});
-    const Transformation xfm2{translation2, rotation2};
+    const Transformation2D xfm2{translation2, rotation2};
 
     ASSERT_NE(translation1, translation2);
     ASSERT_NE(rotation1, rotation2);
@@ -75,7 +75,7 @@ TEST(Transformation, Mul)
 {
     const auto translation1 = Length2{2_m, 4_m};
     const auto rotation1 = UnitVec2::Get(1_rad * Real{Pi / 2});
-    const Transformation xfm{translation1, rotation1};
+    const Transformation2D xfm{translation1, rotation1};
 
     const auto xfm2 = Mul(xfm, xfm);
     const Vec2 translation2{4, 8};
@@ -95,7 +95,7 @@ TEST(Transformation, MulSameAsTransformTwice)
 {
     const auto translation1 = Length2{2_m, 4_m};
     const auto rotation1 = UnitVec2::Get(1_rad * Real{Pi / 2});
-    const Transformation xfm{translation1, rotation1};
+    const Transformation2D xfm{translation1, rotation1};
     const auto xfm2 = Mul(xfm, xfm);
 
     const auto location = Length2{-23.4_m, 0.81_m};

--- a/UnitTests/Velocity.cpp
+++ b/UnitTests/Velocity.cpp
@@ -25,9 +25,9 @@ TEST(Velocity, ByteSize)
 {
     switch (sizeof(Real))
     {
-        case  4: EXPECT_EQ(sizeof(Velocity), std::size_t(12)); break;
-        case  8: EXPECT_EQ(sizeof(Velocity), std::size_t(24)); break;
-        case 16: EXPECT_EQ(sizeof(Velocity), std::size_t(48)); break;
+        case  4: EXPECT_EQ(sizeof(Velocity2D), std::size_t(12)); break;
+        case  8: EXPECT_EQ(sizeof(Velocity2D), std::size_t(24)); break;
+        case 16: EXPECT_EQ(sizeof(Velocity2D), std::size_t(48)); break;
         default: FAIL(); break;
     }
 }

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -2376,7 +2376,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
     ASSERT_NE(ball_fixture, nullptr);
 
     const auto velocity = LinearVelocity2{+1_mps, 0_mps};
-    ball_body->SetVelocity(Velocity{velocity, 0_deg / 1_s});
+    ball_body->SetVelocity(Velocity2D{velocity, 0_deg / 1_s});
 
     const auto time_inc = .01_s;
     auto step = StepConf{};
@@ -2435,7 +2435,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
             else if (listener.begin_contacts > last_contact_count)
             {
                 ++increments;
-                ball_body->SetVelocity(Velocity{
+                ball_body->SetVelocity(Velocity2D{
                     LinearVelocity2{
                         static_cast<Real>(increments) * GetX(velocity),
                         GetY(ball_body->GetVelocity().linear)
@@ -2477,7 +2477,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
             else if (listener.begin_contacts > last_contact_count)
             {
                 ++increments;
-                ball_body->SetVelocity(Velocity{
+                ball_body->SetVelocity(Velocity2D{
                     LinearVelocity2{
                         -static_cast<Real>(increments) * GetX(velocity),
                         GetY(ball_body->GetVelocity().linear)
@@ -2491,7 +2491,7 @@ TEST(World, SpeedingBulletBallWontTunnel)
         }
         
         ++increments;
-        ball_body->SetVelocity(Velocity{
+        ball_body->SetVelocity(Velocity2D{
             LinearVelocity2{
                 static_cast<Real>(increments) * GetX(velocity),
                 GetY(ball_body->GetVelocity().linear)

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -531,7 +531,7 @@ TEST(World, ClearForcesFreeFunction)
 TEST(World, SetAccelerationsFunctionalFF)
 {
     World world;
-    const auto a1 = Acceleration{
+    const auto a1 = Acceleration2D{
         LinearAcceleration2{1_mps2, 2_mps2}, 2.1f * RadianPerSquareSecond
     };
     const auto a2 = a1 * 2;

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -73,8 +73,8 @@ TEST(WorldManifold, UnitVecConstruction)
 TEST(WorldManifold, GetWorldManifoldForUnsetManifold)
 {
     const auto manifold = Manifold{};
-    const auto xfA = Transformation{Length2{(4-1) * Meter, 0_m}, UnitVec2::GetRight()};
-    const auto xfB = Transformation{Length2{(4+1) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto xfA = Transformation2D{Length2{(4-1) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto xfB = Transformation2D{Length2{(4+1) * Meter, 0_m}, UnitVec2::GetRight()};
     const auto rA = 1_m;
     const auto rB = 1_m;
     const auto wm = GetWorldManifold(manifold, xfA, rA, xfB, rB);
@@ -86,10 +86,10 @@ TEST(WorldManifold, GetWorldManifoldForUnsetManifold)
 TEST(WorldManifold, GetWorldManifoldForCirclesTouchingManifold)
 {
     const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
-    const auto xfA = Transformation{
+    const auto xfA = Transformation2D{
         Length2{Real(4-1) * Meter, 0_m}, UnitVec2::GetRight()
     };
-    const auto xfB = Transformation{
+    const auto xfB = Transformation2D{
         Length2{Real(4+1) * Meter, 0_m}, UnitVec2::GetRight()
     };
     const auto rA = 1_m;
@@ -107,10 +107,10 @@ TEST(WorldManifold, GetWorldManifoldForCirclesTouchingManifold)
 TEST(WorldManifold, GetWorldManifoldForCirclesHalfOverlappingManifold)
 {
     const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
-    const auto xfA = Transformation{
+    const auto xfA = Transformation2D{
         Length2{Real(7-0.5) * Meter, 0_m}, UnitVec2::GetRight()
     };
-    const auto xfB = Transformation{
+    const auto xfB = Transformation2D{
         Length2{Real(7+0.5) * Meter, 0_m}, UnitVec2::GetRight()
     };
     const auto rA = 1_m;
@@ -128,8 +128,8 @@ TEST(WorldManifold, GetWorldManifoldForCirclesHalfOverlappingManifold)
 TEST(WorldManifold, GetWorldManifoldForCirclesFullyOverlappingManifold)
 {
     const auto manifold = Manifold::GetForCircles(Length2{}, 0, Length2{}, 0);
-    const auto xfA = Transformation{Length2{Real(3-0) * Meter, 0_m}, UnitVec2::GetRight()};
-    const auto xfB = Transformation{Length2{Real(3+0) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto xfA = Transformation2D{Length2{Real(3-0) * Meter, 0_m}, UnitVec2::GetRight()};
+    const auto xfB = Transformation2D{Length2{Real(3+0) * Meter, 0_m}, UnitVec2::GetRight()};
     const auto rA = 1_m;
     const auto rB = 1_m;
     const auto wm = GetWorldManifold(manifold, xfA, rA, xfB, rB);


### PR DESCRIPTION
#### Description - What's this PR do?
- Renames `Transformation` to `Transformation2D`.
- Renames `Sweep` to `Sweep2D`.
- Renames `Acceleration` to `Acceleration2D`.
- Renames `Velocity` to `Velocity2D`.
- Renames `Position` to `Position2D`.
- Renames `MassData` to `MassData2D`. More specifically, refactors `MassData` into a template class for `N` dimensions, adds `MassData2D` as a type alias to `MassData<2>`, replaces uses of `MassData` with `MassData2D`.
- Updates documentation comments.

#### Related Issues
- Issue #178.