### PR TITLE
Changes for enabling car turning around in car Testbed test and more.

### DIFF
--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -164,4 +164,41 @@ SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices)
     return (secondMomentOfAreaX + secondMomentOfAreaY) / Real{12};
 }
 
+namespace d2 {
+
+LinearVelocity2 GetContactRelVelocity(const Velocity velA, const Length2 relA,
+                                      const Velocity velB, const Length2 relB) noexcept
+{
+#if 0 // Using std::fma appears to be slower!
+    const auto revPerpRelB = GetRevPerpendicular(relB);
+    const auto xRevPerpRelB = StripUnit(revPerpRelB.x);
+    const auto yRevPerpRelB = StripUnit(revPerpRelB.y);
+    const auto angVelB = StripUnit(velB.angular);
+    const auto xLinVelB = StripUnit(velB.linear.x);
+    const auto yLinVelB = StripUnit(velB.linear.y);
+    const auto xFmaB = std::fma(xRevPerpRelB, angVelB, xLinVelB);
+    const auto yFmaB = std::fma(yRevPerpRelB, angVelB, yLinVelB);
+    
+    const auto revPerpRelA = GetRevPerpendicular(relA);
+    const auto xRevPerpRelA = StripUnit(revPerpRelA.x);
+    const auto yRevPerpRelA = StripUnit(revPerpRelA.y);
+    const auto angVelA = StripUnit(velA.angular);
+    const auto xLinVelA = StripUnit(velA.linear.x);
+    const auto yLinVelA = StripUnit(velA.linear.y);
+    const auto xFmaA = std::fma(xRevPerpRelA, angVelA, xLinVelA);
+    const auto yFmaA = std::fma(yRevPerpRelA, angVelA, yLinVelA);
+    
+    const auto deltaFmaX = xFmaB - xFmaA;
+    const auto deltaFmaY = yFmaB - yFmaA;
+    
+    return Vec2{deltaFmaX, deltaFmaY} * MeterPerSecond;
+#else
+    const auto velBrot = GetRevPerpendicular(relB) * (velB.angular / Radian);
+    const auto velArot = GetRevPerpendicular(relA) * (velA.angular / Radian);
+    return (velB.linear + velBrot) - (velA.linear + velArot);
+#endif
+}
+
+} // namespace d2
+
 } // namespace playrho

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -914,39 +914,8 @@ inline Transformation GetTransform1(const Sweep& sweep) noexcept
 /// @brief Gets the contact relative velocity.
 /// @note If <code>relA</code> and <code>relB</code> are the zero vectors, the resulting
 ///    value is simply <code>velB.linear - velA.linear</code>.
-inline LinearVelocity2
-GetContactRelVelocity(const Velocity velA, const Length2 relA,
-                      const Velocity velB, const Length2 relB) noexcept
-{
-#if 0 // Using std::fma appears to be slower!
-    const auto revPerpRelB = GetRevPerpendicular(relB);
-    const auto xRevPerpRelB = StripUnit(revPerpRelB.x);
-    const auto yRevPerpRelB = StripUnit(revPerpRelB.y);
-    const auto angVelB = StripUnit(velB.angular);
-    const auto xLinVelB = StripUnit(velB.linear.x);
-    const auto yLinVelB = StripUnit(velB.linear.y);
-    const auto xFmaB = std::fma(xRevPerpRelB, angVelB, xLinVelB);
-    const auto yFmaB = std::fma(yRevPerpRelB, angVelB, yLinVelB);
-    
-    const auto revPerpRelA = GetRevPerpendicular(relA);
-    const auto xRevPerpRelA = StripUnit(revPerpRelA.x);
-    const auto yRevPerpRelA = StripUnit(revPerpRelA.y);
-    const auto angVelA = StripUnit(velA.angular);
-    const auto xLinVelA = StripUnit(velA.linear.x);
-    const auto yLinVelA = StripUnit(velA.linear.y);
-    const auto xFmaA = std::fma(xRevPerpRelA, angVelA, xLinVelA);
-    const auto yFmaA = std::fma(yRevPerpRelA, angVelA, yLinVelA);
-    
-    const auto deltaFmaX = xFmaB - xFmaA;
-    const auto deltaFmaY = yFmaB - yFmaA;
-    
-    return Vec2{deltaFmaX, deltaFmaY} * MeterPerSecond;
-#else
-    const auto velBrot = GetRevPerpendicular(relB) * (velB.angular / Radian);
-    const auto velArot = GetRevPerpendicular(relA) * (velA.angular / Radian);
-    return (velB.linear + velBrot) - (velA.linear + velArot);
-#endif
-}
+LinearVelocity2 GetContactRelVelocity(const Velocity velA, const Length2 relA,
+                                      const Velocity velB, const Length2 relB) noexcept;
 
 /// @brief Gets whether the given velocity is "under active" based on the given tolerances.
 inline bool IsUnderActive(Velocity velocity,

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -1260,6 +1260,24 @@ inline Angle GetAngle(const Body& body) noexcept
     return body.GetSweep().pos1.angular;
 }
 
