### PR TITLE
Updates 20180204

### DIFF
--- a/Documentation/Doxyfile
+++ b/Documentation/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         = 0.9.0
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "A Real-Time-Oriented 2-D Physics Engine and Library"
+PROJECT_BRIEF          = "An Interactive Real-Time-Oriented C++14-based Physics Engine & Library"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -894,7 +894,7 @@ EXCLUDE_SYMBOLS        =
 # that contain example code fragments that are included (see the \include
 # command).
 
-EXAMPLE_PATH           = ../HelloWorld
+EXAMPLE_PATH           = ../HelloWorld ../UnitTests
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and

--- a/Documentation/extra-words.dic
+++ b/Documentation/extra-words.dic
@@ -11,6 +11,7 @@ centi
 centroid
 chainable
 collinear
+configurability
 constructible
 CRTP
 deallocator

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -234,7 +234,7 @@ DynamicTree::Size DynamicTree::CreateLeaf(const AABB& aabb, const LeafData& leaf
     return index;
 }
 
-void DynamicTree::DestroyLeaf(Size index)
+void DynamicTree::DestroyLeaf(Size index) noexcept
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
@@ -356,7 +356,7 @@ void DynamicTree::InsertLeaf(Size index)
     Rebalance(newParent);
 }
 
-void DynamicTree::RemoveLeaf(Size leaf)
+void DynamicTree::RemoveLeaf(Size leaf) noexcept
 {
     assert(leaf != GetInvalidSize());
     assert(leaf < m_nodeCapacity);
@@ -397,7 +397,7 @@ void DynamicTree::RemoveLeaf(Size leaf)
     FreeNode(parent);
 }
 
