### PR TITLE
Various changes 20180127

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		479B63C31ED9CAC300D49BC7 /* BoundedValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 479B63C21ED9CAC300D49BC7 /* BoundedValue.cpp */; };
 		47AB01BA1D6FA40C0084D721 /* Dump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47AB01B91D6FA40C0084D721 /* Dump.cpp */; };
 		47AFC3051DAEBC120023E9D1 /* PositionSolverManifold.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47AFC3041DAEBC120023E9D1 /* PositionSolverManifold.cpp */; };
+		47B490D7201E6C3000AB07A0 /* IslandStats.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47B490D5201E6C3000AB07A0 /* IslandStats.hpp */; };
 		47B58F551F570E2C00354C34 /* DynamicMemory.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47B58F531F570E2C00354C34 /* DynamicMemory.cpp */; };
 		47B58F561F570E2C00354C34 /* DynamicMemory.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 47B58F541F570E2C00354C34 /* DynamicMemory.hpp */; };
 		47B58F591F57218400354C34 /* Version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 47B58F571F57218400354C34 /* Version.cpp */; };
@@ -574,6 +575,7 @@
 		479B63C21ED9CAC300D49BC7 /* BoundedValue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BoundedValue.cpp; sourceTree = "<group>"; };
 		47AB01B91D6FA40C0084D721 /* Dump.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Dump.cpp; sourceTree = "<group>"; };
 		47AFC3041DAEBC120023E9D1 /* PositionSolverManifold.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PositionSolverManifold.cpp; sourceTree = "<group>"; };
+		47B490D5201E6C3000AB07A0 /* IslandStats.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = IslandStats.hpp; sourceTree = "<group>"; };
 		47B58F531F570E2C00354C34 /* DynamicMemory.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DynamicMemory.cpp; sourceTree = "<group>"; };
 		47B58F541F570E2C00354C34 /* DynamicMemory.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = DynamicMemory.hpp; sourceTree = "<group>"; };
 		47B58F571F57218400354C34 /* Version.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Version.cpp; sourceTree = "<group>"; };
@@ -1051,6 +1053,7 @@
 				4731DE181DDCD0E100E7F931 /* FixtureProxy.hpp */,
 				80BB8953141C3E5900F1753A /* Island.cpp */,
 				80BB8954141C3E5900F1753A /* Island.hpp */,
+				47B490D5201E6C3000AB07A0 /* IslandStats.hpp */,
 				80BB896D141C3E5900F1753A /* Joints */,
 				470F94C31EC4D78300AA3C82 /* JointAtty.hpp */,
 				471E7EAF1F34E34000DFF626 /* MovementConf.cpp */,
@@ -1413,6 +1416,7 @@
 				470F94C01EC4D63400AA3C82 /* ContactAtty.hpp in Headers */,
 				80BB89DB141C3E5900F1753A /* RopeJoint.hpp in Headers */,
 				80BB89DD141C3E5900F1753A /* WeldJoint.hpp in Headers */,
+				47B490D7201E6C3000AB07A0 /* IslandStats.hpp in Headers */,
 				80BB89DF141C3E5900F1753A /* WheelJoint.hpp in Headers */,
 				4787D6DB1F2ECFFB008C115E /* RevoluteJointConf.hpp in Headers */,
 				4751EE2E1CEDD7A300D459CB /* MotorJoint.hpp in Headers */,
@@ -1976,7 +1980,7 @@
 				LD_GENERATE_MAP_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				ONLY_ACTIVE_ARCH = YES;
-                OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;
 				USE_HEADERMAP = NO;
 			};
@@ -2047,9 +2051,9 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_GENERATE_MAP_FILE = YES;
-                LLVM_LTO = NO;
+				LLVM_LTO = NO;
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
-                OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
+				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				SDKROOT = macosx;
 				USE_HEADERMAP = NO;
 			};

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -762,5 +762,14 @@ void Query(const DynamicTree& tree, const AABB& aabb, const DynamicTreeSizeCB& c
     }
 }
 
