### PR TITLE
Misc changes 20171216

### DIFF
--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -148,7 +148,7 @@ namespace playrho {
         const auto rhsEnd = std::cend(rhs.ranges);
         const auto diff = std::mismatch(std::cbegin(lhs.ranges), lhsEnd,
                                         std::cbegin(rhs.ranges), rhsEnd);
-        return (diff.first == lhsEnd) || (*diff.first < *diff.second);
+        return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) < *std::get<1>(diff));
     }
     
     /// @brief Greater-than operator.
@@ -170,7 +170,7 @@ namespace playrho {
         const auto rhsEnd = std::cend(rhs.ranges);
         const auto diff = std::mismatch(std::cbegin(lhs.ranges), lhsEnd,
                                         std::cbegin(rhs.ranges), rhsEnd);
-        return (diff.first == lhsEnd) || (*diff.first > *diff.second);
+        return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) > *std::get<1>(diff));
     }
 
     /// @brief Tests for overlap between two axis aligned bounding boxes.

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -54,16 +54,16 @@ namespace {
         switch (count)
         {
             case 3:
-                simplexEdges[2] = GetSimplexEdge(proxyA, xfA, indexPairs[2].first,
-                                                 proxyB, xfB, indexPairs[2].second);
+                simplexEdges[2] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[2]),
+                                                 proxyB, xfB, std::get<1>(indexPairs[2]));
                 // [[fallthrough]]
             case 2:
-                simplexEdges[1] = GetSimplexEdge(proxyA, xfA, indexPairs[1].first,
-                                                 proxyB, xfB, indexPairs[1].second);
+                simplexEdges[1] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[1]),
+                                                 proxyB, xfB, std::get<1>(indexPairs[1]));
                 // [[fallthrough]]
             case 1:
-                simplexEdges[0] = GetSimplexEdge(proxyA, xfA, indexPairs[0].first,
-                                                 proxyB, xfB, indexPairs[0].second);
+                simplexEdges[0] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[0]),
+                                                 proxyB, xfB, std::get<1>(indexPairs[0]));
                 // [[fallthrough]]
         }
         simplexEdges.size(static_cast<size_type>(count));

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -28,7 +28,7 @@ namespace playrho {
     class DistanceProxy;
 
     /// @brief Pair of Length2 values.
-    using PairLength2 = std::pair<Length2, Length2>;
+    using PairLength2 = std::array<Length2, 2>;
     
     /// @brief Gets the witness points of the given simplex.
     PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept;
@@ -36,7 +36,7 @@ namespace playrho {
     /// @brief Gets the delta of the two points of the given witness points.
     PLAYRHO_CONSTEXPR inline Length2 GetDelta(PairLength2 arg) noexcept
     {
-        return arg.first - arg.second;
+        return std::get<0>(arg) - std::get<1>(arg);
     }
     
     /// @brief Distance Configuration.

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -453,15 +453,15 @@ Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation2D& xfA,
         return Manifold{};
     }
     
-    const auto k_tol = PLAYRHO_MAGIC(conf.linearSlop / Real{10});
+    const auto k_tol = PLAYRHO_MAGIC(conf.linearSlop / 10);
     return (edgeSepB.distance > (edgeSepA.distance + k_tol))?
         GetFaceManifold(Manifold::e_faceB,
-                        shapeB, xfB, edgeSepB.indices.first,
-                        shapeA, xfA, edgeSepB.indices.second,
+                        shapeB, xfB, std::get<0>(edgeSepB.indices),
+                        shapeA, xfA, std::get<1>(edgeSepB.indices),
                         conf):
         GetFaceManifold(Manifold::e_faceA,
-                        shapeA, xfA, edgeSepA.indices.first,
-                        shapeB, xfB, edgeSepA.indices.second,
+                        shapeA, xfA, std::get<0>(edgeSepA.indices),
+                        shapeB, xfB, std::get<1>(edgeSepA.indices),
                         conf);
 }
 

--- a/PlayRho/Collision/SeparationFinder.cpp
+++ b/PlayRho/Collision/SeparationFinder.cpp
@@ -31,15 +31,15 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
     assert(proxyB.GetVertexCount() > 0);
     
     const auto numIndices = GetNumIndices(indices);
