### PR TITLE
Various changes including removing inline from Visit template functions

### DIFF
--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -114,7 +114,7 @@ struct AABB
 template <std::size_t N>
 PLAYRHO_CONSTEXPR inline bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
 {
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         if (lhs.ranges[i] != rhs.ranges[i])
         {

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -64,10 +64,17 @@ struct AABB
     /// @note If an unset AABB is added to another AABB, the result will be the other AABB.
     PLAYRHO_CONSTEXPR inline AABB() = default;
     
-    /// @brief Initializing copy constructor.
+    /// @brief Initializing constructor.
+    /// @details Initializing constructor supporting construction by the same number of elements
+    ///   as this AABB template type is defined for.
+    /// @note For example this enables a 2-dimensional AABB to be constructed as:
+    /// @code{.cpp}
+    /// const auto aabb = AABB<2>{LengthInterval{1_m, 4_m}, LengthInterval{-3_m, 3_m}};
+    /// @endcode
     template<typename... Tail>
-    PLAYRHO_CONSTEXPR inline AABB(typename std::enable_if<sizeof...(Tail)+1 == N, LengthInterval>::type head,
-                   Tail... tail) noexcept: ranges{head, LengthInterval(tail)...}
+    PLAYRHO_CONSTEXPR inline AABB(typename std::enable_if<sizeof...(Tail)+1 == N,
+                                  LengthInterval>::type head, Tail... tail) noexcept:
+        ranges{head, LengthInterval(tail)...}
     {
         // Intentionally empty.
     }

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -23,7 +23,6 @@
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
-#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 

--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -90,7 +90,7 @@ void ChainShapeConf::ResetNormals()
 ChainShapeConf& ChainShapeConf::Transform(const Mat22& m) noexcept
 {
     std::for_each(std::begin(m_vertices), std::end(m_vertices), [=](Length2& v){
-        v = playrho::Transform(v, m);
+        v = m * v;
     });
     ResetNormals();
     return *this;

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -26,6 +26,7 @@
 #include <PlayRho/Collision/Shapes/ShapeConf.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
+#include <PlayRho/Collision/AABB.hpp>
 #include <vector>
 
 namespace playrho {
@@ -57,11 +58,16 @@ public:
     /// @brief Default constructor.
     ChainShapeConf();
     
-    /// @brief Sets the configuration up for representing a chain of the given vertices.
-    ChainShapeConf& Set(std::vector<Length2> vertices);
-
+    /// @brief Sets the configuration up for representing a chain of vertices as given.
+    ChainShapeConf& Set(std::vector<Length2> arg);
+    
     /// @brief Adds the given vertex.
     ChainShapeConf& Add(Length2 vertex);
+    
+    /// @brief Transforms all the vertices by the given transformation matrix.
+    /// @note This updates the normals too.
+    /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+    ChainShapeConf& Transform(const Mat22& m) noexcept;
 
     /// @brief Gets the "child" shape count.
     ChildCounter GetChildCount() const noexcept
@@ -78,7 +84,7 @@ public:
     MassData GetMassData() const noexcept;
     
     /// @brief Uses the given vertex radius.
-    inline ChainShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
+    ChainShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
 
     /// @brief Gets the vertex count.
     ChildCounter GetVertexCount() const noexcept
@@ -129,6 +135,9 @@ public:
     NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
 
 private:
+    /// @brief Resets the normals based on the current vertices.
+    void ResetNormals();
+
     std::vector<Length2> m_vertices; ///< Vertices.
     std::vector<UnitVec> m_normals; ///< Normals.
 };
@@ -183,6 +192,28 @@ inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCount
 {
     return GetVertexRadius(arg);
 }
+
+/// @brief Transforms the given chain shape configuration's vertices by the given
+///   transformation matrix.
+/// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+inline void Transform(ChainShapeConf& arg, const Mat22& m) noexcept
+{
+    arg.Transform(m);
+}
+
+/// @brief Gets an enclosing chain shape configuration for an axis aligned rectangle of the
+///    given dimensions (width and height).
+ChainShapeConf GetChainShapeConf(Length2 dimensions);
+
+/// @brief Gets an enclosing chain shape configuration for an axis aligned square of the
+///    given dimension.
+inline ChainShapeConf GetChainShapeConf(Length dimension)
+{
+    return GetChainShapeConf(Length2{dimension, dimension});
+}
+
+/// @brief Gets an enclosing chain shape configuration for the given axis aligned box.
+ChainShapeConf GetChainShapeConf(const AABB& arg);
 
 } // namespace d2
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -72,7 +72,7 @@ struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
     /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
     PLAYRHO_CONSTEXPR inline DiskShapeConf& Transform(const Mat22& m) noexcept
     {
-        location = playrho::Transform(location, m);
+        location = m * location;
         return *this;
     }
     

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -68,6 +68,14 @@ struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
         return *this;
     }
     
+    /// @brief Transforms the location by the given transformation matrix.
+    /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+    PLAYRHO_CONSTEXPR inline DiskShapeConf& Transform(const Mat22& m) noexcept
+    {
+        location = playrho::Transform(location, m);
+        return *this;
+    }
+    
     /// @brief Gets the radius property.
     NonNegative<Length> GetRadius() const noexcept
     {
@@ -146,6 +154,14 @@ PLAYRHO_CONSTEXPR inline NonNegative<Length> GetVertexRadius(const DiskShapeConf
 inline MassData GetMassData(const DiskShapeConf& arg) noexcept
 {
     return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.location);
+}
+
+/// @brief Transforms the given shape configuration's vertices by the given
+///   transformation matrix.
+/// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+inline void Transform(DiskShapeConf& arg, const Mat22& m) noexcept
+{
+    arg.Transform(m);
 }
 
 } // namespace d2

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
@@ -40,5 +40,12 @@ EdgeShapeConf& EdgeShapeConf::Set(Length2 vA, Length2 vB) noexcept
     return *this;
 }
 
+EdgeShapeConf& EdgeShapeConf::Transform(const Mat22& m) noexcept
+{
+    const auto newA = playrho::Transform(GetVertexA(), m);
+    const auto newB = playrho::Transform(GetVertexB(), m);
+    return Set(newA, newB);
+}
+
 } // namespace d2
 } // namespace playrho

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
@@ -42,8 +42,8 @@ EdgeShapeConf& EdgeShapeConf::Set(Length2 vA, Length2 vB) noexcept
 
 EdgeShapeConf& EdgeShapeConf::Transform(const Mat22& m) noexcept
 {
-    const auto newA = playrho::Transform(GetVertexA(), m);
-    const auto newB = playrho::Transform(GetVertexB(), m);
+    const auto newA = m * GetVertexA();
+    const auto newB = m * GetVertexB();
     return Set(newA, newB);
 }
 

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -63,6 +63,10 @@ public:
     
     /// @brief Uses the given vertex radius.
     EdgeShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
+    
+    /// @brief Transforms both vertices by the given transformation matrix.
+    /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+    EdgeShapeConf& Transform(const Mat22& m) noexcept;
 
     /// @brief Gets vertex A.
     Length2 GetVertexA() const noexcept
@@ -156,6 +160,13 @@ inline MassData GetMassData(const EdgeShapeConf& arg) noexcept
 {
     return playrho::d2::GetMassData(arg.vertexRadius, arg.density,
                                     arg.GetVertexA(), arg.GetVertexB());
+}
+
+/// @brief Transforms the given shape configuration's vertices by the given transformation matrix.
+/// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+inline void Transform(EdgeShapeConf& arg, const Mat22& m) noexcept
+{
+    arg.Transform(m);
 }
 
 } // namespace d2

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -80,7 +80,8 @@ ConvexHull ConvexHull::Get(const VertexSet& pointSet, NonNegative<Length> vertex
 ConvexHull& ConvexHull::Transform(const Mat22& m) noexcept
 {
     auto newPoints = VertexSet{};
-    for (const auto v: vertices)
+    // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
+    for (const auto& v: vertices)
     {
         newPoints.add(playrho::Transform(v, m));
     }

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -21,6 +21,7 @@
 #include <PlayRho/Collision/Shapes/MultiShapeConf.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 #include <algorithm>
+#include <iterator>
 
 namespace playrho {
 namespace d2 {
@@ -76,10 +77,29 @@ ConvexHull ConvexHull::Get(const VertexSet& pointSet, NonNegative<Length> vertex
     return ConvexHull{vertices, normals, vertexRadius};
 }
 
+ConvexHull& ConvexHull::Transform(const Mat22& m) noexcept
+{
+    auto newPoints = VertexSet{};
+    for (const auto v: vertices)
+    {
+        newPoints.add(playrho::Transform(v, m));
+    }
+    *this = Get(newPoints, vertexRadius);
+    return *this;
+}
+
 MultiShapeConf& MultiShapeConf::AddConvexHull(const VertexSet& pointSet,
                                               NonNegative<Length> vertexRadius) noexcept
 {
     children.emplace_back(ConvexHull::Get(pointSet, vertexRadius));
+    return *this;
+}
+
+MultiShapeConf& MultiShapeConf::Transform(const Mat22& m) noexcept
+{
+    std::for_each(std::begin(children), std::end(children), [=](ConvexHull& child){
+        child.Transform(m);
+    });
     return *this;
 }
 

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -83,7 +83,7 @@ ConvexHull& ConvexHull::Transform(const Mat22& m) noexcept
     // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
     for (const auto& v: vertices)
     {
-        newPoints.add(playrho::Transform(v, m));
+        newPoints.add(m * v);
     }
     *this = Get(newPoints, vertexRadius);
     return *this;

--- a/PlayRho/Collision/Shapes/MultiShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.hpp
@@ -57,6 +57,10 @@ public:
         return vertexRadius;
     }
     
+    /// @brief Transforms all the vertices by the given transformation matrix.
+    /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+    ConvexHull& Transform(const Mat22& m) noexcept;
+
     /// @brief Equality operator.
     friend bool operator== (const ConvexHull& lhs, const ConvexHull& rhs) noexcept
     {
@@ -132,6 +136,10 @@ struct MultiShapeConf: public ShapeBuilder<MultiShapeConf>
     MultiShapeConf& AddConvexHull(const VertexSet& pointSet, NonNegative<Length> vertexRadius =
                                   GetDefaultVertexRadius()) noexcept;
     
+    /// @brief Transforms the vertices of all the children by the given transformation matrix.
+    /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+    MultiShapeConf& Transform(const Mat22& m) noexcept;
+
     std::vector<ConvexHull> children; ///< Children.
 };
 
@@ -177,6 +185,14 @@ inline NonNegative<Length> GetVertexRadius(const MultiShapeConf& arg, ChildCount
         throw InvalidArgument("index out of range");
     }
     return arg.children[index].GetVertexRadius();
+}
+
+/// @brief Transforms the given multi shape configuration by the given
+///   transformation matrix.
+/// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+inline void Transform(MultiShapeConf& arg, const Mat22& m) noexcept
+{
+    arg.Transform(m);
 }
 
 } // namespace d2

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -96,7 +96,7 @@ PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m) noexcept
     // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
     for (const auto& v: m_vertices)
     {
-        newPoints.add(playrho::Transform(v, m));
+        newPoints.add(m * v);
     }
     return Set(newPoints);
 }

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -90,6 +90,16 @@ PolygonShapeConf& PolygonShapeConf::Transform(Transformation xfm) noexcept
     return *this;
 }
 
+PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m) noexcept
+{
+    auto newPoints = VertexSet{};
+    for (const auto v: m_vertices)
+    {
+        newPoints.add(playrho::Transform(v, m));
+    }
+    return Set(newPoints);
+}
+
 PolygonShapeConf& PolygonShapeConf::Set(Span<const Length2> points) noexcept
 {
     // Perform welding and copy vertices into local buffer.

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -93,7 +93,8 @@ PolygonShapeConf& PolygonShapeConf::Transform(Transformation xfm) noexcept
 PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m) noexcept
 {
     auto newPoints = VertexSet{};
-    for (const auto v: m_vertices)
+    // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
+    for (const auto& v: m_vertices)
     {
         newPoints.add(playrho::Transform(v, m));
     }

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -95,9 +95,13 @@ public:
     ///   may lead to poor stacking behavior.
     PolygonShapeConf& Set(const VertexSet& points) noexcept;
     
-    /// @brief Transforms the set vertices.
+    /// @brief Transforms the vertices by the given transformation.
     PolygonShapeConf& Transform(Transformation xfm) noexcept;
     
+    /// @brief Transforms the vertices by the given transformation matrix.
+    /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+    PolygonShapeConf& Transform(const Mat22& m) noexcept;
+
     /// @brief Equality operator.
     friend bool operator== (const PolygonShapeConf& lhs, const PolygonShapeConf& rhs) noexcept
     {
@@ -233,6 +237,14 @@ inline MassData GetMassData(const PolygonShapeConf& arg) noexcept
 /// @warning Behavior is undefined if called for a shape with less than 2 vertices.
 /// @relatedalso PolygonShapeConf
 Length2 GetEdge(const PolygonShapeConf& shape, VertexCounter index);
+
+/// @brief Transforms the given polygon configuration's vertices by the given
+///   transformation matrix.
+/// @sa https://en.wikipedia.org/wiki/Transformation_matrix
+inline void Transform(PolygonShapeConf& arg, const Mat22& m) noexcept
+{
+    arg.Transform(m);
+}
 
 /// @brief Validates the convexity of the given collection of vertices.
 /// @note This is a time consuming operation.

--- a/PlayRho/Collision/Shapes/Shape.cpp
+++ b/PlayRho/Collision/Shapes/Shape.cpp
@@ -54,6 +54,11 @@ Real GetRestitution(const DefaultShapeConf&) noexcept
     return Real{0};
 }
 
+void Transform(DefaultShapeConf&, const Mat22&) noexcept
+{
+    // Intentionally empty.
+}
+
 NonNegative<AreaDensity> GetDensity(const DefaultShapeConf&) noexcept
 {
     return NonNegative<AreaDensity>{0_kgpm2};

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -94,7 +94,10 @@ NonNegative<Length> GetVertexRadius(const Shape& shape, ChildCounter idx);
 
 /// @brief Transforms all of the given shape's vertices by the given transformation matrix.
 /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
-void Transform(Shape& shape, const Mat22& m) noexcept;
+/// @note This may throw <code>std::bad_alloc</code> or any exception that's thrown
+///   by the constructor for the model's underlying data type.
+/// @throws std::bad_alloc if there's a failure allocating storage.
+void Transform(Shape& shape, const Mat22& m);
 
 /// @brief Visits the given shape with the potentially non-null user data pointer.
 /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
@@ -228,7 +231,7 @@ public:
         return shape.m_self->GetDensity_();
     }
     
-    friend void Transform(Shape& shape, const Mat22& m) noexcept
+    friend void Transform(Shape& shape, const Mat22& m)
     {
         auto copy = shape.m_self->Clone();
         copy->Transform_(m);
@@ -275,6 +278,9 @@ private:
         virtual ~Concept() = default;
 
         /// @brief Clones this concept and returns a pointer to a mutable copy.
+        /// @note This may throw <code>std::bad_alloc</code> or any exception that's thrown
+        ///   by the constructor for the model's underlying data type.
+        /// @throws std::bad_alloc if there's a failure allocating storage.
         virtual std::unique_ptr<Concept> Clone() const = 0;
         
         /// @brief Gets the "child" count.
@@ -301,7 +307,7 @@ private:
         
         /// @brief Transforms all of the shape's vertices by the given transformation matrix.
         /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
-        virtual void Transform_(const Mat22& m) noexcept = 0;
+        virtual void Transform_(const Mat22& m) = 0;
         
         /// @brief Draws the shape.
         virtual bool Visit_(void* userData) const = 0;
@@ -380,7 +386,7 @@ private:
             return GetRestitution(data);
         }
         
-        void Transform_(const Mat22& m) noexcept override
+        void Transform_(const Mat22& m) override
         {
             Transform(data, m);
         }

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -186,8 +186,8 @@ namespace playrho
 namespace std {
 
     /// Tuple size specialization for <code>ArrayList</code> classes.
-    template< class T, size_t N, typename SIZE_TYPE >
-    class tuple_size< playrho::ArrayList<T, N, SIZE_TYPE> >: public integral_constant<size_t, N>
+    template< class T, std::size_t N, typename SIZE_TYPE >
+    class tuple_size< playrho::ArrayList<T, N, SIZE_TYPE> >: public integral_constant<std::size_t, N>
     {
         // Intentionally empty.
     };

--- a/PlayRho/Common/Interval.hpp
+++ b/PlayRho/Common/Interval.hpp
@@ -27,342 +27,342 @@
 #include <iostream>
 
 namespace playrho {
+
+/// @brief Interval template type.
+/// @details This type encapsulates an interval as a min-max value range relationship.
+/// @invariant The min and max values can only be the result of
+///   <code>std::minmax(a, b)</code> or the special values of the "highest" and
+///   "lowest" values supported by the type for this class respectively indicating
+///   the "unset" value.
+/// @sa https://en.wikipedia.org/wiki/Interval_(mathematics)
+template <typename T>
+class Interval
+{
+public:
     
-    /// @brief Interval template type.
-    /// @details This type encapsulates an interval as a min-max value range relationship.
-    /// @invariant The min and max values can only be the result of
-    ///   <code>std::minmax(a, b)</code> or the special values of the "highest" and
-    ///   "lowest" values supported by the type for this class respectively indicating
-    ///   the "unset" value.
-    /// @sa https://en.wikipedia.org/wiki/Interval_(mathematics)
-    template <typename T>
-    class Interval
+    /// @brief Value type.
+    /// @details Alias for the type of the value that this class was template
+    ///   instantiated for.
+    using value_type = T;
+    
+    /// @brief Limits alias for the <code>value_type</code>.
+    using limits = std::numeric_limits<value_type>;
+    
+    /// @brief Gets the "lowest" value supported by the <code>value_type</code>.
+    /// @return Negative infinity if supported by the value type, limits::lowest()
+    ///   otherwise.
+    static PLAYRHO_CONSTEXPR inline value_type GetLowest() noexcept
     {
-    public:
-        
-        /// @brief Value type.
-        /// @details Alias for the type of the value that this class was template
-        ///   instantiated for.
-        using value_type = T;
-        
-        /// @brief Limits alias for the <code>value_type</code>.
-        using limits = std::numeric_limits<value_type>;
-        
-        /// @brief Gets the "lowest" value supported by the <code>value_type</code>.
-        /// @return Negative infinity if supported by the value type, limits::lowest()
-        ///   otherwise.
-        static PLAYRHO_CONSTEXPR inline value_type GetLowest() noexcept
-        {
-            return (limits::has_infinity)? -limits::infinity(): limits::lowest();
-        }
-        
-        /// @brief Gets the "highest" value supported by the <code>value_type</code>.
-        /// @return Positive infinity if supported by the value type, limits::max()
-        ///   otherwise.
-        static PLAYRHO_CONSTEXPR inline value_type GetHighest() noexcept
-        {
-            return (limits::has_infinity)? limits::infinity(): limits::max();
-        }
+        return (limits::has_infinity)? -limits::infinity(): limits::lowest();
+    }
+    
+    /// @brief Gets the "highest" value supported by the <code>value_type</code>.
+    /// @return Positive infinity if supported by the value type, limits::max()
+    ///   otherwise.
+    static PLAYRHO_CONSTEXPR inline value_type GetHighest() noexcept
+    {
+        return (limits::has_infinity)? limits::infinity(): limits::max();
+    }
 
-        /// @brief Default constructor.
-        /// @details Constructs an "unset" interval.
-        /// @post <code>GetMin()</code> returns the value of <code>GetHighest()</code>.
-        /// @post <code>GetMax()</code> returns the value of <code>GetLowest()</code>.
-        PLAYRHO_CONSTEXPR inline Interval() = default;
-        
-        /// @brief Copy constructor.
-        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-        PLAYRHO_CONSTEXPR inline Interval(const Interval& other) = default;
+    /// @brief Default constructor.
+    /// @details Constructs an "unset" interval.
+    /// @post <code>GetMin()</code> returns the value of <code>GetHighest()</code>.
+    /// @post <code>GetMax()</code> returns the value of <code>GetLowest()</code>.
+    PLAYRHO_CONSTEXPR inline Interval() = default;
+    
+    /// @brief Copy constructor.
+    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+    PLAYRHO_CONSTEXPR inline Interval(const Interval& other) = default;
 
-        /// @brief Move constructor.
-        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-        PLAYRHO_CONSTEXPR inline Interval(Interval&& other) = default;
-        
-        /// @brief Initializing constructor.
-        /// @post <code>GetMin()</code> returns the value of <code>v</code>.
-        /// @post <code>GetMax()</code> returns the value of <code>v</code>.
-        PLAYRHO_CONSTEXPR inline explicit Interval(const value_type& v) noexcept:
-            Interval(pair_type{v, v})
-        {
-            // Intentionally empty.
-        }
-        
-        /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Interval(const value_type& a, const value_type& b) noexcept:
-            Interval(std::minmax(a, b))
-        {
-            // Intentionally empty.
-        }
-        
-        /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Interval(const std::initializer_list<T> ilist) noexcept:
-            Interval(std::minmax(ilist))
-        {
-            // Intentionally empty.
-        }
-        
-        ~Interval() noexcept = default;
-        
-        /// @brief Copy assignment operator.
-        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-        Interval& operator= (const Interval& other) = default;
+    /// @brief Move constructor.
+    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+    PLAYRHO_CONSTEXPR inline Interval(Interval&& other) = default;
+    
+    /// @brief Initializing constructor.
+    /// @post <code>GetMin()</code> returns the value of <code>v</code>.
+    /// @post <code>GetMax()</code> returns the value of <code>v</code>.
+    PLAYRHO_CONSTEXPR inline explicit Interval(const value_type& v) noexcept:
+        Interval(pair_type{v, v})
+    {
+        // Intentionally empty.
+    }
+    
+    /// @brief Initializing constructor.
+    PLAYRHO_CONSTEXPR inline Interval(const value_type& a, const value_type& b) noexcept:
+        Interval(std::minmax(a, b))
+    {
+        // Intentionally empty.
+    }
+    
+    /// @brief Initializing constructor.
+    PLAYRHO_CONSTEXPR inline Interval(const std::initializer_list<T> ilist) noexcept:
+        Interval(std::minmax(ilist))
+    {
+        // Intentionally empty.
+    }
+    
+    ~Interval() noexcept = default;
+    
+    /// @brief Copy assignment operator.
+    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+    Interval& operator= (const Interval& other) = default;
 
-        /// @brief Move assignment operator.
-        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-        Interval& operator= (Interval&& other) = default;
-        
-        /// @brief Moves the interval by the given amount.
-        /// @warning Behavior is undefined if incrementing the min or max value by
-        ///   the given amount overflows the finite range of the <code>value_type</code>,
-        PLAYRHO_CONSTEXPR inline Interval& Move(const value_type& v) noexcept
+    /// @brief Move assignment operator.
+    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+    Interval& operator= (Interval&& other) = default;
+    
+    /// @brief Moves the interval by the given amount.
+    /// @warning Behavior is undefined if incrementing the min or max value by
+    ///   the given amount overflows the finite range of the <code>value_type</code>,
+    PLAYRHO_CONSTEXPR inline Interval& Move(const value_type& v) noexcept
+    {
+        m_min += v;
+        m_max += v;
+        return *this;
+    }
+
+    /// @brief Gets the minimum value of this range.
+    PLAYRHO_CONSTEXPR inline value_type GetMin() const noexcept
+    {
+        return m_min;
+    }
+
+    /// @brief Gets the maximum value of this range.
+    PLAYRHO_CONSTEXPR inline value_type GetMax() const noexcept
+    {
+        return m_max;
+    }
+    
+    /// @brief Includes the given value into this interval.
+    /// @note If this value is the "unset" value then the result of this operation
+    ///   will be the given value.
+    /// @param v Value to "include" into this value.
+    /// @post This value's "min" is the minimum of the given value and this value's "min".
+    PLAYRHO_CONSTEXPR inline Interval& Include(const value_type& v) noexcept
+    {
+        m_min = std::min(v, GetMin());
+        m_max = std::max(v, GetMax());
+        return *this;
+    }
+    
+    /// @brief Includes the given interval into this interval.
+    /// @note If this value is the "unset" value then the result of this operation
+    ///   will be the given value.
+    /// @param v Value to "include" into this value.
+    /// @post This value's "min" is the minimum of the given value's "min" and
+    ///   this value's "min".
+    PLAYRHO_CONSTEXPR inline Interval& Include(const Interval& v) noexcept
+    {
+        m_min = std::min(v.GetMin(), GetMin());
+        m_max = std::max(v.GetMax(), GetMax());
+        return *this;
+    }
+    
+    /// @brief Intersects this interval with the given interval.
+    PLAYRHO_CONSTEXPR inline Interval& Intersect(const Interval& v) noexcept
+    {
+        const auto min = std::max(v.GetMin(), GetMin());
+        const auto max = std::min(v.GetMax(), GetMax());
+        *this = (min <= max)? Interval{pair_type{min, max}}: Interval{};
+        return *this;
+    }
+    
+    /// @brief Expands this interval.
+    /// @details Expands this interval by decreasing the min value if the
+    ///   given value is negative, or by increasing the max value if the
+    ///   given value is positive.
+    /// @param v Amount to expand this interval by.
+    /// @warning Behavior is undefined if expanding the range by
+    ///   the given amount overflows the range of the <code>value_type</code>,
+    PLAYRHO_CONSTEXPR inline Interval& Expand(const value_type& v) noexcept
+    {
+        if (v < value_type{})
         {
             m_min += v;
+        }
+        else
+        {
             m_max += v;
-            return *this;
         }
-
-        /// @brief Gets the minimum value of this range.
-        PLAYRHO_CONSTEXPR inline value_type GetMin() const noexcept
-        {
-            return m_min;
-        }
-
-        /// @brief Gets the maximum value of this range.
-        PLAYRHO_CONSTEXPR inline value_type GetMax() const noexcept
-        {
-            return m_max;
-        }
-        
-        /// @brief Includes the given value into this interval.
-        /// @note If this value is the "unset" value then the result of this operation
-        ///   will be the given value.
-        /// @param v Value to "include" into this value.
-        /// @post This value's "min" is the minimum of the given value and this value's "min".
-        PLAYRHO_CONSTEXPR inline Interval& Include(const value_type& v) noexcept
-        {
-            m_min = std::min(v, GetMin());
-            m_max = std::max(v, GetMax());
-            return *this;
-        }
-        
-        /// @brief Includes the given interval into this interval.
-        /// @note If this value is the "unset" value then the result of this operation
-        ///   will be the given value.
-        /// @param v Value to "include" into this value.
-        /// @post This value's "min" is the minimum of the given value's "min" and
-        ///   this value's "min".
-        PLAYRHO_CONSTEXPR inline Interval& Include(const Interval& v) noexcept
-        {
-            m_min = std::min(v.GetMin(), GetMin());
-            m_max = std::max(v.GetMax(), GetMax());
-            return *this;
-        }
-        
-        /// @brief Intersects this interval with the given interval.
-        PLAYRHO_CONSTEXPR inline Interval& Intersect(const Interval& v) noexcept
-        {
-            const auto min = std::max(v.GetMin(), GetMin());
-            const auto max = std::min(v.GetMax(), GetMax());
-            *this = (min <= max)? Interval{pair_type{min, max}}: Interval{};
-            return *this;
-        }
-        
-        /// @brief Expands this interval.
-        /// @details Expands this interval by decreasing the min value if the
-        ///   given value is negative, or by increasing the max value if the
-        ///   given value is positive.
-        /// @param v Amount to expand this interval by.
-        /// @warning Behavior is undefined if expanding the range by
-        ///   the given amount overflows the range of the <code>value_type</code>,
-        PLAYRHO_CONSTEXPR inline Interval& Expand(const value_type& v) noexcept
-        {
-            if (v < value_type{})
-            {
-                m_min += v;
-            }
-            else
-            {
-                m_max += v;
-            }
-            return *this;
-        }
-        
-        /// @brief Expands equally both ends of this interval.
-        /// @details Expands equally this interval by decreasing the min value and
-        ///   by increasing the max value by the given amount.
-        /// @note This operation has no effect if this interval is "unset".
-        /// @param v Amount to expand both ends of this interval by.
-        /// @warning Behavior is undefined if expanding the range by
-        ///   the given amount overflows the range of the <code>value_type</code>,
-        PLAYRHO_CONSTEXPR inline Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
-        {
-            const auto amount = value_type{v};
-            m_min -= amount;
-            m_max += amount;
-            return *this;
-        }
-        
-    private:
-        /// @brief Internal pair type.
-        /// @note Uses <code>std::pair</code> since it's the most natural type given that
-        ///   <code>std::minmax</code> returns it.
-        using pair_type = std::pair<value_type, value_type>;
-        
-        /// @brief Internal pair type accepting constructor.
-        PLAYRHO_CONSTEXPR inline explicit Interval(pair_type pair) noexcept:
-            m_min{std::get<0>(pair)}, m_max{std::get<1>(pair)}
-        {
-            // Intentionally empty.
-        }
-
-        value_type m_min = GetHighest(); ///< Min value.
-        value_type m_max = GetLowest(); ///< Max value.
-    };
-    
-    /// @brief Gets the size of the given interval.
-    /// @details Gets the difference between the max and min values.
-    /// @warning Behavior is undefined if the difference between the given range's
-    ///   max and min values overflows the range of the <code>Interval::value_type</code>.
-    /// @return Non-negative value unless the given interval is "unset" or invalid.
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline T GetSize(const Interval<T>& v) noexcept
-    {
-        return v.GetMax() - v.GetMin();
+        return *this;
     }
     
-    /// @brief Gets the center of the given interval.
-    /// @warning Behavior is undefined if the difference between the given range's
-    ///   max and min values overflows the range of the <code>Interval::value_type</code>.
-    /// @relatedalso Interval
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline T GetCenter(const Interval<T>& v) noexcept
+    /// @brief Expands equally both ends of this interval.
+    /// @details Expands equally this interval by decreasing the min value and
+    ///   by increasing the max value by the given amount.
+    /// @note This operation has no effect if this interval is "unset".
+    /// @param v Amount to expand both ends of this interval by.
+    /// @warning Behavior is undefined if expanding the range by
+    ///   the given amount overflows the range of the <code>value_type</code>,
+    PLAYRHO_CONSTEXPR inline Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
     {
-        // Rounding may cause issues...
-        return (v.GetMin() + v.GetMax()) / 2;
+        const auto amount = value_type{v};
+        m_min -= amount;
+        m_max += amount;
+        return *this;
     }
     
-    /// @brief Checks whether two value ranges have any intersection/overlap at all.
-    /// @relatedalso Interval
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
-    {
-        const auto maxOfMins = std::max(a.GetMin(), b.GetMin());
-        const auto minOfMaxs = std::min(a.GetMax(), b.GetMax());
-        return minOfMaxs >= maxOfMins;
-    }
+private:
+    /// @brief Internal pair type.
+    /// @note Uses <code>std::pair</code> since it's the most natural type given that
+    ///   <code>std::minmax</code> returns it.
+    using pair_type = std::pair<value_type, value_type>;
     
-    /// @brief Gets the intersecting interval of two given ranges.
-    /// @relatedalso Interval
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
+    /// @brief Internal pair type accepting constructor.
+    PLAYRHO_CONSTEXPR inline explicit Interval(pair_type pair) noexcept:
+        m_min{std::get<0>(pair)}, m_max{std::get<1>(pair)}
     {
-        return a.Intersect(b);
-    }
-    
-    /// @brief Determines whether the first range is entirely before the second range.
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
-    {
-        return a.GetMax() < b.GetMin();
-    }
-    
-    /// @brief Determines whether the first range is entirely after the second range.
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
-    {
-        return a.GetMin() > b.GetMax();
-    }
-    
-    /// @brief Determines whether the first range entirely encloses the second.
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
-    {
-        return a.GetMin() <= b.GetMin() && a.GetMax() >= b.GetMax();
+        // Intentionally empty.
     }
 
-    /// @brief Equality operator.
-    /// @note Satisfies the <code>EqualityComparable</code> concept for Interval objects.
-    /// @relatedalso Interval
-    /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
-    {
-        return (a.GetMin() == b.GetMin()) && (a.GetMax() == b.GetMax());
-    }
-    
-    /// @brief Inequality operator.
-    /// @note Satisfies the <code>EqualityComparable</code> concept for Interval objects.
-    /// @relatedalso Interval
-    /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
-    {
-        return !(a == b);
-    }
-    
-    /// @brief Less-than operator.
-    /// @note Provides a "strict weak ordering" relation.
-    /// @note This is a lexicographical comparison.
-    /// @note Obeys the <code>LessThanComparable</code> concept:
-    ///   <code>for all a, !(a < a); if (a < b) then !(b < a); if (a < b) and (b < c)
-    ///   then (a < c); with equiv = !(a < b) && !(b < a), if equiv(a, b) and equiv(b, c),
-    ///   then equiv(a, c).</code>
-    /// @relatedalso Interval
-    /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-    /// @sa http://en.cppreference.com/w/cpp/concept/LessThanComparable
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-    {
-        return (lhs.GetMin() < rhs.GetMin()) ||
-            (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() < rhs.GetMax());
-    }
-    
-    /// @brief Less-than or equal-to operator.
-    /// @note Provides a "strict weak ordering" relation.
-    /// @note This is a lexicographical comparison.
-    /// @relatedalso Interval
-    /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-    {
-        return (lhs.GetMin() < rhs.GetMin()) ||
-            (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() <= rhs.GetMax());
-    }
-    
-    /// @brief Greater-than operator.
-    /// @note Provides a "strict weak ordering" relation.
-    /// @note This is a lexicographical comparison.
-    /// @relatedalso Interval
-    /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-    {
-        return (lhs.GetMin() > rhs.GetMin()) ||
-            (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() > rhs.GetMax());
-    }
-    
-    /// @brief Greater-than or equal-to operator.
-    /// @note Provides a "strict weak ordering" relation.
-    /// @note This is a lexicographical comparison.
-    /// @relatedalso Interval
-    /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-    template <typename T>
-    PLAYRHO_CONSTEXPR inline bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-    {
-        return (lhs.GetMin() > rhs.GetMin()) ||
-            (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() >= rhs.GetMax());
-    }
-    
-    /// @brief Output stream operator.
-    template <typename T>
-    ::std::ostream& operator<< (::std::ostream& os, const Interval<T>& value)
-    {
-        return os << '{' << value.GetMin() << "..." << value.GetMax() << '}';
-    }
+    value_type m_min = GetHighest(); ///< Min value.
+    value_type m_max = GetLowest(); ///< Max value.
+};
+
+/// @brief Gets the size of the given interval.
+/// @details Gets the difference between the max and min values.
+/// @warning Behavior is undefined if the difference between the given range's
+///   max and min values overflows the range of the <code>Interval::value_type</code>.
+/// @return Non-negative value unless the given interval is "unset" or invalid.
+template <typename T>
+PLAYRHO_CONSTEXPR inline T GetSize(const Interval<T>& v) noexcept
+{
+    return v.GetMax() - v.GetMin();
+}
+
+/// @brief Gets the center of the given interval.
+/// @warning Behavior is undefined if the difference between the given range's
+///   max and min values overflows the range of the <code>Interval::value_type</code>.
+/// @relatedalso Interval
+template <typename T>
+PLAYRHO_CONSTEXPR inline T GetCenter(const Interval<T>& v) noexcept
+{
+    // Rounding may cause issues...
+    return (v.GetMin() + v.GetMax()) / 2;
+}
+
+/// @brief Checks whether two value ranges have any intersection/overlap at all.
+/// @relatedalso Interval
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
+{
+    const auto maxOfMins = std::max(a.GetMin(), b.GetMin());
+    const auto minOfMaxs = std::min(a.GetMax(), b.GetMax());
+    return minOfMaxs >= maxOfMins;
+}
+
+/// @brief Gets the intersecting interval of two given ranges.
+/// @relatedalso Interval
+template <typename T>
+PLAYRHO_CONSTEXPR inline Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
+{
+    return a.Intersect(b);
+}
+
+/// @brief Determines whether the first range is entirely before the second range.
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
+{
+    return a.GetMax() < b.GetMin();
+}
+
+/// @brief Determines whether the first range is entirely after the second range.
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
+{
+    return a.GetMin() > b.GetMax();
+}
+
+/// @brief Determines whether the first range entirely encloses the second.
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
+{
+    return a.GetMin() <= b.GetMin() && a.GetMax() >= b.GetMax();
+}
+
+/// @brief Equality operator.
+/// @note Satisfies the <code>EqualityComparable</code> concept for Interval objects.
+/// @relatedalso Interval
+/// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
+{
+    return (a.GetMin() == b.GetMin()) && (a.GetMax() == b.GetMax());
+}
+
+/// @brief Inequality operator.
+/// @note Satisfies the <code>EqualityComparable</code> concept for Interval objects.
+/// @relatedalso Interval
+/// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
+{
+    return !(a == b);
+}
+
+/// @brief Less-than operator.
+/// @note Provides a "strict weak ordering" relation.
+/// @note This is a lexicographical comparison.
+/// @note Obeys the <code>LessThanComparable</code> concept:
+///   <code>for all a, !(a < a); if (a < b) then !(b < a); if (a < b) and (b < c)
+///   then (a < c); with equiv = !(a < b) && !(b < a), if equiv(a, b) and equiv(b, c),
+///   then equiv(a, c).</code>
+/// @relatedalso Interval
+/// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+/// @sa http://en.cppreference.com/w/cpp/concept/LessThanComparable
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+{
+    return (lhs.GetMin() < rhs.GetMin()) ||
+        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() < rhs.GetMax());
+}
+
+/// @brief Less-than or equal-to operator.
+/// @note Provides a "strict weak ordering" relation.
+/// @note This is a lexicographical comparison.
+/// @relatedalso Interval
+/// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+{
+    return (lhs.GetMin() < rhs.GetMin()) ||
+        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() <= rhs.GetMax());
+}
+
+/// @brief Greater-than operator.
+/// @note Provides a "strict weak ordering" relation.
+/// @note This is a lexicographical comparison.
+/// @relatedalso Interval
+/// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+{
+    return (lhs.GetMin() > rhs.GetMin()) ||
+        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() > rhs.GetMax());
+}
+
+/// @brief Greater-than or equal-to operator.
+/// @note Provides a "strict weak ordering" relation.
+/// @note This is a lexicographical comparison.
+/// @relatedalso Interval
+/// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+template <typename T>
+PLAYRHO_CONSTEXPR inline bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+{
+    return (lhs.GetMin() > rhs.GetMin()) ||
+        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() >= rhs.GetMax());
+}
+
+/// @brief Output stream operator.
+template <typename T>
+::std::ostream& operator<< (::std::ostream& os, const Interval<T>& value)
+{
+    return os << '{' << value.GetMin() << "..." << value.GetMax() << '}';
+}
 
 } // namespace playrho
 

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -3,17 +3,19 @@
  * Modified work Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -566,34 +566,21 @@ PLAYRHO_CONSTEXPR inline auto GetFwdPerpendicular(const T vector) noexcept
 }
 
 /// @brief Multiplies an M-element vector by an M-by-N matrix.
