### PR TITLE
Cpp17 updates 20180617

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -686,7 +686,7 @@ public:
     }
     
 private:
-    playrho::OptionalValue<T> m_element;
+    playrho::Optional<T> m_element;
     std::mutex m_mutex;
     std::condition_variable m_cond;
 };

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -57,15 +57,14 @@ inline SimplexEdges GetSimplexEdges(const IndexPair3 indexPairs,
         case 3:
             simplexEdges[2] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[2]),
                                              proxyB, xfB, std::get<1>(indexPairs[2]));
-            // [[fallthrough]]
+            [[fallthrough]];
         case 2:
             simplexEdges[1] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[1]),
                                              proxyB, xfB, std::get<1>(indexPairs[1]));
-            // [[fallthrough]]
+            [[fallthrough]];
         case 1:
             simplexEdges[0] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[0]),
                                              proxyB, xfB, std::get<1>(indexPairs[0]));
-            // [[fallthrough]]
     }
     simplexEdges.size(static_cast<size_type>(count));
     return simplexEdges;

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -129,7 +129,7 @@ MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
     }
     
     auto center = Length2{};
-    auto area = Area{0};
+    auto area = 0_m2;
     auto I = SecondMomentOfArea{0};
     
     // s is the reference point for forming triangles.
@@ -162,7 +162,7 @@ MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
     const auto mass = Mass{AreaDensity{density} * area};
     
     // Center of mass
-    assert((area > Area{0}) && !AlmostZero(StripUnit(area)));
+    assert((area > 0_m2) && !AlmostZero(StripUnit(area)));
     center /= StripUnit(area);
     const auto massDataCenter = center + s;
     

--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -98,7 +98,7 @@ ChainShapeConf& ChainShapeConf::Transform(const Mat22& m) noexcept
 
 ChainShapeConf& ChainShapeConf::Add(Length2 vertex)
 {
-    if (size(m_vertices) > 0)
+    if (!empty(m_vertices))
     {
         auto vprev = m_vertices.back();
         m_vertices.emplace_back(vertex);

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -89,7 +89,7 @@ public:
     /// @brief Gets the vertex count.
     ChildCounter GetVertexCount() const noexcept
     {
-        return static_cast<ChildCounter>(m_vertices.size());
+        return static_cast<ChildCounter>(size(m_vertices));
     }
     
     /// @brief Gets a vertex by index.

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -41,7 +41,7 @@ MassData GetMassData(const MultiShapeConf& arg) noexcept
                   [&](const ConvexHull& ch) {
         const auto dp = ch.GetDistanceProxy();
         const auto md = playrho::d2::GetMassData(ch.GetVertexRadius(), density,
-            Span<const Length2>(dp.GetVertices().begin(), dp.GetVertexCount()));
+            Span<const Length2>(begin(dp.GetVertices()), dp.GetVertexCount()));
         mass += Mass{md.mass};
         weightedCenter += md.center * Mass{md.mass};
         I += RotInertia{md.I};

--- a/PlayRho/Collision/Shapes/MultiShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.hpp
@@ -45,8 +45,8 @@ public:
     DistanceProxy GetDistanceProxy() const
     {
         return DistanceProxy{
-            vertexRadius, static_cast<VertexCounter>(vertices.size()),
-            vertices.data(), normals.data()
+            vertexRadius, static_cast<VertexCounter>(size(vertices)),
+            data(vertices), data(normals)
         };
     }
     
@@ -161,7 +161,7 @@ inline bool operator!= (const MultiShapeConf& lhs, const MultiShapeConf& rhs) no
 /// @brief Gets the "child" count for the given shape configuration.
 inline ChildCounter GetChildCount(const MultiShapeConf& arg) noexcept
 {
-    return static_cast<ChildCounter>(arg.children.size());
+    return static_cast<ChildCounter>(size(arg.children));
 }
 
 /// @brief Gets the "child" shape for the given shape configuration.

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -68,7 +68,7 @@ PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy) noexcept
 /// @brief Uses the given vertices.
 PolygonShapeConf& PolygonShapeConf::UseVertices(const std::vector<Length2>& verts) noexcept
 {
-    return Set(Span<const Length2>(verts.data(), size(verts)));
+    return Set(Span<const Length2>(data(verts), size(verts)));
 }
     
 PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy,

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -122,7 +122,7 @@ public:
     /// @see MaxShapeVertices
     VertexCounter GetVertexCount() const noexcept
     {
-        return static_cast<VertexCounter>(m_vertices.size());
+        return static_cast<VertexCounter>(size(m_vertices));
     }
     
     /// Gets a vertex by index.
@@ -211,7 +211,7 @@ inline DistanceProxy GetChild(const PolygonShapeConf& arg, ChildCounter index)
         throw InvalidArgument("only index of 0 is supported");
     }
     return DistanceProxy{arg.vertexRadius, arg.GetVertexCount(),
-        arg.GetVertices().data(), arg.GetNormals().data()};
+        data(arg.GetVertices()), data(arg.GetNormals())};
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -61,8 +61,8 @@ namespace playrho
 
         template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t< COPY_MAXSIZE <= MAXSIZE >>
         PLAYRHO_CONSTEXPR inline explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
-            m_size{copy.size()},
-            m_elements{copy.data()}
+            m_size{size(copy)},
+            m_elements{data(copy)}
         {
             // Intentionally empty
         }
@@ -71,8 +71,8 @@ namespace playrho
         template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t< COPY_MAXSIZE <= MAXSIZE >>
         ArrayList& operator= (const ArrayList<VALUE_TYPE, COPY_MAXSIZE, COPY_SIZE_TYPE>& copy)
         {
-            m_size = static_cast<SIZE_TYPE>(copy.size());
-            m_elements = copy.data();
+            m_size = static_cast<SIZE_TYPE>(size(copy));
+            m_elements = data(copy);
             return *this;
         }
 

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -45,8 +45,8 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices)
 {
     assert(size(vertices) >= 3);
     
-    auto c = Length2{} * Area{0};
-    auto area = Area{0};
+    auto c = Length2{} * 0_m2;
+    auto area = 0_m2;
     
     // <code>pRef</code> is the reference point for forming triangles.
     // It's location doesn't change the result (except for rounding error).
@@ -71,7 +71,7 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices)
     }
     
     // Centroid
-    assert((area > Area{0}) && !AlmostZero(area / SquareMeter));
+    assert((area > 0_m2) && !AlmostZero(area / SquareMeter));
     return c / area;
 }
 

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -166,10 +166,12 @@ inline auto Atan2(T y, T x)
 }
 
 /// @brief Computes the average of the given values.
-template <typename T>
-inline auto Average(Span<const T> span)
+template <typename T, typename = std::enable_if_t<
+    IsIterable<T>::value && IsAddable<decltype(*begin(std::declval<T>()))>::value
+    > >
+inline auto Average(const T& span)
 {
-    using value_type = typename std::remove_cv<T>::type;
+    using value_type = decltype(*begin(std::declval<T>()));
 
     // Relies on C++11 zero initialization to zero initialize value_type.
     // See: http://en.cppreference.com/w/cpp/language/zero_initialization
@@ -177,7 +179,7 @@ inline auto Average(Span<const T> span)
     assert(zero * Real{2} == zero);
     
     // For C++17, switch from using std::accumulate to using std::reduce.
-    const auto sum = std::accumulate(cbegin(span), cend(span), zero);
+    const auto sum = std::accumulate(begin(span), end(span), zero);
     const auto count = std::max(size(span), std::size_t{1});
     return sum / static_cast<Real>(count);
 }

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -601,17 +601,6 @@ inline Mat22 abs(const Mat22& A)
     return Mat22{abs(GetX(A)), abs(GetY(A))};
 }
 
-/// @brief Clamps the given value within the given range (inclusive).
-/// @param value Value to clamp.
-/// @param low Lowest value to return or NaN to keep the low-end unbounded.
-/// @param high Highest value to return or NaN to keep the high-end unbounded.
-template <typename T>
-PLAYRHO_CONSTEXPR inline T Clamp(T value, T low, T high) noexcept
-{
-    const auto tmp = (value > high)? high: value; // isnan(high)? a: Min(a, high);
-    return (tmp < low)? low: tmp; // isnan(low)? b: Max(b, low);
-}
-
 /// @brief Gets the next largest power of 2
 /// @details
 /// Given a binary integer value x, the next largest power of 2 can be computed by a S.W.A.R.

--- a/PlayRho/Common/Range.hpp
+++ b/PlayRho/Common/Range.hpp
@@ -43,19 +43,19 @@ namespace playrho {
         }
 
         /// @brief Gets the "begin" index value.
-        iterator_type begin() const noexcept
+        PLAYRHO_CONSTEXPR iterator_type begin() const noexcept
         {
             return m_begin;
         }
 
         /// @brief Gets the "end" index value.
-        iterator_type end() const noexcept
+        PLAYRHO_CONSTEXPR iterator_type end() const noexcept
         {
             return m_end;
         }
 
         /// @brief Whether this range is empty.
-        bool empty() const noexcept
+        PLAYRHO_CONSTEXPR bool empty() const noexcept
         {
             return m_begin == m_end;
         }
@@ -83,7 +83,7 @@ namespace playrho {
         }
 
         /// @brief Gets the size of this range.
-        size_type size() const noexcept
+        PLAYRHO_CONSTEXPR size_type size() const noexcept
         {
             return m_size;
         }

--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -20,6 +20,7 @@
 #define PLAYRHO_COMMON_SPAN_HPP
 
 #include <PlayRho/Defines.hpp>
+#include <PlayRho/Common/Templates.hpp>
 
 #include <cstddef>
 #include <cassert>
@@ -63,31 +64,18 @@ namespace playrho {
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Span(pointer first, pointer last) noexcept:
-            m_array{first}, m_size{static_cast<size_type>(std::distance(first, last))}
-        {
-            assert(first <= last);
-        }
-        
-        /// @brief Initializing constructor.
         template <std::size_t SIZE>
         PLAYRHO_CONSTEXPR inline Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
         
         /// @brief Initializing constructor.
         template <typename U, typename = std::enable_if_t< !std::is_array<U>::value > >
-        PLAYRHO_CONSTEXPR inline Span(U& value) noexcept: m_array{value.begin()}, m_size{value.size()} {}
+        PLAYRHO_CONSTEXPR inline Span(U& value) noexcept:
+        m_array{detail::Data(value)}, m_size{detail::Size(value)} {}
         
-        /// @brief Initializing constructor.
-        template <typename U, typename = std::enable_if_t< !std::is_array<U>::value > >
-        PLAYRHO_CONSTEXPR inline Span(const U& value) noexcept: m_array{value.begin()}, m_size{value.size()} {}
-
-        /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Span(std::vector<T>& value) noexcept: m_array{value.data()}, m_size{value.size()} {}
-
         /// @brief Initializing constructor.
         PLAYRHO_CONSTEXPR inline Span(std::initializer_list<T> list) noexcept:
             m_array{list.begin()}, m_size{list.size()} {}
-        
+
         /// @brief Gets the "begin" iterator value.
         pointer begin() const noexcept { return m_array; }
 

--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -115,10 +115,13 @@ namespace playrho {
         }
 
         /// @brief Gets the size of this span.
-        size_type size() const noexcept { return m_size; }
+        PLAYRHO_CONSTEXPR size_type size() const noexcept { return m_size; }
         
         /// @brief Direct access to data.
         pointer data() const noexcept { return m_array; }
+        
+        /// @brief Checks whether this span is empty.
+        PLAYRHO_CONSTEXPR bool empty() const noexcept { return m_size == 0; }
 
     private:
         pointer m_array = nullptr; ///< Pointer to array of data.

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -84,6 +84,24 @@ PLAYRHO_CONSTEXPR inline auto IsFull(const T& arg) -> decltype(size(arg) == max_
     return size(arg) == max_size(arg);
 }
 
+/// @brief Internal helper template function to avoid confusion for use within classes
+///   that define their own <code>data()</code> method.
+template <typename T>
+static auto Data(T& v)
+{
+    using ::playrho::data;
+    return data(v);
+}
+
+/// @brief Internal helper template function to avoid confusion for use within classes
+///   that define their own <code>size()</code> method.
+template <typename T>
+static auto Size(T& v)
+{
+    using ::playrho::size;
+    return size(v);
+}
+
 } // namespace detail
     
     /// @brief "Not used" annotator.
