### PR TITLE
Shape changes 20180109

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -1798,7 +1798,7 @@ static void DropTilesPlayRho(int count)
             for (auto i = 0; i < N; ++i)
             {
                 conf.SetAsBox(a * playrho::Meter, a * playrho::Meter, position, playrho::Angle{0});
-                ground->CreateFixture(conf);
+                ground->CreateFixture(playrho::d2::Shape{conf});
                 GetX(position) += 2.0f * a * playrho::Meter;
             }
             GetY(position) -= 2.0f * a * playrho::Meter;
@@ -1968,7 +1968,9 @@ private:
     playrho::d2::World m_world;
     playrho::StepConf m_stepConf;
     playrho::Length m_squareLen = 0.125f * playrho::Meter;
-    playrho::d2::Shape m_square = playrho::d2::PolygonShapeConf(m_squareLen, m_squareLen);
+    playrho::d2::Shape m_square = playrho::d2::Shape{
+        playrho::d2::PolygonShapeConf(m_squareLen, m_squareLen)
+    };
 };
 
 Tumbler::Tumbler()
@@ -1986,13 +1988,13 @@ playrho::d2::Body* Tumbler::CreateEnclosure(playrho::d2::World& world)
     playrho::d2::PolygonShapeConf shape;
     shape.UseDensity(5 * playrho::KilogramPerSquareMeter);
     shape.SetAsBox(0.5f * playrho::Meter, 10.0f * playrho::Meter, playrho::Vec2( 10.0f, 0.0f) * playrho::Meter, playrho::Angle{0});
-    b->CreateFixture(shape);
+    b->CreateFixture(playrho::d2::Shape{shape});
     shape.SetAsBox(0.5f * playrho::Meter, 10.0f * playrho::Meter, playrho::Vec2(-10.0f, 0.0f) * playrho::Meter, playrho::Angle{0});
-    b->CreateFixture(shape);
+    b->CreateFixture(playrho::d2::Shape{shape});
     shape.SetAsBox(10.0f * playrho::Meter, 0.5f * playrho::Meter, playrho::Vec2(0.0f, 10.0f) * playrho::Meter, playrho::Angle{0});
-    b->CreateFixture(shape);
+    b->CreateFixture(playrho::d2::Shape{shape});
     shape.SetAsBox(10.0f * playrho::Meter, 0.5f * playrho::Meter, playrho::Vec2(0.0f, -10.0f) * playrho::Meter, playrho::Angle{0});
-    b->CreateFixture(shape);
+    b->CreateFixture(playrho::d2::Shape{shape});
     return b;
 }
 

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		47928F351E5FE19C00EE6E9E /* BodyConstraint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47928F341E5FE19C00EE6E9E /* BodyConstraint.cpp */; };
 		47928F371E66539000EE6E9E /* FrictionJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47928F361E66539000EE6E9E /* FrictionJoint.cpp */; };
 		47928F391E66586400EE6E9E /* DistanceJoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47928F381E66586400EE6E9E /* DistanceJoint.cpp */; };
+		47928F5D200ABCAE00A5DD5B /* double.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47928F5C200ABCAE00A5DD5B /* double.cpp */; };
 		479B63C01ED8B64300D49BC7 /* BoundedValue.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 479B63BD1ED8B64300D49BC7 /* BoundedValue.hpp */; };
 		479B63C31ED9CAC300D49BC7 /* BoundedValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 479B63C21ED9CAC300D49BC7 /* BoundedValue.cpp */; };
 		47AB01BA1D6FA40C0084D721 /* Dump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47AB01B91D6FA40C0084D721 /* Dump.cpp */; };
@@ -568,6 +569,7 @@
 		47928F361E66539000EE6E9E /* FrictionJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FrictionJoint.cpp; sourceTree = "<group>"; };
 		47928F381E66586400EE6E9E /* DistanceJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DistanceJoint.cpp; sourceTree = "<group>"; };
 		47928F5A2009E83500A5DD5B /* UnitTests.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = UnitTests.hpp; sourceTree = "<group>"; };
+		47928F5C200ABCAE00A5DD5B /* double.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = double.cpp; sourceTree = "<group>"; };
 		479B63BD1ED8B64300D49BC7 /* BoundedValue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = BoundedValue.hpp; sourceTree = "<group>"; };
 		479B63C21ED9CAC300D49BC7 /* BoundedValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BoundedValue.cpp; sourceTree = "<group>"; };
 		47AB01B91D6FA40C0084D721 /* Dump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Dump.cpp; sourceTree = "<group>"; };
@@ -816,6 +818,7 @@
 				474BC3F91D41278800447DCD /* DistanceProxy.cpp */,
 				47AB01B91D6FA40C0084D721 /* Dump.cpp */,
 				4731DE1D1DDD0B8700E7F931 /* DynamicTree.cpp */,
+				47928F5C200ABCAE00A5DD5B /* double.cpp */,
 				47D61F771F1FE3B700E702BD /* EdgeShape.cpp */,
 				474BC3FA1D41278800447DCD /* Epsilon.cpp */,
 				475931D11F26ABBD009BACA3 /* Filter.cpp */,
@@ -1630,6 +1633,7 @@
 				47315E041E28A66100DDA856 /* RevoluteJoint.cpp in Sources */,
 				4734B2361DC39F3E00F15E29 /* SimplexEdge.cpp in Sources */,
 				4731DDFA1DC7C9B000E7F931 /* Simplex.cpp in Sources */,
+				47928F5D200ABCAE00A5DD5B /* double.cpp in Sources */,
 				47AB01BA1D6FA40C0084D721 /* Dump.cpp in Sources */,
 				472724231E310BB400C64921 /* Real.cpp in Sources */,
 				47FFD0FB1DAC3EFC000D6D0E /* VelocityConstraint.cpp in Sources */,
@@ -1972,7 +1976,7 @@
 				LD_GENERATE_MAP_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+                OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;
 				USE_HEADERMAP = NO;
 			};
@@ -2043,9 +2047,9 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_GENERATE_MAP_FILE = YES;
-				LLVM_LTO = NO;
+                LLVM_LTO = NO;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+                OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;
 				USE_HEADERMAP = NO;
 			};

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -567,6 +567,7 @@
 		47928F341E5FE19C00EE6E9E /* BodyConstraint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BodyConstraint.cpp; sourceTree = "<group>"; };
 		47928F361E66539000EE6E9E /* FrictionJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FrictionJoint.cpp; sourceTree = "<group>"; };
 		47928F381E66586400EE6E9E /* DistanceJoint.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DistanceJoint.cpp; sourceTree = "<group>"; };
+		47928F5A2009E83500A5DD5B /* UnitTests.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = UnitTests.hpp; sourceTree = "<group>"; };
 		479B63BD1ED8B64300D49BC7 /* BoundedValue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = BoundedValue.hpp; sourceTree = "<group>"; };
 		479B63C21ED9CAC300D49BC7 /* BoundedValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BoundedValue.cpp; sourceTree = "<group>"; };
 		47AB01B91D6FA40C0084D721 /* Dump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Dump.cpp; sourceTree = "<group>"; };
@@ -864,6 +865,7 @@
 				474BC4031D41278800447DCD /* TimeOfImpact.cpp */,
 				474BC4041D41278800447DCD /* Transformation.cpp */,
 				47C96C501FA24BC100A6C587 /* Units.cpp */,
+				47928F5A2009E83500A5DD5B /* UnitTests.hpp */,
 				470F94DD1ECB94D600AA3C82 /* UnitVec.cpp */,
 				474BC4051D41278800447DCD /* Vec2.cpp */,
 				4736DE881DB7DB3B003993CB /* Vec3.cpp */,
@@ -2041,6 +2043,7 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_GENERATE_MAP_FILE = YES;
+				LLVM_LTO = NO;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;

--- a/HelloWorld/HelloWorld.cpp
+++ b/HelloWorld/HelloWorld.cpp
@@ -41,7 +41,7 @@ int main()
 
     // Define the ground shape. Use a polygon configured as a box for this.
     // The extents are the half-width and half-height of the box.
-    const auto box = PolygonShapeConf{}.SetAsBox(50_m, 10_m);
+    const auto box = Shape{PolygonShapeConf{}.SetAsBox(50_m, 10_m)};
 
     // Add the box shape to the ground body.
     ground->CreateFixture(box);
@@ -53,7 +53,7 @@ int main()
                                        .UseLinearAcceleration(EarthlyGravity));
 
     // Define a disk shape for the ball body and create a fixture to add it.
-    ball->CreateFixture(DiskShapeConf{}.UseRadius(1_m));
+    ball->CreateFixture(Shape{DiskShapeConf{}.UseRadius(1_m)});
 
     // Prepare for simulation. Typically code uses a time step of 1/60 of a second
     // (60Hz). The defaults are setup for that and to generally provide a high

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -40,7 +40,6 @@ namespace d2 {
 ///
 struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
 {
-public:
     /// @brief Gets the default radius.
     static PLAYRHO_CONSTEXPR inline Length GetDefaultRadius() noexcept
     {

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -32,12 +32,9 @@
 #include <typeinfo>
 
 namespace playrho {
-
 namespace d2 {
+
 class Shape;
-} // namespace d2
-
-namespace d2 {
 
 // Forward declare functions.
 // Note that these may be friend functions but that declaring these within the class that
@@ -89,6 +86,10 @@ NonNegative<AreaDensity> GetDensity(const Shape& shape) noexcept;
 /// @sa UseVertexRadius
 ///
 NonNegative<Length> GetVertexRadius(const Shape& shape) noexcept;
+
+/// @brief Visits the given shape with the potentially non-null user data pointer.
+/// @sa https://en.wikipedia.org/wiki/Visitor_pattern
+void Visit(const Shape& shape, void* userData);
 
 /// @brief Gets a pointer to the underlying data.
 /// @note Provided for introspective purposes like visitation.
@@ -215,13 +216,9 @@ public:
         return shape.m_self->GetDensity_();
     }
     
-    /// @brief Visits the given shape with the potentially non-null user data pointer.
-    /// @note This is a specialization of the <code>Visit</code> function template for the
-    ///   <code>d2::Shape</code> class.
-    /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
-    friend void Visit<Shape>(const Shape& shape, void* userData)
+    friend void Visit(const Shape& shape, void* userData)
     {
-        return shape.m_self->Visit_(userData);
+        shape.m_self->Visit_(userData);
     }
     
     friend const void* GetData(const Shape& shape) noexcept
@@ -353,7 +350,7 @@ private:
         
         void Visit_(void* userData) const override
         {
-            Visit(data, userData);
+            ::playrho::Visit(data, userData);
         }
         
         bool IsEqual_(const Concept& other) const noexcept override
@@ -382,7 +379,7 @@ private:
     std::shared_ptr<const Concept> m_self; ///< Self shared pointer.
 };
 
-// Forward declare any other related free functions...
+// Related free functions...
 
 /// @brief Test a point for containment in the given shape.
 /// @param shape Shape to use for test.
@@ -394,6 +391,17 @@ private:
 bool TestPoint(const Shape& shape, Length2 point) noexcept;
 
 } // namespace d2
+
+/// @brief Visits the given shape with the potentially non-null user data pointer.
+/// @note This is a specialization of the <code>Visit</code> function template for the
+///   <code>d2::Shape</code> class.
+/// @sa https://en.wikipedia.org/wiki/Visitor_pattern
+template <>
+inline void Visit<d2::Shape>(const d2::Shape& shape, void* userData)
+{
+    return d2::Visit(shape, userData);
+}
+
 } // namespace playrho
 
 #endif // PLAYRHO_COLLISION_SHAPES_SHAPE_HPP

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -89,7 +89,7 @@ NonNegative<Length> GetVertexRadius(const Shape& shape) noexcept;
 
 /// @brief Visits the given shape with the potentially non-null user data pointer.
 /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
-void Visit(const Shape& shape, void* userData);
+bool Visit(const Shape& shape, void* userData);
 
 /// @brief Gets a pointer to the underlying data.
 /// @note Provided for introspective purposes like visitation.
@@ -216,9 +216,9 @@ public:
         return shape.m_self->GetDensity_();
     }
     
-    friend void Visit(const Shape& shape, void* userData)
+    friend bool Visit(const Shape& shape, void* userData)
     {
-        shape.m_self->Visit_(userData);
+        return shape.m_self->Visit_(userData);
     }
     
     friend const void* GetData(const Shape& shape) noexcept
@@ -277,7 +277,7 @@ private:
         virtual Real GetRestitution_() const noexcept = 0;
         
         /// @brief Draws the shape.
-        virtual void Visit_(void* userData) const = 0;
+        virtual bool Visit_(void* userData) const = 0;
         
         /// @brief Equality checking method.
         virtual bool IsEqual_(const Concept& other) const noexcept = 0;
@@ -348,9 +348,9 @@ private:
             return GetRestitution(data);
         }
         
-        void Visit_(void* userData) const override
+        bool Visit_(void* userData) const override
         {
-            ::playrho::Visit(data, userData);
+            return ::playrho::Visit(data, userData);
         }
         
         bool IsEqual_(const Concept& other) const noexcept override
@@ -397,7 +397,7 @@ bool TestPoint(const Shape& shape, Length2 point) noexcept;
 ///   <code>d2::Shape</code> class.
 /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
 template <>
-inline void Visit<d2::Shape>(const d2::Shape& shape, void* userData)
+inline bool Visit<d2::Shape>(const d2::Shape& shape, void* userData)
 {
     return d2::Visit(shape, userData);
 }

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -31,6 +31,17 @@
 #include <utility>
 
 namespace playrho {
+
+namespace d2 {
+class Shape;
+} // namespace d2
+
+/// @brief Visits the given shape with the potentially non-null user data pointer.
+/// @note This is a specialization of the <code>Visit</code> function template for the
+///   <code>d2::Shape</code> class.
+template <>
+void Visit(const d2::Shape& shape, void* userData);
+
 namespace d2 {
 
 // Forward declare functions.
@@ -105,21 +116,7 @@ bool operator== (const Shape& lhs, const Shape& rhs) noexcept;
 /// @brief Inequality operator for shape to shape comparisons.
 bool operator!= (const Shape& lhs, const Shape& rhs) noexcept;
 
-/// @brief Template draw function.
-/// @param shapeConf Shape configuration object.
-/// @param userData Optionally provide user data.
-template <typename T>
-inline void DrawConf(const T& shapeConf, void* userData) noexcept
-{
-    NOT_USED(shapeConf);
-    NOT_USED(userData);
-    // No op.
-}
-
-/// @brief Draws the given shape with the given transformation.
-void Draw(const Shape& shape, void* userData) noexcept;
-
-// Now declare the shape class...
+// Now define the shape class...
     
 /// @defgroup PartsGroup Shape Classes
 /// @brief Classes for configuring shapes with material properties.
@@ -199,9 +196,9 @@ public:
         return shape.m_self->GetDensity_();
     }
     
-    friend void Draw(const Shape& shape, void* userData) noexcept
+    friend void Visit<Shape>(const Shape& shape, void* userData)
     {
-        return shape.m_self->Draw_(userData);
+        return shape.m_self->Visit_(userData);
     }
     
     friend const void* GetData(const Shape& shape) noexcept
@@ -255,7 +252,7 @@ private:
         virtual Real GetRestitution_() const noexcept = 0;
         
         /// @brief Draws the shape.
-        virtual void Draw_(void* userData) const noexcept = 0;
+        virtual void Visit_(void* userData) const = 0;
         
         /// @brief Equality checking method.
         virtual bool IsEqual_(const Concept& other) const noexcept = 0;
@@ -325,9 +322,9 @@ private:
             return GetRestitution(data);
         }
         