-/// @note The matrix is a *transformation matrix*.
-/// @param v Vector.
-/// @param m Matrix to multiply the vector by.
+/// @param v Vector that's interpretted as a matrix with 1 row and M-columns.
+/// @param m An M-row by N-column *transformation matrix* to multiply the vector by.
 /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
 template <std::size_t M, typename T1, std::size_t N, typename T2>
 PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
 {
-    using OT = decltype(T1{} * T2{});
-    auto result = Vector<OT, N>{};
-    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
-    {
-        // So for a 2-element vector v multiplied by a 2-by-2-matrix m...
-        // result[0] = v[0] * m[0][0] + v[1] * m[0][1]
-        // result[1] = v[0] * m[1][0] + v[1] * m[1][1]
-        for (auto j = static_cast<std::size_t>(0); j < M; ++j)
-        {
-            result[i] += v[j] * m[j][i];
-        }
-    }
-    return result;
+    return m * v;
 }
 
 /// @brief Multiplies a vector by a matrix.
 PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 {
     return Vec2{
-        GetX(GetX(A)) * v[0] + GetX(GetY(A)) * v[1],
-        GetY(GetX(A)) * v[0] + GetY(GetY(A)) * v[1]
+        Get<0>(Get<0>(A)) * v[0] + Get<0>(Get<1>(A)) * v[1],
+        Get<1>(Get<0>(A)) * v[0] + Get<1>(Get<1>(A)) * v[1]
     };
 }
 
@@ -602,12 +589,6 @@ PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 PLAYRHO_CONSTEXPR inline Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
 {
     return Vec2{Dot(v, GetX(A)), Dot(v, GetY(A))};
-}
-
-/// @brief Computes A * B.
-PLAYRHO_CONSTEXPR inline Mat22 Mul(const Mat22& A, const Mat22& B) noexcept
-{
-    return Mat22{Transform(GetX(B), A), Transform(GetY(B), A)};
 }
 
 /// @brief Computes A^T * B.

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -3,17 +3,19 @@
  * Modified work Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
@@ -563,33 +565,32 @@ PLAYRHO_CONSTEXPR inline auto GetFwdPerpendicular(const T vector) noexcept
     return T{GetY(vector), -GetX(vector)};
 }
 
-/// Multiply a matrix times a vector. If a rotation matrix is provided,
-/// then this transforms the vector from one frame to another.
-PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat22& A) noexcept
+/// @brief Multiplies an N-element vector by an N-by-N matrix.
+/// @param v Vector.
+/// @param A Matrix to multiply the vector by.
+template <std::size_t N, typename T1, typename T2>
+PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, N> v, const Matrix<T2, N, N>& A) noexcept
+{
+    using OT = decltype(T1{} * T2{});
+    auto result = Vector<OT, N>{};
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
+    {
+        for (auto j = static_cast<std::size_t>(0); j < N; ++j)
+        {
+            result[i] += A[i][j] * v[j];
+        }
+    }
+    return result;
+}
+
+/// @brief Multiplies a vector by a matrix.
+PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 {
     return Vec2{
-        Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
-        Get<1>(Get<0>(A)) * Get<0>(v) + Get<1>(Get<1>(A)) * Get<1>(v)
+        GetX(GetX(A)) * v[0] + GetX(GetY(A)) * v[1],
+        GetY(GetX(A)) * v[0] + GetY(GetY(A)) * v[1]
     };
 }