-    const auto type = (numIndices == 1)? e_points: ((indices[0].first == indices[1].first)? e_faceB: e_faceA);
+    const auto type = (numIndices == 1)? e_points: ((std::get<0>(indices[0]) == std::get<0>(indices[1]))? e_faceB: e_faceA);
     
     switch (type)
     {
         case e_points:
         {
             const auto ip0 = indices[0];
-            const auto localPointA = proxyA.GetVertex(ip0.first);
-            const auto localPointB = proxyB.GetVertex(ip0.second);
+            const auto localPointA = proxyA.GetVertex(std::get<0>(ip0));
+            const auto localPointB = proxyB.GetVertex(std::get<1>(ip0));
             const auto pointA = Transform(localPointA, xfA);
             const auto pointB = Transform(localPointB, xfB);
             const auto axis = GetUnitVector(pointB - pointA, UnitVec2::GetZero());
@@ -51,18 +51,18 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
             const auto ip1 = indices[1];
             
             // Two points on B and one on A.
-            const auto localPointB1 = proxyB.GetVertex(ip0.second);
-            const auto localPointB2 = proxyB.GetVertex(ip1.second);
+            const auto localPointB1 = proxyB.GetVertex(std::get<1>(ip0));
+            const auto localPointB2 = proxyB.GetVertex(std::get<1>(ip1));
             const auto lpDelta = localPointB2 - localPointB1;
             
             const auto axis = GetUnitVector(GetFwdPerpendicular(lpDelta),
                                             UnitVec2::GetZero());
             const auto normal = Rotate(axis, xfB.q);
             
-            const auto localPoint = (localPointB1 + localPointB2) / Real(2);
+            const auto localPoint = (localPointB1 + localPointB2) / 2;
             const auto pointB = Transform(localPoint, xfB);
             
-            const auto localPointA = proxyA.GetVertex(ip0.first);
+            const auto localPointA = proxyA.GetVertex(std::get<0>(ip0));
             const auto pointA = Transform(localPointA, xfA);
             
             const auto deltaPoint = pointA - pointB;
@@ -78,17 +78,17 @@ SeparationFinder SeparationFinder::Get(IndexPair3 indices,
             const auto ip1 = indices[1];
             
             // Two points on A and one or two points on B.
-            const auto localPointA1 = proxyA.GetVertex(ip0.first);
-            const auto localPointA2 = proxyA.GetVertex(ip1.first);
+            const auto localPointA1 = proxyA.GetVertex(std::get<0>(ip0));
+            const auto localPointA2 = proxyA.GetVertex(std::get<0>(ip1));
             const auto delta = localPointA2 - localPointA1;
             
             const auto axis = GetUnitVector(GetFwdPerpendicular(delta), UnitVec2::GetZero());
             const auto normal = Rotate(axis, xfA.q);
             
-            const auto localPoint = (localPointA1 + localPointA2) / Real(2);
+            const auto localPoint = (localPointA1 + localPointA2) / 2;
             const auto pointA = Transform(localPoint, xfA);
             
-            const auto localPointB = proxyB.GetVertex(ip0.second);
+            const auto localPointB = proxyB.GetVertex(std::get<1>(ip0));
             const auto pointB = Transform(localPointB, xfB);
             
             const auto deltaPoint = pointB - pointA;
@@ -150,8 +150,8 @@ SeparationFinder::FindMinSeparationForFaceB(const Transformation2D& xfA,
 Length SeparationFinder::EvaluateForPoints(const Transformation2D& xfA, const Transformation2D& xfB,
                                            IndexPair indexPair) const
 {
-    const auto pointA = Transform(m_proxyA.GetVertex(indexPair.first), xfA);
-    const auto pointB = Transform(m_proxyB.GetVertex(indexPair.second), xfB);
+    const auto pointA = Transform(m_proxyA.GetVertex(std::get<0>(indexPair)), xfA);
+    const auto pointB = Transform(m_proxyB.GetVertex(std::get<1>(indexPair)), xfB);
     const auto delta = pointB - pointA;
     return Dot(delta, m_axis);
 }
@@ -161,7 +161,7 @@ Length SeparationFinder::EvaluateForFaceA(const Transformation2D& xfA, const Tra
 {
     const auto normal = Rotate(m_axis, xfA.q);
     const auto pointA = Transform(m_localPoint, xfA);
-    const auto pointB = Transform(m_proxyB.GetVertex(indexPair.second), xfB);
+    const auto pointB = Transform(m_proxyB.GetVertex(std::get<1>(indexPair)), xfB);
     const auto delta = pointB - pointA;
     return Dot(delta, normal);
 }
@@ -171,7 +171,7 @@ Length SeparationFinder::EvaluateForFaceB(const Transformation2D& xfA, const Tra
 {
     const auto normal = Rotate(m_axis, xfB.q);
     const auto pointB = Transform(m_localPoint, xfB);
-    const auto pointA = Transform(m_proxyA.GetVertex(indexPair.first), xfA);
+    const auto pointA = Transform(m_proxyA.GetVertex(std::get<0>(indexPair)), xfA);
     const auto delta = pointA - pointB;
     return Dot(delta, normal);
 }

--- a/PlayRho/Collision/ShapeSeparation.cpp
+++ b/PlayRho/Collision/ShapeSeparation.cpp
@@ -94,8 +94,8 @@ IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformatio
         if (separation < ap.distance)
         {
             separation = ap.distance;
-            indexPair.first = i;
-            indexPair.second = ap.indices.first;
+            std::get<0>(indexPair) = i;
+            std::get<1>(indexPair) = std::get<0>(ap.indices);
         }
     }
     return IndexPairDistance{separation, indexPair};
@@ -119,8 +119,8 @@ IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D
         if (separation < ap.distance)
         {
             separation = ap.distance;
-            indexPair.first = i;
-            indexPair.second = ap.indices.first;
+            std::get<0>(indexPair) = i;
+            std::get<1>(indexPair) = std::get<0>(ap.indices);
         }
     }
     return IndexPairDistance{separation, indexPair};
@@ -143,13 +143,13 @@ IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D
         const auto ap = GetMinIndexSeparation(proxy2.GetVertices(), normal, offset);
         if (ap.distance > stop)
         {
-            return IndexPairDistance{ap.distance, IndexPair{i, ap.indices.first}};
+            return IndexPairDistance{ap.distance, IndexPair{i, std::get<0>(ap.indices)}};
         }
         if (separation < ap.distance)
         {
             separation = ap.distance;
-            indexPair.first = i;
-            indexPair.second = ap.indices.first;
+            std::get<0>(indexPair) = i;
+            std::get<1>(indexPair) = std::get<0>(ap.indices);
         }
     }
     return IndexPairDistance{separation, indexPair};
@@ -170,13 +170,13 @@ IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, const DistancePr
         const auto ap = GetMinIndexSeparation(proxy2.GetVertices(), normal, offset);
         if (ap.distance > stop)
         {
-            return IndexPairDistance{ap.distance, IndexPair{i, ap.indices.first}};
+            return IndexPairDistance{ap.distance, IndexPair{i, std::get<0>(ap.indices)}};
         }
         if (separation < ap.distance)
         {
             separation = ap.distance;
-            indexPair.first = i;
-            indexPair.second = ap.indices.first;
+            std::get<0>(indexPair) = i;
+            std::get<1>(indexPair) = std::get<0>(ap.indices);
         }
     }
     return IndexPairDistance{separation, indexPair};

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -56,10 +56,10 @@ namespace playrho {
         PLAYRHO_CONSTEXPR inline auto GetPointB() const noexcept { return m_wB; }
 
         /// @brief Gets index A.
-        PLAYRHO_CONSTEXPR inline auto GetIndexA() const noexcept { return m_indexPair.first; }
+        PLAYRHO_CONSTEXPR inline auto GetIndexA() const noexcept { return std::get<0>(m_indexPair); }
         
         /// @brief Gets index B.
-        PLAYRHO_CONSTEXPR inline auto GetIndexB() const noexcept { return m_indexPair.second; }
+        PLAYRHO_CONSTEXPR inline auto GetIndexB() const noexcept { return std::get<1>(m_indexPair); }
 
         /// @brief Gets the index pair.
         PLAYRHO_CONSTEXPR inline auto GetIndexPair() const noexcept { return m_indexPair; }

--- a/PlayRho/Common/Interval.hpp
+++ b/PlayRho/Common/Interval.hpp
@@ -212,7 +212,7 @@ namespace playrho {
         
         /// @brief Internal pair type accepting constructor.
         PLAYRHO_CONSTEXPR inline explicit Interval(pair_type pair) noexcept:
-            m_min{pair.first}, m_max{pair.second}
+            m_min{std::get<0>(pair)}, m_max{std::get<1>(pair)}
         {
             // Intentionally empty.
         }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -947,7 +947,7 @@ PLAYRHO_CONSTEXPR inline Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcep
 template <class T>
 inline UnitVec2 GetUnitVector(Vector2<T> value, UnitVec2 fallback = UnitVec2::GetDefaultFallback())
 {
-    return UnitVec2::Get(StripUnit(GetX(value)), StripUnit(GetY(value)), fallback).first;
+    return std::get<0>(UnitVec2::Get(StripUnit(GetX(value)), StripUnit(GetY(value)), fallback));
 }
     
 /// @brief Gets the vertices for a circle described by the given parameters.

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -403,7 +403,7 @@ PLAYRHO_CONSTEXPR inline bool operator<= (const Vector<T, N>& lhs, const Vector<
     const auto lhsEnd = std::cend(lhs);
     const auto rhsEnd = std::cend(rhs);
     const auto diff = std::mismatch(std::cbegin(lhs), lhsEnd, std::cbegin(rhs), rhsEnd);
-    return (diff.first == lhsEnd) || (*diff.first < *diff.second);
+    return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) < *std::get<1>(diff));
 }
 
 /// @brief Lexicographical greater-than operator.
@@ -423,7 +423,7 @@ PLAYRHO_CONSTEXPR inline bool operator>= (const Vector<T, N>& lhs, const Vector<
     const auto lhsEnd = std::cend(lhs);
     const auto rhsEnd = std::cend(rhs);
     const auto diff = std::mismatch(std::cbegin(lhs), lhsEnd, std::cbegin(rhs), rhsEnd);
-    return (diff.first == lhsEnd) || (*diff.first > *diff.second);
+    return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) > *std::get<1>(diff));
 }
 
 /// @brief Gets the I'th element of the given collection.

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -266,7 +266,7 @@ void Body::SetTransformation(Transformation2D value) noexcept
     {
         m_xf = value;
         std::for_each(cbegin(m_contacts), cend(m_contacts), [&](KeyedContactPtr ci) {
-            ci.second->FlagForUpdating();
+            std::get<Contact*>(ci)->FlagForUpdating();
         });
     }
 }
