### PR TITLE
Several changes to Shape class

### DIFF
--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -43,11 +43,7 @@ namespace {
 #endif
 } // anonymous namespace
 
-ChainShapeConf::ChainShapeConf():
-    ShapeBuilder{ShapeConf{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}}
-{
-    // Intentionally empty.
-}
+ChainShapeConf::ChainShapeConf() = default;
 
 ChainShapeConf& ChainShapeConf::Set(std::vector<Length2> vertices)
 {
@@ -104,7 +100,6 @@ MassData ChainShapeConf::GetMassData() const noexcept
     const auto density = this->density;
     if (density > AreaDensity(0))
     {
-        const auto vertexRadius = this->vertexRadius;
         const auto vertexCount = GetVertexCount();
         if (vertexCount > 1)
         {
@@ -147,7 +142,6 @@ DistanceProxy ChainShapeConf::GetChild(ChildCounter index) const
     {
         throw InvalidArgument("index out of range");
     }
-    const auto vertexRadius = this->vertexRadius;
     const auto vertexCount = GetVertexCount();
     if (vertexCount > 1)
     {

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -51,7 +51,7 @@ public:
     /// @brief Gets the default vertex radius.
     static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
-        return DefaultLinearSlop * 2;
+        return NonNegative<Length>{DefaultLinearSlop * Real{2}};
     }
 
     /// @brief Default constructor.
@@ -126,7 +126,7 @@ public:
     ///
     /// @note This should be a non-negative value.
     ///
-    NonNegative<Length> vertexRadius = NonNegative<Length>{DefaultLinearSlop * Real{2}};
+    NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
 
 private:
     std::vector<Length2> m_vertices; ///< Vertices.
@@ -173,13 +173,13 @@ inline ChildCounter GetNextIndex(const ChainShapeConf& shape, ChildCounter index
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg) noexcept
+inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg)
 {
     return arg.vertexRadius;
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCounter) noexcept
+inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCounter)
 {
     return GetVertexRadius(arg);
 }

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -77,6 +77,9 @@ public:
     /// @brief Gets the mass data.
     MassData GetMassData() const noexcept;
     
+    /// @brief Uses the given vertex radius.
+    inline ChainShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
+
     /// @brief Gets the vertex count.
     ChildCounter GetVertexCount() const noexcept
     {
@@ -112,10 +115,29 @@ public:
         return !(lhs == rhs);
     }
     
+    /// @brief Vertex radius.
+    ///
+    /// @details This is the radius from the vertex that the shape's "skin" should
+    ///   extend outward by. While any edges &mdash; line segments between multiple
+    ///   vertices &mdash; are straight, corners between them (the vertices) are
+    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+    ///   to edge lengths therefore will be more prone to rolling or having other
+    ///   shapes more prone to roll off of them.
+    ///
+    /// @note This should be a non-negative value.
+    ///
+    NonNegative<Length> vertexRadius = NonNegative<Length>{DefaultLinearSlop * Real{2}};
+
 private:
     std::vector<Length2> m_vertices; ///< Vertices.
     std::vector<UnitVec> m_normals; ///< Normals.
 };
+
+inline ChainShapeConf& ChainShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
+{
+    vertexRadius = value;
+    return *this;
+}
 
 // Free functions...
 
@@ -148,6 +170,18 @@ inline bool IsLooped(const ChainShapeConf& shape) noexcept
 inline ChildCounter GetNextIndex(const ChainShapeConf& shape, ChildCounter index) noexcept
 {
     return GetModuloNext(index, shape.GetVertexCount());
+}
+
+/// @brief Gets the vertex radius of the given shape configuration.
+inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg) noexcept
+{
+    return arg.vertexRadius;
+}
+
+/// @brief Gets the vertex radius of the given shape configuration.
+inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCounter) noexcept
+{
+    return GetVertexRadius(arg);
 }
 
 } // namespace d2

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -41,18 +41,15 @@ namespace d2 {
 struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
 {
     /// @brief Gets the default radius.
-    static PLAYRHO_CONSTEXPR inline Length GetDefaultRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultRadius() noexcept
     {
-        return DefaultLinearSlop * 2;
+        return NonNegative<Length>{DefaultLinearSlop * 2};
     }
 
-    PLAYRHO_CONSTEXPR inline DiskShapeConf(): ShapeBuilder{ShapeConf{}.UseVertexRadius(GetDefaultRadius())}
-    {
-        // Intentionally empty.
-    }
+    PLAYRHO_CONSTEXPR DiskShapeConf() = default;
 
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline DiskShapeConf(Length radius): ShapeBuilder{ShapeConf{}.UseVertexRadius(radius)}
+    PLAYRHO_CONSTEXPR inline DiskShapeConf(NonNegative<Length> r): vertexRadius{r}
     {
         // Intentionally empty.
     }
@@ -65,9 +62,9 @@ struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
     }
     
     /// @brief Uses the given value as the radius.
-    PLAYRHO_CONSTEXPR inline DiskShapeConf& UseRadius(Length radius) noexcept
+    PLAYRHO_CONSTEXPR inline DiskShapeConf& UseRadius(NonNegative<Length> r) noexcept
     {
-        vertexRadius = radius;
+        vertexRadius = r;
         return *this;
     }
     
@@ -83,6 +80,19 @@ struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
         return location;
     }
     