-        void Draw_(void* userData) const noexcept override
+        void Visit_(void* userData) const override
         {
-            DrawConf(data, userData);
+            Visit(data, userData);
         }
         
         bool IsEqual_(const Concept& other) const noexcept override

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -37,13 +37,6 @@ namespace d2 {
 class Shape;
 } // namespace d2
 
-/// @brief Visits the given shape with the potentially non-null user data pointer.
-/// @note This is a specialization of the <code>Visit</code> function template for the
-///   <code>d2::Shape</code> class.
-/// @sa https://en.wikipedia.org/wiki/Visitor_pattern
-template <>
-void Visit(const d2::Shape& shape, void* userData);
-
 namespace d2 {
 
 // Forward declare functions.
@@ -222,6 +215,10 @@ public:
         return shape.m_self->GetDensity_();
     }
     
+    /// @brief Visits the given shape with the potentially non-null user data pointer.
+    /// @note This is a specialization of the <code>Visit</code> function template for the
+    ///   <code>d2::Shape</code> class.
+    /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
     friend void Visit<Shape>(const Shape& shape, void* userData)
     {
         return shape.m_self->Visit_(userData);

--- a/PlayRho/Common/CodeDumper.cpp
+++ b/PlayRho/Common/CodeDumper.cpp
@@ -59,92 +59,6 @@ namespace {
         va_end(args);
     }
     
-    class ShapeDumper
-    {
-    public:
-        void operator() (const std::type_info& ti, const void* data)
-        {
-            if (ti == typeid(DiskShapeConf))
-            {
-                Visit(*static_cast<const DiskShapeConf*>(data));
-            }
-            else if (ti == typeid(EdgeShapeConf))
-            {
-                Visit(*static_cast<const EdgeShapeConf*>(data));
-            }
-            else if (ti == typeid(PolygonShapeConf))
-            {
-                Visit(*static_cast<const PolygonShapeConf*>(data));
-            }
-            else if (ti == typeid(ChainShapeConf))
-            {
-                Visit(*static_cast<const ChainShapeConf*>(data));
-            }
-            else if (ti == typeid(MultiShapeConf))
-            {
-                Visit(*static_cast<const MultiShapeConf*>(data));
-            }
-        }
-
-        void Visit(const DiskShapeConf& shape);
-        void Visit(const EdgeShapeConf& shape);
-        void Visit(const PolygonShapeConf& shape);
-        void Visit(const ChainShapeConf& shape);
-        void Visit(const MultiShapeConf& shape);
-    };
-    
-    void ShapeDumper::Visit(const DiskShapeConf& s)
-    {
-        log("    DiskShape shape;\n");
-        log("    shape.m_radius = %.15lef;\n", static_cast<double>(StripUnit(s.GetRadius())));
-        log("    shape.m_p = Vec2(%.15lef, %.15lef);\n",
-            static_cast<double>(StripUnit(Get<0>(s.GetLocation()))),
-            static_cast<double>(StripUnit(Get<1>(s.GetLocation()))));
-    }
-    
-    void ShapeDumper::Visit(const EdgeShapeConf& s)
-    {
-        log("    EdgeShape shape;\n");
-        log("    shape.m_radius = %.15lef;\n", static_cast<double>(StripUnit(s.vertexRadius)));
-        log("    shape.m_vertex1.Set(%.15lef, %.15lef);\n",
-            static_cast<double>(StripUnit(Get<0>(s.GetVertexA()))),
-            static_cast<double>(StripUnit(Get<1>(s.GetVertexA()))));
-        log("    shape.m_vertex2.Set(%.15lef, %.15lef);\n",
-            static_cast<double>(StripUnit(Get<0>(s.GetVertexB()))),
-            static_cast<double>(StripUnit(Get<1>(s.GetVertexB()))));
-    }
-    
-    void ShapeDumper::Visit(const PolygonShapeConf& s)
-    {
-        const auto vertexCount = s.GetVertexCount();
-        log("    PolygonShape shape;\n");
-        log("    Vec2 vs[%d];\n", vertexCount);
-        for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
-        {
-            log("    vs[%d].Set(%.15lef, %.15lef);\n", i,
-                static_cast<double>(StripUnit(Get<0>(s.GetVertex(i)))),
-                static_cast<double>(StripUnit(Get<1>(s.GetVertex(i)))));
-        }
-        log("    shape.Set(vs, %d);\n", vertexCount);
-    }
-    
-    void ShapeDumper::Visit(const ChainShapeConf& s)
-    {
-        log("    ChainShape shape;\n");
-        log("    Vec2 vs[%d];\n", s.GetVertexCount());
-        for (auto i = decltype(s.GetVertexCount()){0}; i < s.GetVertexCount(); ++i)
-        {
-            log("    vs[%d].Set(%.15lef, %.15lef);\n", i,
-                static_cast<double>(StripUnit(Get<0>(s.GetVertex(i)))),
-                static_cast<double>(StripUnit(Get<1>(s.GetVertex(i)))));
-        }
-        log("    shape.CreateChain(vs, %d);\n", s.GetVertexCount());
-    }
-
-    void ShapeDumper::Visit(const MultiShapeConf&)
-    {
-        // TODO
-    }
 }
 
 void Dump(const World& world)
@@ -267,13 +181,12 @@ void Dump(const Fixture& fixture, std::size_t bodyIndex)
         fixture.GetFilterData().maskBits);
     log("    fd.filter.groupIndex = Filter::index_type(%d);\n",
         fixture.GetFilterData().groupIndex);
-    
+#if 0
     const auto shape = fixture.GetShape();
-    ShapeDumper shapeDumper;
-    Accept(shape, [&](const std::type_info& ti, const void* data) {
-        shapeDumper(ti, data);
-    });
-    
+    std::ostringstream os;
+    os << shape << "\n";
+    log(os.str().c_str());
+#endif
     log("\n");
     log("    fd.shape = &shape;\n");
     log("\n");

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -155,15 +155,16 @@ namespace playrho {
     }
     
     /// @brief Template function for visiting objects.
-    /// @note Specialize this function to tie in application specific handling for types which
-    ///   don't already have specialized handling.
+    /// @note Specialize this function to tie in application specific handling for types
+    ///   which don't already have specialized handling. Specializations should always
+    ///   return <code>true</code>.
     /// @note First parameter is the object to visit.
     /// @note Second parameter is user data or the <code>nullptr</code>.
     /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
     template <typename T>
-    inline void Visit(const T& /*object*/, void* /*userData*/)
+    inline bool Visit(const T& /*object*/, void* /*userData*/)
     {
-        // Intentionally does nothing by default.
+        return false;
     }
     
     /// @brief Gets the library defined name for the given type.

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -157,14 +157,12 @@ namespace playrho {
     /// @brief Template function for visiting objects.
     /// @note Specialize this function to tie in application specific handling for types which
     ///   don't already have specialized handling.
-    /// @param object Object to visit.
-    /// @param userData Optionally provided user data.
+    /// @note First parameter is the object to visit.
+    /// @note Second parameter is user data or the <code>nullptr</code>.
     /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
     template <typename T>
-    inline void Visit(const T& object, void* userData)
+    inline void Visit(const T& /*object*/, void* /*userData*/)
     {
-        NOT_USED(object);
-        NOT_USED(userData);
         // Intentionally does nothing by default.
     }
     

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -159,6 +159,7 @@ namespace playrho {
     ///   don't already have specialized handling.
     /// @param object Object to visit.
     /// @param userData Optionally provided user data.
+    /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
     template <typename T>
     inline void Visit(const T& object, void* userData)
     {

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -154,6 +154,19 @@ namespace playrho {
         return value;
     }
     
+    /// @brief Template function for visiting objects.
+    /// @note Specialize this function to tie in application specific handling for types which
+    ///   don't already have specialized handling.
+    /// @param object Object to visit.
+    /// @param userData Optionally provided user data.
+    template <typename T>
+    inline void Visit(const T& object, void* userData)
+    {
+        NOT_USED(object);
+        NOT_USED(userData);
+        // Intentionally does nothing by default.
+    }
+    
     /// @brief Gets the library defined name for the given type.
     /// @details Provides an interface to a function that can be specialized for getting
     ///   a C-style null-terminated array of characters that names the type.

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -57,30 +57,6 @@ public:
         // Intentionally empty.
     }
     
-    void operator() (const std::type_info& ti, const void* data)
-    {
-        if (ti == typeid(DiskShapeConf))
-        {
-            Visit(*static_cast<const DiskShapeConf*>(data));
-        }
-        else if (ti == typeid(EdgeShapeConf))
-        {
-            Visit(*static_cast<const EdgeShapeConf*>(data));
-        }
-        else if (ti == typeid(PolygonShapeConf))
-        {
-            Visit(*static_cast<const PolygonShapeConf*>(data));
-        }
-        else if (ti == typeid(ChainShapeConf))
-        {
-            Visit(*static_cast<const ChainShapeConf*>(data));
-        }
-        else if (ti == typeid(MultiShapeConf))
-        {
-            Visit(*static_cast<const MultiShapeConf*>(data));
-        }
-    }
-    
     void Visit(const DiskShapeConf& shape);
     void Visit(const EdgeShapeConf& shape);
     void Visit(const PolygonShapeConf& shape);
@@ -222,14 +198,63 @@ void ShapeDrawer::Visit(const MultiShapeConf& shape)
     }
 }
 
+namespace playrho {
+namespace d2 {
+
+template <>
+void DrawConf(const EdgeShapeConf& shape, void* userData) noexcept
+{
+    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
+    // No op.
+    //std::cout << "Hello disk!\n";
+    shapeDrawer->Visit(shape);
+}
+
+template <>
+void DrawConf(const DiskShapeConf& shape, void* userData) noexcept
+{
+    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
+    // No op.
+    //std::cout << "Hello disk!\n";
+    shapeDrawer->Visit(shape);
+}
+
+template <>
+void DrawConf(const PolygonShapeConf& shape, void* userData) noexcept
+{
+    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
+    // No op.
+    //std::cout << "Hello polygon!\n";
+    shapeDrawer->Visit(shape);
+}
+
+template <>
+void DrawConf(const ChainShapeConf& shape, void* userData) noexcept
+{
+    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
+    // No op.
+    //std::cout << "Hello polygon!\n";
+    shapeDrawer->Visit(shape);
+}
+
+template <>
+void DrawConf(const MultiShapeConf& shape, void* userData) noexcept
+{
+    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
+    // No op.
+    //std::cout << "Hello polygon!\n";
+    shapeDrawer->Visit(shape);
+}
+
+} // namespace d2
+} // namespace playrho
+
 static void Draw(Drawer& drawer, const Fixture& fixture, const Color& color, bool skins)
 {
     const auto xf = GetTransformation(fixture);
     auto shapeDrawer = ShapeDrawer{drawer, color, skins, xf};
     const auto shape = fixture.GetShape();
-    Accept(shape, [&](const std::type_info& ti, const void* data) {
-        shapeDrawer(ti, data);
-    });
+    playrho::d2::Draw(shape, &shapeDrawer);
 }
 
 static Color GetColor(const Body& body)

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -26,9 +26,10 @@
 #include <utility>
 #include "imgui.h"
 
-using namespace testbed;
 using namespace playrho;
 using namespace playrho::d2;
+
+namespace testbed {
 
 static void DrawCorner(Drawer& drawer, Length2 p, Length r, Angle a0, Angle a1, Color color)
 {
@@ -48,94 +49,7 @@ static void DrawCorner(Drawer& drawer, Length2 p, Length r, Angle a0, Angle a1, 
     }
 }
 
-class ShapeDrawer
-{
-public:
-    ShapeDrawer(Drawer& d, Color c, bool s, Transformation t):
-        drawer{d}, color{c}, skins{s}, xf{t}
-    {
-        // Intentionally empty.
-    }
-    
-    void Visit(const DiskShapeConf& shape);
-    void Visit(const EdgeShapeConf& shape);
-    void Visit(const PolygonShapeConf& shape);
-    void Visit(const ChainShapeConf& shape);
-    void Visit(const MultiShapeConf& shape);
-
-    void Draw(const DistanceProxy& proxy);
-
-    Drawer& drawer;
-    Color color;
-    bool skins;
-    Transformation xf;
-};
-
-void ShapeDrawer::Visit(const DiskShapeConf& shape)
-{
-    const auto center = Transform(shape.GetLocation(), xf);
-    const auto radius = shape.GetRadius();
-    const auto fillColor = Color{0.5f * color.r, 0.5f * color.g, 0.5f * color.b, 0.5f};
-    drawer.DrawSolidCircle(center, radius, fillColor);
-    drawer.DrawCircle(center, radius, color);
-
-    // Draw a line fixed in the circle to animate rotation.
-    const auto axis = Rotate(Vec2{Real{1}, Real{0}}, xf.q);
-    drawer.DrawSegment(center, center + radius * axis, color);
-}
-
-void ShapeDrawer::Visit(const EdgeShapeConf& shape)
-{
-    const auto v1 = Transform(shape.GetVertexA(), xf);
-    const auto v2 = Transform(shape.GetVertexB(), xf);
-    drawer.DrawSegment(v1, v2, color);
-
-    if (skins)
-    {
-        const auto r = GetVertexRadius(shape);
-        if (r > 0_m)
-        {
-            const auto skinColor = Color{color.r * 0.6f, color.g * 0.6f, color.b * 0.6f};
-            const auto worldNormal0 = GetFwdPerpendicular(GetUnitVector(v2 - v1));
-            const auto offset = worldNormal0 * r;
-            drawer.DrawSegment(v1 + offset, v2 + offset, skinColor);
-            drawer.DrawSegment(v1 - offset, v2 - offset, skinColor);
-
-            const auto angle0 = GetAngle(worldNormal0);
-            const auto angle1 = GetAngle(-worldNormal0);
-            DrawCorner(drawer, v2, r, angle0, angle1, skinColor);
-            DrawCorner(drawer, v1, r, angle1, angle0, skinColor);
-        }
-    }
-}
-
-void ShapeDrawer::Visit(const ChainShapeConf& shape)
-{
-    const auto count = shape.GetVertexCount();
-    const auto r = GetVertexRadius(shape);
-    const auto skinColor = Color{color.r * 0.6f, color.g * 0.6f, color.b * 0.6f};
-
-    auto v1 = Transform(shape.GetVertex(0), xf);
-    for (auto i = decltype(count){1}; i < count; ++i)
-    {
-        const auto v2 = Transform(shape.GetVertex(i), xf);
-        drawer.DrawSegment(v1, v2, color);
-        if (skins && r > 0_m)
-        {
-            const auto worldNormal0 = GetFwdPerpendicular(GetUnitVector(v2 - v1));
-            const auto offset = worldNormal0 * r;
-            drawer.DrawSegment(v1 + offset, v2 + offset, skinColor);
-            drawer.DrawSegment(v1 - offset, v2 - offset, skinColor);
-            const auto angle0 = GetAngle(worldNormal0);
-            const auto angle1 = GetAngle(-worldNormal0);
-            DrawCorner(drawer, v2, r, angle0, angle1, skinColor);
-            DrawCorner(drawer, v1, r, angle1, angle0, skinColor);
-        }
-        v1 = v2;
-    }
-}
-
-void ShapeDrawer::Draw(const DistanceProxy& shape)
+static void Draw(Drawer& drawer, const DistanceProxy& shape, Color color, bool skins, Transformation xf)
 {
     const auto vertexCount = shape.GetVertexCount();
     auto vertices = std::vector<Length2>(vertexCount);
@@ -146,12 +60,12 @@ void ShapeDrawer::Draw(const DistanceProxy& shape)
     const auto fillColor = Color{0.5f * color.r, 0.5f * color.g, 0.5f * color.b, 0.5f};
     drawer.DrawSolidPolygon(&vertices[0], vertexCount, fillColor);
     drawer.DrawPolygon(&vertices[0], vertexCount, color);
-
+    
     if (!skins)
     {
         return;
     }
-
+    
     const auto skinColor = Color{color.r * 0.6f, color.g * 0.6f, color.b * 0.6f};
     const auto r = GetVertexRadius(shape);
     for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
@@ -184,65 +98,112 @@ void ShapeDrawer::Draw(const DistanceProxy& shape)
     }
 }
 