@@ -353,7 +353,7 @@ bool Body::Insert(ContactKey key, Contact* contact)
 #ifndef NDEBUG
     // Prevent the same contact from being added more than once...
     const auto it = std::find_if(cbegin(m_contacts), cend(m_contacts), [&](KeyedContactPtr ci) {
-        return ci.second == contact;
+        return std::get<Contact*>(ci) == contact;
     });
     assert(it == end(m_contacts));
     if (it != end(m_contacts))
@@ -369,7 +369,7 @@ bool Body::Insert(ContactKey key, Contact* contact)
 bool Body::Erase(const Joint* joint)
 {
     const auto it = std::find_if(begin(m_joints), end(m_joints), [&](KeyedJointPtr ji) {
-        return ji.second == joint;
+        return std::get<Joint*>(ji) == joint;
     });
     if (it != end(m_joints))
     {
@@ -382,7 +382,7 @@ bool Body::Erase(const Joint* joint)
 bool Body::Erase(const Contact* contact)
 {
     const auto it = std::find_if(begin(m_contacts), end(m_contacts), [&](KeyedContactPtr ci) {
-        return ci.second == contact;
+        return std::get<Contact*>(ci) == contact;
     });
     if (it != end(m_contacts))
     {
@@ -415,7 +415,7 @@ bool ShouldCollide(const Body& lhs, const Body& rhs) noexcept
     // Does a joint prevent collision?
     const auto joints = lhs.GetJoints();
     const auto it = std::find_if(cbegin(joints), cend(joints), [&](Body::KeyedJointPtr ji) {
-        return (ji.first == &rhs) && !(ji.second->GetCollideConnected());
+        return (std::get<0>(ji) == &rhs) && !(std::get<Joint*>(ji)->GetCollideConnected());
     });
     return it == end(joints);
 }
@@ -542,7 +542,7 @@ Acceleration2D CalcGravitationalAcceleration(const Body& body) noexcept
             const auto dir = GetUnitVector(delta);
             const auto rr = GetMagnitudeSquared(delta);
             const auto orderedMass = std::minmax(m1, m2);
-            const auto f = (BigG * orderedMass.first) * (orderedMass.second / rr);
+            const auto f = (BigG * std::get<0>(orderedMass)) * (std::get<1>(orderedMass) / rr);
             sumForce += f * dir;
         }
         // F = m a... i.e.  a = F / m.

--- a/PlayRho/Dynamics/BodyAtty.hpp
+++ b/PlayRho/Dynamics/BodyAtty.hpp
@@ -236,7 +236,7 @@ private:
         auto joints = std::move(b.m_joints);
         assert(b.m_joints.empty());
         std::for_each(cbegin(joints), cend(joints), [&](Body::KeyedJointPtr j) {
-            callback(*(j.second));
+            callback(*(std::get<Joint*>(j)));
         });
     }
     

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -58,13 +58,13 @@ namespace playrho
         /// @brief Gets the minimum index value.
         PLAYRHO_CONSTEXPR inline Index GetMin() const noexcept
         {
-            return m_ids.first;
+            return std::get<0>(m_ids);
         }
         
         /// @brief Gets the maximum index value.
         PLAYRHO_CONSTEXPR inline Index GetMax() const noexcept
         {
-            return m_ids.second;
+            return std::get<1>(m_ids);
         }
 
     private:
@@ -125,7 +125,7 @@ namespace playrho
     /// @brief Gets the contact pointer for the given value.
     inline Contact* GetContactPtr(KeyedContactPtr value)
     {
-        return value.second;
+        return std::get<1>(value);
     }
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -93,8 +93,8 @@ VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impu
 Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2 newImpulses)
 {
     const auto delta_v = GetVelocityDelta(vc, newImpulses - GetNormalImpulses(vc));
-    vc.GetBodyA()->SetVelocity(vc.GetBodyA()->GetVelocity() + delta_v.first);
-    vc.GetBodyB()->SetVelocity(vc.GetBodyB()->GetVelocity() + delta_v.second);
+    vc.GetBodyA()->SetVelocity(vc.GetBodyA()->GetVelocity() + std::get<0>(delta_v));
+    vc.GetBodyB()->SetVelocity(vc.GetBodyB()->GetVelocity() + std::get<1>(delta_v));
     SetNormalImpulses(vc, newImpulses);
     return std::max(Abs(newImpulses[0]), Abs(newImpulses[1]));
 }