+/// @brief Gets the body's transformation.
+inline Transformation GetTransformation(const Body& body) noexcept
+{
+    return body.GetTransformation();
+}
+
+/// @brief Sets the body's transformation.
+inline void SetTransformation(Body& body, const Transformation& xfm) noexcept
+{
+    body.SetTransform(xfm.p, GetAngle(xfm.q));
+}
+
+/// @brief Gets the body's position.
+inline Position GetPosition(const Body& body) noexcept
+{
+    return Position{body.GetLocation(), body.GetAngle()};
+}
+
 /// @brief Sets the body's location.
 /// @details This instantly adjusts the body to be at the new location.
 /// @warning Manipulating a body's location this way can cause non-physical behavior!

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -1267,6 +1267,8 @@ inline Transformation GetTransformation(const Body& body) noexcept
 }
 
 /// @brief Sets the body's transformation.
+/// @note This operation isn't exact. I.e. don't expect that <code>GetTransformation</code>
+///   will return exactly the transformation that had been set.
 inline void SetTransformation(Body& body, const Transformation& xfm) noexcept
 {
     body.SetTransform(xfm.p, GetAngle(xfm.q));

--- a/PlayRho/Dynamics/BodyConf.hpp
+++ b/PlayRho/Dynamics/BodyConf.hpp
@@ -63,6 +63,12 @@ struct BodyConf
     /// @brief Use the given angular velocity.
     PLAYRHO_CONSTEXPR inline BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
     
+    /// @brief Use the given position for the linear and angular positions.
+    PLAYRHO_CONSTEXPR inline BodyConf& Use(Position v) noexcept;
+
+    /// @brief Use the given velocity for the linear and angular velocities.
+    PLAYRHO_CONSTEXPR inline BodyConf& Use(Velocity v) noexcept;
+    
     /// @brief Use the given linear acceleration.
     PLAYRHO_CONSTEXPR inline BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
     
@@ -175,6 +181,20 @@ PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseLocation(Length2 l) noexcept
 PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseAngle(Angle a) noexcept
 {
     angle = a;
+    return *this;
+}
+
+PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::Use(Position v) noexcept
+{
+    location = v.linear;
+    angle = v.angular;
+    return *this;
+}
+
+PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::Use(Velocity v) noexcept
+{
+    linearVelocity = v.linear;
+    angularVelocity = v.angular;
     return *this;
 }
 

--- a/Testbed/Tests/Car.hpp
+++ b/Testbed/Tests/Car.hpp
@@ -25,97 +25,81 @@
 
 namespace testbed {
 
-// This is a fun demo that shows off the wheel joint
+// This is a demo that shows off the wheel joint and reflection transformations.
 class Car : public Test
 {
 public:
     Car()
-    {        
-        m_hz = 4_Hz;
-        m_zeta = 0.7f;
-        m_speed = 50_rad / 1_s;
-
-        RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Move Left.", [&](KeyActionMods) {
-            m_spring1->SetMotorSpeed(m_speed);
-        });
+    {
+        const auto motorSpeed = 50_rad / 1_s;
         RegisterForKey(GLFW_KEY_S, GLFW_PRESS, 0, "Brake.", [&](KeyActionMods) {
-            m_spring1->SetMotorSpeed(0_rpm);
+            m_backSpring->SetMotorSpeed(0_rpm);
+        });
+        RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Move Left.", [&](KeyActionMods) {
+            m_backSpring->SetMotorSpeed(motorSpeed);
         });
         RegisterForKey(GLFW_KEY_D, GLFW_PRESS, 0, "Move Right.", [&](KeyActionMods) {
-            m_spring1->SetMotorSpeed(-m_speed);
+            m_backSpring->SetMotorSpeed(-motorSpeed);
+        });
+        RegisterForKey(GLFW_KEY_A, GLFW_PRESS, GLFW_MOD_SHIFT, "Turn Left.", [&](KeyActionMods) {
+            CreateCar(true);
+            m_backSpring->SetMotorSpeed(motorSpeed);
+        });
+        RegisterForKey(GLFW_KEY_D, GLFW_PRESS, GLFW_MOD_SHIFT, "Turn Right.", [&](KeyActionMods) {
+            CreateCar(false);
+            m_backSpring->SetMotorSpeed(-motorSpeed);
         });
         RegisterForKey(GLFW_KEY_Q, GLFW_PRESS, 0, "Decrease Frequency.", [&](KeyActionMods) {
             m_hz = std::max(0_Hz, m_hz - 1_Hz);
-            m_spring1->SetSpringFrequency(m_hz);
-            m_spring2->SetSpringFrequency(m_hz);
+            m_backSpring->SetSpringFrequency(m_hz);
+            m_frontSpring->SetSpringFrequency(m_hz);
         });
         RegisterForKey(GLFW_KEY_E, GLFW_PRESS, 0, "Increase Frequency.", [&](KeyActionMods) {
             m_hz += 1_Hz;
-            m_spring1->SetSpringFrequency(m_hz);
-            m_spring2->SetSpringFrequency(m_hz);
+            m_backSpring->SetSpringFrequency(m_hz);
+            m_frontSpring->SetSpringFrequency(m_hz);
         });
         
         const auto ground = m_world.CreateBody();
         {
-            auto conf = EdgeShapeConf{};
-            conf.UseDensity(0_kgpm2).UseFriction(Real(0.6f));
-
-            conf.Set(Vec2(-20.0f, 0.0f) * 1_m, Vec2(20.0f, 0.0f) * 1_m);
-            ground->CreateFixture(Shape(conf));
-
-            Real hs[10] = {0.25f, 1.0f, 4.0f, 0.0f, 0.0f, -1.0f, -2.0f, -2.0f, -1.25f, 0.0f};
-
+            const auto hs = {0.25f, 1.0f, 4.0f, 0.0f, 0.0f, -1.0f, -2.0f, -2.0f, -1.25f, 0.0f};
             auto x = Real{20.0f};
             auto y1 = Real{0.0f};
-            const auto dx = Real{5.0f};
-
-            for (auto i = 0; i < 10; ++i)
+            const auto dx = decltype(x){5.0f};
+            auto conf = EdgeShapeConf{}.UseDensity(0_kgpm2).UseFriction(Real(0.6f));
+            ground->CreateFixture(Shape{conf.Set(Vec2(-20, 0) * 1_m, Vec2(20, 0) * 1_m)});
+            for (const auto y2: hs)
             {
-                const auto y2 = hs[i];
-                conf.Set(Vec2(x, y1) * 1_m, Vec2(x + dx, y2) * 1_m);
-                ground->CreateFixture(Shape(conf));
+                ground->CreateFixture(Shape{conf.Set(Vec2(x, y1) * 1_m, Vec2(x + dx, y2) * 1_m)});
                 y1 = y2;
                 x += dx;
             }
-
-            for (auto i = 0; i < 10; ++i)
+            for (const auto y2: hs)
             {
-                const auto y2 = hs[i];
-                conf.Set(Vec2(x, y1) * 1_m, Vec2(x + dx, y2) * 1_m);
-                ground->CreateFixture(Shape(conf));
+                ground->CreateFixture(Shape{conf.Set(Vec2(x, y1) * 1_m, Vec2(x + dx, y2) * 1_m)});
                 y1 = y2;
                 x += dx;
             }
-
-            conf.Set(Vec2(x, 0.0f) * 1_m, Vec2(x + 40.0f, 0.0f) * 1_m);
-            ground->CreateFixture(Shape(conf));
-
+            ground->CreateFixture(Shape{conf.Set(Vec2(x, 0) * 1_m, Vec2(x + 40, 0) * 1_m)});
             x += 80.0f;
-            conf.Set(Vec2(x, 0.0f) * 1_m, Vec2(x + 40.0f, 0.0f) * 1_m);
-            ground->CreateFixture(Shape(conf));
-
+            ground->CreateFixture(Shape{conf.Set(Vec2(x, 0) * 1_m, Vec2(x + 40, 0) * 1_m)});
             x += 40.0f;
-            conf.Set(Vec2(x, 0.0f) * 1_m, Vec2(x + 10.0f, 5.0f) * 1_m);
-            ground->CreateFixture(Shape(conf));
-
+            ground->CreateFixture(Shape{conf.Set(Vec2(x, 0) * 1_m, Vec2(x + 10, 5) * 1_m)});
             x += 20.0f;
-            conf.Set(Vec2(x, 0.0f) * 1_m, Vec2(x + 40.0f, 0.0f) * 1_m);
-            ground->CreateFixture(Shape(conf));
-
+            ground->CreateFixture(Shape{conf.Set(Vec2(x, 0) * 1_m, Vec2(x + 40, 0) * 1_m)});
             x += 40.0f;
-            conf.Set(Vec2(x, 0.0f) * 1_m, Vec2(x, 20.0f) * 1_m);
-            ground->CreateFixture(Shape(conf));
+            ground->CreateFixture(Shape{conf.Set(Vec2(x, 0) * 1_m, Vec2(x, 20) * 1_m)});
         }
 
         // Teeter
         {
-            BodyConf bd;
+            auto bd = BodyConf{};
             bd.location = Vec2(140.0f, 1.0f) * 1_m;
             bd.type = BodyType::Dynamic;
             const auto body = m_world.CreateBody(bd);
             body->CreateFixture(Shape{PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(10_m, 0.25_m)});
 
-            RevoluteJointConf jd(ground, body, body->GetLocation());
+            auto jd = RevoluteJointConf{ground, body, body->GetLocation()};
             jd.lowerAngle = -8_deg;
             jd.upperAngle = +8_deg;
             jd.enableLimit = true;
@@ -134,104 +118,93 @@ public:
             auto prevBody = ground;
             for (auto i = 0; i < N; ++i)
             {
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2(161.0f + 2.0f * i, -0.125f) * 1_m;
+                auto bd = BodyConf{}.UseType(BodyType::Dynamic);
+                bd.location = Vec2(161 + 2 * i, -0.125f) * 1_m;
                 const auto body = m_world.CreateBody(bd);
                 body->CreateFixture(shape);
-
                 m_world.CreateJoint(RevoluteJointConf{prevBody, body,
-                    Vec2(160.0f + 2.0f * i, -0.125f) * 1_m});
-
+                    Vec2(160 + 2 * i, -0.125f) * 1_m});
                 prevBody = body;
             }
             m_world.CreateJoint(RevoluteJointConf{prevBody, ground,
-                Vec2(160.0f + 2.0f * N, -0.125f) * 1_m});
+                Vec2(160 + 2 * N, -0.125f) * 1_m});
         }
 
         // Boxes
         {
             const auto box = Shape{PolygonShapeConf{}.UseDensity(0.5_kgpm2).SetAsBox(0.5_m, 0.5_m)};
-            auto body = static_cast<Body*>(nullptr);
-
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-
-            bd.location = Vec2(230.0f, 0.5f) * 1_m;
-            body = m_world.CreateBody(bd);
-            body->CreateFixture(box);
-
-            bd.location = Vec2(230.0f, 1.5f) * 1_m;
-            body = m_world.CreateBody(bd);
-            body->CreateFixture(box);
-
-            bd.location = Vec2(230.0f, 2.5f) * 1_m;
-            body = m_world.CreateBody(bd);
-            body->CreateFixture(box);
-
-            bd.location = Vec2(230.0f, 3.5f) * 1_m;
-            body = m_world.CreateBody(bd);
-            body->CreateFixture(box);
-
-            bd.location = Vec2(230.0f, 4.5f) * 1_m;
-            body = m_world.CreateBody(bd);
-            body->CreateFixture(box);
+            auto bd = BodyConf{}.UseType(BodyType::Dynamic);
+            m_world.CreateBody(bd.UseLocation(Vec2(230, 0.5f) * 1_m))->CreateFixture(box);
+            m_world.CreateBody(bd.UseLocation(Vec2(230, 1.5f) * 1_m))->CreateFixture(box);
+            m_world.CreateBody(bd.UseLocation(Vec2(230, 2.5f) * 1_m))->CreateFixture(box);
+            m_world.CreateBody(bd.UseLocation(Vec2(230, 3.5f) * 1_m))->CreateFixture(box);
+            m_world.CreateBody(bd.UseLocation(Vec2(230, 4.5f) * 1_m))->CreateFixture(box);
         }
 