-void DynamicTree::Rebalance(Size index)
+void DynamicTree::Rebalance(Size index) noexcept
 {
     for (; index != GetInvalidSize(); index = GetParent(index))
     {

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -129,7 +129,7 @@ public:
 
     /// @brief Destroys a leaf node.
     /// @warning Behavior is undefined if the given index is not valid.
-    void DestroyLeaf(Size index);
+    void DestroyLeaf(Size index) noexcept;
 
     /// @brief Updates a leaf node with a new AABB value.
     /// @warning Behavior is undefined if the given index is not valid.
@@ -268,11 +268,11 @@ private:
     /// @warning Behavior is undefined if the given index is not valid.
     /// @post The specified leaf index is not referenced by any other nodes.
     /// @post The identified node has its other value set to the invalid size.
-    void RemoveLeaf(Size leaf);
+    void RemoveLeaf(Size leaf) noexcept;
     
     /// @brief Rebalances the tree from the given index.
     /// @warning Behavior is undefined if the given index is not valid.
-    void Rebalance(Size index);
+    void Rebalance(Size index) noexcept;
     
     /// @brief Gets the parent node index of the node identified by the given index.
     Size GetParent(Size index) const noexcept;

--- a/PlayRho/Common/FixedMath.hpp
+++ b/PlayRho/Common/FixedMath.hpp
@@ -26,7 +26,7 @@
 
 namespace playrho {
 
-/// @defgroup FixedMath Mathematical Functions For Fixed Types
+/// @defgroup FixedMath Math Functions For Fixed Types
 /// @brief Common Mathematical Functions For Fixed Types.
 /// @sa Fixed
 /// @sa http://en.cppreference.com/w/cpp/numeric/math

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -119,7 +119,7 @@ PLAYRHO_CONSTEXPR inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
     return StripUnit(v.get());
 }
 
-/// @defgroup Math Additional Mathematical Functions
+/// @defgroup Math Additional Math Functions
 /// @brief Additional functions for common mathematical operations.
 /// @details These are non-member non-friend functions for mathematical operations
 ///   especially those with mixed input and output types.

--- a/PlayRho/Common/UnitVec.cpp
+++ b/PlayRho/Common/UnitVec.cpp
@@ -31,6 +31,7 @@ UnitVec::PolarCoord UnitVec::Get(const Real x, const Real y, const UnitVec fallb
     if (isnormal(magnitudeSquared))
     {
         const auto magnitude = sqrt(magnitudeSquared);
+        assert(isnormal(magnitude));
         return std::make_pair(UnitVec{x / magnitude, y / magnitude}, magnitude);
     }
     

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -101,7 +101,7 @@ Body::Body(World* world, const BodyConf& bd):
     SetUnderActiveTime(bd.underActiveTime);
 }
 
-Body::~Body()
+Body::~Body() noexcept
 {
     assert(m_joints.empty());
     assert(m_contacts.empty());
@@ -119,13 +119,13 @@ Fixture* Body::CreateFixture(const Shape& shape, const FixtureConf& def,
     return WorldAtty::CreateFixture(*m_world, *this, shape, def, resetMassData);
 }
 
-bool Body::DestroyFixture(Fixture* fixture, bool resetMassData)
+bool Body::Destroy(Fixture* fixture, bool resetMassData)
 {
     if (fixture->GetBody() != this)
     {
         return false;
     }
-    return WorldAtty::DestroyFixture(*m_world, *fixture, resetMassData);
+    return WorldAtty::Destroy(*m_world, *fixture, resetMassData);
 }
 
 void Body::DestroyFixtures()
@@ -133,7 +133,7 @@ void Body::DestroyFixtures()
     while (!m_fixtures.empty())
     {
         const auto fixture = GetPtr(m_fixtures.front());
-        DestroyFixture(fixture, false);
+        Destroy(fixture, false);
     }
     ResetMassData();
 }

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -60,7 +60,8 @@ struct BodyConf;
 /// @invariant Only "accelerable" bodies can have non-zero accelerations.
 /// @invariant Only "accelerable" bodies can have non-zero "under-active" times.
 ///
-/// @note Create these using the World::Create method.
+/// @note Create these using the <code>World::CreateBody</code> method.
+/// @note Destroy these using the <code>World::Destroy(Body*)</code> method.
 /// @note From a memory management perspective, bodies own Fixture instances.
 /// @note On a 64-bit architecture with 4-byte Real, this data structure is at least
 ///   192-bytes large.
@@ -136,15 +137,6 @@ public:
     /// @brief Gets the flags for the given value.
     static FlagsType GetFlags(const BodyConf& bd) noexcept;
     
-    Body() = delete;
-
-    /// @brief Initializing constructor for unit testing purposes.
-    /// @note This is not meant to be called directly by users of the library API. Call
-    ///   a world instance's <code>CreateBody</code> method instead.
-    Body(World* world, const BodyConf& bd);
-
-    ~Body();
-    
     /// @brief Creates a fixture and attaches it to this body.
     ///
     /// @param shape Shareable shape definition.
@@ -161,7 +153,6 @@ public:
     /// @return Pointer to the created fixture.
     ///
     /// @throws WrongState if called while the world is "locked".
-    /// @throws InvalidArgument if called without a shape.
     /// @throws InvalidArgument if called for a shape with a vertex radius less than the
     ///    minimum vertex radius.
     /// @throws InvalidArgument if called for a shape with a vertex radius greater than the
@@ -189,7 +180,7 @@ public:
     ///
     /// @sa PhysicalEntities
     ///
-    bool DestroyFixture(Fixture* fixture, bool resetMassData = true);
+    bool Destroy(Fixture* fixture, bool resetMassData = true);
     
     /// @brief Destroy fixtures.
     /// @sa PhysicalEntities
@@ -441,7 +432,18 @@ public:
 private:
 
     friend class BodyAtty;
+    
+    Body() = delete;
+    
+    Body(const Body& other) = delete;
 
+    /// @brief Initializing constructor.
+    /// @note This is not meant to be called directly by users of the library API. Call
+    ///   a world instance's <code>CreateBody</code> method instead.
+    Body(World* world, const BodyConf& bd);
+    
+    ~Body() noexcept;
+    
     /// @brief Whether this body is in is-in-island state.
     bool IsIslanded() const noexcept;
 
@@ -554,6 +556,10 @@ private:
     /// @note 4-bytes.
     Time m_underActiveTime = 0;
 };
+
+/// @example Body.cpp
+/// This is the <code>googletest</code> based unit testing file for the
+///   <code>playrho::d2::Body</code> class.
 
 inline Body::FlagsType Body::GetFlags(BodyType type) noexcept
 {

--- a/PlayRho/Dynamics/ContactAtty.hpp
+++ b/PlayRho/Dynamics/ContactAtty.hpp
@@ -31,7 +31,10 @@ namespace d2 {
 
 /// @brief Contact attorney.
 ///
-/// @details This class uses the "attorney-client" idiom to control the granularity of
+/// @details This is the "contact attorney" which provides limited privileged access to the
+///   Contact class for the World class.
+///
+/// @note This class uses the "attorney-client" idiom to control the granularity of
 ///   friend-based access to the Contact class. This is meant to help preserve and enforce
 ///   the invariants of the Contact class.
 ///

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -76,6 +76,7 @@ class ContactListener;
 /// @note This data structure is 104-bytes large (on at least one 64-bit platform).
 ///
 /// @ingroup PhysicalEntities
+/// @ingroup ConstraintsGroup
 ///
 class Contact
 {
@@ -93,7 +94,7 @@ public:
     
     /// @brief Gets the update configuration from the given step configuration data.
     static UpdateConf GetUpdateConf(const StepConf& conf) noexcept;
-
+    
     /// @brief Initializing constructor.
     ///
     /// @param fA Non-null pointer to fixture A that must have a shape
@@ -107,8 +108,6 @@ public:
     /// @warning Behavior is undefined if <code>fA</code> is null.
     /// @warning Behavior is undefined if <code>fB</code> is null.
     /// @warning Behavior is undefined if <code>fA == fB</code>.
-    /// @warning Behavior is undefined if <code>fA</code> has no associated shape.
-    /// @warning Behavior is undefined if <code>fB</code> has no associated shape.
     /// @warning Behavior is undefined if both fixture's have the same body.
     ///
     Contact(Fixture* fA, ChildCounter iA, Fixture* fB, ChildCounter iB);
@@ -118,10 +117,10 @@ public:
     
     /// @brief Copy constructor.
     Contact(const Contact& copy) = default;
-    
+
     /// @brief Gets the contact manifold.
     const Manifold& GetManifold() const noexcept;
-
+    
     /// @brief Is this contact touching?
     /// @details
     /// Touching is defined as either:
@@ -334,6 +333,10 @@ private:
     
     FlagsType m_flags = e_enabledFlag|e_dirtyFlag; ///< Flags.
 };
+
+/// @example Contact.cpp
+/// This is the <code>googletest</code> based unit testing file for the
+///   <code>playrho::d2::Contact</code> class.
 
 inline const Manifold& Contact::GetManifold() const noexcept
 {

--- a/PlayRho/Dynamics/Fixture.cpp
+++ b/PlayRho/Dynamics/Fixture.cpp
@@ -34,33 +34,6 @@ namespace d2 {
 using std::cbegin;
 using std::cend;
 
-Fixture::Fixture(const Fixture& other):
-    m_body{other.m_body},
-    m_userData{other.m_userData},
-    m_shape{other.m_shape},
-    m_proxyCount{other.m_proxyCount},
-    m_filter{other.m_filter},
-    m_isSensor{other.m_isSensor}
-{
-    switch (other.m_proxyCount)
-    {
-        case 2:
-            m_proxies.asArray[1] = other.m_proxies.asArray[1];
-            // [[fallthrough]]
-        case 1:
-            m_proxies.asArray[0] = other.m_proxies.asArray[0];
-            // [[fallthrough]]
-        case 0:
-            break;
-        default:
-            m_proxies.asBuffer = std::make_unique<FixtureProxy[]>(other.m_proxyCount);
-            std::copy(other.m_proxies.asBuffer.get(),
-                      other.m_proxies.asBuffer.get() + other.m_proxyCount,
-                      m_proxies.asBuffer.get());
-            break;
-    }
-}
-
 FixtureProxy Fixture::GetProxy(ChildCounter index) const noexcept
 {
     assert(index < GetProxyCount());

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -50,6 +50,7 @@ class Body;
 ///
 /// @warning you cannot reuse fixtures.
 /// @note Fixtures should be created using the <code>Body::CreateFixture</code> method.
+/// @note Destroy these using the <code>Body::Destroy(Fixture*, bool)</code> method.
 /// @note This structure is 56-bytes large (using a 4-byte Real on at least one 64-bit
 ///   architecture/build).
 ///
@@ -60,42 +61,6 @@ class Body;
 class Fixture
 {
 public:
-    Fixture() = delete; // explicitly deleted
-    
-    /// @brief Initializing constructor.
-    ///
-    /// @warning Behavior is undefined if shape is <code>nullptr</code>.
-    ///
-    /// @note This is not meant to be called by normal user code. Use the
-    ///   <code>Body::CreateFixture</code> method instead.
-    ///
-    /// @param body Body the new fixture is to be associated with.
-    /// @param def Initial fixture settings.
-    ///    Friction must be greater-than-or-equal-to zero.
-    ///    <code>AreaDensity</code> must be greater-than-or-equal-to zero.
-    /// @param shape Shareable shape to associate fixture with. Must be non-null.
-    ///
-    Fixture(NonNull<Body*> body, const FixtureConf& def, const Shape& shape):
-        m_body{body},
-        m_userData{def.userData},
-        m_shape{shape},
-        m_filter{def.filter},
-        m_isSensor{def.isSensor}
-    {
-        // Intentionally empty.
-    }
-    
-    /// @brief Copy constructor.
-    Fixture(const Fixture& other);
-    
-    /// @brief Destructor.
-    /// @pre Proxy count is zero.
-    /// @warning Behavior is undefined if proxy count is greater than zero.
-    ~Fixture()
-    {
-        // Intentionally empty.
-    }
-
     /// @brief Gets the parent body of this fixture.
     /// @return Non-null pointer to the parent body.
     NonNull<Body*> GetBody() const noexcept;
@@ -161,6 +126,40 @@ public:
 private:
 
     friend class FixtureAtty;
+    
+    Fixture() = delete; // explicitly deleted
+    
+    /// @brief Copy constructor (explicitly deleted).
+    Fixture(const Fixture& other) = delete;
+    
+    /// @brief Initializing constructor.
+    ///
+    /// @note This is not meant to be called by normal user code. Use the
+    ///   <code>Body::CreateFixture</code> method instead.
+    ///
+    /// @param body Body the new fixture is to be associated with.
+    /// @param def Initial fixture settings.
+    ///    Friction must be greater-than-or-equal-to zero.
+    ///    <code>AreaDensity</code> must be greater-than-or-equal-to zero.
+    /// @param shape Shareable shape to associate fixture with. Must be non-null.
+    ///
+    Fixture(NonNull<Body*> body, const FixtureConf& def, const Shape& shape):
+        m_body{body},
+        m_userData{def.userData},
+        m_shape{shape},
+        m_filter{def.filter},
+        m_isSensor{def.isSensor}
+    {
+        // Intentionally empty.
+    }
+    
+    /// @brief Destructor.
+    /// @pre Proxy count is zero.
+    /// @warning Behavior is undefined if proxy count is greater than zero.
+    ~Fixture()
+    {
+        // Intentionally empty.
+    }
     
     /// @brief Fixture proxies union.
     union FixtureProxies {

--- a/PlayRho/Dynamics/FixtureAtty.hpp
+++ b/PlayRho/Dynamics/FixtureAtty.hpp
@@ -34,7 +34,10 @@ namespace d2 {
 
 /// @brief Fixture attorney.
 ///
-/// @details This class uses the "attorney-client" idiom to control the granularity of
+/// @details This is the "fixture attorney" which provides limited privileged access to the
+///   Fixture class for the World class.
+///
+/// @note This class uses the "attorney-client" idiom to control the granularity of
 ///   friend-based access to the Fixture class. This is meant to help preserve and enforce
 ///   the invariants of the Fixture class.
 ///
@@ -58,16 +61,21 @@ private:
     }
     
     /// @brief Resets the proxies of the given fixture.
-    static void ResetProxies(Fixture& fixture)
+    static void ResetProxies(Fixture& fixture) noexcept
     {
         fixture.ResetProxies();
     }
     
     /// @brief Creates a new fixture for the given body and with the given settings.
-    static auto Create(Body* body, const FixtureConf& def,
-                           const Shape& shape)
+    static Fixture* Create(Body& body, const FixtureConf& def, Shape shape)
     {
-        return new Fixture{body, def, shape};
+        return new Fixture{&body, def, shape};
+    }
+    
+    /// @brief Deletes a fixture.
+    static void Delete(Fixture *fixture)
+    {
+        delete fixture;
     }
     
     friend class World;

--- a/PlayRho/Dynamics/JointAtty.hpp
+++ b/PlayRho/Dynamics/JointAtty.hpp
@@ -31,7 +31,10 @@ namespace d2 {
 
 /// @brief Joint attorney.
 ///
-/// @details This class uses the "attorney-client" idiom to control the granularity of
+/// @details This is the "joint attorney" which provides limited privileged access to the
+///   Joint class for the World class.
+///
+/// @note This class uses the "attorney-client" idiom to control the granularity of
 ///   friend-based access to the Joint class. This is meant to help preserve and enforce
 ///   the invariants of the Joint class.
 ///
@@ -48,7 +51,7 @@ private:
     }
     
     /// @brief Destroys the given joint.
-    static void Destroy(const Joint* j)
+    static void Destroy(const Joint* j) noexcept
     {
         Joint::Destroy(j);
     }

--- a/PlayRho/Dynamics/Joints/Joint.cpp
+++ b/PlayRho/Dynamics/Joints/Joint.cpp
@@ -90,7 +90,7 @@ Joint::Joint(const JointConf& def):
     // Intentionally empty.
 }
 
-void Joint::Destroy(const Joint* joint)
+void Joint::Destroy(const Joint* joint) noexcept
 {
     delete joint;
 }

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -43,6 +43,7 @@ struct JointConf;
 
 /// @defgroup JointsGroup Joint Classes
 /// @brief The user creatable classes that specify constraints on one or more Body instances.
+/// @ingroup ConstraintsGroup
 
 /// @brief A body constraint pointer alias.
 using BodyConstraintPtr = BodyConstraint*;
@@ -62,8 +63,8 @@ using BodyConstraintsMap =
 
 /// @brief Base joint class.
 ///
-/// @details Joints are used to constraint two bodies together in various fashions.
-///   Some joints also feature limits and motors.
+/// @details Joints are constraints that are used to constrain one or more bodies in various
+///   fashions. Some joints also feature limits and motors.
 ///
 /// @ingroup JointsGroup
 /// @ingroup PhysicalEntities
@@ -75,18 +76,28 @@ class Joint
 public:
     
     /// @brief Limit state.
+    /// @note Only used by joints that implement some notion of a limited range.
     enum LimitState
     {
+        /// @brief Inactive limit.
         e_inactiveLimit,
+
+        /// @brief At-lower limit.
         e_atLowerLimit,
+        
+        /// @brief At-upper limit.
         e_atUpperLimit,
+        
+        /// @brief Equal limit.
+        /// @details Equal limit is used to indicate that a joint's upper and lower limits
+        ///   are approximately the same.
         e_equalLimits
     };
 
     /// @brief Is the given definition okay.
     static bool IsOkay(const JointConf& def) noexcept;
 
-    virtual ~Joint() = default;
+    virtual ~Joint() noexcept = default;
 
     /// @brief Gets the first body attached to this joint.
     Body* GetBodyA() const noexcept;
@@ -175,7 +186,7 @@ private:
 
     /// @brief Destroys the given joint.
     /// @note This calls the joint's destructor.
-    static void Destroy(const Joint* joint);
+    static void Destroy(const Joint* joint) noexcept;
 
     /// @brief Initializes velocity constraint data based on the given solver data.
     /// @note This MUST be called prior to calling <code>SolveVelocityConstraints</code>.

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -303,8 +303,12 @@ public:
     /// @note Used in the regular phase of step processing.
     bool doWarmStart = true;
     
-    /// @brief Do TOI.
-    /// @details Whether or not to perform continuous collision detection.
+    /// @brief Do time of impact (TOI) calculations.
+    /// @details Whether or not to perform any time of impact (TOI) calculations used for doing
+    ///   continuous collision detection. Without this, steps can potentially be computed
+    ///   faster but with increased chance of bodies passing unobstructed through other bodies
+    ///   (a process called "tunneling") even when they're not supposed to be able to go through
+    ///   them.
     /// @note Used in the TOI phase of step processing.
     bool doToi = true;
 

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -1276,9 +1276,6 @@ World::UpdateContactsData World::UpdateContactTOIs(const StepConf& conf)
         // Compute the TOI for this contact (one or both bodies are active and impenetrable).
         // Computes the time of impact in interval [0, 1]
         const auto output = CalcToi(c, toiConf);
-        assert((output.state == TOIOutput::State::e_touching)
-            || (output.state == TOIOutput::State::e_separated)
-            || (output.state == TOIOutput::State::e_overlapped));
         
         // Use Min function to handle floating point imprecision which possibly otherwise
         // could provide a TOI that's greater than 1.

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -397,7 +397,7 @@ namespace {
         return state == TOIOutput::e_touching;
     }
     
-    void FlagContactsForFiltering(const Body& bodyA, const Body& bodyB)
+    void FlagContactsForFiltering(const Body& bodyA, const Body& bodyB) noexcept
     {
         for (auto& ci: bodyB.GetContacts())
         {
@@ -468,12 +468,21 @@ World& World::operator= (const World& other)
     return *this;
 }
     
-World::~World()
+World::~World() noexcept
 {
-    Clear();
+    InternalClear();
 }
 
-void World::Clear() noexcept
+void World::Clear()
+{
+    if (IsLocked())
+    {
+        throw WrongState("World::Clear: world is locked");
+    }
+    InternalClear();
+}
+
+void World::InternalClear() noexcept
 {
     m_proxyKeys.clear();
     m_proxies.clear();
@@ -501,7 +510,7 @@ void World::Clear() noexcept
     });
 
     for_each(cbegin(m_bodies), cend(m_bodies), [&](const Bodies::value_type& b) {
-        delete GetPtr(b);
+        BodyAtty::Delete(GetPtr(b));
     });
     for_each(cbegin(m_contacts), cend(m_contacts), [&](const Contacts::value_type& c){
         delete GetPtr(std::get<Contact*>(c));
@@ -524,7 +533,8 @@ void World::CopyBodies(std::map<const Body*, Body*>& bodyMap,
             const auto& otherFixture = GetRef(of);
             const auto shape = otherFixture.GetShape();
             const auto fixtureConf = GetFixtureConf(otherFixture);
-            const auto newFixture = BodyAtty::CreateFixture(*newBody, shape, fixtureConf);
+            const auto newFixture = FixtureAtty::Create(*newBody, fixtureConf, shape);
+            BodyAtty::AddFixture(*newBody, newFixture);
             fixtureMap[&otherFixture] = newFixture;
             const auto childCount = otherFixture.GetProxyCount();
             auto proxies = std::make_unique<FixtureProxy[]>(childCount);
@@ -717,7 +727,7 @@ Body* World::CreateBody(const BodyConf& def)
         throw LengthError("World::CreateBody: operation would exceed MaxBodies");
     }
     
-    auto& b = *(new Body(this, def));
+    auto& b = *BodyAtty::CreateBody(this, def);
 
     // Add to world bodies collection.
     //
@@ -732,14 +742,14 @@ Body* World::CreateBody(const BodyConf& def)
     return &b;
 }
 
-void World::Remove(const Body& b)
+void World::Remove(const Body& b) noexcept
 {
     const auto it = find_if(cbegin(m_bodies), cend(m_bodies), [&](const Bodies::value_type& body) {
         return GetPtr(body) == &b;
     });
     if (it != m_bodies.end())
     {
-        delete GetPtr(*it);
+        BodyAtty::Delete(GetPtr(*it));
         m_bodies.erase(it);
     }
 }
@@ -776,6 +786,7 @@ void World::Destroy(Body* body)
             m_destructionListener->SayGoodbye(fixture);
         }
         DestroyProxies(fixture);
+        FixtureAtty::Delete(&fixture);
     });
     
     Remove(*body);
@@ -821,7 +832,7 @@ bool World::Add(Joint* j)
     return true;
 }
 
-void World::Remove(const Joint& j)
+void World::Remove(const Joint& j) noexcept
 {
     const auto endIter = cend(m_joints);
     const auto iter = find(cbegin(m_joints), endIter, &j);
@@ -841,7 +852,7 @@ void World::Destroy(Joint* joint)
     }
 }
     
-void World::InternalDestroy(Joint& joint)
+void World::InternalDestroy(Joint& joint) noexcept
 {
     Remove(joint);
     
@@ -1199,7 +1210,7 @@ IslandStats World::SolveRegIslandViaGS(const StepConf& conf, Island island)
     return results;
 }
 
-void World::ResetBodiesForSolveTOI()
+void World::ResetBodiesForSolveTOI() noexcept
 {
     for_each(begin(m_bodies), end(m_bodies), [&](Bodies::value_type& body) {
         auto& b = GetRef(body);
@@ -1208,7 +1219,7 @@ void World::ResetBodiesForSolveTOI()
     });
 }
 
-void World::ResetContactsForSolveTOI()
+void World::ResetContactsForSolveTOI() noexcept
 {
     for_each(begin(m_contacts), end(m_contacts), [&](Contacts::value_type &c) {
         auto& contact = GetRef(std::get<Contact*>(c));
@@ -1682,7 +1693,7 @@ IslandStats World::SolveToiViaGS(const StepConf& conf, Island& island)
     return results;
 }
     
-void World::ResetContactsForSolveTOI(Body& body)
+void World::ResetContactsForSolveTOI(Body& body) noexcept
 {
     // Invalidate all contact TOIs on this displaced body.
     const auto contacts = body.GetContacts();
@@ -2373,7 +2384,9 @@ Fixture* World::CreateFixture(Body& body, const Shape& shape,
         throw WrongState("World::CreateFixture: world is locked");
     }
     
-    const auto fixture = BodyAtty::CreateFixture(body, shape, def);
+    //const auto fixture = BodyAtty::CreateFixture(body, shape, def);
+    const auto fixture = FixtureAtty::Create(body, def, shape);
+    BodyAtty::AddFixture(body, fixture);
 
     if (body.IsEnabled())
     {
@@ -2397,14 +2410,14 @@ Fixture* World::CreateFixture(Body& body, const Shape& shape,
     return fixture;
 }
 
-bool World::DestroyFixture(Fixture& fixture, bool resetMassData)
+bool World::Destroy(Fixture& fixture, bool resetMassData)
 {
     auto& body = *fixture.GetBody();
     assert(body.GetWorld() == this);
 
     if (IsLocked())
     {
-        throw WrongState("World::DestroyFixture: world is locked");
+        throw WrongState("World::Destroy: world is locked");
     }
     
 #if 0
@@ -2432,12 +2445,12 @@ bool World::DestroyFixture(Fixture& fixture, bool resetMassData)
     
     DestroyProxies(fixture);
 
-    const auto found = BodyAtty::DestroyFixture(body, &fixture);
-    if (!found)
+    if (!BodyAtty::RemoveFixture(body, &fixture))
     {
         // Fixture probably destroyed already.
         return false;
     }
+    FixtureAtty::Delete(&fixture);
     
     BodyAtty::SetMassDataDirty(body);
     if (resetMassData)
@@ -2475,7 +2488,7 @@ void World::CreateProxies(Fixture& fixture, Length aabbExtension)
     FixtureAtty::SetProxies(fixture, std::move(proxies), childCount);
 }
 
-void World::DestroyProxies(Fixture& fixture)
+void World::DestroyProxies(Fixture& fixture) noexcept
 {
     const auto proxies = FixtureAtty::GetProxies(fixture);
     const auto childCount = proxies.size();

--- a/PlayRho/Dynamics/WorldAtty.hpp
+++ b/PlayRho/Dynamics/WorldAtty.hpp
@@ -31,7 +31,10 @@ namespace d2 {
     
 /// @brief World attorney.
 ///
-/// @details This class uses the "attorney-client" idiom to control the granularity of
+/// @details This is the "world attorney" which provides limited privileged access to the
+///   World class for the Body and Fixture classes.
+///
+/// @note This class uses the "attorney-client" idiom to control the granularity of
 ///   friend-based access to the World class. This is meant to help preserve and enforce
 ///   the invariants of the World class.
 ///
@@ -90,9 +93,9 @@ private:
     ///
     /// @throws WrongState if this method is called while the world is locked.
     ///
-    static bool DestroyFixture(World& world, Fixture& fixture, bool resetMassData)
+    static bool Destroy(World& world, Fixture& fixture, bool resetMassData)
     {
-        return world.DestroyFixture(fixture, resetMassData);
+        return world.Destroy(fixture, resetMassData);
     }
     
     /// @brief Register for proxies for the given body.

--- a/PlayRho/Dynamics/WorldCallbacks.hpp
+++ b/PlayRho/Dynamics/WorldCallbacks.hpp
@@ -40,13 +40,17 @@ class DestructionListener
 public:
     virtual ~DestructionListener() noexcept = default;
 
-    /// Called when any joint is about to be destroyed due
-    /// to the destruction of one of its attached bodies.
-    virtual void SayGoodbye(const Joint& joint) = 0;
+    /// @brief Called just before destroying a joint.
+    /// @details Called when any joint is about to be destroyed due
+    ///    to the destruction of one of its attached bodies.
+    /// @note Implementations of this method should not throw any exceptions.
+    virtual void SayGoodbye(const Joint& joint) noexcept = 0;
 
-    /// Called when any fixture is about to be destroyed due
-    /// to the destruction of its parent body.
-    virtual void SayGoodbye(const Fixture& fixture) = 0;
+    /// @brief Called just before destroying a fixture.
+    /// @details Called when any fixture is about to be destroyed due
+    ///    to the destruction of its parent body.
+    /// @note Implementations of this method should not throw any exceptions.
+    virtual void SayGoodbye(const Fixture& fixture) noexcept = 0;
 };
 
 /// @brief A pure-virtual interface for "listeners" for contacts.

--- a/PlayRho/PlayRho.hpp
+++ b/PlayRho/PlayRho.hpp
@@ -71,6 +71,14 @@ For a more elaborate example, see
 ///    These classes are all sub-classed from sub-classes of the C++ Standard Library
 ///    std::exception class.
 
+/// @defgroup ConstraintsGroup Library Defined Constraints
+/// @brief Constraints defined and used by the PlayRho library.
+/// @details Constraints remove degrees of freedom from bodies.
+///   A 2D body has 3 degrees of freedom: two translation coordinates and one rotation
+///   coordinate. If we take a body and pin it to the wall (like a pendulum) we have
+///   constrained the body to the wall. At this point the body can only rotate about the
+///   pin, so the constraint has removed 2 degrees of freedom.
+
 /// @namespace std
 /// Name space for specializations of the standard library.
 

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -381,7 +381,7 @@ bool Test::Contains(const FixtureSet& fixtures, const Fixture* f) noexcept
     return fixtures.find(const_cast<Fixture*>(f)) != fixtures.end();
 }
 
-void Test::DestructionListenerImpl::SayGoodbye(const Joint& joint)
+void Test::DestructionListenerImpl::SayGoodbye(const Joint& joint) noexcept
 {
     if (test->m_targetJoint == &joint)
     {

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -277,8 +277,8 @@ protected:
     class DestructionListenerImpl : public DestructionListener
     {
     public:
-        void SayGoodbye(const Fixture& fixture) { NOT_USED(fixture); }
-        void SayGoodbye(const Joint& joint);
+        void SayGoodbye(const Fixture& fixture) noexcept { NOT_USED(fixture); }
+        void SayGoodbye(const Joint& joint) noexcept;
         
         Test* test;
     };

--- a/Testbed/Tests/Breakable.hpp
+++ b/Testbed/Tests/Breakable.hpp
@@ -97,7 +97,7 @@ public:
         const auto body1 = m_piece1->GetBody();
         const auto center = body1->GetWorldCenter();
 
-        body1->DestroyFixture(m_piece2);
+        body1->Destroy(m_piece2);
         m_piece2 = nullptr;
 
         BodyConf bd;

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -127,7 +127,7 @@ public:
                 fixtures.erase(fixtures.begin());
                 fixtures.insert(newf);
                 SetSelectedFixtures(fixtures);
-                body->DestroyFixture(fixture);
+                body->Destroy(fixture);
             }
         });
         RegisterForKey(GLFW_KEY_KP_SUBTRACT, GLFW_PRESS, 0, "decrease vertex radius of selected shape", [&](KeyActionMods) {
@@ -151,7 +151,7 @@ public:
                         fixtures.erase(fixtures.begin());
                         fixtures.insert(newf);
                         SetSelectedFixtures(fixtures);
-                        body->DestroyFixture(fixture);
+                        body->Destroy(fixture);
                     }
                 }
             }

--- a/Testbed/Tests/EdgeShapes.hpp
+++ b/Testbed/Tests/EdgeShapes.hpp
@@ -175,7 +175,7 @@ public:
         Length2 point;
         UnitVec normal;
 
-        RayCast(m_world.GetTree(), RayCastInput{point1, point2, 1},
+        RayCast(m_world.GetTree(), RayCastInput{point1, point2, Real{1}},
                         [&](Fixture* f, ChildCounter, Length2 p, UnitVec n) {
             fixture = f;
             point = p;

--- a/Testbed/Tests/HeavyOnLight.hpp
+++ b/Testbed/Tests/HeavyOnLight.hpp
@@ -67,7 +67,7 @@ public:
             const auto selectedFixture = selectedFixtures.size() == 1? *(selectedFixtures.begin()): nullptr;
             const auto wasSelected = selectedFixture == m_top;
             const auto body = m_top->GetBody();
-            body->DestroyFixture(m_top);
+            body->Destroy(m_top);
             auto conf = DiskShapeConf{};
             conf.vertexRadius = 5_m;
             conf.density = newDensity;

--- a/Testbed/Tests/RayCast.hpp
+++ b/Testbed/Tests/RayCast.hpp
@@ -206,7 +206,7 @@ public:
             Length2 point;
             UnitVec normal;
 
-            d2::RayCast(m_world.GetTree(), RayCastInput{point1, point2, 1},
+            d2::RayCast(m_world.GetTree(), RayCastInput{point1, point2, Real{1}},
                     [&](Fixture* f, const ChildCounter, const Length2& p, const UnitVec& n)
             {
                 const auto body = f->GetBody();
@@ -252,7 +252,7 @@ public:
 
             // This callback finds any hit. Polygon 0 is filtered. For this type of query we are
             // just checking for obstruction, so the actual fixture and hit point are irrelevant.
-            d2::RayCast(m_world.GetTree(), RayCastInput{point1, point2, 1},
+            d2::RayCast(m_world.GetTree(), RayCastInput{point1, point2, Real{1}},
                         [&](Fixture* f, const ChildCounter, const Length2& p, const UnitVec& n)
             {
                 const auto body = f->GetBody();
@@ -296,7 +296,7 @@ public:
             // This ray cast collects multiple hits along the ray. Polygon 0 is filtered.
             // The fixtures are not necessary reported in order, so we might not capture
             // the closest fixture.
-            d2::RayCast(m_world.GetTree(), RayCastInput{point1, point2, 1},
+            d2::RayCast(m_world.GetTree(), RayCastInput{point1, point2, Real{1}},
                         [&](Fixture* f, const ChildCounter, const Length2& p, const UnitVec& n)
             {
                 const auto body = f->GetBody();

--- a/Testbed/Tests/ShapeEditing.hpp
+++ b/Testbed/Tests/ShapeEditing.hpp
@@ -61,7 +61,7 @@ public:
         RegisterForKey(GLFW_KEY_D, GLFW_PRESS, 0, "Destroy a shape.", [&](KeyActionMods) {
             if (m_fixture2)
             {
-                m_body->DestroyFixture(m_fixture2);
+                m_body->Destroy(m_fixture2);
                 m_fixture2 = nullptr;
                 m_body->SetAwake();
             }

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -354,15 +354,17 @@ public:
 
 class MyDestructionListener :  public DestructionListener
 {
-    void SayGoodbye(const Fixture& fixture) override
+    void SayGoodbye(const Fixture& fixture) noexcept override
     {
         const auto fud = static_cast<FixtureUserData*>(fixture.GetUserData());
         if ( fud )
             delete fud;
     }
     
-    //(unused but must implement all pure virtual functions)
-    void SayGoodbye(const Joint&) override {}
+    void SayGoodbye(const Joint&) noexcept override
+    {
+        // Intentionally empty.
+    }
 };
 
 

--- a/Testbed/Tests/iforce2d_Trajectories.hpp
+++ b/Testbed/Tests/iforce2d_Trajectories.hpp
@@ -263,7 +263,7 @@ public:
             
             if (i > 0)
             {
-                d2::RayCast(m_world.GetTree(), RayCastInput{lastTP, trajectoryPosition, 1},
+                d2::RayCast(m_world.GetTree(), RayCastInput{lastTP, trajectoryPosition, Real{1}},
                                 [&](Fixture* f, ChildCounter, Length2 p, UnitVec) {
                     if (f->GetBody() == m_littleBox)
                     {

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -2,17 +2,19 @@
  * Copyright (c) 2017 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
- * warranty.  In no event will the authors be held liable for any damages
+ * warranty. In no event will the authors be held liable for any damages
  * arising from the use of this software.
+ *
  * Permission is granted to anyone to use this software for any purpose,
  * including commercial applications, and to alter it and redistribute it
  * freely, subject to the following restrictions:
+ *
  * 1. The origin of this software must not be misrepresented; you must not
- * claim that you wrote the original software. If you use this software
- * in a product, an acknowledgment in the product documentation would be
- * appreciated but is not required.
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
  * 2. Altered source versions must be plainly marked as such, and must not be
- * misrepresented as being the original software.
+ *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
@@ -24,7 +26,6 @@
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
-
 #include <chrono>
 
 using namespace playrho;
@@ -178,7 +179,7 @@ TEST(Body, Traits)
     EXPECT_FALSE(std::is_nothrow_constructible<Body>::value);
     EXPECT_FALSE(std::is_trivially_constructible<Body>::value);
     
-    EXPECT_TRUE(std::is_copy_constructible<Body>::value);
+    EXPECT_FALSE(std::is_copy_constructible<Body>::value);
     EXPECT_FALSE(std::is_nothrow_copy_constructible<Body>::value);
     EXPECT_FALSE(std::is_trivially_copy_constructible<Body>::value);
     
@@ -186,8 +187,8 @@ TEST(Body, Traits)
     EXPECT_FALSE(std::is_nothrow_copy_assignable<Body>::value);
     EXPECT_FALSE(std::is_trivially_copy_assignable<Body>::value);
     
-    EXPECT_TRUE(std::is_destructible<Body>::value);
-    EXPECT_TRUE(std::is_nothrow_destructible<Body>::value);
+    EXPECT_FALSE(std::is_destructible<Body>::value);
+    EXPECT_FALSE(std::is_nothrow_destructible<Body>::value);
     EXPECT_FALSE(std::is_trivially_destructible<Body>::value);
 }
 
@@ -202,9 +203,9 @@ TEST(Body, GetFlagsStatic)
 
 TEST(Body, WorldCreated)
 {
-    World world;
+    auto world = World{};
     
-    auto body = world.CreateBody();
+    const auto body = world.CreateBody();
     ASSERT_NE(body, nullptr);
 
     EXPECT_EQ(body->GetWorld(), &world);
@@ -218,7 +219,7 @@ TEST(Body, WorldCreated)
 
     EXPECT_TRUE(body->GetFixtures().empty());
     {
-        int i = 0;
+        auto i = 0;
         for (auto&& fixture: body->GetFixtures())
         {
             EXPECT_EQ(GetRef(fixture).GetBody(), body);
@@ -229,7 +230,7 @@ TEST(Body, WorldCreated)
 
     EXPECT_TRUE(body->GetJoints().empty());
     {
-        int i = 0;
+        auto i = 0;
         for (auto&& joint: body->GetJoints())
         {
             NOT_USED(joint);
@@ -240,7 +241,7 @@ TEST(Body, WorldCreated)
     
     EXPECT_TRUE(body->GetContacts().empty());
     {
-        int i = 0;
+        auto i = 0;
         for (auto&& ce: body->GetContacts())
         {
             NOT_USED(ce);
@@ -257,9 +258,9 @@ TEST(Body, SetVelocityDoesNothingToStatic)
         AngularVelocity{Real(0) * RadianPerSecond}
     };
 
-    World world;
+    auto world = World{};
 
-    auto body = world.CreateBody();
+    const auto body = world.CreateBody();
     ASSERT_NE(body, nullptr);
     ASSERT_FALSE(body->IsAwake());
     ASSERT_FALSE(body->IsSpeedable());
@@ -293,9 +294,9 @@ TEST(Body, CreateFixture)
     EXPECT_THROW(body->CreateFixture(Shape{DiskShapeConf{maxRadius + maxRadius / 10}}), InvalidArgument);
 }
 
-TEST(Body, DestroyFixture)
+TEST(Body, Destroy)
 {
-    World world;
+    auto world = World{};
     const auto bodyA = world.CreateBody();
     const auto bodyB = world.CreateBody();
     ASSERT_EQ(GetFixtureCount(*bodyA), std::size_t(0));
@@ -305,16 +306,16 @@ TEST(Body, DestroyFixture)
     ASSERT_NE(fixtureA, nullptr);
     ASSERT_EQ(GetFixtureCount(*bodyA), std::size_t(1));
 
-    EXPECT_FALSE(bodyB->DestroyFixture(fixtureA));
+    EXPECT_FALSE(bodyB->Destroy(fixtureA));
     EXPECT_EQ(GetFixtureCount(*bodyA), std::size_t(1));
-    EXPECT_TRUE(bodyA->DestroyFixture(fixtureA));
+    EXPECT_TRUE(bodyA->Destroy(fixtureA));
     EXPECT_EQ(GetFixtureCount(*bodyA), std::size_t(0));
 }
 
 TEST(Body, SetEnabled)
 {
     auto stepConf = StepConf{};
-    World world;
+    auto world = World{};
     const auto body = world.CreateBody();
     const auto valid_shape = Shape{DiskShapeConf(1_m)};
 
@@ -347,7 +348,7 @@ TEST(Body, SetEnabled)
 
 TEST(Body, SetFixedRotation)
 {
-    World world;
+    auto world = World{};
     const auto body = world.CreateBody();
     const auto valid_shape = Shape{DiskShapeConf(1_m)};
 
@@ -366,7 +367,7 @@ TEST(Body, SetFixedRotation)
 
 TEST(Body, CreateAndDestroyFixture)
 {
-    World world;
+    auto world = World{};
 
     auto body = world.CreateBody();
     ASSERT_NE(body, nullptr);
@@ -386,7 +387,7 @@ TEST(Body, CreateAndDestroyFixture)
         EXPECT_EQ(static_cast<const DiskShapeConf*>(GetData(fshape))->GetLocation(), conf.GetLocation());
         EXPECT_FALSE(body->GetFixtures().empty());
         {
-            int i = 0;
+            auto i = 0;
             for (auto&& f: body->GetFixtures())
             {
                 EXPECT_EQ(GetPtr(f), fixture);
@@ -398,7 +399,7 @@ TEST(Body, CreateAndDestroyFixture)
         body->ResetMassData();
         EXPECT_FALSE(body->IsMassDataDirty());
 
-        body->DestroyFixture(fixture, false);
+        body->Destroy(fixture, false);
         EXPECT_TRUE(body->GetFixtures().empty());
         EXPECT_TRUE(body->IsMassDataDirty());
         
@@ -416,7 +417,7 @@ TEST(Body, CreateAndDestroyFixture)
         EXPECT_EQ(static_cast<const DiskShapeConf*>(GetData(fshape))->GetLocation(), conf.GetLocation());
         EXPECT_FALSE(body->GetFixtures().empty());
         {
-            int i = 0;
+            auto i = 0;
             for (auto&& f: body->GetFixtures())
             {
                 EXPECT_EQ(GetPtr(f), fixture);
@@ -437,7 +438,7 @@ TEST(Body, CreateAndDestroyFixture)
 
 TEST(Body, SetType)
 {
-    BodyConf bd;
+    auto bd = BodyConf{};
     bd.type = BodyType::Dynamic;
     auto world = World{};
     const auto body = world.CreateBody(bd);
@@ -521,9 +522,9 @@ TEST(Body, SetMassData)
 
 TEST(Body, SetTransform)
 {
-    BodyConf bd;
+    auto bd = BodyConf{};
     bd.type = BodyType::Dynamic;
-    World world;
+    auto world = World{};
     const auto body = world.CreateBody(bd);
     const auto xfm1 = Transformation{Length2{}, UnitVec::GetRight()};
     ASSERT_EQ(body->GetTransformation(), xfm1);
@@ -668,7 +669,7 @@ TEST(Body, SetAcceleration)
 
 TEST(Body, CreateLotsOfFixtures)
 {
-    BodyConf bd;
+    auto bd = BodyConf{};
     bd.type = BodyType::Dynamic;
     auto conf = DiskShapeConf{};
     conf.vertexRadius = 2.871_m;
@@ -680,7 +681,7 @@ TEST(Body, CreateLotsOfFixtures)
     
     start = std::chrono::system_clock::now();
     {
-        World world;
+        auto world = World{};
 
         auto body = world.CreateBody(bd);
         ASSERT_NE(body, nullptr);
@@ -709,7 +710,7 @@ TEST(Body, CreateLotsOfFixtures)
 
     start = std::chrono::system_clock::now();
     {
-        World world;
+        auto world = World{};
         
         auto body = world.CreateBody(bd);
         ASSERT_NE(body, nullptr);
@@ -723,7 +724,7 @@ TEST(Body, CreateLotsOfFixtures)
         
         EXPECT_FALSE(body->GetFixtures().empty());
         {
-            int i = decltype(num){0};
+            auto i = decltype(num){0};
             for (auto&& f: body->GetFixtures())
             {
                 NOT_USED(f);
@@ -740,7 +741,7 @@ TEST(Body, CreateLotsOfFixtures)
 
 TEST(Body, GetWorldIndex)
 {
-    World world;
+    auto world = World{};
     ASSERT_EQ(world.GetBodies().size(), std::size_t(0));
     const auto body0 = world.CreateBody();
     ASSERT_EQ(world.GetBodies().size(), std::size_t(1));
@@ -756,9 +757,9 @@ TEST(Body, GetWorldIndex)
 
 TEST(Body, ApplyLinearAccelDoesNothingToStatic)
 {
-    World world;
+    auto world = World{};
     
-    auto body = world.CreateBody();
+    const auto body = world.CreateBody();
     ASSERT_NE(body, nullptr);
     ASSERT_FALSE(body->IsAwake());
     ASSERT_FALSE(body->IsSpeedable());
@@ -777,7 +778,7 @@ TEST(Body, ApplyLinearAccelDoesNothingToStatic)
 
 TEST(Body, GetAccelerationFF)
 {
-    World world;
+    auto world = World{};
     const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
     body->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
     
@@ -789,7 +790,7 @@ TEST(Body, GetAccelerationFF)
 
 TEST(Body, SetAccelerationFF)
 {
-    World world;
+    auto world = World{};
     const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
     body->SetAcceleration(LinearAcceleration2{}, AngularAcceleration{});
     

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -22,6 +22,7 @@
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
+#include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/BodyConf.hpp>
 #include <PlayRho/Dynamics/FixtureConf.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
@@ -58,11 +59,12 @@ TEST(Contact, IsNotCopyAssignable)
 TEST(Contact, Enabled)
 {
     const auto shape = DiskShapeConf{};
-    auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
-    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
-    auto c = Contact{&fA, 0u, &fB, 0u};
+    auto world = World{};
+    const auto bA = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bB = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto fA = bA->CreateFixture(Shape{shape});
+    const auto fB = bB->CreateFixture(Shape{shape});
+    auto c = Contact{fA, 0u, fB, 0u};
     EXPECT_TRUE(c.IsEnabled());
     c.UnsetEnabled();
     EXPECT_FALSE(c.IsEnabled());
@@ -73,32 +75,34 @@ TEST(Contact, Enabled)
 TEST(Contact, SetAwake)
 {
     const auto shape = DiskShapeConf{};
-    auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
-    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
-    const auto c = Contact{&fA, 0u, &fB, 0u};
+    auto world = World{};
+    const auto bA = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bB = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto fA = bA->CreateFixture(Shape{shape});
+    const auto fB = bB->CreateFixture(Shape{shape});
+    const auto c = Contact{fA, 0u, fB, 0u};
     
-    bA.UnsetAwake();
-    ASSERT_FALSE(bA.IsAwake());
+    bA->UnsetAwake();
+    ASSERT_FALSE(bA->IsAwake());
 
-    bB.UnsetAwake();
-    ASSERT_FALSE(bB.IsAwake());
+    bB->UnsetAwake();
+    ASSERT_FALSE(bB->IsAwake());
     
     SetAwake(c);
 
-    EXPECT_TRUE(bA.IsAwake());
-    EXPECT_TRUE(bB.IsAwake());
+    EXPECT_TRUE(bA->IsAwake());
+    EXPECT_TRUE(bB->IsAwake());
 }
 
 TEST(Contact, ResetFriction)
 {
     const auto shape = DiskShapeConf{};
-    auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
-    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
-    auto c = Contact{&fA, 0u, &fB, 0u};
+    auto world = World{};
+    const auto bA = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bB = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto fA = bA->CreateFixture(Shape{shape});
+    const auto fB = bB->CreateFixture(Shape{shape});
+    auto c = Contact{fA, 0u, fB, 0u};
 
     ASSERT_GT(GetFriction(shape), Real(0));
     ASSERT_NEAR(static_cast<double>(c.GetFriction()), static_cast<double>(Real{GetFriction(shape)}), 0.01);
@@ -111,11 +115,12 @@ TEST(Contact, ResetFriction)
 TEST(Contact, ResetRestitution)
 {
     const auto shape = DiskShapeConf{};
-    auto bA = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto bB = Body{nullptr, BodyConf{}.UseType(BodyType::Dynamic)};
-    auto fA = Fixture{&bA, FixtureConf{}, Shape{shape}};
-    auto fB = Fixture{&bB, FixtureConf{}, Shape{shape}};
-    auto c = Contact{&fA, 0u, &fB, 0u};
+    auto world = World{};
+    const auto bA = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bB = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+    const auto fA = bA->CreateFixture(Shape{shape});
+    const auto fB = bB->CreateFixture(Shape{shape});
+    auto c = Contact{fA, 0u, fB, 0u};
 
     ASSERT_EQ(GetRestitution(shape), Real(0));
     ASSERT_EQ(c.GetRestitution(), GetRestitution(shape));

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -52,7 +52,7 @@ TEST(DistanceJoint, ByteSize)
 
 TEST(DistanceJointConf, DefaultConstruction)
 {
-    DistanceJointConf def;
+    auto def = DistanceJointConf{};
 
     EXPECT_EQ(def.type, JointType::Distance);
     EXPECT_EQ(def.bodyA, nullptr);
@@ -122,7 +122,7 @@ TEST(DistanceJoint, ShiftOrigin)
 
 TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
 {
-    World world{};
+    auto world = World{};
     
     const auto shape = Shape{DiskShapeConf{}.UseRadius(0.2_m)};
     
@@ -136,7 +136,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
     ASSERT_EQ(body2->GetLocation(), location2);
     ASSERT_NE(body2->CreateFixture(shape), nullptr);
     
-    DistanceJointConf jointdef;
+    auto jointdef = DistanceJointConf{};
     jointdef.bodyA = body1;
     jointdef.bodyB = body2;
     jointdef.collideConnected = false;
@@ -150,7 +150,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
     auto oldDistance = GetMagnitude(body1->GetLocation() - body2->GetLocation());
     
     auto distanceMet = 0u;
-    StepConf stepConf;
+    auto stepConf = StepConf{};
     for (auto i = 0u; !distanceMet || i < distanceMet + 100; ++i)
     {
         world.Step(stepConf);
@@ -189,7 +189,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
     ASSERT_EQ(body2->GetLocation(), location2);
     ASSERT_NE(body2->CreateFixture(shape), nullptr);
     
-    DistanceJointConf jointdef;
+    auto jointdef = DistanceJointConf{};
     jointdef.bodyA = body1;
     jointdef.bodyB = body2;
     jointdef.collideConnected = false;
@@ -235,7 +235,7 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
 
 TEST(DistanceJointConf, GetDistanceJointDefFreeFunction)
 {
-    World world;
+    auto world = World{};
     
     const auto bA = world.CreateBody();
     ASSERT_NE(bA, nullptr);

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -541,9 +541,37 @@ TEST(Fixed32, regpow)
 
 TEST(Fixed32, sqrt)
 {
+    const auto tolerance = static_cast<double>(Fixed32::GetMin());
+
+    EXPECT_TRUE(isnan(sqrt(Fixed32{-1})));
+    EXPECT_TRUE(isnan(sqrt(Fixed32::GetNaN())));
+    EXPECT_EQ(sqrt(Fixed32{0}), Fixed32{0});
+    EXPECT_EQ(sqrt(Fixed32::GetInfinity()), Fixed32::GetInfinity());
+    EXPECT_EQ(sqrt(Fixed32{1}), Fixed32{1});
+    EXPECT_NEAR(static_cast<double>(sqrt(Fixed32{0.25})), 0.5, 0.0);
+    EXPECT_NEAR(static_cast<double>(sqrt(Fixed32{0.0625})), 0.25, tolerance);
+
     for (auto i = 0; i < 10000; ++i)
     {
         EXPECT_NEAR(static_cast<double>(sqrt(Fixed32(i))), sqrt(double(i)), 0.01);
+    }
+
+    for (auto v = 1.0; v > 0.0; v /= 1.1)
+    {
+        const auto fixedv = Fixed32{v};
+        if (fixedv == Fixed32{0})
+        {
+            break;
+        }
+        EXPECT_LE(Abs(Square(sqrt(fixedv)) - fixedv), Fixed32::GetMin());
+        EXPECT_NEAR(static_cast<double>(sqrt(fixedv)), sqrt(static_cast<double>(fixedv)), tolerance * 5);
+    }
+    const auto maxV = static_cast<double>(std::numeric_limits<Fixed32>::max());
+    for (auto v = 1.0; v < maxV; v *= 1.1)
+    {
+        const auto fixedv = Fixed32{v};
+        EXPECT_NEAR(static_cast<double>(sqrt(fixedv)), sqrt(v), tolerance);
+        //EXPECT_LE(Abs(Square(sqrt(fixedv)) - fixedv), Fixed32::GetMin() * 5);
     }
 }
 

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -547,6 +547,7 @@ TEST(Fixed32, sqrt)
     EXPECT_TRUE(isnan(sqrt(Fixed32::GetNaN())));
     EXPECT_EQ(sqrt(Fixed32{0}), Fixed32{0});
     EXPECT_EQ(sqrt(Fixed32::GetInfinity()), Fixed32::GetInfinity());
+    EXPECT_EQ(sqrt(Fixed32::GetMin()), Fixed32::GetMin());
     EXPECT_EQ(sqrt(Fixed32{1}), Fixed32{1});
     EXPECT_NEAR(static_cast<double>(sqrt(Fixed32{0.25})), 0.5, 0.0);
     EXPECT_NEAR(static_cast<double>(sqrt(Fixed32{0.0625})), 0.25, tolerance);

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -547,7 +547,8 @@ TEST(Fixed32, sqrt)
     EXPECT_TRUE(isnan(sqrt(Fixed32::GetNaN())));
     EXPECT_EQ(sqrt(Fixed32{0}), Fixed32{0});
     EXPECT_EQ(sqrt(Fixed32::GetInfinity()), Fixed32::GetInfinity());
-    EXPECT_EQ(sqrt(Fixed32::GetMin()), Fixed32::GetMin());
+    EXPECT_EQ(sqrt(Fixed32::GetMin()), Fixed32(0.046875));
+    EXPECT_EQ(Square(sqrt(Fixed32::GetMin())), Fixed32::GetMin());
     EXPECT_EQ(sqrt(Fixed32{1}), Fixed32{1});
     EXPECT_NEAR(static_cast<double>(sqrt(Fixed32{0.25})), 0.5, 0.0);
     EXPECT_NEAR(static_cast<double>(sqrt(Fixed32{0.0625})), 0.25, tolerance);

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -114,6 +114,7 @@ TEST(Fixture, SetAwakeFreeFunction)
     EXPECT_TRUE(body->IsAwake());
 }
 
+#if 0
 TEST(Fixture, CopyConstructor)
 {
     const auto density = 2_kgpm2;
@@ -132,7 +133,7 @@ TEST(Fixture, CopyConstructor)
             DiskShapeConf{}.UseFriction(friction).UseRestitution(restitution).UseDensity(density)
         };
 
-        World world;
+        auto world = World{};
         const auto body = world.CreateBody();
         const auto fixture = body->CreateFixture(shape, def);
         
@@ -171,7 +172,7 @@ TEST(Fixture, CopyConstructor)
             ChainShapeConf{}.Add(Length2{-2_m, -3_m}).Add(Length2{-2_m, 0_m}).Add(Length2{0_m, 0_m})
         };
         
-        World world;
+        auto world = World{};
         const auto body = world.CreateBody();
         const auto fixture = body->CreateFixture(shape, def);
         
@@ -233,3 +234,4 @@ TEST(Fixture, CopyConstructor)
         }
     }
 }
+#endif

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -114,11 +114,10 @@ TEST(Fixture, SetAwakeFreeFunction)
     EXPECT_TRUE(body->IsAwake());
 }
 
-#if 0
-TEST(Fixture, CopyConstructor)
+TEST(Fixture, Proxies)
 {
     const auto density = 2_kgpm2;
-    int variable;
+    auto variable = 0;
     const auto userData = &variable;
     const auto friction = Real(0.5);
     const auto restitution = Real(0.4);
@@ -148,23 +147,8 @@ TEST(Fixture, CopyConstructor)
 
         const auto stepConf = StepConf{};
         world.Step(stepConf);
-        ASSERT_EQ(fixture->GetProxyCount(), ChildCounter{1});
-        ASSERT_EQ(fixture->GetProxy(0), FixtureProxy{0});
-
-        Fixture copy{*fixture};
-        
-        EXPECT_EQ(copy.GetBody(), body);
-        EXPECT_EQ(copy.GetShape(), shape);
-        EXPECT_EQ(copy.GetDensity(), density);
-        EXPECT_EQ(copy.GetFriction(), friction);
-        EXPECT_EQ(copy.GetUserData(), userData);
-        EXPECT_EQ(copy.GetRestitution(), restitution);
-        EXPECT_EQ(copy.IsSensor(), isSensor);
-        EXPECT_EQ(copy.GetProxyCount(), fixture->GetProxyCount());
-        if (copy.GetProxyCount() == fixture->GetProxyCount())
-        {
-            EXPECT_EQ(copy.GetProxy(0), fixture->GetProxy(0));
-        }
+        EXPECT_EQ(fixture->GetProxyCount(), ChildCounter{1});
+        EXPECT_EQ(fixture->GetProxy(0), FixtureProxy{0});
     }
     
     {
@@ -183,20 +167,9 @@ TEST(Fixture, CopyConstructor)
         
         const auto stepConf = StepConf{};
         world.Step(stepConf);
-        ASSERT_EQ(fixture->GetProxyCount(), ChildCounter{2});
-        ASSERT_EQ(fixture->GetProxy(0), FixtureProxy{0});
-        ASSERT_EQ(fixture->GetProxy(1), FixtureProxy{1});
-        
-        Fixture copy{*fixture};
-        
-        EXPECT_EQ(copy.GetBody(), body);
-        EXPECT_EQ(copy.GetShape(), shape);
-        EXPECT_EQ(copy.IsSensor(), isSensor);
-        EXPECT_EQ(copy.GetProxyCount(), fixture->GetProxyCount());
-        if (copy.GetProxyCount() == fixture->GetProxyCount())
-        {
-            EXPECT_EQ(copy.GetProxy(0), fixture->GetProxy(0));
-        }
+        EXPECT_EQ(fixture->GetProxyCount(), ChildCounter{2});
+        EXPECT_EQ(fixture->GetProxy(0), FixtureProxy{0});
+        EXPECT_EQ(fixture->GetProxy(1), FixtureProxy{1});
     }
     
     {
@@ -205,7 +178,7 @@ TEST(Fixture, CopyConstructor)
             .Add(Length2{0_m, +2_m}).Add(Length2{2_m, 2_m})
         };
 
-        World world;
+        auto world = World{};
         const auto body = world.CreateBody();
         const auto fixture = body->CreateFixture(shape, def);
         
@@ -216,22 +189,10 @@ TEST(Fixture, CopyConstructor)
         
         const auto stepConf = StepConf{};
         world.Step(stepConf);
-        ASSERT_EQ(fixture->GetProxyCount(), ChildCounter{4});
-        ASSERT_EQ(fixture->GetProxy(0), FixtureProxy{0});
-        ASSERT_EQ(fixture->GetProxy(1), FixtureProxy{1});
-        ASSERT_EQ(fixture->GetProxy(2), FixtureProxy{3});
-        ASSERT_EQ(fixture->GetProxy(3), FixtureProxy{5});
-
-        Fixture copy{*fixture};
-        
-        EXPECT_EQ(copy.GetBody(), body);
-        EXPECT_EQ(copy.GetShape(), shape);
-        EXPECT_EQ(copy.IsSensor(), isSensor);
-        EXPECT_EQ(copy.GetProxyCount(), fixture->GetProxyCount());
-        if (copy.GetProxyCount() == fixture->GetProxyCount())
-        {
-            EXPECT_EQ(copy.GetProxy(0), fixture->GetProxy(0));
-        }
+        EXPECT_EQ(fixture->GetProxyCount(), ChildCounter{4});
+        EXPECT_EQ(fixture->GetProxy(0), FixtureProxy{0});
+        EXPECT_EQ(fixture->GetProxy(1), FixtureProxy{1});
+        EXPECT_EQ(fixture->GetProxy(2), FixtureProxy{3});
+        EXPECT_EQ(fixture->GetProxy(3), FixtureProxy{5});
     }
 }
-#endif

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -113,7 +113,8 @@ TEST(GearJoint, IsOkay)
 
 TEST(GearJoint, Construction)
 {
-    auto body = Body{nullptr, BodyConf{}};
+    auto world = World{};
+    auto& body = *world.CreateBody();
     auto rdef = RevoluteJointConf{&body, &body, Length2{}};
     auto revJoint1 = RevoluteJoint{rdef};
     auto revJoint2 = RevoluteJoint{rdef};
@@ -141,7 +142,8 @@ TEST(GearJoint, Construction)
 
 TEST(GearJoint, ShiftOrigin)
 {
-    auto body = Body{nullptr, BodyConf{}};
+    auto world = World{};
+    auto& body = *world.CreateBody();
     auto rdef = RevoluteJointConf{&body, &body, Length2{}};
     auto revJoint1 = RevoluteJoint{rdef};
     auto revJoint2 = RevoluteJoint{rdef};
@@ -153,7 +155,8 @@ TEST(GearJoint, ShiftOrigin)
 
 TEST(GearJoint, SetRatio)
 {
-    Body body{nullptr, BodyConf{}};
+    auto world = World{};
+    auto& body = *world.CreateBody();
     RevoluteJointConf rdef{&body, &body, Length2{}};
     RevoluteJoint revJoint1{rdef};
     RevoluteJoint revJoint2{rdef};
@@ -166,7 +169,8 @@ TEST(GearJoint, SetRatio)
 
 TEST(GearJoint, GetGearJointConf)
 {
-    Body body{nullptr, BodyConf{}};
+    auto world = World{};
+    auto& body = *world.CreateBody();
     RevoluteJointConf rdef{&body, &body, Length2{}};
     RevoluteJoint revJoint1{rdef};
     RevoluteJoint revJoint2{rdef};

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -112,8 +112,9 @@ TEST(RopeJoint, Construction)
 
 TEST(RopeJoint, GetRopeJointConf)
 {
-    auto bodyA = Body{nullptr, BodyConf{}};
-    auto bodyB = Body{nullptr, BodyConf{}};
+    auto world = World{};
+    auto& bodyA = *world.CreateBody();
+    auto& bodyB = *world.CreateBody();
     RopeJointConf def{&bodyA, &bodyB};
     const auto localAnchorA = Length2{-2_m, 0_m};
     const auto localAnchorB = Length2{+2_m, 0_m};

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -109,8 +109,9 @@ TEST(WeldJoint, Construction)
 
 TEST(WeldJoint, GetWeldJointConf)
 {
-    auto bodyA = Body{nullptr, BodyConf{}};
-    auto bodyB = Body{nullptr, BodyConf{}};
+    auto world = World{};
+    auto& bodyA = *world.CreateBody();
+    auto& bodyB = *world.CreateBody();
     const auto anchor = Length2(2_m, 1_m);
     WeldJointConf def{&bodyA, &bodyB, anchor};
     WeldJoint joint{def};

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -53,12 +53,12 @@ using namespace playrho::d2;
 
 class UnitTestDestructionListener: public playrho::d2::DestructionListener
 {
-    void SayGoodbye(const Joint& joint) override
+    void SayGoodbye(const Joint& joint) noexcept override
     {
         joints.push_back(&joint);
     }
     
-    void SayGoodbye(const Fixture& fixture) override
+    void SayGoodbye(const Fixture& fixture) noexcept override
     {
         fixtures.push_back(&fixture);
     }
@@ -538,16 +538,16 @@ TEST(World, CreateAndDestroyFixture)
     ASSERT_EQ(GetFixtureCount(*bodyA), std::size_t(1));
     EXPECT_FALSE(other.TouchProxies(*fixtureA));
     
-    EXPECT_TRUE(world.DestroyFixture(fixtureA));
+    EXPECT_TRUE(world.Destroy(fixtureA));
     EXPECT_EQ(GetFixtureCount(*bodyA), std::size_t(0));
     
-    EXPECT_FALSE(world.DestroyFixture(nullptr));
+    EXPECT_FALSE(world.Destroy(static_cast<Fixture*>(nullptr)));
     
     const auto bodyC = other.CreateBody();
     ASSERT_NE(bodyC, nullptr);
     const auto fixtureC = other.CreateFixture(*bodyC, Shape{DiskShapeConf(1_m)});
     ASSERT_NE(fixtureC, nullptr);
-    EXPECT_FALSE(world.DestroyFixture(fixtureC));
+    EXPECT_FALSE(world.Destroy(fixtureC));
     
     EXPECT_THROW(world.CreateFixture(*bodyC, Shape{DiskShapeConf(1_m)}), InvalidArgument);
 }
@@ -1396,7 +1396,7 @@ public:
         EXPECT_THROW(w->Step(stepConf), WrongState);
         EXPECT_THROW(w->ShiftOrigin(Length2{}), WrongState);
         EXPECT_THROW(bA->CreateFixture(Shape{DiskShapeConf{}}), WrongState);
-        EXPECT_THROW(bA->DestroyFixture(fA), WrongState);
+        EXPECT_THROW(bA->Destroy(fA), WrongState);
     }
     
     void EndContact(Contact& contact) override

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1392,6 +1392,7 @@ public:
             EXPECT_THROW(bA->SetType(BodyType::Kinematic), WrongState);
         }
         EXPECT_THROW(w->Destroy(bA), WrongState);
+        EXPECT_THROW(w->Clear(), WrongState);
         EXPECT_THROW(w->CreateJoint(DistanceJointConf{bA, bB}), WrongState);
         EXPECT_THROW(w->Step(stepConf), WrongState);
         EXPECT_THROW(w->ShiftOrigin(Length2{}), WrongState);

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -25,6 +25,7 @@
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
+#include <PlayRho/Dynamics/World.hpp>
 #include <PlayRho/Dynamics/BodyConf.hpp>
 #include <PlayRho/Dynamics/FixtureConf.hpp>
 
@@ -166,11 +167,12 @@ TEST(WorldManifold, GetWorldManifoldForCirclesFullyOverlappingManifold)
 TEST(WorldManifold, GetForContact)
 {
     const auto shape = Shape{DiskShapeConf{}};
-    auto bA = Body{nullptr, BodyConf{}};
-    auto bB = Body{nullptr, BodyConf{}};
-    auto fA = Fixture{&bA, FixtureConf{}, shape};
-    auto fB = Fixture{&bB, FixtureConf{}, shape};
-    const auto c = Contact{&fA, 0u, &fB, 0u};
+    auto world = World{};
+    const auto bA = world.CreateBody();
+    const auto bB = world.CreateBody();
+    const auto fA = bA->CreateFixture(shape);
+    const auto fB = bB->CreateFixture(shape);
+    const auto c = Contact{fA, 0u, fB, 0u};
 
     const auto wm = GetWorldManifold(c);
     


### PR DESCRIPTION
#### Description - What's this PR do?
- Removes an assert that didn't make sense anymore.
- Updates for improving support for Fixed type Real.
- Changes for issue #302 and issue #303:
- Corrects handling of sqrt for Fixed for negative, NaN, 0 and 1 values.
- Improves handling of sqrt for Fixed values between 0 and 1.
- Renames DestroyFixture to Destroy to be more consistent with the naming convention.
- Refactors code to make Body constructors and destructor private again.
- Refactors code to make Fixture constructors and destructor private again.
- Marks more code noexcept, including DestructionListener interface's call back methods.
- Various documentation related updates including adding UnitTests directory into doxygen EXAMPLE_PATH and referencing some unit test files.

#### Related Issues
- Issue #302.
- Issue #303.