+    /// @brief Vertex radius.
+    ///
+    /// @details This is the radius from the vertex that the shape's "skin" should
+    ///   extend outward by. While any edges &mdash; line segments between multiple
+    ///   vertices &mdash; are straight, corners between them (the vertices) are
+    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+    ///   to edge lengths therefore will be more prone to rolling or having other
+    ///   shapes more prone to roll off of them.
+    ///
+    /// @note This should be a non-negative value.
+    ///
+    NonNegative<Length> vertexRadius = GetDefaultRadius();
+
     /// @brief Location for the disk shape to be centered at.
     Length2 location = Length2{};
 };
@@ -117,6 +127,19 @@ inline DistanceProxy GetChild(const DiskShapeConf& arg, ChildCounter index)
         throw InvalidArgument("only index of 0 is supported");
     }
     return DistanceProxy{arg.vertexRadius, 1, &arg.location, nullptr};
+}
+
+/// @brief Gets the vertex radius of the given shape configuration.
+PLAYRHO_CONSTEXPR inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg) noexcept
+{
+    return arg.vertexRadius;
+}
+
+/// @brief Gets the vertex radius of the given shape configuration.
+PLAYRHO_CONSTEXPR inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg,
+                                                             ChildCounter) noexcept
+{
+    return GetVertexRadius(arg);
 }
 
 /// @brief Gets the mass data of the given disk shape configuration.

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
@@ -22,14 +22,8 @@
 namespace playrho {
 namespace d2 {
 
-EdgeShapeConf::EdgeShapeConf():
-    ShapeBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
-{
-    // Intentionally empty.
-}
-
 EdgeShapeConf::EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf) noexcept:
-    ShapeBuilder{conf}, m_vertices{vA, vB}
+    ShapeBuilder{conf}, vertexRadius{conf.vertexRadius}, m_vertices{vA, vB}
 {
     const auto normal = GetUnitVector(GetFwdPerpendicular(vB - vA));
     m_normals[0] = normal;

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -42,9 +42,9 @@ class EdgeShapeConf: public ShapeBuilder<EdgeShapeConf>
 {
 public:
     /// @brief Gets the default vertex radius.
-    static PLAYRHO_CONSTEXPR inline Length GetDefaultVertexRadius() noexcept
+    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
-        return DefaultLinearSlop * Real{2};
+        return NonNegative<Length>{DefaultLinearSlop * Real{2}};
     }
     
     /// @brief Gets the default configuration.
@@ -53,7 +53,7 @@ public:
         return EdgeShapeConf{};
     }
 
-    EdgeShapeConf();
+    EdgeShapeConf() = default;
     
     /// @brief Initializing constructor.
     EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf = GetDefaultConf()) noexcept;
@@ -61,6 +61,9 @@ public:
     /// @brief Sets both vertices in one call.
     EdgeShapeConf& Set(Length2 vA, Length2 vB) noexcept;
     
+    /// @brief Uses the given vertex radius.
+    EdgeShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
+
     /// @brief Gets vertex A.
     Length2 GetVertexA() const noexcept
     {
@@ -79,10 +82,29 @@ public:
         return DistanceProxy{vertexRadius, 2, m_vertices, m_normals};
     }
     
+    /// @brief Vertex radius.
+    ///
+    /// @details This is the radius from the vertex that the shape's "skin" should
+    ///   extend outward by. While any edges &mdash; line segments between multiple
+    ///   vertices &mdash; are straight, corners between them (the vertices) are
+    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+    ///   to edge lengths therefore will be more prone to rolling or having other
+    ///   shapes more prone to roll off of them.
+    ///
+    /// @note This should be a non-negative value.
+    ///
+    NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
+
 private:
     Length2 m_vertices[2] = {Length2{}, Length2{}}; ///< Vertices
     UnitVec m_normals[2] = {UnitVec{}, UnitVec{}}; ///< Normals.
 };
+
+inline EdgeShapeConf& EdgeShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
+{
+    vertexRadius = value;
+    return *this;
+}
 
 // Free functions...
 
@@ -115,6 +137,18 @@ inline DistanceProxy GetChild(const EdgeShapeConf& arg, ChildCounter index)
         throw InvalidArgument("only index of 0 is supported");
     }
     return arg.GetChild();