-        // Car
-        {
-            const auto chassis = Shape(PolygonShapeConf{}
-                .UseDensity(1_kgpm2).UseVertices({
-                    Vec2(-1.5f, -0.5f) * 1_m,
-                    Vec2(1.5f, -0.5f) * 1_m,
-                    Vec2(1.5f, 0.0f) * 1_m,
-                    Vec2(0.0f, 0.9f) * 1_m,
-                    Vec2(-1.15f, 0.9f) * 1_m,
-                    Vec2(-1.5f, 0.2f) * 1_m
-                }));
-
-            const auto circle = Shape{
-                DiskShapeConf{}.UseRadius(0.4_m).UseDensity(1_kgpm2).UseFriction(Real(0.9f))
-            };
-            
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(0.0f, 1.0f) * 1_m;
-            m_car = m_world.CreateBody(bd);
-            m_car->CreateFixture(chassis);
-
-            bd.location = Vec2(-1.0f, 0.35f) * 1_m;
-            m_wheel1 = m_world.CreateBody(bd);
-            m_wheel1->CreateFixture(circle);
-
-            bd.location = Vec2(1.0f, 0.4f) * 1_m;
-            m_wheel2 = m_world.CreateBody(bd);
-            m_wheel2->CreateFixture(circle);
-
-            const auto axis = UnitVec::GetTop();
-
-            {
-                WheelJointConf jd(m_car, m_wheel1, m_wheel1->GetLocation(), axis);
-                jd.motorSpeed = 0_rpm;
-                jd.maxMotorTorque = 20_Nm;
-                jd.enableMotor = true;
-                jd.frequency = m_hz;
-                jd.dampingRatio = m_zeta;
-                m_spring1 = static_cast<WheelJoint*>(m_world.CreateJoint(jd));
-            }
-            {
-                WheelJointConf jd(m_car, m_wheel2, m_wheel2->GetLocation(), axis);
-                jd.motorSpeed = 0_rpm;
-                jd.maxMotorTorque = 10_Nm;
-                jd.enableMotor = false;
-                jd.frequency = m_hz;
-                jd.dampingRatio = m_zeta;
-                m_spring2 = static_cast<WheelJoint*>(m_world.CreateJoint(jd));
-            }
-        }
+        CreateCar();
         SetAccelerations(m_world, m_gravity);
     }
 
