### PR TITLE
... and another fix for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,8 +147,9 @@ after_success:
       lcov --version
       pwd && ls -laF . /usr/bin/gcov*
 
-      cd $BUILD_ROOT && pwd
-      find ~/ -name "*gcno" -or -name "*gcda"
+      # cd $BUILD_ROOT && pwd
+      cd $SOURCE_ROOT && pwd
+      # find ~/ -name "*gcno" -or -name "*gcda"
       # lcov --gcov-tool /usr/bin/gcov-8 --directory PlayRho --directory UnitTests --base-directory $SOURCE_ROOT --capture --output-file coverage.info
       lcov --gcov-tool /usr/bin/gcov-8 --compat-libtool --directory PlayRho --directory UnitTests --base-directory ../PlayRho/ --capture --output-file coverage.info --quiet
       echo "Lcov exited with status $?"

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,5 +159,5 @@ after_success:
       ls -laF coverage.info
       lcov --list coverage.info
       cd $SOURCE_ROOT && pwd
-      coveralls-lcov --verbose $BUILD_ROOT/coverage.info
+      coveralls-lcov --verbose $SOURCE_ROOT/coverage.info
     fi


### PR DESCRIPTION
Apparently the last changes weren't enough. After you pulled the stuff in, i noticed coveralls still not working. Seems the with all the recent changes in that squashed mega-commit some paths in travis changed. Seemed to have changed to an in-source-built or something like that.
Anyway - changed the paths in .travis.yml. Hopefully this will do it now.

https://travis-ci.org/ninnghazad/PlayRho/jobs/553746287
https://coveralls.io/builds/24347713