+}
+
+/// @brief Gets the vertex radius of the given shape configuration.
+inline NonNegative<Length> GetVertexRadius(const EdgeShapeConf& arg) noexcept
+{
+    return arg.vertexRadius;
+}
+
+/// @brief Gets the vertex radius of the given shape configuration.
+inline NonNegative<Length> GetVertexRadius(const EdgeShapeConf& arg, ChildCounter) noexcept
+{
+    return GetVertexRadius(arg);
 }
 
 /// @brief Gets the mass data for the given shape configuration.

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -23,11 +23,7 @@
 namespace playrho {
 namespace d2 {
 
-PolygonShapeConf::PolygonShapeConf():
-    ShapeBuilder{ShapeConf{}.UseVertexRadius(GetDefaultVertexRadius())}
-{
-    // Intentionally empty.
-}
+PolygonShapeConf::PolygonShapeConf() = default;
 
 PolygonShapeConf::PolygonShapeConf(Length hx, Length hy,
                                    const PolygonShapeConf& conf) noexcept:

--- a/PlayRho/Collision/Shapes/Shape.cpp
+++ b/PlayRho/Collision/Shapes/Shape.cpp
@@ -23,8 +23,58 @@
 
 namespace playrho {
 namespace d2 {
+namespace {
 
-// Free functions...
+struct DefaultShapeConf
+{
+};
+
+ChildCounter GetChildCount(const DefaultShapeConf&) noexcept
+{
+    return 0;
+}
+
+DistanceProxy GetChild(const DefaultShapeConf&, ChildCounter)
+{
+    throw InvalidArgument("index out of range");
+}
+
+MassData GetMassData(const DefaultShapeConf&) noexcept
+{
+    return MassData{};
+}
+
+Real GetFriction(const DefaultShapeConf&) noexcept
+{
+    return Real{0};
+}
+
+Real GetRestitution(const DefaultShapeConf&) noexcept
+{
+    return Real{0};
+}
+
+NonNegative<AreaDensity> GetDensity(const DefaultShapeConf&) noexcept
+{
+    return NonNegative<AreaDensity>{0_kgpm2};
+}
+
+NonNegative<Length> GetVertexRadius(const DefaultShapeConf&, ChildCounter)
+{
+    throw InvalidArgument("index out of range");
+}
+
+constexpr bool operator== (const DefaultShapeConf&, const DefaultShapeConf&) noexcept
+{
+    return true;
+}
+
+} // annonymous namespace
+
+Shape::Shape(): m_self{std::make_shared<Model<DefaultShapeConf>>(DefaultShapeConf{})}
+{
+    // Intentionally empty.
+}
 
 bool TestPoint(const Shape& shape, Length2 point) noexcept
 {

--- a/PlayRho/Collision/Shapes/ShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ShapeConf.hpp
@@ -33,19 +33,6 @@ namespace d2 {
 /// @note This is a nested base value class for initializing shapes.
 struct BaseShapeConf
 {
-    /// @brief Vertex radius.
-    ///
-    /// @details This is the radius from the vertex that the shape's "skin" should
-    ///   extend outward by. While any edges &mdash; line segments between multiple
-    ///   vertices &mdash; are straight, corners between them (the vertices) are
-    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
-    ///   to edge lengths therefore will be more prone to rolling or having other
-    ///   shapes more prone to roll off of them.
-    ///
-    /// @note This should be a non-negative value.
-    ///
-    NonNegative<Length> vertexRadius = NonNegative<Length>{DefaultLinearSlop * Real{2}};
-    
     /// @brief Friction coefficient.
     ///
     /// @note This must be a value between 0 and +infinity. It is safer however to
@@ -92,9 +79,6 @@ struct ShapeBuilder: BaseShapeConf
     {
         // Intentionally empty.
     }
-
-    /// @brief Uses the given vertex radius.
-    PLAYRHO_CONSTEXPR inline ConcreteConf& UseVertexRadius(NonNegative<Length> value) noexcept;
     
     /// @brief Uses the given friction.
     PLAYRHO_CONSTEXPR inline ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
@@ -105,14 +89,6 @@ struct ShapeBuilder: BaseShapeConf
     /// @brief Uses the given density.
     PLAYRHO_CONSTEXPR inline ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
 };
-
-template <typename ConcreteConf>
-PLAYRHO_CONSTEXPR inline ConcreteConf&
-ShapeBuilder<ConcreteConf>::UseVertexRadius(NonNegative<Length> value) noexcept
-{
-    vertexRadius = value;
-    return static_cast<ConcreteConf&>(*this);
-}
 
 template <typename ConcreteConf>
 PLAYRHO_CONSTEXPR inline ConcreteConf&
@@ -145,12 +121,6 @@ struct ShapeConf: public ShapeBuilder<ShapeConf>
 };
 
 // Free functions...
-
-/// @brief Gets the vertex radius of the given shape configuration.
-PLAYRHO_CONSTEXPR inline NonNegative<Length> GetVertexRadius(const BaseShapeConf& arg) noexcept
-{
-    return arg.vertexRadius;
-}
 
 /// @brief Gets the density of the given shape configuration.
 PLAYRHO_CONSTEXPR inline NonNegative<AreaDensity> GetDensity(const BaseShapeConf& arg) noexcept

--- a/PlayRho/Collision/WorldManifold.cpp
+++ b/PlayRho/Collision/WorldManifold.cpp
@@ -126,12 +126,14 @@ WorldManifold GetWorldManifold(const Manifold& manifold,
 WorldManifold GetWorldManifold(const Contact& contact)
 {
     const auto fA = contact.GetFixtureA();
+    const auto iA = contact.GetChildIndexA();
     const auto xfA = GetTransformation(*fA);
-    const auto radiusA = GetVertexRadius(fA->GetShape());
+    const auto radiusA = GetVertexRadius(fA->GetShape(), iA);
 
     const auto fB = contact.GetFixtureB();
+    const auto iB = contact.GetChildIndexB();
     const auto xfB = GetTransformation(*fB);
-    const auto radiusB = GetVertexRadius(fB->GetShape());
+    const auto radiusB = GetVertexRadius(fB->GetShape(), iB);
 
     return GetWorldManifold(contact.GetManifold(), xfA, radiusA, xfB, radiusB);
 }

--- a/PlayRho/Dynamics/Contacts/Contact.cpp
+++ b/PlayRho/Dynamics/Contacts/Contact.cpp
@@ -67,16 +67,6 @@ Contact::Contact(Fixture* fA, ChildCounter iA, Fixture* fB, ChildCounter iB):
     assert(fA->GetBody() != fB->GetBody());
 }
 
-ChildCounter Contact::GetChildIndexA() const noexcept
-{
-    return m_indexA;
-}
-
-ChildCounter Contact::GetChildIndexB() const noexcept
-{
-    return m_indexB;
-}
-
 void Contact::Update(const UpdateConf& conf, ContactListener* listener)
 {
     const auto oldManifold = m_manifold;

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -510,6 +510,16 @@ inline void Contact::UnsetIslanded() noexcept
     m_flags &= ~e_islandFlag;
 }
 
+inline ChildCounter Contact::GetChildIndexA() const noexcept
+{
+    return m_indexA;
+}
+
+inline ChildCounter Contact::GetChildIndexB() const noexcept
+{
+    return m_indexB;
+}
+
 // Free functions...
 
 /// @brief Contact pointer type.
@@ -535,6 +545,20 @@ inline Fixture* GetFixtureA(const Contact& contact) noexcept
 inline Fixture* GetFixtureB(const Contact& contact) noexcept
 {
     return contact.GetFixtureB();
+}
+
+/// @brief Gets the child index A of the given contact.
+/// @relatedalso Contact
+inline ChildCounter GetChildIndexA(const Contact& contact) noexcept
+{
+    return contact.GetChildIndexA();
+}
+
+/// @brief Gets the child index B of the given contact.
+/// @relatedalso Contact
+inline ChildCounter GetChildIndexB(const Contact& contact) noexcept
+{
+    return contact.GetChildIndexB();
 }
 
 /// @brief Whether the given contact has a sensor.

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -1063,13 +1063,14 @@ inline void ClearForces(World& world) noexcept
 /// @brief Creates a rectangular enclosure.
 /// @relatedalso World
 Body* CreateRectangularEnclosingBody(World& world, Length2 dimensions,
-                                     const ShapeConf& baseConf);
+                                     const ShapeConf& baseConf, Length thickness);
 
 /// @brief Creates a square enclosure.
 /// @relatedalso World
-inline Body* CreateSquareEnclosingBody(World& world, Length size, const ShapeConf& baseConf)
+inline Body* CreateSquareEnclosingBody(World& world, Length size, const ShapeConf& baseConf,
+                                       Length thickness)
 {
-    return CreateRectangularEnclosingBody(world, Length2{size, size}, baseConf);
+    return CreateRectangularEnclosingBody(world, Length2{size, size}, baseConf, thickness);
 }
     
 /// @brief Finds body in given world that's closest to the given location.

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -1147,18 +1147,17 @@ static void EntityUI(const Shape& shape)
     ImGui::ItemWidthContext itemWidthCtx(60);
 
     const auto density = GetDensity(shape);
-    const auto vertexRadius = GetVertexRadius(shape);
+    //const auto vertexRadius = GetVertexRadius(shape);
     const auto friction = GetFriction(shape);
     const auto restitution = GetRestitution(shape);
     const auto childCount = GetChildCount(shape);
 
     ImGui::LabelText("Density (kg/m^2)", "%.2e",
                      static_cast<double>(Real{density * SquareMeter / Kilogram}));
-    ImGui::LabelText("Vertex Radius (m)", "%.2e",
-                     static_cast<double>(Real{vertexRadius / Meter}));
     ImGui::LabelText("Friction", "%f", static_cast<double>(friction));
     ImGui::LabelText("Restitution", "%f", static_cast<double>(restitution));
     ImGui::LabelText("Child Count", "%u", childCount);
+    //ImGui::LabelText("Vertex Radius (m)", "%.2e", static_cast<double>(Real{vertexRadius / Meter}));
 }
 
 static void EntityUI(Fixture& fixture)

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -95,7 +95,7 @@ public:
     Body* CreateEnclosure(Length vertexRadius, Length wallLength)
     {
         const auto body = CreateSquareEnclosingBody(m_world, wallLength, ShapeConf{
-            }.UseVertexRadius(vertexRadius).UseRestitution(Finite<Real>(0)));
+            }.UseRestitution(Finite<Real>(0)), vertexRadius);
         SetLocation(*body, Length2{0_m, 20_m});
         return body;
     }

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -137,7 +137,7 @@ public:
             if (body && fixture)
             {
                 const auto shape = fixture->GetShape();
-                const auto lastLegitVertexRadius = GetVertexRadius(shape);
+                const auto lastLegitVertexRadius = GetVertexRadius(shape, 0);
                 const auto newVertexRadius = lastLegitVertexRadius - RadiusIncrement;
                 if (newVertexRadius >= 0_m)
                 {

--- a/Testbed/Tests/FifteenPuzzle.hpp
+++ b/Testbed/Tests/FifteenPuzzle.hpp
@@ -43,9 +43,8 @@ namespace testbed {
         FifteenPuzzle(): Test(GetTestConf())
         {
             m_gravity = LinearAcceleration2{};
-            const auto enclosure = CreateSquareEnclosingBody(m_world,
-                16_m + 2 * GetVertexRadius(), ShapeConf{}
-                .UseVertexRadius(GetVertexRadius()));
+            const auto enclosure = CreateSquareEnclosingBody(m_world, 16_m + 2 * GetVertexRadius(),
+                                                             ShapeConf{}, GetVertexRadius());
             SetLocation(*enclosure, GetCenter());
             
             for (auto i = 0; i < 15; ++i)

--- a/Testbed/Tests/JointsTest.hpp
+++ b/Testbed/Tests/JointsTest.hpp
@@ -132,7 +132,7 @@ private:
     Body* SetupContainer(Length2 center)
     {
         const auto b = CreateRectangularEnclosingBody(m_world, Length2{ColumnSize, RowSize},
-                                                      ShapeConf{});
+                                                      ShapeConf{}, DefaultLinearSlop * Real{2});
         SetLocation(*b, center);
         return b;
     }
@@ -211,8 +211,8 @@ private:
     {
         const auto containerBody = SetupContainer(center);
 
-        const auto sr = GetVertexRadius(m_smallDiskShape);
-        const auto nr = GetVertexRadius(m_diskShape);
+        const auto sr = GetVertexRadius(m_smallDiskShape, 0);
+        const auto nr = GetVertexRadius(m_diskShape, 0);
         const auto tr = sr + nr;
         const auto bd1 = BodyConf(DynamicBD).UseLocation(center - Length2{tr, 0_m});
         const auto body1 = m_world.CreateBody(bd1);
@@ -247,11 +247,11 @@ private:
         const auto joint3 = static_cast<PrismaticJoint*>(m_world.CreateJoint(jd3));
         
         auto jd4 = GearJointConf{joint1, joint2};
-        jd4.ratio = GetVertexRadius(m_diskShape) / GetVertexRadius(m_smallDiskShape);
+        jd4.ratio = GetVertexRadius(m_diskShape, 0) / GetVertexRadius(m_smallDiskShape, 0);
         m_gearJoint0 = static_cast<GearJoint*>(m_world.CreateJoint(jd4));
         
         auto jd5 = GearJointConf{joint2, joint3};
-        jd5.ratio = -1.0f / (GetVertexRadius(m_diskShape) / 1_m);
+        jd5.ratio = -1.0f / (GetVertexRadius(m_diskShape, 0) / 1_m);
         m_gearJoint1 = static_cast<GearJoint*>(m_world.CreateJoint(jd5));
     }
 

--- a/Testbed/Tests/OneSidedPlatform.hpp
+++ b/Testbed/Tests/OneSidedPlatform.hpp
@@ -84,7 +84,7 @@ public:
 
 #if 1
         const auto position = m_character->GetBody()->GetLocation();
-        if (GetY(position) < m_top + m_radius - GetVertexRadius(m_platform->GetShape()))
+        if (GetY(position) < m_top + m_radius - GetVertexRadius(m_platform->GetShape(), 0))
         {
             contact.UnsetEnabled();
         }

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -362,7 +362,7 @@ TEST(Body, CreateAndDestroyFixture)
     {
         auto fixture = body->CreateFixture(shape, FixtureConf{}, false);
         const auto fshape = fixture->GetShape();
-        EXPECT_EQ(GetVertexRadius(fshape), GetVertexRadius(shape));
+        EXPECT_EQ(GetVertexRadius(fshape, 0), GetVertexRadius(shape, 0));
         EXPECT_EQ(static_cast<const DiskShapeConf*>(GetData(fshape))->GetLocation(), conf.GetLocation());
         EXPECT_FALSE(body->GetFixtures().empty());
         {
@@ -392,7 +392,7 @@ TEST(Body, CreateAndDestroyFixture)
     {
         auto fixture = body->CreateFixture(shape, FixtureConf{}, false);
         const auto fshape = fixture->GetShape();
-        EXPECT_EQ(GetVertexRadius(fshape), GetVertexRadius(shape));
+        EXPECT_EQ(GetVertexRadius(fshape, 0), GetVertexRadius(shape, 0));
         EXPECT_EQ(static_cast<const DiskShapeConf*>(GetData(fshape))->GetLocation(), conf.GetLocation());
         EXPECT_FALSE(body->GetFixtures().empty());
         {

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -64,11 +64,12 @@ TEST(ChainShapeConf, DefaultConstruction)
     EXPECT_EQ(GetChildCount(foo), ChildCounter{0});
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{0});
     EXPECT_EQ(GetMassData(foo), defaultMassData);
-    
     for (auto i = ChildCounter{0}; i < GetChildCount(foo); ++i)
     {
         EXPECT_EQ(GetVertexRadius(foo, i), ChainShapeConf::GetDefaultVertexRadius());
     }
+    EXPECT_THROW(GetChild(foo, GetChildCount(foo)), InvalidArgument);
+    EXPECT_EQ(GetVertexRadius(foo, GetChildCount(foo)), ChainShapeConf::GetDefaultVertexRadius());
     EXPECT_EQ(GetDensity(foo), defaultConf.density);
     EXPECT_EQ(GetFriction(foo), defaultConf.friction);
     EXPECT_EQ(GetRestitution(foo), defaultConf.restitution);

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -65,7 +65,10 @@ TEST(ChainShapeConf, DefaultConstruction)
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{0});
     EXPECT_EQ(GetMassData(foo), defaultMassData);
     
-    EXPECT_EQ(GetVertexRadius(foo), ChainShapeConf::GetDefaultVertexRadius());
+    for (auto i = ChildCounter{0}; i < GetChildCount(foo); ++i)
+    {
+        EXPECT_EQ(GetVertexRadius(foo, i), ChainShapeConf::GetDefaultVertexRadius());
+    }
     EXPECT_EQ(GetDensity(foo), defaultConf.density);
     EXPECT_EQ(GetFriction(foo), defaultConf.friction);
     EXPECT_EQ(GetRestitution(foo), defaultConf.restitution);
@@ -133,7 +136,10 @@ TEST(ChainShapeConf, OneVertexLikeDisk)
     auto foo = ChainShapeConf{conf};
     EXPECT_EQ(GetChildCount(foo), ChildCounter{1});
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{1});
-    EXPECT_EQ(GetVertexRadius(foo), vertexRadius);
+    for (auto i = ChildCounter{0}; i < GetChildCount(foo); ++i)
+    {
+        EXPECT_EQ(GetVertexRadius(foo, i), vertexRadius);
+    }
     EXPECT_EQ(GetMassData(foo), expectedMassData);
     
     const auto child = GetChild(foo, 0);
@@ -156,7 +162,10 @@ TEST(ChainShapeConf, TwoVertexLikeEdge)
     auto foo = ChainShapeConf{conf};
     EXPECT_EQ(GetChildCount(foo), ChildCounter{1});
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{2});
-    EXPECT_EQ(GetVertexRadius(foo), vertexRadius);
+    for (auto i = ChildCounter{0}; i < GetChildCount(foo); ++i)
+    {
+        EXPECT_EQ(GetVertexRadius(foo, i), vertexRadius);
+    }
 }
 
 TEST(ChainShapeConf, TwoVertexDpLikeEdgeDp)
@@ -228,8 +237,10 @@ TEST(ChainShapeConf, FourVertex)
     auto foo = ChainShapeConf{conf};
     EXPECT_EQ(GetChildCount(foo), ChildCounter{4});
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{5});
-    EXPECT_EQ(GetVertexRadius(foo), vertexRadius);
-    
+    for (auto i = ChildCounter{0}; i < GetChildCount(foo); ++i)
+    {
+        EXPECT_EQ(GetVertexRadius(foo, i), vertexRadius);
+    }
     const auto massData = GetMassData(foo);
     EXPECT_EQ(massData.center, (Length2{}));
     const auto expectedMass = Mass{edgeMassData0.mass} * Real(4);
@@ -250,8 +261,10 @@ TEST(ChainShapeConf, WithCircleVertices)
     auto foo = ChainShapeConf{conf};
     EXPECT_EQ(GetChildCount(foo), ChildCounter{4});
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{5});
-    EXPECT_EQ(GetVertexRadius(foo), vertexRadius);
-    
+    for (auto i = ChildCounter{0}; i < GetChildCount(foo); ++i)
+    {
+        EXPECT_EQ(GetVertexRadius(foo, i), vertexRadius);
+    }
     const auto massData = GetMassData(foo);
     EXPECT_NEAR(static_cast<double>(Real(GetX(massData.center) / 1_m)), 0.0, 0.0001);
     EXPECT_NEAR(static_cast<double>(Real(GetY(massData.center) / 1_m)), 2.4142134189605713, 0.0001);

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -66,7 +66,7 @@ TEST(DiskShapeConf, InitConstruction)
     
     EXPECT_EQ(typeid(foo), typeid(Shape));
     EXPECT_EQ(GetChildCount(foo), ChildCounter{1});
-    EXPECT_EQ(GetVertexRadius(foo), radius);
+    EXPECT_EQ(GetVertexRadius(foo, 0), radius);
     EXPECT_EQ(GetX(conf.GetLocation()), GetX(position));
     EXPECT_EQ(GetY(conf.GetLocation()), GetY(position));
 }