+    void CreateCar(bool flip = false)
+    {
+        const auto carPosition = m_car? GetPosition(*m_car): Position{Length2{0_m, 1_m}, 0_deg};
+        const auto carVelocity = m_car? m_car->GetVelocity(): Velocity{};
+        if (m_frontSpring) m_world.Destroy(m_frontSpring->GetBodyB());
+        if (m_backSpring) m_world.Destroy(m_backSpring->GetBodyB());
+        if (m_car) m_world.Destroy(m_car);
+
+        const auto transmat = flip? GetReflectionMatrix(UnitVec::GetRight()): GetIdentity<Mat22>();
+        const auto carShapeConf = PolygonShapeConf{}.UseDensity(1_kgpm2).UseVertices({
+            Vec2(-1.5f, -0.5f) * 1_m /* bottom left of car body */,
+            Vec2(1.5f, -0.5f) * 1_m  /* bottom right of car body */,
+            Vec2(1.5f, 0.0f) * 1_m   /* top right of car engine front */,
+            Vec2(0.0f, 0.9f) * 1_m   /* top right of car roof */,
+            Vec2(-1.15f, 0.9f) * 1_m /* top left of car roof */,
+            Vec2(-1.5f, 0.2f) * 1_m  /* top left of car body */
+        }).Transform(transmat);
+
+        auto bd = BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(m_gravity);
+        m_car = m_world.CreateBody(bd.Use(carPosition).Use(carVelocity));
+        m_car->CreateFixture(Shape{carShapeConf});
+        
+        const auto wheelShape = Shape{
+            DiskShapeConf{}.UseRadius(0.4_m).UseDensity(1_kgpm2).UseFriction(Real(0.9f))
+        };
+        {
+            // setup back wheel
+            const auto location = carPosition.linear + Rotate(transmat * Length2{-1_m, -0.65_m}, UnitVec::Get(carPosition.angular));
+            const auto wheel = m_world.CreateBody(bd.UseLocation(location));
+            wheel->CreateFixture(wheelShape);
+            auto jd = WheelJointConf{m_car, wheel, wheel->GetLocation(), UnitVec::GetTop()};
+            jd.maxMotorTorque = 20_Nm;
+            jd.enableMotor = true;
+            jd.frequency = m_hz;
+            jd.dampingRatio = m_zeta;
+            m_backSpring = static_cast<WheelJoint*>(m_world.CreateJoint(jd));
+        }
+        {
+            // setup front wheel
+            const auto location = carPosition.linear + Rotate(transmat * Length2{+1_m, -0.6_m}, UnitVec::Get(carPosition.angular));
+            const auto wheel = m_world.CreateBody(bd.UseLocation(location));
+            wheel->CreateFixture(wheelShape);
+            auto jd = WheelJointConf{m_car, wheel, wheel->GetLocation(), UnitVec::GetTop()};
+            jd.maxMotorTorque = 10_Nm;
+            jd.enableMotor = false;
+            jd.frequency = m_hz;
+            jd.dampingRatio = m_zeta;
+            m_frontSpring = static_cast<WheelJoint*>(m_world.CreateJoint(jd));
+        }
+    }
+    
+    Length2 DestroyCar()
+    {
+        const auto location = m_car->GetLocation();
+        m_world.Destroy(m_backSpring->GetBodyB());
+        m_world.Destroy(m_frontSpring->GetBodyB());
+        m_world.Destroy(m_car);
+        return location;
+    }
+    
     void PreStep(const Settings&, Drawer& drawer) override
     {
         drawer.SetTranslation(Length2{GetX(m_car->GetLocation()), GetY(drawer.GetTranslation())});
@@ -245,15 +218,11 @@ public:
         m_status = stream.str();
     }
 
