### PR TITLE
fix an assertion issue when world steps after destroying any body with proxies.

### DIFF
--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2111,6 +2111,7 @@ ContactCounter World::FindNewContacts()
     // to eliminate any node pairs that have the same body here before the key pairs are
     // sorted.
     for_each(cbegin(m_proxies), cend(m_proxies), [&](ProxyId pid) {
+        if (pid == DynamicTree::GetInvalidSize()) return;
         const auto body0 = m_tree.GetLeafData(pid).body;
         const auto aabb = m_tree.GetAABB(pid);
         Query(m_tree, aabb, [&](DynamicTree::Size nodeId) {


### PR DESCRIPTION
I was replacing Box2D with PlayRho in my game demos. The work is done quite easily, just encounter this small issue when destroying bodies with proxies that makes m_proxies filled with invalid ids, then assertion will trigger when going through the next world step round.