--- a/PlayRho/Dynamics/Joints/DistanceJoint.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.cpp
@@ -100,8 +100,8 @@ void DistanceJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
 
     // Handle singularity.
     const auto uvresult = UnitVec2::Get(deltaLocation[0]/Meter, deltaLocation[1]/Meter);
-    m_u = uvresult.first;
-    const auto length = uvresult.second * Meter;
+    m_u = std::get<UnitVec2>(uvresult);
+    const auto length = std::get<Real>(uvresult) * 1_m;
 
     const auto crAu = Length{Cross(m_rA, m_u)} / Radian;
     const auto crBu = Length{Cross(m_rB, m_u)} / Radian;
@@ -226,8 +226,8 @@ bool DistanceJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     const auto relLoc = Length2{(posB.linear + rB) - (posA.linear + rA)};
 
     const auto uvresult = UnitVec2::Get(relLoc[0]/Meter, relLoc[1]/Meter);
-    const auto u = uvresult.first;
-    const auto length = uvresult.second * Meter;
+    const auto u = std::get<UnitVec2>(uvresult);
+    const auto length = std::get<Real>(uvresult) * 1_m;
     const auto deltaLength = length - m_length;
     const auto C = Clamp(deltaLength, -conf.maxLinearCorrection, conf.maxLinearCorrection);
 

--- a/PlayRho/Dynamics/Joints/Joint.cpp
+++ b/PlayRho/Dynamics/Joints/Joint.cpp
@@ -155,13 +155,13 @@ BodyConstraintPtr& At(std::vector<BodyConstraintPair>& container, const Body* ke
     auto last = std::end(container);
     auto first = std::begin(container);
     first = std::lower_bound(first, last, key, [](const BodyConstraintPair &a, const Body* b){
-        return a.first < b;
+        return std::get<const Body*>(a) < b;
     });
-    if (first == last || key != (*first).first)
+    if ((first == last) || (key != std::get<const Body*>(*first)))
     {
         throw std::out_of_range{"invalid key"};
     }
-    return (*first).second;
+    return std::get<BodyConstraintPtr>(*first);
 }
 #endif
 