-void ShapeDrawer::Visit(const PolygonShapeConf& shape)
+void Draw(Drawer& drawer, const DiskShapeConf& shape, Color color, Transformation xf)
 {
-    Draw(GetChild(shape, 0));
+    const auto center = Transform(shape.GetLocation(), xf);
+    const auto radius = shape.GetRadius();
+    const auto fillColor = Color{0.5f * color.r, 0.5f * color.g, 0.5f * color.b, 0.5f};
+    drawer.DrawSolidCircle(center, radius, fillColor);
+    drawer.DrawCircle(center, radius, color);
+
+    // Draw a line fixed in the circle to animate rotation.
+    const auto axis = Rotate(Vec2{Real{1}, Real{0}}, xf.q);
+    drawer.DrawSegment(center, center + radius * axis, color);
 }
 
-void ShapeDrawer::Visit(const MultiShapeConf& shape)
+void Draw(Drawer& drawer, const EdgeShapeConf& shape, Color color, bool skins, Transformation xf)
+{
+    const auto v1 = Transform(shape.GetVertexA(), xf);
+    const auto v2 = Transform(shape.GetVertexB(), xf);
+    drawer.DrawSegment(v1, v2, color);
+
+    if (skins)
+    {
+        const auto r = GetVertexRadius(shape);
+        if (r > 0_m)
+        {
+            const auto skinColor = Color{color.r * 0.6f, color.g * 0.6f, color.b * 0.6f};
+            const auto worldNormal0 = GetFwdPerpendicular(GetUnitVector(v2 - v1));
+            const auto offset = worldNormal0 * r;
+            drawer.DrawSegment(v1 + offset, v2 + offset, skinColor);
+            drawer.DrawSegment(v1 - offset, v2 - offset, skinColor);
+
+            const auto angle0 = GetAngle(worldNormal0);
+            const auto angle1 = GetAngle(-worldNormal0);
+            DrawCorner(drawer, v2, r, angle0, angle1, skinColor);
+            DrawCorner(drawer, v1, r, angle1, angle0, skinColor);
+        }
+    }
+}
+
+void Draw(Drawer& drawer, const ChainShapeConf& shape, Color color, bool skins, Transformation xf)
+{
+    const auto count = shape.GetVertexCount();
+    const auto r = GetVertexRadius(shape);
+    const auto skinColor = Color{color.r * 0.6f, color.g * 0.6f, color.b * 0.6f};
+
+    auto v1 = Transform(shape.GetVertex(0), xf);
+    for (auto i = decltype(count){1}; i < count; ++i)
+    {
+        const auto v2 = Transform(shape.GetVertex(i), xf);
+        drawer.DrawSegment(v1, v2, color);
+        if (skins && r > 0_m)
+        {
+            const auto worldNormal0 = GetFwdPerpendicular(GetUnitVector(v2 - v1));
+            const auto offset = worldNormal0 * r;
+            drawer.DrawSegment(v1 + offset, v2 + offset, skinColor);
+            drawer.DrawSegment(v1 - offset, v2 - offset, skinColor);
+            const auto angle0 = GetAngle(worldNormal0);
+            const auto angle1 = GetAngle(-worldNormal0);
+            DrawCorner(drawer, v2, r, angle0, angle1, skinColor);
+            DrawCorner(drawer, v1, r, angle1, angle0, skinColor);
+        }
+        v1 = v2;
+    }
+}
+
+void Draw(Drawer& drawer, const PolygonShapeConf& shape, Color color, bool skins, Transformation xf)
+{
+    Draw(drawer, GetChild(shape, 0), color, skins, xf);
+}
+
+void Draw(Drawer& drawer, const MultiShapeConf& shape, Color color, bool skins, Transformation xf)
 {
     const auto count = GetChildCount(shape);
     for (auto i = decltype(count){0}; i < count; ++i)
     {
-        Draw(GetChild(shape, i));
+        Draw(drawer, GetChild(shape, i), color, skins, xf);
     }
 }
-
-namespace playrho {
-
-template <>
-void Visit(const d2::EdgeShapeConf& shape, void* userData)
-{
-    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    shapeDrawer->Visit(shape);
-}
-
-template <>
-void Visit(const d2::DiskShapeConf& shape, void* userData)
-{
-    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    shapeDrawer->Visit(shape);
-}
-
-template <>
-void Visit(const d2::PolygonShapeConf& shape, void* userData)
-{
-    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    shapeDrawer->Visit(shape);
-}
-
-template <>
-void Visit(const d2::ChainShapeConf& shape, void* userData)
-{
-    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    shapeDrawer->Visit(shape);
-}
-
-template <>
-void Visit(const d2::MultiShapeConf& shape, void* userData)
-{
-    const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    shapeDrawer->Visit(shape);
-}
-
-} // namespace playrho
 
 static void Draw(Drawer& drawer, const Fixture& fixture, const Color& color, bool skins)
 {
     const auto xf = GetTransformation(fixture);
-    auto shapeDrawer = ShapeDrawer{drawer, color, skins, xf};
-    const auto shape = fixture.GetShape();
-    playrho::Visit(shape, &shapeDrawer);
+#if 0
+    auto visitor = FunctionalVisitor{};
+    visitor.visitDisk = [&](const d2::DiskShapeConf& shape) {
+        Draw(drawer, shape, color, xf);
+    };
+    visitor.visitEdge = [&](const d2::EdgeShapeConf& shape) {
+        Draw(drawer, shape, color, skins, xf);
+    };
+    visitor.visitPolygon = [&](const d2::PolygonShapeConf& shape) {
+        Draw(drawer, shape, color, skins, xf);
+    };
+    visitor.visitChain = [&](const d2::ChainShapeConf& shape) {
+        Draw(drawer, shape, color, skins, xf);
+    };
+    visitor.visitMulti = [&](const d2::MultiShapeConf& shape) {
+        Draw(drawer, shape, color, skins, xf);
+    };
+#else
+    auto visitor = VisitorData{};
+    visitor.drawer = &drawer;
+    visitor.xf = xf;
+    visitor.color = color;
+    visitor.skins = skins;
+#endif
+    playrho::Visit(fixture.GetShape(), &visitor);
 }
 
 static Color GetColor(const Body& body)
@@ -1369,4 +1330,6 @@ Real testbed::RandomFloat(Real lo, Real hi)
     r = (hi - lo) * r + lo;
     return r;
 }
+    
+} // namespace testbed
 

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -199,54 +199,42 @@ void ShapeDrawer::Visit(const MultiShapeConf& shape)
 }
 
 namespace playrho {
-namespace d2 {
 
 template <>
-void DrawConf(const EdgeShapeConf& shape, void* userData) noexcept
+void Visit(const d2::EdgeShapeConf& shape, void* userData)
 {
     const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    // No op.
-    //std::cout << "Hello disk!\n";
     shapeDrawer->Visit(shape);
 }
 
 template <>
-void DrawConf(const DiskShapeConf& shape, void* userData) noexcept
+void Visit(const d2::DiskShapeConf& shape, void* userData)
 {
     const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    // No op.
-    //std::cout << "Hello disk!\n";
     shapeDrawer->Visit(shape);
 }
 
 template <>
-void DrawConf(const PolygonShapeConf& shape, void* userData) noexcept
+void Visit(const d2::PolygonShapeConf& shape, void* userData)
 {
     const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    // No op.
-    //std::cout << "Hello polygon!\n";
     shapeDrawer->Visit(shape);
 }
 
 template <>
-void DrawConf(const ChainShapeConf& shape, void* userData) noexcept
+void Visit(const d2::ChainShapeConf& shape, void* userData)
 {
     const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    // No op.
-    //std::cout << "Hello polygon!\n";
     shapeDrawer->Visit(shape);
 }
 
 template <>
-void DrawConf(const MultiShapeConf& shape, void* userData) noexcept
+void Visit(const d2::MultiShapeConf& shape, void* userData)
 {
     const auto shapeDrawer = static_cast<ShapeDrawer*>(userData);
-    // No op.
-    //std::cout << "Hello polygon!\n";
     shapeDrawer->Visit(shape);
 }
 
-} // namespace d2
 } // namespace playrho
 
 static void Draw(Drawer& drawer, const Fixture& fixture, const Color& color, bool skins)
@@ -254,7 +242,7 @@ static void Draw(Drawer& drawer, const Fixture& fixture, const Color& color, boo
     const auto xf = GetTransformation(fixture);
     auto shapeDrawer = ShapeDrawer{drawer, color, skins, xf};
     const auto shape = fixture.GetShape();
-    playrho::d2::Draw(shape, &shapeDrawer);
+    playrho::Visit(shape, &shapeDrawer);
 }
 
 static Color GetColor(const Body& body)

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -1313,9 +1313,9 @@ void Test::RegisterForKey(KeyID key, KeyAction action, KeyMods mods, KeyHandlerI
     m_handledKeys.push_back(std::make_pair(KeyActionMods{key, action, mods}, id));
 }
 
-PLAYRHO_CONSTEXPR const auto RAND_LIMIT = 32767;
+constexpr const auto RAND_LIMIT = 32767;
 
-Real testbed::RandomFloat()
+Real RandomFloat()
 {
     auto r = static_cast<Real>(std::rand() & (RAND_LIMIT));
     r /= RAND_LIMIT;
@@ -1323,7 +1323,7 @@ Real testbed::RandomFloat()
     return r;
 }
 
-Real testbed::RandomFloat(Real lo, Real hi)
+Real RandomFloat(Real lo, Real hi)
 {
     auto r = static_cast<Real>(std::rand() & (RAND_LIMIT));
     r /= RAND_LIMIT;

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -458,38 +458,43 @@ void Draw(Drawer& drawer, const MultiShapeConf& shape, Color color, bool skins, 
 namespace playrho {
 
 template <>
-inline void Visit(const d2::DiskShapeConf& shape, void* userData)
+inline bool Visit(const d2::DiskShapeConf& shape, void* userData)
 {
     const auto data = static_cast<testbed::VisitorData*>(userData);
     Draw(*(data->drawer), shape, data->color, data->xf);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::EdgeShapeConf& shape, void* userData)
+inline bool Visit(const d2::EdgeShapeConf& shape, void* userData)
 {
     const auto data = static_cast<testbed::VisitorData*>(userData);
     Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::PolygonShapeConf& shape, void* userData)
+inline bool Visit(const d2::PolygonShapeConf& shape, void* userData)
 {
     const auto data = static_cast<testbed::VisitorData*>(userData);
     Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::ChainShapeConf& shape, void* userData)
+inline bool Visit(const d2::ChainShapeConf& shape, void* userData)
 {
     const auto data = static_cast<testbed::VisitorData*>(userData);
     Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::MultiShapeConf& shape, void* userData)
+inline bool Visit(const d2::MultiShapeConf& shape, void* userData)
 {
     const auto data = static_cast<testbed::VisitorData*>(userData);
     Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
 }
 
 } // namespace playrho

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -21,6 +21,7 @@
 #define PLAYRHO_TEST_HPP
 
 #include <PlayRho/PlayRho.hpp>
+#include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Collision/RayCastOutput.hpp>
 #include <PlayRho/Collision/ShapeSeparation.hpp>
 #include <PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp>
@@ -408,6 +409,14 @@ private:
     std::deque<std::size_t> m_numTouchingPerStep;
 };
 
+struct VisitorData
+{
+    Drawer* drawer;
+    Transformation xf;
+    Color color;
+    bool skins;
+};
+
 // Free functions...
 
 /// Random number in range [-1,1]
@@ -438,6 +447,51 @@ inline void ForAll(World& world, const std::function<void(RevoluteJoint& e)>& ac
     });
 }
 
+void Draw(Drawer& drawer, const DiskShapeConf& shape, Color color, Transformation xf);
+void Draw(Drawer& drawer, const EdgeShapeConf& shape, Color color, bool skins, Transformation xf);
+void Draw(Drawer& drawer, const PolygonShapeConf& shape, Color color, bool skins, Transformation xf);
+void Draw(Drawer& drawer, const ChainShapeConf& shape, Color color, bool skins, Transformation xf);
+void Draw(Drawer& drawer, const MultiShapeConf& shape, Color color, bool skins, Transformation xf);
+
 } // namespace testbed
+
+namespace playrho {
+
+template <>
+inline void Visit(const d2::DiskShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->xf);
+}
+
+template <>
+inline void Visit(const d2::EdgeShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+}
+
+template <>
+inline void Visit(const d2::PolygonShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+}
+
+template <>
+inline void Visit(const d2::ChainShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+}
+
+template <>
+inline void Visit(const d2::MultiShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+}
+
+} // namespace playrho
 
 #endif

--- a/Testbed/Tests/Breakable.hpp
+++ b/Testbed/Tests/Breakable.hpp
@@ -34,28 +34,30 @@ public:
         e_count = 7
     };
 
-    Breakable()
+    static PolygonShapeConf GetShapeConf1() noexcept
+    {
+        return PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(0.5_m, 0.5_m, Vec2(-0.5f, 0.0f) * 1_m, 0_rad);
+    }
+    
+    static PolygonShapeConf GetShapeConf2() noexcept
+    {
+        return PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(0.5_m, 0.5_m, Vec2(+0.5f, 0.0f) * 1_m, 0_rad);
+    }
+    
+    Breakable(): m_shape1{GetShapeConf1()}, m_shape2{GetShapeConf2()}
     {
         // Ground body
         m_world.CreateBody()->CreateFixture(Shape(EdgeShapeConf{}.Set(Vec2(-40.0f, 0.0f) * 1_m, Vec2(40.0f, 0.0f) * 1_m)));
 
         // Breakable dynamic body
         {
-            auto conf = PolygonShapeConf{}.UseDensity(1_kgpm2);
-
             BodyConf bd;
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = m_gravity;
             bd.location = Vec2(0.0f, 40.0f) * 1_m;
             bd.angle = Pi * 0.25_rad;
             m_body1 = m_world.CreateBody(bd);
-
-            conf.SetAsBox(0.5_m, 0.5_m, Vec2(-0.5f, 0.0f) * 1_m, 0_rad);
-            m_shape1 = conf;
             m_piece1 = m_body1->CreateFixture(m_shape1);
-
-            conf.SetAsBox(0.5_m, 0.5_m, Vec2(0.5f, 0.0f) * 1_m, 0_rad);
-            m_shape2 = conf;
             m_piece2 = m_body1->CreateFixture(m_shape2);
         }
 
@@ -140,8 +142,8 @@ public:
     Body* m_body1;
     LinearVelocity2 m_velocity;
     AngularVelocity m_angularVelocity;
-    PolygonShapeConf m_shape1;
-    PolygonShapeConf m_shape2;
+    Shape m_shape1;
+    Shape m_shape2;
     Fixture* m_piece1;
     Fixture* m_piece2;
 

--- a/Testbed/Tests/ContinuousTest.hpp
+++ b/Testbed/Tests/ContinuousTest.hpp
@@ -44,7 +44,7 @@ public:
             //bd.angle = 0.1f;
 
             m_body = m_world.CreateBody(bd);
-            m_body->CreateFixture(PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(2_m, 0.1_m));
+            m_body->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(2_m, 0.1_m)});
             m_angularVelocity = RandomFloat(-50.0f, 50.0f) * 1_rad / 1_s;
             //m_angularVelocity = 46.661274f;
             m_body->SetVelocity(Velocity{Vec2(0.0f, -100.0f) * 1_mps, m_angularVelocity});