@@ -173,8 +173,8 @@ TEST(DiskShapeConf, Equality)
     EXPECT_FALSE(DiskShapeConf().UseLocation(Length2(1_m, 2_m)) == DiskShapeConf());
     EXPECT_TRUE(DiskShapeConf().UseLocation(Length2(1_m, 2_m)) == DiskShapeConf().UseLocation(Length2(1_m, 2_m)));
     
-    EXPECT_FALSE(DiskShapeConf().UseVertexRadius(10_m) == DiskShapeConf());
-    EXPECT_TRUE(DiskShapeConf().UseVertexRadius(10_m) == DiskShapeConf().UseVertexRadius(10_m));
+    EXPECT_FALSE(DiskShapeConf().UseRadius(10_m) == DiskShapeConf());
+    EXPECT_TRUE(DiskShapeConf().UseRadius(10_m) == DiskShapeConf().UseRadius(10_m));
     
     EXPECT_FALSE(DiskShapeConf().UseDensity(10_kgpm2) == DiskShapeConf());
     EXPECT_TRUE(DiskShapeConf().UseDensity(10_kgpm2) == DiskShapeConf().UseDensity(10_kgpm2));
@@ -194,8 +194,8 @@ TEST(DiskShapeConf, Inequality)
     EXPECT_TRUE(DiskShapeConf().UseLocation(Length2(1_m, 2_m)) != DiskShapeConf());
     EXPECT_FALSE(DiskShapeConf().UseLocation(Length2(1_m, 2_m)) != DiskShapeConf().UseLocation(Length2(1_m, 2_m)));
     
