### PR TITLE
Various changes 20171217

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -217,6 +217,8 @@
 		47D61F781F1FE3B700E702BD /* EdgeShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D61F771F1FE3B700E702BD /* EdgeShape.cpp */; };
 		47D61F7A1F20229A00E702BD /* ChainShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D61F791F20229A00E702BD /* ChainShape.cpp */; };
 		47D61F7C1F21112000E702BD /* MultiShape.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47D61F7B1F21112000E702BD /* MultiShape.cpp */; };
+		47E36F501FE8477000C10B79 /* FixedLimits.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47E36F4E1FE8477000C10B79 /* FixedLimits.hpp */; };
+		47E36F541FE8534500C10B79 /* FixedMath.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47E36F521FE8534500C10B79 /* FixedMath.hpp */; };
 		47E841701DB3FDC400E5F311 /* WorldManifold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47E8416F1DB3FDC400E5F311 /* WorldManifold.cpp */; };
 		47E841721DB4018D00E5F311 /* VelocityConstraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47E841711DB4018D00E5F311 /* VelocityConstraint.cpp */; };
 		47F932A61D11C283006A193C /* AllocatedArray.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47F932A41D11C283006A193C /* AllocatedArray.hpp */; };
@@ -599,6 +601,8 @@
 		47D61F771F1FE3B700E702BD /* EdgeShape.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EdgeShape.cpp; sourceTree = "<group>"; };
 		47D61F791F20229A00E702BD /* ChainShape.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ChainShape.cpp; sourceTree = "<group>"; };
 		47D61F7B1F21112000E702BD /* MultiShape.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MultiShape.cpp; sourceTree = "<group>"; };
+		47E36F4E1FE8477000C10B79 /* FixedLimits.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FixedLimits.hpp; sourceTree = "<group>"; };
+		47E36F521FE8534500C10B79 /* FixedMath.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = FixedMath.hpp; sourceTree = "<group>"; };
 		47E8416F1DB3FDC400E5F311 /* WorldManifold.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WorldManifold.cpp; sourceTree = "<group>"; };
 		47E841711DB4018D00E5F311 /* VelocityConstraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VelocityConstraint.cpp; sourceTree = "<group>"; };
 		47F932A41D11C283006A193C /* AllocatedArray.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = AllocatedArray.hpp; sourceTree = "<group>"; };
@@ -974,6 +978,8 @@
 				47B58F531F570E2C00354C34 /* DynamicMemory.cpp */,
 				47B58F541F570E2C00354C34 /* DynamicMemory.hpp */,
 				4727242D1E315E1A00C64921 /* Fixed.hpp */,
+				47E36F4E1FE8477000C10B79 /* FixedLimits.hpp */,
+				47E36F521FE8534500C10B79 /* FixedMath.hpp */,
 				47B58F5C1F5B314400354C34 /* FlagGuard.hpp */,
 				80BB8943141C3E5900F1753A /* GrowableStack.hpp */,
 				47D28D9F1F72B9340094C032 /* Interval.hpp */,
@@ -1330,6 +1336,8 @@
 				80BB89A2141C3E5900F1753A /* GrowableStack.hpp in Headers */,
 				474BAB301E5D00960058E08A /* BodyConstraint.hpp in Headers */,
 				80BB89A4141C3E5900F1753A /* Math.hpp in Headers */,
+				47E36F501FE8477000C10B79 /* FixedLimits.hpp in Headers */,
+				47E36F541FE8534500C10B79 /* FixedMath.hpp in Headers */,
 				470F9B301EDF5165007EF7B6 /* Velocity.hpp in Headers */,
 				473273251F476C1D00E22AE2 /* OptionalValue.hpp in Headers */,
 				80BB89A6141C3E5900F1753A /* Settings.hpp in Headers */,
@@ -1804,7 +1812,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = /usr/local/lib;
 				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "-lbenchmark";