-
-#ifdef USE_BOOST_UNITS
-PLAYRHO_CONSTEXPR inline auto Transform(const LinearVelocity2 v, const Mass22& A) noexcept
-{
-    return Momentum2{
-        Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
-        Get<1>(Get<0>(A)) * Get<0>(v) + Get<1>(Get<1>(A)) * Get<1>(v)
-    };
-}
-
-PLAYRHO_CONSTEXPR inline auto Transform(const Momentum2 v, const InvMass22 A) noexcept
-{
-    return LinearVelocity2{
-        Get<0>(Get<0>(A)) * Get<0>(v) + Get<0>(Get<1>(A)) * Get<1>(v),
-        Get<1>(Get<0>(A)) * Get<0>(v) + Get<1>(Get<1>(A)) * Get<1>(v)
-    };
-}
-#endif
 
 /// Multiply a matrix transpose times a vector. If a rotation matrix is provided,
 /// then this transforms the vector from one frame to another (inverse transform).
@@ -610,21 +611,6 @@ PLAYRHO_CONSTEXPR inline Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
     const auto c1 = Vec2{Dot(GetX(A), GetX(B)), Dot(GetY(A), GetX(B))};
     const auto c2 = Vec2{Dot(GetX(A), GetY(B)), Dot(GetY(A), GetY(B))};
     return Mat22{c1, c2};
-}
-
-/// @brief Multiplies a matrix by a vector.
-PLAYRHO_CONSTEXPR inline Vec3 Transform(const Vec3& v, const Mat33& A) noexcept
-{
-    return (GetX(v) * GetX(A)) + (GetY(v) * GetY(A)) + (GetZ(v) * GetZ(A));
-}
-
-/// @brief Multiplies a matrix by a vector.
-PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
-{
-    return Vec2{
-        GetX(GetX(A)) * v[0] + GetX(GetY(A)) * v[1],
-        GetY(GetX(A)) * v[0] + GetY(GetY(A)) * v[1]
-    };
 }
 
 /// @brief Gets the absolute value of the given value.

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -566,10 +566,12 @@ PLAYRHO_CONSTEXPR inline auto GetFwdPerpendicular(const T vector) noexcept
 }
 
 /// @brief Multiplies an N-element vector by an N-by-N matrix.
+/// @note The matrix is a *transformation matrix*.
 /// @param v Vector.
-/// @param A Matrix to multiply the vector by.
+/// @param m Matrix to multiply the vector by.
+/// @sa https://en.wikipedia.org/wiki/Transformation_matrix
 template <std::size_t N, typename T1, typename T2>
-PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, N> v, const Matrix<T2, N, N>& A) noexcept
+PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, N> v, const Matrix<T2, N, N>& m) noexcept
 {
     using OT = decltype(T1{} * T2{});
     auto result = Vector<OT, N>{};
@@ -577,7 +579,7 @@ PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, N> v, const Matrix<T2, 
     {
         for (auto j = static_cast<std::size_t>(0); j < N; ++j)
         {
-            result[i] += A[i][j] * v[j];
+            result[i] += m[i][j] * v[j];
         }
     }
     return result;

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -565,21 +565,24 @@ PLAYRHO_CONSTEXPR inline auto GetFwdPerpendicular(const T vector) noexcept
     return T{GetY(vector), -GetX(vector)};
 }
 
-/// @brief Multiplies an N-element vector by an N-by-N matrix.
+/// @brief Multiplies an M-element vector by an M-by-N matrix.
 /// @note The matrix is a *transformation matrix*.
 /// @param v Vector.
 /// @param m Matrix to multiply the vector by.
 /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
-template <std::size_t N, typename T1, typename T2>
-PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, N> v, const Matrix<T2, N, N>& m) noexcept
+template <std::size_t M, typename T1, std::size_t N, typename T2>
+PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
 {
     using OT = decltype(T1{} * T2{});
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
-        for (auto j = static_cast<std::size_t>(0); j < N; ++j)
+        // So for a 2-element vector v multiplied by a 2-by-2-matrix m...
+        // result[0] = v[0] * m[0][0] + v[1] * m[0][1]
+        // result[1] = v[0] * m[1][0] + v[1] * m[1][1]
+        for (auto j = static_cast<std::size_t>(0); j < M; ++j)
         {
-            result[i] += m[i][j] * v[j];
+            result[i] += v[j] * m[j][i];
         }
     }
     return result;

--- a/PlayRho/Common/Matrix.hpp
+++ b/PlayRho/Common/Matrix.hpp
@@ -29,44 +29,123 @@
 #include <PlayRho/Common/Units.hpp>
 
 namespace playrho {
-    
-    /// @brief Generic N by M matrix.
-    template <typename T, std::size_t N, std::size_t M>
-    using Matrix = Vector<Vector<T, M>, N>;
-    
-    /// @brief 2 by 2 matrix.
-    template <typename T>
-    using Matrix22 = Matrix<T, 2, 2>;
-    
-    /// @brief 3 by 3 matrix.
-    template <typename T>
-    using Matrix33 = Matrix<T, 3, 3>;
-    
-    /// @brief 2 by 2 matrix of Real elements.
-    using Mat22 = Matrix22<Real>;
-    
-    /// @brief 2 by 2 matrix of Mass elements.
-    using Mass22 = Matrix22<Mass>;
 
-    /// @brief 2 by 2 matrix of <code>InvMass</code> elements.
-    using InvMass22 = Matrix22<InvMass>;
-    
-    /// @brief 3 by 3 matrix of Real elements.
-    using Mat33 = Matrix33<Real>;
-    
-    /// @brief Determines if the given value is valid.
-    template <>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const Mat22& value) noexcept
+/// @brief Generic M by N matrix.
+/// @note M is the number of rows of the matrix.
+/// @note N is the number of columns of the matrix.
+/// @sa https://en.wikipedia.org/wiki/Matrix_(mathematics)
+template <typename T, std::size_t M, std::size_t N>
+using Matrix = Vector<Vector<T, N>, M>;
+
+/// @brief 2 by 2 matrix.
+template <typename T>
+using Matrix22 = Matrix<T, 2, 2>;
+
+/// @brief 3 by 3 matrix.
+template <typename T>
+using Matrix33 = Matrix<T, 3, 3>;
+
+/// @brief 2 by 2 matrix of Real elements.
+using Mat22 = Matrix22<Real>;
+
+/// @brief 2 by 2 matrix of Mass elements.
+using Mass22 = Matrix22<Mass>;
+
+/// @brief 2 by 2 matrix of <code>InvMass</code> elements.
+using InvMass22 = Matrix22<InvMass>;
+
+/// @brief 3 by 3 matrix of Real elements.
+using Mat33 = Matrix33<Real>;
+
+/// @brief Determines if the given value is valid.
+template <>
+PLAYRHO_CONSTEXPR inline bool IsValid(const Mat22& value) noexcept
+{
+    return IsValid(Get<0>(value)) && IsValid(Get<1>(value));
+}
+
+/// @brief Gets an invalid value for a <code>Mat22</code>.
+template <>
+PLAYRHO_CONSTEXPR inline Mat22 GetInvalid() noexcept
+{
+    return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
+}
+
+/// @brief Multiplies an A-by-B matrix by a B-by-C matrix.
+/// @note From Wikipedia:
+///   > Multiplication of two matrices is defined if and only if the number of columns
+///   > of the left matrix is the same as the number of rows of the right matrix.
+/// @note Matrix multiplication is not commutative.
+/// @note Algorithmically speaking, this implementation is called the "naive" algorithm.
+///   For small matrices, like 3-by-3 or smaller matrices, its complexity shouldn't be an issue.
+///   The matrix dimensions are compile time constants anyway which can help compilers
+///   automatically identify loop unrolling and hardware level parallelism opportunities.
+/// @param lhs Left-hand-side matrix.
+/// @param rhs Right-hand-side matrix.
+/// @return A-by-C matrix product of the left-hand-side matrix and the right-hand-side matrix.
+/// @sa https://en.wikipedia.org/wiki/Matrix_multiplication
+/// @sa https://en.wikipedia.org/wiki/Matrix_multiplication_algorithm
+/// @sa https://en.wikipedia.org/wiki/Commutative_property
+/// @relatedalso Vector
+template <typename T1, typename T2, std::size_t A, std::size_t B, std::size_t C>
+PLAYRHO_CONSTEXPR inline
+auto operator* (const Matrix<T1, A, B>& lhs, const Matrix<T2, B, C>& rhs) noexcept
+{
+    using OT = decltype(T1{} * T2{});
+    auto result = Matrix<OT, A, C>{};
+    for (auto a = static_cast<std::size_t>(0); a < A; ++a)
     {
-        return IsValid(Get<0>(value)) && IsValid(Get<1>(value));
+        for (auto c = static_cast<std::size_t>(0); c < C; ++c)
+        {
+            // So for 2x3 lhs matrix * 3*2 rhs matrix... result is 2x2 matrix:
+            // result[0][0] = lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0]
+            // result[0][1] = lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1]
+            // result[1][0] = lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0]
+            // result[1][1] = lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1]
+            auto element = OT{};
+            for (auto b = static_cast<std::size_t>(0); b < B; ++b)
+            {
+                element += lhs[a][b] * rhs[b][c];
+            }
+            result[a][c] = element;
+        }
     }
-    
-    /// @brief Gets an invalid value for a <code>Mat22</code>.
-    template <>
-    PLAYRHO_CONSTEXPR inline Mat22 GetInvalid() noexcept
+    return result;
+}
+
+/// @brief Matrix addition operator for two same-type, same-sized matrices.
+/// @sa https://en.wikipedia.org/wiki/Matrix_addition
+template <typename T, std::size_t M, std::size_t N>
+PLAYRHO_CONSTEXPR inline
+auto operator+ (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
+{
+    auto result = Matrix<T, M, N>{};
+    for (auto m = static_cast<std::size_t>(0); m < M; ++m)
     {
-        return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
+        for (auto n = static_cast<std::size_t>(0); n < N; ++n)
+        {
+            result[m][n] = lhs[m][n] + rhs[m][n];
+        }
     }
+    return result;
+}
+
+/// @brief Matrix subtraction operator for two same-type, same-sized matrices.
+/// @sa https://en.wikipedia.org/wiki/Matrix_addition
+template <typename T, std::size_t M, std::size_t N>
+PLAYRHO_CONSTEXPR inline
+auto operator- (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
+{
+    auto result = Matrix<T, M, N>{};
+    for (auto m = static_cast<std::size_t>(0); m < M; ++m)
+    {
+        for (auto n = static_cast<std::size_t>(0); n < N; ++n)
+        {
+            result[m][n] = lhs[m][n] - rhs[m][n];
+        }
+    }
+    return result;
+}
 
 } // namespace playrho
 

--- a/PlayRho/Common/Matrix.hpp
+++ b/PlayRho/Common/Matrix.hpp
@@ -35,7 +35,7 @@ namespace playrho {
 /// @note N is the number of columns of the matrix.
 /// @sa https://en.wikipedia.org/wiki/Matrix_(mathematics)
 template <typename T, std::size_t M, std::size_t N>
-using Matrix = Vector<Vector<T, N>, M>;
+    using Matrix = Vector<Vector<T, N>, M>;
 
 /// @brief 2 by 2 matrix.
 template <typename T>
@@ -69,48 +69,6 @@ template <>
 PLAYRHO_CONSTEXPR inline Mat22 GetInvalid() noexcept
 {
     return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
-}
-
-/// @brief Multiplies an A-by-B matrix by a B-by-C matrix.
-/// @note From Wikipedia:
-///   > Multiplication of two matrices is defined if and only if the number of columns
-///   > of the left matrix is the same as the number of rows of the right matrix.
-/// @note Matrix multiplication is not commutative.
-/// @note Algorithmically speaking, this implementation is called the "naive" algorithm.
-///   For small matrices, like 3-by-3 or smaller matrices, its complexity shouldn't be an issue.
-///   The matrix dimensions are compile time constants anyway which can help compilers
-///   automatically identify loop unrolling and hardware level parallelism opportunities.
-/// @param lhs Left-hand-side matrix.
-/// @param rhs Right-hand-side matrix.
-/// @return A-by-C matrix product of the left-hand-side matrix and the right-hand-side matrix.
-/// @sa https://en.wikipedia.org/wiki/Matrix_multiplication
-/// @sa https://en.wikipedia.org/wiki/Matrix_multiplication_algorithm
-/// @sa https://en.wikipedia.org/wiki/Commutative_property
-/// @relatedalso Vector
-template <typename T1, typename T2, std::size_t A, std::size_t B, std::size_t C>
-PLAYRHO_CONSTEXPR inline
-auto operator* (const Matrix<T1, A, B>& lhs, const Matrix<T2, B, C>& rhs) noexcept
-{
-    using OT = decltype(T1{} * T2{});
-    auto result = Matrix<OT, A, C>{};
-    for (auto a = static_cast<std::size_t>(0); a < A; ++a)
-    {
-        for (auto c = static_cast<std::size_t>(0); c < C; ++c)
-        {
-            // So for 2x3 lhs matrix * 3*2 rhs matrix... result is 2x2 matrix:
-            // result[0][0] = lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0]
-            // result[0][1] = lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1]
-            // result[1][0] = lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0]
-            // result[1][1] = lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1]
-            auto element = OT{};
-            for (auto b = static_cast<std::size_t>(0); b < B; ++b)
-            {
-                element += lhs[a][b] * rhs[b][c];
-            }
-            result[a][c] = element;
-        }
-    }
-    return result;
 }
 
 /// @brief Matrix addition operator for two same-type, same-sized matrices.

--- a/PlayRho/Common/Matrix.hpp
+++ b/PlayRho/Common/Matrix.hpp
@@ -71,6 +71,66 @@ PLAYRHO_CONSTEXPR inline Mat22 GetInvalid() noexcept
     return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
 }
 
+/// @brief Trait class for checking if type is a matrix type.
+template <typename>
+struct IsMatrix: std::false_type {};
+
+/// @brief Trait class specialization for checking if type is a matrix type.
+template <typename T, std::size_t M, std::size_t N>
+struct IsMatrix<Vector<Vector<T, N>, M>>: std::true_type {};
+
+/// @brief Trait class for checking if type is a square matrix type.
+template <typename>
+struct IsSquareMatrix: std::false_type {};
+
+/// @brief Trait class specialization for checking if type is a square matrix type.
+template <typename T, std::size_t M>
+struct IsSquareMatrix<Vector<Vector<T, M>, M>>: std::true_type {};
+
+/// @brief Gets the identity matrix of the template type and size.
+template <typename T, std::size_t N>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<!IsVector<T>::value, Matrix<T, N, N>>::type GetIdentityMatrix()
+{
+    auto result = Matrix<Real, N, N>{};
+    for (auto i = std::size_t{0}; i < N; ++i)
+    {
+        result[i][i] = T(1);
+    }
+    return result;
+}
+
+/// @brief Gets the identity matrix of the template type and size as given by the argument.
+template <typename T>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<IsSquareMatrix<T>::value, T>::type GetIdentity()
+{
+    return GetIdentityMatrix<typename T::value_type::value_type, std::tuple_size<T>::value>();
+}
+
+/// @brief Gets the specified row of the given matrix as a row matrix.
+template <typename T, std::size_t N>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<!IsVector<T>::value, Vector<Vector<T, N>, 1>>::type
+GetRowMatrix(Vector<T, N> arg)
+{
+    return Vector<Vector<T, N>, 1>{arg};
+}
+
+/// @brief Gets the specified column of the given matrix as a column matrix.
+template <typename T, std::size_t N>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<!IsVector<T>::value, Vector<Vector<T, 1>, N>>::type
+GetColumnMatrix(Vector<T, N> arg)
+{
+    auto result = Vector<Vector<T, 1>, N>{};
+    for (auto i = std::size_t{0}; i < N; ++i)
+    {
+        result[i][0] = arg[i];
+    }
+    return result;
+}
+
 /// @brief Matrix addition operator for two same-type, same-sized matrices.
 /// @sa https://en.wikipedia.org/wiki/Matrix_addition
 template <typename T, std::size_t M, std::size_t N>

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -162,7 +162,7 @@ namespace playrho {
     /// @note Second parameter is user data or the <code>nullptr</code>.
     /// @sa https://en.wikipedia.org/wiki/Visitor_pattern
     template <typename T>
-    inline bool Visit(const T& /*object*/, void* /*userData*/)
+    bool Visit(const T& /*object*/, void* /*userData*/)
     {
         return false;
     }

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -209,6 +209,18 @@ namespace playrho {
     /// @brief Void type templated alias.
     template<class... Ts> using VoidT = typename Voidify<Ts...>::type;
     
+    template<class T1, class T2, class = void>
+    struct IsMultipliable: std::false_type {};
+    
+    template<class T1, class T2>
+    struct IsMultipliable<T1, T2, VoidT<decltype(T1{} * T2{})> >: std::true_type {};
+    
+    template<class T1, class T2, class = void>
+    struct IsDivisable: std::false_type {};
+    
+    template<class T1, class T2>
+    struct IsDivisable<T1, T2, VoidT<decltype(T1{} / T2{})> >: std::true_type {};
+
     /// @brief Template for determining if the given type is an "arithmetic" type.
     /// @note In the context of this library, "arithmetic" types are all types which
     ///   have +, -, *, / arithmetic operator support.

--- a/PlayRho/Common/UnitVec.hpp
+++ b/PlayRho/Common/UnitVec.hpp
@@ -318,7 +318,7 @@ PLAYRHO_CONSTEXPR inline UnitVec InverseRotate(const UnitVec vector, const UnitV
 }
 
 /// @brief Gets the specified element of the given collection.
-template <size_t I>
+template <std::size_t I>
 PLAYRHO_CONSTEXPR inline UnitVec::value_type Get(UnitVec v) noexcept
 {
     static_assert(I < 2, "Index out of bounds in playrho::Get<> (playrho::UnitVec)");
@@ -366,7 +366,7 @@ namespace std {
 
 /// @brief Tuple size info for <code>playrho::d2::UnitVec</code>.
 template<>
-class tuple_size< playrho::d2::UnitVec >: public std::integral_constant<size_t, 2> {};
+class tuple_size< playrho::d2::UnitVec >: public std::integral_constant<std::size_t, 2> {};
 
 /// @brief Tuple element type info for <code>playrho::d2::UnitVec</code>.
 template<std::size_t I>

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -225,7 +225,7 @@ struct IsVector<Vector<T, N>>: std::true_type {};
 template <typename T, std::size_t N>
 PLAYRHO_CONSTEXPR inline bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         if (lhs[i] != rhs[i])
         {
@@ -260,7 +260,7 @@ PLAYRHO_CONSTEXPR inline
 typename std::enable_if<std::is_same<T, decltype(-T{})>::value, Vector<T, N>>::type
 operator- (Vector<T, N> v) noexcept
 {
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         v[i] = -v[i];
     }
@@ -274,7 +274,7 @@ PLAYRHO_CONSTEXPR inline
 typename std::enable_if<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>&>::type
 operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         lhs[i] += rhs[i];
     }
@@ -288,7 +288,7 @@ PLAYRHO_CONSTEXPR inline
 typename std::enable_if<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>&>::type
 operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         lhs[i] -= rhs[i];
     }
@@ -322,7 +322,7 @@ PLAYRHO_CONSTEXPR inline
 typename std::enable_if<std::is_same<T1, decltype(T1{} * T2{})>::value, Vector<T1, N>&>::type
 operator*= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         lhs[i] *= rhs;
     }
@@ -336,7 +336,7 @@ PLAYRHO_CONSTEXPR inline
 typename std::enable_if<std::is_same<T1, decltype(T1{} / T2{})>::value, Vector<T1, N>&>::type
 operator/= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         lhs[i] /= rhs;
     }
@@ -400,7 +400,7 @@ operator* (const T1 s, Vector<T2, N> a) noexcept
 {
     // Can't base this off of *= since result type in this case can be different
     auto result = Vector<OT, N>{};
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         result[i] = s * a[i];
     }
@@ -418,7 +418,7 @@ operator* (Vector<T1, N> a, const T2 s) noexcept
 {
     // Can't base this off of *= since result type in this case can be different
     auto result = Vector<OT, N>{};
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         result[i] = a[i] * s;
     }
@@ -434,7 +434,7 @@ operator/ (Vector<T1, N> a, const T2 s) noexcept
 {
     // Can't base this off of /= since result type in this case can be different
     auto result = Vector<OT, N>{};
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         result[i] = a[i] / s;
     }
@@ -448,7 +448,7 @@ template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} *
 PLAYRHO_CONSTEXPR inline auto operator* (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) noexcept
 {
     auto result = Vector<OT, N>{};
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         result[i] = lhs[i] * rhs[i];
     }
@@ -461,7 +461,7 @@ template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} /
 PLAYRHO_CONSTEXPR inline auto operator/ (const Vector<T1, N>& lhs, const Vector<T2, N>& rhs) noexcept
 {
     auto result = Vector<OT, N>{};
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
         result[i] = lhs[i] / rhs[i];
     }