--- a/Testbed/Tests/Dominos.hpp
+++ b/Testbed/Tests/Dominos.hpp
@@ -31,13 +31,13 @@ public:
     Dominos()
     {
         const auto b1 = m_world.CreateBody();
-        b1->CreateFixture(EdgeShapeConf(Vec2(-40.0f, 0.0f) * 1_m, Vec2(40.0f, 0.0f) * 1_m));
+        b1->CreateFixture(Shape{EdgeShapeConf(Vec2(-40.0f, 0.0f) * 1_m, Vec2(40.0f, 0.0f) * 1_m)});
 
         {
             BodyConf bd;
             bd.location = Vec2(-1.5f, 10.0f) * 1_m;
             const auto ground = m_world.CreateBody(bd);
-            ground->CreateFixture(PolygonShapeConf{6_m, 0.25_m});
+            ground->CreateFixture(Shape{PolygonShapeConf{6_m, 0.25_m}});
         }
 
         {
@@ -64,7 +64,7 @@ public:
         }
 
         const auto b2 = m_world.CreateBody(BodyConf{}.UseLocation(Vec2(-7.0f, 4.0f) * 1_m));
-        b2->CreateFixture(PolygonShapeConf{}.SetAsBox(0.25_m, 1.5_m));
+        b2->CreateFixture(Shape{PolygonShapeConf{}.SetAsBox(0.25_m, 1.5_m)});
 
         Body* b3;
         {
@@ -73,7 +73,7 @@ public:
             bd.location = Vec2(-0.9f, 1.0f) * 1_m;
             bd.angle = -0.15_rad;
             b3 = m_world.CreateBody(bd);
-            b3->CreateFixture(PolygonShapeConf{}.UseDensity(10_kgpm2).SetAsBox(6_m, 0.125_m));
+            b3->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(10_kgpm2).SetAsBox(6_m, 0.125_m)});
         }
 
         m_world.CreateJoint(RevoluteJointConf{b1, b3, Vec2(-2, 1) * 1_m}.UseCollideConnected(true));
@@ -84,7 +84,7 @@ public:
             bd.type = BodyType::Dynamic;
             bd.location = Vec2(-10.0f, 15.0f) * 1_m;
             b4 = m_world.CreateBody(bd);
-            b4->CreateFixture(PolygonShapeConf{}.UseDensity(10_kgpm2).SetAsBox(0.25_m, 0.25_m));
+            b4->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(10_kgpm2).SetAsBox(0.25_m, 0.25_m)});
         }
 
         m_world.CreateJoint(RevoluteJointConf{b2, b4, Vec2(-7, 15) * 1_m}.UseCollideConnected(true));
@@ -115,7 +115,7 @@ public:
             bd.type = BodyType::Dynamic;
             bd.location = Vec2(6.5f, 4.1f) * 1_m;
             b6 = m_world.CreateBody(bd);
-            b6->CreateFixture(PolygonShapeConf(1_m, 0.1_m).UseDensity(30_kgpm2));
+            b6->CreateFixture(Shape{PolygonShapeConf(1_m, 0.1_m).UseDensity(30_kgpm2)});
         }
 
         m_world.CreateJoint(RevoluteJointConf{b5, b6, Vec2(7.5f, 4.0f) * 1_m}

--- a/Testbed/Tests/EdgeShapes.hpp
+++ b/Testbed/Tests/EdgeShapes.hpp
@@ -204,7 +204,10 @@ public:
 
     int m_bodyIndex;
     Body* m_bodies[e_maxBodies];
-    Shape m_polygons[4] = {PolygonShapeConf{}, PolygonShapeConf{}, PolygonShapeConf{}, PolygonShapeConf{}};
+    Shape m_polygons[4] = {
+        Shape{PolygonShapeConf{}}, Shape{PolygonShapeConf{}},
+        Shape{PolygonShapeConf{}}, Shape{PolygonShapeConf{}}
+    };
     Shape m_circle = Shape{DiskShapeConf{}.UseRadius(0.5_m).UseFriction(Real(0.3f)).UseDensity(20_kgpm2)};
 
     Real m_angle;

--- a/Testbed/Tests/FifteenPuzzle.hpp
+++ b/Testbed/Tests/FifteenPuzzle.hpp
@@ -84,7 +84,7 @@ namespace testbed {
             bd.location = GetCenter() + relPos + Length2{sideLength / 2, sideLength / 2};
             bd.linearDamping = 20_Hz;
             const auto body = m_world.CreateBody(bd);
-            body->CreateFixture(conf);
+            body->CreateFixture(Shape{conf});
             
             return body;
         }

--- a/Testbed/Tests/Gears.hpp
+++ b/Testbed/Tests/Gears.hpp
@@ -52,7 +52,7 @@ public:
             bd3.type = BodyType::Dynamic;
             bd3.location = Vec2(10.0f, 6.0f) * 1_m;
             const auto body3 = m_world.CreateBody(bd3);
-            body3->CreateFixture(circle2);
+            body3->CreateFixture(Shape{circle2});
 
             auto joint1 = m_world.CreateJoint(RevoluteJointConf{body2, body1, bd1.location});
             auto joint2 = m_world.CreateJoint(RevoluteJointConf{body2, body3, bd3.location});
@@ -67,7 +67,7 @@ public:
             bd1.type = BodyType::Dynamic;
             bd1.location = Vec2(-3.0f, 12.0f) * 1_m;
             const auto body1 = m_world.CreateBody(bd1);
-            body1->CreateFixture(circle1);
+            body1->CreateFixture(Shape{circle1});
 
             auto jd1 = RevoluteJointConf{};
             jd1.bodyA = ground;
@@ -81,7 +81,7 @@ public:
             bd2.type = BodyType::Dynamic;
             bd2.location = Vec2(0.0f, 12.0f) * 1_m;
             const auto body2 = m_world.CreateBody(bd2);
-            body2->CreateFixture(circle2);
+            body2->CreateFixture(Shape{circle2});
 
             auto jd2 = RevoluteJointConf{ground, body2, bd2.location};
             m_joint2 = static_cast<RevoluteJoint*>(m_world.CreateJoint(jd2));

--- a/Testbed/Tests/HalfPipe.hpp
+++ b/Testbed/Tests/HalfPipe.hpp
@@ -39,7 +39,9 @@ namespace testbed {
                                                       .UseType(BodyType::Dynamic)
                                                       .UseLocation(Vec2(-19, 28) * 1_m)
                                                      .UseLinearAcceleration(m_gravity));
-            ballBody->CreateFixture(DiskShapeConf{}.UseDensity(0.01_kgpm2).UseRadius(1_m).UseFriction(Real(1)));
+            ballBody->CreateFixture(Shape{
+                DiskShapeConf{}.UseDensity(0.01_kgpm2).UseRadius(1_m).UseFriction(Real(1))
+            });
         }
     };
     

--- a/Testbed/Tests/HeavyOnLightTwo.hpp
+++ b/Testbed/Tests/HeavyOnLightTwo.hpp
@@ -57,8 +57,8 @@ public:
     
     const BodyConf DynBD = BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(m_gravity);
     const DiskShapeConf DiskConf = DiskShapeConf{}.UseDensity(10_kgpm2);
-    const Shape lilDisk = DiskShapeConf(DiskConf).UseRadius(0.5_m);
-    const Shape bigDisk = DiskShapeConf(DiskConf).UseRadius(5.0_m);
+    const Shape lilDisk = Shape{DiskShapeConf(DiskConf).UseRadius(0.5_m)};
+    const Shape bigDisk = Shape{DiskShapeConf(DiskConf).UseRadius(5.0_m)};
     Body* m_heavy = nullptr;
 };
 

--- a/Testbed/Tests/JointsTest.hpp
+++ b/Testbed/Tests/JointsTest.hpp
@@ -185,8 +185,8 @@ private:
         {
             // Use () instead of {} to avoid MSVC++ doing const preserving copy elision.
             const auto conf = DiskConf{}.UseRadius(0.7_m);
-            cbody->CreateFixture(DiskConf(conf).UseLocation(left));
-            cbody->CreateFixture(DiskConf(conf).UseLocation(right));
+            cbody->CreateFixture(Shape{DiskConf(conf).UseLocation(left)});
+            cbody->CreateFixture(Shape{DiskConf(conf).UseLocation(right)});
         }
         {
             const auto shape = Shape{PolyConf{}.UseDensity(5_kgpm2).SetAsBox(0.5_m, 0.5_m)};
@@ -273,7 +273,9 @@ private:
         
         const auto carLocation = center - Vec2(3.3f, 1.0f) * 1_m;
         const auto car = m_world.CreateBody(BodyConf(DynamicBD).UseLocation(carLocation));
-        car->CreateFixture(PolygonShapeConf{}.UseDensity(1_kgpm2).Set(Span<const Length2>(carVerts.data(), carVerts.size())));
+        car->CreateFixture(Shape{
+            PolygonShapeConf{}.UseDensity(1_kgpm2).Set(Span<const Length2>(carVerts.data(), carVerts.size()))
+        });
         
         const auto backWheel  = m_world.CreateBody(BodyConf(DynamicBD).UseLocation(carLocation + Vec2(-1.0f, -0.65f) * 1_m));
         backWheel->CreateFixture(circle);

--- a/Testbed/Tests/MobileBalanced.hpp
+++ b/Testbed/Tests/MobileBalanced.hpp
@@ -39,7 +39,7 @@ public:
         const auto a = 0.5_m;
         const auto h = Length2{0_m, a};
         const auto root = AddNode(ground, Length2{}, 0, 3.0f, a,
-                                  PolygonShapeConf{}.UseDensity(density).SetAsBox(a / 4, a));
+                                  Shape{PolygonShapeConf{}.UseDensity(density).SetAsBox(a / 4, a)});
 
         auto jointConf = RevoluteJointConf{};
         jointConf.bodyA = ground;

--- a/Testbed/Tests/MotorJoint.hpp
+++ b/Testbed/Tests/MotorJoint.hpp
@@ -49,7 +49,9 @@ public:
                                              .UseType(BodyType::Dynamic)
                                              .UseLocation(Vec2(0.0f, 8.0f) * 1_m)
                                              .UseLinearAcceleration(m_gravity));
-        body->CreateFixture(PolygonShapeConf{}.SetAsBox(2_m, 0.5_m).UseFriction(Real(0.6f)).UseDensity(2_kgpm2));
+        body->CreateFixture(Shape{
+            PolygonShapeConf{}.SetAsBox(2_m, 0.5_m).UseFriction(Real(0.6f)).UseDensity(2_kgpm2)
+        });
         auto mjd = MotorJointConf{ground, body};
         mjd.maxForce = 1000_N;
         mjd.maxTorque = 1000_Nm;

--- a/Testbed/Tests/OneSidedPlatform.hpp
+++ b/Testbed/Tests/OneSidedPlatform.hpp
@@ -45,7 +45,7 @@ public:
             BodyConf bd;
             bd.location = Vec2(0.0f, 10.0f) * 1_m;
             const auto body = m_world.CreateBody(bd);
-            m_platform = body->CreateFixture(PolygonShapeConf{}.SetAsBox(3_m, 0.5_m));
+            m_platform = body->CreateFixture(Shape{PolygonShapeConf{}.SetAsBox(3_m, 0.5_m)});
             m_bottom = Real(10.0f - 0.5f) * 1_m;
             m_top = Real(10.0f + 0.5f) * 1_m;
         }

--- a/Testbed/Tests/Orbiter.hpp
+++ b/Testbed/Tests/Orbiter.hpp
@@ -37,12 +37,12 @@ namespace testbed {
             bd.type = BodyType::Static;
             bd.location = m_center;
             const auto ctrBody = m_world.CreateBody(bd);
-            ctrBody->CreateFixture(DiskShapeConf{}.UseRadius(3_m));
+            ctrBody->CreateFixture(Shape{DiskShapeConf{}.UseRadius(3_m)});
 
             bd.type = BodyType::Dynamic;
             bd.location = Length2{GetX(m_center), GetY(m_center) + radius * 1_m};
             m_orbiter = m_world.CreateBody(bd);
-            m_orbiter->CreateFixture(DiskShapeConf{}.UseRadius(0.5_m).UseDensity(1_kgpm2));
+            m_orbiter->CreateFixture(Shape{DiskShapeConf{}.UseRadius(0.5_m).UseDensity(1_kgpm2)});
             
             const auto velocity = Velocity{
                 Vec2{Pi * radius / 2, 0} * 1_mps,

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -52,7 +52,7 @@ public:
     {
         const auto center = Transform(shape.GetLocation(), m_xf);
         const auto radius = shape.GetRadius();
-        g_debugDraw->DrawCircle(center, radius, m_color);
+        debugDraw->DrawCircle(center, radius, m_color);
     }
 
     void Visit(const PolygonShapeConf& shape)
@@ -63,12 +63,12 @@ public:
         {
             vertices[i] = Transform(shape.GetVertex(i), m_xf);
         }
-        g_debugDraw->DrawPolygon(&vertices[0], vertexCount, m_color);
+        debugDraw->DrawPolygon(&vertices[0], vertexCount, m_color);
     }
     
     Color m_color = Color(0.95f, 0.95f, 0.6f);
     Transformation m_xf;
-    Drawer* g_debugDraw;
+    Drawer* debugDraw;
 };
 
 class PolyShapes : public Test
@@ -115,19 +115,19 @@ public:
         m_bodyIndex = 0;
         std::memset(m_bodies, 0, sizeof(m_bodies));
         