+				OTHER_LDFLAGS = (
+					"-lbenchmark",
+					"-lBox2D",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1819,7 +1830,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = /usr/local/lib;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "-lbenchmark";
+				OTHER_LDFLAGS = (
+					"-lbenchmark",
+					"-lBox2D",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -26,17 +26,20 @@
 namespace playrho {
 
     class DistanceProxy;
+    struct ToiConf;
 
     /// @brief Pair of Length2 values.
-    using PairLength2 = std::array<Length2, 2>;
+    /// @note Uses <code>std::pair</code> because this is a pair and also because
+    ///   <code>std::pair</code> has more support for constant expressions.
+    using PairLength2 = std::pair<Length2, Length2>;
     
     /// @brief Gets the witness points of the given simplex.
     PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept;
     
-    /// @brief Gets the delta of the two points of the given witness points.
+    /// @brief Gets the delta to go from the first element to the second.
     PLAYRHO_CONSTEXPR inline Length2 GetDelta(PairLength2 arg) noexcept
     {
-        return std::get<0>(arg) - std::get<1>(arg);
+        return std::get<1>(arg) - std::get<0>(arg);
     }
     
     /// @brief Distance Configuration.
@@ -48,11 +51,13 @@ namespace playrho {
         Simplex::Cache cache; ///< Cache.
         iteration_type maxIterations = DefaultMaxDistanceIters; ///< Max iterations.
     };
+    
+    /// @brief Gets the distance configuration for the given time of impact configuration.
+    DistanceConf GetDistanceConf(const ToiConf& conf) noexcept;
 
     /// @brief Distance Output.
     struct DistanceOutput
     {
-        
         /// @brief State of the distance output.
         enum State: std::uint8_t
         {

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -56,6 +56,12 @@ namespace playrho
         /// @brief Constant vertex iterator.
         using ConstVertexIterator = ConstVertexPointer;
         
+        /// @brief Constant normal pointer.
+        using ConstNormalPointer = const UnitVec2*;
+        
+        /// @brief Constant normal iterator.
+        using ConstNormalIterator = ConstNormalPointer;
+
         DistanceProxy() = default;
         
         /// @brief Copy constructor.
@@ -128,6 +134,12 @@ namespace playrho
         {
             return {m_vertices, m_vertices + m_count};
         }
+        
+        /// @brief Gets the range of normal.
+        Range<ConstNormalIterator> GetNormals() const noexcept
+        {
+            return {m_normals, m_normals + m_count};
+        }
 
         /// Gets the vertex count.
         /// @details This is the count of valid vertex elements that this object provides.
@@ -198,23 +210,23 @@ namespace playrho
     ///   vector and returns its index.
     /// @note 0 is returned for a given zero length direction vector.
     /// @param proxy Distance proxy object to find index in if a valid index exists for it.
-    /// @param d Direction vector to find index for.
+    /// @param dir Direction vector to find index for.
     /// @return InvalidVertex if d is invalid or the count of vertices is zero, otherwise a
     ///   value from 0 to one less than count.
     /// @sa GetVertexCount().
     /// @relatedalso DistanceProxy
     template <class T>
-    inline VertexCounter GetSupportIndex(const DistanceProxy& proxy, T d) noexcept
+    inline VertexCounter GetSupportIndex(const DistanceProxy& proxy, T dir) noexcept
     {
         using VT = typename T::value_type;
         using OT = decltype(VT{} * 0_m);
 
-        auto index = InvalidVertex; ///< Index of vertex that when dotted with d has the max value.
+        auto index = InvalidVertex; ///< Index of vertex that when dotted with dir has the max value.
         auto maxValue = -std::numeric_limits<OT>::infinity(); ///< Max dot value.
         auto i = VertexCounter{0};
         for (const auto& vertex: proxy.GetVertices())
         {
-            const auto value = Dot(vertex, d);
+            const auto value = Dot(vertex, dir);
             if (maxValue < value)
             {
                 maxValue = value;

--- a/PlayRho/Collision/SeparationFinder.hpp
+++ b/PlayRho/Collision/SeparationFinder.hpp
@@ -59,7 +59,7 @@ namespace playrho {
         /// Finds the minimum separation.
         /// @return indexes of proxy A's and proxy B's vertices that have the minimum
         ///    distance between them and what that distance is.
-        IndexPairDistance FindMinSeparation(const Transformation2D& xfA,
+        LengthIndexPair FindMinSeparation(const Transformation2D& xfA,
                                             const Transformation2D& xfB) const
         {
             switch (m_type)
@@ -71,7 +71,7 @@ namespace playrho {
             
             // Should never be reached
             assert(false);
-            return IndexPairDistance{0, InvalidIndexPair};
+            return LengthIndexPair{0, InvalidIndexPair};
         }
         
         /// Evaluates the separation of the identified proxy vertices at the given time factor.
@@ -117,15 +117,15 @@ namespace playrho {
         }
         
         /// @brief Finds the minimum separation for points.
-        IndexPairDistance FindMinSeparationForPoints(const Transformation2D& xfA,
+        LengthIndexPair FindMinSeparationForPoints(const Transformation2D& xfA,
                                                      const Transformation2D& xfB) const;
         
         /// @brief Finds the minimum separation for face A.
-        IndexPairDistance FindMinSeparationForFaceA(const Transformation2D& xfA,
+        LengthIndexPair FindMinSeparationForFaceA(const Transformation2D& xfA,
                                                     const Transformation2D& xfB) const;
         
         /// @brief Finds the minimum separation for face B.
-        IndexPairDistance FindMinSeparationForFaceB(const Transformation2D& xfA,
+        LengthIndexPair FindMinSeparationForFaceB(const Transformation2D& xfA,
                                                     const Transformation2D& xfB) const;
         
         /// @brief Evaluates for points.

--- a/PlayRho/Collision/ShapeSeparation.hpp
+++ b/PlayRho/Collision/ShapeSeparation.hpp
@@ -34,16 +34,16 @@ namespace playrho
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
-                                       const DistanceProxy& proxy2, Transformation2D xf2);
+    SeparationInfo2D GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
+                                      const DistanceProxy& proxy2, Transformation2D xf2);
     
     /// @brief Gets the max separation information.
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
-                                       const DistanceProxy& proxy2, Transformation2D xf2,
-                                       Length stop);
+    SeparationInfo2D GetMaxSeparation(const DistanceProxy& proxy1, Transformation2D xf1,
+                                      const DistanceProxy& proxy2, Transformation2D xf2,
+                                      Length stop);
     
     /// @brief Gets the max separation information for the first four vertices of the two
     ///   given shapes.
@@ -52,16 +52,16 @@ namespace playrho
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairDistance GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation2D xf1,
-                                          const DistanceProxy& proxy2, Transformation2D xf2);
+    SeparationInfo2D GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation2D xf1,
+                                         const DistanceProxy& proxy2, Transformation2D xf2);
 
     /// @brief Gets the max separation information.
     /// @return Index of the vertex and normal from <code>proxy1</code>,
     ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
     ///   distance from each other in the direction of that normal), and the maximal distance.
-    IndexPairDistance GetMaxSeparation(const DistanceProxy& proxy1,
-                                       const DistanceProxy& proxy2,
-                                       Length stop = MaxFloat * Meter);
+    SeparationInfo2D GetMaxSeparation(const DistanceProxy& proxy1,
+                                      const DistanceProxy& proxy2,
+                                      Length stop = MaxFloat * Meter);
     
 } // namespace playrho
 

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -78,7 +78,7 @@ namespace playrho {
     }
     
     /// @brief Gets "w".
-    /// @return 2D vector value of wB minus wA.
+    /// @return 2D vector value of the simplex edge's point B minus its point A.
     PLAYRHO_CONSTEXPR inline Length2 GetPointDelta(const SimplexEdge& sv) noexcept
     {
         return sv.GetPointB() - sv.GetPointA();

--- a/PlayRho/Collision/TimeOfImpact.cpp
+++ b/PlayRho/Collision/TimeOfImpact.cpp
@@ -25,17 +25,6 @@
 
 namespace playrho {
 
-namespace {
-        
-inline DistanceConf GetDistanceConf(const ToiConf& conf)
-{
-    auto distanceConf = DistanceConf{};
-    distanceConf.maxIterations = conf.maxDistIters;
-    return distanceConf;
-}
-
-} // anonymous namespace
-
 TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep2D& sweepA,
                        const DistanceProxy& proxyB, const Sweep2D& sweepB,
                        ToiConf conf)
@@ -43,10 +32,6 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep2D& sweepA,
     assert(IsValid(sweepA));
     assert(IsValid(sweepB));
     assert(sweepA.GetAlpha0() == sweepB.GetAlpha0());
-    //assert(isfinite(GetMagnitudeSquared(sweepA.pos0.linear - sweepB.pos0.linear)));
-    //assert(isfinite(GetMagnitudeSquared(sweepA.pos0.linear - sweepB.pos1.linear)));
-    //assert(isfinite(GetMagnitudeSquared(sweepA.pos1.linear - sweepB.pos0.linear)));
-    //assert(isfinite(GetMagnitudeSquared(sweepA.pos1.linear - sweepB.pos1.linear)));
     assert(conf.tMax >= 0 && conf.tMax <=1);
 
     // CCD via the local separating axis method. This seeks progression
@@ -59,20 +44,10 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep2D& sweepA,
     {
         return TOIOutput{0, stats, TOIOutput::e_targetDepthExceedsTotalRadius};
     }
-    //assert(conf.targetDepth >= conf.tolerance);
     
     const auto target = totalRadius - conf.targetDepth;
-    //assert(target != totalRadius);
-    //assert(target > conf.tolerance);
-    
     const auto maxTarget = std::max(target + conf.tolerance, 0_m);
-    //assert(maxTarget != target);
-    //assert(maxTarget <= totalRadius);
-    
     const auto minTarget = std::max(target - conf.tolerance, 0_m);
-    //assert(minTarget != target);
-    //assert(minTarget < maxTarget);
-    //assert(minTarget > 0_m && !AlmostZero(minTarget / Meter));
     
     const auto minTargetSquared = Square(minTarget);
     if (!isfinite(minTargetSquared) && isfinite(minTarget))
@@ -137,7 +112,7 @@ TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep2D& sweepA,
         // From here on, the real distance squared at time t1 is > than maxTargetSquared
 
         // Initialize the separating axis.
-        const auto fcn = SeparationFinder::Get(distanceConf.cache.GetIndices(),
+        const auto fcn = SeparationFinder::Get(distanceConf.cache.indices,
                                                proxyA, t1xfA, proxyB, t1xfB);
 
         // Compute the TOI on the separating axis. We do this by successively

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -37,11 +37,6 @@ namespace playrho {
     ///
     class WorldManifold
     {
-    public:
-        
-        /// @brief Size type.
-        using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
-
     private:
         UnitVec2 m_normal = GetInvalid<UnitVec2>(); ///< world vector pointing from A to B
         
@@ -60,6 +55,9 @@ namespace playrho {
         
     public:
         
+        /// @brief Size type.
+        using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
+
         /// @brief Point data for world manifold.
         /// @note This data structure is 20-bytes large at least on one 64-bit architecture.
         struct PointData

--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -27,12 +27,11 @@
 #include <cstdint>
 #include <limits>
 #include <cassert>
-#include <cmath>
 #include <type_traits>
 #include <iostream>
 
-namespace playrho
-{
+namespace playrho {
+
     /// @brief Template class for fixed-point numbers.
     ///
     /// @details This is a fixed point type template for a given base type using a given number
@@ -661,127 +660,6 @@ namespace playrho
     {
         lhs %= rhs;
         return lhs;
-    }    
-
-    /// @brief Square root's the given value.
-    /// @note This implementation isn't meant to be fast, only correct enough.
-    template <typename BT, unsigned int FB>
-    inline auto sqrt(Fixed<BT, FB> arg)
-    {
-        return static_cast<Fixed<BT, FB>>(std::sqrt(static_cast<long double>(arg)));
-    }
-
-    /// @brief Gets whether the given value is normal - i.e. not 0 nor infinite.
-    template <typename BT, unsigned int FB>
-    inline bool isnormal(Fixed<BT, FB> arg)
-    {
-        return arg != Fixed<BT, FB>{0} && arg.isfinite();
-    }
-    
-    /// @brief Computes the sine of the argument for Fixed types.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> sin(Fixed<BT, FB> arg)
-    {
-        return static_cast<Fixed<BT, FB>>(std::sin(static_cast<double>(arg)));
-    }
-    
-    /// @brief Computes the cosine of the argument for Fixed types.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> cos(Fixed<BT, FB> arg)
-    {
-        return static_cast<Fixed<BT, FB>>(std::cos(static_cast<double>(arg)));
-    }
-    
-    /// @brief Computes the arc tangent.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> atan2(Fixed<BT, FB> y, Fixed<BT, FB> x)
-    {
-        return static_cast<Fixed<BT, FB>>(std::atan2(static_cast<double>(y), static_cast<double>(x)));
-    }
-
-    /// @brief Computes the value of the base number raised to the power of the exponent.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> pow(Fixed<BT, FB> base, Fixed<BT, FB> exp)
-    {
-        return static_cast<Fixed<BT, FB>>(std::pow(static_cast<double>(base),
-                                                   static_cast<double>(exp)));
-    }
-    
-    /// @brief Computes the value of the base number raised to the power of the exponent.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> pow(Fixed<BT, FB> base, double exp)
-    {
-        return static_cast<Fixed<BT, FB>>(std::pow(static_cast<double>(base), exp));
-    }
-    
-    /// @brief Computes the square root of the sum of the squares.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> hypot(Fixed<BT, FB> x, Fixed<BT, FB> y)
-    {
-        return static_cast<Fixed<BT, FB>>(std::hypot(static_cast<double>(x), static_cast<double>(y)));
-    }
-    
-    /// @brief Rounds the given value.
-    /// @sa http://en.cppreference.com/w/cpp/numeric/math/round
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> round(Fixed<BT, FB> value) noexcept
-    {
-        const auto tmp = value + (Fixed<BT, FB>{1} / Fixed<BT, FB>{2});
-        const auto truncated = static_cast<typename Fixed<BT, FB>::value_type>(tmp);
-        return Fixed<BT, FB>{truncated, 0};
-    }
-    
-    /// @brief Truncates the given value.
-    /// @sa http://en.cppreference.com/w/c/numeric/math/trunc
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> trunc(Fixed<BT, FB> arg)
-    {
-        return static_cast<Fixed<BT, FB>>(static_cast<long long>(arg));
-    }
-    
-    /// @brief Determines whether the given value is negative.
-    template <typename BT, unsigned int FB>
-    inline bool signbit(Fixed<BT, FB> value) noexcept
-    {
-        return value.getsign() < 0;
-    }
-    
-    /// @brief Gets whether the given value is not-a-number.
-    template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool isnan(Fixed<BT, FB> value) noexcept
-    {
-        return value.Compare(0) == Fixed<BT, FB>::CmpResult::Incomparable;
-    }
-    
-    /// @brief Gets whether the given value is finite.
-    template <typename BT, unsigned int FB>
-    inline bool isfinite(Fixed<BT, FB> value) noexcept
-    {
-        return (value > Fixed<BT, FB>::GetNegativeInfinity())
-            && (value < Fixed<BT, FB>::GetInfinity());
-    }
-    
-    /// @brief Next after function for Fixed types.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> nextafter(Fixed<BT, FB> from, Fixed<BT, FB> to) noexcept
-    {
-        if (from < to)
-        {
-            return static_cast<Fixed<BT, FB>>(from + Fixed<BT,FB>::GetMin());
-        }
-        if (from > to)
-        {
-            return static_cast<Fixed<BT, FB>>(from - Fixed<BT,FB>::GetMin());
-        }
-        return static_cast<Fixed<BT, FB>>(to);
-    }
-    
-    /// @brief Computes the rounded value of the given value.
-    template <typename BT, unsigned int FB>
-    inline Fixed<BT, FB> RoundOff(Fixed<BT, FB> value, std::uint32_t precision = 100000)
-    {
-        const auto factor = Fixed<BT, FB>(precision);
-        return round(value * factor) / factor;
     }
 
     /// @brief Gets whether a given value is almost zero.
@@ -1020,87 +898,5 @@ namespace playrho
 #endif /* PLAYRHO_INT128 */
 
 } // namespace playrho
-
-namespace std
-{
-    /// @brief Template specialization of numeric limits for Fixed types.
-    /// @sa http://en.cppreference.com/w/cpp/types/numeric_limits
-    template <typename BT, unsigned int FB>
-    class numeric_limits<playrho::Fixed<BT,FB>>
-    {
-    public:
-        static PLAYRHO_CONSTEXPR const bool is_specialized = true; ///< Type is specialized.
-        
-        /// @brief Gets the min value available for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
-
-        /// @brief Gets the max value available for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
-
-        /// @brief Gets the lowest value available for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
-        
-        /// @brief Number of radix digits that can be represented.
-        static PLAYRHO_CONSTEXPR const int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
-
-        /// @brief Number of decimal digits that can be represented.
-        static PLAYRHO_CONSTEXPR const int digits10 = playrho::Fixed<BT,FB>::WholeBits - 1;
-        
-        /// @brief Number of decimal digits necessary to differentiate all values.
-        static PLAYRHO_CONSTEXPR const int max_digits10 = 5; // TODO(lou): check this
-        
-        static PLAYRHO_CONSTEXPR const bool is_signed = true; ///< Identifies signed types.
-        static PLAYRHO_CONSTEXPR const bool is_integer = false; ///< Identifies integer types.
-        static PLAYRHO_CONSTEXPR const bool is_exact = true; ///< Identifies exact type.
-        static PLAYRHO_CONSTEXPR const int radix = 0; ///< Radix used by the type.
-
-        /// @brief Gets the epsilon value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
-        
-        /// @brief Gets the round error value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
-        
-        /// @brief One more than smallest negative power of the radix that's a valid
-        ///    normalized floating-point value.
-        static PLAYRHO_CONSTEXPR const int min_exponent = 0;
-
-        /// @brief Smallest negative power of ten that's a valid normalized floating-point value.
-        static PLAYRHO_CONSTEXPR const int min_exponent10 = 0;
-        
-        /// @brief One more than largest integer power of radix that's a valid finite
-        ///   floating-point value.
-        static PLAYRHO_CONSTEXPR const int max_exponent = 0;
-        
-        /// @brief Largest integer power of 10 that's a valid finite floating-point value.
-        static PLAYRHO_CONSTEXPR const int max_exponent10 = 0;
-        
-        static PLAYRHO_CONSTEXPR const bool has_infinity = true; ///< Whether can represent infinity.
-        static PLAYRHO_CONSTEXPR const bool has_quiet_NaN = true; ///< Whether can represent quiet-NaN.
-        static PLAYRHO_CONSTEXPR const bool has_signaling_NaN = false; ///< Whether can represent signaling-NaN.
-        static PLAYRHO_CONSTEXPR const float_denorm_style has_denorm = denorm_absent; ///< Denorm style used.
-        static PLAYRHO_CONSTEXPR const bool has_denorm_loss = false; ///< Has denorm loss amount.
-
-        /// @brief Gets the infinite value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
-        
-        /// @brief Gets the quiet NaN value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
-
-        /// @brief Gets the signaling NaN value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
-        
-        /// @brief Gets the denorm value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
-        
-        static PLAYRHO_CONSTEXPR const bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
-        static PLAYRHO_CONSTEXPR const bool is_bounded = true; ///< Type bounded: has limited precision.
-        static PLAYRHO_CONSTEXPR const bool is_modulo = false; ///< Doesn't modulo arithmetic overflows.
-        
-        static PLAYRHO_CONSTEXPR const bool traps = false; ///< Doesn't do traps.
-        static PLAYRHO_CONSTEXPR const bool tinyness_before = false; ///< Doesn't detect tinyness before rounding.
-        static PLAYRHO_CONSTEXPR const float_round_style round_style = round_toward_zero; ///< Rounds down.
-    };
-    
-} // namespace std
 
 #endif // PLAYRHO_COMMON_FIXED_HPP

--- a/PlayRho/Common/FixedLimits.hpp
+++ b/PlayRho/Common/FixedLimits.hpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_COMMON_FIXEDLIMITS_HPP
+#define PLAYRHO_COMMON_FIXEDLIMITS_HPP
+
+#include <PlayRho/Common/Fixed.hpp>
+
+namespace std {
+
+    /// @brief Template specialization of numeric limits for Fixed types.
+    /// @sa http://en.cppreference.com/w/cpp/types/numeric_limits
+    template <typename BT, unsigned int FB>
+    class numeric_limits<playrho::Fixed<BT,FB>>
+    {
+    public:
+        static PLAYRHO_CONSTEXPR const bool is_specialized = true; ///< Type is specialized.
+        
+        /// @brief Gets the min value available for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
+        
+        /// @brief Gets the max value available for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
+        
+        /// @brief Gets the lowest value available for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
+        
+        /// @brief Number of radix digits that can be represented.
+        static PLAYRHO_CONSTEXPR const int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
+        
+        /// @brief Number of decimal digits that can be represented.
+        static PLAYRHO_CONSTEXPR const int digits10 = playrho::Fixed<BT,FB>::WholeBits - 1;
+        
+        /// @brief Number of decimal digits necessary to differentiate all values.
+        static PLAYRHO_CONSTEXPR const int max_digits10 = 5; // TODO(lou): check this
+        
+        static PLAYRHO_CONSTEXPR const bool is_signed = true; ///< Identifies signed types.
+        static PLAYRHO_CONSTEXPR const bool is_integer = false; ///< Identifies integer types.
+        static PLAYRHO_CONSTEXPR const bool is_exact = true; ///< Identifies exact type.
+        static PLAYRHO_CONSTEXPR const int radix = 0; ///< Radix used by the type.
+        
+        /// @brief Gets the epsilon value for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        
+        /// @brief Gets the round error value for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        
+        /// @brief One more than smallest negative power of the radix that's a valid
+        ///    normalized floating-point value.
+        static PLAYRHO_CONSTEXPR const int min_exponent = 0;
+        
+        /// @brief Smallest negative power of ten that's a valid normalized floating-point value.
+        static PLAYRHO_CONSTEXPR const int min_exponent10 = 0;
+        
+        /// @brief One more than largest integer power of radix that's a valid finite
+        ///   floating-point value.
+        static PLAYRHO_CONSTEXPR const int max_exponent = 0;
+        
+        /// @brief Largest integer power of 10 that's a valid finite floating-point value.
+        static PLAYRHO_CONSTEXPR const int max_exponent10 = 0;
+        
+        static PLAYRHO_CONSTEXPR const bool has_infinity = true; ///< Whether can represent infinity.
+        static PLAYRHO_CONSTEXPR const bool has_quiet_NaN = true; ///< Whether can represent quiet-NaN.
+        static PLAYRHO_CONSTEXPR const bool has_signaling_NaN = false; ///< Whether can represent signaling-NaN.
+        static PLAYRHO_CONSTEXPR const float_denorm_style has_denorm = denorm_absent; ///< Denorm style used.
+        static PLAYRHO_CONSTEXPR const bool has_denorm_loss = false; ///< Has denorm loss amount.
+        
+        /// @brief Gets the infinite value for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
+        
+        /// @brief Gets the quiet NaN value for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
+        
+        /// @brief Gets the signaling NaN value for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        
+        /// @brief Gets the denorm value for the type.
+        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        
+        static PLAYRHO_CONSTEXPR const bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
+        static PLAYRHO_CONSTEXPR const bool is_bounded = true; ///< Type bounded: has limited precision.
+        static PLAYRHO_CONSTEXPR const bool is_modulo = false; ///< Doesn't modulo arithmetic overflows.
+        
+        static PLAYRHO_CONSTEXPR const bool traps = false; ///< Doesn't do traps.
+        static PLAYRHO_CONSTEXPR const bool tinyness_before = false; ///< Doesn't detect tinyness before rounding.
+        static PLAYRHO_CONSTEXPR const float_round_style round_style = round_toward_zero; ///< Rounds down.
+    };
+    
+} // namespace std
+
+#endif // PLAYRHO_COMMON_FIXEDLIMITS_HPP

--- a/PlayRho/Common/FixedMath.hpp
+++ b/PlayRho/Common/FixedMath.hpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_COMMON_FIXEDMATH_HPP
+#define PLAYRHO_COMMON_FIXEDMATH_HPP
+
+#include <PlayRho/Common/Fixed.hpp>
+#include <cmath>
+
+namespace playrho {
+    
+    /// @defgroup FixedMath Mathematical Functions For Fixed Types
+    /// @brief Common Mathematical Functions For Fixed Types.
+    /// @sa Fixed
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math
+    /// @{
+
+    /// @brief Square root's the given value.
+    /// @note This implementation isn't meant to be fast, only correct enough.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/sqrt
+    template <typename BT, unsigned int FB>
+    inline auto sqrt(Fixed<BT, FB> arg)
+    {
+        return static_cast<Fixed<BT, FB>>(std::sqrt(static_cast<double>(arg)));
+    }
+    
+    /// @brief Gets whether the given value is normal - i.e. not 0 nor infinite.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/isnormal
+    template <typename BT, unsigned int FB>
+    inline bool isnormal(Fixed<BT, FB> arg)
+    {
+        return arg != Fixed<BT, FB>{0} && arg.isfinite();
+    }
+    
+    /// @brief Computes the sine of the argument for Fixed types.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/sin
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> sin(Fixed<BT, FB> arg)
+    {
+        return static_cast<Fixed<BT, FB>>(std::sin(static_cast<double>(arg)));
+    }
+    
+    /// @brief Computes the cosine of the argument for Fixed types.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/cos
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> cos(Fixed<BT, FB> arg)
+    {
+        return static_cast<Fixed<BT, FB>>(std::cos(static_cast<double>(arg)));
+    }
+    
+    /// @brief Computes the arc tangent.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/atan2
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> atan2(Fixed<BT, FB> y, Fixed<BT, FB> x)
+    {
+        return static_cast<Fixed<BT, FB>>(std::atan2(static_cast<double>(y), static_cast<double>(x)));
+    }
+    
+    /// @brief Computes the value of the base number raised to the power of the exponent.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/pow
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> pow(Fixed<BT, FB> base, Fixed<BT, FB> exp)
+    {
+        return static_cast<Fixed<BT, FB>>(std::pow(static_cast<double>(base),
+                                                   static_cast<double>(exp)));
+    }
+    
+    /// @brief Computes the value of the base number raised to the power of the exponent.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/pow
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> pow(Fixed<BT, FB> base, double exp)
+    {
+        return static_cast<Fixed<BT, FB>>(std::pow(static_cast<double>(base), exp));
+    }
+    
+    /// @brief Computes the square root of the sum of the squares.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/hypot
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> hypot(Fixed<BT, FB> x, Fixed<BT, FB> y)
+    {
+        return static_cast<Fixed<BT, FB>>(std::hypot(static_cast<double>(x), static_cast<double>(y)));
+    }
+    
+    /// @brief Rounds the given value.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/round
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> round(Fixed<BT, FB> value) noexcept
+    {
+        const auto tmp = value + (Fixed<BT, FB>{1} / Fixed<BT, FB>{2});
+        const auto truncated = static_cast<typename Fixed<BT, FB>::value_type>(tmp);
+        return Fixed<BT, FB>{truncated, 0};
+    }
+    
+    /// @brief Truncates the given value.
+    /// @sa http://en.cppreference.com/w/c/numeric/math/trunc
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> trunc(Fixed<BT, FB> arg)
+    {
+        return static_cast<Fixed<BT, FB>>(static_cast<long long>(arg));
+    }
+    
+    /// @brief Determines whether the given value is negative.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/signbit
+    template <typename BT, unsigned int FB>
+    inline bool signbit(Fixed<BT, FB> value) noexcept
+    {
+        return value.getsign() < 0;
+    }
+    
+    /// @brief Gets whether the given value is not-a-number.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/isnan
+    template <typename BT, unsigned int FB>
+    PLAYRHO_CONSTEXPR inline bool isnan(Fixed<BT, FB> value) noexcept
+    {
+        return value.Compare(0) == Fixed<BT, FB>::CmpResult::Incomparable;
+    }
+    
+    /// @brief Gets whether the given value is finite.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/isfinite
+    template <typename BT, unsigned int FB>
+    inline bool isfinite(Fixed<BT, FB> value) noexcept
+    {
+        return (value > Fixed<BT, FB>::GetNegativeInfinity())
+        && (value < Fixed<BT, FB>::GetInfinity());
+    }
+    
+    /// @brief Next after function for Fixed types.
+    /// @sa http://en.cppreference.com/w/cpp/numeric/math/nextafter
+    template <typename BT, unsigned int FB>
+    inline Fixed<BT, FB> nextafter(Fixed<BT, FB> from, Fixed<BT, FB> to) noexcept
+    {
+        if (from < to)
+        {
+            return static_cast<Fixed<BT, FB>>(from + Fixed<BT,FB>::GetMin());
+        }
+        if (from > to)
+        {
+            return static_cast<Fixed<BT, FB>>(from - Fixed<BT,FB>::GetMin());
+        }
+        return static_cast<Fixed<BT, FB>>(to);
+    }
+    
+    /// @}
+
+} // namespace playrho
+
+#endif // PLAYRHO_COMMON_FIXEDMATH_HPP

--- a/PlayRho/Common/Interval.hpp
+++ b/PlayRho/Common/Interval.hpp
@@ -208,6 +208,8 @@ namespace playrho {
         
     private:
         /// @brief Internal pair type.
+        /// @note Uses <code>std::pair</code> since it's the most natural type given that
+        ///   <code>std::minmax</code> returns it.
         using pair_type = std::pair<value_type, value_type>;
         
         /// @brief Internal pair type accepting constructor.

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -32,13 +32,29 @@
 #include <PlayRho/Common/Transformation.hpp>
 #include <PlayRho/Common/Sweep.hpp>
 #include <PlayRho/Common/Matrix.hpp>
+#include <PlayRho/Common/FixedMath.hpp>
 
 #include <cmath>
 #include <vector>
 #include <numeric>
 
-namespace playrho
-{
+namespace playrho {
+
+// Import common standard mathematical functions into the playrho namespace...
+using std::signbit;
+using std::nextafter;
+using std::trunc;
+using std::fmod;
+using std::isfinite;
+using std::round;
+using std::isnormal;
+using std::isnan;
+using std::hypot;
+using std::cos;
+using std::sin;
+using std::atan2;
+using std::sqrt;
+using std::pow;
 
 // Other templates.
 
@@ -91,8 +107,8 @@ PLAYRHO_CONSTEXPR inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
     return StripUnit(v.get());
 }
 
-/// @defgroup Math Mathematical Functions
-/// @brief Functions for common mathematical operations.
+/// @defgroup Math Additional Mathematical Functions
+/// @brief Additional functions for common mathematical operations.
 /// @details These are non-member non-friend functions for mathematical operations
 ///   especially those with mixed input and output types.
 /// @{
@@ -126,21 +142,6 @@ PLAYRHO_CONSTEXPR inline bool IsOdd(T val) noexcept
 /// @brief Squares the given value.
 template<class TYPE>
 PLAYRHO_CONSTEXPR inline auto Square(TYPE t) noexcept { return t * t; }
-
-using std::signbit;
-using std::nextafter;
-using std::trunc;
-using std::fmod;
-using std::isfinite;
-using std::round;
-using std::isnormal;
-using std::isnan;
-using std::hypot;
-using std::cos;
-using std::sin;
-using std::atan2;
-using std::sqrt;
-using std::pow;
 
 #ifdef USE_BOOST_UNITS
 /// @brief Square roots the given area.
@@ -190,11 +191,11 @@ inline auto Average(Span<const T> span)
 
 /// @brief Computes the rounded value of the given value.
 template <typename T>
-inline typename std::enable_if<std::is_arithmetic<T>::value, T>::type
+inline typename std::enable_if<IsArithmetic<T>::value, T>::type
 RoundOff(T value, unsigned precision = 100000)
 {
     const auto factor = static_cast<T>(precision);
-    return std::round(value * factor) / factor;
+    return round(value * factor) / factor;
 }
 
 /// @brief Computes the rounded value of the given value.
@@ -322,8 +323,8 @@ inline Angle GetAngle(const Vector2<T> value)
 }
 
 /// @brief Gets the square of the magnitude of the given iterable value.
-/// @note For performance, use this instead of GetMagnitude(T value) (if possible).
-/// @return Non-negative value.
+/// @note For performance, use this instead of <code>GetMagnitude(T value)</code> (if possible).
+/// @return Non-negative value from 0 to infinity, or NaN.
 template <typename T>
 PLAYRHO_CONSTEXPR inline auto GetMagnitudeSquared(T value) noexcept
 {
@@ -784,8 +785,8 @@ inline Mat22 Abs(const Mat22& A)
 template <typename T>
 PLAYRHO_CONSTEXPR inline T Clamp(T value, T low, T high) noexcept
 {
-    const auto tmp = (value > high)? high: value; // std::isnan(high)? a: Min(a, high);
-    return (tmp < low)? low: tmp; // std::isnan(low)? b: Max(b, low);
+    const auto tmp = (value > high)? high: value; // isnan(high)? a: Min(a, high);
+    return (tmp < low)? low: tmp; // isnan(low)? b: Max(b, low);
 }
 
 /// @brief Gets the next largest power of 2

--- a/PlayRho/Common/Real.hpp
+++ b/PlayRho/Common/Real.hpp
@@ -29,6 +29,8 @@
 #define PLAYRHO_COMMON_REAL_HPP
 
 #include <PlayRho/Common/Fixed.hpp>
+#include <PlayRho/Common/FixedMath.hpp>
+#include <PlayRho/Common/FixedLimits.hpp>
 
 namespace playrho {
 

--- a/PlayRho/Common/Real.hpp.in
+++ b/PlayRho/Common/Real.hpp.in
@@ -29,6 +29,8 @@
 #define PLAYRHO_COMMON_REAL_HPP
 
 #include <PlayRho/Common/Fixed.hpp>
+#include <PlayRho/Common/FixedMath.hpp>
+#include <PlayRho/Common/FixedLimits.hpp>
 
 namespace playrho {
 

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -52,7 +52,7 @@ namespace playrho
         //    to compare it with itself:
         //      bool is_nan(double x) { return x != x; }
         //
-        // So for all T, for which std::isnan() is implemented, this should work
+        // So for all T, for which isnan() is implemented, this should work
         // correctly and quite usefully!
         //
         return value == value;
@@ -251,7 +251,39 @@ namespace playrho
     {
         return (a >= T{0}) ? a : -a;
     }
+
+    /// @brief Checks whether the given container is empty.
+    /// @note This is from <code>std::empty</code> for C++17.
+    /// @sa http://en.cppreference.com/w/cpp/iterator/empty
+    template <class T>
+    PLAYRHO_CONSTEXPR inline auto IsEmpty(const T& arg) -> decltype(arg.empty())
+    {
+        return arg.empty();
+    }
+
+    /// @brief Gets the current size of the given container.
+    /// @note This is from <code>std::size</code> for C++17.
+    /// @sa http://en.cppreference.com/w/cpp/iterator/size
+    template <class T>
+    PLAYRHO_CONSTEXPR inline auto GetSize(const T& arg) -> decltype(arg.size())
+    {
+        return arg.size();
+    }
     
+    /// @brief Gets the maximum size of the given container.
+    template <class T>
+    PLAYRHO_CONSTEXPR inline auto GetMaxSize(const T& arg) -> decltype(arg.max_size())
+    {
+        return arg.max_size();
+    }
+
+    /// @brief Checks whether the given container is full.
+    template <class T>
+    PLAYRHO_CONSTEXPR inline auto IsFull(const T& arg) -> decltype(GetSize(arg) == arg.max_size())
+    {
+        return GetSize(arg) == GetMaxSize(arg);
+    }
+
 } // namespace playrho
 
 #endif // PLAYRHO_COMMON_TEMPLATES_HPP

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -39,37 +39,37 @@ namespace playrho
     class ContactKey
     {
     public:
-        
-        /// @brief Index type.
-        using Index = ContactCounter;
-        
         PLAYRHO_CONSTEXPR inline ContactKey() noexcept
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline ContactKey(Index fp1, Index fp2) noexcept:
+        PLAYRHO_CONSTEXPR inline ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept:
             m_ids{std::minmax(fp1, fp2)}
         {
             // Intentionally empty
         }
 
         /// @brief Gets the minimum index value.
-        PLAYRHO_CONSTEXPR inline Index GetMin() const noexcept
+        PLAYRHO_CONSTEXPR inline ContactCounter GetMin() const noexcept
         {
             return std::get<0>(m_ids);
         }
         
         /// @brief Gets the maximum index value.
-        PLAYRHO_CONSTEXPR inline Index GetMax() const noexcept
+        PLAYRHO_CONSTEXPR inline ContactCounter GetMax() const noexcept
         {
             return std::get<1>(m_ids);
         }
 
     private:
-        /// @brief Index ID pair.
-        std::pair<Index, Index> m_ids{static_cast<Index>(-1), static_cast<Index>(-1)};
+        /// @brief Contact counter ID pair.
+        /// @note Uses <code>std::pair</code> given that <code>std::minmax</code> returns
+        ///   this type making it the most natural type for this class.
+        std::pair<ContactCounter, ContactCounter> m_ids{
+            static_cast<ContactCounter>(-1), static_cast<ContactCounter>(-1)
+        };
     };
 
     /// @brief Equality operator.

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2495,7 +2495,7 @@ PreStepStats::counter_type World::SynchronizeProxies(const StepConf& conf)
     auto proxiesMoved = PreStepStats::counter_type{0};
     for_each(begin(m_bodiesForProxies), end(m_bodiesForProxies), [&](Body *b) {
         const auto xfm = b->GetTransformation();
-        assert(GetTransform0(b->GetSweep()) == xfm);
+        // Not always true: assert(GetTransform0(b->GetSweep()) == xfm);
         proxiesMoved += Synchronize(*b, xfm, xfm, conf.displaceMultiplier, conf.aabbExtension);
     });
     m_bodiesForProxies.clear();
@@ -2818,7 +2818,8 @@ size_t GetShapeCount(const World& world) noexcept
 
 BodyCounter GetAwakeCount(const World& world) noexcept
 {
-    return static_cast<BodyCounter>(count_if(cbegin(world.GetBodies()), cend(world.GetBodies()),
+    const auto bodies = world.GetBodies();
+    return static_cast<BodyCounter>(count_if(cbegin(bodies), cend(bodies),
                                              [&](const World::Bodies::value_type &b) {
                                                  return GetRef(b).IsAwake(); }));
 }

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -307,11 +307,11 @@ public:
 
         os << "Max separation:\n";
         os << "  " << static_cast<double>(Real{maxIndicesAB.distance / 1_m});
-        os << " for a-face[" << unsigned{std::get<0>(maxIndicesAB.indices)} << "]";
-        os << " b-vert[" << unsigned{std::get<1>(maxIndicesAB.indices)} << "].\n";
+        os << " for a-face[" << unsigned{GetFirstShapeVertexIdx(maxIndicesAB)} << "]";
+        os << " b-vert[" << unsigned{GetSecondShapeVertexIdx<0>(maxIndicesAB)} << "].\n";
         os << "  " << static_cast<double>(Real{maxIndicesBA.distance / 1_m});
-        os << " for b-face[" << unsigned{std::get<0>(maxIndicesBA.indices)} << "]";
-        os << " a-vert[" << unsigned{std::get<1>(maxIndicesBA.indices)} << "].\n\n";
+        os << " for b-face[" << unsigned{GetFirstShapeVertexIdx(maxIndicesBA)} << "]";
+        os << " a-vert[" << unsigned{GetSecondShapeVertexIdx<0>(maxIndicesBA)} << "].\n\n";
 
         if (AlmostEqual(static_cast<double>(Real{maxIndicesAB.distance / 1_m}),
                          static_cast<double>(Real{maxIndicesBA.distance / 1_m})))
@@ -320,10 +320,10 @@ public:
             const auto childB = GetChild(shapeB, 0);
             //assert(maxIndicesAB.index1 == maxIndicesBA.index2);
             //assert(maxIndicesAB.index2 == maxIndicesBA.index1);
-            const auto ifaceA = std::get<0>(maxIndicesAB.indices);
+            const auto ifaceA = GetFirstShapeVertexIdx(maxIndicesAB);
             const auto nA = InverseRotate(Rotate(childA.GetNormal(ifaceA), xfmA.q), xfmB.q);
             // shapeA face maxIndicesAB.index1 is coplanar to an edge intersecting shapeB vertex maxIndicesAB.index2
-            const auto i1 = std::get<1>(maxIndicesAB.indices);
+            const auto i1 = GetSecondShapeVertexIdx<0>(maxIndicesAB);
             const auto i0 = GetModuloPrev(i1, childB.GetVertexCount());
             const auto n0 = childB.GetNormal(i0);
             const auto n1 = childB.GetNormal(i1);

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -555,29 +555,29 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction1)
     switch (sizeof(Real))
     {
         case 4:
-            EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), VertexCounter{0}); // v0 of shape0
-            EXPECT_EQ(std::get<0>(maxSep01_NxN.indices), VertexCounter{0}); // v0 of shape0
-            EXPECT_EQ(std::get<0>(maxSep01_nos.indices), VertexCounter{0}); // v0 of shape0
-            EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), VertexCounter{3}); // v3 of shape1
-            EXPECT_EQ(std::get<1>(maxSep01_NxN.indices), VertexCounter{3}); // v3 of shape1
-            EXPECT_EQ(std::get<1>(maxSep01_nos.indices), VertexCounter{3}); // v3 of shape1
+            EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_4x4), VertexCounter{0}); // v0 of shape0
+            EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_NxN), VertexCounter{0}); // v0 of shape0
+            EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_nos), VertexCounter{0}); // v0 of shape0
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_4x4), VertexCounter{3}); // v3 of shape1
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_NxN), VertexCounter{3}); // v3 of shape1
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_nos), VertexCounter{3}); // v3 of shape1
             break;
         case 8:
-            EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), VertexCounter{1}); // v1 of shape0
-            EXPECT_EQ(std::get<0>(maxSep01_NxN.indices), VertexCounter{1}); // v1 of shape0
-            EXPECT_EQ(std::get<0>(maxSep01_nos.indices), VertexCounter{1}); // v1 of shape0
-            EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), VertexCounter{0}); // v0 of shape1
-            EXPECT_EQ(std::get<1>(maxSep01_NxN.indices), VertexCounter{0}); // v0 of shape1
-            EXPECT_EQ(std::get<1>(maxSep01_nos.indices), VertexCounter{0}); // v0 of shape1
+            EXPECT_EQ(GetFirstShapeVertexIdx(maxSep01_4x4), VertexCounter{1}); // v1 of shape0
+            EXPECT_EQ(GetFirstShapeVertexIdx(maxSep01_NxN), VertexCounter{1}); // v1 of shape0
+            EXPECT_EQ(GetFirstShapeVertexIdx(maxSep01_nos), VertexCounter{1}); // v1 of shape0
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_4x4), VertexCounter{0}); // v0 of shape1
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_NxN), VertexCounter{0}); // v0 of shape1
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_nos), VertexCounter{0}); // v0 of shape1
             break;
     }
     