--- a/PlayRho/Dynamics/Joints/JointKey.hpp
+++ b/PlayRho/Dynamics/Joints/JointKey.hpp
@@ -108,7 +108,7 @@ namespace playrho {
     /// @brief Gets the joint pointer from the given value.
     inline Joint* GetJointPtr(std::pair<JointKey, Joint*> value)
     {
-        return value.second;
+        return std::get<Joint*>(value);
     }
     
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/PulleyJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJoint.cpp
@@ -179,13 +179,13 @@ bool PulleyJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     // Get the pulley axes.
     const auto pA = Length2{posA.linear + rA - m_groundAnchorA};
     const auto uvresultA = UnitVec2::Get(pA[0]/Meter, pA[1]/Meter);
-    const auto uA = uvresultA.first;
-    const auto lengthA = uvresultA.second * Meter;
+    const auto uA = std::get<UnitVec2>(uvresultA);
+    const auto lengthA = std::get<Real>(uvresultA) * 1_m;
 
     const auto pB = Length2{posB.linear + rB - m_groundAnchorB};
     const auto uvresultB = UnitVec2::Get(pB[0]/Meter, pB[1]/Meter);
-    const auto uB = uvresultB.first;
-    const auto lengthB = uvresultB.second * Meter;
+    const auto uB = std::get<UnitVec2>(uvresultB);
+    const auto lengthB = std::get<Real>(uvresultB) * 1_m;
 
     // Compute effective mass.
     const auto ruA = Length{Cross(rA, uA)};

--- a/PlayRho/Dynamics/Joints/RopeJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.cpp
@@ -79,8 +79,8 @@ void RopeJoint::InitVelocityConstraints(BodyConstraintsMap& bodies,
     const auto posDelta = Length2{(posB.linear + m_rB) - (posA.linear + m_rA)};
     
     const auto uvresult = UnitVec2::Get(posDelta[0]/Meter, posDelta[1]/Meter);
-    const auto uv = uvresult.first;
-    m_length = uvresult.second * Meter;
+    const auto uv = std::get<UnitVec2>(uvresult);
+    m_length = std::get<Real>(uvresult) * 1_m;
 
     const auto C = m_length - m_maxLength;
     m_state = (C > 0_m)? e_atUpperLimit: e_inactiveLimit;
@@ -183,8 +183,8 @@ bool RopeJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     const auto posDelta = (posB.linear + rB) - (posA.linear + rA);
     
     const auto uvresult = UnitVec2::Get(posDelta[0]/Meter, posDelta[1]/Meter);
-    const auto u = uvresult.first;
-    const auto length = uvresult.second * Meter;
+    const auto u = std::get<UnitVec2>(uvresult);
+    const auto length = std::get<Real>(uvresult) * 1_m;
     
     const auto C = Clamp(length - m_maxLength, 0_m, conf.maxLinearCorrection);
 

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -708,10 +708,11 @@ static void AboutTestUI()
             //ImGui::SetColumnWidth(2, 200);
             for (auto& handledKey: handledKeys)
             {
-                const auto keyID = handledKey.first.key;
-                const auto mods = handledKey.first.mods;
+                const auto keyActionMods = std::get<0>(handledKey);
+                const auto keyID = keyActionMods.key;
+                const auto mods = keyActionMods.mods;
                 
-                ImGui::TextUnformatted(GetKeyActionName(handledKey.first.action));
+                ImGui::TextUnformatted(GetKeyActionName(keyActionMods.action));
                 ImGui::NextColumn();
                 
                 if (std::isgraph(keyID))
@@ -722,15 +723,15 @@ static void AboutTestUI()
                 }
                 else
                 {
-                    ImGui::Text("%s", GetKeyShortName(handledKey.first.key));
-                    if (ImGui::IsItemHovered() && GetKeyLongName(handledKey.first.key))
+                    ImGui::Text("%s", GetKeyShortName(keyID));
+                    if (ImGui::IsItemHovered() && GetKeyLongName(keyID))
                     {
-                        ImGui::SetTooltip("%s", GetKeyLongName(handledKey.first.key));
+                        ImGui::SetTooltip("%s", GetKeyLongName(keyID));
                     }
                 }
                 ImGui::NextColumn();
                 //ImGui::SameLine();
-                const auto info = test->GetKeyHandlerInfo(handledKey.second);
+                const auto info = test->GetKeyHandlerInfo(std::get<1>(handledKey));
                 ImGui::TextWrapped("%s", info.c_str());
                 ImGui::NextColumn();
             }
@@ -2016,7 +2017,7 @@ static void CollectionUI(const BodyJointsRange& joints)
     auto i = 0;
     for (auto& e: joints)
     {
-        const auto j = e.second;
+        const auto j = std::get<1>(e);
         const auto flags = 0;
         if (ImGui::TreeNodeEx(j, flags, "Joint %d (%s)", i, ToString(GetType(*j))))
         {
@@ -2032,7 +2033,7 @@ static void CollectionUI(const ContactsRange& contacts)
     auto i = 0;
     for (auto& ct: contacts)
     {
-        const auto e = ct.second;
+        const auto e = std::get<1>(ct);
         const auto flags = 0;
         if (ImGui::TreeNodeEx(e, flags, "Contact %d%s",
                               i, ((e->IsTouching())? " (touching)": "")))

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -1270,7 +1270,7 @@ void Test::KeyboardHandler(KeyID key, KeyAction action, KeyMods mods)
 {
     for (const auto& handledKey: m_handledKeys)
     {
-        const auto& keyActionMods = handledKey.first;
+        const auto& keyActionMods = std::get<0>(handledKey);
         if (keyActionMods.key != key)
         {
             continue;
@@ -1283,8 +1283,8 @@ void Test::KeyboardHandler(KeyID key, KeyAction action, KeyMods mods)
         {
             continue;
         }
-        const auto handlerID = handledKey.second;
-        m_keyHandlers[handlerID].second(KeyActionMods{key, action, mods});
+        const auto handlerID = std::get<1>(handledKey);
+        std::get<1>(m_keyHandlers[handlerID])(KeyActionMods{key, action, mods});
     }
 }
 

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -37,6 +37,7 @@
 #include <algorithm>
 #include <limits>
 #include <set>
+#include <utility>
 
 /// @brief Adds the entire playrho namespace into any code that includes this file.
 /// @warning Using a namespace like this within a header file is ill advised. It's done
@@ -164,7 +165,7 @@ public:
     
     const std::string& GetKeyHandlerInfo(KeyHandlerID id) const
     {
-        return m_keyHandlers[id].first;
+        return std::get<0>(m_keyHandlers[id]);
     }
     
     SizedRange<HandledKeys::const_iterator> GetHandledKeys() const

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -330,7 +330,7 @@ protected:
 
     std::string m_status;
     TextLinePos m_textLine = TextLinePos{30};
-    AreaDensity m_bombDensity = 20 * KilogramPerSquareMeter;
+    AreaDensity m_bombDensity = 20_kgpm2;
     Length m_bombRadius = 0.3f * Meter;
 
 private:

--- a/Testbed/Tests/AddPair.hpp
+++ b/Testbed/Tests/AddPair.hpp
@@ -44,7 +44,7 @@ public:
             const auto maxY = 6.0f;
             const auto bd = BodyDef{}.UseType(BodyType::Dynamic);
             const auto shape = Shape{
-                DiskShapeConf{}.UseRadius(0.1f * Meter).UseDensity(0.01f * KilogramPerSquareMeter)
+                DiskShapeConf{}.UseRadius(0.1_m).UseDensity(0.01_kgpm2)
             };
             for (auto i = 0; i < 400; ++i)
             {
@@ -55,9 +55,9 @@ public:
             }
         }
         const auto bd = BodyDef{}.UseType(BodyType::Dynamic).UseBullet(true)
-            .UseLocation(Length2{-40 * Meter, 5 * Meter}).UseLinearVelocity(LinearVelocity2{150 * MeterPerSecond, 0 * MeterPerSecond});
+            .UseLocation(Length2{-40_m, 5_m}).UseLinearVelocity(LinearVelocity2{150_mps, 0_mps});
         const auto body = m_world.CreateBody(bd);
-        const auto conf = PolygonShapeConf{}.UseDensity(1.0f * KilogramPerSquareMeter).SetAsBox(1.5f * Meter, 1.5_m);
+        const auto conf = PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(1.5_m, 1.5_m);
         body->CreateFixture(Shape{conf});
     }
 };

--- a/Testbed/Tests/BreakableTwo.hpp
+++ b/Testbed/Tests/BreakableTwo.hpp
@@ -108,8 +108,8 @@ public:
 private:
     const Length vr = 2 * DefaultLinearSlop;
     Shape m_shape{
-        PolygonShapeConf{}.UseVertexRadius(vr).UseDensity(100 * KilogramPerSquareMeter)
-        .SetAsBox(0.5f * Meter - vr, 0.5f * Meter - vr)
+        PolygonShapeConf{}.UseVertexRadius(vr).UseDensity(100_kgpm2)
+        .SetAsBox(0.5_m - vr, 0.5_m - vr)
     };
     Body* m_body = nullptr;
 };

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -179,8 +179,8 @@ public:
         //forward linear velocity
         const auto forwardVelocity = getForwardVelocity();
         const auto uvresult = UnitVec2::Get(StripUnit(GetX(forwardVelocity)), StripUnit(GetY(forwardVelocity)));
-        const auto forwardDir = uvresult.first;
-        const auto currentForwardSpeed = uvresult.second * MeterPerSecond;
+        const auto forwardDir = std::get<UnitVec2>(uvresult);
+        const auto currentForwardSpeed = std::get<Real>(uvresult) * 1_mps;
         const auto dragForceMagnitude = -2 * currentForwardSpeed;
         const auto newForce = Force2{m_currentTraction * dragForceMagnitude * forwardDir * 1_kg / 1_s};
         SetForce(*m_body, newForce, m_body->GetWorldCenter());

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -555,29 +555,29 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction1)
     switch (sizeof(Real))
     {
         case 4:
-            EXPECT_EQ(maxSep01_4x4.indices.first, decltype(maxSep01_4x4.indices.first){0}); // v0 of shape0
-            EXPECT_EQ(maxSep01_NxN.indices.first, decltype(maxSep01_NxN.indices.first){0}); // v0 of shape0
-            EXPECT_EQ(maxSep01_nos.indices.first, decltype(maxSep01_nos.indices.first){0}); // v0 of shape0
-            EXPECT_EQ(maxSep01_4x4.indices.second, decltype(maxSep01_4x4.indices.second){3}); // v3 of shape1
-            EXPECT_EQ(maxSep01_NxN.indices.second, decltype(maxSep01_NxN.indices.second){3}); // v3 of shape1
-            EXPECT_EQ(maxSep01_nos.indices.second, decltype(maxSep01_nos.indices.second){3}); // v3 of shape1
+            EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), VertexCounter{0}); // v0 of shape0
+            EXPECT_EQ(std::get<0>(maxSep01_NxN.indices), VertexCounter{0}); // v0 of shape0
+            EXPECT_EQ(std::get<0>(maxSep01_nos.indices), VertexCounter{0}); // v0 of shape0
+            EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), VertexCounter{3}); // v3 of shape1
+            EXPECT_EQ(std::get<1>(maxSep01_NxN.indices), VertexCounter{3}); // v3 of shape1
+            EXPECT_EQ(std::get<1>(maxSep01_nos.indices), VertexCounter{3}); // v3 of shape1
             break;
         case 8:
-            EXPECT_EQ(maxSep01_4x4.indices.first, decltype(maxSep01_4x4.indices.first){1}); // v1 of shape0
-            EXPECT_EQ(maxSep01_NxN.indices.first, decltype(maxSep01_NxN.indices.first){1}); // v1 of shape0
-            EXPECT_EQ(maxSep01_nos.indices.first, decltype(maxSep01_nos.indices.first){1}); // v1 of shape0
-            EXPECT_EQ(maxSep01_4x4.indices.second, decltype(maxSep01_4x4.indices.first){0}); // v0 of shape1
-            EXPECT_EQ(maxSep01_NxN.indices.second, decltype(maxSep01_NxN.indices.first){0}); // v0 of shape1
-            EXPECT_EQ(maxSep01_nos.indices.second, decltype(maxSep01_nos.indices.second){0}); // v0 of shape1
+            EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), VertexCounter{1}); // v1 of shape0
+            EXPECT_EQ(std::get<0>(maxSep01_NxN.indices), VertexCounter{1}); // v1 of shape0
+            EXPECT_EQ(std::get<0>(maxSep01_nos.indices), VertexCounter{1}); // v1 of shape0
+            EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), VertexCounter{0}); // v0 of shape1
+            EXPECT_EQ(std::get<1>(maxSep01_NxN.indices), VertexCounter{0}); // v0 of shape1
+            EXPECT_EQ(std::get<1>(maxSep01_nos.indices), VertexCounter{0}); // v0 of shape1
             break;
     }
     
-    EXPECT_EQ(maxSep10_4x4.indices.first, decltype(maxSep10_4x4.indices.first){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_NxN.indices.first, decltype(maxSep10_NxN.indices.first){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_nos.indices.first, decltype(maxSep10_nos.indices.first){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_4x4.indices.second, decltype(maxSep10_4x4.indices.first){1}); // v1 of shape0
-    EXPECT_EQ(maxSep10_NxN.indices.second, decltype(maxSep10_NxN.indices.first){1}); // v1 of shape0
-    EXPECT_EQ(maxSep10_nos.indices.second, decltype(maxSep10_nos.indices.second){1}); // v1 of shape0
+    EXPECT_EQ(std::get<0>(maxSep10_4x4.indices), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(std::get<0>(maxSep10_NxN.indices), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(std::get<0>(maxSep10_nos.indices), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(std::get<1>(maxSep10_4x4.indices), VertexCounter{1}); // v1 of shape0
+    EXPECT_EQ(std::get<1>(maxSep10_NxN.indices), VertexCounter{1}); // v1 of shape0
+    EXPECT_EQ(std::get<1>(maxSep10_nos.indices), VertexCounter{1}); // v1 of shape0
     
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)), -2.0, std::abs(-2.0) / 100);
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_NxN.distance / Meter)), -2.0, std::abs(-2.0) / 100);
@@ -610,20 +610,20 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction2)
     const auto maxSep01_NxN = GetMaxSeparation(child0, xfm0, child0, xfm1, totalRadius);
     const auto maxSep10_NxN = GetMaxSeparation(child0, xfm1, child0, xfm0, totalRadius);
     
-    EXPECT_EQ(maxSep01_4x4.indices.first, decltype(maxSep01_4x4.indices.first){1}); // v0 of shape0
-    EXPECT_EQ(maxSep01_4x4.indices.first, maxSep01_NxN.indices.first);
-    EXPECT_EQ(maxSep01_4x4.indices.second, decltype(maxSep01_4x4.indices.first){0}); // v3 of shape1
-    EXPECT_EQ(maxSep01_4x4.indices.second, maxSep01_NxN.indices.second);
+    EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), VertexCounter{1}); // v0 of shape0
+    EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), std::get<0>(maxSep01_NxN.indices));
+    EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), VertexCounter{0}); // v3 of shape1
+    EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), std::get<1>(maxSep01_NxN.indices));
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)),
                 -2.0, 0.0);
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)),
                 static_cast<double>(Real(maxSep01_NxN.distance / Meter)),
                 std::abs(static_cast<double>(Real(maxSep01_4x4.distance / Meter)) / 1000000.0));
     