-        RegisterForKey(GLFW_KEY_1, GLFW_PRESS, 0, "drop stuff", [&](KeyActionMods kam) {
+        RegisterForKey(GLFW_KEY_1, GLFW_PRESS, 0, "drop triangle", [&](KeyActionMods kam) {
             Create(kam.key - GLFW_KEY_1);
         });
-        RegisterForKey(GLFW_KEY_2, GLFW_PRESS, 0, "drop stuff", [&](KeyActionMods kam) {
+        RegisterForKey(GLFW_KEY_2, GLFW_PRESS, 0, "drop thin triangle", [&](KeyActionMods kam) {
             Create(kam.key - GLFW_KEY_1);
         });
-        RegisterForKey(GLFW_KEY_3, GLFW_PRESS, 0, "drop stuff", [&](KeyActionMods kam) {
+        RegisterForKey(GLFW_KEY_3, GLFW_PRESS, 0, "drop octagon", [&](KeyActionMods kam) {
             Create(kam.key - GLFW_KEY_1);
         });
-        RegisterForKey(GLFW_KEY_4, GLFW_PRESS, 0, "drop stuff", [&](KeyActionMods kam) {
+        RegisterForKey(GLFW_KEY_4, GLFW_PRESS, 0, "drop square", [&](KeyActionMods kam) {
             Create(kam.key - GLFW_KEY_1);
         });
-        RegisterForKey(GLFW_KEY_5, GLFW_PRESS, 0, "drop stuff", [&](KeyActionMods kam) {
+        RegisterForKey(GLFW_KEY_5, GLFW_PRESS, 0, "drop disk", [&](KeyActionMods kam) {
             Create(kam.key - GLFW_KEY_1);
         });
         RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "(de)activate some bodies", [&](KeyActionMods) {
@@ -202,7 +202,7 @@ public:
         const auto transform = Transform_identity;
 
         ShapeDrawer shapeDrawer;
-        shapeDrawer.g_debugDraw = &drawer;
+        shapeDrawer.debugDraw = &drawer;
 
         PLAYRHO_CONSTEXPR const int e_maxCount = 4;
         int count = 0;
@@ -213,14 +213,15 @@ public:
             {
                 const auto xfm = GetTransformation(*f);
                 const auto shape = f->GetShape();
-                const auto shapeChild = GetChild(shape, 0);
-                const auto overlap = TestOverlap(shapeChild, xfm, circleChild, transform);
+                const auto overlap = TestOverlap(GetChild(shape, 0), xfm, circleChild, transform);
                 if (overlap >= Area{0})
                 {
+#if 0
                     shapeDrawer.m_xf = xfm;
                     Accept(shape, [&](const std::type_info& ti, const void* data) {
                         shapeDrawer(ti, data);
                     });
+#endif
                     ++count;
                 }
                 return true;

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -23,6 +23,7 @@
 #include "../Framework/Test.hpp"
 #include <vector>
 #include <cstring>
+#include <typeinfo>
 
 /// This tests stacking. It also shows how to use World::Query
 /// and TestOverlap.
@@ -214,7 +215,7 @@ public:
                 const auto xfm = GetTransformation(*f);
                 const auto shape = f->GetShape();
                 const auto overlap = TestOverlap(GetChild(shape, 0), xfm, circleChild, transform);
-                if (overlap >= Area{0})
+                if (overlap >= 0_m2)
                 {
 #if 0
                     shapeDrawer.m_xf = xfm;
@@ -235,8 +236,11 @@ public:
 
     int m_bodyIndex;
     Body* m_bodies[e_maxBodies];
-    Shape m_polygons[4] = {PolygonShapeConf{}, PolygonShapeConf{}, PolygonShapeConf{}, PolygonShapeConf{}};
-    Shape m_circle = DiskShapeConf{}.UseRadius(0.5_m).UseDensity(1_kgpm2).UseFriction(Real(0.3f));
+    Shape m_polygons[4] = {
+        Shape{PolygonShapeConf{}}, Shape{PolygonShapeConf{}},
+        Shape{PolygonShapeConf{}}, Shape{PolygonShapeConf{}}
+    };
+    Shape m_circle = Shape{DiskShapeConf{}.UseRadius(0.5_m).UseDensity(1_kgpm2).UseFriction(Real(0.3f))};
 };
 
 } // namespace testbed

--- a/Testbed/Tests/Prismatic.hpp
+++ b/Testbed/Tests/Prismatic.hpp
@@ -41,7 +41,7 @@ public:
             bd.angle = 0.5_rad * Pi;
             bd.allowSleep = false;
             const auto body = m_world.CreateBody(bd);
-            body->CreateFixture(PolygonShapeConf{}.UseDensity(5_kgpm2).SetAsBox(2_m, 0.5_m));
+            body->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(5_kgpm2).SetAsBox(2_m, 0.5_m)});
 
             // Bouncy limit
             const auto axis = GetUnitVector(Vec2(2.0f, 1.0f));

--- a/Testbed/Tests/RayCast.hpp
+++ b/Testbed/Tests/RayCast.hpp
@@ -372,8 +372,11 @@ public:
     int m_bodyIndex = 0;
     Body* m_bodies[e_maxBodies];
     int m_userData[e_maxBodies];
-    Shape m_polygons[4] = {PolygonShapeConf{}, PolygonShapeConf{}, PolygonShapeConf{}, PolygonShapeConf{}};
-    Shape m_circle = DiskShapeConf{}.UseRadius(0.5_m).UseFriction(Real(0.3f));
+    Shape m_polygons[4] = {
+        Shape{PolygonShapeConf{}}, Shape{PolygonShapeConf{}},
+        Shape{PolygonShapeConf{}}, Shape{PolygonShapeConf{}}
+    };
+    Shape m_circle = Shape{DiskShapeConf{}.UseRadius(0.5_m).UseFriction(Real(0.3f))};
     Shape m_edge = Shape{EdgeShapeConf{Vec2(-1.0f, 0.0f) * 1_m, Vec2(1.0f, 0.0f) * 1_m}.UseFriction(Real(0.3f))};
     Real m_angle = 0.0f;
     Mode m_mode = Mode::e_closest;

--- a/Testbed/Tests/SliderCrank.hpp
+++ b/Testbed/Tests/SliderCrank.hpp
@@ -42,7 +42,7 @@ public:
                 bd.type = BodyType::Dynamic;
                 bd.location = Vec2(0.0f, 7.0f) * 1_m;
                 const auto body = m_world.CreateBody(bd);
-                body->CreateFixture(PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(0.5_m, 2_m));
+                body->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(0.5_m, 2_m)});
 
                 RevoluteJointConf rjd{prevBody, body, Vec2(0.0f, 5.0f) * 1_m};
                 rjd.motorSpeed = Pi * 1_rad / 1_s;
@@ -59,7 +59,7 @@ public:
                 bd.type = BodyType::Dynamic;
                 bd.location = Vec2(0.0f, 13.0f) * 1_m;
                 const auto body = m_world.CreateBody(bd);
-                body->CreateFixture(PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(0.5_m, 4_m));
+                body->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(0.5_m, 4_m)});
 
                 RevoluteJointConf rjd{prevBody, body, Vec2(0.0f, 9.0f) * 1_m};
                 rjd.enableMotor = false;
@@ -75,7 +75,7 @@ public:
                 bd.fixedRotation = true;
                 bd.location = Vec2(0.0f, 17.0f) * 1_m;
                 const auto body = m_world.CreateBody(bd);
-                body->CreateFixture(PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(1.5_m, 1.5_m));
+                body->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(1.5_m, 1.5_m)});
                 m_world.CreateJoint(RevoluteJointConf{prevBody, body, Vec2(0.0f, 17.0f) * 1_m});
 
                 PrismaticJointConf pjd(ground, body, Vec2(0.0f, 17.0f) * 1_m, UnitVec::GetTop());
@@ -89,7 +89,7 @@ public:
                 BodyConf bd;
                 bd.type = BodyType::Dynamic;
                 bd.location = Vec2(0.0f, 23.0f) * 1_m;
-                m_world.CreateBody(bd)->CreateFixture(PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(1.5_m, 1.5_m));
+                m_world.CreateBody(bd)->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(1.5_m, 1.5_m)});
             }
         }
         SetAccelerations(m_world, m_gravity);

--- a/Testbed/Tests/TheoJansen.hpp
+++ b/Testbed/Tests/TheoJansen.hpp
@@ -136,7 +136,7 @@ public:
             bd.type = BodyType::Dynamic;
             bd.location = pivot + m_offset;
             m_chassis = m_world.CreateBody(bd);
-            m_chassis->CreateFixture(PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(2.5_m, 1_m), sd);
+            m_chassis->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(2.5_m, 1_m)}, sd);
         }
 
         {

--- a/Testbed/Tests/Tiles.hpp
+++ b/Testbed/Tests/Tiles.hpp
@@ -54,7 +54,7 @@ public:
                 GetX(position) = -N * a;
                 for (auto i = 0; i < N; ++i)
                 {
-                    ground->CreateFixture(PolygonShapeConf{}.SetAsBox(a * 1_m, a * 1_m, position * 1_m, 0_deg));
+                    ground->CreateFixture(Shape{PolygonShapeConf{}.SetAsBox(a * 1_m, a * 1_m, position * 1_m, 0_deg)});
                     ++m_fixtureCount;
                     GetX(position) += 2.0f * a;
                 }

--- a/Testbed/Tests/VerticalStack.hpp
+++ b/Testbed/Tests/VerticalStack.hpp
@@ -91,7 +91,7 @@ public:
     }
 
     Body* m_bullet;
-    Shape m_bulletshape = DiskShapeConf{}.UseRadius(0.25_m).UseDensity(20_kgpm2).UseRestitution(Real(0.05f));
+    Shape m_bulletshape = Shape{DiskShapeConf{}.UseRadius(0.25_m).UseDensity(20_kgpm2).UseRestitution(Real(0.05f))};
 };
     
 } // namespace testbed

--- a/Testbed/Tests/iforce2d_Trajectories.hpp
+++ b/Testbed/Tests/iforce2d_Trajectories.hpp
@@ -83,8 +83,8 @@ public:
         myBodyConf.type = BodyType::Dynamic;
         myBodyConf.location = Vec2(-15, 5) * 1_m;
         m_launcherBody = m_world.CreateBody(myBodyConf);
-        m_launcherBody->CreateFixture(DiskShapeConf{}.UseRadius(2_m).UseFriction(Real(0.95f)).UseDensity(1_kgpm2),
-                                      myFixtureConf);
+        m_launcherBody->CreateFixture(Shape{DiskShapeConf{}.UseRadius(2_m)
+            .UseFriction(Real(0.95f)).UseDensity(1_kgpm2)}, myFixtureConf);
         
         //pin the circle in place
         RevoluteJointConf revoluteJointConf;
@@ -106,9 +106,8 @@ public:
         
         //ball for computer 'player' to fire
         m_littleBox2 = m_world.CreateBody(myBodyConf);
-        m_littleBox2->CreateFixture(DiskShapeConf{}.UseRadius(BallSize * 1_m)
-                                    .UseFriction(Real(0.95f)).UseDensity(1_kgpm2),
-                                    myFixtureConf);
+        m_littleBox2->CreateFixture(Shape{DiskShapeConf{}.UseRadius(BallSize * 1_m)
+            .UseFriction(Real(0.95f)).UseDensity(1_kgpm2)}, myFixtureConf);
         
         m_firing = false;
         m_littleBox->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -422,7 +422,7 @@ TEST(AABB, ComputeAabbForFixtureAtBodyOrigin)
 
     World world;
     const auto body = world.CreateBody();
-    const auto fixture = body->CreateFixture(shape);
+    const auto fixture = body->CreateFixture(Shape{shape});
     const auto fixtureAabb = ComputeAABB(*fixture);
     
     ASSERT_NE(shapeAabb, AABB{});
@@ -432,12 +432,12 @@ TEST(AABB, ComputeAabbForFixtureAtBodyOrigin)
 TEST(AABB, ComputeAabbForFixtureOffFromBodyOrigin)
 {
     const auto shape = DiskShapeConf{};
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(Shape{shape}, Transformation{});
     
     const auto bodyLocation = Length2{2_m, 3_m};
     World world;
     const auto body = world.CreateBody(BodyConf{}.UseLocation(bodyLocation));
-    const auto fixture = body->CreateFixture(shape);
+    const auto fixture = body->CreateFixture(Shape{shape});
     const auto fixtureAabb = ComputeAABB(*fixture);
     
     ASSERT_NE(shapeAabb, AABB{});
@@ -448,11 +448,11 @@ TEST(AABB, ComputeAabbForFixtureOffFromBodyOrigin)
 TEST(AABB, ComputeIntersectingAABBForSameFixture)
 {
     const auto shape = DiskShapeConf{};
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(Shape{shape}, Transformation{});
     
     World world;
     const auto body = world.CreateBody();
-    const auto fixture = body->CreateFixture(shape);
+    const auto fixture = body->CreateFixture(Shape{shape});
     const auto fixtureAabb = ComputeAABB(*fixture);
     
     const auto intersectingAabb = ComputeIntersectingAABB(*fixture, 0, *fixture, 0);
@@ -467,7 +467,7 @@ TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
     const auto shapeInterval = LengthInterval{-2_m, +2_m};
 
     const auto shape = DiskShapeConf{}.UseRadius(2_m);
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(Shape{shape}, Transformation{});
     ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
 
     const auto bodyLocation0 = Length2{+1_m, 0_m};
@@ -477,8 +477,8 @@ TEST(AABB, ComputeIntersectingAABBForTwoFixtures)
     const auto body0 = world.CreateBody(BodyConf{}.UseLocation(bodyLocation0));
     const auto body1 = world.CreateBody(BodyConf{}.UseLocation(bodyLocation1));
 
-    const auto fixture0 = body0->CreateFixture(shape);
-    const auto fixture1 = body1->CreateFixture(shape);
+    const auto fixture0 = body0->CreateFixture(Shape{shape});
+    const auto fixture1 = body1->CreateFixture(Shape{shape});
 
     const auto fixtureAabb0 = ComputeAABB(*fixture0);
     const auto fixtureAabb1 = ComputeAABB(*fixture1);
@@ -496,7 +496,7 @@ TEST(AABB, ComputeIntersectingAABBForContact)
     const auto shapeInterval = LengthInterval{-2_m, +2_m};
     
     const auto shape = DiskShapeConf{}.UseRadius(2_m);
-    const auto shapeAabb = ComputeAABB(shape, Transformation{});
+    const auto shapeAabb = ComputeAABB(Shape{shape}, Transformation{});
     ASSERT_EQ(shapeAabb, (AABB{shapeInterval, shapeInterval}));
     
     const auto bodyLocation0 = Length2{+1_m, 0_m};
@@ -506,8 +506,8 @@ TEST(AABB, ComputeIntersectingAABBForContact)
     const auto body0 = world.CreateBody(BodyConf{}.UseLocation(bodyLocation0));
     const auto body1 = world.CreateBody(BodyConf{}.UseLocation(bodyLocation1));
     
-    const auto fixture0 = body0->CreateFixture(shape);
-    const auto fixture1 = body1->CreateFixture(shape);
+    const auto fixture0 = body0->CreateFixture(Shape{shape});
+    const auto fixture1 = body1->CreateFixture(Shape{shape});
     
     const auto fixtureAabb0 = ComputeAABB(*fixture0);
     const auto fixtureAabb1 = ComputeAABB(*fixture1);

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/AABB.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>

--- a/UnitTests/Acceleration.cpp
+++ b/UnitTests/Acceleration.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Acceleration.hpp>
 
 using namespace playrho;

--- a/UnitTests/Angle.cpp
+++ b/UnitTests/Angle.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/ArrayList.cpp
+++ b/UnitTests/ArrayList.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/ArrayList.hpp>
 #include <PlayRho/Common/Vector.hpp>
 //#include <PlayRho/Common/Math.hpp>

--- a/UnitTests/BlockAllocator.cpp
+++ b/UnitTests/BlockAllocator.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/BlockAllocator.hpp>
 
 using namespace playrho;

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyConf.hpp>
 #include <PlayRho/Dynamics/World.hpp>

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -267,7 +267,7 @@ TEST(Body, CreateFixture)
     const auto body = world.CreateBody();
     EXPECT_EQ(GetFixtureCount(*body), std::size_t(0));
 
-    const auto valid_shape = DiskShapeConf(1_m);
+    const auto valid_shape = Shape{DiskShapeConf(1_m)};
     EXPECT_NE(body->CreateFixture(valid_shape, FixtureConf{}), nullptr);
 
     EXPECT_EQ(GetFixtureCount(*body), std::size_t(1));
@@ -281,7 +281,7 @@ TEST(Body, DestroyFixture)
     ASSERT_EQ(GetFixtureCount(*bodyA), std::size_t(0));
     ASSERT_EQ(GetFixtureCount(*bodyB), std::size_t(0));
 
-    const auto fixtureA = bodyA->CreateFixture(DiskShapeConf(1_m), FixtureConf{});
+    const auto fixtureA = bodyA->CreateFixture(Shape{DiskShapeConf(1_m)}, FixtureConf{});
     ASSERT_NE(fixtureA, nullptr);
     ASSERT_EQ(GetFixtureCount(*bodyA), std::size_t(1));
 
@@ -296,7 +296,7 @@ TEST(Body, SetEnabled)
     auto stepConf = StepConf{};
     World world;
     const auto body = world.CreateBody();
-    const auto valid_shape = DiskShapeConf(1_m);
+    const auto valid_shape = Shape{DiskShapeConf(1_m)};
 
     const auto fixture = body->CreateFixture(valid_shape, FixtureConf{});
     ASSERT_NE(fixture, nullptr);
@@ -329,7 +329,7 @@ TEST(Body, SetFixedRotation)
 {
     World world;
     const auto body = world.CreateBody();
-    const auto valid_shape = DiskShapeConf(1_m);
+    const auto valid_shape = Shape{DiskShapeConf(1_m)};
 
     ASSERT_NE(body->CreateFixture(valid_shape, FixtureConf{}), nullptr);
     ASSERT_FALSE(body->IsFixedRotation());
@@ -790,7 +790,7 @@ TEST(Body, CalcGravitationalAcceleration)
     const auto l1 = Length2{-8_m, 0_m};
     const auto l2 = Length2{+8_m, 0_m};
     const auto l3 = Length2{+16_m, 0_m};
-    const auto shape = DiskShapeConf{}.UseRadius(2_m).UseDensity(1e10_kgpm2);
+    const auto shape = Shape{DiskShapeConf{}.UseRadius(2_m).UseDensity(1e10_kgpm2)};
     
     const auto b1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l1));
     b1->CreateFixture(shape);
@@ -837,7 +837,7 @@ TEST(Body, GetCentripetalForce)
     const auto l1 = Length2{-8_m, 0_m};
     auto world = World{};
     const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l1));