@@ -511,7 +511,7 @@ PLAYRHO_CONSTEXPR inline bool operator>= (const Vector<T, N>& lhs, const Vector<
 
 /// @brief Gets the I'th element of the given collection.
 /// @relatedalso Vector
-template <size_t I, size_t N, typename T>
+template <std::size_t I, std::size_t N, typename T>
 PLAYRHO_CONSTEXPR inline auto& Get(Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::Get<> (playrho::Vector)");
@@ -519,7 +519,7 @@ PLAYRHO_CONSTEXPR inline auto& Get(Vector<T, N>& v) noexcept
 }
 
 /// @brief Gets the I'th element of the given collection.
-template <size_t I, size_t N, typename T>
+template <std::size_t I, std::size_t N, typename T>
 PLAYRHO_CONSTEXPR inline auto Get(const Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::Get<> (playrho::Vector)");
@@ -532,9 +532,9 @@ template <typename T, std::size_t N>
 ::std::ostream& operator<< (::std::ostream& os, const Vector<T, N>& value)
 {
     os << "{";
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    for (auto i = static_cast<std::size_t>(0); i < N; ++i)
     {
-        if (i > static_cast<size_t>(0))
+        if (i > static_cast<std::size_t>(0))
         {
             os << ',';
         }
@@ -550,10 +550,10 @@ namespace std {
     
     /// @brief Tuple size info for playrho::Vector
     template<class T, std::size_t N>
-    class tuple_size< playrho::Vector<T, N> >: public std::integral_constant<size_t, N> {};
+    class tuple_size< playrho::Vector<T, N> >: public std::integral_constant<std::size_t, N> {};
     
     /// @brief Tuple element type info for playrho::Vector
-    template<std::size_t I, class T, size_t N>
+    template<std::size_t I, class T, std::size_t N>
     class tuple_element<I, playrho::Vector<T, N>>
     {
     public:

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -48,7 +48,6 @@ template <typename T, std::size_t N>
 struct Vector
 {
     static_assert(N > 0, "Number of elements must be greater than 0");
-    static_assert(IsArithmetic<T>::value, "Type must be arithmetic");
 
     /// @brief Value type.
     using value_type = T;
@@ -213,6 +212,14 @@ struct Vector
     value_type elements[N];
 };
 
+/// @brief Trait class for checking if type is a Vector type.
+template <typename>
+struct IsVector: std::false_type {};
+
+/// @brief Trait class specialization for checking if type is a Vector type.
+template <typename T, std::size_t N>
+struct IsVector<Vector<T, N>>: std::true_type {};
+
 /// @brief Equality operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
@@ -239,7 +246,9 @@ PLAYRHO_CONSTEXPR inline bool operator!= (const Vector<T, N>& lhs, const Vector<
 /// @brief Unary plus operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto operator+ (Vector<T, N> v) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T, decltype(+T{})>::value, Vector<T, N>>::type
+operator+ (Vector<T, N> v) noexcept
 {
     return v;
 }
@@ -247,7 +256,9 @@ PLAYRHO_CONSTEXPR inline auto operator+ (Vector<T, N> v) noexcept
 /// @brief Unary negation operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto operator- (Vector<T, N> v) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T, decltype(-T{})>::value, Vector<T, N>>::type
+operator- (Vector<T, N> v) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -259,7 +270,9 @@ PLAYRHO_CONSTEXPR inline auto operator- (Vector<T, N> v) noexcept
 /// @brief Increments the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto& operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>&>::type
+operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -271,7 +284,9 @@ PLAYRHO_CONSTEXPR inline auto& operator+= (Vector<T, N>& lhs, const Vector<T, N>
 /// @brief Decrements the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto& operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>&>::type
+operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -283,7 +298,9 @@ PLAYRHO_CONSTEXPR inline auto& operator-= (Vector<T, N>& lhs, const Vector<T, N>
 /// @brief Adds two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>>::type
+operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
     return lhs += rhs;
 }
@@ -291,15 +308,19 @@ PLAYRHO_CONSTEXPR inline auto operator+ (Vector<T, N> lhs, const Vector<T, N> rh
 /// @brief Subtracts two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>>::type
+operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
     return lhs -= rhs;
 }
 
 /// @brief Multiplication assignment operator.
 /// @relatedalso Vector
-template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto& operator*= (Vector<T, N>& lhs, const Real rhs) noexcept
+template <typename T1, typename T2, std::size_t N>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T1, decltype(T1{} * T2{})>::value, Vector<T1, N>&>::type
+operator*= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -310,8 +331,10 @@ PLAYRHO_CONSTEXPR inline auto& operator*= (Vector<T, N>& lhs, const Real rhs) no
 
 /// @brief Division assignment operator.
 /// @relatedalso Vector
-template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline auto& operator/= (Vector<T, N>& lhs, const Real rhs) noexcept
+template <typename T1, typename T2, std::size_t N>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<std::is_same<T1, decltype(T1{} / T2{})>::value, Vector<T1, N>&>::type
+operator/= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -320,24 +343,80 @@ PLAYRHO_CONSTEXPR inline auto& operator/= (Vector<T, N>& lhs, const Real rhs) no
     return lhs;
 }
 
-/// @brief Multiplication operator.
+/// @brief Multiplies an A-by-B vector of vectors by a B-by-C vector of vectors.
+/// @note From Wikipedia:
+///   > Multiplication of two matrices is defined if and only if the number of columns
+///   > of the left matrix is the same as the number of rows of the right matrix.
+/// @note Matrix multiplication is not commutative.
+/// @note Algorithmically speaking, this implementation is called the "naive" algorithm.
+///   For small matrices, like 3-by-3 or smaller matrices, its complexity shouldn't be an issue.
+///   The matrix dimensions are compile time constants anyway which can help compilers
+///   automatically identify loop unrolling and hardware level parallelism opportunities.
+/// @param lhs Left-hand-side matrix.
+/// @param rhs Right-hand-side matrix.
+/// @return A-by-C matrix product of the left-hand-side matrix and the right-hand-side matrix.
+/// @sa https://en.wikipedia.org/wiki/Matrix_multiplication
+/// @sa https://en.wikipedia.org/wiki/Matrix_multiplication_algorithm
+/// @sa https://en.wikipedia.org/wiki/Commutative_property
 /// @relatedalso Vector
-template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-PLAYRHO_CONSTEXPR inline auto operator* (const T1 s, const Vector<T2, N>& a) noexcept
+template <typename T1, typename T2, std::size_t A, std::size_t B, std::size_t C, typename OT = decltype(T1{} * T2{})>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<IsMultipliable<T1, T2>::value, Vector<Vector<OT, C>, A>>::type
+operator* (const Vector<Vector<T1, B>, A>& lhs, const Vector<Vector<T2, C>, B>& rhs) noexcept
 {
-    auto result = Vector<OT, N>{};
-    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    //using OT = decltype(T1{} * T2{});
+    auto result = Vector<Vector<OT, C>, A>{};
+    for (auto a = static_cast<std::size_t>(0); a < A; ++a)
     {
-        result[i] = a[i] * s;
+        for (auto c = static_cast<std::size_t>(0); c < C; ++c)
+        {
+            // So for 2x3 lhs matrix * 3*2 rhs matrix... result is 2x2 matrix:
+            // result[0][0] = lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0]
+            // result[0][1] = lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1]
+            // result[1][0] = lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0]
+            // result[1][1] = lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1]
+            auto element = OT{};
+            for (auto b = static_cast<std::size_t>(0); b < B; ++b)
+            {
+                element += lhs[a][b] * rhs[b][c];
+            }
+            result[a][c] = element;
+        }
     }
     return result;
 }
 
-/// @brief Multiplication operator.
+// Have to make sure a lhs Vector<T1, N> is not multipliable by a rhs vector unless
+// rhs is Vector<Vector<T2, M>, N> where IsMultipliable<T1, T2>::value.
+
+/// @brief Multiplication operator for non vector times vector.
 /// @relatedalso Vector
+/// @note Explicitly disabled for Vector * Vector to prevent this function from existing
+///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-PLAYRHO_CONSTEXPR inline auto operator* (const Vector<T1, N>& a, const T2 s) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, N>>::type
+operator* (const T1 s, Vector<T2, N> a) noexcept
 {
+    // Can't base this off of *= since result type in this case can be different
+    auto result = Vector<OT, N>{};
+    for (auto i = static_cast<size_t>(0); i < N; ++i)
+    {
+        result[i] = s * a[i];
+    }
+    return result;
+}
+
+/// @brief Multiplication operator for vector times non vector.
+/// @relatedalso Vector
+/// @note Explicitly disabled for Vector * Vector to prevent this function from existing
+///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
+template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>::type
+operator* (Vector<T1, N> a, const T2 s) noexcept
+{
+    // Can't base this off of *= since result type in this case can be different
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -349,8 +428,11 @@ PLAYRHO_CONSTEXPR inline auto operator* (const Vector<T1, N>& a, const T2 s) noe
 /// @brief Division operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} / T2{})>
-PLAYRHO_CONSTEXPR inline auto operator/ (const Vector<T1, N>& a, const T2 s) noexcept
+PLAYRHO_CONSTEXPR inline
+typename std::enable_if<IsDivisable<T1, T2>::value, Vector<OT, N>>::type
+operator/ (Vector<T1, N> a, const T2 s) noexcept
 {
+    // Can't base this off of /= since result type in this case can be different
     auto result = Vector<OT, N>{};
     for (auto i = static_cast<size_t>(0); i < N; ++i)
     {
@@ -359,6 +441,7 @@ PLAYRHO_CONSTEXPR inline auto operator/ (const Vector<T1, N>& a, const T2 s) noe
     return result;
 }
 
+#if 0
 /// @brief Multiplication operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
@@ -384,6 +467,7 @@ PLAYRHO_CONSTEXPR inline auto operator/ (const Vector<T1, N>& lhs, const Vector<
     }
     return result;
 }
+#endif
 
 /// @brief Lexicographical less-than operator.
 /// @relatedalso Vector
@@ -463,20 +547,20 @@ template <typename T, std::size_t N>
 } // namespace playrho
 
 namespace std {
-
-/// @brief Tuple size info for playrho::Vector
-template<class T, std::size_t N>
-class tuple_size< playrho::Vector<T, N> >: public std::integral_constant<size_t, N> {};
-
-/// @brief Tuple element type info for playrho::Vector
-template<std::size_t I, class T, size_t N>
-class tuple_element<I, playrho::Vector<T, N>>
-{
-public:
-    /// @brief Type alias revealing the actual element type of the given Vector.
-    using type = T;
-};
-
+    
+    /// @brief Tuple size info for playrho::Vector
+    template<class T, std::size_t N>
+    class tuple_size< playrho::Vector<T, N> >: public std::integral_constant<size_t, N> {};
+    
+    /// @brief Tuple element type info for playrho::Vector
+    template<std::size_t I, class T, size_t N>
+    class tuple_element<I, playrho::Vector<T, N>>
+    {
+    public:
+        /// @brief Type alias revealing the actual element type of the given Vector.
+        using type = T;
+    };
+    
 } // namespace std
 
 #endif // PLAYRHO_COMMON_VECTOR_HPP

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -56,8 +56,6 @@
 #include <PlayRho/Collision/TimeOfImpact.hpp>
 #include <PlayRho/Collision/RayCastOutput.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
-#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
-#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 
 #include <PlayRho/Common/LengthError.hpp>
 #include <PlayRho/Common/DynamicMemory.hpp>
@@ -2698,35 +2696,6 @@ void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept
     for_each(begin(world.GetBodies()), end(world.GetBodies()), [&](World::Bodies::value_type &b) {
         SetLinearAcceleration(GetRef(b), acceleration);
     });
-}
-
-Body* CreateRectangularEnclosingBody(World& world, Length2 dimensions, const ShapeConf& baseConf,
-                                     Length thickness)
-{
-    const auto body = world.CreateBody();
-    
-    auto conf = ChainShapeConf{};
-    conf.restitution = baseConf.restitution;
-    conf.friction = baseConf.friction;
-    conf.density = baseConf.density;
-    conf.vertexRadius = thickness;
-    
-    const auto halfWidth = GetX(dimensions) / Real{2};
-    const auto halfHeight = GetY(dimensions) / Real{2};
-    const auto btmLeft  = Length2(-halfWidth, -halfHeight);
-    const auto btmRight = Length2(+halfWidth, -halfHeight);
-    const auto topLeft  = Length2(-halfWidth, +halfHeight);
-    const auto topRight = Length2(+halfWidth, +halfHeight);
-    
-    conf.Add(btmRight);
-    conf.Add(topRight);
-    conf.Add(topLeft);
-    conf.Add(btmLeft);
-    conf.Add(conf.GetVertex(0));
-    
-    body->CreateFixture(Shape{conf});
-    
-    return body;
 }
 
 Body* FindClosestBody(const World& world, Length2 location) noexcept

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -34,7 +34,6 @@
 #include <PlayRho/Dynamics/WorldCallbacks.hpp>
 #include <PlayRho/Dynamics/StepStats.hpp>
 #include <PlayRho/Collision/DynamicTree.hpp>
-#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
 #include <PlayRho/Dynamics/ContactAtty.hpp>
 #include <PlayRho/Dynamics/JointAtty.hpp>
@@ -62,6 +61,7 @@ class Fixture;
 class Joint;
 struct Island;
 class Shape;
+struct ShapeConf;
 
 /// @defgroup PhysicalEntities Physical Entity Classes
 ///
@@ -1058,19 +1058,6 @@ inline void ClearForces(World& world) noexcept
     SetAccelerations(world, Acceleration{
         LinearAcceleration2{0_mps2, 0_mps2}, 0 * RadianPerSquareSecond
     });
-}
-
-/// @brief Creates a rectangular enclosure.
-/// @relatedalso World
-Body* CreateRectangularEnclosingBody(World& world, Length2 dimensions,
-                                     const ShapeConf& baseConf, Length thickness);
-
-/// @brief Creates a square enclosure.
-/// @relatedalso World
-inline Body* CreateSquareEnclosingBody(World& world, Length size, const ShapeConf& baseConf,
-                                       Length thickness)
-{
-    return CreateRectangularEnclosingBody(world, Length2{size, size}, baseConf, thickness);
 }
     
 /// @brief Finds body in given world that's closest to the given location.

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -1330,6 +1330,49 @@ Real RandomFloat(Real lo, Real hi)
     r = (hi - lo) * r + lo;
     return r;
 }
-    
+
 } // namespace testbed
 
+namespace playrho {
+
+template <>
+bool Visit(const d2::DiskShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->xf);
+    return true;
+}
+
+template <>
+bool Visit(const d2::EdgeShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
+}
+
+template <>
+bool Visit(const d2::PolygonShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
+}
+
+template <>
+bool Visit(const d2::ChainShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
+}
+
+template <>
+bool Visit(const d2::MultiShapeConf& shape, void* userData)
+{
+    const auto data = static_cast<testbed::VisitorData*>(userData);
+    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
+    return true;
+}
+
+} // namespace playrho

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -458,44 +458,19 @@ void Draw(Drawer& drawer, const MultiShapeConf& shape, Color color, bool skins, 
 namespace playrho {
 
 template <>
-inline bool Visit(const d2::DiskShapeConf& shape, void* userData)
-{
-    const auto data = static_cast<testbed::VisitorData*>(userData);
-    Draw(*(data->drawer), shape, data->color, data->xf);
-    return true;
-}
+bool Visit(const d2::DiskShapeConf& shape, void* userData);
 
 template <>
-inline bool Visit(const d2::EdgeShapeConf& shape, void* userData)
-{
-    const auto data = static_cast<testbed::VisitorData*>(userData);
-    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
-    return true;
-}
+bool Visit(const d2::EdgeShapeConf& shape, void* userData);
 
 template <>
-inline bool Visit(const d2::PolygonShapeConf& shape, void* userData)
-{
-    const auto data = static_cast<testbed::VisitorData*>(userData);
-    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
-    return true;
-}
+bool Visit(const d2::PolygonShapeConf& shape, void* userData);
 
 template <>
-inline bool Visit(const d2::ChainShapeConf& shape, void* userData)
-{
-    const auto data = static_cast<testbed::VisitorData*>(userData);
-    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
-    return true;
-}
+bool Visit(const d2::ChainShapeConf& shape, void* userData);
 
 template <>
-inline bool Visit(const d2::MultiShapeConf& shape, void* userData)
-{
-    const auto data = static_cast<testbed::VisitorData*>(userData);
-    Draw(*(data->drawer), shape, data->color, data->skins, data->xf);
-    return true;
-}
+bool Visit(const d2::MultiShapeConf& shape, void* userData);
 
 } // namespace playrho
 

--- a/Testbed/Tests/Confined.hpp
+++ b/Testbed/Tests/Confined.hpp
@@ -94,8 +94,9 @@ public:
     
     Body* CreateEnclosure(Length vertexRadius, Length wallLength)
     {
-        const auto body = CreateSquareEnclosingBody(m_world, wallLength, ShapeConf{
-            }.UseRestitution(Finite<Real>(0)), vertexRadius);
+        const auto body = m_world.CreateBody();
+        body->CreateFixture(Shape{GetChainShapeConf(wallLength)
+            .UseRestitution(Finite<Real>(0)).UseVertexRadius(vertexRadius)});
         SetLocation(*body, Length2{0_m, 20_m});
         return body;
     }

--- a/Testbed/Tests/FifteenPuzzle.hpp
+++ b/Testbed/Tests/FifteenPuzzle.hpp
@@ -43,10 +43,11 @@ namespace testbed {
         FifteenPuzzle(): Test(GetTestConf())
         {
             m_gravity = LinearAcceleration2{};
-            const auto enclosure = CreateSquareEnclosingBody(m_world, 16_m + 2 * GetVertexRadius(),
-                                                             ShapeConf{}, GetVertexRadius());
+            auto conf = GetChainShapeConf(16_m + 2 * GetVertexRadius());
+            conf.UseVertexRadius(GetVertexRadius());
+            const auto enclosure = m_world.CreateBody();
+            enclosure->CreateFixture(Shape{conf});
             SetLocation(*enclosure, GetCenter());
-            
             for (auto i = 0; i < 15; ++i)
             {
                 const auto row = 3 - i / 4;

--- a/Testbed/Tests/JointsTest.hpp
+++ b/Testbed/Tests/JointsTest.hpp
@@ -131,8 +131,9 @@ private:
 
     Body* SetupContainer(Length2 center)
     {
-        const auto b = CreateRectangularEnclosingBody(m_world, Length2{ColumnSize, RowSize},
-                                                      ShapeConf{}, DefaultLinearSlop * Real{2});
+        const auto conf = GetChainShapeConf(Length2{ColumnSize, RowSize});
+        const auto b = m_world.CreateBody();
+        b->CreateFixture(Shape{conf});
         SetLocation(*b, center);
         return b;
     }

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -122,6 +122,35 @@ TEST(ChainShapeConf, Accept)
 #endif
 }
 
+TEST(ChainShapeConf, TransformFF)
+{
+    {
+        auto foo = ChainShapeConf{};
+        auto tmp = foo;
+        Transform(foo, Mat22{});
+        EXPECT_EQ(foo, tmp);
+    }
+    {
+        auto foo = ChainShapeConf{};
+        auto tmp = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, tmp);
+    }
+    {
+        const auto v1 = Length2{1_m, 2_m};
+        const auto v2 = Length2{3_m, 4_m};
+        auto foo = ChainShapeConf{};
+        foo.Add(v1);
+        foo.Add(v2);
+        auto tmp = foo;
+        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        EXPECT_NE(foo, tmp);
+        ASSERT_EQ(foo.GetVertexCount(), ChildCounter(2));
+        EXPECT_EQ(foo.GetVertex(0), v1 * 2);
+        EXPECT_EQ(foo.GetVertex(1), v2 * 2);
+    }
+}
+
 TEST(ChainShapeConf, OneVertexLikeDisk)
 {
     const auto vertexRadius = 1_m;

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -367,3 +367,24 @@ TEST(ChainShapeConf, GetSquareChainShapeConf)
     }
     EXPECT_EQ(vertices.size(), decltype(vertices.size()){4});
 }
+
+TEST(ChainShapeConf, GetAabbChainShapeConf)
+{
+    const auto v0 = Length2{2_m, -3_m};
+    const auto v1 = Length2{2_m,  4_m};
+    const auto v2 = Length2{1_m,  4_m};
+    const auto v3 = Length2{1_m, -3_m};
+    auto aabb = AABB{};
+    Include(aabb, v0);
+    Include(aabb, v1);
+    Include(aabb, v2);
+    Include(aabb, v3);
+    const auto conf = GetChainShapeConf(aabb);
+    EXPECT_EQ(conf.GetChildCount(), ChildCounter(4));
+    EXPECT_EQ(conf.GetVertexCount(), ChildCounter(5));
+    EXPECT_EQ(conf.GetVertex(0), v0);
+    EXPECT_EQ(conf.GetVertex(1), v1);
+    EXPECT_EQ(conf.GetVertex(2), v2);
+    EXPECT_EQ(conf.GetVertex(3), v3);
+    EXPECT_EQ(conf.GetVertex(4), v0);
+}

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -133,7 +133,7 @@ TEST(ChainShapeConf, TransformFF)
     {
         auto foo = ChainShapeConf{};
         auto tmp = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, tmp);
     }
     {
@@ -143,7 +143,7 @@ TEST(ChainShapeConf, TransformFF)
         foo.Add(v1);
         foo.Add(v2);
         auto tmp = foo;
-        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        Transform(foo, GetIdentity<Mat22>() * 2);
         EXPECT_NE(foo, tmp);
         ASSERT_EQ(foo.GetVertexCount(), ChildCounter(2));
         EXPECT_EQ(foo.GetVertex(0), v1 * 2);

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -321,3 +321,20 @@ TEST(ChainShapeConf, Inequality)
     EXPECT_TRUE(ChainShapeConf().Add(Length2(1_m, 2_m)) != ChainShapeConf());
     EXPECT_FALSE(ChainShapeConf().Add(Length2(1_m, 2_m)) != ChainShapeConf().Add(Length2(1_m, 2_m)));
 }
+
+TEST(ChainShapeConf, GetSquareChainShapeConf)
+{
+    const auto conf = GetChainShapeConf(2_m);
+    auto vertices = std::set<Length2>();
+    const auto childCount = GetChildCount(conf);
+    for (auto i = ChildCounter{0}; i < childCount; ++i)
+    {
+        const auto child = GetChild(conf, i);
+        const auto numVertices = child.GetVertexCount();
+        for (auto j = decltype(numVertices){0}; j < numVertices; ++j)
+        {
+            vertices.insert(child.GetVertex(j));
+        }
+    }
+    EXPECT_EQ(vertices.size(), decltype(vertices.size()){4});
+}

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -71,6 +71,30 @@ TEST(DiskShapeConf, InitConstruction)
     EXPECT_EQ(GetY(conf.GetLocation()), GetY(position));
 }
 
+TEST(DiskShapeConf, TransformFF)
+{
+    {
+        auto foo = DiskShapeConf{};
+        auto tmp = foo;
+        Transform(foo, Mat22{});
+        EXPECT_EQ(foo, tmp);
+    }
+    {
+        auto foo = DiskShapeConf{};
+        auto tmp = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, tmp);
+    }
+    {
+        const auto v1 = Length2{1_m, 2_m};
+        auto foo = DiskShapeConf{}.UseLocation(v1).UseRadius(1_m);
+        auto tmp = foo;
+        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        EXPECT_NE(foo, tmp);
+        EXPECT_EQ(foo.GetLocation(), v1 * 2);
+    }
+}
+
 TEST(DiskShapeConf, GetInvalidChildThrows)
 {
     Shape foo{DiskShapeConf{}};

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -82,14 +82,14 @@ TEST(DiskShapeConf, TransformFF)
     {
         auto foo = DiskShapeConf{};
         auto tmp = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, tmp);
     }
     {
         const auto v1 = Length2{1_m, 2_m};
         auto foo = DiskShapeConf{}.UseLocation(v1).UseRadius(1_m);
         auto tmp = foo;
-        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        Transform(foo, GetIdentity<Mat22>() * 2);
         EXPECT_NE(foo, tmp);
         EXPECT_EQ(foo.GetLocation(), v1 * 2);
     }

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -63,7 +63,7 @@ TEST(EdgeShapeConf, TransformFF)
     {
         auto foo = EdgeShapeConf{};
         auto tmp = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, tmp);
     }
     {
@@ -71,7 +71,7 @@ TEST(EdgeShapeConf, TransformFF)
         const auto v2 = Length2{3_m, 4_m};
         auto foo = EdgeShapeConf{v1, v2};
         auto tmp = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, tmp);
     }
     {
@@ -79,7 +79,7 @@ TEST(EdgeShapeConf, TransformFF)
         const auto v2 = Length2{3_m, 4_m};
         auto foo = EdgeShapeConf{v1, v2};
         auto tmp = foo;
-        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        Transform(foo, GetIdentity<Mat22>() * 2);
         EXPECT_NE(foo, tmp);
         EXPECT_EQ(foo.GetVertexA(), v1 * 2);
         EXPECT_EQ(foo.GetVertexB(), v2 * 2);

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -52,6 +52,40 @@ TEST(EdgeShapeConf, GetInvalidChildThrows)
     EXPECT_THROW(GetChild(foo, 1), InvalidArgument);
 }
 
