### PR TITLE
Transforms Vector <, <=, >, >= support to more generic support

### DIFF
--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -23,6 +23,9 @@
 
 #include <PlayRho/Defines.hpp>
 
+#include <algorithm>
+#include <functional>
+#include <iterator>
 #include <limits>
 #include <typeinfo>
 #include <type_traits>
@@ -331,6 +334,94 @@ namespace playrho {
     template <class T, std::size_t N>
     PLAYRHO_CONSTEXPR inline std::size_t GetSize(T (&)[N]) { return N; }
     
+    /// @brief Function object for performing lexicographical less-than
+    ///   comparisons of containers.
+    /// @sa http://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @sa http://en.cppreference.com/w/cpp/utility/functional/less
+    template <typename T>
+    struct LexicographicalLess
+    {
+        /// @brief Checks whether the first argument is lexicographically less-than the
+        ///   second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::begin;
+            using std::end;
+            using std::lexicographical_compare;
+            using std::less;
+            using ElementType = decltype(*begin(lhs));
+            return lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs),
+                                           less<ElementType>{});
+        }
+    };
+    
+    /// @brief Function object for performing lexicographical greater-than
+    ///   comparisons of containers.
+    /// @sa http://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @sa http://en.cppreference.com/w/cpp/utility/functional/greater
+    template <typename T>
+    struct LexicographicalGreater
+    {
+        /// @brief Checks whether the first argument is lexicographically greater-than the
+        ///   second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::begin;
+            using std::end;
+            using std::lexicographical_compare;
+            using std::greater;
+            using ElementType = decltype(*begin(lhs));
+            return lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs),
+                                           greater<ElementType>{});
+        }
+    };
+
+    /// @brief Function object for performing lexicographical less-than or equal-to
+    ///   comparisons of containers.
+    /// @sa http://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @sa http://en.cppreference.com/w/cpp/utility/functional/less_equal
+    template <typename T>
+    struct LexicographicalLessEqual
+    {
+        /// @brief Checks whether the first argument is lexicographically less-than or
+        ///   equal-to the second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::begin;
+            using std::end;
+            using std::mismatch;
+            using std::less;
+            using std::get;
+            using ElementType = decltype(*begin(lhs));
+            const auto lhsEnd = end(lhs);
+            const auto diff = mismatch(begin(lhs), lhsEnd, begin(rhs), end(rhs));
+            return (get<0>(diff) == lhsEnd) || less<ElementType>{}(*get<0>(diff), *get<1>(diff));
+        }
+    };
+
+    /// @brief Function object for performing lexicographical greater-than or equal-to
+    ///   comparisons of containers.
+    /// @sa http://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @sa http://en.cppreference.com/w/cpp/utility/functional/greater_equal
+    template <typename T>
+    struct LexicographicalGreaterEqual
+    {
+        /// @brief Checks whether the first argument is lexicographically greater-than or
+        ///   equal-to the second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::begin;
+            using std::end;
+            using std::mismatch;
+            using std::greater;
+            using std::get;
+            using ElementType = decltype(*begin(lhs));
+            const auto lhsEnd = end(lhs);
+            const auto diff = mismatch(begin(lhs), lhsEnd, begin(rhs), end(rhs));
+            return (get<0>(diff) == lhsEnd) || greater<ElementType>{}(*get<0>(diff), *get<1>(diff));
+        }
+    };
+
 } // namespace playrho
 
 #endif // PLAYRHO_COMMON_TEMPLATES_HPP

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -514,46 +514,6 @@ operator/ (Vector<T1, N> a, const T2 s) noexcept
     return result;
 }
 