-    const auto shape = DiskShapeConf{}.UseRadius(2_m).UseDensity(1_kgpm2);
+    const auto shape = Shape{DiskShapeConf{}.UseRadius(2_m).UseDensity(1_kgpm2)};
     body->CreateFixture(shape);
     SetLinearVelocity(*body, LinearVelocity2{2_mps, 3_mps});
     EXPECT_EQ(GetLinearVelocity(*body), LinearVelocity2(2_mps, 3_mps));

--- a/UnitTests/BodyConstraint.cpp
+++ b/UnitTests/BodyConstraint.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
 using namespace playrho;

--- a/UnitTests/BoundedValue.cpp
+++ b/UnitTests/BoundedValue.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/BoundedValue.hpp>
 #include <limits>
 #include <cmath>

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -89,7 +89,7 @@ TEST(ChainShapeConf, Visit)
     ASSERT_EQ(data.visitedPolygon, 0);
     ASSERT_EQ(data.visitedChain, 0);
     ASSERT_EQ(data.visitedMulti, 0);
-    Visit(s, &data);
+    EXPECT_TRUE(Visit(s, &data));
     EXPECT_EQ(data.visitedDisk, 0);
     EXPECT_EQ(data.visitedEdge, 0);
     EXPECT_EQ(data.visitedPolygon, 0);

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -22,6 +22,7 @@
 #include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <array>
+#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -81,6 +82,7 @@ TEST(ChainShapeConf, GetInvalidChildThrows)
 
 TEST(ChainShapeConf, Accept)
 {
+#if 0
     auto visited = false;
     auto shapeVisited = false;
     const auto foo = ChainShapeConf{};
@@ -96,6 +98,7 @@ TEST(ChainShapeConf, Accept)
     });
     EXPECT_TRUE(visited);
     EXPECT_TRUE(shapeVisited);
+#endif
 }
 
 TEST(ChainShapeConf, OneVertexLikeDisk)

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <array>
@@ -78,6 +78,23 @@ TEST(ChainShapeConf, GetInvalidChildThrows)
     ASSERT_EQ(GetChildCount(foo), ChildCounter{0});
     EXPECT_THROW(GetChild(foo, 0), InvalidArgument);
     EXPECT_THROW(GetChild(foo, 1), InvalidArgument);
+}
+
+TEST(ChainShapeConf, Visit)
+{
+    const auto s = Shape{ChainShapeConf{}};
+    auto data = UnitTestsVisitorData{};
+    ASSERT_EQ(data.visitedDisk, 0);
+    ASSERT_EQ(data.visitedEdge, 0);
+    ASSERT_EQ(data.visitedPolygon, 0);
+    ASSERT_EQ(data.visitedChain, 0);
+    ASSERT_EQ(data.visitedMulti, 0);
+    Visit(s, &data);
+    EXPECT_EQ(data.visitedDisk, 0);
+    EXPECT_EQ(data.visitedEdge, 0);
+    EXPECT_EQ(data.visitedPolygon, 0);
+    EXPECT_EQ(data.visitedChain, 1);
+    EXPECT_EQ(data.visitedMulti, 0);
 }
 
 TEST(ChainShapeConf, Accept)

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Manifold.hpp>
 #include <PlayRho/Collision/WorldManifold.hpp>
 #include <PlayRho/Collision/ShapeSeparation.hpp>

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -60,8 +60,8 @@ TEST(Contact, Enabled)
     const auto shape = DiskShapeConf{};
     auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
     auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, shape};
-    auto fB = Fixture{&bB, FixtureConf{}, shape};
+    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
+    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
     auto c = Contact{&fA, 0u, &fB, 0u};
     EXPECT_TRUE(c.IsEnabled());
     c.UnsetEnabled();
@@ -75,8 +75,8 @@ TEST(Contact, SetAwake)
     const auto shape = DiskShapeConf{};
     auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
     auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, shape};
-    auto fB = Fixture{&bB, FixtureConf{}, shape};
+    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
+    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
     const auto c = Contact{&fA, 0u, &fB, 0u};
     
     bA.UnsetAwake();
@@ -96,8 +96,8 @@ TEST(Contact, ResetFriction)
     const auto shape = DiskShapeConf{};
     auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
     auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, shape};
-    auto fB = Fixture{&bB, FixtureConf{}, shape};
+    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
+    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
     auto c = Contact{&fA, 0u, &fB, 0u};
 
     ASSERT_GT(GetFriction(shape), Real(0));
@@ -113,8 +113,8 @@ TEST(Contact, ResetRestitution)
     const auto shape = DiskShapeConf{};
     auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
     auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, shape};
-    auto fB = Fixture{&bB, FixtureConf{}, shape};
+    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
+    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
     auto c = Contact{&fA, 0u, &fB, 0u};
 
     ASSERT_EQ(GetRestitution(shape), Real(0));

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Body.hpp>

--- a/UnitTests/ContactFeature.cpp
+++ b/UnitTests/ContactFeature.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/ContactFeature.hpp>
 #include <sstream>
 

--- a/UnitTests/ContactImpulsesList.cpp
+++ b/UnitTests/ContactImpulsesList.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/ContactImpulsesList.hpp>
 
 using namespace playrho;

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/PositionConstraint.hpp>
 #include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
 #include <PlayRho/Collision/AABB.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
@@ -78,6 +78,23 @@ TEST(DiskShapeConf, GetInvalidChildThrows)
     ASSERT_EQ(GetChildCount(foo), ChildCounter{1});
     EXPECT_NO_THROW(GetChild(foo, 0));
     EXPECT_THROW(GetChild(foo, 1), InvalidArgument);
+}
+
+TEST(DiskShapeConf, Visit)
+{
+    const auto s = Shape{DiskShapeConf{}};
+    auto data = UnitTestsVisitorData{};
+    ASSERT_EQ(data.visitedDisk, 0);
+    ASSERT_EQ(data.visitedEdge, 0);
+    ASSERT_EQ(data.visitedPolygon, 0);
+    ASSERT_EQ(data.visitedChain, 0);
+    ASSERT_EQ(data.visitedMulti, 0);
+    Visit(s, &data);
+    EXPECT_EQ(data.visitedDisk, 1);
+    EXPECT_EQ(data.visitedEdge, 0);
+    EXPECT_EQ(data.visitedPolygon, 0);
+    EXPECT_EQ(data.visitedChain, 0);
+    EXPECT_EQ(data.visitedMulti, 0);
 }
 
 TEST(DiskShapeConf, Accept)

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -89,7 +89,7 @@ TEST(DiskShapeConf, Visit)
     ASSERT_EQ(data.visitedPolygon, 0);
     ASSERT_EQ(data.visitedChain, 0);
     ASSERT_EQ(data.visitedMulti, 0);
-    Visit(s, &data);
+    EXPECT_TRUE(Visit(s, &data));
     EXPECT_EQ(data.visitedDisk, 1);
     EXPECT_EQ(data.visitedEdge, 0);
     EXPECT_EQ(data.visitedPolygon, 0);

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -22,6 +22,7 @@
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
 #include <PlayRho/Collision/AABB.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
+#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -81,6 +82,7 @@ TEST(DiskShapeConf, GetInvalidChildThrows)
 
 TEST(DiskShapeConf, Accept)
 {
+#if 0
     auto visited = false;
     auto diskVisited = false;
     Shape foo{DiskShapeConf{}};
@@ -95,6 +97,7 @@ TEST(DiskShapeConf, Accept)
     });
     EXPECT_TRUE(visited);
     EXPECT_TRUE(diskVisited);
+#endif
 }
 
 #if 0

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Distance.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -124,7 +124,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
 {
     World world{};
     
-    const auto shape = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto shape = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     
     const auto location1 = Length2{-1_m, 0_m};
     const auto body1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location1));
@@ -178,7 +178,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
 {
     auto world = World{};
     
-    const auto shape = DiskShapeConf{}.UseRadius(0.2_m).UseDensity(1_kgpm2);
+    const auto shape = Shape{DiskShapeConf{}.UseRadius(0.2_m).UseDensity(1_kgpm2)};
     const auto location1 = Length2{-10_m, 10_m};
     const auto body1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location1));
     ASSERT_EQ(body1->GetLocation(), location1);

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/DistanceJoint.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/ShapeSeparation.hpp>
 #include <initializer_list>

--- a/UnitTests/Dump.cpp
+++ b/UnitTests/Dump.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/PlayRho.hpp>
 #include <PlayRho/Common/CodeDumper.hpp>
 

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/DynamicTree.hpp>
 #include <type_traits>
 

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
+#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -53,6 +54,7 @@ TEST(EdgeShapeConf, GetInvalidChildThrows)
 
 TEST(EdgeShapeConf, Accept)
 {
+#if 0
     auto visited = false;
     auto shapeVisited = false;
     const auto foo = EdgeShapeConf{};
@@ -67,6 +69,7 @@ TEST(EdgeShapeConf, Accept)
     });
     EXPECT_TRUE(visited);
     EXPECT_TRUE(shapeVisited);
+#endif
 }
 
 #if 0

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <typeinfo>
@@ -50,6 +50,19 @@ TEST(EdgeShapeConf, GetInvalidChildThrows)
     ASSERT_EQ(GetChildCount(foo), ChildCounter{1});
     EXPECT_NO_THROW(GetChild(foo, 0));
     EXPECT_THROW(GetChild(foo, 1), InvalidArgument);
+}
+
+TEST(EdgeShapeConf, Visit)
+{
+    const auto s = Shape{EdgeShapeConf{}};
+    auto data = UnitTestsVisitorData{};
+    ASSERT_EQ(data.visitedDisk, 0);
+    ASSERT_EQ(data.visitedEdge, 0);
+    ASSERT_EQ(data.visitedPolygon, 0);
+    ASSERT_EQ(data.visitedChain, 0);
+    ASSERT_EQ(data.visitedMulti, 0);
+    Visit(s, &data);
+    EXPECT_EQ(data.visitedEdge, 1);
 }
 
 TEST(EdgeShapeConf, Accept)

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -61,7 +61,7 @@ TEST(EdgeShapeConf, Visit)
     ASSERT_EQ(data.visitedPolygon, 0);
     ASSERT_EQ(data.visitedChain, 0);
     ASSERT_EQ(data.visitedMulti, 0);
-    Visit(s, &data);
+    EXPECT_TRUE(Visit(s, &data));
     EXPECT_EQ(data.visitedDisk, 0);
     EXPECT_EQ(data.visitedEdge, 1);
     EXPECT_EQ(data.visitedPolygon, 0);

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -62,7 +62,11 @@ TEST(EdgeShapeConf, Visit)
     ASSERT_EQ(data.visitedChain, 0);
     ASSERT_EQ(data.visitedMulti, 0);
     Visit(s, &data);
+    EXPECT_EQ(data.visitedDisk, 0);
     EXPECT_EQ(data.visitedEdge, 1);
+    EXPECT_EQ(data.visitedPolygon, 0);
+    EXPECT_EQ(data.visitedChain, 0);
+    EXPECT_EQ(data.visitedMulti, 0);
 }
 
 TEST(EdgeShapeConf, Accept)

--- a/UnitTests/Epsilon.cpp
+++ b/UnitTests/Epsilon.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/Filter.cpp
+++ b/UnitTests/Filter.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Filter.hpp>
 
 using namespace playrho;

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Fixed.hpp>
 #include <PlayRho/Common/FixedLimits.hpp>
 #include <PlayRho/Common/Math.hpp>

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/World.hpp>

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -75,7 +75,7 @@ TEST(Fixture, CreateMatchesConf)
 
 TEST(Fixture, SetSensor)
 {
-    const auto shapeA = DiskShapeConf{};
+    const auto shapeA = Shape{DiskShapeConf{}};
     const auto bodyCtrPos = Length2(1_m, 2_m);
     
     World world;
@@ -91,7 +91,7 @@ TEST(Fixture, SetSensor)
 
 TEST(Fixture, TestPointFreeFunction)
 {
-    const auto shapeA = DiskShapeConf{};
+    const auto shapeA = Shape{DiskShapeConf{}};
     const auto bodyCtrPos = Length2(1_m, 2_m);
 
     World world;
@@ -103,7 +103,7 @@ TEST(Fixture, TestPointFreeFunction)
 
 TEST(Fixture, SetAwakeFreeFunction)
 {
-    const auto shapeA = DiskShapeConf{};
+    const auto shapeA = Shape{DiskShapeConf{}};
 
     World world;
     const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));

--- a/UnitTests/FixtureProxy.cpp
+++ b/UnitTests/FixtureProxy.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
 
 using namespace playrho;

--- a/UnitTests/FlagGuard.cpp
+++ b/UnitTests/FlagGuard.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <cstdint>
 #include <cstddef>
 #include <PlayRho/Common/FlagGuard.hpp>

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/FrictionJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -144,8 +144,8 @@ TEST(FrictionJoint, WithDynamicCircles)
     const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
-    b1->CreateFixture(circle);
-    b2->CreateFixture(circle);
+    b1->CreateFixture(Shape{circle});
+    b2->CreateFixture(Shape{circle});
     auto jd = FrictionJointConf{};
     jd.bodyA = b1;
     jd.bodyB = b2;

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 #include <PlayRho/Dynamics/Joints/GearJoint.hpp>
 #include <PlayRho/Dynamics/Joints/DistanceJointConf.hpp>

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -199,7 +199,7 @@ TEST(GearJoint, GetGearJointConf)
 
 TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -230,7 +230,7 @@ TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
 
 TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -261,7 +261,7 @@ TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
 
 TEST(GearJoint, GetAnchorAandB)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/GrowableStack.cpp
+++ b/UnitTests/GrowableStack.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 #include <PlayRho/Common/GrowableStack.hpp>
 

--- a/UnitTests/IndexPair.cpp
+++ b/UnitTests/IndexPair.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/IndexPair.hpp>
 
 using namespace playrho;

--- a/UnitTests/Interval.cpp
+++ b/UnitTests/Interval.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Interval.hpp>
 #include <PlayRho/Common/OptionalValue.hpp>
 #include <limits>

--- a/UnitTests/Island.cpp
+++ b/UnitTests/Island.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/StackAllocator.hpp>
 #include <PlayRho/Dynamics/Island.hpp>
 #include <type_traits>

--- a/UnitTests/Joint.cpp
+++ b/UnitTests/Joint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 #include <type_traits>

--- a/UnitTests/JointType.cpp
+++ b/UnitTests/JointType.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/JointType.hpp>
 
 using namespace playrho;

--- a/UnitTests/Manifold.cpp
+++ b/UnitTests/Manifold.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Manifold.hpp>
 
 using namespace playrho;

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/MassData.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>

--- a/UnitTests/Mat22.cpp
+++ b/UnitTests/Mat22.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/Mat33.cpp
+++ b/UnitTests/Mat33.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 #include <type_traits>
 #include <chrono>

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -190,7 +190,7 @@ TEST(MotorJoint, GetMotorJointConf)
 
 TEST(MotorJoint, WithDynamicCircles)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -216,7 +216,7 @@ TEST(MotorJoint, WithDynamicCircles)
 
 TEST(MotorJoint, SetLinearOffset)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -240,7 +240,7 @@ TEST(MotorJoint, SetLinearOffset)
 
 TEST(MotorJoint, SetAngularOffset)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 #include <PlayRho/Dynamics/Joints/MotorJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -23,6 +23,7 @@
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 #include <array>
+#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -81,6 +82,7 @@ TEST(MultiShapeConf, GetInvalidChildThrows)
 
 TEST(MultiShapeConf, Accept)
 {
+#if 0
     auto visited = false;
     auto shapeVisited = false;
     
@@ -96,7 +98,9 @@ TEST(MultiShapeConf, Accept)
     });
     EXPECT_TRUE(visited);
     EXPECT_TRUE(shapeVisited);