-    EXPECT_EQ(maxSep10_4x4.indices.first, decltype(maxSep10_4x4.indices.first){3}); // v3 of shape1
-    EXPECT_EQ(maxSep10_4x4.indices.first, maxSep10_NxN.indices.first);
-    EXPECT_EQ(maxSep10_4x4.indices.second, decltype(maxSep10_4x4.indices.first){1}); // v1 of shape0
-    EXPECT_EQ(maxSep10_4x4.indices.second, maxSep10_NxN.indices.second);
+    EXPECT_EQ(std::get<0>(maxSep10_4x4.indices), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(std::get<0>(maxSep10_4x4.indices), std::get<0>(maxSep10_NxN.indices));
+    EXPECT_EQ(std::get<1>(maxSep10_4x4.indices), VertexCounter{1}); // v1 of shape0
+    EXPECT_EQ(std::get<1>(maxSep10_4x4.indices), std::get<1>(maxSep10_NxN.indices));
     EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.distance / Meter)),
                 -2.0, 0.0);
     EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.distance / Meter)),

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -85,11 +85,11 @@ TEST(Contact, ResetFriction)
     auto c = Contact{&fA, 0u, &fB, 0u};
 
     ASSERT_GT(GetFriction(shape), Real(0));
-    ASSERT_NEAR(static_cast<double>(c.GetFriction()), static_cast<double>(GetFriction(shape)), 0.01);
+    ASSERT_NEAR(static_cast<double>(c.GetFriction()), static_cast<double>(Real{GetFriction(shape)}), 0.01);
     c.SetFriction(GetFriction(shape) * Real(2));
     ASSERT_NE(c.GetFriction(), GetFriction(shape));
     ResetFriction(c);
-    EXPECT_NEAR(static_cast<double>(c.GetFriction()), static_cast<double>(GetFriction(shape)), 0.01);
+    EXPECT_NEAR(static_cast<double>(c.GetFriction()), static_cast<double>(Real{GetFriction(shape)}), 0.01);
 }
 
 TEST(Contact, ResetRestitution)

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -47,13 +47,13 @@ TEST(Distance, MatchingCircles)
 
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(witnessPoints.first, pos1);
-    EXPECT_EQ(witnessPoints.second, pos1);
+    EXPECT_EQ(std::get<0>(witnessPoints), pos1);
+    EXPECT_EQ(std::get<1>(witnessPoints), pos1);
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
 
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -74,19 +74,19 @@ TEST(Distance, OpposingCircles)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), GetX(pos1));
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), GetY(pos1));
 
-    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), GetX(pos2));
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), GetY(pos2));
 
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -110,19 +110,19 @@ TEST(Distance, HorTouchingCircles)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), GetX(pos1));
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), GetX(pos2));
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -143,19 +143,19 @@ TEST(Distance, OverlappingCirclesPN)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), GetX(pos1));
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), GetX(pos2));
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -176,19 +176,19 @@ TEST(Distance, OverlappingCirclesNP)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), GetX(pos1));
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), GetX(pos2));
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -210,19 +210,19 @@ TEST(Distance, SeparatedCircles)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos1));
-    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos1));
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), GetX(pos1));
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), GetY(pos1));
     
-    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos2));
-    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos2));
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), GetX(pos2));
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), GetY(pos2));
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -249,23 +249,23 @@ TEST(Distance, EdgeCircleOverlapping)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos3));
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), GetX(pos3));
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), GetY(pos3));
 
-    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos3));
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), GetX(pos3));
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), GetY(pos3));
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.first, VertexCounter{0});
-    EXPECT_EQ(ip0.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
 
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.first, VertexCounter{1});
-    EXPECT_EQ(ip1.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip1), VertexCounter{1});
+    EXPECT_EQ(std::get<1>(ip1), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
@@ -291,23 +291,23 @@ TEST(Distance, EdgeCircleOverlapping2)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.first), GetY(pos3));
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), GetX(pos3));
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), GetY(pos3));
     
-    EXPECT_EQ(GetX(witnessPoints.second), GetX(pos3));
-    EXPECT_EQ(GetY(witnessPoints.second), GetY(pos3));
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), GetX(pos3));
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), GetY(pos3));
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.first, VertexCounter{0});
-    EXPECT_EQ(ip0.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.first, VertexCounter{1});
-    EXPECT_EQ(ip1.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip1), VertexCounter{1});
+    EXPECT_EQ(std::get<1>(ip1), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{10});
@@ -333,23 +333,23 @@ TEST(Distance, EdgeCircleTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.first), 3_m);
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), 2_m);
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), 3_m);
     
-    EXPECT_EQ(GetX(witnessPoints.second), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.second), 1_m);
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), 2_m);
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), 1_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.first, VertexCounter{0});
-    EXPECT_EQ(ip0.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.first, VertexCounter{1});
-    EXPECT_EQ(ip1.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip1), VertexCounter{1});
+    EXPECT_EQ(std::get<1>(ip1), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
@@ -384,23 +384,23 @@ TEST(Distance, HorEdgeSquareTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), 1_m);
-    EXPECT_EQ(GetY(witnessPoints.first), 1_m);
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), 1_m);
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), 1_m);
     
-    EXPECT_EQ(GetX(witnessPoints.second), 1_m);
-    EXPECT_EQ(GetY(witnessPoints.second), 0_m);
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), 1_m);
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), 0_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.first, VertexCounter{0});
-    EXPECT_EQ(ip0.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.first, VertexCounter{0});
-    EXPECT_EQ(ip1.second, VertexCounter{1});
+    EXPECT_EQ(std::get<0>(ip1), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip1), VertexCounter{1});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 8.0, 0.000001);
@@ -435,25 +435,25 @@ TEST(Distance, VerEdgeSquareTouching)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_NEAR(static_cast<double>(Real{sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second)) / Meter}),
+    EXPECT_NEAR(static_cast<double>(Real{sqrt(GetMagnitudeSquared(std::get<0>(witnessPoints) - std::get<1>(witnessPoints))) / Meter}),
                 1.0, 0.000001);
-    EXPECT_EQ(GetX(witnessPoints.first), 3_m);
-    EXPECT_EQ(GetY(witnessPoints.first), 2_m);
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), 3_m);
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), 2_m);
     
-    EXPECT_EQ(GetX(witnessPoints.second), 4_m);
-    EXPECT_EQ(GetY(witnessPoints.second), 2_m);
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), 4_m);
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), 2_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip0 = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip0.first, VertexCounter{2});
-    EXPECT_EQ(ip0.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip0), VertexCounter{2});
+    EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
     const auto ip1 = conf.cache.GetIndexPair(1);