+TEST(EdgeShapeConf, TransformFF)
+{
+    {
+        auto foo = EdgeShapeConf{};
+        auto tmp = foo;
+        Transform(foo, Mat22{});
+        EXPECT_EQ(foo, tmp);
+    }
+    {
+        auto foo = EdgeShapeConf{};
+        auto tmp = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, tmp);
+    }
+    {
+        const auto v1 = Length2{1_m, 2_m};
+        const auto v2 = Length2{3_m, 4_m};
+        auto foo = EdgeShapeConf{v1, v2};
+        auto tmp = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, tmp);
+    }
+    {
+        const auto v1 = Length2{1_m, 2_m};
+        const auto v2 = Length2{3_m, 4_m};
+        auto foo = EdgeShapeConf{v1, v2};
+        auto tmp = foo;
+        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        EXPECT_NE(foo, tmp);
+        EXPECT_EQ(foo.GetVertexA(), v1 * 2);
+        EXPECT_EQ(foo.GetVertexB(), v2 * 2);
+    }
+}
+
 TEST(EdgeShapeConf, Visit)
 {
     const auto s = Shape{EdgeShapeConf{}};

--- a/UnitTests/Mat22.cpp
+++ b/UnitTests/Mat22.cpp
@@ -34,46 +34,102 @@ TEST(Mat22, ByteSizeIs_16_32_or_64)
 
 TEST(Mat22, Init)
 {
-    Vec2 c1{1, 1};
-    Vec2 c2{2, 2};
-    const Mat22 foo{c1, c2};
-    EXPECT_EQ(c1, GetX(foo));
-    EXPECT_EQ(c2, GetY(foo));
+    const auto v1 = Vec2{1, 1};
+    const auto v2 = Vec2{2, 2};
+    const auto foo = Mat22{v1, v2};
+    EXPECT_EQ(v1, Get<0>(foo));
+    EXPECT_EQ(v2, Get<1>(foo));
 }
 
 TEST(Mat22, Invert)
 {
-    Vec2 ex{1, 2};
-    Vec2 ey{3, 4};
-    const Mat22 foo{ex, ey};
-    ASSERT_EQ(GetX(foo), ex);
-    ASSERT_EQ(GetY(foo), ey);
+    const auto v1 = Vec2{1, 2};
+    const auto v2 = Vec2{3, 4};
+    const auto foo = Mat22{v1, v2};
+    ASSERT_EQ(Get<0>(foo), v1);
+    ASSERT_EQ(Get<1>(foo), v2);
 
     const auto inverted = Invert(foo);
-    const auto cp = Cross(ex, ey);
+    const auto cp = Cross(v1, v2);
     ASSERT_EQ(cp, Real(-2));
     const auto det = (cp != 0)? Real(1)/cp : Real(0);
     
-    EXPECT_EQ(GetX(GetX(inverted)), det * GetY(GetY(foo)));
-    EXPECT_EQ(GetY(GetX(inverted)), -det * GetY(GetX(foo)));
-    EXPECT_EQ(GetX(GetY(inverted)), -det * GetX(GetY(foo)));
-    EXPECT_EQ(GetY(GetY(inverted)), det * GetX(GetX(foo)));
+    EXPECT_EQ(Get<0>(Get<0>(inverted)), det * Get<1>(Get<1>(foo)));
+    EXPECT_EQ(Get<1>(Get<0>(inverted)), -det * Get<1>(Get<0>(foo)));
+    EXPECT_EQ(Get<0>(Get<1>(inverted)), -det * Get<0>(Get<1>(foo)));
+    EXPECT_EQ(Get<1>(Get<1>(inverted)), det * Get<0>(Get<0>(foo)));
     
-    EXPECT_EQ(GetX(GetX(inverted)), Real(-2));
-    EXPECT_EQ(GetY(GetX(inverted)), Real(1));
-    EXPECT_EQ(GetX(GetY(inverted)), Real(1.5));
-    EXPECT_EQ(GetY(GetY(inverted)), Real(-0.5));
+    EXPECT_EQ(Get<0>(Get<0>(inverted)), Real(-2));
+    EXPECT_EQ(Get<1>(Get<0>(inverted)), Real(1));
+    EXPECT_EQ(Get<0>(Get<1>(inverted)), Real(1.5));
+    EXPECT_EQ(Get<1>(Get<1>(inverted)), Real(-0.5));
 }
 
 TEST(Mat22, InvertInvertedIsOriginal)
 {
-    Vec2 c1{1, 2};
-    Vec2 c2{3, 4};
-    const Mat22 foo{c1, c2};
+    const auto v1 = Vec2{1, 2};
+    const auto v2 = Vec2{3, 4};
+    const auto foo = Mat22{v1, v2};
     const auto inverted = Invert(foo);
     const auto inverted2 = Invert(inverted);
-    EXPECT_EQ(GetX(GetX(foo)), GetX(GetX(inverted2)));
-    EXPECT_EQ(GetY(GetX(foo)), GetY(GetX(inverted2)));
-    EXPECT_EQ(GetX(GetY(foo)), GetX(GetY(inverted2)));
-    EXPECT_EQ(GetY(GetY(foo)), GetY(GetY(inverted2)));
+    EXPECT_EQ(Get<0>(Get<0>(foo)), Get<0>(Get<0>(inverted2)));
+    EXPECT_EQ(Get<1>(Get<0>(foo)), Get<1>(Get<0>(inverted2)));
+    EXPECT_EQ(Get<0>(Get<1>(foo)), Get<0>(Get<1>(inverted2)));
+    EXPECT_EQ(Get<1>(Get<1>(foo)), Get<1>(Get<1>(inverted2)));
+}
+
+TEST(Mat22, Addition)
+{
+    {
+        const auto m1 = Mat22{};
+        const auto m2 = Mat22{};
+        EXPECT_EQ(m1 + m2, Mat22());
+    }
+    {
+        const auto m1 = Mat22{Vec2{1, 2}, Vec2{3, 4}};
+        const auto m2 = Mat22{Vec2{1, 2}, Vec2{3, 4}};
+        EXPECT_EQ(m1 + m2, Mat22(Vec2(2, 4), Vec2(6, 8)));
+    }
+}
+
+TEST(Mat22, Subtraction)
+{
+    {
+        const auto m1 = Mat22{};
+        const auto m2 = Mat22{};
+        EXPECT_EQ(m1 - m2, Mat22());
+    }
+    {
+        const auto m1 = Mat22{Vec2{1, 2}, Vec2{3, 4}};
+        const auto m2 = Mat22{Vec2{1, 2}, Vec2{3, 4}};
+        EXPECT_EQ(m1 - m2, Mat22());
+    }
+}
+
+TEST(Mat22, Multiplication)
+{
+    {
+        const auto m1 = Mat22{};
+        const auto m2 = Mat22{};
+        EXPECT_EQ(m1 * m2, Mat22());
+    }
+    {
+        const auto m1 = Mat22{Vec2{1, 2}, Vec2{3, 4}};
+        const auto m2 = Mat22{Vec2{1, 2}, Vec2{3, 4}};
+        //
+        // | 1 2 |   | 1 2 |   | 1*1+2*3=7  1*2+2*4=10 |
+        // |     | * |     | = |                       |
+        // | 3 4 |   | 3 4 |   | 3*1+4*3=15 3*2+4*4=22 |
+        //
+        EXPECT_EQ(m1 * m2, Mat22(Vec2(7, 10), Vec2(15, 22)));
+        
+        static_assert(!IsVector<int>::value, "supposed to not be vector but is");
+        const auto m3 = Mat33{};
+        static_assert(IsVector<Mat33>::value, "supposed to be vector but not");
+        const auto m23 = Vector<Vector<Real, 3>, 2>{};
+        static_assert(IsVector<Vector<Vector<Real, 3>, 2>>::value, "supposed to be vector but not");
+        static_assert(!IsMultipliable<decltype(m3), decltype(m2)>::value, "");
+        static_assert(!IsMultipliable<decltype(m2), decltype(m3)>::value, "");
+        EXPECT_EQ(m2 * m23, (Matrix<Real, 2, 3>{}));
+    }
 }

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -82,7 +82,7 @@ TEST(MultiShapeConf, TransformFF)
     {
         auto foo = MultiShapeConf{};
         auto copy = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, copy);
     }
     {
@@ -101,7 +101,7 @@ TEST(MultiShapeConf, TransformFF)
         ASSERT_EQ(foo.children.size(), std::size_t(1));
 
         copy = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, copy);
 
         const auto v3 = Length2{-1_m, -2_m};
