### PR TITLE
Doxyfile modification to generate tagfile.

### DIFF
--- a/Documentation/Doxyfile
+++ b/Documentation/Doxyfile
@@ -2123,7 +2123,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = API/html/PlayRho.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
Doxygen tagfiles can be used to link between doxygen documentations that use the same symbols (https://www.doxygen.nl/manual/external.html). I would like to link from API references of my project that uses PlayRho into PlayRho references. I will be able to do it once newly generated PlayRho.tag file is uploaded to gh-pages together with the rest of the documentation.