-    EXPECT_EQ(std::get<0>(maxSep10_4x4.indices), VertexCounter{3}); // v3 of shape1
-    EXPECT_EQ(std::get<0>(maxSep10_NxN.indices), VertexCounter{3}); // v3 of shape1
-    EXPECT_EQ(std::get<0>(maxSep10_nos.indices), VertexCounter{3}); // v3 of shape1
-    EXPECT_EQ(std::get<1>(maxSep10_4x4.indices), VertexCounter{1}); // v1 of shape0
-    EXPECT_EQ(std::get<1>(maxSep10_NxN.indices), VertexCounter{1}); // v1 of shape0
-    EXPECT_EQ(std::get<1>(maxSep10_nos.indices), VertexCounter{1}); // v1 of shape0
+    EXPECT_EQ(GetFirstShapeVertexIdx(maxSep10_4x4), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(GetFirstShapeVertexIdx(maxSep10_NxN), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(GetFirstShapeVertexIdx(maxSep10_nos), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep10_4x4), VertexCounter{1}); // v1 of shape0
+    EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep10_NxN), VertexCounter{1}); // v1 of shape0
+    EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep10_nos), VertexCounter{1}); // v1 of shape0
     
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)), -2.0, std::abs(-2.0) / 100);
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_NxN.distance / Meter)), -2.0, std::abs(-2.0) / 100);
@@ -610,20 +610,20 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction2)
     const auto maxSep01_NxN = GetMaxSeparation(child0, xfm0, child0, xfm1, totalRadius);
     const auto maxSep10_NxN = GetMaxSeparation(child0, xfm1, child0, xfm0, totalRadius);
     