@@ -123,7 +123,7 @@ TEST(MultiShapeConf, TransformFF)
         EXPECT_EQ(dp1.GetVertex(1), v4);
 
         copy = foo;
-        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        Transform(foo, GetIdentity<Mat22>() * 2);
         ASSERT_NE(foo, copy);
         
         dp0 = foo.children[0].GetDistanceProxy();

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -71,6 +71,73 @@ TEST(MultiShapeConf, DefaultConstruction)
     EXPECT_THROW(GetVertexRadius(foo, 0), InvalidArgument);
 }
 
+TEST(MultiShapeConf, TransformFF)
+{
+    {
+        auto foo = MultiShapeConf{};
+        auto copy = foo;
+        Transform(foo, Mat22{});
+        EXPECT_EQ(foo, copy);
+    }
+    {
+        auto foo = MultiShapeConf{};
+        auto copy = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, copy);
+    }
+    {
+        auto foo = MultiShapeConf{};
+        auto copy = foo;
+        auto vs = VertexSet{};
+        auto dp0 = DistanceProxy{};
+        auto dp1 = DistanceProxy{};
+
+        const auto v1 = Length2{1_m, 2_m};
+        const auto v2 = Length2{3_m, 4_m};
+        vs.clear();
+        vs.add(v1);
+        vs.add(v2);
+        foo.AddConvexHull(vs);
+        ASSERT_EQ(foo.children.size(), std::size_t(1));
+
+        copy = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, copy);
+
+        const auto v3 = Length2{-1_m, -2_m};
+        const auto v4 = Length2{-3_m, -4_m};
+        vs.clear();
+        vs.add(v3);
+        vs.add(v4);
+        foo.AddConvexHull(vs);
+        ASSERT_EQ(foo.children.size(), std::size_t(2));
+        
+        dp0 = foo.children[0].GetDistanceProxy();
+        ASSERT_EQ(dp0.GetVertexCount(), VertexCounter(2));
+        EXPECT_EQ(dp0.GetVertex(0), v2);
+        EXPECT_EQ(dp0.GetVertex(1), v1);
+
+        dp1 = foo.children[1].GetDistanceProxy();
+        ASSERT_EQ(dp1.GetVertexCount(), VertexCounter(2));
+        EXPECT_EQ(dp1.GetVertex(0), v3);
+        EXPECT_EQ(dp1.GetVertex(1), v4);
+
+        copy = foo;
+        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        ASSERT_NE(foo, copy);
+        
+        dp0 = foo.children[0].GetDistanceProxy();
+        ASSERT_EQ(dp0.GetVertexCount(), VertexCounter(2));
+        EXPECT_EQ(dp0.GetVertex(0), v2 * 2);
+        EXPECT_EQ(dp0.GetVertex(1), v1 * 2);
+        
+        dp1 = foo.children[1].GetDistanceProxy();
+        ASSERT_EQ(dp1.GetVertexCount(), VertexCounter(2));
+        EXPECT_EQ(dp1.GetVertex(0), v3 * 2);
+        EXPECT_EQ(dp1.GetVertex(1), v4 * 2);
+    }
+}
+
 TEST(MultiShapeConf, GetInvalidChildThrows)
 {
     const auto foo = MultiShapeConf{};

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -441,7 +441,7 @@ TEST(PolygonShapeConf, TransformFF)
     {
         auto foo = PolygonShapeConf{};
         auto copy = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, copy);
     }
     {
@@ -450,7 +450,7 @@ TEST(PolygonShapeConf, TransformFF)
         const auto vertices = std::vector<Length2>{v1, v2};
         auto foo = PolygonShapeConf{Span<const Length2>{vertices.data(), vertices.size()}};
         auto copy = foo;
-        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, copy);
     }
     {
@@ -462,7 +462,7 @@ TEST(PolygonShapeConf, TransformFF)
         ASSERT_EQ(foo.GetVertex(0), v2);
         ASSERT_EQ(foo.GetVertex(1), v1);
         auto copy = foo;
-        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        Transform(foo, GetIdentity<Mat22>() * 2);
         EXPECT_EQ(foo.GetVertex(0), v2 * 2);
         EXPECT_EQ(foo.GetVertex(1), v1 * 2);
     }

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -430,6 +430,44 @@ TEST(PolygonShapeConf, CanSetOnePoint)
     EXPECT_EQ(GetVertexRadius(shape), vertexRadius);
 }
 