-    EXPECT_TRUE(DiskShapeConf().UseVertexRadius(10_m) != DiskShapeConf());
-    EXPECT_FALSE(DiskShapeConf().UseVertexRadius(10_m) != DiskShapeConf().UseVertexRadius(10_m));
+    EXPECT_TRUE(DiskShapeConf().UseRadius(10_m) != DiskShapeConf());
+    EXPECT_FALSE(DiskShapeConf().UseRadius(10_m) != DiskShapeConf().UseRadius(10_m));
     
     EXPECT_TRUE(DiskShapeConf().UseDensity(10_kgpm2) != DiskShapeConf());
     EXPECT_FALSE(DiskShapeConf().UseDensity(10_kgpm2) != DiskShapeConf().UseDensity(10_kgpm2));

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -43,14 +43,14 @@ TEST(MultiShapeConf, ByteSize)
 #if !defined(NDEBUG)
             EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(36));
 #else
-            EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(28));
+            EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(24));
 #endif
 #else
             EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(40));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(56)); break;
-        case 16: EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(96)); break;
+        case  8: EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(48)); break;
+        case 16: EXPECT_EQ(sizeof(MultiShapeConf), std::size_t(80)); break;
         default: FAIL(); break;
     }
 }
@@ -64,10 +64,11 @@ TEST(MultiShapeConf, DefaultConstruction)
     EXPECT_EQ(typeid(foo), typeid(MultiShapeConf));
     EXPECT_EQ(GetChildCount(foo), ChildCounter{0});
     EXPECT_EQ(GetMassData(foo), defaultMassData);