-    EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), VertexCounter{1}); // v0 of shape0
-    EXPECT_EQ(std::get<0>(maxSep01_4x4.indices), std::get<0>(maxSep01_NxN.indices));
-    EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), VertexCounter{0}); // v3 of shape1
-    EXPECT_EQ(std::get<1>(maxSep01_4x4.indices), std::get<1>(maxSep01_NxN.indices));
+    EXPECT_EQ(GetFirstShapeVertexIdx(maxSep01_4x4), VertexCounter{1}); // v0 of shape0
+    EXPECT_EQ(GetFirstShapeVertexIdx(maxSep01_4x4), GetFirstShapeVertexIdx(maxSep01_NxN));
+    EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_4x4), VertexCounter{0}); // v3 of shape1
+    EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_4x4), GetSecondShapeVertexIdx<0>(maxSep01_NxN));
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)),
                 -2.0, 0.0);
     EXPECT_NEAR(static_cast<double>(Real(maxSep01_4x4.distance / Meter)),
                 static_cast<double>(Real(maxSep01_NxN.distance / Meter)),
                 std::abs(static_cast<double>(Real(maxSep01_4x4.distance / Meter)) / 1000000.0));
     
-    EXPECT_EQ(std::get<0>(maxSep10_4x4.indices), VertexCounter{3}); // v3 of shape1
-    EXPECT_EQ(std::get<0>(maxSep10_4x4.indices), std::get<0>(maxSep10_NxN.indices));
-    EXPECT_EQ(std::get<1>(maxSep10_4x4.indices), VertexCounter{1}); // v1 of shape0
-    EXPECT_EQ(std::get<1>(maxSep10_4x4.indices), std::get<1>(maxSep10_NxN.indices));
+    EXPECT_EQ(GetFirstShapeVertexIdx(maxSep10_4x4), VertexCounter{3}); // v3 of shape1
+    EXPECT_EQ(GetFirstShapeVertexIdx(maxSep10_4x4), GetFirstShapeVertexIdx(maxSep10_NxN));
+    EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep10_4x4), VertexCounter{1}); // v1 of shape0
+    EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep10_4x4), GetSecondShapeVertexIdx<0>(maxSep10_NxN));
     EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.distance / Meter)),
                 -2.0, 0.0);
     EXPECT_NEAR(static_cast<double>(Real(maxSep10_4x4.distance / Meter)),

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -37,13 +37,13 @@ TEST(Distance, MatchingCircles)
     const auto edges = output.simplex.GetEdges();
     ASSERT_EQ(edges.size(), std::uint8_t(1));
 
-    const auto ips = Simplex::GetIndexPairs(edges);
+    const auto ips = GetIndexPairs(edges);
     EXPECT_EQ(ips[0], (IndexPair{0, 0}));
     EXPECT_EQ(ips[1], InvalidIndexPair);
     EXPECT_EQ(ips[2], InvalidIndexPair);
 
     conf.cache = Simplex::GetCache(edges);
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
 
     const auto witnessPoints = GetWitnessPoints(output.simplex);
 
@@ -51,12 +51,11 @@ TEST(Distance, MatchingCircles)
     EXPECT_EQ(std::get<1>(witnessPoints), pos1);
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
 
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 TEST(Distance, OpposingCircles)
@@ -82,14 +81,13 @@ TEST(Distance, OpposingCircles)
 
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 TEST(Distance, HorTouchingCircles)
@@ -118,14 +116,13 @@ TEST(Distance, HorTouchingCircles)
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 TEST(Distance, OverlappingCirclesPN)
@@ -151,14 +148,13 @@ TEST(Distance, OverlappingCirclesPN)
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 TEST(Distance, OverlappingCirclesNP)
@@ -184,14 +180,13 @@ TEST(Distance, OverlappingCirclesNP)
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 
@@ -218,14 +213,13 @@ TEST(Distance, SeparatedCircles)
     
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 TEST(Distance, EdgeCircleOverlapping)
@@ -257,18 +251,17 @@ TEST(Distance, EdgeCircleOverlapping)
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{2});
     