-    EXPECT_EQ(ip1.first, VertexCounter{3});
-    EXPECT_EQ(ip1.second, VertexCounter{1});
+    EXPECT_EQ(std::get<0>(ip1), VertexCounter{3});
+    EXPECT_EQ(std::get<1>(ip1), VertexCounter{1});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{10});
@@ -480,19 +480,19 @@ TEST(Distance, SquareTwice)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.first), 2_m);
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), 2_m);
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), 2_m);
 
-    EXPECT_EQ(GetX(witnessPoints.second), 2_m);
-    EXPECT_EQ(GetY(witnessPoints.second), 2_m);
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), 2_m);
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), 2_m);
 
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -532,19 +532,19 @@ TEST(Distance, SquareSquareTouchingVertically)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), 4_m);
-    EXPECT_EQ(GetY(witnessPoints.first), 3_m);
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), 4_m);
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), 3_m);
     
-    EXPECT_EQ(GetX(witnessPoints.second), 4_m);
-    EXPECT_EQ(GetY(witnessPoints.second), 3_m);
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), 4_m);
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), 3_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{3});
-    EXPECT_EQ(ip.second, VertexCounter{1});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{3});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{1});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
@@ -583,19 +583,19 @@ TEST(Distance, SquareSquareDiagonally)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), -1_m);
-    EXPECT_EQ(GetY(witnessPoints.first), -1_m);
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), -1_m);
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), -1_m);
     
-    EXPECT_EQ(GetX(witnessPoints.second), 1_m);
-    EXPECT_EQ(GetY(witnessPoints.second), 1_m);
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), 1_m);
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), 1_m);
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{2});
-    EXPECT_EQ(ip.second, VertexCounter{3});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{2});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{3});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{0});
@@ -658,19 +658,19 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
     conf.cache = Simplex::GetCache(output.simplex.GetEdges());
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
-    EXPECT_EQ(GetX(witnessPoints.first), 0_m);
-    EXPECT_EQ(GetY(witnessPoints.first), 0.5_m);
+    EXPECT_EQ(GetX(std::get<0>(witnessPoints)), 0_m);
+    EXPECT_EQ(GetY(std::get<0>(witnessPoints)), 0.5_m);
     
-    EXPECT_EQ(GetX(witnessPoints.second), 0_m);
-    EXPECT_EQ(GetY(witnessPoints.second), 0.5_m);
+    EXPECT_EQ(GetX(std::get<1>(witnessPoints)), 0_m);
+    EXPECT_EQ(GetY(std::get<1>(witnessPoints)), 0.5_m);
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
     EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{3});
     
     const auto ip = conf.cache.GetIndexPair(0);
-    EXPECT_EQ(ip.first, VertexCounter{0});
-    EXPECT_EQ(ip.second, VertexCounter{0});
+    EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
+    EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
     EXPECT_EQ(true, conf.cache.IsMetricSet());
     EXPECT_EQ(conf.cache.GetMetric(), Real{-64});

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -227,14 +227,14 @@ TEST(DistanceProxy, GetMaxSeparationFromWorld)
     const auto result1 = GetMaxSeparation(squareDp, circleDp);
     
     EXPECT_NEAR(static_cast<double>(Real(result1.distance / Meter)), 3.0, 0.0001);
-    EXPECT_EQ(result1.indices.first, static_cast<decltype(result1.indices.first)>(2));
-    EXPECT_EQ(result1.indices.second, static_cast<decltype(result1.indices.second)>(0));
+    EXPECT_EQ(std::get<0>(result1.indices), static_cast<decltype(std::get<0>(result1.indices))>(2));
+    EXPECT_EQ(std::get<1>(result1.indices), static_cast<decltype(std::get<1>(result1.indices))>(0));
     
     const auto result2 = GetMaxSeparation(squareDp, circleDp, 0_m);
     
     EXPECT_NEAR(static_cast<double>(Real(result2.distance / Meter)), 3.0, 0.0001);
-    EXPECT_EQ(result2.indices.first, static_cast<decltype(result2.indices.first)>(2));
-    EXPECT_EQ(result2.indices.second, static_cast<decltype(result2.indices.second)>(0));
+    EXPECT_EQ(std::get<0>(result2.indices), static_cast<decltype(std::get<0>(result2.indices))>(2));
+    EXPECT_EQ(std::get<1>(result2.indices), static_cast<decltype(std::get<1>(result2.indices))>(0));
 }
 
 TEST(DistanceProxy, Equality)

--- a/UnitTests/IndexPair.cpp
+++ b/UnitTests/IndexPair.cpp
@@ -24,8 +24,8 @@ using namespace playrho;
 TEST(IndexPair, Init)
 {
     IndexPair ip{1, 2};
-    EXPECT_EQ(ip.first, 1);
-    EXPECT_EQ(ip.second, 2);
+    EXPECT_EQ(std::get<0>(ip), 1);
+    EXPECT_EQ(std::get<1>(ip), 2);
 }
 
 TEST(IndexPair, Equality)
@@ -50,6 +50,6 @@ TEST(IndexPair, InvalidIndex)
 {
     const auto invalid_index = InvalidVertex;
     IndexPair ip{invalid_index, 2};    
-    EXPECT_EQ(invalid_index, ip.first);
-    EXPECT_NE(invalid_index, ip.second);
+    EXPECT_EQ(invalid_index, std::get<0>(ip));
+    EXPECT_NE(invalid_index, std::get<1>(ip));
 }

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -77,7 +77,7 @@ TEST(SeparationFinder, BehavesAsExpected)
     {
         // Prepare input for distance query.
         const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
-        const auto distance = sqrt(GetMagnitudeSquared(witnessPoints.first - witnessPoints.second));
+        const auto distance = GetMagnitude(std::get<0>(witnessPoints) - std::get<1>(witnessPoints));
 
         const auto minSeparation = fcn.FindMinSeparation(xfA, xfB);
 


### PR DESCRIPTION
#### Description - What's this PR do?
- Switches some Testbed code to using PlayRho's user defined literal units.
- Replaces uses of first/second member names of `std::pair` types with uses of `std::get<0>` and `std::get<1>` instead.

#### Related Issues
- Issue #244.