+TEST(PolygonShapeConf, TransformFF)
+{
+    {
+        auto foo = PolygonShapeConf{};
+        auto copy = foo;
+        Transform(foo, Mat22{});
+        EXPECT_EQ(foo, copy);
+    }
+    {
+        auto foo = PolygonShapeConf{};
+        auto copy = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, copy);
+    }
+    {
+        const auto v1 = Length2{1_m, 2_m};
+        const auto v2 = Length2{3_m, 4_m};
+        const auto vertices = std::vector<Length2>{v1, v2};
+        auto foo = PolygonShapeConf{Span<const Length2>{vertices.data(), vertices.size()}};
+        auto copy = foo;
+        Transform(foo, Mat22{Vec2{1, 0}, Vec2{0, 1}});
+        EXPECT_EQ(foo, copy);
+    }
+    {
+        const auto v1 = Length2{1_m, 2_m};
+        const auto v2 = Length2{3_m, 4_m};
+        const auto vertices = std::vector<Length2>{v1, v2};
+        auto foo = PolygonShapeConf{Span<const Length2>{vertices.data(), vertices.size()}};
+        ASSERT_EQ(foo.GetVertexCount(), VertexCounter(2));
+        ASSERT_EQ(foo.GetVertex(0), v2);
+        ASSERT_EQ(foo.GetVertex(1), v1);
+        auto copy = foo;
+        Transform(foo, Mat22{Vec2{2, 0}, Vec2{0, 2}});
+        EXPECT_EQ(foo.GetVertex(0), v2 * 2);
+        EXPECT_EQ(foo.GetVertex(1), v1 * 2);
+    }
+}
+
 TEST(PolygonShapeConf, Equality)
 {
     EXPECT_TRUE(PolygonShapeConf() == PolygonShapeConf());

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -264,6 +264,11 @@ Finite<Real> GetRestitution(const X&) noexcept
     return Real{0};
 }
 
+void Transform(X&, const Mat22&) noexcept
+{
+    // Intentionally empty.
+}
+
 NonNegative<Real> GetFriction(const X&) noexcept
 {
     return Real{0};

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -94,7 +94,7 @@ TEST(Shape, DefaultConstruction)
     EXPECT_EQ(GetRestitution(s), Real(0));
     EXPECT_EQ(GetDensity(s), 0_kgpm2);
     EXPECT_THROW(GetVertexRadius(s, 0), InvalidArgument);
-    EXPECT_EQ(GetChildCount(s), 0);
+    EXPECT_EQ(GetChildCount(s), ChildCounter(0));
     EXPECT_THROW(GetChild(s, 0), InvalidArgument);
     EXPECT_TRUE(s == s);
     const auto t = Shape{};

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -97,8 +97,9 @@ TEST(Shape, DefaultConstruction)
     EXPECT_EQ(GetChildCount(s), ChildCounter(0));
     EXPECT_THROW(GetChild(s, 0), InvalidArgument);
     EXPECT_TRUE(s == s);
-    const auto t = Shape{};
+    auto t = Shape{};
     EXPECT_TRUE(s == t);
+    EXPECT_NO_THROW(Transform(t, Mat22{}));
 }
 
 TEST(Shape, types)

--- a/UnitTests/UnitTests.hpp
+++ b/UnitTests/UnitTests.hpp
@@ -51,44 +51,19 @@ struct MultiShapeConf;
 //   that uses the Shape class in order to avoid U.B. from O.D.R. violations.
 
 template <>
-inline bool Visit(const d2::DiskShapeConf&, void* userData)
-{
-    const auto data = static_cast<UnitTestsVisitorData*>(userData);
-    ++(data->visitedDisk);
-    return true;
-}
+bool Visit(const d2::DiskShapeConf&, void* userData);
 
 template <>
-inline bool Visit(const d2::EdgeShapeConf&, void* userData)
-{
-    const auto data = static_cast<UnitTestsVisitorData*>(userData);
-    ++(data->visitedEdge);
-    return true;
-}
+bool Visit(const d2::EdgeShapeConf&, void* userData);
 
 template <>
-inline bool Visit(const d2::PolygonShapeConf&, void* userData)
-{
-    const auto data = static_cast<UnitTestsVisitorData*>(userData);
-    ++(data->visitedPolygon);
-    return true;
-}
+bool Visit(const d2::PolygonShapeConf&, void* userData);
 
 template <>
-inline bool Visit(const d2::ChainShapeConf&, void* userData)
-{
-    const auto data = static_cast<UnitTestsVisitorData*>(userData);
-    ++(data->visitedChain);
-    return true;
-}
+bool Visit(const d2::ChainShapeConf&, void* userData);
 
 template <>
-inline bool Visit(const d2::MultiShapeConf&, void* userData)
-{
-    const auto data = static_cast<UnitTestsVisitorData*>(userData);
-    ++(data->visitedMulti);
-    return true;
-}
+bool Visit(const d2::MultiShapeConf&, void* userData);
 
 } // namespace playrho
 

--- a/UnitTests/Vector.cpp
+++ b/UnitTests/Vector.cpp
@@ -227,3 +227,23 @@ TEST(Vector, ReverseIterateWith_rbeginend)
         }
     }
 }
+
+TEST(Vector, ScalarTimesVector)
+{
+    const auto s = 2_m;
+    const auto v = Vector<Length, 3>{1_m, 2_m, 3_m};
+    const auto r = s * v;
+    EXPECT_EQ(Get<0>(r), 2_m2);
+    EXPECT_EQ(Get<1>(r), 4_m2);
+    EXPECT_EQ(Get<2>(r), 6_m2);
+}
+
+TEST(Vector, VectorTimesScalar)
+{
+    const auto v = Vector<Length, 3>{1_m, 2_m, 3_m};
+    const auto s = 10_m;
+    const auto r = v * s;
+    EXPECT_EQ(Get<0>(r), 10_m2);
+    EXPECT_EQ(Get<1>(r), 20_m2);
+    EXPECT_EQ(Get<2>(r), 30_m2);
+}

--- a/UnitTests/Vector.cpp
+++ b/UnitTests/Vector.cpp
@@ -27,6 +27,16 @@
 
 using namespace playrho;
 
+TEST(Vector, IsVector)
+{
+    EXPECT_TRUE((IsVector<Vector<int, 2>>::value));
+    EXPECT_TRUE((IsVector<Vector<float, 1>>::value));
+    EXPECT_TRUE((IsVector<Vector<Vector<float, 1>, 1>>::value));
+    EXPECT_FALSE(IsVector<int>::value);
+    EXPECT_FALSE(IsVector<float>::value);
+    EXPECT_FALSE(IsVector<nullptr_t>::value);
+}
+
 TEST(Vector, Equality)
 {
     Vector<int, 10> a;

--- a/UnitTests/Vector.cpp
+++ b/UnitTests/Vector.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <type_traits>
 #include <algorithm>
+#include <cstddef>
 
 using namespace playrho;
 
@@ -34,7 +35,7 @@ TEST(Vector, IsVector)
     EXPECT_TRUE((IsVector<Vector<Vector<float, 1>, 1>>::value));
     EXPECT_FALSE(IsVector<int>::value);
     EXPECT_FALSE(IsVector<float>::value);
-    EXPECT_FALSE(IsVector<nullptr_t>::value);
+    EXPECT_FALSE(IsVector<std::nullptr_t>::value);
 }
 
 TEST(Vector, Equality)

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1610,7 +1610,7 @@ TEST(World, HeavyOnLight)
         while (GetAwakeCount(world) > 0)
         {
             world.Step(smallerStepConf);
-            EXPECT_EQ(GetTouchingCount(world), 2);
+            EXPECT_EQ(GetTouchingCount(world), ContactCounter(2));
             upperBodysLowestPoint = std::min(upperBodysLowestPoint, GetY(upperBody->GetLocation()));
             ++numSteps;
         }
@@ -1643,9 +1643,9 @@ TEST(World, HeavyOnLight)
         upperBody->CreateFixture(Shape(biggerDiskConf), FixtureConf{}.UseIsSensor(true));
         ASSERT_LT(GetMass(*lowerBody), GetMass(*upperBody));
         
-        EXPECT_EQ(GetAwakeCount(world), 2);
+        EXPECT_EQ(GetAwakeCount(world), BodyCounter(2));
         world.Step(smallerStepConf);
-        EXPECT_EQ(GetTouchingCount(world), 2);
+        EXPECT_EQ(GetTouchingCount(world), ContactCounter(2));
     }
 }
 

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -927,33 +927,6 @@ TEST(World, AwakenFreeFunction)
     EXPECT_TRUE(body->IsAwake());
 }
 
-TEST(World, CreateSquareEnclosingBody)
-{
-    World world;
-    Body* body = nullptr;
-    EXPECT_NO_THROW(body = CreateSquareEnclosingBody(world, 2_m, ShapeConf{}, DefaultLinearSlop * Real{2}));
-    ASSERT_NE(body, nullptr);
-    EXPECT_EQ(body->GetType(), BodyType::Static);
-    const auto fixtures = body->GetFixtures();
-    EXPECT_GT(fixtures.size(), decltype(fixtures.size()){0});
-    auto vertices = std::set<Length2>();
-    for (auto& f: fixtures)
-    {
-        const auto s = f->GetShape();
-        const auto childCount = GetChildCount(s);
-        for (auto i = ChildCounter{0}; i < childCount; ++i)
-        {
-            const auto child = GetChild(s, i);
-            const auto numVertices = child.GetVertexCount();
-            for (auto j = decltype(numVertices){0}; j < numVertices; ++j)
-            {
-                vertices.insert(child.GetVertex(j));
-            }
-        }
-    }
-    EXPECT_EQ(vertices.size(), decltype(vertices.size()){4});
-}
-
 TEST(World, GetTouchingCountFreeFunction)
 {
     World world;

--- a/UnitTests/main.cpp
+++ b/UnitTests/main.cpp
@@ -20,6 +20,50 @@
 
 #include "UnitTests.hpp"
 
+namespace playrho {
+
+template <>
+bool Visit(const d2::DiskShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedDisk);
+    return true;
+}
+
+template <>
+bool Visit(const d2::EdgeShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedEdge);
+    return true;
+}
+
+template <>
+bool Visit(const d2::PolygonShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedPolygon);
+    return true;
+}
+
+template <>
+bool Visit(const d2::ChainShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedChain);
+    return true;
+}
+
+template <>
+bool Visit(const d2::MultiShapeConf&, void* userData)
+{
+    const auto data = static_cast<UnitTestsVisitorData*>(userData);
+    ++(data->visitedMulti);
+    return true;
+}
+
+} // namespace playrho
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
#### Description - What's this PR do?
- Visitation changes to do away with explicit inline of the template functions.
- Changes documentation comments and some source code formatting.
- Some white space changes.
- Changes documentation comments and renames parameter.
- Fixes compiler warnings about mismatched signed vs. unsigned arithmetic.
- Makes Transform function more generic.

#### Related Issues
- Issue #283.