-    const auto ip0 = conf.cache.GetIndexPair(0);
+    const auto ip0 = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
 
-    const auto ip1 = conf.cache.GetIndexPair(1);
+    const auto ip1 = std::get<1>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip1), VertexCounter{1});
     EXPECT_EQ(std::get<1>(ip1), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
+    EXPECT_NEAR(static_cast<double>(conf.cache.metric), 4.0, 0.000001);
 }
 
 TEST(Distance, EdgeCircleOverlapping2)
@@ -299,18 +292,17 @@ TEST(Distance, EdgeCircleOverlapping2)
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{2});
     
-    const auto ip0 = conf.cache.GetIndexPair(0);
+    const auto ip0 = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
-    const auto ip1 = conf.cache.GetIndexPair(1);
+    const auto ip1 = std::get<1>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip1), VertexCounter{1});
     EXPECT_EQ(std::get<1>(ip1), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{10});
+    EXPECT_EQ(conf.cache.metric, Real{10});
 }
 
 TEST(Distance, EdgeCircleTouching)
@@ -341,18 +333,17 @@ TEST(Distance, EdgeCircleTouching)
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{2});
     
-    const auto ip0 = conf.cache.GetIndexPair(0);
+    const auto ip0 = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
-    const auto ip1 = conf.cache.GetIndexPair(1);
+    const auto ip1 = std::get<1>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip1), VertexCounter{1});
     EXPECT_EQ(std::get<1>(ip1), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
+    EXPECT_NEAR(static_cast<double>(conf.cache.metric), 4.0, 0.000001);
 }
 
 TEST(Distance, HorEdgeSquareTouching)