-/// @brief Lexicographical less-than operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator< (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
-{
-    return std::lexicographical_compare(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
-                                        std::less<T>{});
-}
-
-/// @brief Lexicographical less-than or equal-to operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator<= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
-{
-    const auto lhsEnd = std::cend(lhs);
-    const auto rhsEnd = std::cend(rhs);
-    const auto diff = std::mismatch(std::cbegin(lhs), lhsEnd, std::cbegin(rhs), rhsEnd);
-    return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) < *std::get<1>(diff));
-}
-
-/// @brief Lexicographical greater-than operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator> (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
-{
-    return std::lexicographical_compare(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend(),
-                                        std::greater<T>{});
-}
-
-/// @brief Lexicographical greater-than or equal-to operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator>= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
-{
-    const auto lhsEnd = std::cend(lhs);
-    const auto rhsEnd = std::cend(rhs);
-    const auto diff = std::mismatch(std::cbegin(lhs), lhsEnd, std::cbegin(rhs), rhsEnd);
-    return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) > *std::get<1>(diff));
-}
-
 /// @brief Gets the specified element of the given collection.
 /// @relatedalso Vector
 template <std::size_t I, std::size_t N, typename T>

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -354,8 +354,23 @@ TEST(ChainShapeConf, Inequality)
 TEST(ChainShapeConf, GetSquareChainShapeConf)
 {
     const auto conf = GetChainShapeConf(2_m);
-    auto vertices = std::set<Length2>();
     const auto childCount = GetChildCount(conf);
+    EXPECT_EQ(childCount, decltype(childCount){4});
+    for (auto i = ChildCounter{0}; i < childCount; ++i)
+    {
+        const auto childI = GetChild(conf, i);
+        EXPECT_EQ(childI.GetVertexCount(), decltype(childI.GetVertexCount()){2});
+        for (auto j = ChildCounter{0}; j < childCount; ++j)
+        {
+            const auto childJ = GetChild(conf, j);
+            if (i != j)
+            {
+                EXPECT_NE(childI, childJ);
+            }
+        }
+    }
+
+    auto vertices = std::set<Length2, LexicographicalLess<Length2>>();
     for (auto i = ChildCounter{0}; i < childCount; ++i)
     {
         const auto child = GetChild(conf, i);

--- a/UnitTests/Vector.cpp
+++ b/UnitTests/Vector.cpp
@@ -90,108 +90,108 @@ TEST(Vector, Inequality)
     EXPECT_FALSE(a != b);
 }
 
-TEST(Vector, LessThan)
+TEST(Vector, LexicographicalLess)
 {
     Vector<int, 10> a;
     Vector<int, 10> b;
     
     std::fill(a.begin(), a.end(), 1);
     std::fill(b.begin(), b.end(), 1);
-    EXPECT_FALSE(a < b);
+    EXPECT_FALSE((LexicographicalLess<Vector<int, 10>>{}(a, b)));
     
     std::fill(b.begin(), b.end(), 2);
-    EXPECT_TRUE(a < b);
+    EXPECT_TRUE((LexicographicalLess<Vector<int, 10>>{}(a, b)));
     
     std::fill(a.begin(), a.end(), 2);
-    EXPECT_FALSE(a < b);
+    EXPECT_FALSE((LexicographicalLess<Vector<int, 10>>{}(a, b)));
     
     for (auto& e: b)
     {
         const auto old = e;
         e = 10;
-        EXPECT_TRUE(a < b);
+        EXPECT_TRUE((LexicographicalLess<Vector<int, 10>>{}(a, b)));
         e = old;
     }
     
-    EXPECT_FALSE(a < b);
+    EXPECT_FALSE((LexicographicalLess<Vector<int, 10>>{}(a, b)));
 }
 
-TEST(Vector, GreaterThan)
+TEST(Vector, LexicographicalGreaterThan)
 {
     Vector<int, 10> a;
     Vector<int, 10> b;
     
     std::fill(a.begin(), a.end(), 1);
     std::fill(b.begin(), b.end(), 1);
-    EXPECT_FALSE(a > b);
+    EXPECT_FALSE((LexicographicalGreater<Vector<int, 10>>{}(a, b)));
     
     std::fill(b.begin(), b.end(), 2);
-    EXPECT_FALSE(a > b);
+    EXPECT_FALSE((LexicographicalGreater<Vector<int, 10>>{}(a, b)));
     
     std::fill(a.begin(), a.end(), 2);
-    EXPECT_FALSE(a > b);
+    EXPECT_FALSE((LexicographicalGreater<Vector<int, 10>>{}(a, b)));
     
     for (auto& e: b)
     {
         const auto old = e;
         e = 10;
-        EXPECT_TRUE(b > a);
+        EXPECT_TRUE((LexicographicalGreater<Vector<int, 10>>{}(b, a)));
         e = old;
     }
     
-    EXPECT_FALSE(b > a);
+    EXPECT_FALSE((LexicographicalGreater<Vector<int, 10>>{}(b, a)));
 }
 
-TEST(Vector, LessThanOrEqualTo)
+TEST(Vector, LexicographicalLessThanOrEqualTo)
 {
     Vector<int, 10> a;
     Vector<int, 10> b;
     
     std::fill(a.begin(), a.end(), 1);
     std::fill(b.begin(), b.end(), 1);
-    EXPECT_TRUE(a <= b);
+    EXPECT_TRUE((LexicographicalLessEqual<Vector<int, 10>>{}(a, b)));
     
     std::fill(b.begin(), b.end(), 2);
-    EXPECT_TRUE(a <= b);
+    EXPECT_TRUE((LexicographicalLessEqual<Vector<int, 10>>{}(a, b)));
     
     std::fill(a.begin(), a.end(), 2);
-    EXPECT_TRUE(a <= b);
+    EXPECT_TRUE((LexicographicalLessEqual<Vector<int, 10>>{}(a, b)));
     
     for (auto& e: b)
     {
         const auto old = e;
         e = 10;
-        EXPECT_TRUE(a <= b);
+        EXPECT_TRUE((LexicographicalLessEqual<Vector<int, 10>>{}(a, b)));
         e = old;
     }
     
-    EXPECT_TRUE(a <= b);
+    EXPECT_TRUE((LexicographicalLessEqual<Vector<int, 10>>{}(a, b)));
 }
 
-TEST(Vector, GreaterThanOrEqualTo)
+TEST(Vector, LexicographicalGreaterThanOrEqualTo)
 {
     Vector<int, 10> a;
     Vector<int, 10> b;
     
     std::fill(a.begin(), a.end(), 1);
     std::fill(b.begin(), b.end(), 1);
-    EXPECT_TRUE(a >= b);
+    EXPECT_TRUE((LexicographicalGreaterEqual<Vector<int, 10>>{}(a, b)));
     
     std::fill(b.begin(), b.end(), 2);
-    EXPECT_FALSE(a >= b);
+    EXPECT_FALSE((LexicographicalGreaterEqual<Vector<int, 10>>{}(a, b)));
     
     std::fill(a.begin(), a.end(), 2);
-    EXPECT_TRUE(a >= b);
+    EXPECT_TRUE((LexicographicalGreaterEqual<Vector<int, 10>>{}(a, b)));
     
     for (auto& e: b)
     {
         const auto old = e;
         e = 10;
-        EXPECT_TRUE(b >= a);
+        EXPECT_TRUE((LexicographicalGreaterEqual<Vector<int, 10>>{}(b, a)));
         e = old;
     }
     
-    EXPECT_TRUE(b >= a);
+    EXPECT_TRUE((LexicographicalGreaterEqual<Vector<int, 10>>{}(b, a)));
 }
 
 TEST(Vector, ReverseIterateWith_crbeginend)


### PR DESCRIPTION
#### Description - What's this PR do?
Transforms Vector <, <=, >, >= support to more generic lexicographical function objects operating over containers.

Vectors don't inherently have a natural singular concept of these comparisons anyway. Arguably it's more natural for them to use these comparisons based on magnitudes. But that fails to provide regularity with respect to equality - i.e. !(A < B) && !(B < A) should mean that A == B. In the case of using magnitudes, it doesn't.