-    Body* m_car;
-    Body* m_wheel1;
-    Body* m_wheel2;
-
-    Frequency m_hz ;
-    Real m_zeta;
-    AngularVelocity m_speed;
-    WheelJoint* m_spring1;
-    WheelJoint* m_spring2;
+    const Real m_zeta = 0.7f;
+    Frequency m_hz = 4_Hz;
+    Body* m_car = nullptr;
+    WheelJoint* m_backSpring = nullptr;
+    WheelJoint* m_frontSpring = nullptr;
 };
 
 } // namespace testbed

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -30,6 +30,20 @@
 using namespace playrho;
 using namespace playrho::d2;
 
+TEST(BodyConf, UsePosition)
+{
+    const auto p = Position{Length2{3_m, -4_m}, 22_deg};
+    EXPECT_EQ(BodyConf{}.Use(p).location, p.linear);
+    EXPECT_EQ(BodyConf{}.Use(p).angle, p.angular);
+}
+
+TEST(BodyConf, UseVelocity)
+{
+    const auto v = Velocity{LinearVelocity2{3_mps, -4_mps}, 22_rad / 1_s};
+    EXPECT_EQ(BodyConf{}.Use(v).linearVelocity, v.linear);
+    EXPECT_EQ(BodyConf{}.Use(v).angularVelocity, v.angular);
+}
+
 TEST(Body, ContactsByteSize)
 {
 #if defined(__APPLE__)
@@ -846,3 +860,25 @@ TEST(Body, GetCentripetalForce)
     EXPECT_NEAR(static_cast<double>(Real(GetX(force)/Newton)), 8.1230141222476959, 0.01);
     EXPECT_NEAR(static_cast<double>(Real(GetY(force)/Newton)), 9.0255714952945709, 0.01);
 }