@@ -392,18 +383,17 @@ TEST(Distance, HorEdgeSquareTouching)
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{2});
     
-    const auto ip0 = conf.cache.GetIndexPair(0);
+    const auto ip0 = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip0), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
-    const auto ip1 = conf.cache.GetIndexPair(1);
+    const auto ip1 = std::get<1>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip1), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip1), VertexCounter{1});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 8.0, 0.000001);
+    EXPECT_NEAR(static_cast<double>(conf.cache.metric), 8.0, 0.000001);
 }
 
 TEST(Distance, VerEdgeSquareTouching)
@@ -445,18 +435,17 @@ TEST(Distance, VerEdgeSquareTouching)
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{2});
     
-    const auto ip0 = conf.cache.GetIndexPair(0);
+    const auto ip0 = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip0), VertexCounter{2});
     EXPECT_EQ(std::get<1>(ip0), VertexCounter{0});
     
-    const auto ip1 = conf.cache.GetIndexPair(1);
+    const auto ip1 = std::get<1>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip1), VertexCounter{3});
     EXPECT_EQ(std::get<1>(ip1), VertexCounter{1});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{10});
+    EXPECT_EQ(conf.cache.metric, Real{10});
 }
 
 TEST(Distance, SquareTwice)
@@ -488,14 +477,13 @@ TEST(Distance, SquareTwice)
 
     EXPECT_EQ(decltype(output.iterations){1}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 
@@ -540,14 +528,13 @@ TEST(Distance, SquareSquareTouchingVertically)
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{2});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{2});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{3});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{1});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_NEAR(static_cast<double>(conf.cache.GetMetric()), 4.0, 0.000001);
+    EXPECT_NEAR(static_cast<double>(conf.cache.metric), 4.0, 0.000001);
 }
 
 TEST(Distance, SquareSquareDiagonally)