@@ -273,6 +291,14 @@ PLAYRHO_CONSTEXPR inline auto IsFull(const T& arg) -> decltype(size(arg) == max_
     /// @brief Template specialization for inequality comparable types.
     template<class T1, class T2>
     struct IsInequalityComparable<T1, T2, detail::VoidT<decltype(T1{} != T2{})> >: std::true_type {};
+
+    /// @brief Template for determining if the given types are addable.
+    template<class T1, class T2 = T1, class = void>
+    struct IsAddable: std::false_type {};
+    
+    /// @brief Template specializing for addable types.
+    template<class T1, class T2>
+    struct IsAddable<T1, T2, detail::VoidT<decltype(T1{} + T2{})> >: std::true_type {};
 
     /// @brief Template for determining if the given types are multipliable.
     template<class T1, class T2, class = void>

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -41,6 +41,7 @@ using std::cbegin;
 using std::cend;
 using std::size;
 using std::empty;
+using std::data;
 using std::swap;
 
 namespace detail {

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -73,13 +73,21 @@ public:
     }
 
     /// @brief Gets the current size of this set.
-    std::size_t size() const noexcept { return m_elements.size(); }
+    std::size_t size() const noexcept
+    {
+        using ::playrho::size;
+        return size(m_elements);
+    }
     
     /// @brief Gets the "begin" iterator value.
-    const_pointer begin() const { return m_elements.data(); }
+    const_pointer begin() const { return data(m_elements); }
     
     /// @brief Gets the "end" iterator value.
-    const_pointer end() const { return m_elements.data() + m_elements.size(); }
+    const_pointer end() const
+    {
+        using ::playrho::size;
+        return data(m_elements) + size(m_elements);
+    }
 
     /// Finds contained point whose delta with the given point has a squared length less
     /// than or equal to this set's minimum length squared value.

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -49,7 +49,7 @@ public:
     explicit VertexSet(Area minSepSquared = GetDefaultMinSeparationSquared()):
         m_minSepSquared{minSepSquared}
     {
-        assert(minSepSquared >= Area{0});
+        assert(minSepSquared >= 0_m2);
     }
 
     /// @brief Gets the min separation squared.
@@ -75,19 +75,17 @@ public:
     /// @brief Gets the current size of this set.
     std::size_t size() const noexcept
     {
-        using ::playrho::size;
-        return size(m_elements);
+        return detail::Size(m_elements);
     }
+    
+    /// @brief Gets the pointer to the data buffer.
+    const_pointer data() const { return detail::Data(m_elements); }
     
     /// @brief Gets the "begin" iterator value.
-    const_pointer begin() const { return data(m_elements); }
+    const_pointer begin() const { return data(); }
     
     /// @brief Gets the "end" iterator value.
-    const_pointer end() const
-    {
-        using ::playrho::size;
-        return data(m_elements) + size(m_elements);
-    }
+    const_pointer end() const { return data() + size(); }
 
     /// Finds contained point whose delta with the given point has a squared length less
     /// than or equal to this set's minimum length squared value.

--- a/PlayRho/Defines.hpp
+++ b/PlayRho/Defines.hpp
@@ -21,27 +21,6 @@
 #ifndef PLAYRHO_DEFINES_HPP
 #define PLAYRHO_DEFINES_HPP
 
-// Setup a define for unreachable code.
-//
-// Note that if someday the C++ standard picks up the unreachable attribute
-// (see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0627r0.pdf ),
-// then this macro can be replaced with [[unreachable]].
-//
-#if defined(__clang__)
-#define PLAYRHO_UNREACHABLE __builtin_unreachable()
-#elif defined(__GNUC__)
-#define PLAYRHO_UNREACHABLE __builtin_unreachable()
-#elif defined(__ICC) || defined(__INTEL_COMPILER)
-#define PLAYRHO_UNREACHABLE __builtin_unreachable()
-#elif defined(__MSC_VER)
-// For MS documentation on this use of its __assume, see:
-//   https://msdn.microsoft.com/en-us/library/1b3fsfxw.aspx#Anchor_3
-#define PLAYRHO_UNREACHABLE __assume(0)
-#else // for any other compiler
-#include <cstdlib>
-#define PLAYRHO_UNREACHABLE std::abort()
-#endif
-
 // Macro for constant expressions.
 // Value of this macro should either be 'constexpr' or empty.
 #define PLAYRHO_CONSTEXPR constexpr

--- a/PlayRho/Dynamics/BodyAtty.hpp
+++ b/PlayRho/Dynamics/BodyAtty.hpp
@@ -260,17 +260,17 @@ private:
     /// @brief Erases the given body's contacts.
     static void EraseContacts(Body& b, const std::function<bool(Contact&)>& callback)
     {
-        auto end = b.m_contacts.end();
-        auto iter = b.m_contacts.begin();
+        auto last = end(b.m_contacts);
+        auto iter = begin(b.m_contacts);
         auto index = Body::Contacts::difference_type{0};
-        while (iter != end)
+        while (iter != last)
         {
             const auto contact = GetContactPtr(*iter);
             if (callback(*contact))
             {
                 b.m_contacts.erase(iter);
-                iter = b.m_contacts.begin() + index;
-                end = b.m_contacts.end();
+                iter = begin(b.m_contacts) + index;
+                last = end(b.m_contacts);
             }
             else
             {

--- a/PlayRho/Dynamics/Contacts/Contact.cpp
+++ b/PlayRho/Dynamics/Contacts/Contact.cpp
@@ -96,7 +96,7 @@ void Contact::Update(const UpdateConf& conf, ContactListener* listener)
     if (sensor)
     {
         const auto overlapping = TestOverlap(childA, xfA, childB, xfB, conf.distance);
-        newTouching = (overlapping >= Area{0});
+        newTouching = (overlapping >= 0_m2);
 
 #ifdef OVERLAP_TOLERANCE
 #ifndef NDEBUG
@@ -123,7 +123,7 @@ void Contact::Update(const UpdateConf& conf, ContactListener* listener)
 #ifndef NDEBUG
         const auto tolerance = OVERLAP_TOLERANCE;
         const auto overlapping = TestOverlap(childA, xfA, childB, xfB, conf.distance);
-        assert(newTouching == (overlapping >= Area{0}) ||
+        assert(newTouching == (overlapping >= 0_m2) ||
                abs(overlapping) < tolerance);
 #endif
 #endif

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -403,7 +403,7 @@ inline Momentum SolveTangentConstraint(VelocityConstraint& vc)
         const auto lambda = vcp.tangentMass * directionalVel;
         const auto maxImpulse = friction * vcp.normalImpulse;
         const auto oldImpulse = vcp.tangentImpulse;
-        const auto newImpulse = Clamp(oldImpulse + lambda, -maxImpulse, maxImpulse);
+        const auto newImpulse = std::clamp(oldImpulse + lambda, -maxImpulse, maxImpulse);
 #if 0
         // Note: using AlmostEqual here results in increased iteration counts and is slower.
         const auto incImpulse = AlmostEqual(newImpulse, oldImpulse)? 0_Ns: newImpulse - oldImpulse;
@@ -541,8 +541,8 @@ d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
         assert(K >= InvMass{0});
         
         // Prevent large corrections & don't push separation above -conf.linearSlop.
-        const auto C = -Clamp(conf.resolutionRate * (separation + conf.linearSlop),
-                              -conf.maxLinearCorrection, 0_m);
+        const auto C = -std::clamp(conf.resolutionRate * (separation + conf.linearSlop),
+                                   -conf.maxLinearCorrection, 0_m);
         
         // Compute response factors...
         const auto P = Length2{psm.m_normal * C} / K; // L M

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -253,10 +253,10 @@ inline void Fixture::SetProxies(std::unique_ptr<FixtureProxy[]> value, std::size
     {
         case 2:
             m_proxies.asArray[1] = value[1];
-            // [[fallthrough]]
+            [[fallthrough]];
         case 1:
             m_proxies.asArray[0] = value[0];
-            // [[fallthrough]]
+            [[fallthrough]];
         case 0:
             break;
         default:

--- a/PlayRho/Dynamics/Joints/DistanceJoint.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJoint.cpp
@@ -26,6 +26,8 @@
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
+#include <algorithm>
+
 namespace playrho {
 namespace d2 {
 
@@ -230,7 +232,7 @@ bool DistanceJoint::SolvePositionConstraints(BodyConstraintsMap& bodies,
     const auto u = std::get<UnitVec>(uvresult);
     const auto length = std::get<Length>(uvresult);
     const auto deltaLength = length - m_length;
-    const auto C = Clamp(deltaLength, -conf.maxLinearCorrection, conf.maxLinearCorrection);
+    const auto C = std::clamp(deltaLength, -conf.maxLinearCorrection, conf.maxLinearCorrection);
 
     const auto impulse = -m_mass * C;
     const auto P = impulse * u;

--- a/PlayRho/Dynamics/Joints/FrictionJoint.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJoint.cpp
@@ -25,6 +25,8 @@
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
+#include <algorithm>
+
 namespace playrho {
 namespace d2 {
 
@@ -161,7 +163,8 @@ bool FrictionJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
 
         const auto oldAngularImpulse = m_angularImpulse;
         const auto maxAngularImpulse = h * m_maxTorque;
-        m_angularImpulse = Clamp(m_angularImpulse + angularImpulse, -maxAngularImpulse, maxAngularImpulse);
+        m_angularImpulse = std::clamp(m_angularImpulse + angularImpulse,
+                                      -maxAngularImpulse, maxAngularImpulse);
         const auto incAngularImpulse = m_angularImpulse - oldAngularImpulse;
 
         if (incAngularImpulse != AngularMomentum{0})

--- a/PlayRho/Dynamics/Joints/MotorJoint.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJoint.cpp
@@ -170,7 +170,8 @@ bool MotorJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
 
         const auto oldAngularImpulse = m_angularImpulse;
         const auto maxAngularImpulse = h * m_maxTorque;
-        const auto newAngularImpulse = Clamp(oldAngularImpulse + angularImpulse, -maxAngularImpulse, maxAngularImpulse);
+        const auto newAngularImpulse = std::clamp(oldAngularImpulse + angularImpulse,
+                                                  -maxAngularImpulse, maxAngularImpulse);
         m_angularImpulse = newAngularImpulse;
         const auto incAngularImpulse = newAngularImpulse - oldAngularImpulse;
 

--- a/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJoint.cpp
@@ -25,6 +25,8 @@
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
+#include <algorithm>
+
 namespace playrho {
 namespace d2 {
 
@@ -279,7 +281,7 @@ bool PrismaticJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const 
         auto impulse = Momentum{m_motorMass * (m_motorSpeed * Meter / Radian - Cdot)};
         const auto oldImpulse = m_motorImpulse;
         const auto maxImpulse = step.GetTime() * m_maxMotorForce;
-        m_motorImpulse = Clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse);
+        m_motorImpulse = std::clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse);
         impulse = m_motorImpulse - oldImpulse;
 
         const auto P = Momentum2{impulse * m_axis};
@@ -425,21 +427,21 @@ bool PrismaticJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const 
         if (abs(m_upperTranslation - m_lowerTranslation) < (Real{2} * conf.linearSlop))
         {
             // Prevent large angular corrections
-            C2 = StripUnit(Clamp(translation, -conf.maxLinearCorrection, conf.maxLinearCorrection));
+            C2 = StripUnit(std::clamp(translation, -conf.maxLinearCorrection, conf.maxLinearCorrection));
             linearError = std::max(linearError, abs(translation));
             active = true;
         }
         else if (translation <= m_lowerTranslation)
         {
             // Prevent large linear corrections and allow some slop.
-            C2 = StripUnit(Clamp(translation - m_lowerTranslation + conf.linearSlop, -conf.maxLinearCorrection, 0_m));
+            C2 = StripUnit(std::clamp(translation - m_lowerTranslation + conf.linearSlop, -conf.maxLinearCorrection, 0_m));
             linearError = std::max(linearError, m_lowerTranslation - translation);
             active = true;
         }
         else if (translation >= m_upperTranslation)
         {
             // Prevent large linear corrections and allow some slop.
-            C2 = StripUnit(Clamp(translation - m_upperTranslation - conf.linearSlop, 0_m, conf.maxLinearCorrection));
+            C2 = StripUnit(std::clamp(translation - m_upperTranslation - conf.linearSlop, 0_m, conf.maxLinearCorrection));
             linearError = std::max(linearError, translation - m_upperTranslation);
             active = true;
         }

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
@@ -91,7 +91,7 @@ struct PrismaticJointConf : public JointBuilder<PrismaticJointConf>
     bool enableMotor = false;
     
     /// The maximum motor force.
-    Force maxMotorForce = Force{0};
+    Force maxMotorForce = 0_N;
     
     /// The desired angular motor speed.
     AngularVelocity motorSpeed = 0_rpm;

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -26,6 +26,8 @@
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
+#include <algorithm>
+
 namespace playrho {
 namespace d2 {
 
@@ -238,7 +240,7 @@ bool RevoluteJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const S
         const auto impulse = AngularMomentum{-m_motorMass * (velB.angular - velA.angular - m_motorSpeed)};
         const auto oldImpulse = m_motorImpulse;
         const auto maxImpulse = step.GetTime() * m_maxMotorTorque;
-        m_motorImpulse = Clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse);
+        m_motorImpulse = std::clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse);
         const auto incImpulse = m_motorImpulse - oldImpulse;
 
         velA.angular -= invRotInertiaA * incImpulse;
@@ -372,7 +374,7 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
                 angularError = -C;
                 
                 // Prevent large angular corrections and allow some slop.
-                C = Clamp(C + conf.angularSlop, -conf.maxAngularCorrection, 0_rad);
+                C = std::clamp(C + conf.angularSlop, -conf.maxAngularCorrection, 0_rad);
                 limitImpulse = -m_motorMass * C;
                 break;
             }
@@ -382,7 +384,7 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
                 angularError = C;
                 
                 // Prevent large angular corrections and allow some slop.
-                C = Clamp(C - conf.angularSlop, 0_rad, conf.maxAngularCorrection);
+                C = std::clamp(C - conf.angularSlop, 0_rad, conf.maxAngularCorrection);
                 limitImpulse = -m_motorMass * C;
                 break;
             }
@@ -390,7 +392,8 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
             {
                 assert(m_limitState == e_equalLimits);
                 // Prevent large angular corrections
-                const auto C = Clamp(angle - m_lowerAngle, -conf.maxAngularCorrection, conf.maxAngularCorrection);
+                const auto C = std::clamp(angle - m_lowerAngle,
+                                          -conf.maxAngularCorrection, conf.maxAngularCorrection);
                 limitImpulse = -m_motorMass * C;
                 angularError = abs(C);
                 break;

--- a/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJoint.cpp
@@ -406,7 +406,7 @@ bool RevoluteJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const C
     }
 
     // Solve point-to-point constraint.
-    auto positionError = Area{0};
+    auto positionError = 0_m2;
     {
         const auto qA = UnitVec::Get(posA.angular);
         const auto qB = UnitVec::Get(posB.angular);

--- a/PlayRho/Dynamics/Joints/RopeJoint.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJoint.cpp
@@ -26,6 +26,8 @@
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
+#include <algorithm>
+
 namespace playrho {
 namespace d2 {
 
@@ -187,7 +189,7 @@ bool RopeJoint::SolvePositionConstraints(BodyConstraintsMap& bodies, const Const
     const auto u = std::get<UnitVec>(uvresult);
     const auto length = std::get<Length>(uvresult);
     
-    const auto C = Clamp(length - m_maxLength, 0_m, conf.maxLinearCorrection);
+    const auto C = std::clamp(length - m_maxLength, 0_m, conf.maxLinearCorrection);
 
     const auto impulse = -m_mass * C;
     const auto linImpulse = impulse * u;

--- a/PlayRho/Dynamics/Joints/WheelJoint.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJoint.cpp
@@ -233,7 +233,7 @@ bool WheelJoint::SolveVelocityConstraints(BodyConstraintsMap& bodies, const Step
 
         const auto oldImpulse = m_motorImpulse;
         const auto maxImpulse = AngularMomentum{step.GetTime() * m_maxMotorTorque};
-        m_motorImpulse = Clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse);
+        m_motorImpulse = std::clamp(m_motorImpulse + impulse, -maxImpulse, maxImpulse);
         impulse = m_motorImpulse - oldImpulse;
 
         velA.angular -= AngularVelocity{invRotInertiaA * impulse};

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -69,7 +69,7 @@ public:
     PLAYRHO_CONSTEXPR inline StepConf& SetTime(Time value) noexcept
     {
         time = value;
-        invTime = (value != Time{0})? Real{1} / value: 0_Hz;
+        invTime = (value != 0_s)? Real{1} / value: 0_Hz;
         return *this;
     }
 
@@ -83,7 +83,7 @@ public:
     PLAYRHO_CONSTEXPR inline StepConf& SetInvTime(Frequency value) noexcept
     {
         invTime = value;
-        time = (value != 0_Hz)? Time{Real{1} / value}: Time{0};
+        time = (value != 0_Hz)? Time{Real{1} / value}: 0_s;
         return *this;
     }
     

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -1576,7 +1576,7 @@ IslandStats World::SolveToiViaGS(const StepConf& conf, Island& island)
      * the body constraint doesn't need to pass an elapsed time (and doesn't need to
      * update the velocity from what it already is).
      */
-    auto bodyConstraints = GetBodyConstraints(island.m_bodies, Time{0}, GetMovementConf(conf));
+    auto bodyConstraints = GetBodyConstraints(island.m_bodies, 0_s, GetMovementConf(conf));
     auto bodyConstraintsMap = GetBodyConstraintsMap(island.m_bodies, bodyConstraints);
 
     // Initialize the body state.

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -177,7 +177,7 @@ namespace {
         auto map = BodyConstraintsMap{};
         map.reserve(size(bodies));
         for_each(cbegin(bodies), cend(bodies), [&](const BodyPtr& body) {
-            const auto i = static_cast<size_t>(&body - bodies.data());
+            const auto i = static_cast<size_t>(&body - data(bodies));
             assert(i < size(bodies));
 #ifdef USE_VECTOR_MAP
             map.push_back(BodyConstraintPair{body, &bodyConstraints[i]});
@@ -747,7 +747,7 @@ void World::Remove(const Body& b) noexcept
     const auto it = find_if(cbegin(m_bodies), cend(m_bodies), [&](const Bodies::value_type& body) {
         return GetPtr(body) == &b;
     });
-    if (it != m_bodies.end())
+    if (it != end(m_bodies))
     {
         BodyAtty::Delete(GetPtr(*it));
         m_bodies.erase(it);
@@ -1180,13 +1180,13 @@ IslandStats World::SolveRegIslandViaGS(const StepConf& conf, Island island)
     
     // Update normal and tangent impulses of contacts' manifold points
     for_each(cbegin(velConstraints), cend(velConstraints), [&](const VelocityConstraint& vc) {
-        const auto i = static_cast<VelocityConstraints::size_type>(&vc - velConstraints.data());
+        const auto i = static_cast<VelocityConstraints::size_type>(&vc - data(velConstraints));
         auto& manifold = ContactAtty::GetMutableManifold(*island.m_contacts[i]);
         AssignImpulses(manifold, vc);
     });
     
     for_each(cbegin(bodyConstraints), cend(bodyConstraints), [&](const BodyConstraint& bc) {
-        const auto i = static_cast<size_t>(&bc - bodyConstraints.data());
+        const auto i = static_cast<size_t>(&bc - data(bodyConstraints));
         assert(i < size(bodyConstraints));
         // Could normalize position here to avoid unbounded angles but angular
         // normalization isn't handled correctly by joints that constrain rotation.
@@ -1643,7 +1643,7 @@ IslandStats World::SolveToiViaGS(const StepConf& conf, Island& island)
     }
 #else
     for_each(cbegin(bodyConstraints), cend(bodyConstraints), [&](const BodyConstraint& bc) {
-        const auto i = static_cast<size_t>(&bc - bodyConstraints.data());
+        const auto i = static_cast<size_t>(&bc - data(bodyConstraints));
         assert(i < size(bodyConstraints));
         BodyAtty::SetPosition0(*island.m_bodies[i], bc.GetPosition());
     });
@@ -1678,7 +1678,7 @@ IslandStats World::SolveToiViaGS(const StepConf& conf, Island& island)
     IntegratePositions(bodyConstraints, conf.GetTime());
     
     for_each(cbegin(bodyConstraints), cend(bodyConstraints), [&](const BodyConstraint& bc) {
-        const auto i = static_cast<size_t>(&bc - bodyConstraints.data());
+        const auto i = static_cast<size_t>(&bc - data(bodyConstraints));
         assert(i < size(bodyConstraints));
         UpdateBody(*island.m_bodies[i], bc.GetPosition(), bc.GetVelocity());
     });

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -860,45 +860,37 @@ private:
 
 inline SizedRange<World::Bodies::iterator> World::GetBodies() noexcept
 {
-    return {m_bodies.begin(), m_bodies.end(), m_bodies.size()};
+    return {begin(m_bodies), end(m_bodies), size(m_bodies)};
 }
 
 inline SizedRange<World::Bodies::const_iterator> World::GetBodies() const noexcept
 {
-    return {m_bodies.begin(), m_bodies.end(), m_bodies.size()};
+    return {begin(m_bodies), end(m_bodies), size(m_bodies)};
 }
 
 inline SizedRange<World::Bodies::const_iterator> World::GetBodiesForProxies() const noexcept
 {
-    return {
-        cbegin(m_bodiesForProxies),
-        cend(m_bodiesForProxies),
-        m_bodiesForProxies.size()
-    };
+    return {cbegin(m_bodiesForProxies), cend(m_bodiesForProxies), size(m_bodiesForProxies)};
 }
 
 inline SizedRange<World::Fixtures::const_iterator> World::GetFixturesForProxies() const noexcept
 {
-    return {
-        cbegin(m_fixturesForProxies),
-        cend(m_fixturesForProxies),
-        m_fixturesForProxies.size()
-    };
+    return {cbegin(m_fixturesForProxies), cend(m_fixturesForProxies), size(m_fixturesForProxies)};
 }
 
 inline SizedRange<World::Joints::const_iterator> World::GetJoints() const noexcept
 {
-    return {m_joints.begin(), m_joints.end(), m_joints.size()};
+    return {begin(m_joints), end(m_joints), size(m_joints)};
 }
 
 inline SizedRange<World::Joints::iterator> World::GetJoints() noexcept
 {
-    return {m_joints.begin(), m_joints.end(), m_joints.size()};
+    return {begin(m_joints), end(m_joints), size(m_joints)};
 }
 
 inline SizedRange<World::Contacts::const_iterator> World::GetContacts() const noexcept
 {
-    return {m_contacts.begin(), m_contacts.end(), m_contacts.size()};
+    return {begin(m_contacts), end(m_contacts), size(m_contacts)};
 }
 
 inline bool World::IsLocked() const noexcept
@@ -1043,7 +1035,7 @@ inline void World::RegisterForProcessing(ProxyId pid) noexcept
 /// @relatedalso World
 inline BodyCounter GetBodyCount(const World& world) noexcept
 {
-    return static_cast<BodyCounter>(world.GetBodies().size());
+    return static_cast<BodyCounter>(size(world.GetBodies()));
 }
 
 /// Gets the count of joints in the given world.
@@ -1051,7 +1043,7 @@ inline BodyCounter GetBodyCount(const World& world) noexcept
 /// @relatedalso World
 inline JointCounter GetJointCount(const World& world) noexcept
 {
-    return static_cast<JointCounter>(world.GetJoints().size());
+    return static_cast<JointCounter>(size(world.GetJoints()));
 }
 
 /// @brief Gets the count of contacts in the given world.
@@ -1061,7 +1053,7 @@ inline JointCounter GetJointCount(const World& world) noexcept
 /// @relatedalso World
 inline ContactCounter GetContactCount(const World& world) noexcept
 {
-    return static_cast<ContactCounter>(world.GetContacts().size());
+    return static_cast<ContactCounter>(size(world.GetContacts()));
 }
 
 /// @brief Gets the touching count for the given world.

--- a/Testbed/Framework/Drawer.hpp
+++ b/Testbed/Framework/Drawer.hpp
@@ -21,6 +21,7 @@
 #define PLAYRHO_DRAWER_HPP
 
 #include <PlayRho/Common/Math.hpp>
+#include <algorithm>
 
 namespace testbed {
 
@@ -31,10 +32,10 @@ struct Color
     Color() = default;
     
     constexpr inline Color(float ri, float gi, float bi, float ai = 1):
-        r(playrho::Clamp(ri, 0.0f, 1.0f)),
-        g(playrho::Clamp(gi, 0.0f, 1.0f)),
-        b(playrho::Clamp(bi, 0.0f, 1.0f)),
-        a(playrho::Clamp(ai, 0.0f, 1.0f))
+        r(std::clamp(ri, 0.0f, 1.0f)),
+        g(std::clamp(gi, 0.0f, 1.0f)),
+        b(std::clamp(bi, 0.0f, 1.0f)),
+        a(std::clamp(ai, 0.0f, 1.0f))
     {
         // Intentionally empty.
     }

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -41,6 +41,7 @@
 #include "DroidSansTtfData.h"
 #endif
 
+#include <algorithm>
 #include <sstream>
 #include <iostream>
 #include <iomanip>
@@ -780,7 +781,7 @@ static void BasicStepOptionsUI()
         const auto max = 1.0f / testSettings.minDt;
         const auto min = 1.0f / testSettings.maxDt;
         ImGui::SliderFloat("Frequency", &frequency, min, max, "%.2e Hz");
-        frequency = Clamp(frequency, min, max);
+        frequency = std::clamp(frequency, min, max);
         testSettings.dt = 1.0f / frequency;
     }
     else

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -157,15 +157,15 @@ class TestSuite
 public:
     TestSuite(Span<const TestEntry> testEntries, int index = 0):
     	m_testEntries(testEntries),
-    	m_testIndex(index < static_cast<int>(testEntries.size())? index: 0)
+    	m_testIndex(index < static_cast<int>(size(testEntries))? index: 0)
     {
-        assert(testEntries.size() > 0);
+        assert(!empty(testEntries));
         m_test = testEntries[static_cast<unsigned>(m_testIndex)].createFcn();
     }
     
     int GetTestCount() const
     {
-        return static_cast<int>(m_testEntries.size());
+        return static_cast<int>(size(m_testEntries));
     }
     
     Test* GetTest() const
@@ -264,7 +264,7 @@ static void CreateUI(GLFWwindow* window)
     };
 
     const auto cwd = GetCwd();
-    if (cwd.empty())
+    if (empty(cwd))
     {
         std::perror("GetCwd");
     }
@@ -680,9 +680,9 @@ static void AboutTestUI()
 
     ImGui::LabelText("Test Name", "%s", name);
     
-    if (!test->GetSeeAlso().empty())
+    if (!empty(test->GetSeeAlso()))
     {
-        const auto length = test->GetSeeAlso().size();
+        const auto length = size(test->GetSeeAlso());
         char buffer[512];
         std::strncpy(buffer, test->GetSeeAlso().c_str(), length);
         buffer[length] = '\0';
@@ -690,7 +690,7 @@ static void AboutTestUI()
                          ImGuiInputTextFlags_ReadOnly|ImGuiInputTextFlags_AutoSelectAll);
     }
     
-    if (!test->GetDescription().empty())
+    if (!empty(test->GetDescription()))
     {
         if (ImGui::CollapsingHeader("Description", ImGuiTreeNodeFlags_DefaultOpen))
         {
@@ -699,7 +699,7 @@ static void AboutTestUI()
     }
     
     const auto handledKeys = test->GetHandledKeys();
-    if (!handledKeys.empty())
+    if (!empty(handledKeys))
     {
         if (ImGui::CollapsingHeader("Key Controls", ImGuiTreeNodeFlags_DefaultOpen))
         {
@@ -740,7 +740,7 @@ static void AboutTestUI()
         }
     }
     
-    if (!test->GetStatus().empty())
+    if (!empty(test->GetStatus()))
     {
         if (ImGui::CollapsingHeader("Status Info", ImGuiTreeNodeFlags_DefaultOpen))
         {
@@ -748,7 +748,7 @@ static void AboutTestUI()
         }
     }
     
-    if (!test->GetCredits().empty())
+    if (!empty(test->GetCredits()))
     {
         if (ImGui::CollapsingHeader("Credits"))
         {
@@ -1367,7 +1367,7 @@ static void EntityUI(Fixture& fixture)
 #if 0
     {
         const auto proxies = fixture.GetProxies();
-        if (ImGui::TreeNodeEx("Proxies", 0, "Proxies (%u)", proxies.size()))
+        if (ImGui::TreeNodeEx("Proxies", 0, "Proxies (%u)", size(proxies)))
         {
             CollectionUI(proxies);
             ImGui::TreePop();
@@ -1451,7 +1451,7 @@ static void EntityUI(Body& b, const FixtureSet& selectedFixtures)
     EntityUI(b);
     {
         const auto fixtures = b.GetFixtures();
-        if (ImGui::TreeNodeEx("Fixtures", 0, "Fixtures (%lu)", fixtures.size()))
+        if (ImGui::TreeNodeEx("Fixtures", 0, "Fixtures (%lu)", size(fixtures)))
         {
             CollectionUI(fixtures, selectedFixtures);
             ImGui::TreePop();
@@ -1460,7 +1460,7 @@ static void EntityUI(Body& b, const FixtureSet& selectedFixtures)
     {
         const auto joints = b.GetJoints();
         if (ImGui::TreeNodeEx("Joints", 0,
-                              "Joints (%lu)", joints.size()))
+                              "Joints (%lu)", size(joints)))
         {
             CollectionUI(joints);
             ImGui::TreePop();
@@ -1469,7 +1469,7 @@ static void EntityUI(Body& b, const FixtureSet& selectedFixtures)
     {
         const auto contacts = b.GetContacts();
         if (ImGui::TreeNodeEx("Contacts", 0,
-                              "Contacts (%lu)", contacts.size()))
+                              "Contacts (%lu)", size(contacts)))
         {
             CollectionUI(contacts);
             ImGui::TreePop();
@@ -2172,7 +2172,7 @@ static void ModelEntitiesUI()
     const auto test = g_testSuite->GetTest();
     const auto selectedFixtures = test->GetSelectedFixtures();
     const auto selectedBodies = test->GetSelectedBodies();
-    const auto selBodies = !selectedFixtures.empty();
+    const auto selBodies = !empty(selectedFixtures);
     const auto selJoints = false;
     const auto selContacts = false;
 
@@ -2180,7 +2180,7 @@ static void ModelEntitiesUI()
     {
         const auto bodies = test->m_world.GetBodies();
         if (ImGui::TreeNodeEx("Bodies", selBodies? ImGuiTreeNodeFlags_DefaultOpen: 0,
-                              "Bodies (%lu)", bodies.size()))
+                              "Bodies (%lu)", size(bodies)))
         {
             CollectionUI(bodies, selectedBodies, selectedFixtures);
             ImGui::TreePop();
@@ -2189,7 +2189,7 @@ static void ModelEntitiesUI()
     {
         const auto joints = test->m_world.GetJoints();
         if (ImGui::TreeNodeEx("Joints", selJoints? ImGuiTreeNodeFlags_DefaultOpen: 0,
-                              "Joints (%lu)", joints.size()))
+                              "Joints (%lu)", size(joints)))
         {
             CollectionUI(joints);
             ImGui::TreePop();
@@ -2198,7 +2198,7 @@ static void ModelEntitiesUI()
     {
         const auto contacts = test->m_world.GetContacts();
         if (ImGui::TreeNodeEx("Contacts", selContacts? ImGuiTreeNodeFlags_DefaultOpen: 0,
-                              "Contacts (%lu)", contacts.size()))
+                              "Contacts (%lu)", size(contacts)))
         {
             CollectionUI(contacts);
             ImGui::TreePop();

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -380,7 +380,7 @@ const LinearAcceleration2 Test::Gravity = LinearAcceleration2{
 
 bool Test::Contains(const FixtureSet& fixtures, const Fixture* f) noexcept
 {
-    return fixtures.find(const_cast<Fixture*>(f)) != fixtures.end();
+    return fixtures.find(const_cast<Fixture*>(f)) != end(fixtures);
 }
 
 void Test::DestructionListenerImpl::SayGoodbye(const Joint& joint) noexcept
@@ -418,10 +418,10 @@ void Test::ResetWorld(const World &saved)
 {
     ClearSelectedFixtures();
 
-    auto bombIndex = static_cast<decltype(m_world.GetBodies().size())>(-1);
+    auto bombIndex = static_cast<decltype(size(m_world.GetBodies()))>(-1);
 
     {
-        auto i = decltype(m_world.GetBodies().size()){0};
+        auto i = decltype(size(m_world.GetBodies())){0};
         for (auto&& b: m_world.GetBodies())
         {
             const auto body = GetPtr(b);
@@ -436,7 +436,7 @@ void Test::ResetWorld(const World &saved)
     m_world = saved;
 
     {
-        auto i = decltype(m_world.GetBodies().size()){0};
+        auto i = decltype(size(m_world.GetBodies())){0};
         for (auto&& b: m_world.GetBodies())
         {
             const auto body = GetPtr(b);
@@ -513,9 +513,9 @@ void Test::MouseDown(const Length2& p)
     });
 
     SetSelectedFixtures(fixtures);
-    if (fixtures.size() == 1)
+    if (size(fixtures) == 1)
     {
-        const auto body = (*(fixtures.begin()))->GetBody();
+        const auto body = (*(begin(fixtures)))->GetBody();
         if (body->GetType() == BodyType::Dynamic)
         {
             auto md = TargetJointConf{};
@@ -637,7 +637,7 @@ void Test::DrawStats(const StepConf& stepConf, UiState& ui)
     const auto shapeCount = GetShapeCount(m_world);
     const auto touchingCount = GetTouchingCount(m_world);
  
-    if (m_numTouchingPerStep.size() >= m_maxHistory)
+    if (size(m_numTouchingPerStep) >= m_maxHistory)
     {
         m_numTouchingPerStep.pop_front();
     }
@@ -1129,9 +1129,9 @@ struct DequeValuesGetter
     static float Func(void* data, int idx)
     {
         const std::deque<T>& deque = *static_cast<std::deque<T>*>(data);
-        const auto size = deque.size();
-        return (idx >= 0 && static_cast<decltype(size)>(idx) < size)?
-            static_cast<float>(deque[static_cast<decltype(size)>(idx)]): 0.0f;
+        const auto numElements = size(deque);
+        return (idx >= 0 && static_cast<decltype(numElements)>(idx) < numElements)?
+            static_cast<float>(deque[static_cast<decltype(numElements)>(idx)]): 0.0f;
     }
 };
 
@@ -1252,7 +1252,7 @@ void Test::Step(const Settings& settings, Drawer& drawer, UiState& ui)
     m_numContacts = GetContactCount(m_world);
     m_maxContacts = std::max(m_maxContacts, m_numContacts);
     
-    if (m_numContactsPerStep.size() >= m_maxHistory)
+    if (size(m_numContactsPerStep) >= m_maxHistory)
     {
         m_numContactsPerStep.pop_front();
     }
@@ -1275,13 +1275,13 @@ void Test::Step(const Settings& settings, Drawer& drawer, UiState& ui)
         
         std::sprintf(buffer, "Max of %u", m_maxTouching);
         ImGui::PlotHistogram("# Touching", DequeValuesGetter<std::size_t>::Func,
-                             &m_numTouchingPerStep, static_cast<int>(m_numTouchingPerStep.size()),
+                             &m_numTouchingPerStep, static_cast<int>(size(m_numTouchingPerStep)),
                              0, buffer, 0.0f, static_cast<float>(m_maxContacts),
                              ImVec2(600, 100));
 
         std::sprintf(buffer, "Max of %u", m_maxContacts);
         ImGui::PlotHistogram("# Contacts", DequeValuesGetter<std::size_t>::Func,
-                             &m_numContactsPerStep, static_cast<int>(m_numContactsPerStep.size()),
+                             &m_numContactsPerStep, static_cast<int>(size(m_numContactsPerStep)),
                              0, buffer, 0.0f, static_cast<float>(m_maxContacts),
                              ImVec2(600, 100));
     }

--- a/Testbed/Framework/Test.hpp
+++ b/Testbed/Framework/Test.hpp
@@ -181,7 +181,7 @@ public:
     {
         return SizedRange<HandledKeys::const_iterator>(cbegin(m_handledKeys),
                                                        cend(m_handledKeys),
-                                                       m_handledKeys.size());
+                                                       size(m_handledKeys));
     }
 
     void MouseDown(const Length2& p);
@@ -322,7 +322,7 @@ protected:
     
     KeyHandlerID RegisterKeyHandler(const std::string& info, KeyHandler handler)
     {
-        const auto index = m_keyHandlers.size();
+        const auto index = size(m_keyHandlers);
         m_keyHandlers.push_back(std::make_pair(info, handler));
         return index;
     }

--- a/Testbed/Tests/ApplyForce.hpp
+++ b/Testbed/Tests/ApplyForce.hpp
@@ -85,7 +85,7 @@ public:
             auto conf = PolygonShapeConf{};
 
             conf.density = 4_kgpm2;
-            const auto poly1 = PolygonShapeConf(Span<const Length2>(vertices, 3), conf);
+            const auto poly1 = PolygonShapeConf(vertices, conf);
 
             Transformation xf2;
             xf2.q = UnitVec::Get(-0.3524_rad * Pi);
@@ -96,7 +96,7 @@ public:
             vertices[2] = Transform(Length2{0_m, 0.5_m}, xf2);
 
             conf.density = 2_kgpm2;
-            const auto poly2 = PolygonShapeConf(Span<const Length2>(vertices, 3), conf);
+            const auto poly2 = PolygonShapeConf(vertices, conf);
 
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;

--- a/Testbed/Tests/CollisionFiltering.hpp
+++ b/Testbed/Tests/CollisionFiltering.hpp
@@ -58,7 +58,7 @@ public:
         vertices[2] = Vec2(0.0f, 2.0f) * 1_m;
         auto polygon = PolygonShapeConf{};
         polygon.UseDensity(1_kgpm2);
-        polygon.Set(Span<const Length2>{vertices, 3});
+        polygon.Set(vertices);
 
         auto triangleShapeConf = FixtureConf{};
         triangleShapeConf.filter.groupIndex = k_smallGroup;
@@ -76,7 +76,7 @@ public:
         vertices[0] *= 2.0f;
         vertices[1] *= 2.0f;
         vertices[2] *= 2.0f;
-        polygon.Set(Span<const Length2>{vertices, 3});
+        polygon.Set(vertices);
         triangleShapeConf.filter.groupIndex = k_largeGroup;
         triangleBodyConf.location = Vec2(-5.0f, 6.0f) * 1_m;
         triangleBodyConf.fixedRotation = true; // look at me!

--- a/Testbed/Tests/CollisionProcessing.hpp
+++ b/Testbed/Tests/CollisionProcessing.hpp
@@ -48,7 +48,7 @@ public:
         vertices[2] = Vec2(0.0f, 2.0f) * 1_m;
 
         auto polygon = PolygonShapeConf{};
-        polygon.Set(Span<const Length2>{vertices, 3});
+        polygon.Set(vertices);
         polygon.UseDensity(1_kgpm2);
 
         BodyConf triangleBodyConf;
@@ -62,7 +62,7 @@ public:
         vertices[0] *= 2.0f;
         vertices[1] *= 2.0f;
         vertices[2] *= 2.0f;
-        polygon.Set(Span<const Length2>{vertices, 3});
+        polygon.Set(vertices);
 
         triangleBodyConf.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
 

--- a/Testbed/Tests/CompoundShapes.hpp
+++ b/Testbed/Tests/CompoundShapes.hpp
@@ -80,7 +80,7 @@ public:
             xf1.p = GetVec2(GetXAxis(xf1.q)) * 1_m;
 
             auto triangleConf1 = PolygonShapeConf{};
-            triangleConf1.Set(Span<const Length2>{
+            triangleConf1.Set({
                 Transform(Vec2(-1.0f, 0.0f) * 1_m, xf1),
                 Transform(Vec2(1.0f, 0.0f) * 1_m, xf1),
                 Transform(Vec2(0.0f, 0.5f) * 1_m, xf1)
@@ -93,7 +93,7 @@ public:
             xf2.p = -GetVec2(GetXAxis(xf2.q)) * 1_m;
 
             auto trianglConf2 = PolygonShapeConf{};
-            trianglConf2.Set(Span<const Length2>{
+            trianglConf2.Set({
                 Transform(Vec2(-1.0f, 0.0f) * 1_m, xf2),
                 Transform(Vec2(1.0f, 0.0f) * 1_m, xf2),
                 Transform(Vec2(0.0f, 0.5f) * 1_m, xf2)

--- a/Testbed/Tests/ConvexHull.hpp
+++ b/Testbed/Tests/ConvexHull.hpp
@@ -69,7 +69,7 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        const auto shape = PolygonShapeConf{}.Set(Span<const Length2>{data(m_points), size(m_points)});
+        const auto shape = PolygonShapeConf{}.Set(m_points);
 
         drawer.DrawPolygon(begin(shape.GetVertices()), shape.GetVertexCount(), Color(0.9f, 0.9f, 0.9f));
 

--- a/Testbed/Tests/ConvexHull.hpp
+++ b/Testbed/Tests/ConvexHull.hpp
@@ -60,8 +60,8 @@ public:
             // Clamp onto a square to help create collinearities.
             // This will stress the convex hull algorithm.
             const auto v = Vec2{
-                Clamp(x, GetX(lowerBound), GetX(upperBound)),
-                Clamp(y, GetY(lowerBound), GetY(upperBound))
+                std::clamp(x, GetX(lowerBound), GetX(upperBound)),
+                std::clamp(y, GetY(lowerBound), GetY(upperBound))
             } * 1_m;
             m_points.emplace_back(v);
         }

--- a/Testbed/Tests/ConvexHull.hpp
+++ b/Testbed/Tests/ConvexHull.hpp
@@ -69,11 +69,11 @@ public:
 
     void PostStep(const Settings&, Drawer& drawer) override
     {
-        const auto shape = PolygonShapeConf{}.Set(Span<const Length2>{&m_points[0], m_points.size()});
+        const auto shape = PolygonShapeConf{}.Set(Span<const Length2>{data(m_points), size(m_points)});
 
-        drawer.DrawPolygon(shape.GetVertices().begin(), shape.GetVertexCount(), Color(0.9f, 0.9f, 0.9f));
+        drawer.DrawPolygon(begin(shape.GetVertices()), shape.GetVertexCount(), Color(0.9f, 0.9f, 0.9f));
 
-        for (auto i = std::size_t{0}; i < m_points.size(); ++i)
+        for (auto i = std::size_t{0}; i < size(m_points); ++i)
         {
             drawer.DrawPoint(m_points[i], 3.0f, Color(0.3f, 0.9f, 0.3f));
             drawer.DrawString(m_points[i] + Vec2(0.05f, 0.05f) * 1_m, Drawer::Left, "%d", i);

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -187,7 +187,7 @@ public:
     static const Fixture* GetFixture(Body* body)
     {
         const auto& fixtures = body->GetFixtures();
-        return (begin(fixtures) != end(fixtures))? GetPtr(*begin(fixtures)): nullptr;
+        return !empty(fixtures)? GetPtr(*begin(fixtures)): nullptr;
     }
 
     void DestroyFixtures()

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -55,7 +55,7 @@ public:
         
         RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Move selected shape left.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -65,7 +65,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_D, GLFW_PRESS, 0, "Move selected shape right.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -75,7 +75,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_W, GLFW_PRESS, 0, "Move selected shape up.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -85,7 +85,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_S, GLFW_PRESS, 0, "Move selected shape down.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -95,7 +95,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_Q, GLFW_PRESS, 0, "Move selected counter-clockwise.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -105,7 +105,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_E, GLFW_PRESS, 0, "Move selected clockwise.", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body)
             {
@@ -115,7 +115,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_KP_ADD, GLFW_PRESS, 0, "increase vertex radius of selected shape", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body && fixture)
             {
@@ -124,7 +124,7 @@ public:
                 conf.Set(polygon->GetVertices());
                 conf.UseVertexRadius(polygon->vertexRadius + RadiusIncrement);
                 const auto newf = body->CreateFixture(Shape{conf});
-                fixtures.erase(fixtures.begin());
+                fixtures.erase(begin(fixtures));
                 fixtures.insert(newf);
                 SetSelectedFixtures(fixtures);
                 body->Destroy(fixture);
@@ -132,7 +132,7 @@ public:
         });
         RegisterForKey(GLFW_KEY_KP_SUBTRACT, GLFW_PRESS, 0, "decrease vertex radius of selected shape", [&](KeyActionMods) {
             auto fixtures = GetSelectedFixtures();
-            const auto fixture = fixtures.size() == 1? *(fixtures.begin()): nullptr;
+            const auto fixture = size(fixtures) == 1? *(begin(fixtures)): nullptr;
             const auto body = fixture? static_cast<Body*>(fixture->GetBody()): nullptr;
             if (body && fixture)
             {
@@ -148,7 +148,7 @@ public:
                     auto newf = body->CreateFixture(Shape{conf});
                     if (newf)
                     {
-                        fixtures.erase(fixtures.begin());
+                        fixtures.erase(begin(fixtures));
                         fixtures.insert(newf);
                         SetSelectedFixtures(fixtures);
                         body->Destroy(fixture);
@@ -187,7 +187,7 @@ public:
     static const Fixture* GetFixture(Body* body)
     {
         const auto& fixtures = body->GetFixtures();
-        return (fixtures.begin() != fixtures.end())? GetPtr(*fixtures.begin()): nullptr;
+        return (begin(fixtures) != end(fixtures))? GetPtr(*begin(fixtures)): nullptr;
     }
 
     void DestroyFixtures()

--- a/Testbed/Tests/DistanceTest.hpp
+++ b/Testbed/Tests/DistanceTest.hpp
@@ -173,14 +173,14 @@ public:
         conf.vertexRadius = radius;
         auto polygonA = conf;
         //polygonA.SetAsBox(8.0f, 6.0f);
-        polygonA.Set(Span<const Length2>{Vec2{-8, -6} * 1_m, Vec2{8, -6} * 1_m, Vec2{0, 6} * 1_m});
+        polygonA.Set({Vec2{-8, -6} * 1_m, Vec2{8, -6} * 1_m, Vec2{0, 6} * 1_m});
         m_bodyA->CreateFixture(Shape(polygonA));
         
         conf.vertexRadius = radius * Real{2};
         auto polygonB = conf;
         // polygonB.SetAsBox(7.2_m, 0.8_m);
-        polygonB.Set(Span<const Length2>{Vec2{-7.2f, 0} * 1_m, Vec2{+7.2f, 0} * 1_m});
-        //polygonB.Set(Span<const Vec2>{Vec2{float(-7.2), 0}, Vec2{float(7.2), 0}});
+        polygonB.Set({Vec2{-7.2f, 0} * 1_m, Vec2{+7.2f, 0} * 1_m});
+        //polygonB.Set({Vec2{float(-7.2), 0}, Vec2{float(7.2), 0}});
         m_bodyB->CreateFixture(Shape(polygonB));
     }
 

--- a/Testbed/Tests/DumpShell.hpp
+++ b/Testbed/Tests/DumpShell.hpp
@@ -64,12 +64,12 @@ public:
 
             {
                 auto shape = PolygonShapeConf{};
-                Length2 vs[8];
+                Length2 vs[4];
                 vs[0] = Vec2(7.733039855957031e-01f, -1.497260034084320e-01f) * 1_m;
                 vs[1] = Vec2(-4.487270116806030e-01f, 1.138330027461052e-01f) * 1_m;
                 vs[2] = Vec2(-1.880589962005615e+00f, -1.365900039672852e-01f) * 1_m;
                 vs[3] = Vec2(3.972740173339844e-01f, -3.897832870483398e+00f) * 1_m;
-                shape.Set(Span<const Length2>(vs, 4));
+                shape.Set(vs);
                 shape.UseFriction(Real(2.000000029802322e-01f));
                 shape.UseRestitution(Real(0.000000000000000e+00f));
                 shape.UseDensity(Real{1.000000000000000e+00f} * 1_kgpm2);
@@ -100,14 +100,14 @@ public:
 
             {
                 auto shape = PolygonShapeConf{};
-                Length2 vs[8];
+                Length2 vs[6];
                 vs[0] = Vec2(3.473900079727173e+00f, -2.009889930486679e-01f) * 1_m;
                 vs[1] = Vec2(3.457079887390137e+00f, 3.694039955735207e-02f) * 1_m;
                 vs[2] = Vec2(-3.116359949111938e+00f, 2.348500071093440e-03f) * 1_m;
                 vs[3] = Vec2(-3.109960079193115e+00f, -3.581250011920929e-01f) * 1_m;
                 vs[4] = Vec2(-2.590820074081421e+00f, -5.472509860992432e-01f) * 1_m;
                 vs[5] = Vec2(2.819370031356812e+00f, -5.402340292930603e-01f) * 1_m;
-                shape.Set(Span<const Length2>(vs, 6));
+                shape.Set(vs);
                 shape.UseFriction(Real(5.000000000000000e-01f));
                 shape.UseRestitution(Real(0.000000000000000e+00f));
                 shape.UseDensity(Real{5.000000000000000e+00f} * 1_kgpm2);
@@ -137,12 +137,12 @@ public:
 
             {
                 auto shape = PolygonShapeConf{};
-                Length2 vs[8];
+                Length2 vs[4];
                 vs[0] = Vec2(1.639146506786346e-01f, 4.428443685173988e-02f) * 1_m;
                 vs[1] = Vec2(-1.639146655797958e-01f, 4.428443685173988e-02f) * 1_m;
                 vs[2] = Vec2(-1.639146655797958e-01f, -4.428443312644958e-02f) * 1_m;
                 vs[3] = Vec2(1.639146357774734e-01f, -4.428444057703018e-02f) * 1_m;
-                shape.Set(Span<const Length2>(vs, 4));
+                shape.Set(vs);
                 shape.UseFriction(Real(9.499999880790710e-01f));
                 shape.UseRestitution(Real(0.000000000000000e+00f));
                 shape.UseDensity(Real{1.000000000000000e+01f} * 1_kgpm2);

--- a/Testbed/Tests/HeavyOnLight.hpp
+++ b/Testbed/Tests/HeavyOnLight.hpp
@@ -64,7 +64,7 @@ public:
         if (newDensity != oldDensity)
         {
             auto selectedFixtures = GetSelectedFixtures();
-            const auto selectedFixture = selectedFixtures.size() == 1? *(selectedFixtures.begin()): nullptr;
+            const auto selectedFixture = size(selectedFixtures) == 1? *(begin(selectedFixtures)): nullptr;
             const auto wasSelected = selectedFixture == m_top;
             const auto body = m_top->GetBody();
             body->Destroy(m_top);
@@ -74,7 +74,7 @@ public:
             m_top = body->CreateFixture(Shape(conf));
             if (wasSelected)
             {
-                selectedFixtures.erase(selectedFixtures.begin());
+                selectedFixtures.erase(begin(selectedFixtures));
                 selectedFixtures.insert(m_top);
                 SetSelectedFixtures(selectedFixtures);
             }

--- a/Testbed/Tests/JointsTest.hpp
+++ b/Testbed/Tests/JointsTest.hpp
@@ -275,7 +275,7 @@ private:
         const auto carLocation = center - Vec2(3.3f, 1.0f) * 1_m;
         const auto car = m_world.CreateBody(BodyConf(DynamicBD).UseLocation(carLocation));
         car->CreateFixture(Shape{
-            PolygonShapeConf{}.UseDensity(1_kgpm2).Set(Span<const Length2>(data(carVerts), size(carVerts)))
+            PolygonShapeConf{}.UseDensity(1_kgpm2).Set(carVerts)
         });
         
         const auto backWheel  = m_world.CreateBody(BodyConf(DynamicBD).UseLocation(carLocation + Vec2(-1.0f, -0.65f) * 1_m));

--- a/Testbed/Tests/JointsTest.hpp
+++ b/Testbed/Tests/JointsTest.hpp
@@ -275,7 +275,7 @@ private:
         const auto carLocation = center - Vec2(3.3f, 1.0f) * 1_m;
         const auto car = m_world.CreateBody(BodyConf(DynamicBD).UseLocation(carLocation));
         car->CreateFixture(Shape{
-            PolygonShapeConf{}.UseDensity(1_kgpm2).Set(Span<const Length2>(carVerts.data(), carVerts.size()))
+            PolygonShapeConf{}.UseDensity(1_kgpm2).Set(Span<const Length2>(data(carVerts), size(carVerts)))
         });
         
         const auto backWheel  = m_world.CreateBody(BodyConf(DynamicBD).UseLocation(carLocation + Vec2(-1.0f, -0.65f) * 1_m));

--- a/Testbed/Tests/Tiles.hpp
+++ b/Testbed/Tests/Tiles.hpp
@@ -100,7 +100,7 @@ public:
             m_snapshot = m_world;
         });
         RegisterForKey(GLFW_KEY_BACKSPACE, GLFW_PRESS, 0, "Restore to snapshot.", [&](KeyActionMods) {
-            if (m_snapshot.GetBodies().size() > 0)
+            if (!empty(m_snapshot.GetBodies()))
             {
                 ResetWorld(m_snapshot);
             }

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -341,7 +341,7 @@ public:
         }
         const auto angleNow = GetJointAngle(*flJoint);
         const auto desiredAngleToTurn = desiredAngle - angleNow;
-        const auto angleToTurn = Clamp(desiredAngleToTurn, -turnPerTimeStep, turnPerTimeStep);
+        const auto angleToTurn = std::clamp(desiredAngleToTurn, -turnPerTimeStep, turnPerTimeStep);
         if (angleToTurn != 0_deg)
         {
             const auto newAngle = angleNow + angleToTurn;

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -126,14 +126,14 @@ public:
     
     void updateTraction()
     {
-        if ( m_groundAreas.empty() )
+        if ( empty(m_groundAreas) )
             m_currentTraction = 1;
         else
         {
             //find area with highest traction
             m_currentTraction = 0;
-            auto it = m_groundAreas.begin();
-            while (it != m_groundAreas.end())
+            auto it = begin(m_groundAreas);
+            while (it != end(m_groundAreas))
             {
                 const auto ga = *it;
                 if ( ga->frictionModifier > m_currentTraction )
@@ -314,17 +314,17 @@ public:
     
     ~TDCar()
     {
-        for (auto i = decltype(m_tires.size()){0}; i < m_tires.size(); i++)
+        for (auto i = decltype(size(m_tires)){0}; i < size(m_tires); i++)
             delete m_tires[i];
     }
     
     void update(ControlStateType controlState)
     {
-        for (auto i = decltype(m_tires.size()){0}; i < m_tires.size(); i++)
+        for (auto i = decltype(size(m_tires)){0}; i < size(m_tires); i++)
         {
             m_tires[i]->updateFriction();
         }
-        for (auto i = decltype(m_tires.size()){0}; i < m_tires.size(); i++)
+        for (auto i = decltype(size(m_tires)){0}; i < size(m_tires); i++)
         {
             m_tires[i]->updateDrive(controlState);
         }

--- a/Testbed/Tests/iforce2d_TopdownCar.hpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.hpp
@@ -253,7 +253,7 @@ public:
         vertices[6] = Vec2(-3.0f,  +2.5f) * 1_m;
         vertices[7] = Vec2(-1.5f,  +0.0f) * 1_m;
         auto polygonShape = PolygonShapeConf{};
-        polygonShape.Set(Span<const Length2>(vertices, 8));
+        polygonShape.Set(vertices);
         polygonShape.UseDensity(0.1_kgpm2);
         m_body->CreateFixture(Shape(polygonShape));
         

--- a/Testbed/Tests/iforce2d_Trajectories.hpp
+++ b/Testbed/Tests/iforce2d_Trajectories.hpp
@@ -70,12 +70,12 @@ public:
         verts[0] = Length2(  0_m, -2*w);
         verts[1] = Length2(  w,    0_m);
         verts[2] = Length2(  0_m,   -w);
-        polygonShape.Set(Span<const Length2>(verts, 3));
+        polygonShape.Set(verts);
         m_targetBody->CreateFixture(Shape(polygonShape), myFixtureConf);
         verts[0] = Length2(  0_m, -2*w);
         verts[2] = Length2(  0_m,   -w);
         verts[1] = Length2( -w,    0_m);
-        polygonShape.Set(Span<const Length2>(verts, 3));
+        polygonShape.Set(verts);
         m_targetBody->CreateFixture(Shape(polygonShape), myFixtureConf);
         
         //create dynamic circle body

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -51,6 +51,9 @@ TEST(AABB, DefaultConstruction)
 
 TEST(AABB, Traits)
 {
+    EXPECT_FALSE(IsIterable<AABB>::value);
+    EXPECT_FALSE(IsAddable<AABB>::value);
+
     EXPECT_TRUE(std::is_default_constructible<AABB>::value);
     //EXPECT_TRUE(std::is_nothrow_default_constructible<AABB>::value);
     EXPECT_FALSE(std::is_trivially_default_constructible<AABB>::value);

--- a/UnitTests/Angle.cpp
+++ b/UnitTests/Angle.cpp
@@ -90,7 +90,7 @@ TEST(Angle, limits)
 
 TEST(Angle, GetNormalized)
 {
-    EXPECT_EQ(GetNormalized(Angle(0)) / Degree, Real(0));
+    EXPECT_EQ(GetNormalized(0_deg) / Degree, Real(0));
     EXPECT_NEAR(double(Real(GetNormalized(    0.0_deg) / Degree)),    0.0, 0.01);
     EXPECT_NEAR(double(Real(GetNormalized(   21.3_deg) / Degree)),   21.3, 0.01);
     EXPECT_NEAR(double(Real(GetNormalized(   90.0_deg) / Degree)),   90.0, 0.01);

--- a/UnitTests/ArrayList.cpp
+++ b/UnitTests/ArrayList.cpp
@@ -23,6 +23,12 @@
 
 using namespace playrho;
 
+TEST(ArrayList, traits)
+{
+    EXPECT_TRUE((IsIterable<ArrayList<int, 4u>>::value));
+    EXPECT_FALSE((IsAddable<ArrayList<int, 4u>>::value));
+}
+
 TEST(ArrayList, DefaultConstruction)
 {
     {

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -171,25 +171,31 @@ TEST(Body, ByteSize)
 
 TEST(Body, Traits)
 {
-    EXPECT_FALSE(std::is_default_constructible<Body>::value);
-    EXPECT_FALSE(std::is_nothrow_default_constructible<Body>::value);
-    EXPECT_FALSE(std::is_trivially_default_constructible<Body>::value);
+    using Type = Body;
     
-    EXPECT_FALSE(std::is_constructible<Body>::value);
-    EXPECT_FALSE(std::is_nothrow_constructible<Body>::value);
-    EXPECT_FALSE(std::is_trivially_constructible<Body>::value);
+    EXPECT_FALSE(IsIterable<Type>::value);
+    EXPECT_FALSE(IsAddable<Type>::value);
+    EXPECT_FALSE((IsAddable<Type, Type>::value));
+
+    EXPECT_FALSE(std::is_default_constructible<Type>::value);
+    EXPECT_FALSE(std::is_nothrow_default_constructible<Type>::value);
+    EXPECT_FALSE(std::is_trivially_default_constructible<Type>::value);
     
-    EXPECT_FALSE(std::is_copy_constructible<Body>::value);
-    EXPECT_FALSE(std::is_nothrow_copy_constructible<Body>::value);
-    EXPECT_FALSE(std::is_trivially_copy_constructible<Body>::value);
+    EXPECT_FALSE(std::is_constructible<Type>::value);
+    EXPECT_FALSE(std::is_nothrow_constructible<Type>::value);
+    EXPECT_FALSE(std::is_trivially_constructible<Type>::value);
     
-    EXPECT_FALSE(std::is_copy_assignable<Body>::value);
-    EXPECT_FALSE(std::is_nothrow_copy_assignable<Body>::value);
-    EXPECT_FALSE(std::is_trivially_copy_assignable<Body>::value);
+    EXPECT_FALSE(std::is_copy_constructible<Type>::value);
+    EXPECT_FALSE(std::is_nothrow_copy_constructible<Type>::value);
+    EXPECT_FALSE(std::is_trivially_copy_constructible<Type>::value);
     
-    EXPECT_FALSE(std::is_destructible<Body>::value);
-    EXPECT_FALSE(std::is_nothrow_destructible<Body>::value);
-    EXPECT_FALSE(std::is_trivially_destructible<Body>::value);
+    EXPECT_FALSE(std::is_copy_assignable<Type>::value);
+    EXPECT_FALSE(std::is_nothrow_copy_assignable<Type>::value);
+    EXPECT_FALSE(std::is_trivially_copy_assignable<Type>::value);
+    
+    EXPECT_FALSE(std::is_destructible<Type>::value);
+    EXPECT_FALSE(std::is_nothrow_destructible<Type>::value);
+    EXPECT_FALSE(std::is_trivially_destructible<Type>::value);
 }
 
 TEST(Body, GetFlagsStatic)

--- a/UnitTests/BodyConstraint.cpp
+++ b/UnitTests/BodyConstraint.cpp
@@ -22,7 +22,7 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(BodyConstraint, ByteSizeIs_40_80_or_160)
+TEST(BodyConstraint, ByteSize)
 {
     switch (sizeof(Real))
     {

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -206,7 +206,7 @@ TEST(ChainShapeConf, TwoVertexDpLikeEdgeDp)
         Length2{0_m, 0_m}, Length2(4_m, 0_m)
     }};
     const auto normals = std::array<UnitVec, 2>{{UnitVec::GetTop(), UnitVec::GetBottom()}};
-    const auto expectedDistanceProxy = DistanceProxy{vertexRadius, 2, locations.data(), normals.data()};
+    const auto expectedDistanceProxy = DistanceProxy{vertexRadius, 2, data(locations), data(normals)};
     
     auto conf = ChainShapeConf{};
     conf.density = density;

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -41,19 +41,15 @@ TEST(Contact, ByteSize)
     }
 }
 
-TEST(Contact, IsNotDefaultConstructible)
+TEST(Contact, Traits)
 {
     EXPECT_FALSE(std::is_default_constructible<Contact>::value);
-}
-
-TEST(Contact, IsCopyConstructible)
-{
     EXPECT_TRUE(std::is_copy_constructible<Contact>::value);
-}
+    EXPECT_FALSE(std::is_copy_assignable<Contact>::value);
 
-TEST(Contact, IsNotCopyAssignable)
-{
-    EXPECT_FALSE(std::is_copy_assignable<Contact>::value);    
+    EXPECT_FALSE(IsAddable<Contact>::value);
+    EXPECT_FALSE((IsAddable<Contact, Contact>::value));
+    EXPECT_FALSE(IsIterable<Contact>::value);
 }
 
 TEST(Contact, Enabled)

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -138,8 +138,7 @@ TEST(DistanceProxy, ThreeVertices)
 TEST(DistanceProxy, FindLowestRightMostVertex)
 {
     const auto vertices = std::vector<Length2>();
-    const auto span = Span<const Length2>(data(vertices), std::size_t{0});
-    const auto result = FindLowestRightMostVertex(span);
+    const auto result = FindLowestRightMostVertex(vertices);
     EXPECT_EQ(result, static_cast<std::size_t>(-1));
 }
 

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -138,7 +138,7 @@ TEST(DistanceProxy, ThreeVertices)
 TEST(DistanceProxy, FindLowestRightMostVertex)
 {
     const auto vertices = std::vector<Length2>();
-    const auto span = Span<const Length2>(vertices.data(), std::size_t{0});
+    const auto span = Span<const Length2>(data(vertices), std::size_t{0});
     const auto result = FindLowestRightMostVertex(span);
     EXPECT_EQ(result, static_cast<std::size_t>(-1));
 }

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -56,6 +56,10 @@ TEST(DynamicTree, TreeNodeByteSize)
 
 TEST(DynamicTree, Traits)
 {
+    EXPECT_FALSE(IsAddable<DynamicTree>::value);
+    EXPECT_FALSE((IsAddable<DynamicTree, DynamicTree>::value));
+    EXPECT_FALSE((IsIterable<DynamicTree>::value));
+    
     EXPECT_TRUE(std::is_default_constructible<DynamicTree>::value);
     EXPECT_TRUE(std::is_nothrow_default_constructible<DynamicTree>::value);
     EXPECT_FALSE(std::is_trivially_default_constructible<DynamicTree>::value);
@@ -958,7 +962,7 @@ TEST(DynamicTree, UpdateLeaf)
 
     std::for_each(begin(leafs), end(leafs), [&foo,&leafs](const auto leaf) {
         const auto aabb{foo.GetAABB(leaf)};
-        foo.UpdateLeaf(leaf, GetFattenedAABB(aabb, Length{0.5_m}));
+        foo.UpdateLeaf(leaf, GetFattenedAABB(aabb, 0.5_m));
         std::for_each(begin(leafs), end(leafs), [&foo](const auto leaf) {
             ASSERT_NE(foo.GetOther(leaf), DynamicTree::GetInvalidSize());
             EXPECT_TRUE(foo.GetBranchData(foo.GetOther(leaf)).child1 == leaf || foo.GetBranchData(foo.GetOther(leaf)).child2 == leaf);

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -53,6 +53,8 @@ TEST(GearJointConf, ByteSize)
 
 TEST(GearJointConf, Traits)
 {
+    EXPECT_FALSE(IsIterable<GearJointConf>::value);
+
     EXPECT_FALSE(std::is_default_constructible<GearJointConf>::value);
     EXPECT_FALSE(std::is_nothrow_default_constructible<GearJointConf>::value);
     EXPECT_FALSE(std::is_trivially_default_constructible<GearJointConf>::value);

--- a/UnitTests/Joint.cpp
+++ b/UnitTests/Joint.cpp
@@ -77,6 +77,10 @@ TEST(Joint, ByteSize)
 
 TEST(Joint, Traits)
 {
+    EXPECT_FALSE(IsIterable<Joint>::value);
+    EXPECT_FALSE((IsAddable<Joint>::value));
+    EXPECT_FALSE((IsAddable<Joint,Joint>::value));
+
     EXPECT_FALSE(std::is_default_constructible<Joint>::value);
     EXPECT_FALSE(std::is_nothrow_default_constructible<Joint>::value);
     EXPECT_FALSE(std::is_trivially_default_constructible<Joint>::value);

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -46,6 +46,8 @@ TEST(MassData, DefaultConstruct)
 
 TEST(MassData, Traits)
 {
+    EXPECT_FALSE(IsIterable<MassData>::value);
+
     EXPECT_TRUE(std::is_default_constructible<MassData>::value);
     // EXPECT_FALSE(std::is_nothrow_default_constructible<MassData>::value); // clang-3.7 and 4.0
     // EXPECT_TRUE(std::is_nothrow_default_constructible<MassData>::value); // gcc 6.3
@@ -168,7 +170,7 @@ TEST(MassData, GetAreaOfPolygon)
 
 TEST(MassData, GetMassDataFreeFunctionForNoVertices)
 {
-    const auto vertexRadius = Length{1_m};
+    const auto vertexRadius = 1_m;
     const auto density = NonNegative<AreaDensity>(1_kgpm2);
     const auto vertices = Span<const Length2>{
         static_cast<const Length2*>(nullptr), Span<const Length2>::size_type{0}

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -807,20 +807,20 @@ TEST(Math, InvertOneIsZero)
 #pragma warning( pop )
 }
 
-TEST(Math, Clamp)
+TEST(Math, clamp)
 {
-    // Check lo and hi work as documented on Clamp...
+    // Check lo and hi work as documented on clamp...
     const auto NaN = std::numeric_limits<double>::quiet_NaN();
-    EXPECT_EQ(Clamp(-1.0,  0.0, +1.0), 0.0);
-    EXPECT_EQ(Clamp(+1.0, -1.0,  0.0), 0.0);
-    EXPECT_EQ(Clamp(0.0, NaN, NaN), 0.0);
-    EXPECT_EQ(Clamp(0.0, -1.0, NaN), 0.0);
-    EXPECT_EQ(Clamp(0.0, NaN, +1.0), 0.0);
-    EXPECT_EQ(Clamp(0.0, -1.0, +1.0), 0.0);
-    EXPECT_TRUE(std::isnan(Clamp(NaN, -1.0, +1.0)));
-    EXPECT_TRUE(std::isnan(Clamp(NaN, NaN, +1.0)));
-    EXPECT_TRUE(std::isnan(Clamp(NaN, -1.0, NaN)));
-    EXPECT_TRUE(std::isnan(Clamp(NaN, NaN, NaN)));
+    EXPECT_EQ(std::clamp(-1.0,  0.0, +1.0), 0.0);
+    EXPECT_EQ(std::clamp(+1.0, -1.0,  0.0), 0.0);
+    EXPECT_EQ(std::clamp(0.0, NaN, NaN), 0.0);
+    EXPECT_EQ(std::clamp(0.0, -1.0, NaN), 0.0);
+    EXPECT_EQ(std::clamp(0.0, NaN, +1.0), 0.0);
+    EXPECT_EQ(std::clamp(0.0, -1.0, +1.0), 0.0);
+    EXPECT_TRUE(std::isnan(std::clamp(NaN, -1.0, +1.0)));
+    EXPECT_TRUE(std::isnan(std::clamp(NaN, NaN, +1.0)));
+    EXPECT_TRUE(std::isnan(std::clamp(NaN, -1.0, NaN)));
+    EXPECT_TRUE(std::isnan(std::clamp(NaN, NaN, NaN)));
 }
 
 TEST(Math, GetReflectionMatrix)

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -18,6 +18,8 @@
 
 #include "UnitTests.hpp"
 #include <PlayRho/Common/Math.hpp>
+
+#include <array>
 #include <type_traits>
 #include <chrono>
 #include <cmath>
@@ -127,7 +129,7 @@ TEST(Math, Span)
 {
     {
         const auto vector = Vector<int, 3>{1, 2, 4};
-        const Span<const int> foo = Span<const int>(vector.data(), vector.size());
+        const Span<const int> foo = Span<const int>(vector);
         EXPECT_EQ(foo.size(), std::size_t(3));
         EXPECT_EQ(foo[0], 1);
         EXPECT_EQ(foo[1], 2);
@@ -160,45 +162,46 @@ TEST(Math, Span)
         float array[15];
         EXPECT_EQ(Span<float>(array).size(), std::size_t(15));
         EXPECT_EQ(Span<float>(array, 2).size(), std::size_t(2));        
-        EXPECT_EQ(Span<float>(array, array + 4).size(), std::size_t(4));
-        EXPECT_EQ(Span<float>(array + 1, array + 3).size(), std::size_t(2));
     }
 }
 
 TEST(Math, Average)
 {
-    EXPECT_EQ(Average<int>({}), 0);
-    EXPECT_EQ(Average<float>({}), float(0));
+    EXPECT_EQ(Average(std::initializer_list<int>{}), 0);
+    EXPECT_EQ(Average(std::initializer_list<float>{}), float(0));
 
-    EXPECT_EQ(Average<int>({0}), 0);
-    EXPECT_EQ(Average<int>({4}), 4);
-    EXPECT_EQ(Average<int>({-3}), -3);
-    EXPECT_EQ(Average<float>({float(-3)}), float(-3));
+    EXPECT_EQ(Average(std::initializer_list<int>{0}), 0);
+    EXPECT_EQ(Average(std::initializer_list<int>{4}), 4);
+    EXPECT_EQ(Average(std::initializer_list<int>{-3}), -3);
+    EXPECT_EQ(Average(std::initializer_list<float>{float(-3)}), float(-3));
 
-    EXPECT_EQ(Average<int>({0, 0}), 0);
-    EXPECT_EQ(Average<int>({2, 2}), 2);
-    EXPECT_EQ(Average<int>({2, 4}), 3);
-    EXPECT_EQ(Average<float>({float(2), float(3)}), float(2.5));
+    EXPECT_EQ(Average(std::initializer_list<int>{0, 0}), 0);
+    EXPECT_EQ(Average(std::initializer_list<int>{2, 2}), 2);
+    EXPECT_EQ(Average(std::initializer_list<int>{2, 4}), 3);
+    EXPECT_EQ(Average(std::initializer_list<float>{float(2), float(3)}), float(2.5));
 
-    EXPECT_EQ(Average<int>({2, 4, 6}), 4);
-    EXPECT_EQ(Average<int>({2, 4, 12}), 6);
-    EXPECT_EQ(Average<double>({2.0, 4.0, 6.0}), 4.0);
-    EXPECT_EQ(Average<double>({2.0, 4.0, 12.0}), 6.0);
+    EXPECT_EQ(Average(std::initializer_list<int>{2, 4, 6}), 4);
+    EXPECT_EQ(Average(std::initializer_list<int>{2, 4, 12}), 6);
+    EXPECT_EQ(Average(std::initializer_list<double>{2.0, 4.0, 6.0}), 4.0);
+    EXPECT_EQ(Average(std::initializer_list<double>{2.0, 4.0, 12.0}), 6.0);
+    
+    EXPECT_EQ(Average(std::array<double, 3>{{2.0, 4.0, 12.0}}), 6.0);
+    EXPECT_EQ(Average(std::vector<double>{2.0, 4.0, 12.0}), 6.0);
 }
 
 TEST(Math, AverageVec2)
 {
-    EXPECT_EQ(Average<Vec2>({}), Vec2(0, 0));
+    EXPECT_EQ(Average(std::initializer_list<Vec2>{}), Vec2(0, 0));
     
     {
         const auto val = Vec2{Real(3.9), Real(-0.1)};
-        EXPECT_EQ(Average<Vec2>({val}), val);
+        EXPECT_EQ(Average(std::initializer_list<Vec2>{val}), val);
     }
     
     {
         const auto val1 = Vec2{Real(2.2), Real(-1.1)};
         const auto val2 = Vec2{Real(4.4), Real(-1.3)};
-        const auto average = Average<Vec2>({val1, val2});
+        const auto average = Average(std::initializer_list<Vec2>{val1, val2});
         const auto expected = Vec2(Real(3.3), Real(-1.2));
         EXPECT_NEAR(double(GetX(average)), double(GetX(expected)), 0.0001);
         EXPECT_NEAR(double(GetY(average)), double(GetY(expected)), 0.0001);
@@ -370,7 +373,7 @@ TEST(Math, ComputeCentroidCenteredR1)
     EXPECT_EQ(GetX(center), GetX(real_center) * Meter);
     EXPECT_EQ(GetY(center), GetY(real_center) * Meter);
     
-    const auto average = Average<Length2>(vertices);
+    const auto average = Average(vertices);
     EXPECT_EQ(average, center);
 }
 
@@ -390,7 +393,7 @@ TEST(Math, ComputeCentroidCentered0R1000)
     EXPECT_EQ(GetX(center), GetX(real_center) * Meter);
     EXPECT_EQ(GetY(center), GetY(real_center) * Meter);
     
-    const auto average = Average<Length2>(vertices);
+    const auto average = Average(vertices);
     EXPECT_EQ(average, center);
 }
 
@@ -409,7 +412,7 @@ TEST(Math, ComputeCentroidUpRight1000R1)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2>(vertices);
+    const auto average = Average(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }
@@ -429,7 +432,7 @@ TEST(Math, ComputeCentroidUpRight1000R100)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2>(vertices);
+    const auto average = Average(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }
@@ -449,7 +452,7 @@ TEST(Math, ComputeCentroidUpRight10000R01)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.1);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.1);
     
-    const auto average = Average<Length2>(vertices);
+    const auto average = Average(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.1);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.1);
 }
@@ -469,7 +472,7 @@ TEST(Math, ComputeCentroidDownLeft1000R1)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2>(vertices);
+    const auto average = Average(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }
@@ -491,7 +494,7 @@ TEST(Math, ComputeCentroidOfHexagonalVertices)
     EXPECT_NEAR(double(Real{GetX(center) / Meter}), double(GetX(real_center)), 0.01);
     EXPECT_NEAR(double(Real{GetY(center) / Meter}), double(GetY(real_center)), 0.01);
     
-    const auto average = Average<Length2>(vertices);
+    const auto average = Average(vertices);
     EXPECT_NEAR(double(Real{GetX(average) / Meter}), double(Real{GetX(center) / Meter}), 0.01);
     EXPECT_NEAR(double(Real{GetY(average) / Meter}), double(Real{GetY(center) / Meter}), 0.01);
 }

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -412,7 +412,7 @@ TEST(PolygonShapeConf, CanSetTwoPoints)
                 +0.0, 1.0/100000.0);
     EXPECT_NEAR(static_cast<double>(GetY(GetVec2(shape.GetNormal(1)))),
                 -1.0, 1.0/100000.0);
-    EXPECT_EQ(shape.GetCentroid(), Average(Span<const Length2>(points.data(), points.size())));
+    EXPECT_EQ(shape.GetCentroid(), Average(points));
     EXPECT_EQ(GetVertexRadius(shape), vertexRadius);
 
     EXPECT_TRUE(Validate(shape.GetVertices()));
@@ -448,7 +448,7 @@ TEST(PolygonShapeConf, TransformFF)
         const auto v1 = Length2{1_m, 2_m};
         const auto v2 = Length2{3_m, 4_m};
         const auto vertices = std::vector<Length2>{v1, v2};
-        auto foo = PolygonShapeConf{Span<const Length2>{vertices.data(), vertices.size()}};
+        auto foo = PolygonShapeConf{vertices};
         auto copy = foo;
         Transform(foo, GetIdentity<Mat22>());
         EXPECT_EQ(foo, copy);
@@ -457,7 +457,7 @@ TEST(PolygonShapeConf, TransformFF)
         const auto v1 = Length2{1_m, 2_m};
         const auto v2 = Length2{3_m, 4_m};
         const auto vertices = std::vector<Length2>{v1, v2};
-        auto foo = PolygonShapeConf{Span<const Length2>{vertices.data(), vertices.size()}};
+        auto foo = PolygonShapeConf{vertices};
         ASSERT_EQ(foo.GetVertexCount(), VertexCounter(2));
         ASSERT_EQ(foo.GetVertex(0), v2);
         ASSERT_EQ(foo.GetVertex(1), v1);
@@ -511,13 +511,13 @@ TEST(PolygonShapeConf, Inequality)
 TEST(PolygonShapeConf, ValidateFF)
 {
     auto vertices = std::vector<Length2>{};
-    EXPECT_TRUE(Validate(Span<const Length2>(vertices.data(), vertices.size())));
+    EXPECT_TRUE(Validate(vertices));
     vertices.push_back(Length2{0_m, 0_m});
-    EXPECT_TRUE(Validate(Span<const Length2>(vertices.data(), vertices.size())));
+    EXPECT_TRUE(Validate(vertices));
     vertices.push_back(Length2{1_m, 1_m});
-    EXPECT_TRUE(Validate(Span<const Length2>(vertices.data(), vertices.size())));
+    EXPECT_TRUE(Validate(vertices));
     vertices.push_back(Length2{-1_m, 1_m});
-    EXPECT_TRUE(Validate(Span<const Length2>(vertices.data(), vertices.size())));
+    EXPECT_TRUE(Validate(vertices));
     vertices.push_back(Length2{+2_m, 1_m});
-    EXPECT_FALSE(Validate(Span<const Length2>(vertices.data(), vertices.size())));
+    EXPECT_FALSE(Validate(vertices));
 }

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -133,7 +133,7 @@ TEST(Shape, TestOverlapSlowerThanCollideShapesForCircles)
             const auto start = std::chrono::high_resolution_clock::now();
             for (auto i = decltype(maxloops){0}; i < maxloops; ++i)
             {
-                if (TestOverlap(child, xfm, child, xfm) >= Area{0})
+                if (TestOverlap(child, xfm, child, xfm) >= 0_m2)
                 {
                     ++count;
                 }
@@ -180,7 +180,7 @@ TEST(Shape, TestOverlapFasterThanCollideShapesForPolygons)
             const auto start = std::chrono::high_resolution_clock::now();
             for (auto i = decltype(maxloops){0}; i < maxloops; ++i)
             {
-                if (TestOverlap(child, xfm, child, xfm) >= Area{0})
+                if (TestOverlap(child, xfm, child, xfm) >= 0_m2)
                 {
                     ++count;
                 }

--- a/UnitTests/Vec2.cpp
+++ b/UnitTests/Vec2.cpp
@@ -44,6 +44,9 @@ TEST(Vec2, max_size) {
 
 TEST(Vec2, Traits)
 {
+    EXPECT_TRUE((IsAddable<Vec2>::value));
+    EXPECT_TRUE((IsAddable<Vec2,Vec2>::value));
+
     EXPECT_TRUE(std::is_default_constructible<Vec2>::value);
     EXPECT_TRUE(std::is_nothrow_default_constructible<Vec2>::value);
     EXPECT_TRUE(std::is_trivially_default_constructible<Vec2>::value);

--- a/UnitTests/Vec3.cpp
+++ b/UnitTests/Vec3.cpp
@@ -38,6 +38,9 @@ TEST(Vec3, ByteSizeIs_12_24_or_48)
 
 TEST(Vec3, Traits)
 {
+    EXPECT_TRUE((IsAddable<Vec3>::value));
+    EXPECT_TRUE((IsAddable<Vec3,Vec3>::value));
+
     EXPECT_TRUE(std::is_default_constructible<Vec3>::value);
     EXPECT_TRUE(std::is_nothrow_default_constructible<Vec3>::value);
     EXPECT_TRUE(std::is_trivially_default_constructible<Vec3>::value);

--- a/UnitTests/VertexSet.cpp
+++ b/UnitTests/VertexSet.cpp
@@ -22,6 +22,13 @@
 using namespace playrho;
 using namespace playrho::d2;
 
+TEST(VertexSet, Traits)
+{
+    EXPECT_TRUE((IsIterable<VertexSet>::value));
+    EXPECT_FALSE((IsAddable<VertexSet>::value));
+    EXPECT_FALSE((IsAddable<VertexSet,VertexSet>::value));
+}
+
 TEST(VertexSet, ByteSize)
 {
     switch (sizeof(Real))

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -31,6 +31,13 @@
 using namespace playrho;
 using namespace playrho::d2;
 
+TEST(WeldJoint, Traits)
+{
+    EXPECT_FALSE((IsIterable<WeldJoint>::value));
+    EXPECT_FALSE((IsAddable<WeldJoint>::value));
+    EXPECT_FALSE((IsAddable<WeldJoint,WeldJoint>::value));
+}
+
 TEST(WeldJointConf, ByteSize)
 {
     switch (sizeof(Real))

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -68,6 +68,13 @@ TEST(WheelJointConf, DefaultConstruction)
     EXPECT_EQ(def.dampingRatio, Real(0.7f));
 }
 
+TEST(WheelJoint, Traits)
+{
+    EXPECT_FALSE((IsIterable<WheelJoint>::value));
+    EXPECT_FALSE((IsAddable<WheelJoint>::value));
+    EXPECT_FALSE((IsAddable<WheelJoint,WheelJoint>::value));
+}
+
 TEST(WheelJoint, ByteSize)
 {
     switch (sizeof(Real))

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -755,7 +755,7 @@ TEST(World, Query)
     ASSERT_NE(fixture, nullptr);
     
     auto stepConf = StepConf{};
-    stepConf.SetTime(Time(0));
+    stepConf.SetTime(0_s);
     world.Step(stepConf);
 
     {
@@ -813,7 +813,7 @@ TEST(World, RayCast)
     ASSERT_NE(fixture, nullptr);
     
     auto stepConf = StepConf{};
-    stepConf.SetTime(Time(0));
+    stepConf.SetTime(0_s);
     world.Step(stepConf);
     
     {

--- a/UnitTests/double.cpp
+++ b/UnitTests/double.cpp
@@ -36,3 +36,10 @@ TEST(double, GetTypeName)
     EXPECT_STREQ(name, "double");
 }
 
+TEST(double, traits)
+{
+    EXPECT_TRUE((playrho::IsAddable<double>::value));
+    EXPECT_TRUE((playrho::IsAddable<double,double>::value));
+    EXPECT_TRUE((playrho::IsAddable<double,float>::value));
+    EXPECT_TRUE((playrho::IsAddable<double,int>::value));
+}

--- a/UnitTests/float.cpp
+++ b/UnitTests/float.cpp
@@ -371,3 +371,11 @@ TEST(float, GetTypeName)
     const auto name = playrho::GetTypeName<float>();
     EXPECT_STREQ(name, "float");
 }
+
+TEST(float, traits)
+{
+    EXPECT_TRUE((playrho::IsAddable<float>::value));
+    EXPECT_TRUE((playrho::IsAddable<float,float>::value));
+    EXPECT_TRUE((playrho::IsAddable<float,double>::value));
+    EXPECT_TRUE((playrho::IsAddable<float,int>::value));
+}


### PR DESCRIPTION
#### Description - What's this PR do?
More changes towards increasing genericity:
- Fixes `Span` to work the way it had originally been intended.
- Adds an `IsAddable` trait.
- Updates the `Average` math function to take any iterable container of addable elements.
- Replaces `Clamp` with `std::clamp`.
- Switches to using the free function forms of `begin`, `end`, `data`, `size`, `empty`, `cbegin`, `cend`.
- Makes use of the `[[fallthrough]]` attribute.