+
+TEST(Body, GetPositionFF)
+{
+    const auto position = Position{Length2{-33_m, +4_m}, 10_deg};
+    auto world = World{};
+    auto body = world.CreateBody();
+    EXPECT_NE(GetPosition(*body), position);
+    SetLocation(*body, position.linear);
+    SetAngle(*body, position.angular);
+    EXPECT_EQ(GetPosition(*body), position);
+}
+
+TEST(Body, GetSetTransformationFF)
+{
+    const auto transformation = Transformation{Length2{-33_m, +4_m}, UnitVec::GetTopRight()};
+    auto world = World{};
+    auto body = world.CreateBody();
+    EXPECT_NE(GetTransformation(*body), transformation);
+    SetTransformation(*body, transformation);
+    EXPECT_EQ(GetTransformation(*body), transformation);
+}
+

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -874,15 +874,14 @@ TEST(Body, GetPositionFF)
 
 TEST(Body, GetSetTransformationFF)
 {
-    const auto transformation = Transformation{Length2{-33_m, +4_m}, UnitVec::GetTopRight()};
+    const auto xfm0 = Transformation{Length2{-33_m, +4_m}, UnitVec::GetTopRight()};
     auto world = World{};
     auto body = world.CreateBody();
-    EXPECT_NE(GetTransformation(*body), transformation);
-    SetTransformation(*body, transformation);
-    EXPECT_EQ(GetTransformation(*body).p, transformation.p);
-    EXPECT_NEAR(static_cast<double>(GetX(GetTransformation(*body).q)),
-                static_cast<double>(GetX(transformation.q)), 0.0001);
-    EXPECT_NEAR(static_cast<double>(GetY(GetTransformation(*body).q)),
-                static_cast<double>(GetY(transformation.q)), 0.0001);
+    EXPECT_NE(GetTransformation(*body), xfm0);
+    SetTransformation(*body, xfm0);
+    const auto xfm1 = GetTransformation(*body);
+    EXPECT_EQ(xfm1.p, xfm0.p);
+    EXPECT_NEAR(static_cast<double>(GetX(xfm1.q)), static_cast<double>(GetX(xfm0.q)), 0.0001);
+    EXPECT_NEAR(static_cast<double>(GetY(xfm1.q)), static_cast<double>(GetY(xfm0.q)), 0.0001);
 }
 

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -879,6 +879,10 @@ TEST(Body, GetSetTransformationFF)
     auto body = world.CreateBody();
     EXPECT_NE(GetTransformation(*body), transformation);
     SetTransformation(*body, transformation);
-    EXPECT_EQ(GetTransformation(*body), transformation);
+    EXPECT_EQ(GetTransformation(*body).p, transformation.p);
+    EXPECT_NEAR(static_cast<double>(GetX(GetTransformation(*body).q)),
+                static_cast<double>(GetX(transformation.q)), 0.0001);
+    EXPECT_NEAR(static_cast<double>(GetY(GetTransformation(*body).q)),
+                static_cast<double>(GetY(transformation.q)), 0.0001);
 }
 


### PR DESCRIPTION
#### Description - What's this PR do?    
- Adds new BodyConf builder convenience methods.
- Adds new free functions for getting and setting Body settings.
- Updates the Car Testbed Test/demo to enable car turning around via reflection transformations.
- Adds associated unit test code.
- Moves the GetContactRelVelocity implementation code into the Math.cpp file.

#### Related Issues
- Issue #287.