+#endif
 }
+
 #if 0
 TEST(MultiShapeConf, BaseVisitorForDiskShape)
 {

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/MultiShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
@@ -78,6 +78,19 @@ TEST(MultiShapeConf, GetInvalidChildThrows)
     ASSERT_EQ(GetChildCount(foo), ChildCounter{0});
     EXPECT_THROW(GetChild(foo, 0), InvalidArgument);
     EXPECT_THROW(GetChild(foo, 1), InvalidArgument);
+}
+
+TEST(MultiShapeConf, Visit)
+{
+    const auto s = Shape{MultiShapeConf{}};
+    auto data = UnitTestsVisitorData{};
+    ASSERT_EQ(data.visitedDisk, 0);
+    ASSERT_EQ(data.visitedEdge, 0);
+    ASSERT_EQ(data.visitedPolygon, 0);
+    ASSERT_EQ(data.visitedChain, 0);
+    ASSERT_EQ(data.visitedMulti, 0);
+    Visit(s, &data);
+    EXPECT_EQ(data.visitedMulti, 1);
 }
 
 TEST(MultiShapeConf, Accept)

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -89,7 +89,7 @@ TEST(MultiShapeConf, Visit)
     ASSERT_EQ(data.visitedPolygon, 0);
     ASSERT_EQ(data.visitedChain, 0);
     ASSERT_EQ(data.visitedMulti, 0);
-    Visit(s, &data);
+    EXPECT_TRUE(Visit(s, &data));
     EXPECT_EQ(data.visitedDisk, 0);
     EXPECT_EQ(data.visitedEdge, 0);
     EXPECT_EQ(data.visitedPolygon, 0);

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -90,6 +90,10 @@ TEST(MultiShapeConf, Visit)
     ASSERT_EQ(data.visitedChain, 0);
     ASSERT_EQ(data.visitedMulti, 0);
     Visit(s, &data);
+    EXPECT_EQ(data.visitedDisk, 0);
+    EXPECT_EQ(data.visitedEdge, 0);
+    EXPECT_EQ(data.visitedPolygon, 0);
+    EXPECT_EQ(data.visitedChain, 0);
     EXPECT_EQ(data.visitedMulti, 1);
 }
 

--- a/UnitTests/OptionalValue.cpp
+++ b/UnitTests/OptionalValue.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/OptionalValue.hpp>
 
 using namespace playrho;

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
+#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -72,6 +73,7 @@ TEST(PolygonShapeConf, GetInvalidChildThrows)
 
 TEST(PolygonShapeConf, Accept)
 {
+#if 0
     auto visited = false;
     auto shapeVisited = false;
     const auto foo = PolygonShapeConf{};
@@ -86,6 +88,7 @@ TEST(PolygonShapeConf, Accept)
     });
     EXPECT_TRUE(visited);
     EXPECT_TRUE(shapeVisited);
+#endif
 }
 
 TEST(PolygonShapeConf, FindLowestRightMostVertex)

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -80,7 +80,7 @@ TEST(PolygonShapeConf, Visit)
     ASSERT_EQ(data.visitedPolygon, 0);
     ASSERT_EQ(data.visitedChain, 0);
     ASSERT_EQ(data.visitedMulti, 0);
-    Visit(s, &data);
+    EXPECT_TRUE(Visit(s, &data));
     EXPECT_EQ(data.visitedPolygon, 1);
 }
 

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <typeinfo>
@@ -69,6 +69,19 @@ TEST(PolygonShapeConf, GetInvalidChildThrows)
     ASSERT_EQ(GetChildCount(foo), ChildCounter{1});
     EXPECT_NO_THROW(GetChild(foo, 0));
     EXPECT_THROW(GetChild(foo, 1), InvalidArgument);
+}
+
+TEST(PolygonShapeConf, Visit)
+{
+    const auto s = Shape{PolygonShapeConf{}};
+    auto data = UnitTestsVisitorData{};
+    ASSERT_EQ(data.visitedDisk, 0);
+    ASSERT_EQ(data.visitedEdge, 0);
+    ASSERT_EQ(data.visitedPolygon, 0);
+    ASSERT_EQ(data.visitedChain, 0);
+    ASSERT_EQ(data.visitedMulti, 0);
+    Visit(s, &data);
+    EXPECT_EQ(data.visitedPolygon, 1);
 }
 
 TEST(PolygonShapeConf, Accept)

--- a/UnitTests/PositionConstraint.cpp
+++ b/UnitTests/PositionConstraint.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Contacts/PositionConstraint.hpp>
 
 using namespace playrho;

--- a/UnitTests/PositionSolverManifold.cpp
+++ b/UnitTests/PositionSolverManifold.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp>
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/WorldManifold.hpp>

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/PrismaticJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -262,8 +262,8 @@ TEST(PrismaticJoint, WithDynamicCirclesAndLimitEnabled)
     const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
-    b1->CreateFixture(circle);
-    b2->CreateFixture(circle);
+    b1->CreateFixture(Shape{circle});
+    b2->CreateFixture(Shape{circle});
     const auto anchor = Length2(2_m, 1_m);
     const auto jd = PrismaticJointConf{b1, b2, anchor, UnitVec::GetRight()}.UseEnableLimit(true);
     const auto joint = static_cast<PrismaticJoint*>(world.CreateJoint(jd));

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/PulleyJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>

--- a/UnitTests/RayCastOutput.cpp
+++ b/UnitTests/RayCastOutput.cpp
@@ -180,7 +180,7 @@ TEST(RayCastOutput, RayCastShapeFF)
     const auto maxFraction = Real(1);
     const auto input = RayCastInput{p1, p2, maxFraction};
     const auto xfm = Transform_identity;
-    const auto output = RayCast(DiskShapeConf{1_m}, ChildCounter{0}, input, xfm);
+    const auto output = RayCast(Shape{DiskShapeConf{1_m}}, ChildCounter{0}, input, xfm);
     EXPECT_TRUE(output.has_value());
     EXPECT_EQ(output->normal, d2::UnitVec::GetRight());
     EXPECT_NEAR(static_cast<double>(output->fraction), 0.75, 0.01);

--- a/UnitTests/RayCastOutput.cpp
+++ b/UnitTests/RayCastOutput.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 #include <PlayRho/Collision/RayCastOutput.hpp>
 #include <PlayRho/Collision/RayCastInput.hpp>

--- a/UnitTests/Real.cpp
+++ b/UnitTests/Real.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Real.hpp>
 #include <PlayRho/Common/Settings.hpp>
 #include <string>

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/RevoluteJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -310,7 +310,7 @@ TEST(RevoluteJoint, MaxMotorTorque)
 
 TEST(RevoluteJoint, MovesDynamicCircles)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     World world;
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -338,7 +338,7 @@ TEST(RevoluteJoint, MovesDynamicCircles)
 
 TEST(RevoluteJoint, LimitEnabledDynamicCircles)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m).UseDensity(1_kgpm2);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m).UseDensity(1_kgpm2)};
 
     World world;
     const auto p1 = Length2{-1_m, 0_m};
@@ -415,10 +415,10 @@ TEST(RevoluteJoint, DynamicJoinedToStaticStaysPut)
     const auto b1 = world.CreateBody(BodyConf{}.UseType(BodyType::Static).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
 
-    const auto shape1 = PolygonShapeConf{}.SetAsBox(1_m, 1_m);
+    const auto shape1 = Shape{PolygonShapeConf{}.SetAsBox(1_m, 1_m)};
     b1->CreateFixture(shape1);
     
-    const auto shape2 = PolygonShapeConf{}.SetAsBox(0.5_m, 0.5_m).UseDensity(1_kgpm2);
+    const auto shape2 = Shape{PolygonShapeConf{}.SetAsBox(0.5_m, 0.5_m).UseDensity(1_kgpm2)};
     b2->CreateFixture(shape2);
     
     auto jd = RevoluteJointConf{b1, b2, Length2{}};

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 #include <PlayRho/Dynamics/Joints/RopeJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -145,7 +145,7 @@ TEST(RopeJoint, GetRopeJointConf)
 
 TEST(RopeJoint, WithDynamicCircles)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/Rot.cpp
+++ b/UnitTests/Rot.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/SeparationFinder.cpp
+++ b/UnitTests/SeparationFinder.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/SeparationFinder.hpp>
 #include <PlayRho/Collision/Simplex.hpp>
 #include <PlayRho/Collision/TimeOfImpact.hpp>

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -24,6 +24,7 @@
 #include <PlayRho/Collision/Distance.hpp>
 #include <PlayRho/Collision/Manifold.hpp>
 #include <chrono>
+#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -43,6 +44,57 @@ TEST(Shape, ByteSize)
         case 16: EXPECT_EQ(sizeof(Shape), std::size_t(16)); break;
         default: FAIL(); break;
     }
+}
+
+TEST(Shape, Traits)
+{
+    EXPECT_FALSE(std::is_default_constructible<Shape>::value);
+    EXPECT_FALSE(std::is_nothrow_default_constructible<Shape>::value);
+    EXPECT_FALSE(std::is_trivially_default_constructible<Shape>::value);
+    
+    // Construction with any 1 supporting argument should succeed...
+    using X = DiskShapeConf;
+    EXPECT_TRUE((std::is_constructible<Shape, X>::value));
+    EXPECT_FALSE((std::is_nothrow_constructible<Shape, X>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<Shape, X>::value));
+
+    // Construction with 2 arguments should fail...
+    EXPECT_FALSE((std::is_constructible<Shape, X, X>::value));
+    EXPECT_FALSE((std::is_nothrow_constructible<Shape, X, X>::value));
+    EXPECT_FALSE((std::is_trivially_constructible<Shape, X, X>::value));
+    
+    EXPECT_TRUE(std::is_copy_constructible<Shape>::value);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible<Shape>::value);
+    EXPECT_FALSE(std::is_trivially_copy_constructible<Shape>::value);
+    
+    EXPECT_TRUE(std::is_move_constructible<Shape>::value);
+    EXPECT_TRUE(std::is_nothrow_move_constructible<Shape>::value);
+    EXPECT_FALSE(std::is_trivially_move_constructible<Shape>::value);
+    
+    EXPECT_TRUE(std::is_copy_assignable<Shape>::value);
+    EXPECT_TRUE(std::is_nothrow_copy_assignable<Shape>::value);
+    EXPECT_FALSE(std::is_trivially_copy_assignable<Shape>::value);
+    
+    EXPECT_TRUE(std::is_move_assignable<Shape>::value);
+    EXPECT_TRUE(std::is_nothrow_move_assignable<Shape>::value);
+    EXPECT_FALSE(std::is_trivially_move_assignable<Shape>::value);
+    
+    EXPECT_TRUE(std::is_destructible<Shape>::value);
+    EXPECT_TRUE(std::is_nothrow_destructible<Shape>::value);
+    EXPECT_FALSE(std::is_trivially_destructible<Shape>::value);
+}
+
+TEST(Shape, types)
+{
+    const auto sc = DiskShapeConf{1_m};
+    const auto s1 = Shape{sc};
+    ASSERT_EQ(typeid(Shape), typeid(s1));
+    const auto& st1 = GetUseTypeInfo(s1);
+    ASSERT_NE(st1, typeid(Shape));
+    EXPECT_EQ(st1, typeid(sc));
+    const auto s2 = Shape{s1}; // This should copy construct
+    const auto& st2 = GetUseTypeInfo(s2);
+    EXPECT_EQ(st2, typeid(sc)); // Confirm s2 was a copy construction
 }
 
 TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -214,3 +214,68 @@ TEST(Shape, Inequality)
 
     EXPECT_TRUE(Shape(DiskShapeConf()) != Shape(EdgeShapeConf()));
 }
+
+namespace {
+
+struct X {};
+
+ChildCounter GetChildCount(const X&) noexcept
+{
+    return ChildCounter{0};
+}
+
+DistanceProxy GetChild(const X&, ChildCounter)
+{
+    return DistanceProxy{};
+}
+
+MassData GetMassData(const X&) noexcept
+{
+    return MassData{};
+}
+
+NonNegative<Length> GetVertexRadius(const X&) noexcept
+{
+    return 0_m;
+}
+
+NonNegative<AreaDensity> GetDensity(const X&) noexcept
+{
+    return 0_kgpm2;
+}
+
+Finite<Real> GetRestitution(const X&) noexcept
+{
+    return Real{0};
+}
+
+NonNegative<Real> GetFriction(const X&) noexcept
+{
+    return Real{0};
+}
+
+bool operator== (const X&, const X&) noexcept
+{
+    return true;
+}
+
+#if 0
+bool operator!= (const X& lhs, const X& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+#endif
+
+} // anonymous namespace
+
+TEST(Shape, NewConfig)
+{
+    const auto s = Shape{X{}};
+    auto data = UnitTestsVisitorData{};
+    EXPECT_FALSE(Visit(s, &data));
+    EXPECT_EQ(data.visitedDisk, 0);
+    EXPECT_EQ(data.visitedEdge, 0);
+    EXPECT_EQ(data.visitedPolygon, 0);
+    EXPECT_EQ(data.visitedChain, 0);
+    EXPECT_EQ(data.visitedMulti, 0);
+}

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -2,21 +2,23 @@
  * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>

--- a/UnitTests/Simplex.cpp
+++ b/UnitTests/Simplex.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/Simplex.hpp>
 
 using namespace playrho;

--- a/UnitTests/SimplexEdge.cpp
+++ b/UnitTests/SimplexEdge.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/SimplexEdge.hpp>
 
 using namespace playrho;

--- a/UnitTests/StackAllocator.cpp
+++ b/UnitTests/StackAllocator.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/StackAllocator.hpp>
 #include <chrono>
 

--- a/UnitTests/StepConf.cpp
+++ b/UnitTests/StepConf.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/World.hpp>
 

--- a/UnitTests/StepStats.cpp
+++ b/UnitTests/StepStats.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/StepStats.hpp>
 
 using namespace playrho;

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Joints/TargetJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 #include <PlayRho/Dynamics/World.hpp>

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/TimeOfImpact.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/UnitTests.hpp
+++ b/UnitTests/UnitTests.hpp
@@ -42,7 +42,7 @@ struct DiskShapeConf;
 class EdgeShapeConf;
 class PolygonShapeConf;
 class ChainShapeConf;
-class MultiShapeConf;
+struct MultiShapeConf;
 
 } // namespace d2
 