@@ -591,14 +578,13 @@ TEST(Distance, SquareSquareDiagonally)
     
     EXPECT_EQ(decltype(output.iterations){2}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{1});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{1});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{2});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{3});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{0});
+    EXPECT_EQ(conf.cache.metric, Real{0});
 }
 
 TEST(Distance, SquareSquareOverlappingDiagnally)
@@ -666,12 +652,11 @@ TEST(Distance, SquareSquareOverlappingDiagnally)
     
     EXPECT_EQ(decltype(output.iterations){3}, output.iterations);
     
-    EXPECT_EQ(GetNumIndices(conf.cache.GetIndices()), std::uint8_t{3});
+    EXPECT_EQ(GetNumValidIndices(conf.cache.indices), std::uint8_t{3});
     
-    const auto ip = conf.cache.GetIndexPair(0);
+    const auto ip = std::get<0>(conf.cache.indices);
     EXPECT_EQ(std::get<0>(ip), VertexCounter{0});
     EXPECT_EQ(std::get<1>(ip), VertexCounter{0});
     
-    EXPECT_EQ(true, conf.cache.IsMetricSet());
-    EXPECT_EQ(conf.cache.GetMetric(), Real{-64});
+    EXPECT_EQ(conf.cache.metric, Real{-64});
 }

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -227,14 +227,14 @@ TEST(DistanceProxy, GetMaxSeparationFromWorld)
     const auto result1 = GetMaxSeparation(squareDp, circleDp);
     
     EXPECT_NEAR(static_cast<double>(Real(result1.distance / Meter)), 3.0, 0.0001);
-    EXPECT_EQ(std::get<0>(result1.indices), static_cast<decltype(std::get<0>(result1.indices))>(2));
-    EXPECT_EQ(std::get<1>(result1.indices), static_cast<decltype(std::get<1>(result1.indices))>(0));
+    EXPECT_EQ(result1.firstShape, static_cast<VertexCounter>(2));
+    EXPECT_EQ(std::get<0>(result1.secondShape), static_cast<VertexCounter>(0));
     
     const auto result2 = GetMaxSeparation(squareDp, circleDp, 0_m);
     
     EXPECT_NEAR(static_cast<double>(Real(result2.distance / Meter)), 3.0, 0.0001);
-    EXPECT_EQ(std::get<0>(result2.indices), static_cast<decltype(std::get<0>(result2.indices))>(2));
-    EXPECT_EQ(std::get<1>(result2.indices), static_cast<decltype(std::get<1>(result2.indices))>(0));
+    EXPECT_EQ(result2.firstShape, static_cast<VertexCounter>(2));
+    EXPECT_EQ(std::get<0>(result2.secondShape), static_cast<VertexCounter>(0));
 }
 
 TEST(DistanceProxy, Equality)

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 #include <PlayRho/Common/Fixed.hpp>
+#include <PlayRho/Common/FixedLimits.hpp>
 #include <PlayRho/Common/Math.hpp>
 #include <iostream>
 
@@ -120,7 +121,7 @@ DECL_INT_CONSTRUCTION_AND_COMPARE_TEST(Fixed32)
 DECL_INT_CONSTRUCTION_AND_COMPARE_TEST(Fixed64)
 #endif
 
-// Tests of std::isfinite(Fixed<T>)
+// Tests of isfinite(Fixed<T>)
 
 #define DECL_ISFINITE_TEST(type) \
 TEST(type, isfinite) \

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -619,8 +619,8 @@ TEST(Math, ToiTolerance)
 {
     // What is the max vr for which the following still holds true?
     //   vr + DefaultLinearSlop / 4 > vr
-    // The max vr for which (std::nextafter(vr, MaxFloat) - vr) <= DefaultLinearSlop / 4.
-    // I.e. the max vr for which (std::nextafter(vr, MaxFloat) - vr) <= 0.000025
+    // The max vr for which (nextafter(vr, MaxFloat) - vr) <= DefaultLinearSlop / 4.
+    // I.e. the max vr for which (nextafter(vr, MaxFloat) - vr) <= 0.000025
 
     const auto linearSlop = 0.0001f;
     const auto tolerance = linearSlop / 4;

--- a/UnitTests/Real.cpp
+++ b/UnitTests/Real.cpp
@@ -75,7 +75,7 @@ TEST(Real, BiggerValsIdenticallyInaccurate)
     auto val = Real(1);
     for (auto i = 0; i < 16; ++i)
     {
-        const auto next = std::nextafter(val, std::numeric_limits<decltype(val)>::max());
+        const auto next = nextafter(val, std::numeric_limits<decltype(val)>::max());
         const auto delta = static_cast<float>(next - val);
         ASSERT_EQ(val + (delta / 2.0f), val);
 #if 0

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -66,7 +66,7 @@ TEST(SeparationFinder, BehavesAsExpected)
     DistanceConf conf;
     auto distanceInfo = Distance(distproxy, xfA, distproxy, xfB, conf);
     conf.cache = Simplex::GetCache(distanceInfo.simplex.GetEdges());
-    const auto fcn = SeparationFinder::Get(conf.cache.GetIndices(), distproxy, xfA, distproxy, xfB);
+    const auto fcn = SeparationFinder::Get(conf.cache.indices, distproxy, xfA, distproxy, xfB);
     EXPECT_EQ(fcn.GetType(), SeparationFinder::e_faceA);
     EXPECT_NEAR(static_cast<double>(GetX(GetVec2(fcn.GetAxis()))), 1.0, 0.000001);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(fcn.GetAxis()))), 0.0, 0.000001);
@@ -111,7 +111,7 @@ TEST(SeparationFinder, BehavesAsExpected)
         }
         EXPECT_LT(s, last_s);
         
-        //t = std::nextafter(t, 1.0f);
+        //t = nextafter(t, 1.0f);
         t += Real(.001);
         last_distance = distance;
         last_s = s;