+void Query(const DynamicTree& tree, const AABB& aabb, QueryFixtureCallback callback)
+{
+    Query(tree, aabb, [&](DynamicTree::Size treeId) {
+        const auto leafData = tree.GetLeafData(treeId);
+        return callback(leafData.fixture, leafData.childIndex)?
+        DynamicTreeOpcode::Continue: DynamicTreeOpcode::End;
+    });
+}
+
 } // namespace d2
 } // namespace playrho

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -851,6 +851,16 @@ using DynamicTreeSizeCB = std::function<DynamicTreeOpcode(DynamicTree::Size)>;
 void Query(const DynamicTree& tree, const AABB& aabb,
            const DynamicTreeSizeCB& callback);
 
+/// @brief Query AABB for fixtures callback function type.
+/// @note Returning true will continue the query. Returning false will terminate the query.
+using QueryFixtureCallback = std::function<bool(Fixture* fixture, ChildCounter child)>;
+
+/// @brief Queries the world for all fixtures that potentially overlap the provided AABB.
+/// @param tree Dynamic tree to do the query over.
+/// @param aabb The query box.
+/// @param callback User implemented callback function.
+void Query(const DynamicTree& tree, const AABB& aabb, QueryFixtureCallback callback);
+
 } // namespace d2
 } // namespace playrho
 