-    
     EXPECT_EQ(GetDensity(foo), defaultConf.density);
     EXPECT_EQ(GetFriction(foo), defaultConf.friction);
     EXPECT_EQ(GetRestitution(foo), defaultConf.restitution);
+    EXPECT_THROW(GetChild(foo, 0), InvalidArgument);
+    EXPECT_THROW(GetVertexRadius(foo, 0), InvalidArgument);
 }
 
 TEST(MultiShapeConf, GetInvalidChildThrows)

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -97,6 +97,8 @@ TEST(Shape, DefaultConstruction)
     EXPECT_EQ(GetChildCount(s), 0);
     EXPECT_THROW(GetChild(s, 0), InvalidArgument);
     EXPECT_TRUE(s == s);
+    const auto t = Shape{};
+    EXPECT_TRUE(s == t);
 }
 
 TEST(Shape, types)

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -50,7 +50,7 @@ TEST(Shape, ByteSize)
 
 TEST(Shape, Traits)
 {
-    EXPECT_FALSE(std::is_default_constructible<Shape>::value);
+    EXPECT_TRUE(std::is_default_constructible<Shape>::value);
     EXPECT_FALSE(std::is_nothrow_default_constructible<Shape>::value);
     EXPECT_FALSE(std::is_trivially_default_constructible<Shape>::value);
     
@@ -84,6 +84,19 @@ TEST(Shape, Traits)
     EXPECT_TRUE(std::is_destructible<Shape>::value);
     EXPECT_TRUE(std::is_nothrow_destructible<Shape>::value);
     EXPECT_FALSE(std::is_trivially_destructible<Shape>::value);
+}
+
+TEST(Shape, DefaultConstruction)
+{
+    const auto s = Shape{};
+    EXPECT_EQ(GetMassData(s), MassData());
+    EXPECT_EQ(GetFriction(s), Real(0));
+    EXPECT_EQ(GetRestitution(s), Real(0));
+    EXPECT_EQ(GetDensity(s), 0_kgpm2);
+    EXPECT_THROW(GetVertexRadius(s, 0), InvalidArgument);
+    EXPECT_EQ(GetChildCount(s), 0);
+    EXPECT_THROW(GetChild(s, 0), InvalidArgument);
+    EXPECT_TRUE(s == s);
 }
 
 TEST(Shape, types)