--- a/UnitTests/Simplex.cpp
+++ b/UnitTests/Simplex.cpp
@@ -21,7 +21,7 @@
 
 using namespace playrho;
 
-TEST(SimplexCache, ByteSizeIs_12_16_or_32)
+TEST(SimplexCache, ByteSize)
 {
     switch (sizeof(Real))
     {
@@ -41,19 +41,13 @@ TEST(SimplexCache, DefaultInit)
 {
     {
         Simplex::Cache foo;
-        EXPECT_EQ(std::uint8_t{0}, GetNumIndices(foo.GetIndices()));
-        EXPECT_FALSE(foo.IsMetricSet());
-        
-        // Can't test following cause of undefined behavior (assert's in debug build).
-        //EXPECT_FALSE(IsValid(foo.GetMetric()));
+        EXPECT_EQ(std::uint8_t{0}, GetNumValidIndices(foo.indices));
+        EXPECT_FALSE(IsValid(foo.metric));
     }
     {
         Simplex::Cache foo{};
-        EXPECT_EQ(std::uint8_t{0}, GetNumIndices(foo.GetIndices()));
-        EXPECT_FALSE(foo.IsMetricSet());
-        
-        // Can't test following cause of undefined behavior (assert's in debug build).
-        //EXPECT_FALSE(IsValid(foo.GetMetric()));
+        EXPECT_EQ(std::uint8_t{0}, GetNumValidIndices(foo.indices));
+        EXPECT_FALSE(IsValid(foo.metric));
     }
 }
 
@@ -64,9 +58,8 @@ TEST(SimplexCache, InitializingConstructor)
         const auto indices = IndexPair3{{InvalidIndexPair, InvalidIndexPair, InvalidIndexPair}};
         Simplex::Cache foo{metric, indices};
         
-        EXPECT_EQ(GetNumIndices(foo.GetIndices()), decltype(GetNumIndices(foo.GetIndices())){0});
-        EXPECT_FALSE(foo.IsMetricSet());
-        //EXPECT_EQ(foo.GetMetric(), metric);
+        EXPECT_EQ(GetNumValidIndices(foo.indices), decltype(GetNumValidIndices(foo.indices)){0});
+        EXPECT_EQ(foo.metric, metric);
     }
     {
         const auto ip0 = IndexPair{0, 0};
@@ -74,11 +67,10 @@ TEST(SimplexCache, InitializingConstructor)
         const auto metric = Real(-1.4);
         Simplex::Cache foo{metric, IndexPair3{{ip0, ip1, InvalidIndexPair}}};
         
-        EXPECT_EQ(GetNumIndices(foo.GetIndices()), decltype(GetNumIndices(foo.GetIndices())){2});
-        EXPECT_EQ(foo.GetIndexPair(0), ip0);
-        EXPECT_EQ(foo.GetIndexPair(1), ip1);
-        EXPECT_TRUE(foo.IsMetricSet());
-        EXPECT_EQ(foo.GetMetric(), metric);
+        EXPECT_EQ(GetNumValidIndices(foo.indices), decltype(GetNumValidIndices(foo.indices)){2});
+        EXPECT_EQ(std::get<0>(foo.indices), ip0);
+        EXPECT_EQ(std::get<1>(foo.indices), ip1);
+        EXPECT_EQ(foo.metric, metric);
     }
     {
         const auto ip0 = IndexPair{0, 0};
@@ -87,12 +79,11 @@ TEST(SimplexCache, InitializingConstructor)
         const auto metric = Real(-1.4);
         Simplex::Cache foo{metric, IndexPair3{{ip0, ip1, ip2}}};
         
-        EXPECT_EQ(GetNumIndices(foo.GetIndices()), decltype(GetNumIndices(foo.GetIndices())){3});
-        EXPECT_EQ(foo.GetIndexPair(0), ip0);
-        EXPECT_EQ(foo.GetIndexPair(1), ip1);
-        EXPECT_EQ(foo.GetIndexPair(2), ip2);
-        EXPECT_TRUE(foo.IsMetricSet());
-        EXPECT_EQ(foo.GetMetric(), metric);
+        EXPECT_EQ(GetNumValidIndices(foo.indices), decltype(GetNumValidIndices(foo.indices)){3});
+        EXPECT_EQ(std::get<0>(foo.indices), ip0);
+        EXPECT_EQ(std::get<1>(foo.indices), ip1);
+        EXPECT_EQ(std::get<2>(foo.indices), ip2);
+        EXPECT_EQ(foo.metric, metric);
     }
 }
 
@@ -102,9 +93,8 @@ TEST(SimplexCache, Assignment)
     const auto indices = IndexPair3{{InvalidIndexPair, InvalidIndexPair, InvalidIndexPair}};
     Simplex::Cache foo{metric, indices};
     
-    ASSERT_EQ(GetNumIndices(foo.GetIndices()), decltype(GetNumIndices(foo.GetIndices())){0});
-    ASSERT_FALSE(foo.IsMetricSet());
-    //ASSERT_EQ(foo.GetMetric(), metric);
+    ASSERT_EQ(GetNumValidIndices(foo.indices), decltype(GetNumValidIndices(foo.indices)){0});
+    ASSERT_EQ(foo.metric, metric);
     
     const auto ip0 = IndexPair{0, 0};
     const auto ip1 = IndexPair{1, 0};
@@ -114,12 +104,11 @@ TEST(SimplexCache, Assignment)
     
     foo = roo;
     
-    EXPECT_EQ(GetNumIndices(foo.GetIndices()), decltype(GetNumIndices(foo.GetIndices())){3});
-    EXPECT_EQ(foo.GetIndexPair(0), ip0);
-    EXPECT_EQ(foo.GetIndexPair(1), ip1);
-    EXPECT_EQ(foo.GetIndexPair(2), ip2);
-    EXPECT_TRUE(foo.IsMetricSet());
-    EXPECT_EQ(foo.GetMetric(), roo_metric);
+    EXPECT_EQ(GetNumValidIndices(foo.indices), decltype(GetNumValidIndices(foo.indices)){3});
+    EXPECT_EQ(std::get<0>(foo.indices), ip0);
+    EXPECT_EQ(std::get<1>(foo.indices), ip1);
+    EXPECT_EQ(std::get<2>(foo.indices), ip2);
+    EXPECT_EQ(foo.metric, roo_metric);
 }
 
 TEST(SimplexEdgeList, ByteSize)

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -664,7 +664,7 @@ TEST(TimeOfImpact, SucceedsWithClosingSpeedOf800_2)
 
     auto touching = true;
     auto iterations = 0u;
-    for (auto t = output.time; t > 0; t = std::nextafter(t, 0.0f))
+    for (auto t = output.time; t > 0; t = nextafter(t, 0.0f))
     {
         const auto conf2 = ToiConf{}.UseMaxToiIters(200).UseMaxRootIters(200).UseTimeMax(t);
         const auto output2 = TimeOfImpact(proxyA, sweepA, proxyB, sweepB, conf2);

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1180,7 +1180,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     // steps = t / time_inc = 200
     EXPECT_GE(steps, 199u);
     EXPECT_LE(steps, 201u);
-    //EXPECT_EQ(int64_t(steps), static_cast<int64_t>(std::round(((x * 2) / x) / time_inc)));
+    //EXPECT_EQ(int64_t(steps), static_cast<int64_t>(round(((x * 2) / x) / time_inc)));
 }
 
 TEST(World, HeavyOnLight)
@@ -2880,7 +2880,7 @@ TEST(World, MouseJointWontCauseTunnelling)
     }
 #if 0
     std::cout << "angle=" << angle;
-    std::cout << " target=(" << distance * std::cos(angle) << "," << distance * std::sin(angle) << ")";
+    std::cout << " target=(" << distance * cos(angle) << "," << distance * sin(angle) << ")";
     std::cout << " maxvel=" << max_velocity;
     std::cout << " range=(" << min_x << "," << min_y << ")-(" << max_x << "," << max_y << ")";
     std::cout << std::endl;


### PR DESCRIPTION
#### Description - What's this PR do?
- Updates documentation comments.
- Replaces use of ContactKey::Index alias with direct use of ContactCounter.
- Adds convenience function for checking if an ArrayList is full.
- Switches from using long double to using double for doing sqrt of Fixed values.
- Moves std::numeric_limits specialization for Fixed types out to the FixedLimits.hpp file.
- Moves import of common mathematical functions up in the Math.hpp file to better recognize these being within playrho namespace.
- Generalizes implementation of Math.hpp based RoundOff to work for Fixed types as well.
- Removes specialization of RoundOff for Fixed types now that a more general solution does the job.
- Moves Fixed types common mathematical functions out from Fixed.hpp and in to FixedMath.hpp.
- Changes related to Fixed math functions being off on their own now.
- Moves code out from GetFaceManifold and calls function instead.
- Adds compile time option to benchmark Box2D also.
- Removes unused function.
- Small tweak to GetAwakeCount function.

#### Related Issues
- Issue #178.
