### PR TITLE
remove the use of RTTI to tell shape types

### DIFF
--- a/PlayRho/Collision/Shapes/Shape.cpp
+++ b/PlayRho/Collision/Shapes/Shape.cpp
@@ -23,6 +23,9 @@
 
 namespace playrho {
 namespace d2 {
+
+int Shape::m_shapeTypeIndex = 0;
+
 namespace {
 
 struct DefaultShapeConf

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2111,6 +2111,7 @@ ContactCounter World::FindNewContacts()
     // to eliminate any node pairs that have the same body here before the key pairs are
     // sorted.
     for_each(cbegin(m_proxies), cend(m_proxies), [&](ProxyId pid) {
+        if (pid == DynamicTree::GetInvalidSize()) return;
         const auto body0 = m_tree.GetLeafData(pid).body;
         const auto aabb = m_tree.GetAABB(pid);
         Query(m_tree, aabb, [&](DynamicTree::Size nodeId) {


### PR DESCRIPTION
Add a small trick to remove the use of RTTI features to tell different shape types.