@@ -234,7 +247,7 @@ MassData GetMassData(const X&) noexcept
     return MassData{};
 }
 
-NonNegative<Length> GetVertexRadius(const X&) noexcept
+NonNegative<Length> GetVertexRadius(const X&, ChildCounter) noexcept
 {
     return 0_m;
 }

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -931,7 +931,7 @@ TEST(World, CreateSquareEnclosingBody)
 {
     World world;
     Body* body = nullptr;
-    EXPECT_NO_THROW(body = CreateSquareEnclosingBody(world, 2_m, ShapeConf{}));
+    EXPECT_NO_THROW(body = CreateSquareEnclosingBody(world, 2_m, ShapeConf{}, DefaultLinearSlop * Real{2}));
     ASSERT_NE(body, nullptr);
     EXPECT_EQ(body->GetType(), BodyType::Static);
     const auto fixtures = body->GetFixtures();
@@ -1019,14 +1019,14 @@ TEST(World, DynamicEdgeBodyHasCorrectMass)
     const auto v2 = Length2{+1_m, 0_m};
     const auto conf = EdgeShapeConf{}.UseVertexRadius(1_m).UseDensity(1_kgpm2).Set(v1, v2);
     const auto shape = Shape{conf};
-    ASSERT_EQ(GetVertexRadius(shape), 1_m);
+    ASSERT_EQ(GetVertexRadius(shape, 0), 1_m);
 
     const auto fixture = body->CreateFixture(shape);
     ASSERT_NE(fixture, nullptr);
     ASSERT_EQ(fixture->GetDensity(), 1_kgpm2);
 
-    const auto circleMass = Mass{fixture->GetDensity() * (Pi * Square(GetVertexRadius(shape)))};
-    const auto rectMass = Mass{fixture->GetDensity() * (GetVertexRadius(shape) * 2 * GetMagnitude(v2 - v1))};
+    const auto circleMass = Mass{fixture->GetDensity() * (Pi * Square(GetVertexRadius(shape, 0)))};
+    const auto rectMass = Mass{fixture->GetDensity() * (GetVertexRadius(shape, 0) * 2 * GetMagnitude(v2 - v1))};
     const auto totalMass = Mass{circleMass + rectMass};
     
     EXPECT_EQ(body->GetType(), BodyType::Dynamic);


### PR DESCRIPTION
#### Description - What's this PR do?
- Changes the Shape class to make the vertex radius dependent on the child index.
- Adds default construction to Shape class. This makes it usable for types like std::vector.

#### Related Issues
- Issue #276.