--- a/PlayRho/Dynamics/IslandStats.hpp
+++ b/PlayRho/Dynamics/IslandStats.hpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_DYNAMICS_ISLANDSTATS_HPP
+#define PLAYRHO_DYNAMICS_ISLANDSTATS_HPP
+
+#include <PlayRho/Common/Units.hpp>
+#include <PlayRho/Common/Settings.hpp>
+
+namespace playrho {
+
+/// @brief Island solver statistics.
+struct IslandStats
+{
+    Length minSeparation = std::numeric_limits<Length>::infinity(); ///< Minimum separation.
+    Momentum maxIncImpulse = 0; ///< Maximum incremental impulse.
+    BodyCounter bodiesSlept = 0; ///< Bodies slept.
+    ContactCounter contactsUpdated = 0; ///< Contacts updated.
+    ContactCounter contactsSkipped = 0; ///< Contacts skipped.
+    bool solved = false; ///< Solved. <code>true</code> if position constraints solved, <code>false</code> otherwise.
+    TimestepIters positionIterations = 0; ///< Position iterations actually performed.
+    TimestepIters velocityIterations = 0; ///< Velocity iterations actually performed.
+};
+
+} // namespace playrho
+
+#endif // PLAYRHO_DYNAMICS_ISLANDSTATS_HPP

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -481,6 +481,10 @@ void World::Clear() noexcept
     m_bodiesForProxies.clear();
 
     for_each(cbegin(m_joints), cend(m_joints), [&](const Joint *j) {
+        if (m_destructionListener)
+        {
+            m_destructionListener->SayGoodbye(*j);
+        }
         JointAtty::Destroy(j);
     });
     for_each(begin(m_bodies), end(m_bodies), [&](Bodies::value_type& body) {

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -1859,15 +1859,6 @@ StepStats World::Step(const StepConf& conf)
     return stepStats;
 }
 
-void World::QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const
-{
-    Query(m_tree, aabb, [&](DynamicTree::Size treeId) {
-        const auto leafData = m_tree.GetLeafData(treeId);
-        return callback(leafData.fixture, leafData.childIndex)?
-            DynamicTreeOpcode::Continue: DynamicTreeOpcode::End;
-    });
-}
-
 void World::ShiftOrigin(Length2 newOrigin)
 {
     if (IsLocked())
@@ -1875,7 +1866,8 @@ void World::ShiftOrigin(Length2 newOrigin)
         throw WrongState("World::ShiftOrigin: world is locked");
     }
 
-    for (auto&& body: GetBodies())
+    const auto bodies = GetBodies();
+    for (auto&& body: bodies)
     {
         auto& b = GetRef(body);
 
@@ -2637,7 +2629,8 @@ ContactCounter GetTouchingCount(const World& world) noexcept
 size_t GetFixtureCount(const World& world) noexcept
 {
     auto sum = size_t{0};
-    for_each(cbegin(world.GetBodies()), cend(world.GetBodies()),
+    const auto bodies = world.GetBodies();
+    for_each(cbegin(bodies), cend(bodies),
              [&](const World::Bodies::value_type &body) {
         sum += GetFixtureCount(GetRef(body));
     });
@@ -2647,7 +2640,8 @@ size_t GetFixtureCount(const World& world) noexcept
 size_t GetShapeCount(const World& world) noexcept
 {
     auto shapes = std::set<const void*>();
-    for_each(cbegin(world.GetBodies()), cend(world.GetBodies()), [&](const World::Bodies::value_type &b) {
+    const auto bodies = world.GetBodies();
+    for_each(cbegin(bodies), cend(bodies), [&](const World::Bodies::value_type &b) {
         const auto fixtures = GetRef(b).GetFixtures();
         for_each(cbegin(fixtures), cend(fixtures), [&](const Body::Fixtures::value_type& f) {
             shapes.insert(GetData(GetRef(f).GetShape()));
@@ -2668,7 +2662,8 @@ BodyCounter Awaken(World& world) noexcept
 {
     // Can't use count_if since body gets modified.
     auto awoken = BodyCounter{0};
-    for_each(begin(world.GetBodies()), end(world.GetBodies()), [&](World::Bodies::value_type &b) {
+    const auto bodies = world.GetBodies();
+    for_each(begin(bodies), end(bodies), [&](World::Bodies::value_type &b) {
         if (playrho::d2::Awaken(GetRef(b)))
         {
             ++awoken;
@@ -2677,23 +2672,18 @@ BodyCounter Awaken(World& world) noexcept
     return awoken;
 }
 
-void SetAccelerations(World& world, std::function<Acceleration(const Body& b)> fn) noexcept
-{
-    for_each(begin(world.GetBodies()), end(world.GetBodies()), [&](World::Bodies::value_type &b) {
-        SetAcceleration(GetRef(b), fn(GetRef(b)));
-    });
-}
-
 void SetAccelerations(World& world, Acceleration acceleration) noexcept
 {
-    for_each(begin(world.GetBodies()), end(world.GetBodies()), [&](World::Bodies::value_type &b) {
+    const auto bodies = world.GetBodies();
+    for_each(begin(bodies), end(bodies), [&](World::Bodies::value_type &b) {
         SetAcceleration(GetRef(b), acceleration);
     });
 }
 
 void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept
 {
-    for_each(begin(world.GetBodies()), end(world.GetBodies()), [&](World::Bodies::value_type &b) {
+    const auto bodies = world.GetBodies();
+    for_each(begin(bodies), end(bodies), [&](World::Bodies::value_type &b) {
         SetLinearAcceleration(GetRef(b), acceleration);
     });
 }

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -212,15 +212,6 @@ public:
     ///
     StepStats Step(const StepConf& conf);
 
-    /// @brief Query AABB for fixtures callback function type.
-    /// @note Returning true will continue the query. Returning false will terminate the query.
-    using QueryFixtureCallback = std::function<bool(Fixture* fixture, ChildCounter child)>;
-
-    /// @brief Queries the world for all fixtures that potentially overlap the provided AABB.
-    /// @param aabb the query box.
-    /// @param callback User implemented callback function.
-    void QueryAABB(const AABB& aabb, QueryFixtureCallback callback) const;
-
     /// @brief Gets the world body range for this world.
     /// @return Body range that can be iterated over using its begin and end methods
     ///   or using ranged-based for-loops.
@@ -1038,8 +1029,18 @@ BodyCounter GetAwakeCount(const World& world) noexcept;
 BodyCounter Awaken(World& world) noexcept;
 
 /// @brief Sets the accelerations of all the world's bodies.
+/// @param world World instance to set the acceleration of all contained bodies for.
+/// @param fn Function or functor with a signature like:
+///   <code>Acceleration (*fn)(const Body& body)</code>.
 /// @relatedalso World
-void SetAccelerations(World& world, std::function<Acceleration(const Body& b)> fn) noexcept;
+template <class F>
+void SetAccelerations(World& world, F fn) noexcept
+{
+    const auto bodies = world.GetBodies();
+    std::for_each(std::begin(bodies), std::end(bodies), [&](World::Bodies::value_type &b) {
+        SetAcceleration(GetRef(b), fn(GetRef(b)));
+    });
+}
 
 /// @brief Sets the accelerations of all the world's bodies to the given value.
 /// @relatedalso World

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -37,6 +37,7 @@
 #include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
 #include <PlayRho/Dynamics/ContactAtty.hpp>
 #include <PlayRho/Dynamics/JointAtty.hpp>
+#include <PlayRho/Dynamics/IslandStats.hpp>
 
 #include <vector>
 #include <map>
@@ -97,10 +98,6 @@ struct ShapeConf;
 class World
 {
 public:
-    
-    /// @brief Proxy size type.
-    using proxy_size_type = std::remove_const<decltype(MaxContacts)>::type;
-    
     /// @brief Bodies container type.
     using Bodies = std::vector<Body*>;
 
@@ -352,22 +349,6 @@ private:
         e_stepComplete  = 0x0040,
     };
 
-    /// @brief Island solver results.
-    struct IslandSolverResults
-    {
-        Length minSeparation = std::numeric_limits<Length>::infinity(); ///< Minimum separation.
-        Momentum maxIncImpulse = 0; ///< Maximum incremental impulse.
-        BodyCounter bodiesSlept = 0; ///< Bodies slept.
-        ContactCounter contactsUpdated = 0; ///< Contacts updated.
-        ContactCounter contactsSkipped = 0; ///< Contacts skipped.
-        bool solved = false; ///< Solved. <code>true</code> if position constraints solved, <code>false</code> otherwise.
-        TimestepIters positionIterations = 0; ///< Position iterations actually performed.
-        TimestepIters velocityIterations = 0; ///< Velocity iterations actually performed.
-    };
-    
-    /// @brief Updates the given regular step statistics.
-    static RegStepStats& Update(RegStepStats& lhs, const IslandSolverResults& rhs) noexcept;
-
     /// @brief Copies bodies.
     void CopyBodies(std::map<const Body*, Body*>& bodyMap,
                     std::map<const Fixture*, Fixture*>& fixtureMap,
@@ -413,7 +394,7 @@ private:
     ///
     /// @return Island solver results.
     ///
-    IslandSolverResults SolveRegIslandViaGS(const StepConf& conf, Island island);
+    IslandStats SolveRegIslandViaGS(const StepConf& conf, Island island);
     
     /// @brief Adds to the island based off of a given "seed" body.
     /// @post Contacts are listed in the island in the order that bodies provide those contacts.
@@ -460,7 +441,7 @@ private:
     /// @note Precondition 2: there is not a lower TOI in the time step for which collisions have
     ///   not already been processed.
     ///
-    IslandSolverResults SolveToi(const StepConf& conf, Contact& contact);
+    IslandStats SolveToi(const StepConf& conf, Contact& contact);
     
     /// @brief Solves the time of impact for bodies 0 and 1 of the given island.
     ///
@@ -482,7 +463,7 @@ private:
     ///
     /// @return Island solver results.
     ///
-    IslandSolverResults SolveToiViaGS(const StepConf& conf, Island& island);
+    IslandStats SolveToiViaGS(const StepConf& conf, Island& island);
 
     /// @brief Updates the given body.
     /// @details Updates the given body's velocity, sweep position 1, and its transformation.
@@ -931,17 +912,6 @@ inline void World::RegisterForProcessing(ProxyId pid) noexcept
     m_proxies.push_back(pid);
 }
 
-inline RegStepStats& World::Update(RegStepStats& lhs, const World::IslandSolverResults& rhs) noexcept
-{
-    lhs.maxIncImpulse = std::max(lhs.maxIncImpulse, rhs.maxIncImpulse);
-    lhs.minSeparation = std::min(lhs.minSeparation, rhs.minSeparation);
-    lhs.islandsSolved += rhs.solved;
-    lhs.sumPosIters += rhs.positionIterations;
-    lhs.sumVelIters += rhs.velocityIterations;
-    lhs.bodiesSlept += rhs.bodiesSlept;
-    return lhs;
-}
-
 // Free functions.
 
 /// @brief Gets the body count in the given world.
@@ -1060,12 +1030,16 @@ inline void ClearForces(World& world) noexcept
         LinearAcceleration2{0_mps2, 0_mps2}, 0 * RadianPerSquareSecond
     });
 }
-    
+
 /// @brief Finds body in given world that's closest to the given location.
 /// @relatedalso World
 Body* FindClosestBody(const World& world, Length2 location) noexcept;
 
 } // namespace d2
+
+/// @brief Updates the given regular step statistics.
+RegStepStats& Update(RegStepStats& lhs, const IslandStats& rhs) noexcept;
+
 } // namespace playrho
 
 #endif // PLAYRHO_DYNAMICS_WORLD_HPP

--- a/PlayRho/Dynamics/WorldCallbacks.hpp
+++ b/PlayRho/Dynamics/WorldCallbacks.hpp
@@ -42,11 +42,11 @@ public:
 
     /// Called when any joint is about to be destroyed due
     /// to the destruction of one of its attached bodies.
-    virtual void SayGoodbye(Joint& joint) = 0;
+    virtual void SayGoodbye(const Joint& joint) = 0;
 
     /// Called when any fixture is about to be destroyed due
     /// to the destruction of its parent body.
-    virtual void SayGoodbye(Fixture& fixture) = 0;
+    virtual void SayGoodbye(const Fixture& fixture) = 0;
 };
 
 /// @brief A pure-virtual interface for "listeners" for contacts.

--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -213,7 +213,7 @@ struct GLRenderPoints
 {
     GLRenderPoints()
     {
-        static PLAYRHO_CONSTEXPR const char vs[] = \
+        static constexpr const char vs[] = \
         "#version 330\n"
         "uniform mat4 projectionMatrix;\n"
         "layout(location = 0) in vec2 v_position;\n"
@@ -227,7 +227,7 @@ struct GLRenderPoints
         "    gl_PointSize = v_size;\n"
         "}\n";
         
-        static PLAYRHO_CONSTEXPR const char fs[] = \
+        static constexpr const char fs[] = \
         "#version 330\n"
         "in vec4 f_color;\n"
         "out vec4 color;\n"

--- a/Testbed/Framework/Drawer.hpp
+++ b/Testbed/Framework/Drawer.hpp
@@ -30,7 +30,7 @@ struct Color
 {
     Color() = default;
     
-    PLAYRHO_CONSTEXPR inline Color(float ri, float gi, float bi, float ai = 1):
+    constexpr inline Color(float ri, float gi, float bi, float ai = 1):
         r(playrho::Clamp(ri, 0.0f, 1.0f)),
         g(playrho::Clamp(gi, 0.0f, 1.0f)),
         b(playrho::Clamp(bi, 0.0f, 1.0f)),
@@ -39,7 +39,7 @@ struct Color
         // Intentionally empty.
     }
 
-    PLAYRHO_CONSTEXPR inline Color(Color copy, float new_a):
+    constexpr inline Color(Color copy, float new_a):
         Color{copy.r, copy.g, copy.b, new_a}
     {
         // Intentionally empty.

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -502,7 +502,7 @@ void Test::MouseDown(const Length2& p)
     auto fixtures = FixtureSet{};
 
     // Query the world for overlapping shapes.
-    m_world.QueryAABB(aabb, [&](Fixture* f, const ChildCounter) {
+    Query(m_world.GetTree(), aabb, [&](Fixture* f, const ChildCounter) {
         if (TestPoint(*f, p))
         {
             fixtures.insert(f);

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -381,7 +381,7 @@ bool Test::Contains(const FixtureSet& fixtures, const Fixture* f) noexcept
     return fixtures.find(const_cast<Fixture*>(f)) != fixtures.end();
 }
 
-void Test::DestructionListenerImpl::SayGoodbye(Joint& joint)
+void Test::DestructionListenerImpl::SayGoodbye(const Joint& joint)
 {
     if (test->m_targetJoint == &joint)
     {

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -182,14 +182,13 @@ public:
     void MouseUp(const Length2& p);
     
     // Let derived tests know that a joint was destroyed.
-    virtual void JointDestroyed(Joint* joint) { NOT_USED(joint); }
+    virtual void JointDestroyed(const Joint* joint) { NOT_USED(joint); }
 
     // Callbacks for derived classes.
-    virtual void BeginContact(Contact&) override { }
-    virtual void EndContact(Contact&) override { }
-    virtual void PreSolve(Contact& contact, const Manifold& oldManifold) override;
-    virtual void PostSolve(Contact&, const ContactImpulsesList&,
-                           ContactListener::iteration_type) override { }
+    void BeginContact(Contact&) override { }
+    void EndContact(Contact&) override { }
+    void PreSolve(Contact& contact, const Manifold& oldManifold) override;
+    void PostSolve(Contact&, const ContactImpulsesList&, ContactListener::iteration_type) override { }
 
     static bool Contains(const FixtureSet& fixtures, const Fixture* f) noexcept;
     
@@ -278,8 +277,8 @@ protected:
     class DestructionListenerImpl : public DestructionListener
     {
     public:
-        void SayGoodbye(Fixture& fixture) { NOT_USED(fixture); }
-        void SayGoodbye(Joint& joint);
+        void SayGoodbye(const Fixture& fixture) { NOT_USED(fixture); }
+        void SayGoodbye(const Joint& joint);
         
         Test* test;
     };

--- a/Testbed/Tests/BagOfDisks.hpp
+++ b/Testbed/Tests/BagOfDisks.hpp
@@ -29,7 +29,7 @@ namespace testbed {
 class BagOfDisks: public Test
 {
 public:
-    static PLAYRHO_CONSTEXPR const auto Count = 180;
+    static constexpr const auto Count = 180;
 
     static Test::Conf GetTestConf()
     {

--- a/Testbed/Tests/Bridge.hpp
+++ b/Testbed/Tests/Bridge.hpp
@@ -28,7 +28,7 @@ class Bridge : public Test
 {
 public:
 
-    static PLAYRHO_CONSTEXPR const auto Count = 30;
+    static constexpr const auto Count = 30;
 
     Bridge()
     {        

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -30,7 +30,7 @@
 
 namespace testbed {
 
-/// This callback is called by World::QueryAABB. We find all the fixtures
+/// This callback is called by the Query free function. We find all the fixtures
 /// that overlap an AABB. Of those, we use TestOverlap to determine which fixtures
 /// overlap a circle. Up to 4 overlapped fixtures will be highlighted with a yellow border.
 class ShapeDrawer
@@ -205,11 +205,11 @@ public:
         ShapeDrawer shapeDrawer;
         shapeDrawer.debugDraw = &drawer;
 
-        PLAYRHO_CONSTEXPR const int e_maxCount = 4;
+        constexpr const int e_maxCount = 4;
         int count = 0;
         const auto circleChild = GetChild(circleConf, 0);
         const auto aabb = ComputeAABB(circleChild, transform);
-        m_world.QueryAABB(aabb, [&](Fixture* f, const ChildCounter) {
+        Query(m_world.GetTree(), aabb, [&](Fixture* f, const ChildCounter) {
             if (count < e_maxCount)
             {
                 const auto xfm = GetTransformation(*f);

--- a/Testbed/Tests/SolarSystem.hpp
+++ b/Testbed/Tests/SolarSystem.hpp
@@ -38,7 +38,7 @@ struct SolarSystemObject
     Time rotationalPeriod; ///< Rotational period.
 };
 
-static PLAYRHO_CONSTEXPR const SolarSystemObject SolarSystemBodies[] = {
+static const SolarSystemObject SolarSystemBodies[] = {
     { "The Sun", 696342_km, 1988550000.0_Yg,     0.000_d,    0_Gm,   25.050_d },
     { "Mercury",   2439_km,        330.2_Yg,    87.969_d,   57_Gm,   58.646_d },
     { "Venus",     6051_km,       4868.5_Yg,   224.701_d,  108_Gm, -243.025_d },

--- a/Testbed/Tests/Tumbler.hpp
+++ b/Testbed/Tests/Tumbler.hpp
@@ -27,7 +27,7 @@ namespace testbed {
 class Tumbler : public Test
 {
 public:
-    static PLAYRHO_CONSTEXPR const auto Count = 800;
+    static constexpr const auto Count = 800;
     
     Tumbler()
     {

--- a/Testbed/Tests/Web.hpp
+++ b/Testbed/Tests/Web.hpp
@@ -174,7 +174,7 @@ public:
         });
     }
 
-    void JointDestroyed(Joint* joint) override
+    void JointDestroyed(const Joint* joint) override
     {
         for (auto i = 0; i < 8; ++i)
         {

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -173,7 +173,7 @@ public:
         
         //angular velocity
         const auto rotInertia = GetRotInertia(*m_body);
-        PLAYRHO_CONSTEXPR const auto Tenth = Real{1} / Real{10};
+        const auto Tenth = Real{1} / Real{10};
         ApplyAngularImpulse(*m_body, m_currentTraction * Tenth * rotInertia * -GetAngularVelocity(*m_body));
         
         //forward linear velocity

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -354,7 +354,7 @@ public:
 
 class MyDestructionListener :  public DestructionListener
 {
-    void SayGoodbye(Fixture& fixture) override
+    void SayGoodbye(const Fixture& fixture) override
     {
         const auto fud = static_cast<FixtureUserData*>(fixture.GetUserData());
         if ( fud )
@@ -362,7 +362,7 @@ class MyDestructionListener :  public DestructionListener
     }
     
     //(unused but must implement all pure virtual functions)
-    void SayGoodbye(Joint&) override {}
+    void SayGoodbye(const Joint&) override {}
 };
 
 

--- a/UnitTests/ArrayList.cpp
+++ b/UnitTests/ArrayList.cpp
@@ -26,7 +26,7 @@ using namespace playrho;
 TEST(ArrayList, DefaultConstruction)
 {
     {
-        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
+        constexpr const unsigned max_size = 4;
         ArrayList<int, max_size> list;
         EXPECT_EQ(list.size(), decltype(list.size()){0});
         EXPECT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -38,9 +38,9 @@ TEST(ArrayList, DefaultConstruction)
 TEST(ArrayList, ArrayConstruction)
 {
     {
-        PLAYRHO_CONSTEXPR const auto array_size = 2;
+        constexpr const auto array_size = 2;
         int array[array_size];
-        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
+        constexpr const unsigned max_size = 4;
         ArrayList<int, max_size> list(array);
         EXPECT_EQ(list.size(), decltype(list.size()){array_size});
         EXPECT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -48,9 +48,9 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(std::distance(list.begin(), list.end()), array_size);
     }
     {
-        PLAYRHO_CONSTEXPR const auto array_size = 6;
+        constexpr const auto array_size = 6;
         float array[array_size];
-        PLAYRHO_CONSTEXPR const unsigned max_size = 6;
+        constexpr const unsigned max_size = 6;
         ArrayList<float, max_size> list(array);
         EXPECT_EQ(list.size(), decltype(list.size()){array_size});
         EXPECT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -58,13 +58,13 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(std::distance(list.begin(), list.end()), array_size);
     }
     {
-        PLAYRHO_CONSTEXPR const auto maxsize = std::size_t{10};
+        constexpr const auto maxsize = std::size_t{10};
         ArrayList<int, maxsize> list = { 1, 2, 3 };
         EXPECT_EQ(list.size(), decltype(list.size()){3});
         EXPECT_EQ(list.max_size(), maxsize);
     }
     {
-        PLAYRHO_CONSTEXPR const auto maxsize = std::size_t{10};
+        constexpr const auto maxsize = std::size_t{10};
         PLAYRHO_CONSTEXPR const auto list = std::array<int, maxsize>{{5, 4, 3}};
         EXPECT_EQ(list.size(), decltype(list.size()){maxsize});
         EXPECT_EQ(list.max_size(), maxsize);
@@ -73,7 +73,7 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(list[2], 3);
     }
     {
-        PLAYRHO_CONSTEXPR const auto maxsize = std::size_t{10};
+        constexpr const auto maxsize = std::size_t{10};
         
         // Note: list cannot be PLAYRHO_CONSTEXPR const.
         const auto list = ArrayList<int, maxsize>{1, 2, 3};
@@ -96,7 +96,7 @@ TEST(ArrayList, ArrayConstruction)
 TEST(ArrayList, add)
 {
     {
-        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
+        constexpr const unsigned max_size = 4;
         ArrayList<int, max_size> list;
         ASSERT_EQ(list.size(), decltype(list.size()){0});
         ASSERT_EQ(list.max_size(), decltype(list.size()){max_size});
@@ -126,7 +126,7 @@ TEST(ArrayList, add)
 TEST(ArrayList, clear)
 {
     {
-        PLAYRHO_CONSTEXPR const unsigned max_size = 4;
+        constexpr const unsigned max_size = 4;
         ArrayList<int, max_size> list;
         ASSERT_EQ(list.size(), decltype(list.size()){0});
         ASSERT_EQ(list.max_size(), decltype(list.size()){max_size});

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -98,7 +98,7 @@ TEST(DynamicTree, ZeroCapacityConstructionThrows)
 
 TEST(DynamicTree, InitializingConstruction)
 {
-    PLAYRHO_CONSTEXPR const auto initCapacity = DynamicTree::GetDefaultInitialNodeCapacity() * 2;
+    constexpr const auto initCapacity = DynamicTree::GetDefaultInitialNodeCapacity() * 2;
     DynamicTree foo{initCapacity};
     EXPECT_EQ(foo.GetNodeCapacity(), initCapacity);
     EXPECT_EQ(foo.GetNodeCount(), DynamicTree::Size(0));

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -642,7 +642,7 @@ struct Coords {
 #if 0
 TEST(Math, LengthFasterThanHypot)
 {
-    PLAYRHO_CONSTEXPR inline auto iterations = unsigned(5000000);
+    constexpr inline auto iterations = unsigned(5000000);
     
     std::chrono::duration<double> elapsed_secs_length;
     std::chrono::duration<double> elapsed_secs_hypot;

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -136,10 +136,10 @@ TEST(World, DefaultInit)
     World world;
 
     EXPECT_EQ(GetBodyCount(world), BodyCounter(0));
-    EXPECT_EQ(world.GetTree().GetLeafCount(), World::proxy_size_type(0));
+    EXPECT_EQ(world.GetTree().GetLeafCount(), ContactCounter(0));
     EXPECT_EQ(GetJointCount(world), JointCounter(0));
     EXPECT_EQ(GetContactCount(world), ContactCounter(0));
-    EXPECT_EQ(GetHeight(world.GetTree()), World::proxy_size_type(0));
+    EXPECT_EQ(GetHeight(world.GetTree()), ContactCounter(0));
     EXPECT_EQ(ComputePerimeterRatio(world.GetTree()), Real(0));
 
     {

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -177,7 +177,7 @@ TEST(World, Init)
     
     {
         auto calls = 0;
-        world.QueryAABB(AABB{}, [&](Fixture*, ChildCounter) {
+        Query(world.GetTree(), AABB{}, [&](Fixture*, ChildCounter) {
             ++calls;
             return true;
         });
@@ -534,7 +534,7 @@ TEST(World, RegisterFixtureForProxies)
     EXPECT_TRUE(world.RegisterForProxies(fixture));
 }
 
-TEST(World, QueryAABB)
+TEST(World, Query)
 {
     auto world = World{};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
@@ -564,7 +564,7 @@ TEST(World, QueryAABB)
     {
         auto foundOurs = 0;
         auto foundOthers = 0;
-        world.QueryAABB(AABB{v1, v2}, [&](Fixture* f, ChildCounter i) {
+        Query(world.GetTree(), AABB{v1, v2}, [&](Fixture* f, ChildCounter i) {
             if (f == fixture && i == 0)
             {
                 ++foundOurs;
@@ -2215,7 +2215,7 @@ TEST(World, TilesComesToRest)
     auto conf = PolygonShapeConf{}.UseVertexRadius(VertexRadius);
     const auto m_world = std::make_unique<World>(WorldConf{}.UseMinVertexRadius(VertexRadius));
     
-    PLAYRHO_CONSTEXPR const auto e_count = 36;
+    constexpr const auto e_count = 36;
     
     {
         const auto a = Real{0.5f};
@@ -2838,7 +2838,7 @@ TEST(World, TargetJointWontCauseTunnelling)
         ASSERT_NE(ball_fixture, nullptr);
     }
 
-    PLAYRHO_CONSTEXPR const unsigned numBodies = 1;
+    constexpr const unsigned numBodies = 1;
     Length2 last_opos[numBodies];
     Body *bodies[numBodies];
     for (auto i = decltype(numBodies){0}; i < numBodies; ++i)


### PR DESCRIPTION
#### Description - What's this PR do?
- Moves World::IslandSolverResults to IslandStats for issue #291.
- For issue #290: moves QueryAABB and QueryFixtureCallback out from World class and into DynamicTree.*.
- Lifts the acquisition of world.GetBodies() data out from multiple call sites in favor of using a saved value for it.
- Gets rid of some uses of PLAYRHO_CONSTEXPR outside of the PlayRho library in favor of directly using 'constexpr'.

#### Related Issues
- Issue #291.
- Issue #290.