--- a/UnitTests/UnitTests.hpp
+++ b/UnitTests/UnitTests.hpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef UnitTests_hpp
+#define UnitTests_hpp
+
+#include "gtest/gtest.h"
+
+#include <PlayRho/Common/Templates.hpp>
+
+struct UnitTestsVisitorData
+{
+    int visitedShape = 0;
+    int visitedDisk = 0;
+    int visitedEdge = 0;
+    int visitedPolygon = 0;
+    int visitedChain = 0;
+    int visitedMulti = 0;
+};
+
+namespace playrho {
+namespace d2 {
+
+struct DiskShapeConf;
+class EdgeShapeConf;
+class PolygonShapeConf;
+class ChainShapeConf;
+class MultiShapeConf;
+
+} // namespace d2
+
+// Specialize the template Visit function.
+// Note: These should be included by all code (within the UnitTests application)
+//   that uses the Shape class in order to avoid U.B. from O.D.R. violations.
+
+template <>
+inline void Visit(const d2::DiskShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedDisk);
+}
+
+template <>
+inline void Visit(const d2::EdgeShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedEdge);
+}
+
+template <>
+inline void Visit(const d2::PolygonShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedPolygon);
+}
+
+template <>
+inline void Visit(const d2::ChainShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedChain);
+}
+
+template <>
+inline void Visit(const d2::MultiShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedMulti);
+}
+
+} // namespace playrho
+
+#endif /* UnitTests_hpp */

--- a/UnitTests/UnitTests.hpp
+++ b/UnitTests/UnitTests.hpp
@@ -51,38 +51,43 @@ class MultiShapeConf;
 //   that uses the Shape class in order to avoid U.B. from O.D.R. violations.
 
 template <>
-inline void Visit(const d2::DiskShapeConf&, void* userData)
+inline bool Visit(const d2::DiskShapeConf&, void* userData)
 {
     const auto data = static_cast<UnitTestsVisitorData*>(userData);
     ++(data->visitedDisk);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::EdgeShapeConf&, void* userData)
+inline bool Visit(const d2::EdgeShapeConf&, void* userData)
 {
     const auto data = static_cast<UnitTestsVisitorData*>(userData);
     ++(data->visitedEdge);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::PolygonShapeConf&, void* userData)
+inline bool Visit(const d2::PolygonShapeConf&, void* userData)
 {
     const auto data = static_cast<UnitTestsVisitorData*>(userData);
     ++(data->visitedPolygon);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::ChainShapeConf&, void* userData)
+inline bool Visit(const d2::ChainShapeConf&, void* userData)
 {
     const auto data = static_cast<UnitTestsVisitorData*>(userData);
     ++(data->visitedChain);
+    return true;
 }
 
 template <>
-inline void Visit(const d2::MultiShapeConf&, void* userData)
+inline bool Visit(const d2::MultiShapeConf&, void* userData)
 {
     const auto data = static_cast<UnitTestsVisitorData*>(userData);
     ++(data->visitedMulti);
+    return true;
 }
 
 } // namespace playrho

--- a/UnitTests/UnitVec.cpp
+++ b/UnitTests/UnitVec.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/UnitVec.hpp>
 #include <PlayRho/Common/Math.hpp>
 #include <iostream>

--- a/UnitTests/Units.cpp
+++ b/UnitTests/Units.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Units.hpp>
 
 using namespace playrho;

--- a/UnitTests/Vec2.cpp
+++ b/UnitTests/Vec2.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 #include <sstream>
 #include <type_traits>

--- a/UnitTests/Vec3.cpp
+++ b/UnitTests/Vec3.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 #include <sstream>
 #include <type_traits>

--- a/UnitTests/Vector.cpp
+++ b/UnitTests/Vector.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Vector.hpp>
 #include <PlayRho/Common/Math.hpp>
 #include <sstream>

--- a/UnitTests/Velocity.cpp
+++ b/UnitTests/Velocity.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
 
 using namespace playrho;

--- a/UnitTests/VelocityConstraint.cpp
+++ b/UnitTests/VelocityConstraint.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 #include <PlayRho/Collision/WorldManifold.hpp>

--- a/UnitTests/Version.cpp
+++ b/UnitTests/Version.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/Version.hpp>
 
 using namespace playrho;

--- a/UnitTests/VertexSet.cpp
+++ b/UnitTests/VertexSet.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Common/VertexSet.hpp>
 
 using namespace playrho;

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -143,7 +143,7 @@ TEST(WeldJoint, GetWeldJointConf)
 
 TEST(WeldJoint, WithDynamicCircles)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
@@ -165,7 +165,7 @@ TEST(WeldJoint, WithDynamicCircles)
 
 TEST(WeldJoint, WithDynamicCircles2)
 {
-    const auto circle = DiskShapeConf{}.UseRadius(0.2_m);
+    const auto circle = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 #include <PlayRho/Dynamics/Joints/WeldJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 #include <PlayRho/Dynamics/Joints/WheelJoint.hpp>
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -263,8 +263,8 @@ TEST(WheelJoint, WithDynamicCircles)
     const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
     const auto b2 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
-    b1->CreateFixture(circle);
-    b2->CreateFixture(circle);
+    b1->CreateFixture(Shape{circle});
+    b2->CreateFixture(Shape{circle});
     const auto anchor = Length2(2_m, 1_m);
     const auto jd = WheelJointConf{b1, b2, anchor, UnitVec::GetRight()};
     const auto joint = static_cast<WheelJoint*>(world.CreateJoint(jd));

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -593,6 +593,9 @@ TEST(World, RayCast)
     const auto b1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
     ASSERT_NE(b1->CreateFixture(Shape{DiskShapeConf{0.1_m}}), nullptr);
 
+    const auto b2 = world.CreateBody(BodyConf{}.UseType(BodyType::Static).UseLocation(Length2{-100_m, -100_m}));
+    ASSERT_NE(b2->CreateFixture(Shape{EdgeShapeConf{Length2{}, Length2{-20_m, -20_m}}}), nullptr);
+
     const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
     ASSERT_NE(body, nullptr);
     ASSERT_EQ(body->GetType(), BodyType::Dynamic);
@@ -752,6 +755,16 @@ TEST(World, RayCast)
         EXPECT_FALSE(retval);
         EXPECT_EQ(foundOurs, 0);
         EXPECT_EQ(foundOthers, 0);
+    }
+    {
+        auto found = 0;
+        const auto rci = RayCastInput{Length2{-100_m, -101_m}, Length2{-120_m, -121_m}, Real{0.9f}};
+        const auto retval = RayCast(world.GetTree(), rci, [&](Fixture*, ChildCounter, Length2, UnitVec) {
+            ++found;
+            return RayCastOpcode::Terminate;
+        });
+        EXPECT_FALSE(retval);
+        EXPECT_EQ(found, 0);
     }
 }
 

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Body.hpp>

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -394,8 +394,8 @@ TEST(World, CreateDestroyJoinedBodies)
     const auto body2 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
     EXPECT_EQ(GetBodyCount(world), BodyCounter(2));
 
-    body->CreateFixture(DiskShapeConf{1_m});
-    body2->CreateFixture(DiskShapeConf{1_m});
+    body->CreateFixture(Shape{DiskShapeConf{1_m}});
+    body2->CreateFixture(Shape{DiskShapeConf{1_m}});
 
     EXPECT_EQ(world.GetContacts().size(), ContactCounter(0));
     
@@ -440,8 +440,8 @@ TEST(World, CreateDestroyContactingBodies)
     const auto body2 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l2));
     EXPECT_EQ(GetBodyCount(world), BodyCounter(2));
     
-    EXPECT_NE(body1->CreateFixture(DiskShapeConf{1_m}.UseDensity(1_kgpm2)), nullptr);
-    EXPECT_NE(body2->CreateFixture(DiskShapeConf{1_m}.UseDensity(1_kgpm2)), nullptr);
+    EXPECT_NE(body1->CreateFixture(Shape{DiskShapeConf{1_m}.UseDensity(1_kgpm2)}), nullptr);
+    EXPECT_NE(body2->CreateFixture(Shape{DiskShapeConf{1_m}.UseDensity(1_kgpm2)}), nullptr);
     EXPECT_EQ(GetFixtureCount(world), std::size_t(2));
     
     auto stepConf = StepConf{};
@@ -470,10 +470,10 @@ TEST(World, CreateAndDestroyFixture)
     ASSERT_EQ(GetFixtureCount(*bodyA), std::size_t(0));
     ASSERT_EQ(GetFixtureCount(*bodyB), std::size_t(0));
     
-    EXPECT_THROW(world.CreateFixture(*bodyA, DiskShapeConf(0_m)), InvalidArgument);
-    EXPECT_THROW(world.CreateFixture(*bodyA, DiskShapeConf(WorldConf{}.maxVertexRadius * 2)), InvalidArgument);
+    EXPECT_THROW(world.CreateFixture(*bodyA, Shape{DiskShapeConf(0_m)}), InvalidArgument);
+    EXPECT_THROW(world.CreateFixture(*bodyA, Shape{DiskShapeConf(WorldConf{}.maxVertexRadius * 2)}), InvalidArgument);
 
-    const auto fixtureA = world.CreateFixture(*bodyA, DiskShapeConf(1_m));
+    const auto fixtureA = world.CreateFixture(*bodyA, Shape{DiskShapeConf(1_m)});
     ASSERT_NE(fixtureA, nullptr);
     ASSERT_EQ(GetFixtureCount(*bodyA), std::size_t(1));
     EXPECT_FALSE(other.TouchProxies(*fixtureA));
@@ -485,11 +485,11 @@ TEST(World, CreateAndDestroyFixture)
     
     const auto bodyC = other.CreateBody();
     ASSERT_NE(bodyC, nullptr);
-    const auto fixtureC = other.CreateFixture(*bodyC, DiskShapeConf(1_m));
+    const auto fixtureC = other.CreateFixture(*bodyC, Shape{DiskShapeConf(1_m)});
     ASSERT_NE(fixtureC, nullptr);
     EXPECT_FALSE(world.DestroyFixture(fixtureC));
     
-    EXPECT_THROW(world.CreateFixture(*bodyC, DiskShapeConf(1_m)), InvalidArgument);
+    EXPECT_THROW(world.CreateFixture(*bodyC, Shape{DiskShapeConf(1_m)}), InvalidArgument);
 }
 
 TEST(World, SynchronizeProxies)
@@ -499,7 +499,7 @@ TEST(World, SynchronizeProxies)
     
     EXPECT_EQ(world.Step(stepConf).pre.proxiesMoved, PreStepStats::counter_type(0));
     const auto bodyA = world.CreateBody();
-    world.CreateFixture(*bodyA, DiskShapeConf(1_m));
+    world.CreateFixture(*bodyA, Shape{DiskShapeConf(1_m)});
     EXPECT_EQ(world.Step(stepConf).pre.proxiesMoved, PreStepStats::counter_type(0));
     SetLocation(*bodyA, Length2{10_m, -4_m});
     EXPECT_EQ(world.Step(stepConf).pre.proxiesMoved, PreStepStats::counter_type(1));
@@ -530,7 +530,7 @@ TEST(World, RegisterFixtureForProxies)
     auto world = World{};
     EXPECT_FALSE(world.RegisterForProxies(static_cast<Fixture*>(nullptr)));
     const auto body = world.CreateBody();
-    const auto fixture = body->CreateFixture(DiskShapeConf(1_m));
+    const auto fixture = body->CreateFixture(Shape{DiskShapeConf(1_m)});
     EXPECT_TRUE(world.RegisterForProxies(fixture));
 }
 
@@ -554,7 +554,7 @@ TEST(World, QueryAABB)
     const auto v2 = Length2{+1_m, 0_m};
     const auto conf = EdgeShapeConf{}.UseVertexRadius(1_m).UseDensity(1_kgpm2).Set(v1, v2);
     ASSERT_EQ(GetChildCount(conf), ChildCounter(1));
-    const auto fixture = body->CreateFixture(conf);
+    const auto fixture = body->CreateFixture(Shape{conf});
     ASSERT_NE(fixture, nullptr);
     
     auto stepConf = StepConf{};
@@ -587,11 +587,11 @@ TEST(World, RayCast)
 
     const auto p0 = Length2{-10_m, +3_m};
     const auto b0 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p0));
-    ASSERT_NE(b0->CreateFixture(DiskShapeConf{1_m}), nullptr);
+    ASSERT_NE(b0->CreateFixture(Shape{DiskShapeConf{1_m}}), nullptr);
 
     const auto p1 = Length2{+1_m, 0_m};
     const auto b1 = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    ASSERT_NE(b1->CreateFixture(DiskShapeConf{0.1_m}), nullptr);
+    ASSERT_NE(b1->CreateFixture(Shape{DiskShapeConf{0.1_m}}), nullptr);
 
     const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
     ASSERT_NE(body, nullptr);
@@ -3299,7 +3299,7 @@ public:
     {
         const auto hw_ground = 40.0_m;
         const auto ground = world.CreateBody();
-        ground->CreateFixture(EdgeShapeConf{}.Set(Length2{-hw_ground, 0_m}, Length2{hw_ground, 0_m}));
+        ground->CreateFixture(Shape{EdgeShapeConf{}.Set(Length2{-hw_ground, 0_m}, Length2{hw_ground, 0_m})});
         const auto numboxes = boxes.size();
         original_x = GetParam();
         

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -165,7 +165,7 @@ TEST(WorldManifold, GetWorldManifoldForCirclesFullyOverlappingManifold)
 
 TEST(WorldManifold, GetForContact)
 {
-    const auto shape = DiskShapeConf{};
+    const auto shape = Shape{DiskShapeConf{}};
     auto bA = Body{nullptr, BodyConf{}};
     auto bB = Body{nullptr, BodyConf{}};
     auto fA = Fixture{&bA, FixtureConf{}, shape};

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <PlayRho/Collision/WorldManifold.hpp>
 #include <PlayRho/Collision/Manifold.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>

--- a/UnitTests/double.cpp
+++ b/UnitTests/double.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "UnitTests.hpp"
+#include <type_traits>
+#include <cmath>
+
+TEST(double, GetInvalid)
+{
+    auto val = playrho::GetInvalid<double>();
+    EXPECT_TRUE(std::isnan(val));
+    const auto same = std::is_same<decltype(val), double>::value;
+    EXPECT_TRUE(same);
+}
+
+TEST(double, GetTypeName)
+{
+    const auto name = playrho::GetTypeName<double>();
+    EXPECT_STREQ(name, "double");
+}
+

--- a/UnitTests/float.cpp
+++ b/UnitTests/float.cpp
@@ -24,6 +24,7 @@
 #include <limits>
 #include <iostream>
 #include <cstring>
+#include <type_traits>
 
 TEST(float, BiggerValsIncreasinglyInaccurate)
 {
@@ -355,4 +356,18 @@ TEST(float, zero)
     EXPECT_EQ(-0.0f / 1.0f, 0.0f);
     EXPECT_TRUE(-3.0f * 0.0f == +0.0f);
     EXPECT_EQ(-3.0f * 0.0f, -0.0f);
+}
+
+TEST(float, GetInvalid)
+{
+    auto val = playrho::GetInvalid<float>();
+    EXPECT_TRUE(std::isnan(val));
+    const auto same = std::is_same<decltype(val), float>::value;
+    EXPECT_TRUE(same);
+}
+
+TEST(float, GetTypeName)
+{
+    const auto name = playrho::GetTypeName<float>();
+    EXPECT_STREQ(name, "float");
 }

--- a/UnitTests/float.cpp
+++ b/UnitTests/float.cpp
@@ -18,7 +18,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <cmath>
 #include <algorithm>
 #include <limits>

--- a/UnitTests/forward_list.cpp
+++ b/UnitTests/forward_list.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <forward_list>
 
 TEST(forward_list, EmptyListIsEmpty)

--- a/UnitTests/functional.cpp
+++ b/UnitTests/functional.cpp
@@ -16,7 +16,7 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 #include <functional>
 
 TEST(functional, FunctionSize)

--- a/UnitTests/main.cpp
+++ b/UnitTests/main.cpp
@@ -2,21 +2,23 @@
  * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "gtest/gtest.h"
+#include "UnitTests.hpp"
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
#### Description - What's this PR do?
- Renames playrho::d2::Draw* visiting functions to playrho::Visit* functions.
-Ties in Testbed visitation of shapes more directly into the Visit function template.
- Makes initialization construction of Shape instances explicit.
- Updates documentation comments.