### PR TITLE
Updates 20200901

### DIFF
--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -63,7 +63,7 @@ struct AABB
     /// @brief Default constructor.
     /// @details Constructs an "unset" AABB.
     /// @note If an unset AABB is added to another AABB, the result will be the other AABB.
-    constexpr inline AABB() = default;
+    constexpr AABB() = default;
     
     /// @brief Initializing constructor.
     /// @details Initializing constructor supporting construction by the same number of elements
@@ -73,7 +73,7 @@ struct AABB
     /// const auto aabb = AABB<2>{LengthInterval{1_m, 4_m}, LengthInterval{-3_m, 3_m}};
     /// @endcode
     template<typename... Tail>
-    constexpr inline AABB(std::enable_if_t<sizeof...(Tail)+1 == N, LengthInterval> head,
+    constexpr AABB(std::enable_if_t<sizeof...(Tail)+1 == N, LengthInterval> head,
                                   Tail... tail) noexcept:
         ranges{head, LengthInterval(tail)...}
     {
@@ -86,7 +86,7 @@ struct AABB
     ///   given point's X value.
     /// @post <code>rangeY</code> will have its min and max values both set to the
     ///   given point's Y value.
-    constexpr inline explicit AABB(const Location p) noexcept
+    constexpr explicit AABB(const Location p) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -97,7 +97,7 @@ struct AABB
     /// @brief Initializing constructor for two points.
     /// @param a Point location "A" to initialize this AABB with.
     /// @param b Point location "B" to initialize this AABB with.
-    constexpr inline AABB(const Location a, const Location b) noexcept
+    constexpr AABB(const Location a, const Location b) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -113,7 +113,7 @@ struct AABB
 /// @return <code>true</code> if the two values are equal, <code>false</code> otherwise.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
+constexpr bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -129,7 +129,7 @@ constexpr inline bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexce
 /// @return <code>true</code> if the two values are not equal, <code>false</code> otherwise.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline bool operator!= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
+constexpr bool operator!= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
 {
     return !(lhs == rhs);
 }
@@ -182,7 +182,7 @@ inline bool operator>= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
 /// @note This function's complexity is constant.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
+constexpr bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -196,7 +196,7 @@ constexpr inline bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
 
 /// @brief Gets the intersecting AABB of the two given AABBs'.
 template <std::size_t N>
-constexpr inline AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
+constexpr AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
 {
     auto result = AABB<N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -209,7 +209,7 @@ constexpr inline AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b)
 /// @brief Gets the center of the AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
+constexpr Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -222,7 +222,7 @@ constexpr inline Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
 /// @brief Gets dimensions of the given AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
+constexpr Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -235,7 +235,7 @@ constexpr inline Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
 /// @brief Gets the extents of the AABB (half-widths).
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
+constexpr Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
 {
     constexpr const auto RealInverseOfTwo = Real{1} / Real{2};
     return GetDimensions(aabb) * RealInverseOfTwo;
@@ -250,7 +250,7 @@ constexpr inline Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
 /// @param b AABB to test whether it's contained by the first AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
+constexpr bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -265,7 +265,7 @@ constexpr inline bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
 /// @brief Includes the given location into the given AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
+constexpr AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -280,7 +280,7 @@ constexpr inline AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) 
 ///   the other AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
+constexpr AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -291,7 +291,7 @@ constexpr inline AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
 
 /// @brief Moves the given AABB by the given value.
 template <std::size_t N>
-constexpr inline AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
+constexpr AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -303,7 +303,7 @@ constexpr inline AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noex
 /// @brief Fattens an AABB by the given amount.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
+constexpr AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -316,7 +316,7 @@ constexpr inline AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount)
 ///   displacement amount.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
+constexpr AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -328,7 +328,7 @@ constexpr inline AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> 
 /// @brief Gets the fattened AABB result.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
+constexpr AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
 {
     return Fatten(aabb, amount);
 }
@@ -336,7 +336,7 @@ constexpr inline AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
 /// @brief Gets the result of moving the given AABB by the given value.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
+constexpr AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
 {
     return Move(aabb, value);
 }
@@ -344,7 +344,7 @@ constexpr inline AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> valu
 /// @brief Gets the AABB that minimally encloses the given AABBs.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
+constexpr AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
 {
     return Include(a, b);
 }
@@ -352,7 +352,7 @@ constexpr inline AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
 /// @brief Gets the lower bound.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
+constexpr Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -365,7 +365,7 @@ constexpr inline Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
 /// @brief Gets the upper bound.
 /// @relatedalso AABB
 template <std::size_t N>
-constexpr inline Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
+constexpr Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -420,7 +420,7 @@ using AABB = detail::AABB<2>;
 /// @return Twice the sum of the width and height.
 /// @relatedalso playrho::detail::AABB
 /// @sa https://en.wikipedia.org/wiki/Perimeter
-constexpr inline Length GetPerimeter(const AABB& aabb) noexcept
+constexpr Length GetPerimeter(const AABB& aabb) noexcept
 {
     return (GetSize(aabb.ranges[0]) + GetSize(aabb.ranges[1])) * 2;
 }
@@ -481,7 +481,7 @@ AABB GetAABB(const playrho::detail::RayCastInput<2>& input) noexcept;
 /// @brief Gets an invalid AABB value.
 /// @relatedalso detail::AABB
 template <>
-constexpr inline d2::AABB GetInvalid() noexcept
+constexpr d2::AABB GetInvalid() noexcept
 {
     return d2::AABB{LengthInterval{GetInvalid<Length>()}, LengthInterval{GetInvalid<Length>()}};
 }

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -63,7 +63,7 @@ struct AABB
     /// @brief Default constructor.
     /// @details Constructs an "unset" AABB.
     /// @note If an unset AABB is added to another AABB, the result will be the other AABB.
-    PLAYRHO_CONSTEXPR inline AABB() = default;
+    constexpr inline AABB() = default;
     
     /// @brief Initializing constructor.
     /// @details Initializing constructor supporting construction by the same number of elements
@@ -73,7 +73,7 @@ struct AABB
     /// const auto aabb = AABB<2>{LengthInterval{1_m, 4_m}, LengthInterval{-3_m, 3_m}};
     /// @endcode
     template<typename... Tail>
-    PLAYRHO_CONSTEXPR inline AABB(std::enable_if_t<sizeof...(Tail)+1 == N, LengthInterval> head,
+    constexpr inline AABB(std::enable_if_t<sizeof...(Tail)+1 == N, LengthInterval> head,
                                   Tail... tail) noexcept:
         ranges{head, LengthInterval(tail)...}
     {
@@ -86,7 +86,7 @@ struct AABB
     ///   given point's X value.
     /// @post <code>rangeY</code> will have its min and max values both set to the
     ///   given point's Y value.
-    PLAYRHO_CONSTEXPR inline explicit AABB(const Location p) noexcept
+    constexpr inline explicit AABB(const Location p) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -97,7 +97,7 @@ struct AABB
     /// @brief Initializing constructor for two points.
     /// @param a Point location "A" to initialize this AABB with.
     /// @param b Point location "B" to initialize this AABB with.
-    PLAYRHO_CONSTEXPR inline AABB(const Location a, const Location b) noexcept
+    constexpr inline AABB(const Location a, const Location b) noexcept
     {
         for (auto i = decltype(N){0}; i < N; ++i)
         {
@@ -113,7 +113,7 @@ struct AABB
 /// @return <code>true</code> if the two values are equal, <code>false</code> otherwise.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
+constexpr inline bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -129,7 +129,7 @@ PLAYRHO_CONSTEXPR inline bool operator== (const AABB<N>& lhs, const AABB<N>& rhs
 /// @return <code>true</code> if the two values are not equal, <code>false</code> otherwise.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator!= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
+constexpr inline bool operator!= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
 {
     return !(lhs == rhs);
 }
@@ -182,7 +182,7 @@ inline bool operator>= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
 /// @note This function's complexity is constant.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
+constexpr inline bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -196,7 +196,7 @@ PLAYRHO_CONSTEXPR inline bool TestOverlap(const AABB<N>& a, const AABB<N>& b) no
 
 /// @brief Gets the intersecting AABB of the two given AABBs'.
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
+constexpr inline AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
 {
     auto result = AABB<N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -209,7 +209,7 @@ PLAYRHO_CONSTEXPR inline AABB<N> GetIntersectingAABB(const AABB<N>& a, const AAB
 /// @brief Gets the center of the AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
+constexpr inline Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -222,7 +222,7 @@ PLAYRHO_CONSTEXPR inline Vector<Length, N> GetCenter(const AABB<N>& aabb) noexce
 /// @brief Gets dimensions of the given AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
+constexpr inline Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -235,9 +235,9 @@ PLAYRHO_CONSTEXPR inline Vector<Length, N> GetDimensions(const AABB<N>& aabb) no
 /// @brief Gets the extents of the AABB (half-widths).
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
+constexpr inline Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
 {
-    PLAYRHO_CONSTEXPR const auto RealInverseOfTwo = Real{1} / Real{2};
+    constexpr const auto RealInverseOfTwo = Real{1} / Real{2};
     return GetDimensions(aabb) * RealInverseOfTwo;
 }
 
@@ -250,7 +250,7 @@ PLAYRHO_CONSTEXPR inline Vector<Length, N> GetExtents(const AABB<N>& aabb) noexc
 /// @param b AABB to test whether it's contained by the first AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
+constexpr inline bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -265,7 +265,7 @@ PLAYRHO_CONSTEXPR inline bool Contains(const AABB<N>& a, const AABB<N>& b) noexc
 /// @brief Includes the given location into the given AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
+constexpr inline AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -280,7 +280,7 @@ PLAYRHO_CONSTEXPR inline AABB<N>& Include(AABB<N>& var, const Vector<Length, N>&
 ///   the other AABB.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
+constexpr inline AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -291,7 +291,7 @@ PLAYRHO_CONSTEXPR inline AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noex
 
 /// @brief Moves the given AABB by the given value.
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
+constexpr inline AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -303,7 +303,7 @@ PLAYRHO_CONSTEXPR inline AABB<N>& Move(AABB<N>& var, const Vector<Length, N> val
 /// @brief Fattens an AABB by the given amount.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
+constexpr inline AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -316,7 +316,7 @@ PLAYRHO_CONSTEXPR inline AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length>
 ///   displacement amount.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
+constexpr inline AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -328,7 +328,7 @@ PLAYRHO_CONSTEXPR inline AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Len
 /// @brief Gets the fattened AABB result.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
+constexpr inline AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
 {
     return Fatten(aabb, amount);
 }
@@ -336,7 +336,7 @@ PLAYRHO_CONSTEXPR inline AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amou
 /// @brief Gets the result of moving the given AABB by the given value.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
+constexpr inline AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
 {
     return Move(aabb, value);
 }
@@ -344,7 +344,7 @@ PLAYRHO_CONSTEXPR inline AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length,
 /// @brief Gets the AABB that minimally encloses the given AABBs.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
+constexpr inline AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
 {
     return Include(a, b);
 }
@@ -352,7 +352,7 @@ PLAYRHO_CONSTEXPR inline AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
 /// @brief Gets the lower bound.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
+constexpr inline Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -365,7 +365,7 @@ PLAYRHO_CONSTEXPR inline Vector<Length, N> GetLowerBound(const AABB<N>& aabb) no
 /// @brief Gets the upper bound.
 /// @relatedalso AABB
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
+constexpr inline Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
 {
     auto result = Vector<Length, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -420,7 +420,7 @@ using AABB = detail::AABB<2>;
 /// @return Twice the sum of the width and height.
 /// @relatedalso playrho::detail::AABB
 /// @sa https://en.wikipedia.org/wiki/Perimeter
-PLAYRHO_CONSTEXPR inline Length GetPerimeter(const AABB& aabb) noexcept
+constexpr inline Length GetPerimeter(const AABB& aabb) noexcept
 {
     return (GetSize(aabb.ranges[0]) + GetSize(aabb.ranges[1])) * 2;
 }
@@ -481,7 +481,7 @@ AABB GetAABB(const playrho::detail::RayCastInput<2>& input) noexcept;
 /// @brief Gets an invalid AABB value.
 /// @relatedalso detail::AABB
 template <>
-PLAYRHO_CONSTEXPR inline d2::AABB GetInvalid() noexcept
+constexpr inline d2::AABB GetInvalid() noexcept
 {
     return d2::AABB{LengthInterval{GetInvalid<Length>()}, LengthInterval{GetInvalid<Length>()}};
 }

--- a/PlayRho/Collision/ContactFeature.hpp
+++ b/PlayRho/Collision/ContactFeature.hpp
@@ -57,7 +57,7 @@ struct ContactFeature
 
 /// @brief Gets the vertex vertex contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr inline ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
+constexpr ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
                                                        ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_vertex, b};
@@ -65,7 +65,7 @@ constexpr inline ContactFeature GetVertexVertexContactFeature(ContactFeature::In
 
 /// @brief Gets the vertex face contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr inline ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
+constexpr ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
                                                      ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_face, b};
@@ -73,7 +73,7 @@ constexpr inline ContactFeature GetVertexFaceContactFeature(ContactFeature::Inde
 
 /// @brief Gets the face vertex contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr inline ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
+constexpr ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
                                                      ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_vertex, b};
@@ -81,7 +81,7 @@ constexpr inline ContactFeature GetFaceVertexContactFeature(ContactFeature::Inde
 
 /// @brief Gets the face face contact feature for the given indices.
 /// @relatedalso ContactFeature
-constexpr inline ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
+constexpr ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
                                                    ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_face, b};
@@ -89,14 +89,14 @@ constexpr inline ContactFeature GetFaceFaceContactFeature(ContactFeature::Index 
 
 /// @brief Flips contact features information.
 /// @relatedalso ContactFeature
-constexpr inline ContactFeature Flip(ContactFeature val) noexcept
+constexpr ContactFeature Flip(ContactFeature val) noexcept
 {
     return ContactFeature{val.typeB, val.indexB, val.typeA, val.indexA};
 }
 
 /// @brief Determines if the given two contact features are equal.
 /// @relatedalso ContactFeature
-constexpr inline bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
+constexpr bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
 {
     return (lhs.typeA == rhs.typeA) && (lhs.indexA == rhs.indexA)
         && (lhs.typeB == rhs.typeB) && (lhs.indexB == rhs.indexB);
@@ -104,7 +104,7 @@ constexpr inline bool operator==(ContactFeature lhs, ContactFeature rhs) noexcep
 
 /// @brief Determines if the given two contact features are not equal.
 /// @relatedalso ContactFeature
-constexpr inline bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
+constexpr bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/PlayRho/Collision/ContactFeature.hpp
+++ b/PlayRho/Collision/ContactFeature.hpp
@@ -57,7 +57,7 @@ struct ContactFeature
 
 /// @brief Gets the vertex vertex contact feature for the given indices.
 /// @relatedalso ContactFeature
-PLAYRHO_CONSTEXPR inline ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
+constexpr inline ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
                                                        ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_vertex, b};
@@ -65,7 +65,7 @@ PLAYRHO_CONSTEXPR inline ContactFeature GetVertexVertexContactFeature(ContactFea
 
 /// @brief Gets the vertex face contact feature for the given indices.
 /// @relatedalso ContactFeature
-PLAYRHO_CONSTEXPR inline ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
+constexpr inline ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
                                                      ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_face, b};
@@ -73,7 +73,7 @@ PLAYRHO_CONSTEXPR inline ContactFeature GetVertexFaceContactFeature(ContactFeatu
 
 /// @brief Gets the face vertex contact feature for the given indices.
 /// @relatedalso ContactFeature
-PLAYRHO_CONSTEXPR inline ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
+constexpr inline ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
                                                      ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_vertex, b};
@@ -81,7 +81,7 @@ PLAYRHO_CONSTEXPR inline ContactFeature GetFaceVertexContactFeature(ContactFeatu
 
 /// @brief Gets the face face contact feature for the given indices.
 /// @relatedalso ContactFeature
-PLAYRHO_CONSTEXPR inline ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
+constexpr inline ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
                                                    ContactFeature::Index b) noexcept
 {
     return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_face, b};
@@ -89,14 +89,14 @@ PLAYRHO_CONSTEXPR inline ContactFeature GetFaceFaceContactFeature(ContactFeature
 
 /// @brief Flips contact features information.
 /// @relatedalso ContactFeature
-PLAYRHO_CONSTEXPR inline ContactFeature Flip(ContactFeature val) noexcept
+constexpr inline ContactFeature Flip(ContactFeature val) noexcept
 {
     return ContactFeature{val.typeB, val.indexB, val.typeA, val.indexA};
 }
 
 /// @brief Determines if the given two contact features are equal.
 /// @relatedalso ContactFeature
-PLAYRHO_CONSTEXPR inline bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
+constexpr inline bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
 {
     return (lhs.typeA == rhs.typeA) && (lhs.indexA == rhs.indexA)
         && (lhs.typeB == rhs.typeB) && (lhs.indexB == rhs.indexB);
@@ -104,7 +104,7 @@ PLAYRHO_CONSTEXPR inline bool operator==(ContactFeature lhs, ContactFeature rhs)
 
 /// @brief Determines if the given two contact features are not equal.
 /// @relatedalso ContactFeature
-PLAYRHO_CONSTEXPR inline bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
+constexpr inline bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -40,7 +40,7 @@ class DistanceProxy;
 PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept;
 
 /// @brief Gets the delta to go from the first element to the second.
-PLAYRHO_CONSTEXPR inline Length2 GetDelta(PairLength2 arg) noexcept
+constexpr inline Length2 GetDelta(PairLength2 arg) noexcept
 {
     return std::get<1>(arg) - std::get<0>(arg);
 }

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -40,7 +40,7 @@ class DistanceProxy;
 PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept;
 
 /// @brief Gets the delta to go from the first element to the second.
-constexpr inline Length2 GetDelta(PairLength2 arg) noexcept
+constexpr Length2 GetDelta(PairLength2 arg) noexcept
 {
     return std::get<1>(arg) - std::get<0>(arg);
 }

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -82,7 +82,7 @@ public:
     union VariantData;
     
     /// @brief Gets the invalid size value.
-    static PLAYRHO_CONSTEXPR inline Size GetInvalidSize() noexcept
+    static constexpr inline Size GetInvalidSize() noexcept
     {
         return static_cast<Size>(-1);
     }
@@ -93,34 +93,34 @@ public:
     using Height = ContactCounter;
     
     /// @brief Invalid height constant value.
-    static PLAYRHO_CONSTEXPR const auto InvalidHeight = static_cast<Height>(-1);
+    static constexpr const auto InvalidHeight = static_cast<Height>(-1);
 
     /// @brief Gets the invalid height value.
-    static PLAYRHO_CONSTEXPR inline Height GetInvalidHeight() noexcept
+    static constexpr inline Height GetInvalidHeight() noexcept
     {
         return InvalidHeight;
     }
     
     /// @brief Gets whether the given height is the height for an "unused" node.
-    static PLAYRHO_CONSTEXPR inline bool IsUnused(Height value) noexcept
+    static constexpr inline bool IsUnused(Height value) noexcept
     {
         return value == GetInvalidHeight();
     }
     
     /// @brief Gets whether the given height is the height for a "leaf" node.
-    static PLAYRHO_CONSTEXPR inline bool IsLeaf(Height value) noexcept
+    static constexpr inline bool IsLeaf(Height value) noexcept
     {
         return value == 0;
     }
     
     /// @brief Gets whether the given height is a height for a "branch" node.
-    static PLAYRHO_CONSTEXPR inline bool IsBranch(Height value) noexcept
+    static constexpr inline bool IsBranch(Height value) noexcept
     {
         return !IsUnused(value) && !IsLeaf(value);
     }
 
     /// @brief Gets the default initial node capacity.
-    static PLAYRHO_CONSTEXPR inline Size GetDefaultInitialNodeCapacity() noexcept;
+    static constexpr inline Size GetDefaultInitialNodeCapacity() noexcept;
     
     /// @brief Default constructor.
     DynamicTree() noexcept;
@@ -358,7 +358,7 @@ struct DynamicTree::LeafData
 
 /// @brief Equality operator.
 /// @relatedalso DynamicTree::LeafData
-PLAYRHO_CONSTEXPR inline bool operator== (const DynamicTree::LeafData& lhs,
+constexpr inline bool operator== (const DynamicTree::LeafData& lhs,
                                           const DynamicTree::LeafData& rhs) noexcept
 {
     return lhs.fixture == rhs.fixture && lhs.childIndex == rhs.childIndex;
@@ -366,7 +366,7 @@ PLAYRHO_CONSTEXPR inline bool operator== (const DynamicTree::LeafData& lhs,
 
 /// @brief Inequality operator.
 /// @relatedalso DynamicTree::LeafData
-PLAYRHO_CONSTEXPR inline bool operator!= (const DynamicTree::LeafData& lhs,
+constexpr inline bool operator!= (const DynamicTree::LeafData& lhs,
                                           const DynamicTree::LeafData& rhs) noexcept
 {
     return !(lhs == rhs);
@@ -389,31 +389,31 @@ union DynamicTree::VariantData
     VariantData() noexcept = default;
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline VariantData(UnusedData value) noexcept: unused{value} {}
+    constexpr inline VariantData(UnusedData value) noexcept: unused{value} {}
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline VariantData(LeafData value) noexcept: leaf{value} {}
+    constexpr inline VariantData(LeafData value) noexcept: leaf{value} {}
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline VariantData(BranchData value) noexcept: branch{value} {}
+    constexpr inline VariantData(BranchData value) noexcept: branch{value} {}
 };
 
 /// @brief Is unused.
 /// @details Determines whether the given dynamic tree node is an unused node.
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
+constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is leaf.
 /// @details Determines whether the given dynamic tree node is a leaf node.
 ///   Leaf nodes have a pointer to user data.
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
+constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is branch.
 /// @details Determines whether the given dynamic tree node is a branch node.
 ///   Branch nodes have 2 indices to child nodes.
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
+constexpr inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief A node in the dynamic tree.
 /// @note Users do not interact with this directly.
@@ -428,20 +428,20 @@ public:
     ~TreeNode() = default;
     
     /// @brief Copy constructor.
-    PLAYRHO_CONSTEXPR inline TreeNode(const TreeNode& other) = default;
+    constexpr inline TreeNode(const TreeNode& other) = default;
 
     /// @brief Move constructor.
-    PLAYRHO_CONSTEXPR inline TreeNode(TreeNode&& other) = default;
+    constexpr inline TreeNode(TreeNode&& other) = default;
 
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
+    constexpr inline explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_other{other}
     {
         assert(IsUnused(m_height));
     }
 
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline TreeNode(const LeafData& value, AABB aabb,
+    constexpr inline TreeNode(const LeafData& value, AABB aabb,
                                       Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{0}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -449,7 +449,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline TreeNode(const BranchData& value, AABB aabb, Height height,
+    constexpr inline TreeNode(const BranchData& value, AABB aabb, Height height,
                        Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{height}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -462,26 +462,26 @@ public:
     TreeNode& operator= (const TreeNode& other) = default;
     
     /// @brief Gets the node "height".
-    PLAYRHO_CONSTEXPR inline Height GetHeight() const noexcept
+    constexpr inline Height GetHeight() const noexcept
     {
         return m_height;
     }
     
     /// @brief Gets the node's "other" index.
-    PLAYRHO_CONSTEXPR inline Size GetOther() const noexcept
+    constexpr inline Size GetOther() const noexcept
     {
         return m_other;
     }
                 
     /// @brief Sets the node's "other" index to the given value.
-    PLAYRHO_CONSTEXPR inline void SetOther(Size other) noexcept
+    constexpr inline void SetOther(Size other) noexcept
     {
         m_other = other;
     }
 
     /// @brief Gets the node's AABB.
     /// @warning Behavior is undefined if called on a free/unused node!
-    PLAYRHO_CONSTEXPR inline AABB GetAABB() const noexcept
+    constexpr inline AABB GetAABB() const noexcept
     {
         assert(!IsUnused(m_height));
         return m_aabb;
@@ -489,7 +489,7 @@ public:
 
     /// @brief Sets the node's AABB.
     /// @warning Behavior is undefined if called on a free/unused node!
-    PLAYRHO_CONSTEXPR inline void SetAABB(AABB value) noexcept
+    constexpr inline void SetAABB(AABB value) noexcept
     {
         assert(!IsUnused(m_height));
         m_aabb = value;
@@ -497,7 +497,7 @@ public:
     
     /// @brief Gets the node as an "unused" value.
     /// @warning Behavior is undefined unless called on a free/unused node!
-    PLAYRHO_CONSTEXPR inline UnusedData AsUnused() const noexcept
+    constexpr inline UnusedData AsUnused() const noexcept
     {
         assert(IsUnused(m_height));
         return m_variant.unused;
@@ -505,7 +505,7 @@ public:
     
     /// @brief Gets the node as a "leaf" value.
     /// @warning Behavior is undefined unless called on a leaf node!
-    PLAYRHO_CONSTEXPR inline LeafData AsLeaf() const noexcept
+    constexpr inline LeafData AsLeaf() const noexcept
     {
         assert(IsLeaf(m_height));
         return m_variant.leaf;
@@ -513,28 +513,28 @@ public:
     
     /// @brief Gets the node as a "branch" value.
     /// @warning Behavior is undefined unless called on a branch node!
-    PLAYRHO_CONSTEXPR inline BranchData AsBranch() const noexcept
+    constexpr inline BranchData AsBranch() const noexcept
     {
         assert(IsBranch(m_height));
         return m_variant.branch;
     }
 
     /// @brief Gets the node as an "unused" value.
-    PLAYRHO_CONSTEXPR inline void Assign(const UnusedData& v) noexcept
+    constexpr inline void Assign(const UnusedData& v) noexcept
     {
         m_variant.unused = v;
         m_height = static_cast<Height>(-1);
     }
     
     /// @brief Gets the node as a "leaf" value.
-    PLAYRHO_CONSTEXPR inline void Assign(const LeafData& v) noexcept
+    constexpr inline void Assign(const LeafData& v) noexcept
     {
         m_variant.leaf = v;
         m_height = 0;
     }
     
     /// @brief Assigns the node as a "branch" value.
-    PLAYRHO_CONSTEXPR inline void Assign(const BranchData& v, const AABB& bb, Height h) noexcept
+    constexpr inline void Assign(const BranchData& v, const AABB& bb, Height h) noexcept
     {
         assert(v.child1 != GetInvalidSize());
         assert(v.child2 != GetInvalidSize());
@@ -565,7 +565,7 @@ private:
     VariantData m_variant{UnusedData{}};
 };
 
-PLAYRHO_CONSTEXPR inline DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
+constexpr inline DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
 {
     return Size{64};
 }
@@ -648,7 +648,7 @@ inline void DynamicTree::SetLeafData(Size index, LeafData value) noexcept
 // Free functions...
 
 /// @brief Replaces the old child with the new child.
-PLAYRHO_CONSTEXPR inline DynamicTree::BranchData
+constexpr inline DynamicTree::BranchData
 ReplaceChild(DynamicTree::BranchData bd, DynamicTree::Size oldChild, DynamicTree::Size newChild)
 {
     assert(bd.child1 == oldChild || bd.child2 == oldChild);
@@ -658,7 +658,7 @@ ReplaceChild(DynamicTree::BranchData bd, DynamicTree::Size oldChild, DynamicTree
 
 /// @brief Whether this node is free (or allocated).
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
+constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsUnused(node.GetHeight());
 }
@@ -667,7 +667,7 @@ PLAYRHO_CONSTEXPR inline bool IsUnused(const DynamicTree::TreeNode& node) noexce
 /// @note This has constant complexity.
 /// @return <code>true</code> if this is a leaf node, <code>false</code> otherwise.
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
+constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsLeaf(node.GetHeight());
 }
@@ -675,14 +675,14 @@ PLAYRHO_CONSTEXPR inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 /// @brief Is branch.
 /// @details Determines whether the given node is a "branch" node.
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
+constexpr inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsBranch(node.GetHeight());
 }
 
 /// @brief Gets the AABB of the given dynamic tree node.
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
+constexpr inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
 {
     assert(!IsUnused(node));
     return node.GetAABB();
@@ -691,7 +691,7 @@ PLAYRHO_CONSTEXPR inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcep
 /// @brief Gets the next index of the given node.
 /// @warning Behavior is undefined if the given node is not an "unused" node.
 /// @relatedalso DynamicTree::TreeNode
-PLAYRHO_CONSTEXPR inline DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
+constexpr inline DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
 {
     assert(IsUnused(node));
     return node.GetOther();

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -82,7 +82,7 @@ public:
     union VariantData;
     
     /// @brief Gets the invalid size value.
-    static constexpr inline Size GetInvalidSize() noexcept
+    static constexpr Size GetInvalidSize() noexcept
     {
         return static_cast<Size>(-1);
     }
@@ -96,31 +96,31 @@ public:
     static constexpr const auto InvalidHeight = static_cast<Height>(-1);
 
     /// @brief Gets the invalid height value.
-    static constexpr inline Height GetInvalidHeight() noexcept
+    static constexpr Height GetInvalidHeight() noexcept
     {
         return InvalidHeight;
     }
     
     /// @brief Gets whether the given height is the height for an "unused" node.
-    static constexpr inline bool IsUnused(Height value) noexcept
+    static constexpr bool IsUnused(Height value) noexcept
     {
         return value == GetInvalidHeight();
     }
     
     /// @brief Gets whether the given height is the height for a "leaf" node.
-    static constexpr inline bool IsLeaf(Height value) noexcept
+    static constexpr bool IsLeaf(Height value) noexcept
     {
         return value == 0;
     }
     
     /// @brief Gets whether the given height is a height for a "branch" node.
-    static constexpr inline bool IsBranch(Height value) noexcept
+    static constexpr bool IsBranch(Height value) noexcept
     {
         return !IsUnused(value) && !IsLeaf(value);
     }
 
     /// @brief Gets the default initial node capacity.
-    static constexpr inline Size GetDefaultInitialNodeCapacity() noexcept;
+    static constexpr Size GetDefaultInitialNodeCapacity() noexcept;
     
     /// @brief Default constructor.
     DynamicTree() noexcept;
@@ -358,7 +358,7 @@ struct DynamicTree::LeafData
 
 /// @brief Equality operator.
 /// @relatedalso DynamicTree::LeafData
-constexpr inline bool operator== (const DynamicTree::LeafData& lhs,
+constexpr bool operator== (const DynamicTree::LeafData& lhs,
                                           const DynamicTree::LeafData& rhs) noexcept
 {
     return lhs.fixture == rhs.fixture && lhs.childIndex == rhs.childIndex;
@@ -366,7 +366,7 @@ constexpr inline bool operator== (const DynamicTree::LeafData& lhs,
 
 /// @brief Inequality operator.
 /// @relatedalso DynamicTree::LeafData
-constexpr inline bool operator!= (const DynamicTree::LeafData& lhs,
+constexpr bool operator!= (const DynamicTree::LeafData& lhs,
                                           const DynamicTree::LeafData& rhs) noexcept
 {
     return !(lhs == rhs);
@@ -389,31 +389,31 @@ union DynamicTree::VariantData
     VariantData() noexcept = default;
     
     /// @brief Initializing constructor.
-    constexpr inline VariantData(UnusedData value) noexcept: unused{value} {}
+    constexpr VariantData(UnusedData value) noexcept: unused{value} {}
     
     /// @brief Initializing constructor.
-    constexpr inline VariantData(LeafData value) noexcept: leaf{value} {}
+    constexpr VariantData(LeafData value) noexcept: leaf{value} {}
     
     /// @brief Initializing constructor.
-    constexpr inline VariantData(BranchData value) noexcept: branch{value} {}
+    constexpr VariantData(BranchData value) noexcept: branch{value} {}
 };
 
 /// @brief Is unused.
 /// @details Determines whether the given dynamic tree node is an unused node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
+constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is leaf.
 /// @details Determines whether the given dynamic tree node is a leaf node.
 ///   Leaf nodes have a pointer to user data.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
+constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief Is branch.
 /// @details Determines whether the given dynamic tree node is a branch node.
 ///   Branch nodes have 2 indices to child nodes.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
+constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
 
 /// @brief A node in the dynamic tree.
 /// @note Users do not interact with this directly.
@@ -428,20 +428,20 @@ public:
     ~TreeNode() = default;
     
     /// @brief Copy constructor.
-    constexpr inline TreeNode(const TreeNode& other) = default;
+    constexpr TreeNode(const TreeNode& other) = default;
 
     /// @brief Move constructor.
-    constexpr inline TreeNode(TreeNode&& other) = default;
+    constexpr TreeNode(TreeNode&& other) = default;
 
     /// @brief Initializing constructor.
-    constexpr inline explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
+    constexpr explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_other{other}
     {
         assert(IsUnused(m_height));
     }
 
     /// @brief Initializing constructor.
-    constexpr inline TreeNode(const LeafData& value, AABB aabb,
+    constexpr TreeNode(const LeafData& value, AABB aabb,
                                       Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{0}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -449,7 +449,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr inline TreeNode(const BranchData& value, AABB aabb, Height height,
+    constexpr TreeNode(const BranchData& value, AABB aabb, Height height,
                        Size other = DynamicTree::GetInvalidSize()) noexcept:
         m_height{height}, m_other{other}, m_aabb{aabb}, m_variant{value}
     {
@@ -462,26 +462,26 @@ public:
     TreeNode& operator= (const TreeNode& other) = default;
     
     /// @brief Gets the node "height".
-    constexpr inline Height GetHeight() const noexcept
+    constexpr Height GetHeight() const noexcept
     {
         return m_height;
     }
     
     /// @brief Gets the node's "other" index.
-    constexpr inline Size GetOther() const noexcept
+    constexpr Size GetOther() const noexcept
     {
         return m_other;
     }
                 
     /// @brief Sets the node's "other" index to the given value.
-    constexpr inline void SetOther(Size other) noexcept
+    constexpr void SetOther(Size other) noexcept
     {
         m_other = other;
     }
 
     /// @brief Gets the node's AABB.
     /// @warning Behavior is undefined if called on a free/unused node!
-    constexpr inline AABB GetAABB() const noexcept
+    constexpr AABB GetAABB() const noexcept
     {
         assert(!IsUnused(m_height));
         return m_aabb;
@@ -489,7 +489,7 @@ public:
 
     /// @brief Sets the node's AABB.
     /// @warning Behavior is undefined if called on a free/unused node!
-    constexpr inline void SetAABB(AABB value) noexcept
+    constexpr void SetAABB(AABB value) noexcept
     {
         assert(!IsUnused(m_height));
         m_aabb = value;
@@ -497,7 +497,7 @@ public:
     
     /// @brief Gets the node as an "unused" value.
     /// @warning Behavior is undefined unless called on a free/unused node!
-    constexpr inline UnusedData AsUnused() const noexcept
+    constexpr UnusedData AsUnused() const noexcept
     {
         assert(IsUnused(m_height));
         return m_variant.unused;
@@ -505,7 +505,7 @@ public:
     
     /// @brief Gets the node as a "leaf" value.
     /// @warning Behavior is undefined unless called on a leaf node!
-    constexpr inline LeafData AsLeaf() const noexcept
+    constexpr LeafData AsLeaf() const noexcept
     {
         assert(IsLeaf(m_height));
         return m_variant.leaf;
@@ -513,28 +513,28 @@ public:
     
     /// @brief Gets the node as a "branch" value.
     /// @warning Behavior is undefined unless called on a branch node!
-    constexpr inline BranchData AsBranch() const noexcept
+    constexpr BranchData AsBranch() const noexcept
     {
         assert(IsBranch(m_height));
         return m_variant.branch;
     }
 
     /// @brief Gets the node as an "unused" value.
-    constexpr inline void Assign(const UnusedData& v) noexcept
+    constexpr void Assign(const UnusedData& v) noexcept
     {
         m_variant.unused = v;
         m_height = static_cast<Height>(-1);
     }
     
     /// @brief Gets the node as a "leaf" value.
-    constexpr inline void Assign(const LeafData& v) noexcept
+    constexpr void Assign(const LeafData& v) noexcept
     {
         m_variant.leaf = v;
         m_height = 0;
     }
     
     /// @brief Assigns the node as a "branch" value.
-    constexpr inline void Assign(const BranchData& v, const AABB& bb, Height h) noexcept
+    constexpr void Assign(const BranchData& v, const AABB& bb, Height h) noexcept
     {
         assert(v.child1 != GetInvalidSize());
         assert(v.child2 != GetInvalidSize());
@@ -565,7 +565,7 @@ private:
     VariantData m_variant{UnusedData{}};
 };
 
-constexpr inline DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
+constexpr DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
 {
     return Size{64};
 }
@@ -648,7 +648,7 @@ inline void DynamicTree::SetLeafData(Size index, LeafData value) noexcept
 // Free functions...
 
 /// @brief Replaces the old child with the new child.
-constexpr inline DynamicTree::BranchData
+constexpr DynamicTree::BranchData
 ReplaceChild(DynamicTree::BranchData bd, DynamicTree::Size oldChild, DynamicTree::Size newChild)
 {
     assert(bd.child1 == oldChild || bd.child2 == oldChild);
@@ -658,7 +658,7 @@ ReplaceChild(DynamicTree::BranchData bd, DynamicTree::Size oldChild, DynamicTree
 
 /// @brief Whether this node is free (or allocated).
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
+constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsUnused(node.GetHeight());
 }
@@ -667,7 +667,7 @@ constexpr inline bool IsUnused(const DynamicTree::TreeNode& node) noexcept
 /// @note This has constant complexity.
 /// @return <code>true</code> if this is a leaf node, <code>false</code> otherwise.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
+constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsLeaf(node.GetHeight());
 }
@@ -675,14 +675,14 @@ constexpr inline bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
 /// @brief Is branch.
 /// @details Determines whether the given node is a "branch" node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline bool IsBranch(const DynamicTree::TreeNode& node) noexcept
+constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept
 {
     return DynamicTree::IsBranch(node.GetHeight());
 }
 
 /// @brief Gets the AABB of the given dynamic tree node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
+constexpr AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
 {
     assert(!IsUnused(node));
     return node.GetAABB();
@@ -691,7 +691,7 @@ constexpr inline AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
 /// @brief Gets the next index of the given node.
 /// @warning Behavior is undefined if the given node is not an "unused" node.
 /// @relatedalso DynamicTree::TreeNode
-constexpr inline DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
+constexpr DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
 {
     assert(IsUnused(node));
     return node.GetOther();

--- a/PlayRho/Collision/IndexPair.hpp
+++ b/PlayRho/Collision/IndexPair.hpp
@@ -57,7 +57,7 @@ static_assert(MaxSimplexEdges == 3, "Invalid assumption about size of MaxSimplex
 /// @note Any element with a value of <code>InvalidIndexPair</code> is interpreted
 ///   as being invalid in this context.
 /// @return Value between 0 and 3 inclusive.
-constexpr inline std::size_t GetNumValidIndices(IndexPair3 pairs) noexcept
+constexpr std::size_t GetNumValidIndices(IndexPair3 pairs) noexcept
 {
     return std::size_t{3}
     - ((std::get<0>(pairs) == InvalidIndexPair)? 1u: 0u)
@@ -66,7 +66,7 @@ constexpr inline std::size_t GetNumValidIndices(IndexPair3 pairs) noexcept
 }
 
 /// @brief Checks whether the given collection of index pairs is empty.
-constexpr inline bool empty(IndexPair3 pairs) noexcept
+constexpr bool empty(IndexPair3 pairs) noexcept
 {
     return GetNumValidIndices(pairs) == 0;
 }
@@ -74,14 +74,14 @@ constexpr inline bool empty(IndexPair3 pairs) noexcept
 /// @brief Gets the dynamic size of the given collection of index pairs.
 /// @note This just calls <code>GetNumValidIndices</code>.
 /// @sa GetNumValidIndices
-constexpr inline auto size(IndexPair3 pairs) -> decltype(GetNumValidIndices(pairs))
+constexpr auto size(IndexPair3 pairs) -> decltype(GetNumValidIndices(pairs))
 {
     return GetNumValidIndices(pairs);
 }
 
 /// @brief Gets the maximum size of the given container of index pairs.
 /// @return Always returns 3.
-constexpr inline auto max_size(IndexPair3 pairs) -> decltype(pairs.max_size())
+constexpr auto max_size(IndexPair3 pairs) -> decltype(pairs.max_size())
 {
     return pairs.max_size();
 }

--- a/PlayRho/Collision/IndexPair.hpp
+++ b/PlayRho/Collision/IndexPair.hpp
@@ -36,7 +36,7 @@ namespace playrho {
 using IndexPair = std::pair<VertexCounter, VertexCounter>;
 
 /// @brief Invalid index-pair value.
-PLAYRHO_CONSTEXPR const auto InvalidIndexPair = IndexPair{
+constexpr const auto InvalidIndexPair = IndexPair{
     InvalidVertex, InvalidVertex
 };
 
@@ -47,7 +47,7 @@ PLAYRHO_CONSTEXPR const auto InvalidIndexPair = IndexPair{
 using IndexPair3 = std::array<IndexPair, MaxSimplexEdges>;
 
 /// @brief Invalid array of three index-pair elements.
-PLAYRHO_CONSTEXPR const auto InvalidIndexPair3 = IndexPair3{{
+constexpr const auto InvalidIndexPair3 = IndexPair3{{
     InvalidIndexPair, InvalidIndexPair, InvalidIndexPair
 }};
 
@@ -57,7 +57,7 @@ static_assert(MaxSimplexEdges == 3, "Invalid assumption about size of MaxSimplex
 /// @note Any element with a value of <code>InvalidIndexPair</code> is interpreted
 ///   as being invalid in this context.
 /// @return Value between 0 and 3 inclusive.
-PLAYRHO_CONSTEXPR inline std::size_t GetNumValidIndices(IndexPair3 pairs) noexcept
+constexpr inline std::size_t GetNumValidIndices(IndexPair3 pairs) noexcept
 {
     return std::size_t{3}
     - ((std::get<0>(pairs) == InvalidIndexPair)? 1u: 0u)
@@ -66,7 +66,7 @@ PLAYRHO_CONSTEXPR inline std::size_t GetNumValidIndices(IndexPair3 pairs) noexce
 }
 
 /// @brief Checks whether the given collection of index pairs is empty.
-PLAYRHO_CONSTEXPR inline bool empty(IndexPair3 pairs) noexcept
+constexpr inline bool empty(IndexPair3 pairs) noexcept
 {
     return GetNumValidIndices(pairs) == 0;
 }
@@ -74,14 +74,14 @@ PLAYRHO_CONSTEXPR inline bool empty(IndexPair3 pairs) noexcept
 /// @brief Gets the dynamic size of the given collection of index pairs.
 /// @note This just calls <code>GetNumValidIndices</code>.
 /// @sa GetNumValidIndices
-PLAYRHO_CONSTEXPR inline auto size(IndexPair3 pairs) -> decltype(GetNumValidIndices(pairs))
+constexpr inline auto size(IndexPair3 pairs) -> decltype(GetNumValidIndices(pairs))
 {
     return GetNumValidIndices(pairs);
 }
 
 /// @brief Gets the maximum size of the given container of index pairs.
 /// @return Always returns 3.
-PLAYRHO_CONSTEXPR inline auto max_size(IndexPair3 pairs) -> decltype(pairs.max_size())
+constexpr inline auto max_size(IndexPair3 pairs) -> decltype(pairs.max_size())
 {
     return pairs.max_size();
 }

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -534,7 +534,7 @@ Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
         }
     }
     
-    PLAYRHO_CONSTEXPR const auto k_tol = PLAYRHO_MAGIC(DefaultLinearSlop / Real{10});
+    constexpr const auto k_tol = PLAYRHO_MAGIC(DefaultLinearSlop / Real{10});
     return (edgeSepB.separation > (edgeSepA.separation + k_tol))?
     GetManifold(Manifold::e_faceB,
                 shapeB, xfB, edgeSepB.index1,

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -314,7 +314,7 @@ public:
     /// @note This must be a constant expression in order to use it in the context
     ///   of the <code>IsValid</code> specialized template function for it.
     ///
-    PLAYRHO_CONSTEXPR inline Type GetType() const noexcept { return m_type; }
+    constexpr inline Type GetType() const noexcept { return m_type; }
     
     /// Gets the manifold point count.
     ///
@@ -329,10 +329,10 @@ public:
     /// @sa AddPoint().
     /// @sa GetPoint().
     ///
-    PLAYRHO_CONSTEXPR inline size_type GetPointCount() const noexcept { return m_pointCount; }
+    constexpr inline size_type GetPointCount() const noexcept { return m_pointCount; }
     
     /// @brief Gets the contact feature for the given index.
-    PLAYRHO_CONSTEXPR inline ContactFeature GetContactFeature(size_type index) const noexcept
+    constexpr inline ContactFeature GetContactFeature(size_type index) const noexcept
     {
         assert(index < m_pointCount);
         return m_points[index].contactFeature;
@@ -341,7 +341,7 @@ public:
     /// @brief Gets the contact impulses for the given index.
     /// @return Pair of impulses where the first impulse is the "normal impulse"
     ///   and the second impulse is the "tangent impulse".
-    PLAYRHO_CONSTEXPR inline Momentum2 GetContactImpulses(size_type index) const noexcept
+    constexpr inline Momentum2 GetContactImpulses(size_type index) const noexcept
     {
         assert(index < m_pointCount);
         return Momentum2{m_points[index].normalImpulse, m_points[index].tangentImpulse};
@@ -388,7 +388,7 @@ public:
     /// @warning Behavior is undefined for unset (e_unset) type manifolds.
     /// @warning Behavior is undefined for circles (e_circles) type manifolds.
     /// @return Local normal if the manifold type is face A or face B, else invalid value.
-    PLAYRHO_CONSTEXPR inline UnitVec GetLocalNormal() const noexcept
+    constexpr inline UnitVec GetLocalNormal() const noexcept
     {
         assert(m_type != e_unset);
         assert(m_type != e_circles);
@@ -403,14 +403,14 @@ public:
     /// @note Only valid for circle, face-A, or face-B type manifolds.
     /// @warning Behavior is undefined for unset (e_unset) type manifolds.
     /// @return Local point.
-    PLAYRHO_CONSTEXPR inline Length2 GetLocalPoint() const noexcept
+    constexpr inline Length2 GetLocalPoint() const noexcept
     {
         assert(m_type != e_unset);
         return m_localPoint;
     }
     
     /// @brief Gets the opposing point.
-    PLAYRHO_CONSTEXPR inline Length2 GetOpposingPoint(size_type index) const noexcept
+    constexpr inline Length2 GetOpposingPoint(size_type index) const noexcept
     {
         assert((0 <= index) && (index < m_pointCount));
         return m_points[index].localPoint;
@@ -424,10 +424,10 @@ private:
         Point elements[MaxManifoldPoints]; ///< Elements.
 
         /// @brief Array indexing operator.
-        PLAYRHO_CONSTEXPR inline Point& operator[](std::size_t i) { return elements[i]; }
+        constexpr inline Point& operator[](std::size_t i) { return elements[i]; }
         
         /// @brief Array indexing operator.
-        PLAYRHO_CONSTEXPR const Point& operator[](std::size_t i) const { return elements[i]; }
+        constexpr const Point& operator[](std::size_t i) const { return elements[i]; }
     };
 
     /// Constructs manifold with array of points using the given values.
@@ -436,7 +436,7 @@ private:
     /// @param lp Local point.
     /// @param n number of points defined in array.
     /// @param mpa Manifold point array.
-    PLAYRHO_CONSTEXPR inline Manifold(Type t, UnitVec ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
+    constexpr inline Manifold(Type t, UnitVec ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
     
     Type m_type = e_unset; ///< Type of collision this manifold is associated with (1-byte).
     size_type m_pointCount = 0; ///< Number of defined manifold points (1-byte).
@@ -476,12 +476,12 @@ struct Manifold::Conf
 
 /// @brief Gets the default manifold configuration.
 /// @relatedalso Manifold::Conf
-PLAYRHO_CONSTEXPR inline Manifold::Conf GetDefaultManifoldConf() noexcept
+constexpr inline Manifold::Conf GetDefaultManifoldConf() noexcept
 {
     return Manifold::Conf{};
 }
 
-PLAYRHO_CONSTEXPR inline Manifold::Manifold(Type t, UnitVec ln, Length2 lp, size_type n,
+constexpr inline Manifold::Manifold(Type t, UnitVec ln, Length2 lp, size_type n,
                                           const PointArray& mpa) noexcept:
     m_type{t}, m_pointCount{n}, m_localNormal{ln}, m_localPoint{lp}, m_points{mpa}
 {
@@ -617,7 +617,7 @@ const char* GetName(Manifold::Type type) noexcept;
 /// @brief Gets whether the given manifold is valid.
 /// @relatedalso d2::Manifold
 template <>
-PLAYRHO_CONSTEXPR inline bool IsValid(const d2::Manifold& value) noexcept
+constexpr inline bool IsValid(const d2::Manifold& value) noexcept
 {
     return value.GetType() != d2::Manifold::e_unset;
 }

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -314,7 +314,7 @@ public:
     /// @note This must be a constant expression in order to use it in the context
     ///   of the <code>IsValid</code> specialized template function for it.
     ///
-    constexpr inline Type GetType() const noexcept { return m_type; }
+    constexpr Type GetType() const noexcept { return m_type; }
     
     /// Gets the manifold point count.
     ///
@@ -329,10 +329,10 @@ public:
     /// @sa AddPoint().
     /// @sa GetPoint().
     ///
-    constexpr inline size_type GetPointCount() const noexcept { return m_pointCount; }
+    constexpr size_type GetPointCount() const noexcept { return m_pointCount; }
     
     /// @brief Gets the contact feature for the given index.
-    constexpr inline ContactFeature GetContactFeature(size_type index) const noexcept
+    constexpr ContactFeature GetContactFeature(size_type index) const noexcept
     {
         assert(index < m_pointCount);
         return m_points[index].contactFeature;
@@ -341,7 +341,7 @@ public:
     /// @brief Gets the contact impulses for the given index.
     /// @return Pair of impulses where the first impulse is the "normal impulse"
     ///   and the second impulse is the "tangent impulse".
-    constexpr inline Momentum2 GetContactImpulses(size_type index) const noexcept
+    constexpr Momentum2 GetContactImpulses(size_type index) const noexcept
     {
         assert(index < m_pointCount);
         return Momentum2{m_points[index].normalImpulse, m_points[index].tangentImpulse};
@@ -388,7 +388,7 @@ public:
     /// @warning Behavior is undefined for unset (e_unset) type manifolds.
     /// @warning Behavior is undefined for circles (e_circles) type manifolds.
     /// @return Local normal if the manifold type is face A or face B, else invalid value.
-    constexpr inline UnitVec GetLocalNormal() const noexcept
+    constexpr UnitVec GetLocalNormal() const noexcept
     {
         assert(m_type != e_unset);
         assert(m_type != e_circles);
@@ -403,14 +403,14 @@ public:
     /// @note Only valid for circle, face-A, or face-B type manifolds.
     /// @warning Behavior is undefined for unset (e_unset) type manifolds.
     /// @return Local point.
-    constexpr inline Length2 GetLocalPoint() const noexcept
+    constexpr Length2 GetLocalPoint() const noexcept
     {
         assert(m_type != e_unset);
         return m_localPoint;
     }
     
     /// @brief Gets the opposing point.
-    constexpr inline Length2 GetOpposingPoint(size_type index) const noexcept
+    constexpr Length2 GetOpposingPoint(size_type index) const noexcept
     {
         assert((0 <= index) && (index < m_pointCount));
         return m_points[index].localPoint;
@@ -424,7 +424,7 @@ private:
         Point elements[MaxManifoldPoints]; ///< Elements.
 
         /// @brief Array indexing operator.
-        constexpr inline Point& operator[](std::size_t i) { return elements[i]; }
+        constexpr Point& operator[](std::size_t i) { return elements[i]; }
         
         /// @brief Array indexing operator.
         constexpr const Point& operator[](std::size_t i) const { return elements[i]; }
@@ -436,7 +436,7 @@ private:
     /// @param lp Local point.
     /// @param n number of points defined in array.
     /// @param mpa Manifold point array.
-    constexpr inline Manifold(Type t, UnitVec ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
+    constexpr Manifold(Type t, UnitVec ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
     
     Type m_type = e_unset; ///< Type of collision this manifold is associated with (1-byte).
     size_type m_pointCount = 0; ///< Number of defined manifold points (1-byte).
@@ -476,12 +476,12 @@ struct Manifold::Conf
 
 /// @brief Gets the default manifold configuration.
 /// @relatedalso Manifold::Conf
-constexpr inline Manifold::Conf GetDefaultManifoldConf() noexcept
+constexpr Manifold::Conf GetDefaultManifoldConf() noexcept
 {
     return Manifold::Conf{};
 }
 
-constexpr inline Manifold::Manifold(Type t, UnitVec ln, Length2 lp, size_type n,
+constexpr Manifold::Manifold(Type t, UnitVec ln, Length2 lp, size_type n,
                                           const PointArray& mpa) noexcept:
     m_type{t}, m_pointCount{n}, m_localNormal{ln}, m_localPoint{lp}, m_points{mpa}
 {
@@ -617,7 +617,7 @@ const char* GetName(Manifold::Type type) noexcept;
 /// @brief Gets whether the given manifold is valid.
 /// @relatedalso d2::Manifold
 template <>
-constexpr inline bool IsValid(const d2::Manifold& value) noexcept
+constexpr bool IsValid(const d2::Manifold& value) noexcept
 {
     return value.GetType() != d2::Manifold::e_unset;
 }

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -145,18 +145,18 @@ MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
         
         const auto D = Cross(e1, e2);
         
-        PLAYRHO_CONSTEXPR const auto RealReciprocalOfTwo = Real{1} / Real{2}; // .5
+        constexpr const auto RealReciprocalOfTwo = Real{1} / Real{2}; // .5
         const auto triangleArea = D * RealReciprocalOfTwo;
         area += triangleArea;
         
         // Area weighted centroid
-        PLAYRHO_CONSTEXPR const auto RealReciprocalOfThree = Real{1} / Real{3}; // .3333333...
+        constexpr const auto RealReciprocalOfThree = Real{1} / Real{3}; // .3333333...
         center += StripUnit(triangleArea) * (e1 + e2) * RealReciprocalOfThree;
         
         const auto intx2 = Square(GetX(e1)) + GetX(e2) * GetX(e1) + Square(GetX(e2));
         const auto inty2 = Square(GetY(e1)) + GetY(e2) * GetY(e1) + Square(GetY(e2));
         
-        PLAYRHO_CONSTEXPR const auto RealReciprocalOfTwelve = Real{1} / Real{3 * 4}; // .083333..
+        constexpr const auto RealReciprocalOfTwelve = Real{1} / Real{3 * 4}; // .083333..
         const auto triangleI = D * (intx2 + inty2) * RealReciprocalOfTwelve;
         I += triangleI;
     }

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -53,7 +53,7 @@ struct MassData
 /// @brief Equality operator for mass data.
 /// @relatedalso MassData
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator== (MassData<N> lhs, MassData<N> rhs)
+constexpr inline bool operator== (MassData<N> lhs, MassData<N> rhs)
 {
     return lhs.center == rhs.center && lhs.mass == rhs.mass && lhs.I == rhs.I;
 }
@@ -61,7 +61,7 @@ PLAYRHO_CONSTEXPR inline bool operator== (MassData<N> lhs, MassData<N> rhs)
 /// @brief Inequality operator for mass data.
 /// @relatedalso MassData
 template <std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator!= (MassData<N> lhs, MassData<N> rhs)
+constexpr inline bool operator!= (MassData<N> lhs, MassData<N> rhs)
 {
     return !(lhs == rhs);
 }

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -53,7 +53,7 @@ struct MassData
 /// @brief Equality operator for mass data.
 /// @relatedalso MassData
 template <std::size_t N>
-constexpr inline bool operator== (MassData<N> lhs, MassData<N> rhs)
+constexpr bool operator== (MassData<N> lhs, MassData<N> rhs)
 {
     return lhs.center == rhs.center && lhs.mass == rhs.mass && lhs.I == rhs.I;
 }
@@ -61,7 +61,7 @@ constexpr inline bool operator== (MassData<N> lhs, MassData<N> rhs)
 /// @brief Inequality operator for mass data.
 /// @relatedalso MassData
 template <std::size_t N>
-constexpr inline bool operator!= (MassData<N> lhs, MassData<N> rhs)
+constexpr bool operator!= (MassData<N> lhs, MassData<N> rhs)
 {
     return !(lhs == rhs);
 }

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -50,7 +50,7 @@ class ChainShapeConf: public ShapeBuilder<ChainShapeConf>
 {
 public:
     /// @brief Gets the default vertex radius.
-    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * Real{2}};
     }

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -50,7 +50,7 @@ class ChainShapeConf: public ShapeBuilder<ChainShapeConf>
 {
 public:
     /// @brief Gets the default vertex radius.
-    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * Real{2}};
     }

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -41,28 +41,28 @@ namespace d2 {
 struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
 {
     /// @brief Gets the default radius.
-    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultRadius() noexcept
+    static constexpr inline NonNegative<Length> GetDefaultRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * 2};
     }
 
-    PLAYRHO_CONSTEXPR DiskShapeConf() = default;
+    constexpr DiskShapeConf() = default;
 
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline DiskShapeConf(NonNegative<Length> r): vertexRadius{r}
+    constexpr inline DiskShapeConf(NonNegative<Length> r): vertexRadius{r}
     {
         // Intentionally empty.
     }
 
     /// @brief Uses the given value as the location.
-    PLAYRHO_CONSTEXPR inline DiskShapeConf& UseLocation(Length2 value) noexcept
+    constexpr inline DiskShapeConf& UseLocation(Length2 value) noexcept
     {
         location = value;
         return *this;
     }
     
     /// @brief Uses the given value as the radius.
-    PLAYRHO_CONSTEXPR inline DiskShapeConf& UseRadius(NonNegative<Length> r) noexcept
+    constexpr inline DiskShapeConf& UseRadius(NonNegative<Length> r) noexcept
     {
         vertexRadius = r;
         return *this;
@@ -70,7 +70,7 @@ struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
     
     /// @brief Transforms the location by the given transformation matrix.
     /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
-    PLAYRHO_CONSTEXPR inline DiskShapeConf& Transform(const Mat22& m) noexcept
+    constexpr inline DiskShapeConf& Transform(const Mat22& m) noexcept
     {
         location = m * location;
         return *this;
@@ -122,7 +122,7 @@ inline bool operator!= (const DiskShapeConf& lhs, const DiskShapeConf& rhs) noex
 }
 
 /// @brief Gets the "child" count of the given disk shape configuration.
-PLAYRHO_CONSTEXPR inline ChildCounter GetChildCount(const DiskShapeConf&) noexcept
+constexpr inline ChildCounter GetChildCount(const DiskShapeConf&) noexcept
 {
     return 1;
 }
@@ -138,13 +138,13 @@ inline DistanceProxy GetChild(const DiskShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-PLAYRHO_CONSTEXPR inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg) noexcept
+constexpr inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg) noexcept
 {
     return arg.vertexRadius;
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-PLAYRHO_CONSTEXPR inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg,
+constexpr inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg,
                                                              ChildCounter) noexcept
 {
     return GetVertexRadius(arg);

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -41,7 +41,7 @@ namespace d2 {
 struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
 {
     /// @brief Gets the default radius.
-    static constexpr inline NonNegative<Length> GetDefaultRadius() noexcept
+    static constexpr NonNegative<Length> GetDefaultRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * 2};
     }
@@ -49,20 +49,20 @@ struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
     constexpr DiskShapeConf() = default;
 
     /// @brief Initializing constructor.
-    constexpr inline DiskShapeConf(NonNegative<Length> r): vertexRadius{r}
+    constexpr DiskShapeConf(NonNegative<Length> r): vertexRadius{r}
     {
         // Intentionally empty.
     }
 
     /// @brief Uses the given value as the location.
-    constexpr inline DiskShapeConf& UseLocation(Length2 value) noexcept
+    constexpr DiskShapeConf& UseLocation(Length2 value) noexcept
     {
         location = value;
         return *this;
     }
     
     /// @brief Uses the given value as the radius.
-    constexpr inline DiskShapeConf& UseRadius(NonNegative<Length> r) noexcept
+    constexpr DiskShapeConf& UseRadius(NonNegative<Length> r) noexcept
     {
         vertexRadius = r;
         return *this;
@@ -70,7 +70,7 @@ struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
     
     /// @brief Transforms the location by the given transformation matrix.
     /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
-    constexpr inline DiskShapeConf& Transform(const Mat22& m) noexcept
+    constexpr DiskShapeConf& Transform(const Mat22& m) noexcept
     {
         location = m * location;
         return *this;
@@ -122,7 +122,7 @@ inline bool operator!= (const DiskShapeConf& lhs, const DiskShapeConf& rhs) noex
 }
 
 /// @brief Gets the "child" count of the given disk shape configuration.
-constexpr inline ChildCounter GetChildCount(const DiskShapeConf&) noexcept
+constexpr ChildCounter GetChildCount(const DiskShapeConf&) noexcept
 {
     return 1;
 }
@@ -138,13 +138,13 @@ inline DistanceProxy GetChild(const DiskShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-constexpr inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg) noexcept
+constexpr NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg) noexcept
 {
     return arg.vertexRadius;
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-constexpr inline NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg,
+constexpr NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg,
                                                              ChildCounter) noexcept
 {
     return GetVertexRadius(arg);

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -42,7 +42,7 @@ class EdgeShapeConf: public ShapeBuilder<EdgeShapeConf>
 {
 public:
     /// @brief Gets the default vertex radius.
-    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * Real{2}};
     }
@@ -128,7 +128,7 @@ inline bool operator!= (const EdgeShapeConf& lhs, const EdgeShapeConf& rhs) noex
 
 /// @brief Gets the "child" count for the given shape configuration.
 /// @return 1.
-PLAYRHO_CONSTEXPR inline ChildCounter GetChildCount(const EdgeShapeConf&) noexcept
+constexpr inline ChildCounter GetChildCount(const EdgeShapeConf&) noexcept
 {
     return 1;
 }

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -42,7 +42,7 @@ class EdgeShapeConf: public ShapeBuilder<EdgeShapeConf>
 {
 public:
     /// @brief Gets the default vertex radius.
-    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * Real{2}};
     }
@@ -128,7 +128,7 @@ inline bool operator!= (const EdgeShapeConf& lhs, const EdgeShapeConf& rhs) noex
 
 /// @brief Gets the "child" count for the given shape configuration.
 /// @return 1.
-constexpr inline ChildCounter GetChildCount(const EdgeShapeConf&) noexcept
+constexpr ChildCounter GetChildCount(const EdgeShapeConf&) noexcept
 {
     return 1;
 }

--- a/PlayRho/Collision/Shapes/MultiShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.hpp
@@ -111,7 +111,7 @@ private:
 struct MultiShapeConf: public ShapeBuilder<MultiShapeConf>
 {
     /// @brief Gets the default vertex radius for the <code>MultiShapeConf</code>.
-    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * 2};
     }

--- a/PlayRho/Collision/Shapes/MultiShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.hpp
@@ -111,7 +111,7 @@ private:
 struct MultiShapeConf: public ShapeBuilder<MultiShapeConf>
 {
     /// @brief Gets the default vertex radius for the <code>MultiShapeConf</code>.
-    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * 2};
     }

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -42,7 +42,7 @@ class PolygonShapeConf: public ShapeBuilder<PolygonShapeConf>
 {
 public:
     /// @brief Gets the default vertex radius for the <code>PolygonShapeConf</code>.
-    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * 2};
     }
@@ -198,7 +198,7 @@ inline PolygonShapeConf& PolygonShapeConf::UseVertexRadius(NonNegative<Length> v
 
 /// @brief Gets the "child" count for the given shape configuration.
 /// @return 1.
-constexpr inline ChildCounter GetChildCount(const PolygonShapeConf&) noexcept
+constexpr ChildCounter GetChildCount(const PolygonShapeConf&) noexcept
 {
     return 1;
 }

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -42,7 +42,7 @@ class PolygonShapeConf: public ShapeBuilder<PolygonShapeConf>
 {
 public:
     /// @brief Gets the default vertex radius for the <code>PolygonShapeConf</code>.
-    static PLAYRHO_CONSTEXPR inline NonNegative<Length> GetDefaultVertexRadius() noexcept
+    static constexpr inline NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
         return NonNegative<Length>{DefaultLinearSlop * 2};
     }
@@ -198,7 +198,7 @@ inline PolygonShapeConf& PolygonShapeConf::UseVertexRadius(NonNegative<Length> v
 
 /// @brief Gets the "child" count for the given shape configuration.
 /// @return 1.
-PLAYRHO_CONSTEXPR inline ChildCounter GetChildCount(const PolygonShapeConf&) noexcept
+constexpr inline ChildCounter GetChildCount(const PolygonShapeConf&) noexcept
 {
     return 1;
 }

--- a/PlayRho/Collision/Shapes/ShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ShapeConf.hpp
@@ -71,27 +71,27 @@ struct ShapeBuilder: BaseShapeConf
     // Note: don't use 'using ShapeConf::ShapeConf' here as it doesn't work in this context!
     
     /// @brief Default constructor.
-    PLAYRHO_CONSTEXPR inline ShapeBuilder() = default;
+    constexpr inline ShapeBuilder() = default;
 
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit ShapeBuilder(const BaseShapeConf& value) noexcept:
+    constexpr inline explicit ShapeBuilder(const BaseShapeConf& value) noexcept:
         BaseShapeConf{value}
     {
         // Intentionally empty.
     }
     
     /// @brief Uses the given friction.
-    PLAYRHO_CONSTEXPR inline ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
+    constexpr inline ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
     
     /// @brief Uses the given restitution.
-    PLAYRHO_CONSTEXPR inline ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
+    constexpr inline ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
     
     /// @brief Uses the given density.
-    PLAYRHO_CONSTEXPR inline ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
+    constexpr inline ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
 };
 
 template <typename ConcreteConf>
-PLAYRHO_CONSTEXPR inline ConcreteConf&
+constexpr inline ConcreteConf&
 ShapeBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
 {
     friction = value;
@@ -99,7 +99,7 @@ ShapeBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
 }
 
 template <typename ConcreteConf>
-PLAYRHO_CONSTEXPR inline ConcreteConf&
+constexpr inline ConcreteConf&
 ShapeBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
 {
     restitution = value;
@@ -107,7 +107,7 @@ ShapeBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
 }
 
 template <typename ConcreteConf>
-PLAYRHO_CONSTEXPR inline ConcreteConf&
+constexpr inline ConcreteConf&
 ShapeBuilder<ConcreteConf>::UseDensity(NonNegative<AreaDensity> value) noexcept
 {
     density = value;
@@ -123,19 +123,19 @@ struct ShapeConf: public ShapeBuilder<ShapeConf>
 // Free functions...
 
 /// @brief Gets the density of the given shape configuration.
-PLAYRHO_CONSTEXPR inline NonNegative<AreaDensity> GetDensity(const BaseShapeConf& arg) noexcept
+constexpr inline NonNegative<AreaDensity> GetDensity(const BaseShapeConf& arg) noexcept
 {
     return arg.density;
 }
 
 /// @brief Gets the restitution of the given shape configuration.
-PLAYRHO_CONSTEXPR inline Finite<Real> GetRestitution(const BaseShapeConf& arg) noexcept
+constexpr inline Finite<Real> GetRestitution(const BaseShapeConf& arg) noexcept
 {
     return arg.restitution;
 }
 
 /// @brief Gets the friction of the given shape configuration.
-PLAYRHO_CONSTEXPR inline NonNegative<Real> GetFriction(const BaseShapeConf& arg) noexcept
+constexpr inline NonNegative<Real> GetFriction(const BaseShapeConf& arg) noexcept
 {
     return arg.friction;
 }

--- a/PlayRho/Collision/Shapes/ShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ShapeConf.hpp
@@ -71,27 +71,27 @@ struct ShapeBuilder: BaseShapeConf
     // Note: don't use 'using ShapeConf::ShapeConf' here as it doesn't work in this context!
     
     /// @brief Default constructor.
-    constexpr inline ShapeBuilder() = default;
+    constexpr ShapeBuilder() = default;
 
     /// @brief Initializing constructor.
-    constexpr inline explicit ShapeBuilder(const BaseShapeConf& value) noexcept:
+    constexpr explicit ShapeBuilder(const BaseShapeConf& value) noexcept:
         BaseShapeConf{value}
     {
         // Intentionally empty.
     }
     
     /// @brief Uses the given friction.
-    constexpr inline ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
+    constexpr ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
     
     /// @brief Uses the given restitution.
-    constexpr inline ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
+    constexpr ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
     
     /// @brief Uses the given density.
-    constexpr inline ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
+    constexpr ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
 };
 
 template <typename ConcreteConf>
-constexpr inline ConcreteConf&
+constexpr ConcreteConf&
 ShapeBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
 {
     friction = value;
@@ -99,7 +99,7 @@ ShapeBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
 }
 
 template <typename ConcreteConf>
-constexpr inline ConcreteConf&
+constexpr ConcreteConf&
 ShapeBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
 {
     restitution = value;
@@ -107,7 +107,7 @@ ShapeBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
 }
 
 template <typename ConcreteConf>
-constexpr inline ConcreteConf&
+constexpr ConcreteConf&
 ShapeBuilder<ConcreteConf>::UseDensity(NonNegative<AreaDensity> value) noexcept
 {
     density = value;
@@ -123,19 +123,19 @@ struct ShapeConf: public ShapeBuilder<ShapeConf>
 // Free functions...
 
 /// @brief Gets the density of the given shape configuration.
-constexpr inline NonNegative<AreaDensity> GetDensity(const BaseShapeConf& arg) noexcept
+constexpr NonNegative<AreaDensity> GetDensity(const BaseShapeConf& arg) noexcept
 {
     return arg.density;
 }
 
 /// @brief Gets the restitution of the given shape configuration.
-constexpr inline Finite<Real> GetRestitution(const BaseShapeConf& arg) noexcept
+constexpr Finite<Real> GetRestitution(const BaseShapeConf& arg) noexcept
 {
     return arg.restitution;
 }
 
 /// @brief Gets the friction of the given shape configuration.
-constexpr inline NonNegative<Real> GetFriction(const BaseShapeConf& arg) noexcept
+constexpr NonNegative<Real> GetFriction(const BaseShapeConf& arg) noexcept
 {
     return arg.friction;
 }

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -126,16 +126,16 @@ namespace d2 {
         Simplex() = default;
 
         /// @brief Gets the edges.
-        PLAYRHO_CONSTEXPR inline SimplexEdges GetEdges() const noexcept;
+        constexpr inline SimplexEdges GetEdges() const noexcept;
 
         /// @brief Gets the give indexed simplex edge.
         const SimplexEdge& GetSimplexEdge(size_type index) const noexcept;
 
         /// @brief Gets the coefficient for the given index.
-        PLAYRHO_CONSTEXPR inline Real GetCoefficient(size_type index) const noexcept;
+        constexpr inline Real GetCoefficient(size_type index) const noexcept;
 
         /// @brief Gets the size in number of simplex edges that this instance is made up of.
-        PLAYRHO_CONSTEXPR inline size_type size() const noexcept;
+        constexpr inline size_type size() const noexcept;
 
     private:
         
@@ -175,7 +175,7 @@ namespace d2 {
 #endif
     }
 
-    PLAYRHO_CONSTEXPR inline SimplexEdges Simplex::GetEdges() const noexcept
+    constexpr inline SimplexEdges Simplex::GetEdges() const noexcept
     {
         return m_simplexEdges;
     }
@@ -185,14 +185,14 @@ namespace d2 {
         return m_simplexEdges[index];
     }
     
-    PLAYRHO_CONSTEXPR inline Real Simplex::GetCoefficient(size_type index) const noexcept
+    constexpr inline Real Simplex::GetCoefficient(size_type index) const noexcept
     {
         return m_normalizedWeights[index];
     }
     
     /// @brief Gets the size in number of valid edges of this Simplex.
     /// @return Value between 0 and <code>MaxEdges</code> (inclusive).
-    PLAYRHO_CONSTEXPR inline Simplex::size_type Simplex::size() const noexcept
+    constexpr inline Simplex::size_type Simplex::size() const noexcept
     {
         return m_simplexEdges.size();
     }
@@ -204,7 +204,7 @@ namespace d2 {
     }
 
     /// Gets the "closest point".
-    PLAYRHO_CONSTEXPR inline Length2 GetClosestPoint(const Simplex& simplex)
+    constexpr inline Length2 GetClosestPoint(const Simplex& simplex)
     {
         switch (simplex.size())
         {

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -126,16 +126,16 @@ namespace d2 {
         Simplex() = default;
 
         /// @brief Gets the edges.
-        constexpr inline SimplexEdges GetEdges() const noexcept;
+        constexpr SimplexEdges GetEdges() const noexcept;
 
         /// @brief Gets the give indexed simplex edge.
         const SimplexEdge& GetSimplexEdge(size_type index) const noexcept;
 
         /// @brief Gets the coefficient for the given index.
-        constexpr inline Real GetCoefficient(size_type index) const noexcept;
+        constexpr Real GetCoefficient(size_type index) const noexcept;
 
         /// @brief Gets the size in number of simplex edges that this instance is made up of.
-        constexpr inline size_type size() const noexcept;
+        constexpr size_type size() const noexcept;
 
     private:
         
@@ -175,7 +175,7 @@ namespace d2 {
 #endif
     }
 
-    constexpr inline SimplexEdges Simplex::GetEdges() const noexcept
+    constexpr SimplexEdges Simplex::GetEdges() const noexcept
     {
         return m_simplexEdges;
     }
@@ -185,14 +185,14 @@ namespace d2 {
         return m_simplexEdges[index];
     }
     
-    constexpr inline Real Simplex::GetCoefficient(size_type index) const noexcept
+    constexpr Real Simplex::GetCoefficient(size_type index) const noexcept
     {
         return m_normalizedWeights[index];
     }
     
     /// @brief Gets the size in number of valid edges of this Simplex.
     /// @return Value between 0 and <code>MaxEdges</code> (inclusive).
-    constexpr inline Simplex::size_type Simplex::size() const noexcept
+    constexpr Simplex::size_type Simplex::size() const noexcept
     {
         return m_simplexEdges.size();
     }
@@ -204,7 +204,7 @@ namespace d2 {
     }
 
     /// Gets the "closest point".
-    constexpr inline Length2 GetClosestPoint(const Simplex& simplex)
+    constexpr Length2 GetClosestPoint(const Simplex& simplex)
     {
         switch (simplex.size())
         {

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -40,30 +40,30 @@ public:
     SimplexEdge() = default;
     
     /// @brief Copy constructor.
-    constexpr inline SimplexEdge(const SimplexEdge& copy) = default;
+    constexpr SimplexEdge(const SimplexEdge& copy) = default;
     
     /// @brief Initializing constructor.
     /// @param pA Point A in world coordinates.
     /// @param iA Index of point A within the shape that it comes from.
     /// @param pB Point B in world coordinates.
     /// @param iB Index of point B within the shape that it comes from.
-    constexpr inline SimplexEdge(Length2 pA, VertexCounter iA,
+    constexpr SimplexEdge(Length2 pA, VertexCounter iA,
                                          Length2 pB, VertexCounter iB) noexcept;
     
     /// @brief Gets point A (in world coordinates).
-    constexpr inline auto GetPointA() const noexcept { return m_wA; }
+    constexpr auto GetPointA() const noexcept { return m_wA; }
     
     /// @brief Gets point B (in world coordinates).
-    constexpr inline auto GetPointB() const noexcept { return m_wB; }
+    constexpr auto GetPointB() const noexcept { return m_wB; }
 
     /// @brief Gets index A.
-    constexpr inline auto GetIndexA() const noexcept { return std::get<0>(m_indexPair); }
+    constexpr auto GetIndexA() const noexcept { return std::get<0>(m_indexPair); }
     
     /// @brief Gets index B.
-    constexpr inline auto GetIndexB() const noexcept { return std::get<1>(m_indexPair); }
+    constexpr auto GetIndexB() const noexcept { return std::get<1>(m_indexPair); }
 
     /// @brief Gets the index pair.
-    constexpr inline auto GetIndexPair() const noexcept { return m_indexPair; }
+    constexpr auto GetIndexPair() const noexcept { return m_indexPair; }
 
 private:
     Length2 m_wA; ///< Point A in world coordinates. This is the support point in proxy A. 8-bytes.
@@ -71,7 +71,7 @@ private:
     IndexPair m_indexPair; ///< Index pair. @details Indices of points A and B. 2-bytes.
 };
 
-constexpr inline SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
+constexpr SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
                                                   Length2 pB, VertexCounter iB) noexcept:
     m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
 {
@@ -80,13 +80,13 @@ constexpr inline SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
 
 /// @brief Gets "w".
 /// @return 2-dimensional vector value of the simplex edge's point B minus its point A.
-constexpr inline Length2 GetPointDelta(const SimplexEdge& sv) noexcept
+constexpr Length2 GetPointDelta(const SimplexEdge& sv) noexcept
 {
     return sv.GetPointB() - sv.GetPointA();
 }
 
 /// @brief Equality operator for <code>SimplexEdge</code>.
-constexpr inline bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+constexpr bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
 {
     return (lhs.GetPointA() == rhs.GetPointA())
         && (lhs.GetPointB() == rhs.GetPointB())
@@ -94,7 +94,7 @@ constexpr inline bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs
 }
 
 /// @brief Inequality operator for <code>SimplexEdge</code>.
-constexpr inline bool operator!= (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+constexpr bool operator!= (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -40,30 +40,30 @@ public:
     SimplexEdge() = default;
     
     /// @brief Copy constructor.
-    PLAYRHO_CONSTEXPR inline SimplexEdge(const SimplexEdge& copy) = default;
+    constexpr inline SimplexEdge(const SimplexEdge& copy) = default;
     
     /// @brief Initializing constructor.
     /// @param pA Point A in world coordinates.
     /// @param iA Index of point A within the shape that it comes from.
     /// @param pB Point B in world coordinates.
     /// @param iB Index of point B within the shape that it comes from.
-    PLAYRHO_CONSTEXPR inline SimplexEdge(Length2 pA, VertexCounter iA,
+    constexpr inline SimplexEdge(Length2 pA, VertexCounter iA,
                                          Length2 pB, VertexCounter iB) noexcept;
     
     /// @brief Gets point A (in world coordinates).
-    PLAYRHO_CONSTEXPR inline auto GetPointA() const noexcept { return m_wA; }
+    constexpr inline auto GetPointA() const noexcept { return m_wA; }
     
     /// @brief Gets point B (in world coordinates).
-    PLAYRHO_CONSTEXPR inline auto GetPointB() const noexcept { return m_wB; }
+    constexpr inline auto GetPointB() const noexcept { return m_wB; }
 
     /// @brief Gets index A.
-    PLAYRHO_CONSTEXPR inline auto GetIndexA() const noexcept { return std::get<0>(m_indexPair); }
+    constexpr inline auto GetIndexA() const noexcept { return std::get<0>(m_indexPair); }
     
     /// @brief Gets index B.
-    PLAYRHO_CONSTEXPR inline auto GetIndexB() const noexcept { return std::get<1>(m_indexPair); }
+    constexpr inline auto GetIndexB() const noexcept { return std::get<1>(m_indexPair); }
 
     /// @brief Gets the index pair.
-    PLAYRHO_CONSTEXPR inline auto GetIndexPair() const noexcept { return m_indexPair; }
+    constexpr inline auto GetIndexPair() const noexcept { return m_indexPair; }
 
 private:
     Length2 m_wA; ///< Point A in world coordinates. This is the support point in proxy A. 8-bytes.
@@ -71,7 +71,7 @@ private:
     IndexPair m_indexPair; ///< Index pair. @details Indices of points A and B. 2-bytes.
 };
 
-PLAYRHO_CONSTEXPR inline SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
+constexpr inline SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
                                                   Length2 pB, VertexCounter iB) noexcept:
     m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
 {
@@ -80,13 +80,13 @@ PLAYRHO_CONSTEXPR inline SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
 
 /// @brief Gets "w".
 /// @return 2-dimensional vector value of the simplex edge's point B minus its point A.
-PLAYRHO_CONSTEXPR inline Length2 GetPointDelta(const SimplexEdge& sv) noexcept
+constexpr inline Length2 GetPointDelta(const SimplexEdge& sv) noexcept
 {
     return sv.GetPointB() - sv.GetPointA();
 }
 
 /// @brief Equality operator for <code>SimplexEdge</code>.
-PLAYRHO_CONSTEXPR inline bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+constexpr inline bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
 {
     return (lhs.GetPointA() == rhs.GetPointA())
         && (lhs.GetPointB() == rhs.GetPointB())
@@ -94,7 +94,7 @@ PLAYRHO_CONSTEXPR inline bool operator== (const SimplexEdge& lhs, const SimplexE
 }
 
 /// @brief Inequality operator for <code>SimplexEdge</code>.
-PLAYRHO_CONSTEXPR inline bool operator!= (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+constexpr inline bool operator!= (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -60,22 +60,22 @@ struct ToiConf
     using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
 
     /// @brief Uses the given time max value.
-    constexpr inline ToiConf& UseTimeMax(Real value) noexcept;
+    constexpr ToiConf& UseTimeMax(Real value) noexcept;
 
     /// @brief Uses the given target depth value.
-    constexpr inline ToiConf& UseTargetDepth(Length value) noexcept;
+    constexpr ToiConf& UseTargetDepth(Length value) noexcept;
     
     /// @brief Uses the given tolerance value.
-    constexpr inline ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
+    constexpr ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
     
     /// @brief Uses the given max root iterations value.
-    constexpr inline ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
+    constexpr ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
     
     /// @brief Uses the given max TOI iterations value.
-    constexpr inline ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
+    constexpr ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
     
     /// @brief Uses the given max distance iterations value.
-    constexpr inline ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
+    constexpr ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
 
     /// @brief T-Max.
     Real tMax = 1;
@@ -106,37 +106,37 @@ struct ToiConf
     dist_iter_type maxDistIters = DefaultMaxDistanceIters; ///< Max distance iterations.
 };
 
-constexpr inline ToiConf& ToiConf::UseTimeMax(Real value) noexcept
+constexpr ToiConf& ToiConf::UseTimeMax(Real value) noexcept
 {
     tMax = value;
     return *this;
 }
 
-constexpr inline ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
+constexpr ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
 {
     targetDepth = value;
     return *this;
 }
 
-constexpr inline ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
+constexpr ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
 {
     tolerance = value;
     return *this;
 }
 
-constexpr inline ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
+constexpr ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
 {
     maxRootIters = value;
     return *this;
 }
 
-constexpr inline ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
+constexpr ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
 {
     maxToiIters = value;
     return *this;
 }
 
-constexpr inline ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
+constexpr ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
 {
     maxDistIters = value;
     return *this;
@@ -144,7 +144,7 @@ constexpr inline ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcep
 
 /// @brief Gets the default time of impact configuration.
 /// @relatedalso ToiConf
-constexpr inline auto GetDefaultToiConf()
+constexpr auto GetDefaultToiConf()
 {
     return ToiConf{};
 }

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -60,22 +60,22 @@ struct ToiConf
     using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
 
     /// @brief Uses the given time max value.
-    PLAYRHO_CONSTEXPR inline ToiConf& UseTimeMax(Real value) noexcept;
+    constexpr inline ToiConf& UseTimeMax(Real value) noexcept;
 
     /// @brief Uses the given target depth value.
-    PLAYRHO_CONSTEXPR inline ToiConf& UseTargetDepth(Length value) noexcept;
+    constexpr inline ToiConf& UseTargetDepth(Length value) noexcept;
     
     /// @brief Uses the given tolerance value.
-    PLAYRHO_CONSTEXPR inline ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
+    constexpr inline ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
     
     /// @brief Uses the given max root iterations value.
-    PLAYRHO_CONSTEXPR inline ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
+    constexpr inline ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
     
     /// @brief Uses the given max TOI iterations value.
-    PLAYRHO_CONSTEXPR inline ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
+    constexpr inline ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
     
     /// @brief Uses the given max distance iterations value.
-    PLAYRHO_CONSTEXPR inline ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
+    constexpr inline ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
 
     /// @brief T-Max.
     Real tMax = 1;
@@ -106,37 +106,37 @@ struct ToiConf
     dist_iter_type maxDistIters = DefaultMaxDistanceIters; ///< Max distance iterations.
 };
 
-PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseTimeMax(Real value) noexcept
+constexpr inline ToiConf& ToiConf::UseTimeMax(Real value) noexcept
 {
     tMax = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
+constexpr inline ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
 {
     targetDepth = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
+constexpr inline ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
 {
     tolerance = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
+constexpr inline ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
 {
     maxRootIters = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
+constexpr inline ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
 {
     maxToiIters = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
+constexpr inline ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
 {
     maxDistIters = value;
     return *this;
@@ -144,7 +144,7 @@ PLAYRHO_CONSTEXPR inline ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value)
 
 /// @brief Gets the default time of impact configuration.
 /// @relatedalso ToiConf
-PLAYRHO_CONSTEXPR inline auto GetDefaultToiConf()
+constexpr inline auto GetDefaultToiConf()
 {
     return ToiConf{};
 }

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -75,7 +75,7 @@ public:
     WorldManifold() = default;
     
     /// @brief Initializing constructor.
-    constexpr inline explicit WorldManifold(UnitVec normal) noexcept:
+    constexpr explicit WorldManifold(UnitVec normal) noexcept:
         m_normal{normal}
     {
         assert(IsValid(normal));
@@ -83,7 +83,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr inline explicit WorldManifold(UnitVec normal, PointData ps0) noexcept:
+    constexpr explicit WorldManifold(UnitVec normal, PointData ps0) noexcept:
         m_normal{normal},
         m_points{ps0.location, GetInvalid<Length2>()},
         m_impulses{ps0.impulse, Momentum2{}},
@@ -94,7 +94,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr inline explicit WorldManifold(UnitVec normal, PointData ps0, PointData ps1) noexcept:
+    constexpr explicit WorldManifold(UnitVec normal, PointData ps0, PointData ps1) noexcept:
         m_normal{normal},
         m_points{ps0.location, ps1.location},
         m_impulses{ps0.impulse, ps1.impulse},

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -75,7 +75,7 @@ public:
     WorldManifold() = default;
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit WorldManifold(UnitVec normal) noexcept:
+    constexpr inline explicit WorldManifold(UnitVec normal) noexcept:
         m_normal{normal}
     {
         assert(IsValid(normal));
@@ -83,7 +83,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit WorldManifold(UnitVec normal, PointData ps0) noexcept:
+    constexpr inline explicit WorldManifold(UnitVec normal, PointData ps0) noexcept:
         m_normal{normal},
         m_points{ps0.location, GetInvalid<Length2>()},
         m_impulses{ps0.impulse, Momentum2{}},
@@ -94,7 +94,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit WorldManifold(UnitVec normal, PointData ps0, PointData ps1) noexcept:
+    constexpr inline explicit WorldManifold(UnitVec normal, PointData ps0, PointData ps1) noexcept:
         m_normal{normal},
         m_points{ps0.location, ps1.location},
         m_impulses{ps0.impulse, ps1.impulse},

--- a/PlayRho/Common/Acceleration.hpp
+++ b/PlayRho/Common/Acceleration.hpp
@@ -38,21 +38,21 @@ namespace d2 {
     
     /// @brief Equality operator.
     /// @relatedalso Acceleration
-    constexpr inline bool operator==(const Acceleration& lhs, const Acceleration& rhs)
+    constexpr bool operator==(const Acceleration& lhs, const Acceleration& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Acceleration
-    constexpr inline bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
+    constexpr bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Multiplication assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator*= (Acceleration& lhs, const Real rhs)
+    constexpr Acceleration& operator*= (Acceleration& lhs, const Real rhs)
     {
         lhs.linear *= rhs;
         lhs.angular *= rhs;
@@ -61,7 +61,7 @@ namespace d2 {
     
     /// @brief Division assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator/= (Acceleration& lhs, const Real rhs)
+    constexpr Acceleration& operator/= (Acceleration& lhs, const Real rhs)
     {
         lhs.linear /= rhs;
         lhs.angular /= rhs;
@@ -70,7 +70,7 @@ namespace d2 {
     
     /// @brief Addition assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
+    constexpr Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -79,14 +79,14 @@ namespace d2 {
     
     /// @brief Addition operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
+    constexpr Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
     {
         return Acceleration{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
+    constexpr Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -95,42 +95,42 @@ namespace d2 {
     
     /// @brief Subtraction operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
+    constexpr Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
     {
         return Acceleration{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Negation operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator- (const Acceleration& value)
+    constexpr Acceleration operator- (const Acceleration& value)
     {
         return Acceleration{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator+ (const Acceleration& value)
+    constexpr Acceleration operator+ (const Acceleration& value)
     {
         return value;
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator* (const Acceleration& lhs, const Real rhs)
+    constexpr Acceleration operator* (const Acceleration& lhs, const Real rhs)
     {
         return Acceleration{lhs.linear * rhs, lhs.angular * rhs};
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator* (const Real lhs, const Acceleration& rhs)
+    constexpr Acceleration operator* (const Real lhs, const Acceleration& rhs)
     {
         return Acceleration{rhs.linear * lhs, rhs.angular * lhs};
     }
     
     /// @brief Division operator.
     /// @relatedalso Acceleration
-    constexpr inline Acceleration operator/ (const Acceleration& lhs, const Real rhs)
+    constexpr Acceleration operator/ (const Acceleration& lhs, const Real rhs)
     {
         const auto inverseRhs = Real{1} / rhs;
         return Acceleration{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
@@ -141,7 +141,7 @@ namespace d2 {
 /// @brief Determines if the given value is valid.
 /// @relatedalso playrho::d2::Acceleration
 template <>
-constexpr inline bool IsValid(const d2::Acceleration& value) noexcept
+constexpr bool IsValid(const d2::Acceleration& value) noexcept
 {
     return IsValid(value.linear) && IsValid(value.angular);
 }

--- a/PlayRho/Common/Acceleration.hpp
+++ b/PlayRho/Common/Acceleration.hpp
@@ -38,21 +38,21 @@ namespace d2 {
     
     /// @brief Equality operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline bool operator==(const Acceleration& lhs, const Acceleration& rhs)
+    constexpr inline bool operator==(const Acceleration& lhs, const Acceleration& rhs)
     {
         return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
     }
     
     /// @brief Inequality operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
+    constexpr inline bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
     {
         return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
     }
     
     /// @brief Multiplication assignment operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator*= (Acceleration& lhs, const Real rhs)
+    constexpr inline Acceleration& operator*= (Acceleration& lhs, const Real rhs)
     {
         lhs.linear *= rhs;
         lhs.angular *= rhs;
@@ -61,7 +61,7 @@ namespace d2 {
     
     /// @brief Division assignment operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator/= (Acceleration& lhs, const Real rhs)
+    constexpr inline Acceleration& operator/= (Acceleration& lhs, const Real rhs)
     {
         lhs.linear /= rhs;
         lhs.angular /= rhs;
@@ -70,7 +70,7 @@ namespace d2 {
     
     /// @brief Addition assignment operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
+    constexpr inline Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
     {
         lhs.linear += rhs.linear;
         lhs.angular += rhs.angular;
@@ -79,14 +79,14 @@ namespace d2 {
     
     /// @brief Addition operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
+    constexpr inline Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
     {
         return Acceleration{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
     }
     
     /// @brief Subtraction assignment operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
+    constexpr inline Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
     {
         lhs.linear -= rhs.linear;
         lhs.angular -= rhs.angular;
@@ -95,42 +95,42 @@ namespace d2 {
     
     /// @brief Subtraction operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
+    constexpr inline Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
     {
         return Acceleration{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
     }
     
     /// @brief Negation operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator- (const Acceleration& value)
+    constexpr inline Acceleration operator- (const Acceleration& value)
     {
         return Acceleration{-value.linear, -value.angular};
     }
     
     /// @brief Positive operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator+ (const Acceleration& value)
+    constexpr inline Acceleration operator+ (const Acceleration& value)
     {
         return value;
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator* (const Acceleration& lhs, const Real rhs)
+    constexpr inline Acceleration operator* (const Acceleration& lhs, const Real rhs)
     {
         return Acceleration{lhs.linear * rhs, lhs.angular * rhs};
     }
     
     /// @brief Multiplication operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator* (const Real lhs, const Acceleration& rhs)
+    constexpr inline Acceleration operator* (const Real lhs, const Acceleration& rhs)
     {
         return Acceleration{rhs.linear * lhs, rhs.angular * lhs};
     }
     
     /// @brief Division operator.
     /// @relatedalso Acceleration
-    PLAYRHO_CONSTEXPR inline Acceleration operator/ (const Acceleration& lhs, const Real rhs)
+    constexpr inline Acceleration operator/ (const Acceleration& lhs, const Real rhs)
     {
         const auto inverseRhs = Real{1} / rhs;
         return Acceleration{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
@@ -141,7 +141,7 @@ namespace d2 {
 /// @brief Determines if the given value is valid.
 /// @relatedalso playrho::d2::Acceleration
 template <>
-PLAYRHO_CONSTEXPR inline bool IsValid(const d2::Acceleration& value) noexcept
+constexpr inline bool IsValid(const d2::Acceleration& value) noexcept
 {
     return IsValid(value.linear) && IsValid(value.angular);
 }

--- a/PlayRho/Common/AllocatedArray.hpp
+++ b/PlayRho/Common/AllocatedArray.hpp
@@ -67,7 +67,7 @@ public:
     using const_iterator = const_pointer;
 
     /// @brief Initializing constructor.
-    constexpr inline AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter):
+    constexpr AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter):
         m_max_size{max_size}, m_data{data}, m_deleter{deleter}
     {
         assert(data);

--- a/PlayRho/Common/AllocatedArray.hpp
+++ b/PlayRho/Common/AllocatedArray.hpp
@@ -67,7 +67,7 @@ public:
     using const_iterator = const_pointer;
 
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter):
+    constexpr inline AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter):
         m_max_size{max_size}, m_data{data}, m_deleter{deleter}
     {
         assert(data);

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -52,7 +52,7 @@ namespace playrho
         /// @brief Constant pointer type.
         using const_pointer = const value_type*;
 
-        PLAYRHO_CONSTEXPR inline ArrayList() noexcept
+        constexpr inline ArrayList() noexcept
         {
             // Intentionally empty.
             // Note that defaulting this method instead of writing it out here,
@@ -60,7 +60,7 @@ namespace playrho
         }
 
         template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t< COPY_MAXSIZE <= MAXSIZE >>
-        PLAYRHO_CONSTEXPR inline explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
+        constexpr inline explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
             m_size{size(copy)},
             m_elements{data(copy)}
         {
@@ -93,13 +93,13 @@ namespace playrho
             }
         }
         
-        PLAYRHO_CONSTEXPR inline ArrayList& Append(const value_type& value)
+        constexpr inline ArrayList& Append(const value_type& value)
         {
             push_back(value);
             return *this;
         }
 
-        PLAYRHO_CONSTEXPR inline void push_back(const value_type& value) noexcept
+        constexpr inline void push_back(const value_type& value) noexcept
         {
             assert(m_size < MAXSIZE);
             m_elements[m_size] = value;
@@ -136,7 +136,7 @@ namespace playrho
             return m_elements[index];
         }
         
-        PLAYRHO_CONSTEXPR inline const_reference operator[](size_type index) const noexcept
+        constexpr inline const_reference operator[](size_type index) const noexcept
         {
             assert(index < MAXSIZE);
             return m_elements[index];
@@ -146,11 +146,11 @@ namespace playrho
         /// @details This is the number of elements that have been added to this collection.
         /// @return Value between 0 and the maximum size for this collection.
         /// @sa max_size().
-        PLAYRHO_CONSTEXPR inline size_type size() const noexcept { return m_size; }
+        constexpr inline size_type size() const noexcept { return m_size; }
         
         /// Gets the maximum size that this collection can be.
         /// @details This is the maximum number of elements that can be contained in this collection.
-        PLAYRHO_CONSTEXPR inline size_type max_size() const noexcept { return MAXSIZE; }
+        constexpr inline size_type max_size() const noexcept { return MAXSIZE; }
 
         auto data() const noexcept { return m_elements.data(); }
 

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -52,7 +52,7 @@ namespace playrho
         /// @brief Constant pointer type.
         using const_pointer = const value_type*;
 
-        constexpr inline ArrayList() noexcept
+        constexpr ArrayList() noexcept
         {
             // Intentionally empty.
             // Note that defaulting this method instead of writing it out here,
@@ -60,7 +60,7 @@ namespace playrho
         }
 
         template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t< COPY_MAXSIZE <= MAXSIZE >>
-        constexpr inline explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
+        constexpr explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
             m_size{size(copy)},
             m_elements{data(copy)}
         {
@@ -93,13 +93,13 @@ namespace playrho
             }
         }
         
-        constexpr inline ArrayList& Append(const value_type& value)
+        constexpr ArrayList& Append(const value_type& value)
         {
             push_back(value);
             return *this;
         }
 
-        constexpr inline void push_back(const value_type& value) noexcept
+        constexpr void push_back(const value_type& value) noexcept
         {
             assert(m_size < MAXSIZE);
             m_elements[m_size] = value;
@@ -136,7 +136,7 @@ namespace playrho
             return m_elements[index];
         }
         
-        constexpr inline const_reference operator[](size_type index) const noexcept
+        constexpr const_reference operator[](size_type index) const noexcept
         {
             assert(index < MAXSIZE);
             return m_elements[index];
@@ -146,11 +146,11 @@ namespace playrho
         /// @details This is the number of elements that have been added to this collection.
         /// @return Value between 0 and the maximum size for this collection.
         /// @sa max_size().
-        constexpr inline size_type size() const noexcept { return m_size; }
+        constexpr size_type size() const noexcept { return m_size; }
         
         /// Gets the maximum size that this collection can be.
         /// @details This is the maximum number of elements that can be contained in this collection.
-        constexpr inline size_type max_size() const noexcept { return MAXSIZE; }
+        constexpr size_type max_size() const noexcept { return MAXSIZE; }
 
         auto data() const noexcept { return m_elements.data(); }
 

--- a/PlayRho/Common/BlockAllocator.cpp
+++ b/PlayRho/Common/BlockAllocator.cpp
@@ -54,7 +54,7 @@ static constexpr const LookupTable BlockSizeLookup;
 #endif
 
 /// @brief Block size lookup array.
-static PLAYRHO_CONSTEXPR const std::uint8_t s_blockSizeLookup[BlockAllocator::GetMaxBlockSize() + 1] =
+static constexpr const std::uint8_t s_blockSizeLookup[BlockAllocator::GetMaxBlockSize() + 1] =
 {
     0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 1-16

--- a/PlayRho/Common/BlockAllocator.hpp
+++ b/PlayRho/Common/BlockAllocator.hpp
@@ -25,7 +25,7 @@
 namespace playrho {
 
     /// @brief Allocator block sizes array data.
-    PLAYRHO_CONSTEXPR const std::size_t AllocatorBlockSizes[] =
+    constexpr const std::size_t AllocatorBlockSizes[] =
     {
         16, 32, 64, 96, 128, 160, 192, 224, 256, 320, 384, 448, 512, 640,
     };
@@ -45,16 +45,16 @@ namespace playrho {
         using size_type = std::size_t;
 
         /// @brief Chunk size.
-        static PLAYRHO_CONSTEXPR const auto ChunkSize = size_type{16 * 1024};
+        static constexpr const auto ChunkSize = size_type{16 * 1024};
         
         /// @brief Max block size (before using external allocator).
-        static PLAYRHO_CONSTEXPR size_type GetMaxBlockSize() noexcept
+        static constexpr size_type GetMaxBlockSize() noexcept
         {
             return AllocatorBlockSizes[size(AllocatorBlockSizes) - 1];
         }
         
         /// @brief Chunk array increment.
-        static PLAYRHO_CONSTEXPR size_type GetChunkArrayIncrement() noexcept
+        static constexpr size_type GetChunkArrayIncrement() noexcept
         {
             return size_type{128};
         }
@@ -133,7 +133,7 @@ namespace playrho {
         BlockDeallocator() = default;
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline BlockDeallocator(BlockAllocator* a, size_type n) noexcept:
+        constexpr inline BlockDeallocator(BlockAllocator* a, size_type n) noexcept:
             allocator{a}, nelem{n}
         {
             // Intentionally empty.

--- a/PlayRho/Common/BlockAllocator.hpp
+++ b/PlayRho/Common/BlockAllocator.hpp
@@ -133,7 +133,7 @@ namespace playrho {
         BlockDeallocator() = default;
 
         /// @brief Initializing constructor.
-        constexpr inline BlockDeallocator(BlockAllocator* a, size_type n) noexcept:
+        constexpr BlockDeallocator(BlockAllocator* a, size_type n) noexcept:
             allocator{a}, nelem{n}
         {
             // Intentionally empty.

--- a/PlayRho/Common/BoundedValue.hpp
+++ b/PlayRho/Common/BoundedValue.hpp
@@ -59,7 +59,7 @@ namespace playrho {
         static constexpr const bool has_one = false;
         
         /// @brief Gets the "one" value.
-        static constexpr inline T one() noexcept { return T{0}; }
+        static constexpr T one() noexcept { return T{0}; }
     };
 
     template<class T, class = void>
@@ -77,12 +77,12 @@ namespace playrho {
         static constexpr const bool has_one = true;
 
         /// @brief Gets the "one" value.
-        static constexpr inline T one() noexcept { return T{1}; }
+        static constexpr T one() noexcept { return T{1}; }
     };
 
     /// @brief Checks if the given value is above negative infinity.
     template <typename T>
-    constexpr inline std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
+    constexpr std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
     CheckIfAboveNegInf(T value)
     {
         if (!(value > -std::numeric_limits<T>::infinity()))
@@ -93,7 +93,7 @@ namespace playrho {
     
     /// @brief Checks if the given value is above negative infinity.
     template <typename T>
-    constexpr inline std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
+    constexpr std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
     CheckIfAboveNegInf(T /*value*/)
     {
         // Intentionally empty.
@@ -101,7 +101,7 @@ namespace playrho {
 
     /// @brief Checks that the given value is below positive infinity.
     template <typename T>
-    constexpr inline std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
+    constexpr std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
     CheckIfBelowPosInf(T value)
     {
         if (!(value < +std::numeric_limits<T>::infinity()))
@@ -112,7 +112,7 @@ namespace playrho {
 
     /// @brief Checks that the given value is below positive infinity.
     template <typename T>
-    constexpr inline std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
+    constexpr std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
     CheckIfBelowPosInf(T /*value*/)
     {
         // Intentionally empty.
@@ -138,13 +138,13 @@ namespace playrho {
         using this_type = BoundedValue<value_type, lo, hi>;
 
         /// @brief Gets the lo check.
-        static constexpr inline LoValueCheck GetLoCheck() { return lo; }
+        static constexpr LoValueCheck GetLoCheck() { return lo; }
 
         /// @brief Gets the hi check.
-        static constexpr inline HiValueCheck GetHiCheck() { return hi; }
+        static constexpr HiValueCheck GetHiCheck() { return hi; }
 
         /// @brief Performs the lo check.
-        static constexpr inline void DoLoCheck(value_type value)
+        static constexpr void DoLoCheck(value_type value)
         {
             switch (GetLoCheck())
             {
@@ -175,7 +175,7 @@ namespace playrho {
         }
         
         /// @brief Performs the hi check.
-        static constexpr inline void DoHiCheck(value_type value)
+        static constexpr void DoHiCheck(value_type value)
         {
             switch (GetHiCheck())
             {
@@ -210,7 +210,7 @@ namespace playrho {
         }
 
         /// @brief Initializing constructor.
-        constexpr inline BoundedValue(value_type value): m_value{value}
+        constexpr BoundedValue(value_type value): m_value{value}
         {
             DoLoCheck(value);
             DoHiCheck(value);
@@ -218,17 +218,17 @@ namespace playrho {
 
         /// @brief Initializing constructor for implicitly convertible types.
         template <typename U>
-        constexpr inline BoundedValue(U value): m_value{value_type(value)}
+        constexpr BoundedValue(U value): m_value{value_type(value)}
         {
             DoLoCheck(value_type(value));
             DoHiCheck(value_type(value));
         }
 
         /// @brief Copy constructor.
-        constexpr inline BoundedValue(const this_type& value) = default;
+        constexpr BoundedValue(const this_type& value) = default;
 
         /// @brief Move constructor.
-        constexpr inline BoundedValue(this_type&& value) noexcept:
+        constexpr BoundedValue(this_type&& value) noexcept:
             m_value{std::move(value.m_value)}
         {
             // Intentionally empty.
@@ -239,14 +239,14 @@ namespace playrho {
         ~BoundedValue() noexcept = default;
 
         /// @brief Assignment operator.
-        constexpr inline BoundedValue& operator= (const this_type& other) noexcept
+        constexpr BoundedValue& operator= (const this_type& other) noexcept
         {
             m_value = other.m_value;
             return *this;
         }
 
         /// @brief Assignment operator.
-        constexpr inline BoundedValue& operator= (const T& value)
+        constexpr BoundedValue& operator= (const T& value)
         {
             DoLoCheck(value);
             DoHiCheck(value);
@@ -256,7 +256,7 @@ namespace playrho {
 
         /// @brief Assignment operator for implicitly convertible types.
         template <typename U>
-        constexpr inline std::enable_if_t<std::is_convertible<U, T>::value, BoundedValue&>
+        constexpr std::enable_if_t<std::is_convertible<U, T>::value, BoundedValue&>
         operator= (const U& tmpVal)
         {
             const auto value = T(tmpVal);
@@ -267,7 +267,7 @@ namespace playrho {
         }
 
         /// @brief Move assignment operator.
-        constexpr inline BoundedValue& operator= (this_type&& value) noexcept
+        constexpr BoundedValue& operator= (this_type&& value) noexcept
         {
             // Note that the exception specification of this method
             //   doesn't match the defaulted one (when built with boost units).
@@ -276,27 +276,27 @@ namespace playrho {
         }
 
         /// @brief Gets the underlying value.
-        constexpr inline value_type get() const noexcept
+        constexpr value_type get() const noexcept
         {
             return m_value;
         }
 
         /// @brief Gets the underlying value.
-        constexpr inline operator value_type () const noexcept
+        constexpr operator value_type () const noexcept
         {
             return m_value;
         }
 
         /// @brief Member of pointer operator.
         template <typename U = T>
-        constexpr inline std::enable_if_t<std::is_pointer<U>::value, U> operator-> () const
+        constexpr std::enable_if_t<std::is_pointer<U>::value, U> operator-> () const
         {
             return m_value;
         }
 
         /// @brief Indirection operator.
         template <typename U = T>
-        constexpr inline std::enable_if_t<std::is_pointer<U>::value, remove_pointer_type>&
+        constexpr std::enable_if_t<std::is_pointer<U>::value, remove_pointer_type>&
         operator* () const
         {
             return *m_value;
@@ -310,14 +310,14 @@ namespace playrho {
 
     /// @brief Bounded value equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator== (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator== (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} == T{rhs};
     }
     
     /// @brief Bounded value inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator!= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} != T{rhs};
     }
@@ -326,56 +326,56 @@ namespace playrho {
 
     /// @brief Bounded value less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator<= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} <= T{rhs};
     }
     
     /// @brief Bounded value greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator>= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} >= T{rhs};
     }
     
     /// @brief Bounded value less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator< (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator< (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} < T{rhs};
     }
     
     /// @brief Bounded value greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator> (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator> (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} > T{rhs};
     }
     
     /// @brief Bounded value multiplication operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator* (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator* (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} * T{rhs};
     }
     
     /// @brief Bounded value division operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator/ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} / T{rhs};
     }
     
     /// @brief Bounded value addition operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator+ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} + T{rhs};
     }
     
     /// @brief Bounded value subtraction operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator- (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator- (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} - T{rhs};
     }
@@ -384,14 +384,14 @@ namespace playrho {
 
     /// @brief Bounded value equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator== (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr bool operator== (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} == rhs;
     }
     
     /// @brief Bounded value inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr bool operator!= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} != rhs;
     }
@@ -400,56 +400,56 @@ namespace playrho {
 
     /// @brief Bounded value less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr bool operator<= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} <= rhs;
     }
     
     /// @brief Bounded value greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr bool operator>= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} >= rhs;
     }
     
     /// @brief Bounded value less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator< (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr bool operator< (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} < rhs;
     }
     
     /// @brief Bounded value greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator> (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr bool operator> (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} > rhs;
     }
     
     /// @brief Bounded value multiplication operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator* (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr auto operator* (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} * rhs;
     }
     
     /// @brief Bounded value division operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr auto operator/ (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} / rhs;
     }
     
     /// @brief Bounded value addition operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr auto operator+ (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} + rhs;
     }
     
     /// @brief Bounded value subtraction operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator- (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr auto operator- (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} - T{rhs};
     }
@@ -458,14 +458,14 @@ namespace playrho {
 
     /// @brief Bounded value equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator== (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator== (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs == T{rhs};
     }
     
     /// @brief Bounded value inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator!= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator!= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs != T{rhs};
     }
@@ -474,56 +474,56 @@ namespace playrho {
 
     /// @brief Bounded value less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator<= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator<= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs <= T{rhs};
     }
     
     /// @brief Bounded value greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator>= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator>= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs >= T{rhs};
     }
     
     /// @brief Bounded value less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator< (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator< (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs < T{rhs};
     }
     
     /// @brief Bounded value greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline bool operator> (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr bool operator> (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs > T{rhs};
     }
     
     /// @brief Bounded value multiplication operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator* (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator* (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs * T{rhs};
     }
     
     /// @brief Bounded value division operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator/ (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator/ (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs / T{rhs};
     }
     
     /// @brief Bounded value addition operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator+ (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator+ (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs + T{rhs};
     }
     
     /// @brief Bounded value subtraction operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    constexpr inline auto operator- (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr auto operator- (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs - T{rhs};
     }

--- a/PlayRho/Common/BoundedValue.hpp
+++ b/PlayRho/Common/BoundedValue.hpp
@@ -56,10 +56,10 @@ namespace playrho {
     struct ValueCheckHelper
     {
         /// @brief Has one.
-        static PLAYRHO_CONSTEXPR const bool has_one = false;
+        static constexpr const bool has_one = false;
         
         /// @brief Gets the "one" value.
-        static PLAYRHO_CONSTEXPR inline T one() noexcept { return T{0}; }
+        static constexpr inline T one() noexcept { return T{0}; }
     };
 
     template<class T, class = void>
@@ -74,15 +74,15 @@ namespace playrho {
     struct ValueCheckHelper<T, std::enable_if_t<HasOne<T>::value>>
     {
         /// @brief Has one.
-        static PLAYRHO_CONSTEXPR const bool has_one = true;
+        static constexpr const bool has_one = true;
 
         /// @brief Gets the "one" value.
-        static PLAYRHO_CONSTEXPR inline T one() noexcept { return T{1}; }
+        static constexpr inline T one() noexcept { return T{1}; }
     };
 
     /// @brief Checks if the given value is above negative infinity.
     template <typename T>
-    PLAYRHO_CONSTEXPR inline std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
+    constexpr inline std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
     CheckIfAboveNegInf(T value)
     {
         if (!(value > -std::numeric_limits<T>::infinity()))
@@ -93,7 +93,7 @@ namespace playrho {
     
     /// @brief Checks if the given value is above negative infinity.
     template <typename T>
-    PLAYRHO_CONSTEXPR inline std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
+    constexpr inline std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
     CheckIfAboveNegInf(T /*value*/)
     {
         // Intentionally empty.
@@ -101,7 +101,7 @@ namespace playrho {
 
     /// @brief Checks that the given value is below positive infinity.
     template <typename T>
-    PLAYRHO_CONSTEXPR inline std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
+    constexpr inline std::enable_if_t<std::numeric_limits<T>::has_infinity, void>
     CheckIfBelowPosInf(T value)
     {
         if (!(value < +std::numeric_limits<T>::infinity()))
@@ -112,7 +112,7 @@ namespace playrho {
 
     /// @brief Checks that the given value is below positive infinity.
     template <typename T>
-    PLAYRHO_CONSTEXPR inline std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
+    constexpr inline std::enable_if_t<!std::numeric_limits<T>::has_infinity, void>
     CheckIfBelowPosInf(T /*value*/)
     {
         // Intentionally empty.
@@ -138,13 +138,13 @@ namespace playrho {
         using this_type = BoundedValue<value_type, lo, hi>;
 
         /// @brief Gets the lo check.
-        static PLAYRHO_CONSTEXPR inline LoValueCheck GetLoCheck() { return lo; }
+        static constexpr inline LoValueCheck GetLoCheck() { return lo; }
 
         /// @brief Gets the hi check.
-        static PLAYRHO_CONSTEXPR inline HiValueCheck GetHiCheck() { return hi; }
+        static constexpr inline HiValueCheck GetHiCheck() { return hi; }
 
         /// @brief Performs the lo check.
-        static PLAYRHO_CONSTEXPR inline void DoLoCheck(value_type value)
+        static constexpr inline void DoLoCheck(value_type value)
         {
             switch (GetLoCheck())
             {
@@ -175,7 +175,7 @@ namespace playrho {
         }
         
         /// @brief Performs the hi check.
-        static PLAYRHO_CONSTEXPR inline void DoHiCheck(value_type value)
+        static constexpr inline void DoHiCheck(value_type value)
         {
             switch (GetHiCheck())
             {
@@ -210,7 +210,7 @@ namespace playrho {
         }
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline BoundedValue(value_type value): m_value{value}
+        constexpr inline BoundedValue(value_type value): m_value{value}
         {
             DoLoCheck(value);
             DoHiCheck(value);
@@ -218,17 +218,17 @@ namespace playrho {
 
         /// @brief Initializing constructor for implicitly convertible types.
         template <typename U>
-        PLAYRHO_CONSTEXPR inline BoundedValue(U value): m_value{value_type(value)}
+        constexpr inline BoundedValue(U value): m_value{value_type(value)}
         {
             DoLoCheck(value_type(value));
             DoHiCheck(value_type(value));
         }
 
         /// @brief Copy constructor.
-        PLAYRHO_CONSTEXPR inline BoundedValue(const this_type& value) = default;
+        constexpr inline BoundedValue(const this_type& value) = default;
 
         /// @brief Move constructor.
-        PLAYRHO_CONSTEXPR inline BoundedValue(this_type&& value) noexcept:
+        constexpr inline BoundedValue(this_type&& value) noexcept:
             m_value{std::move(value.m_value)}
         {
             // Intentionally empty.
@@ -239,14 +239,14 @@ namespace playrho {
         ~BoundedValue() noexcept = default;
 
         /// @brief Assignment operator.
-        PLAYRHO_CONSTEXPR inline BoundedValue& operator= (const this_type& other) noexcept
+        constexpr inline BoundedValue& operator= (const this_type& other) noexcept
         {
             m_value = other.m_value;
             return *this;
         }
 
         /// @brief Assignment operator.
-        PLAYRHO_CONSTEXPR inline BoundedValue& operator= (const T& value)
+        constexpr inline BoundedValue& operator= (const T& value)
         {
             DoLoCheck(value);
             DoHiCheck(value);
@@ -256,7 +256,7 @@ namespace playrho {
 
         /// @brief Assignment operator for implicitly convertible types.
         template <typename U>
-        PLAYRHO_CONSTEXPR inline std::enable_if_t<std::is_convertible<U, T>::value, BoundedValue&>
+        constexpr inline std::enable_if_t<std::is_convertible<U, T>::value, BoundedValue&>
         operator= (const U& tmpVal)
         {
             const auto value = T(tmpVal);
@@ -267,7 +267,7 @@ namespace playrho {
         }
 
         /// @brief Move assignment operator.
-        PLAYRHO_CONSTEXPR inline BoundedValue& operator= (this_type&& value) noexcept
+        constexpr inline BoundedValue& operator= (this_type&& value) noexcept
         {
             // Note that the exception specification of this method
             //   doesn't match the defaulted one (when built with boost units).
@@ -276,27 +276,27 @@ namespace playrho {
         }
 
         /// @brief Gets the underlying value.
-        PLAYRHO_CONSTEXPR inline value_type get() const noexcept
+        constexpr inline value_type get() const noexcept
         {
             return m_value;
         }
 
         /// @brief Gets the underlying value.
-        PLAYRHO_CONSTEXPR inline operator value_type () const noexcept
+        constexpr inline operator value_type () const noexcept
         {
             return m_value;
         }
 
         /// @brief Member of pointer operator.
         template <typename U = T>
-        PLAYRHO_CONSTEXPR inline std::enable_if_t<std::is_pointer<U>::value, U> operator-> () const
+        constexpr inline std::enable_if_t<std::is_pointer<U>::value, U> operator-> () const
         {
             return m_value;
         }
 
         /// @brief Indirection operator.
         template <typename U = T>
-        PLAYRHO_CONSTEXPR inline std::enable_if_t<std::is_pointer<U>::value, remove_pointer_type>&
+        constexpr inline std::enable_if_t<std::is_pointer<U>::value, remove_pointer_type>&
         operator* () const
         {
             return *m_value;
@@ -310,14 +310,14 @@ namespace playrho {
 
     /// @brief Bounded value equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator== (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator== (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} == T{rhs};
     }
     
     /// @brief Bounded value inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} != T{rhs};
     }
@@ -326,56 +326,56 @@ namespace playrho {
 
     /// @brief Bounded value less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} <= T{rhs};
     }
     
     /// @brief Bounded value greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} >= T{rhs};
     }
     
     /// @brief Bounded value less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator< (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator< (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} < T{rhs};
     }
     
     /// @brief Bounded value greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator> (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator> (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} > T{rhs};
     }
     
     /// @brief Bounded value multiplication operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator* (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator* (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} * T{rhs};
     }
     
     /// @brief Bounded value division operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} / T{rhs};
     }
     
     /// @brief Bounded value addition operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} + T{rhs};
     }
     
     /// @brief Bounded value subtraction operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator- (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator- (const BoundedValue<T, lo, hi> lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return T{lhs} - T{rhs};
     }
@@ -384,14 +384,14 @@ namespace playrho {
 
     /// @brief Bounded value equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator== (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr inline bool operator== (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} == rhs;
     }
     
     /// @brief Bounded value inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr inline bool operator!= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} != rhs;
     }
@@ -400,56 +400,56 @@ namespace playrho {
 
     /// @brief Bounded value less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr inline bool operator<= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} <= rhs;
     }
     
     /// @brief Bounded value greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr inline bool operator>= (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} >= rhs;
     }
     
     /// @brief Bounded value less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator< (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr inline bool operator< (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} < rhs;
     }
     
     /// @brief Bounded value greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator> (const BoundedValue<T, lo, hi> lhs, const T rhs)
+    constexpr inline bool operator> (const BoundedValue<T, lo, hi> lhs, const T rhs)
     {
         return T{lhs} > rhs;
     }
     
     /// @brief Bounded value multiplication operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator* (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr inline auto operator* (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} * rhs;
     }
     
     /// @brief Bounded value division operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr inline auto operator/ (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} / rhs;
     }
     
     /// @brief Bounded value addition operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr inline auto operator+ (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} + rhs;
     }
     
     /// @brief Bounded value subtraction operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator- (const BoundedValue<T, lo, hi> lhs, const U rhs)
+    constexpr inline auto operator- (const BoundedValue<T, lo, hi> lhs, const U rhs)
     {
         return T{lhs} - T{rhs};
     }
@@ -458,14 +458,14 @@ namespace playrho {
 
     /// @brief Bounded value equality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator== (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator== (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs == T{rhs};
     }
     
     /// @brief Bounded value inequality operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator!= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator!= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs != T{rhs};
     }
@@ -474,56 +474,56 @@ namespace playrho {
 
     /// @brief Bounded value less-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator<= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator<= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs <= T{rhs};
     }
     
     /// @brief Bounded value greater-than or equal-to operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator>= (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator>= (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs >= T{rhs};
     }
     
     /// @brief Bounded value less-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator< (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator< (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs < T{rhs};
     }
     
     /// @brief Bounded value greater-than operator.
     template <typename T, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline bool operator> (const T lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline bool operator> (const T lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs > T{rhs};
     }
     
     /// @brief Bounded value multiplication operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator* (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator* (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs * T{rhs};
     }
     
     /// @brief Bounded value division operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator/ (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator/ (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs / T{rhs};
     }
     
     /// @brief Bounded value addition operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator+ (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator+ (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs + T{rhs};
     }
     
     /// @brief Bounded value subtraction operator.
     template <typename T, typename U, LoValueCheck lo, HiValueCheck hi>
-    PLAYRHO_CONSTEXPR inline auto operator- (const U lhs, const BoundedValue<T, lo, hi> rhs)
+    constexpr inline auto operator- (const U lhs, const BoundedValue<T, lo, hi> rhs)
     {
         return lhs - T{rhs};
     }

--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -70,39 +70,39 @@ namespace playrho {
         };
 
         /// @brief Gets the min value this type is capable of expressing.
-        static constexpr inline Fixed GetMin() noexcept
+        static constexpr Fixed GetMin() noexcept
         {
             return Fixed{1, scalar_type{1}};
         }
         
         /// @brief Gets an infinite value for this type.
-        static constexpr inline Fixed GetInfinity() noexcept
+        static constexpr Fixed GetInfinity() noexcept
         {
             return Fixed{numeric_limits::max(), scalar_type{1}};
         }
         
         /// @brief Gets the max value this type is capable of expressing.
-        static constexpr inline Fixed GetMax() noexcept
+        static constexpr Fixed GetMax() noexcept
         {
             // max reserved for +inf
             return Fixed{numeric_limits::max() - 1, scalar_type{1}};
         }
 
         /// @brief Gets a NaN value for this type.
-        static constexpr inline Fixed GetNaN() noexcept
+        static constexpr Fixed GetNaN() noexcept
         {
             return Fixed{numeric_limits::lowest(), scalar_type{1}};
         }
 
         /// @brief Gets the negative infinity value for this type.
-        static constexpr inline Fixed GetNegativeInfinity() noexcept
+        static constexpr Fixed GetNegativeInfinity() noexcept
         {
             // lowest reserved for NaN
             return Fixed{numeric_limits::lowest() + 1, scalar_type{1}};
         }
         
         /// @brief Gets the lowest value this type is capable of expressing.
-        static constexpr inline Fixed GetLowest() noexcept
+        static constexpr Fixed GetLowest() noexcept
         {
             // lowest reserved for NaN
             // lowest + 1 reserved for -inf
@@ -111,7 +111,7 @@ namespace playrho {
 
         /// @brief Gets the value from a floating point value.
         template <typename T>
-        static constexpr inline value_type GetFromFloat(T val) noexcept
+        static constexpr value_type GetFromFloat(T val) noexcept
         {
             static_assert(std::is_floating_point<T>::value, "floating point value required");
             // Note: std::isnan(val) *NOT* constant expression, so can't use here!
@@ -123,7 +123,7 @@ namespace playrho {
         
         /// @brief Gets the value from a signed integral value.
         template <typename T>
-        static constexpr inline value_type GetFromSignedInt(T val) noexcept
+        static constexpr value_type GetFromSignedInt(T val) noexcept
         {
             static_assert(std::is_integral<T>::value, "integral value required");
             static_assert(std::is_signed<T>::value, "must be signed");
@@ -134,7 +134,7 @@ namespace playrho {
         
         /// @brief Gets the value from an unsigned integral value.
         template <typename T>
-        static constexpr inline value_type GetFromUnsignedInt(T val) noexcept
+        static constexpr value_type GetFromUnsignedInt(T val) noexcept
         {
             static_assert(std::is_integral<T>::value, "integral value required");
             static_assert(!std::is_signed<T>::value, "must be unsigned");
@@ -145,77 +145,77 @@ namespace playrho {
         Fixed() = default;
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(long double val) noexcept:
+        constexpr Fixed(long double val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(double val) noexcept:
+        constexpr Fixed(double val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
 
         /// @brief Initializing constructor.
-        constexpr inline Fixed(float val) noexcept:
+        constexpr Fixed(float val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(unsigned long long val) noexcept:
+        constexpr Fixed(unsigned long long val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        constexpr inline Fixed(unsigned long val) noexcept:
+        constexpr Fixed(unsigned long val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(unsigned int val) noexcept:
+        constexpr Fixed(unsigned int val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        constexpr inline Fixed(long long val) noexcept:
+        constexpr Fixed(long long val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        constexpr inline Fixed(long val) noexcept:
+        constexpr Fixed(long val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(int val) noexcept:
+        constexpr Fixed(int val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(short val) noexcept:
+        constexpr Fixed(short val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(value_type val, unsigned int fraction) noexcept:
+        constexpr Fixed(value_type val, unsigned int fraction) noexcept:
             m_value{static_cast<value_type>(static_cast<std::uint32_t>(val * ScaleFactor) | fraction)}
         {
             // Intentionally empty.
@@ -223,7 +223,7 @@ namespace playrho {
         
         /// @brief Initializing constructor.
         template <typename BT, unsigned int FB>
-        constexpr inline Fixed(const Fixed<BT, FB> val) noexcept:
+        constexpr Fixed(const Fixed<BT, FB> val) noexcept:
             Fixed(static_cast<long double>(val))
         {
             // Intentionally empty
@@ -233,7 +233,7 @@ namespace playrho {
         
         /// @brief Converts the value to the expressed type.
         template <typename T>
-        constexpr inline T ConvertTo() const noexcept
+        constexpr T ConvertTo() const noexcept
         {
             return isnan()? std::numeric_limits<T>::signaling_NaN():
                 !isfinite()? std::numeric_limits<T>::infinity() * getsign():
@@ -241,7 +241,7 @@ namespace playrho {
         }
 
         /// @brief Compares this value to the given one.
-        constexpr inline CmpResult Compare(const Fixed other) const noexcept
+        constexpr CmpResult Compare(const Fixed other) const noexcept
         {
             if (isnan() || other.isnan())
             {
@@ -261,94 +261,94 @@ namespace playrho {
         // Unary operations
 
         /// @brief Long double operator.
-        explicit constexpr inline operator long double() const noexcept
+        explicit constexpr operator long double() const noexcept
         {
             return ConvertTo<long double>();
         }
         
         /// @brief Double operator.
-        explicit constexpr inline operator double() const noexcept
+        explicit constexpr operator double() const noexcept
         {
             return ConvertTo<double>();
         }
         
         /// @brief Float operator.
-        explicit constexpr inline operator float() const noexcept
+        explicit constexpr operator float() const noexcept
         {
             return ConvertTo<float>();
         }
     
         /// @brief Long long operator.
-        explicit constexpr inline operator long long() const noexcept
+        explicit constexpr operator long long() const noexcept
         {
             return m_value / ScaleFactor;
         }
         
         /// @brief Long operator.
-        explicit constexpr inline operator long() const noexcept
+        explicit constexpr operator long() const noexcept
         {
             return m_value / ScaleFactor;
         }
 
         /// @brief Unsigned long long operator.
-        explicit constexpr inline operator unsigned long long() const noexcept
+        explicit constexpr operator unsigned long long() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned long long>(m_value / ScaleFactor);
         }
 
         /// @brief Unsigned long operator.
-        explicit constexpr inline operator unsigned long() const noexcept
+        explicit constexpr operator unsigned long() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned long>(m_value / ScaleFactor);
         }
         
         /// @brief Unsigned int operator.
-        explicit constexpr inline operator unsigned int() const noexcept
+        explicit constexpr operator unsigned int() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned int>(m_value / ScaleFactor);
         }
 
         /// @brief int operator.
-        explicit constexpr inline operator int() const noexcept
+        explicit constexpr operator int() const noexcept
         {
             return static_cast<int>(m_value / ScaleFactor);
         }
         
         /// @brief short operator.
-        explicit constexpr inline operator short() const noexcept
+        explicit constexpr operator short() const noexcept
         {
             return static_cast<short>(m_value / ScaleFactor);
         }
         
         /// @brief Negation operator.
-        constexpr inline Fixed operator- () const noexcept
+        constexpr Fixed operator- () const noexcept
         {
             return (isnan())? *this: Fixed{-m_value, scalar_type{1}};
         }
         
         /// @brief Positive operator.
-        constexpr inline Fixed operator+ () const noexcept
+        constexpr Fixed operator+ () const noexcept
         {
             return *this;
         }
         
         /// @brief Boolean operator.
-        explicit constexpr inline operator bool() const noexcept
+        explicit constexpr operator bool() const noexcept
         {
             return m_value != 0;
         }
         
         /// @brief Logical not operator.
-        constexpr inline bool operator! () const noexcept
+        constexpr bool operator! () const noexcept
         {
             return m_value == 0;
         }
         
         /// @brief Addition assignment operator.
-        constexpr inline Fixed& operator+= (Fixed val) noexcept
+        constexpr Fixed& operator+= (Fixed val) noexcept
         {
             if (isnan() || val.isnan()
                 || ((m_value == GetInfinity().m_value) && (val.m_value == GetNegativeInfinity().m_value))
@@ -387,7 +387,7 @@ namespace playrho {
         }
 
         /// @brief Subtraction assignment operator.
-        constexpr inline Fixed& operator-= (Fixed val) noexcept
+        constexpr Fixed& operator-= (Fixed val) noexcept
         {
             if (isnan() || val.isnan()
                 || ((m_value == GetInfinity().m_value) && (val.m_value == GetInfinity().m_value))
@@ -426,7 +426,7 @@ namespace playrho {
         }
 
         /// @brief Multiplication assignment operator.
-        constexpr inline Fixed& operator*= (Fixed val) noexcept
+        constexpr Fixed& operator*= (Fixed val) noexcept
         {
             if (isnan() || val.isnan())
             {
@@ -472,7 +472,7 @@ namespace playrho {
         }
 
         /// @brief Division assignment operator.
-        constexpr inline Fixed& operator/= (Fixed val) noexcept
+        constexpr Fixed& operator/= (Fixed val) noexcept
         {
             if (isnan() || val.isnan())
             {
@@ -519,7 +519,7 @@ namespace playrho {
         }
         
         /// @brief Modulo operator.
-        constexpr inline Fixed& operator%= (Fixed val) noexcept
+        constexpr Fixed& operator%= (Fixed val) noexcept
         {
             assert(!isnan());
             assert(!val.isnan());
@@ -529,20 +529,20 @@ namespace playrho {
         }
         
         /// @brief Is finite.
-        constexpr inline bool isfinite() const noexcept
+        constexpr bool isfinite() const noexcept
         {
             return (m_value > GetNegativeInfinity().m_value)
             && (m_value < GetInfinity().m_value);
         }
         
         /// @brief Is NaN.
-        constexpr inline bool isnan() const noexcept
+        constexpr bool isnan() const noexcept
         {
             return m_value == GetNaN().m_value;
         }
         
         /// @brief Gets this value's sign.
-        constexpr inline int getsign() const noexcept
+        constexpr int getsign() const noexcept
         {
             return (m_value >= 0)? +1: -1;
         }
@@ -565,7 +565,7 @@ namespace playrho {
         using numeric_limits = std::numeric_limits<value_type>;
         
         /// @brief Initializing constructor.
-        constexpr inline Fixed(value_type val, scalar_type scalar) noexcept:
+        constexpr Fixed(value_type val, scalar_type scalar) noexcept:
             m_value{val * scalar.value}
         {
             // Intentionally empty.
@@ -576,35 +576,35 @@ namespace playrho {
 
     /// @brief Equality operator.
     template <typename BT, unsigned int FB>
-    constexpr inline bool operator== (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr bool operator== (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
     template <typename BT, unsigned int FB>
-    constexpr inline bool operator!= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr bool operator!= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed<BT, FB>::CmpResult::Equal;
     }
     
     /// @brief Less-than operator.
     template <typename BT, unsigned int FB>
-    constexpr inline bool operator< (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr bool operator< (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::LessThan;
     }
 
     /// @brief Greater-than operator.
     template <typename BT, unsigned int FB>
-    constexpr inline bool operator> (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr bool operator> (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::GreaterThan;
     }
     
     /// @brief Less-than or equal-to operator.
     template <typename BT, unsigned int FB>
-    constexpr inline bool operator<= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr bool operator<= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed<BT, FB>::CmpResult::LessThan ||
@@ -613,7 +613,7 @@ namespace playrho {
     
     /// @brief Greater-than or equal-to operator.
     template <typename BT, unsigned int FB>
-    constexpr inline bool operator>= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr bool operator>= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed<BT, FB>::CmpResult::GreaterThan || result == Fixed<BT, FB>::CmpResult::Equal;
@@ -621,7 +621,7 @@ namespace playrho {
 
     /// @brief Addition operator.
     template <typename BT, unsigned int FB>
-    constexpr inline Fixed<BT, FB> operator+ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr Fixed<BT, FB> operator+ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs += rhs;
         return lhs;
@@ -629,7 +629,7 @@ namespace playrho {
     
     /// @brief Subtraction operator.
     template <typename BT, unsigned int FB>
-    constexpr inline Fixed<BT, FB> operator- (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr Fixed<BT, FB> operator- (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
@@ -637,7 +637,7 @@ namespace playrho {
     
     /// @brief Multiplication operator.
     template <typename BT, unsigned int FB>
-    constexpr inline Fixed<BT, FB> operator* (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr Fixed<BT, FB> operator* (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
@@ -645,7 +645,7 @@ namespace playrho {
     
     /// @brief Division operator.
     template <typename BT, unsigned int FB>
-    constexpr inline Fixed<BT, FB> operator/ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr Fixed<BT, FB> operator/ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
@@ -653,7 +653,7 @@ namespace playrho {
     
     /// @brief Modulo operator.
     template <typename BT, unsigned int FB>
-    constexpr inline Fixed<BT, FB> operator% (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr Fixed<BT, FB> operator% (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
@@ -664,14 +664,14 @@ namespace playrho {
     /// odd results like a divide by zero trap occurring.
     /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
     template <typename BT, unsigned int FB>
-    constexpr inline bool AlmostZero(Fixed<BT, FB> value)
+    constexpr bool AlmostZero(Fixed<BT, FB> value)
     {
         return value == 0;
     }
 
     /// @brief Determines whether the given two values are "almost equal".
     template <typename BT, unsigned int FB>
-    constexpr inline bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
+    constexpr bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
     {
         return abs(x - y) <= Fixed<BT, FB>{0, static_cast<std::uint32_t>(ulp)};
     }
@@ -679,7 +679,7 @@ namespace playrho {
 #ifdef CONFLICT_WITH_GETINVALID
     /// @brief Gets an invalid value.
     template <typename BT, unsigned int FB>
-    constexpr inline Fixed<BT, FB> GetInvalid() noexcept
+    constexpr Fixed<BT, FB> GetInvalid() noexcept
     {
         return Fixed<BT, FB>::GetNaN();
     }
@@ -712,81 +712,81 @@ namespace playrho {
     
     /// @brief Gets an invalid value.
     template <>
-    constexpr inline Fixed32 GetInvalid() noexcept
+    constexpr Fixed32 GetInvalid() noexcept
     {
         return Fixed32::GetNaN();
     }
     
     /// @brief Addition operator.
-    constexpr inline Fixed32 operator+ (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr Fixed32 operator+ (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs += rhs;
         return lhs;
     }
 
     /// @brief Subtraction operator.
-    constexpr inline Fixed32 operator- (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr Fixed32 operator- (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
     }
     
     /// @brief Multiplication operator.
-    constexpr inline Fixed32 operator* (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr Fixed32 operator* (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
     }
     
     /// @brief Division operator.
-    constexpr inline Fixed32 operator/ (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr Fixed32 operator/ (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
     }
     
     /// @brief Modulo operator.
-    constexpr inline Fixed32 operator% (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr Fixed32 operator% (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
     }    
     
     /// @brief Equality operator.
-    constexpr inline bool operator== (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr bool operator== (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed32::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
-    constexpr inline bool operator!= (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr bool operator!= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed32::CmpResult::Equal;
     }
     
     /// @brief Less-than or equal-to operator.
-    constexpr inline bool operator <= (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr bool operator <= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed32::CmpResult::LessThan) || (result == Fixed32::CmpResult::Equal);
     }
     
     /// @brief Greater-than or equal-to operator.
-    constexpr inline bool operator >= (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr bool operator >= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed32::CmpResult::GreaterThan) || (result == Fixed32::CmpResult::Equal);
     }
     
     /// @brief Less-than operator.
-    constexpr inline bool operator < (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr bool operator < (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed32::CmpResult::LessThan;
     }
     
     /// @brief Greater-than operator.
-    constexpr inline bool operator > (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr bool operator > (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed32::CmpResult::GreaterThan;
@@ -821,76 +821,76 @@ namespace playrho {
     
     /// @brief Gets an invalid value.
     template <>
-    constexpr inline Fixed64 GetInvalid() noexcept
+    constexpr Fixed64 GetInvalid() noexcept
     {
         return Fixed64::GetNaN();
     }
 
     /// @brief Addition operator.
-    constexpr inline Fixed64 operator+ (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr Fixed64 operator+ (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs += rhs;
         return lhs;
     }
     
     /// @brief Subtraction operator.
-    constexpr inline Fixed64 operator- (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr Fixed64 operator- (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
     }
     
     /// @brief Multiplication operator.
-    constexpr inline Fixed64 operator* (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr Fixed64 operator* (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
     }
     
     /// @brief Division operator.
-    constexpr inline Fixed64 operator/ (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr Fixed64 operator/ (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
     }
     
-    constexpr inline Fixed64 operator% (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr Fixed64 operator% (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
     }
     
     /// @brief Equality operator.
-    constexpr inline bool operator== (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr bool operator== (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed64::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
-    constexpr inline bool operator!= (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr bool operator!= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed64::CmpResult::Equal;
     }
     
-    constexpr inline bool operator <= (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr bool operator <= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed64::CmpResult::LessThan) || (result == Fixed64::CmpResult::Equal);
     }
     
-    constexpr inline bool operator >= (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr bool operator >= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed64::CmpResult::GreaterThan) || (result == Fixed64::CmpResult::Equal);
     }
     
-    constexpr inline bool operator < (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr bool operator < (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed64::CmpResult::LessThan;
     }
     
-    constexpr inline bool operator > (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr bool operator > (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed64::CmpResult::GreaterThan;

--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -49,16 +49,16 @@ namespace playrho {
         using value_type = BASE_TYPE;
         
         /// @brief Total number of bits.
-        static PLAYRHO_CONSTEXPR const unsigned int TotalBits = sizeof(BASE_TYPE) * 8;
+        static constexpr const unsigned int TotalBits = sizeof(BASE_TYPE) * 8;
 
         /// @brief Fraction bits.
-        static PLAYRHO_CONSTEXPR const unsigned int FractionBits = FRACTION_BITS;
+        static constexpr const unsigned int FractionBits = FRACTION_BITS;
         
         /// @brief Whole value bits.
-        static PLAYRHO_CONSTEXPR const unsigned int WholeBits = TotalBits - FractionBits;
+        static constexpr const unsigned int WholeBits = TotalBits - FractionBits;
 
         /// @brief Scale factor.
-        static PLAYRHO_CONSTEXPR const value_type ScaleFactor = static_cast<value_type>(1u << FractionBits);
+        static constexpr const value_type ScaleFactor = static_cast<value_type>(1u << FractionBits);
 
         /// @brief Compare result enumeration.
         enum class CmpResult
@@ -70,39 +70,39 @@ namespace playrho {
         };
 
         /// @brief Gets the min value this type is capable of expressing.
-        static PLAYRHO_CONSTEXPR inline Fixed GetMin() noexcept
+        static constexpr inline Fixed GetMin() noexcept
         {
             return Fixed{1, scalar_type{1}};
         }
         
         /// @brief Gets an infinite value for this type.
-        static PLAYRHO_CONSTEXPR inline Fixed GetInfinity() noexcept
+        static constexpr inline Fixed GetInfinity() noexcept
         {
             return Fixed{numeric_limits::max(), scalar_type{1}};
         }
         
         /// @brief Gets the max value this type is capable of expressing.
-        static PLAYRHO_CONSTEXPR inline Fixed GetMax() noexcept
+        static constexpr inline Fixed GetMax() noexcept
         {
             // max reserved for +inf
             return Fixed{numeric_limits::max() - 1, scalar_type{1}};
         }
 
         /// @brief Gets a NaN value for this type.
-        static PLAYRHO_CONSTEXPR inline Fixed GetNaN() noexcept
+        static constexpr inline Fixed GetNaN() noexcept
         {
             return Fixed{numeric_limits::lowest(), scalar_type{1}};
         }
 
         /// @brief Gets the negative infinity value for this type.
-        static PLAYRHO_CONSTEXPR inline Fixed GetNegativeInfinity() noexcept
+        static constexpr inline Fixed GetNegativeInfinity() noexcept
         {
             // lowest reserved for NaN
             return Fixed{numeric_limits::lowest() + 1, scalar_type{1}};
         }
         
         /// @brief Gets the lowest value this type is capable of expressing.
-        static PLAYRHO_CONSTEXPR inline Fixed GetLowest() noexcept
+        static constexpr inline Fixed GetLowest() noexcept
         {
             // lowest reserved for NaN
             // lowest + 1 reserved for -inf
@@ -111,7 +111,7 @@ namespace playrho {
 
         /// @brief Gets the value from a floating point value.
         template <typename T>
-        static PLAYRHO_CONSTEXPR inline value_type GetFromFloat(T val) noexcept
+        static constexpr inline value_type GetFromFloat(T val) noexcept
         {
             static_assert(std::is_floating_point<T>::value, "floating point value required");
             // Note: std::isnan(val) *NOT* constant expression, so can't use here!
@@ -123,7 +123,7 @@ namespace playrho {
         
         /// @brief Gets the value from a signed integral value.
         template <typename T>
-        static PLAYRHO_CONSTEXPR inline value_type GetFromSignedInt(T val) noexcept
+        static constexpr inline value_type GetFromSignedInt(T val) noexcept
         {
             static_assert(std::is_integral<T>::value, "integral value required");
             static_assert(std::is_signed<T>::value, "must be signed");
@@ -134,7 +134,7 @@ namespace playrho {
         
         /// @brief Gets the value from an unsigned integral value.
         template <typename T>
-        static PLAYRHO_CONSTEXPR inline value_type GetFromUnsignedInt(T val) noexcept
+        static constexpr inline value_type GetFromUnsignedInt(T val) noexcept
         {
             static_assert(std::is_integral<T>::value, "integral value required");
             static_assert(!std::is_signed<T>::value, "must be unsigned");
@@ -145,77 +145,77 @@ namespace playrho {
         Fixed() = default;
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(long double val) noexcept:
+        constexpr inline Fixed(long double val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(double val) noexcept:
+        constexpr inline Fixed(double val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(float val) noexcept:
+        constexpr inline Fixed(float val) noexcept:
             m_value{GetFromFloat(val)}
         {
             // Intentionally empty
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(unsigned long long val) noexcept:
+        constexpr inline Fixed(unsigned long long val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(unsigned long val) noexcept:
+        constexpr inline Fixed(unsigned long val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(unsigned int val) noexcept:
+        constexpr inline Fixed(unsigned int val) noexcept:
             m_value{GetFromUnsignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(long long val) noexcept:
+        constexpr inline Fixed(long long val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(long val) noexcept:
+        constexpr inline Fixed(long val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(int val) noexcept:
+        constexpr inline Fixed(int val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(short val) noexcept:
+        constexpr inline Fixed(short val) noexcept:
             m_value{GetFromSignedInt(val)}
         {
             // Intentionally empty.
         }
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(value_type val, unsigned int fraction) noexcept:
+        constexpr inline Fixed(value_type val, unsigned int fraction) noexcept:
             m_value{static_cast<value_type>(static_cast<std::uint32_t>(val * ScaleFactor) | fraction)}
         {
             // Intentionally empty.
@@ -223,7 +223,7 @@ namespace playrho {
         
         /// @brief Initializing constructor.
         template <typename BT, unsigned int FB>
-        PLAYRHO_CONSTEXPR inline Fixed(const Fixed<BT, FB> val) noexcept:
+        constexpr inline Fixed(const Fixed<BT, FB> val) noexcept:
             Fixed(static_cast<long double>(val))
         {
             // Intentionally empty
@@ -233,7 +233,7 @@ namespace playrho {
         
         /// @brief Converts the value to the expressed type.
         template <typename T>
-        PLAYRHO_CONSTEXPR inline T ConvertTo() const noexcept
+        constexpr inline T ConvertTo() const noexcept
         {
             return isnan()? std::numeric_limits<T>::signaling_NaN():
                 !isfinite()? std::numeric_limits<T>::infinity() * getsign():
@@ -241,7 +241,7 @@ namespace playrho {
         }
 
         /// @brief Compares this value to the given one.
-        PLAYRHO_CONSTEXPR inline CmpResult Compare(const Fixed other) const noexcept
+        constexpr inline CmpResult Compare(const Fixed other) const noexcept
         {
             if (isnan() || other.isnan())
             {
@@ -261,94 +261,94 @@ namespace playrho {
         // Unary operations
 
         /// @brief Long double operator.
-        explicit PLAYRHO_CONSTEXPR inline operator long double() const noexcept
+        explicit constexpr inline operator long double() const noexcept
         {
             return ConvertTo<long double>();
         }
         
         /// @brief Double operator.
-        explicit PLAYRHO_CONSTEXPR inline operator double() const noexcept
+        explicit constexpr inline operator double() const noexcept
         {
             return ConvertTo<double>();
         }
         
         /// @brief Float operator.
-        explicit PLAYRHO_CONSTEXPR inline operator float() const noexcept
+        explicit constexpr inline operator float() const noexcept
         {
             return ConvertTo<float>();
         }
     
         /// @brief Long long operator.
-        explicit PLAYRHO_CONSTEXPR inline operator long long() const noexcept
+        explicit constexpr inline operator long long() const noexcept
         {
             return m_value / ScaleFactor;
         }
         
         /// @brief Long operator.
-        explicit PLAYRHO_CONSTEXPR inline operator long() const noexcept
+        explicit constexpr inline operator long() const noexcept
         {
             return m_value / ScaleFactor;
         }
 
         /// @brief Unsigned long long operator.
-        explicit PLAYRHO_CONSTEXPR inline operator unsigned long long() const noexcept
+        explicit constexpr inline operator unsigned long long() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned long long>(m_value / ScaleFactor);
         }
 
         /// @brief Unsigned long operator.
-        explicit PLAYRHO_CONSTEXPR inline operator unsigned long() const noexcept
+        explicit constexpr inline operator unsigned long() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned long>(m_value / ScaleFactor);
         }
         
         /// @brief Unsigned int operator.
-        explicit PLAYRHO_CONSTEXPR inline operator unsigned int() const noexcept
+        explicit constexpr inline operator unsigned int() const noexcept
         {
             // Behavior is undefined if m_value is negative
             return static_cast<unsigned int>(m_value / ScaleFactor);
         }
 
         /// @brief int operator.
-        explicit PLAYRHO_CONSTEXPR inline operator int() const noexcept
+        explicit constexpr inline operator int() const noexcept
         {
             return static_cast<int>(m_value / ScaleFactor);
         }
         
         /// @brief short operator.
-        explicit PLAYRHO_CONSTEXPR inline operator short() const noexcept
+        explicit constexpr inline operator short() const noexcept
         {
             return static_cast<short>(m_value / ScaleFactor);
         }
         
         /// @brief Negation operator.
-        PLAYRHO_CONSTEXPR inline Fixed operator- () const noexcept
+        constexpr inline Fixed operator- () const noexcept
         {
             return (isnan())? *this: Fixed{-m_value, scalar_type{1}};
         }
         
         /// @brief Positive operator.
-        PLAYRHO_CONSTEXPR inline Fixed operator+ () const noexcept
+        constexpr inline Fixed operator+ () const noexcept
         {
             return *this;
         }
         
         /// @brief Boolean operator.
-        explicit PLAYRHO_CONSTEXPR inline operator bool() const noexcept
+        explicit constexpr inline operator bool() const noexcept
         {
             return m_value != 0;
         }
         
         /// @brief Logical not operator.
-        PLAYRHO_CONSTEXPR inline bool operator! () const noexcept
+        constexpr inline bool operator! () const noexcept
         {
             return m_value == 0;
         }
         
         /// @brief Addition assignment operator.
-        PLAYRHO_CONSTEXPR inline Fixed& operator+= (Fixed val) noexcept
+        constexpr inline Fixed& operator+= (Fixed val) noexcept
         {
             if (isnan() || val.isnan()
                 || ((m_value == GetInfinity().m_value) && (val.m_value == GetNegativeInfinity().m_value))
@@ -387,7 +387,7 @@ namespace playrho {
         }
 
         /// @brief Subtraction assignment operator.
-        PLAYRHO_CONSTEXPR inline Fixed& operator-= (Fixed val) noexcept
+        constexpr inline Fixed& operator-= (Fixed val) noexcept
         {
             if (isnan() || val.isnan()
                 || ((m_value == GetInfinity().m_value) && (val.m_value == GetInfinity().m_value))
@@ -426,7 +426,7 @@ namespace playrho {
         }
 
         /// @brief Multiplication assignment operator.
-        PLAYRHO_CONSTEXPR inline Fixed& operator*= (Fixed val) noexcept
+        constexpr inline Fixed& operator*= (Fixed val) noexcept
         {
             if (isnan() || val.isnan())
             {
@@ -472,7 +472,7 @@ namespace playrho {
         }
 
         /// @brief Division assignment operator.
-        PLAYRHO_CONSTEXPR inline Fixed& operator/= (Fixed val) noexcept
+        constexpr inline Fixed& operator/= (Fixed val) noexcept
         {
             if (isnan() || val.isnan())
             {
@@ -519,7 +519,7 @@ namespace playrho {
         }
         
         /// @brief Modulo operator.
-        PLAYRHO_CONSTEXPR inline Fixed& operator%= (Fixed val) noexcept
+        constexpr inline Fixed& operator%= (Fixed val) noexcept
         {
             assert(!isnan());
             assert(!val.isnan());
@@ -529,20 +529,20 @@ namespace playrho {
         }
         
         /// @brief Is finite.
-        PLAYRHO_CONSTEXPR inline bool isfinite() const noexcept
+        constexpr inline bool isfinite() const noexcept
         {
             return (m_value > GetNegativeInfinity().m_value)
             && (m_value < GetInfinity().m_value);
         }
         
         /// @brief Is NaN.
-        PLAYRHO_CONSTEXPR inline bool isnan() const noexcept
+        constexpr inline bool isnan() const noexcept
         {
             return m_value == GetNaN().m_value;
         }
         
         /// @brief Gets this value's sign.
-        PLAYRHO_CONSTEXPR inline int getsign() const noexcept
+        constexpr inline int getsign() const noexcept
         {
             return (m_value >= 0)? +1: -1;
         }
@@ -565,7 +565,7 @@ namespace playrho {
         using numeric_limits = std::numeric_limits<value_type>;
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Fixed(value_type val, scalar_type scalar) noexcept:
+        constexpr inline Fixed(value_type val, scalar_type scalar) noexcept:
             m_value{val * scalar.value}
         {
             // Intentionally empty.
@@ -576,35 +576,35 @@ namespace playrho {
 
     /// @brief Equality operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool operator== (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline bool operator== (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool operator!= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline bool operator!= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed<BT, FB>::CmpResult::Equal;
     }
     
     /// @brief Less-than operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool operator< (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline bool operator< (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::LessThan;
     }
 
     /// @brief Greater-than operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool operator> (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline bool operator> (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::GreaterThan;
     }
     
     /// @brief Less-than or equal-to operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool operator<= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline bool operator<= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed<BT, FB>::CmpResult::LessThan ||
@@ -613,7 +613,7 @@ namespace playrho {
     
     /// @brief Greater-than or equal-to operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool operator>= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline bool operator>= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed<BT, FB>::CmpResult::GreaterThan || result == Fixed<BT, FB>::CmpResult::Equal;
@@ -621,7 +621,7 @@ namespace playrho {
 
     /// @brief Addition operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator+ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline Fixed<BT, FB> operator+ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs += rhs;
         return lhs;
@@ -629,7 +629,7 @@ namespace playrho {
     
     /// @brief Subtraction operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator- (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline Fixed<BT, FB> operator- (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
@@ -637,7 +637,7 @@ namespace playrho {
     
     /// @brief Multiplication operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator* (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline Fixed<BT, FB> operator* (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
@@ -645,7 +645,7 @@ namespace playrho {
     
     /// @brief Division operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator/ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline Fixed<BT, FB> operator/ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
@@ -653,7 +653,7 @@ namespace playrho {
     
     /// @brief Modulo operator.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> operator% (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    constexpr inline Fixed<BT, FB> operator% (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
@@ -664,14 +664,14 @@ namespace playrho {
     /// odd results like a divide by zero trap occurring.
     /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool AlmostZero(Fixed<BT, FB> value)
+    constexpr inline bool AlmostZero(Fixed<BT, FB> value)
     {
         return value == 0;
     }
 
     /// @brief Determines whether the given two values are "almost equal".
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
+    constexpr inline bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
     {
         return abs(x - y) <= Fixed<BT, FB>{0, static_cast<std::uint32_t>(ulp)};
     }
@@ -679,7 +679,7 @@ namespace playrho {
 #ifdef CONFLICT_WITH_GETINVALID
     /// @brief Gets an invalid value.
     template <typename BT, unsigned int FB>
-    PLAYRHO_CONSTEXPR inline Fixed<BT, FB> GetInvalid() noexcept
+    constexpr inline Fixed<BT, FB> GetInvalid() noexcept
     {
         return Fixed<BT, FB>::GetNaN();
     }
@@ -712,81 +712,81 @@ namespace playrho {
     
     /// @brief Gets an invalid value.
     template <>
-    PLAYRHO_CONSTEXPR inline Fixed32 GetInvalid() noexcept
+    constexpr inline Fixed32 GetInvalid() noexcept
     {
         return Fixed32::GetNaN();
     }
     
     /// @brief Addition operator.
-    PLAYRHO_CONSTEXPR inline Fixed32 operator+ (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline Fixed32 operator+ (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs += rhs;
         return lhs;
     }
 
     /// @brief Subtraction operator.
-    PLAYRHO_CONSTEXPR inline Fixed32 operator- (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline Fixed32 operator- (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
     }
     
     /// @brief Multiplication operator.
-    PLAYRHO_CONSTEXPR inline Fixed32 operator* (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline Fixed32 operator* (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
     }
     
     /// @brief Division operator.
-    PLAYRHO_CONSTEXPR inline Fixed32 operator/ (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline Fixed32 operator/ (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
     }
     
     /// @brief Modulo operator.
-    PLAYRHO_CONSTEXPR inline Fixed32 operator% (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline Fixed32 operator% (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
     }    
     
     /// @brief Equality operator.
-    PLAYRHO_CONSTEXPR inline bool operator== (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline bool operator== (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed32::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
-    PLAYRHO_CONSTEXPR inline bool operator!= (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline bool operator!= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed32::CmpResult::Equal;
     }
     
     /// @brief Less-than or equal-to operator.
-    PLAYRHO_CONSTEXPR inline bool operator <= (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline bool operator <= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed32::CmpResult::LessThan) || (result == Fixed32::CmpResult::Equal);
     }
     
     /// @brief Greater-than or equal-to operator.
-    PLAYRHO_CONSTEXPR inline bool operator >= (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline bool operator >= (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed32::CmpResult::GreaterThan) || (result == Fixed32::CmpResult::Equal);
     }
     
     /// @brief Less-than operator.
-    PLAYRHO_CONSTEXPR inline bool operator < (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline bool operator < (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed32::CmpResult::LessThan;
     }
     
     /// @brief Greater-than operator.
-    PLAYRHO_CONSTEXPR inline bool operator > (Fixed32 lhs, Fixed32 rhs) noexcept
+    constexpr inline bool operator > (Fixed32 lhs, Fixed32 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed32::CmpResult::GreaterThan;
@@ -821,76 +821,76 @@ namespace playrho {
     
     /// @brief Gets an invalid value.
     template <>
-    PLAYRHO_CONSTEXPR inline Fixed64 GetInvalid() noexcept
+    constexpr inline Fixed64 GetInvalid() noexcept
     {
         return Fixed64::GetNaN();
     }
 
     /// @brief Addition operator.
-    PLAYRHO_CONSTEXPR inline Fixed64 operator+ (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline Fixed64 operator+ (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs += rhs;
         return lhs;
     }
     
     /// @brief Subtraction operator.
-    PLAYRHO_CONSTEXPR inline Fixed64 operator- (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline Fixed64 operator- (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs -= rhs;
         return lhs;
     }
     
     /// @brief Multiplication operator.
-    PLAYRHO_CONSTEXPR inline Fixed64 operator* (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline Fixed64 operator* (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs *= rhs;
         return lhs;
     }
     
     /// @brief Division operator.
-    PLAYRHO_CONSTEXPR inline Fixed64 operator/ (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline Fixed64 operator/ (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs /= rhs;
         return lhs;
     }
     
-    PLAYRHO_CONSTEXPR inline Fixed64 operator% (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline Fixed64 operator% (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         lhs %= rhs;
         return lhs;
     }
     
     /// @brief Equality operator.
-    PLAYRHO_CONSTEXPR inline bool operator== (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline bool operator== (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         return lhs.Compare(rhs) == Fixed64::CmpResult::Equal;
     }
     
     /// @brief Inequality operator.
-    PLAYRHO_CONSTEXPR inline bool operator!= (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline bool operator!= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         return lhs.Compare(rhs) != Fixed64::CmpResult::Equal;
     }
     
-    PLAYRHO_CONSTEXPR inline bool operator <= (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline bool operator <= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed64::CmpResult::LessThan) || (result == Fixed64::CmpResult::Equal);
     }
     
-    PLAYRHO_CONSTEXPR inline bool operator >= (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline bool operator >= (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return (result == Fixed64::CmpResult::GreaterThan) || (result == Fixed64::CmpResult::Equal);
     }
     
-    PLAYRHO_CONSTEXPR inline bool operator < (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline bool operator < (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed64::CmpResult::LessThan;
     }
     
-    PLAYRHO_CONSTEXPR inline bool operator > (Fixed64 lhs, Fixed64 rhs) noexcept
+    constexpr inline bool operator > (Fixed64 lhs, Fixed64 rhs) noexcept
     {
         const auto result = lhs.Compare(rhs);
         return result == Fixed64::CmpResult::GreaterThan;

--- a/PlayRho/Common/FixedLimits.hpp
+++ b/PlayRho/Common/FixedLimits.hpp
@@ -34,13 +34,13 @@ namespace std {
         static constexpr const bool is_specialized = true; ///< Type is specialized.
         
         /// @brief Gets the min value available for the type.
-        static constexpr inline playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
+        static constexpr playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
         
         /// @brief Gets the max value available for the type.
-        static constexpr inline playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
+        static constexpr playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
         
         /// @brief Gets the lowest value available for the type.
-        static constexpr inline playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
+        static constexpr playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
         
         /// @brief Number of radix digits that can be represented.
         static constexpr const int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
@@ -57,10 +57,10 @@ namespace std {
         static constexpr const int radix = 0; ///< Radix used by the type.
         
         /// @brief Gets the epsilon value for the type.
-        static constexpr inline playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        static constexpr playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
         
         /// @brief Gets the round error value for the type.
-        static constexpr inline playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        static constexpr playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
         
         /// @brief One more than smallest negative power of the radix that's a valid
         ///    normalized floating-point value.
@@ -83,16 +83,16 @@ namespace std {
         static constexpr const bool has_denorm_loss = false; ///< Has <code>denorm</code> loss amount.
         
         /// @brief Gets the infinite value for the type.
-        static constexpr inline playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
+        static constexpr playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
         
         /// @brief Gets the quiet NaN value for the type.
-        static constexpr inline playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
+        static constexpr playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
         
         /// @brief Gets the signaling NaN value for the type.
-        static constexpr inline playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        static constexpr playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
         
         /// @brief Gets the <code>denorm</code> value for the type.
-        static constexpr inline playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        static constexpr playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
         
         static constexpr const bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
         static constexpr const bool is_bounded = true; ///< Type bounded: has limited precision.

--- a/PlayRho/Common/FixedLimits.hpp
+++ b/PlayRho/Common/FixedLimits.hpp
@@ -31,76 +31,76 @@ namespace std {
     class numeric_limits<playrho::Fixed<BT,FB>>
     {
     public:
-        static PLAYRHO_CONSTEXPR const bool is_specialized = true; ///< Type is specialized.
+        static constexpr const bool is_specialized = true; ///< Type is specialized.
         
         /// @brief Gets the min value available for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
+        static constexpr inline playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
         
         /// @brief Gets the max value available for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
+        static constexpr inline playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
         
         /// @brief Gets the lowest value available for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
+        static constexpr inline playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
         
         /// @brief Number of radix digits that can be represented.
-        static PLAYRHO_CONSTEXPR const int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
+        static constexpr const int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
         
         /// @brief Number of decimal digits that can be represented.
-        static PLAYRHO_CONSTEXPR const int digits10 = playrho::Fixed<BT,FB>::WholeBits - 1;
+        static constexpr const int digits10 = playrho::Fixed<BT,FB>::WholeBits - 1;
         
         /// @brief Number of decimal digits necessary to differentiate all values.
-        static PLAYRHO_CONSTEXPR const int max_digits10 = 5; // TODO(lou): check this
+        static constexpr const int max_digits10 = 5; // TODO(lou): check this
         
-        static PLAYRHO_CONSTEXPR const bool is_signed = true; ///< Identifies signed types.
-        static PLAYRHO_CONSTEXPR const bool is_integer = false; ///< Identifies integer types.
-        static PLAYRHO_CONSTEXPR const bool is_exact = true; ///< Identifies exact type.
-        static PLAYRHO_CONSTEXPR const int radix = 0; ///< Radix used by the type.
+        static constexpr const bool is_signed = true; ///< Identifies signed types.
+        static constexpr const bool is_integer = false; ///< Identifies integer types.
+        static constexpr const bool is_exact = true; ///< Identifies exact type.
+        static constexpr const int radix = 0; ///< Radix used by the type.
         
         /// @brief Gets the epsilon value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        static constexpr inline playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
         
         /// @brief Gets the round error value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
+        static constexpr inline playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
         
         /// @brief One more than smallest negative power of the radix that's a valid
         ///    normalized floating-point value.
-        static PLAYRHO_CONSTEXPR const int min_exponent = 0;
+        static constexpr const int min_exponent = 0;
         
         /// @brief Smallest negative power of ten that's a valid normalized floating-point value.
-        static PLAYRHO_CONSTEXPR const int min_exponent10 = 0;
+        static constexpr const int min_exponent10 = 0;
         
         /// @brief One more than largest integer power of radix that's a valid finite
         ///   floating-point value.
-        static PLAYRHO_CONSTEXPR const int max_exponent = 0;
+        static constexpr const int max_exponent = 0;
         
         /// @brief Largest integer power of 10 that's a valid finite floating-point value.
-        static PLAYRHO_CONSTEXPR const int max_exponent10 = 0;
+        static constexpr const int max_exponent10 = 0;
         
-        static PLAYRHO_CONSTEXPR const bool has_infinity = true; ///< Whether can represent infinity.
-        static PLAYRHO_CONSTEXPR const bool has_quiet_NaN = true; ///< Whether can represent quiet-NaN.
-        static PLAYRHO_CONSTEXPR const bool has_signaling_NaN = false; ///< Whether can represent signaling-NaN.
-        static PLAYRHO_CONSTEXPR const float_denorm_style has_denorm = denorm_absent; ///< <code>Denorm</code> style used.
-        static PLAYRHO_CONSTEXPR const bool has_denorm_loss = false; ///< Has <code>denorm</code> loss amount.
+        static constexpr const bool has_infinity = true; ///< Whether can represent infinity.
+        static constexpr const bool has_quiet_NaN = true; ///< Whether can represent quiet-NaN.
+        static constexpr const bool has_signaling_NaN = false; ///< Whether can represent signaling-NaN.
+        static constexpr const float_denorm_style has_denorm = denorm_absent; ///< <code>Denorm</code> style used.
+        static constexpr const bool has_denorm_loss = false; ///< Has <code>denorm</code> loss amount.
         
         /// @brief Gets the infinite value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
+        static constexpr inline playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
         
         /// @brief Gets the quiet NaN value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
+        static constexpr inline playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
         
         /// @brief Gets the signaling NaN value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        static constexpr inline playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
         
         /// @brief Gets the <code>denorm</code> value for the type.
-        static PLAYRHO_CONSTEXPR inline playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
+        static constexpr inline playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
         
-        static PLAYRHO_CONSTEXPR const bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
-        static PLAYRHO_CONSTEXPR const bool is_bounded = true; ///< Type bounded: has limited precision.
-        static PLAYRHO_CONSTEXPR const bool is_modulo = false; ///< Doesn't modulo arithmetic overflows.
+        static constexpr const bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
+        static constexpr const bool is_bounded = true; ///< Type bounded: has limited precision.
+        static constexpr const bool is_modulo = false; ///< Doesn't modulo arithmetic overflows.
         
-        static PLAYRHO_CONSTEXPR const bool traps = false; ///< Doesn't do traps.
-        static PLAYRHO_CONSTEXPR const bool tinyness_before = false; ///< Doesn't detect <code>tinyness</code> before rounding.
-        static PLAYRHO_CONSTEXPR const float_round_style round_style = round_toward_zero; ///< Rounds down.
+        static constexpr const bool traps = false; ///< Doesn't do traps.
+        static constexpr const bool tinyness_before = false; ///< Doesn't detect <code>tinyness</code> before rounding.
+        static constexpr const float_round_style round_style = round_toward_zero; ///< Rounds down.
     };
     
 } // namespace std

--- a/PlayRho/Common/FixedMath.hpp
+++ b/PlayRho/Common/FixedMath.hpp
@@ -45,7 +45,7 @@ namespace playrho {
 /// @brief Computes the absolute value.
 /// @sa http://en.cppreference.com/w/cpp/numeric/math/fabs
 template <typename BT, unsigned int FB, int N = 5>
-constexpr inline Fixed<BT, FB> abs(Fixed<BT, FB> arg)
+constexpr Fixed<BT, FB> abs(Fixed<BT, FB> arg)
 {
     return arg >= 0? arg: -arg;
 }
@@ -113,7 +113,7 @@ template <typename BT, unsigned int FB>
 constexpr const auto FixedPi = Fixed<BT, FB>{3.14159265358979323846264338327950288};
 
 /// @brief Computes the factorial.
-constexpr inline auto factorial(std::int64_t n)
+constexpr auto factorial(std::int64_t n)
 {
     // n! = n·(n – 1)·(n – 2) · · · 3·2·1
     auto res = n;
@@ -131,7 +131,7 @@ constexpr inline auto factorial(std::int64_t n)
 /// @sa https://en.wikipedia.org/wiki/Exponentiation
 /// @sa https://en.wikipedia.org/wiki/Exponential_function
 template <typename BT, unsigned int FB, int N = 6>
-constexpr inline Fixed<BT, FB> exp(Fixed<BT, FB> arg)
+constexpr Fixed<BT, FB> exp(Fixed<BT, FB> arg)
 {
     const auto doReciprocal = (arg < 0);
     if (doReciprocal)
@@ -215,7 +215,7 @@ Fixed<BT, FB> log(Fixed<BT, FB> arg)
 /// @brief Computes the sine of the given argument via Maclaurin series approximation.
 /// @sa https://en.wikipedia.org/wiki/Taylor_series
 template <typename BT, unsigned int FB, int N = 5>
-constexpr inline Fixed<BT, FB> sin(Fixed<BT, FB> arg)
+constexpr Fixed<BT, FB> sin(Fixed<BT, FB> arg)
 {
     // Maclaurin series approximation...
     // sin x = sum((-1^n)*(x^(2n+1))/(2n+1)!)
@@ -244,7 +244,7 @@ constexpr inline Fixed<BT, FB> sin(Fixed<BT, FB> arg)
 /// @brief Computes the cosine of the given argument via Maclaurin series approximation.
 /// @sa https://en.wikipedia.org/wiki/Taylor_series
 template <typename BT, unsigned int FB, int N = 5>
-constexpr inline Fixed<BT, FB> cos(Fixed<BT, FB> arg)
+constexpr Fixed<BT, FB> cos(Fixed<BT, FB> arg)
 {
     // Maclaurin series approximation...
     // cos x = sum((-1^n)*(x^(2n))/(2n)!)
@@ -272,7 +272,7 @@ constexpr inline Fixed<BT, FB> cos(Fixed<BT, FB> arg)
 /// @sa http://en.cppreference.com/w/cpp/numeric/math/atan
 /// @sa https://en.wikipedia.org/wiki/Taylor_series
 template <typename BT, unsigned int FB, int N = 5>
-constexpr inline Fixed<BT, FB> atan(Fixed<BT, FB> arg)
+constexpr Fixed<BT, FB> atan(Fixed<BT, FB> arg)
 {
     // Note: if (x > 0) then arctan(x) ==  Pi/2 - arctan(1/x)
     //       if (x < 0) then arctan(x) == -Pi/2 - arctan(1/x).
@@ -307,7 +307,7 @@ constexpr inline Fixed<BT, FB> atan(Fixed<BT, FB> arg)
 /// @brief Computes the square root of a non-negative value.
 /// @sa https://en.wikipedia.org/wiki/Methods_of_computing_square_roots
 template <typename BT, unsigned int FB>
-constexpr inline auto ComputeSqrt(Fixed<BT, FB> arg)
+constexpr auto ComputeSqrt(Fixed<BT, FB> arg)
 {
     auto temp = Fixed<BT, FB>{1};
     auto tempSquared = Square(temp);
@@ -340,7 +340,7 @@ constexpr inline auto ComputeSqrt(Fixed<BT, FB> arg)
 /// @brief Truncates the given value.
 /// @sa http://en.cppreference.com/w/c/numeric/math/trunc
 template <typename BT, unsigned int FB>
-constexpr inline Fixed<BT, FB> trunc(Fixed<BT, FB> arg)
+constexpr Fixed<BT, FB> trunc(Fixed<BT, FB> arg)
 {
     return static_cast<Fixed<BT, FB>>(static_cast<long long>(arg));
 }
@@ -563,7 +563,7 @@ inline bool signbit(Fixed<BT, FB> value) noexcept
 /// @brief Gets whether the given value is not-a-number.
 /// @sa http://en.cppreference.com/w/cpp/numeric/math/isnan
 template <typename BT, unsigned int FB>
-constexpr inline bool isnan(Fixed<BT, FB> value) noexcept
+constexpr bool isnan(Fixed<BT, FB> value) noexcept
 {
     return value.Compare(0) == Fixed<BT, FB>::CmpResult::Incomparable;
 }

--- a/PlayRho/Common/FixedMath.hpp
+++ b/PlayRho/Common/FixedMath.hpp
@@ -563,7 +563,7 @@ inline bool signbit(Fixed<BT, FB> value) noexcept
 /// @brief Gets whether the given value is not-a-number.
 /// @sa http://en.cppreference.com/w/cpp/numeric/math/isnan
 template <typename BT, unsigned int FB>
-PLAYRHO_CONSTEXPR inline bool isnan(Fixed<BT, FB> value) noexcept
+constexpr inline bool isnan(Fixed<BT, FB> value) noexcept
 {
     return value.Compare(0) == Fixed<BT, FB>::CmpResult::Incomparable;
 }

--- a/PlayRho/Common/GrowableStack.hpp
+++ b/PlayRho/Common/GrowableStack.hpp
@@ -42,13 +42,13 @@ public:
     using CountType = std::size_t;
 
     /// @brief Gets the initial capacity.
-    static constexpr inline CountType GetInitialCapacity() noexcept
+    static constexpr CountType GetInitialCapacity() noexcept
     {
         return CountType(N);
     }
     
     /// @brief Gets the buffer growth rate.
-    static constexpr inline CountType GetBufferGrowthRate() noexcept
+    static constexpr CountType GetBufferGrowthRate() noexcept
     {
         return CountType{2};
     }
@@ -108,19 +108,19 @@ public:
     }
 
     /// @brief Gets the current size in numbers of elements.
-    constexpr inline CountType size() const noexcept
+    constexpr CountType size() const noexcept
     {
         return m_count;
     }
     
     /// @brief Gets the capacity in number of elements.
-    constexpr inline CountType capacity() const noexcept
+    constexpr CountType capacity() const noexcept
     {
         return m_capacity;
     }
 
     /// @brief Whether this stack is empty.
-    constexpr inline bool empty() const noexcept
+    constexpr bool empty() const noexcept
     {
         return m_count == 0;
     }

--- a/PlayRho/Common/GrowableStack.hpp
+++ b/PlayRho/Common/GrowableStack.hpp
@@ -42,13 +42,13 @@ public:
     using CountType = std::size_t;
 
     /// @brief Gets the initial capacity.
-    static PLAYRHO_CONSTEXPR inline CountType GetInitialCapacity() noexcept
+    static constexpr inline CountType GetInitialCapacity() noexcept
     {
         return CountType(N);
     }
     
     /// @brief Gets the buffer growth rate.
-    static PLAYRHO_CONSTEXPR inline CountType GetBufferGrowthRate() noexcept
+    static constexpr inline CountType GetBufferGrowthRate() noexcept
     {
         return CountType{2};
     }
@@ -108,19 +108,19 @@ public:
     }
 
     /// @brief Gets the current size in numbers of elements.
-    PLAYRHO_CONSTEXPR inline CountType size() const noexcept
+    constexpr inline CountType size() const noexcept
     {
         return m_count;
     }
     
     /// @brief Gets the capacity in number of elements.
-    PLAYRHO_CONSTEXPR inline CountType capacity() const noexcept
+    constexpr inline CountType capacity() const noexcept
     {
         return m_capacity;
     }
 
     /// @brief Whether this stack is empty.
-    PLAYRHO_CONSTEXPR inline bool empty() const noexcept
+    constexpr inline bool empty() const noexcept
     {
         return m_count == 0;
     }

--- a/PlayRho/Common/Interval.hpp
+++ b/PlayRho/Common/Interval.hpp
@@ -51,7 +51,7 @@ public:
     /// @brief Gets the "lowest" value supported by the <code>value_type</code>.
     /// @return Negative infinity if supported by the value type, limits::lowest()
     ///   otherwise.
-    static PLAYRHO_CONSTEXPR value_type GetLowest() noexcept
+    static constexpr value_type GetLowest() noexcept
     {
         return (limits::has_infinity)? -limits::infinity(): limits::lowest();
     }
@@ -59,7 +59,7 @@ public:
     /// @brief Gets the "highest" value supported by the <code>value_type</code>.
     /// @return Positive infinity if supported by the value type, limits::max()
     ///   otherwise.
-    static PLAYRHO_CONSTEXPR value_type GetHighest() noexcept
+    static constexpr value_type GetHighest() noexcept
     {
         return (limits::has_infinity)? limits::infinity(): limits::max();
     }
@@ -68,36 +68,36 @@ public:
     /// @details Constructs an "unset" interval.
     /// @post <code>GetMin()</code> returns the value of <code>GetHighest()</code>.
     /// @post <code>GetMax()</code> returns the value of <code>GetLowest()</code>.
-    PLAYRHO_CONSTEXPR Interval() = default;
+    constexpr Interval() = default;
     
     /// @brief Copy constructor.
     /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
     /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    PLAYRHO_CONSTEXPR Interval(const Interval& other) = default;
+    constexpr Interval(const Interval& other) = default;
 
     /// @brief Move constructor.
     /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
     /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    PLAYRHO_CONSTEXPR Interval(Interval&& other) = default;
+    constexpr Interval(Interval&& other) = default;
     
     /// @brief Initializing constructor.
     /// @post <code>GetMin()</code> returns the value of <code>v</code>.
     /// @post <code>GetMax()</code> returns the value of <code>v</code>.
-    PLAYRHO_CONSTEXPR explicit Interval(const value_type& v) noexcept:
+    constexpr explicit Interval(const value_type& v) noexcept:
         Interval(pair_type{v, v})
     {
         // Intentionally empty.
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR Interval(const value_type& a, const value_type& b) noexcept:
+    constexpr Interval(const value_type& a, const value_type& b) noexcept:
         Interval(std::minmax(a, b))
     {
         // Intentionally empty.
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR Interval(const std::initializer_list<T> ilist) noexcept:
+    constexpr Interval(const std::initializer_list<T> ilist) noexcept:
         Interval(std::minmax(ilist))
     {
         // Intentionally empty.
@@ -118,7 +118,7 @@ public:
     /// @brief Moves the interval by the given amount.
     /// @warning Behavior is undefined if incrementing the min or max value by
     ///   the given amount overflows the finite range of the <code>value_type</code>,
-    PLAYRHO_CONSTEXPR Interval& Move(const value_type& v) noexcept
+    constexpr Interval& Move(const value_type& v) noexcept
     {
         m_min += v;
         m_max += v;
@@ -126,13 +126,13 @@ public:
     }
 
     /// @brief Gets the minimum value of this range.
-    PLAYRHO_CONSTEXPR value_type GetMin() const noexcept
+    constexpr value_type GetMin() const noexcept
     {
         return m_min;
     }
 
     /// @brief Gets the maximum value of this range.
-    PLAYRHO_CONSTEXPR value_type GetMax() const noexcept
+    constexpr value_type GetMax() const noexcept
     {
         return m_max;
     }
@@ -142,7 +142,7 @@ public:
     ///   will be the given value.
     /// @param v Value to "include" into this value.
     /// @post This value's "min" is the minimum of the given value and this value's "min".
-    PLAYRHO_CONSTEXPR Interval& Include(const value_type& v) noexcept
+    constexpr Interval& Include(const value_type& v) noexcept
     {
         m_min = std::min(v, GetMin());
         m_max = std::max(v, GetMax());
@@ -155,7 +155,7 @@ public:
     /// @param v Value to "include" into this value.
     /// @post This value's "min" is the minimum of the given value's "min" and
     ///   this value's "min".
-    PLAYRHO_CONSTEXPR Interval& Include(const Interval& v) noexcept
+    constexpr Interval& Include(const Interval& v) noexcept
     {
         m_min = std::min(v.GetMin(), GetMin());
         m_max = std::max(v.GetMax(), GetMax());
@@ -163,7 +163,7 @@ public:
     }
     
     /// @brief Intersects this interval with the given interval.
-    PLAYRHO_CONSTEXPR Interval& Intersect(const Interval& v) noexcept
+    constexpr Interval& Intersect(const Interval& v) noexcept
     {
         const auto min = std::max(v.GetMin(), GetMin());
         const auto max = std::min(v.GetMax(), GetMax());
@@ -178,7 +178,7 @@ public:
     /// @param v Amount to expand this interval by.
     /// @warning Behavior is undefined if expanding the range by
     ///   the given amount overflows the range of the <code>value_type</code>,
-    PLAYRHO_CONSTEXPR Interval& Expand(const value_type& v) noexcept
+    constexpr Interval& Expand(const value_type& v) noexcept
     {
         if (v < value_type{})
         {
@@ -198,7 +198,7 @@ public:
     /// @param v Amount to expand both ends of this interval by.
     /// @warning Behavior is undefined if expanding the range by
     ///   the given amount overflows the range of the <code>value_type</code>,
-    PLAYRHO_CONSTEXPR Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
+    constexpr Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
     {
         const auto amount = value_type{v};
         m_min -= amount;
@@ -213,7 +213,7 @@ private:
     using pair_type = std::pair<value_type, value_type>;
     
     /// @brief Internal pair type accepting constructor.
-    PLAYRHO_CONSTEXPR explicit Interval(pair_type pair) noexcept:
+    constexpr explicit Interval(pair_type pair) noexcept:
         m_min{std::get<0>(pair)}, m_max{std::get<1>(pair)}
     {
         // Intentionally empty.
@@ -229,7 +229,7 @@ private:
 ///   max and min values overflows the range of the <code>Interval::value_type</code>.
 /// @return Non-negative value unless the given interval is "unset" or invalid.
 template <typename T>
-PLAYRHO_CONSTEXPR T GetSize(const Interval<T>& v) noexcept
+constexpr T GetSize(const Interval<T>& v) noexcept
 {
     return v.GetMax() - v.GetMin();
 }
@@ -239,7 +239,7 @@ PLAYRHO_CONSTEXPR T GetSize(const Interval<T>& v) noexcept
 ///   max and min values overflows the range of the <code>Interval::value_type</code>.
 /// @relatedalso Interval
 template <typename T>
-PLAYRHO_CONSTEXPR T GetCenter(const Interval<T>& v) noexcept
+constexpr T GetCenter(const Interval<T>& v) noexcept
 {
     // Rounding may cause issues...
     return (v.GetMin() + v.GetMax()) / 2;
@@ -248,7 +248,7 @@ PLAYRHO_CONSTEXPR T GetCenter(const Interval<T>& v) noexcept
 /// @brief Checks whether two value ranges have any intersection/overlap at all.
 /// @relatedalso Interval
 template <typename T>
-PLAYRHO_CONSTEXPR bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
+constexpr bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
 {
     const auto maxOfMins = std::max(a.GetMin(), b.GetMin());
     const auto minOfMaxs = std::min(a.GetMax(), b.GetMax());
@@ -258,28 +258,28 @@ PLAYRHO_CONSTEXPR bool IsIntersecting(const Interval<T>& a, const Interval<T>& b
 /// @brief Gets the intersecting interval of two given ranges.
 /// @relatedalso Interval
 template <typename T>
-PLAYRHO_CONSTEXPR Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
+constexpr Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
 {
     return a.Intersect(b);
 }
 
 /// @brief Determines whether the first range is entirely before the second range.
 template <typename T>
-PLAYRHO_CONSTEXPR bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
+constexpr bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
 {
     return a.GetMax() < b.GetMin();
 }
 
 /// @brief Determines whether the first range is entirely after the second range.
 template <typename T>
-PLAYRHO_CONSTEXPR bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
+constexpr bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
 {
     return a.GetMin() > b.GetMax();
 }
 
 /// @brief Determines whether the first range entirely encloses the second.
 template <typename T>
-PLAYRHO_CONSTEXPR bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
+constexpr bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
 {
     return a.GetMin() <= b.GetMin() && a.GetMax() >= b.GetMax();
 }
@@ -289,7 +289,7 @@ PLAYRHO_CONSTEXPR bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<
 /// @relatedalso Interval
 /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
 template <typename T>
-PLAYRHO_CONSTEXPR bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
+constexpr bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
 {
     return (a.GetMin() == b.GetMin()) && (a.GetMax() == b.GetMax());
 }
@@ -299,7 +299,7 @@ PLAYRHO_CONSTEXPR bool operator== (const Interval<T>& a, const Interval<T>& b) n
 /// @relatedalso Interval
 /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
 template <typename T>
-PLAYRHO_CONSTEXPR bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
+constexpr bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
 {
     return !(a == b);
 }
@@ -315,7 +315,7 @@ PLAYRHO_CONSTEXPR bool operator!= (const Interval<T>& a, const Interval<T>& b) n
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 /// @sa http://en.cppreference.com/w/cpp/concept/LessThanComparable
 template <typename T>
-PLAYRHO_CONSTEXPR bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+constexpr bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() < rhs.GetMax());
@@ -327,7 +327,7 @@ PLAYRHO_CONSTEXPR bool operator< (const Interval<T>& lhs, const Interval<T>& rhs
 /// @relatedalso Interval
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 template <typename T>
-PLAYRHO_CONSTEXPR bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+constexpr bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() <= rhs.GetMax());
@@ -339,7 +339,7 @@ PLAYRHO_CONSTEXPR bool operator<= (const Interval<T>& lhs, const Interval<T>& rh
 /// @relatedalso Interval
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 template <typename T>
-PLAYRHO_CONSTEXPR bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+constexpr bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() > rhs.GetMax());
@@ -351,7 +351,7 @@ PLAYRHO_CONSTEXPR bool operator> (const Interval<T>& lhs, const Interval<T>& rhs
 /// @relatedalso Interval
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 template <typename T>
-PLAYRHO_CONSTEXPR bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+constexpr bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() >= rhs.GetMax());

--- a/PlayRho/Common/Interval.hpp
+++ b/PlayRho/Common/Interval.hpp
@@ -51,7 +51,7 @@ public:
     /// @brief Gets the "lowest" value supported by the <code>value_type</code>.
     /// @return Negative infinity if supported by the value type, limits::lowest()
     ///   otherwise.
-    static PLAYRHO_CONSTEXPR inline value_type GetLowest() noexcept
+    static PLAYRHO_CONSTEXPR value_type GetLowest() noexcept
     {
         return (limits::has_infinity)? -limits::infinity(): limits::lowest();
     }
@@ -59,7 +59,7 @@ public:
     /// @brief Gets the "highest" value supported by the <code>value_type</code>.
     /// @return Positive infinity if supported by the value type, limits::max()
     ///   otherwise.
-    static PLAYRHO_CONSTEXPR inline value_type GetHighest() noexcept
+    static PLAYRHO_CONSTEXPR value_type GetHighest() noexcept
     {
         return (limits::has_infinity)? limits::infinity(): limits::max();
     }
@@ -68,36 +68,36 @@ public:
     /// @details Constructs an "unset" interval.
     /// @post <code>GetMin()</code> returns the value of <code>GetHighest()</code>.
     /// @post <code>GetMax()</code> returns the value of <code>GetLowest()</code>.
-    PLAYRHO_CONSTEXPR inline Interval() = default;
+    PLAYRHO_CONSTEXPR Interval() = default;
     
     /// @brief Copy constructor.
     /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
     /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    PLAYRHO_CONSTEXPR inline Interval(const Interval& other) = default;
+    PLAYRHO_CONSTEXPR Interval(const Interval& other) = default;
 
     /// @brief Move constructor.
     /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
     /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    PLAYRHO_CONSTEXPR inline Interval(Interval&& other) = default;
+    PLAYRHO_CONSTEXPR Interval(Interval&& other) = default;
     
     /// @brief Initializing constructor.
     /// @post <code>GetMin()</code> returns the value of <code>v</code>.
     /// @post <code>GetMax()</code> returns the value of <code>v</code>.
-    PLAYRHO_CONSTEXPR inline explicit Interval(const value_type& v) noexcept:
+    PLAYRHO_CONSTEXPR explicit Interval(const value_type& v) noexcept:
         Interval(pair_type{v, v})
     {
         // Intentionally empty.
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline Interval(const value_type& a, const value_type& b) noexcept:
+    PLAYRHO_CONSTEXPR Interval(const value_type& a, const value_type& b) noexcept:
         Interval(std::minmax(a, b))
     {
         // Intentionally empty.
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline Interval(const std::initializer_list<T> ilist) noexcept:
+    PLAYRHO_CONSTEXPR Interval(const std::initializer_list<T> ilist) noexcept:
         Interval(std::minmax(ilist))
     {
         // Intentionally empty.
@@ -118,7 +118,7 @@ public:
     /// @brief Moves the interval by the given amount.
     /// @warning Behavior is undefined if incrementing the min or max value by
     ///   the given amount overflows the finite range of the <code>value_type</code>,
-    PLAYRHO_CONSTEXPR inline Interval& Move(const value_type& v) noexcept
+    PLAYRHO_CONSTEXPR Interval& Move(const value_type& v) noexcept
     {
         m_min += v;
         m_max += v;
@@ -126,13 +126,13 @@ public:
     }
 
     /// @brief Gets the minimum value of this range.
-    PLAYRHO_CONSTEXPR inline value_type GetMin() const noexcept
+    PLAYRHO_CONSTEXPR value_type GetMin() const noexcept
     {
         return m_min;
     }
 
     /// @brief Gets the maximum value of this range.
-    PLAYRHO_CONSTEXPR inline value_type GetMax() const noexcept
+    PLAYRHO_CONSTEXPR value_type GetMax() const noexcept
     {
         return m_max;
     }
@@ -142,7 +142,7 @@ public:
     ///   will be the given value.
     /// @param v Value to "include" into this value.
     /// @post This value's "min" is the minimum of the given value and this value's "min".
-    PLAYRHO_CONSTEXPR inline Interval& Include(const value_type& v) noexcept
+    PLAYRHO_CONSTEXPR Interval& Include(const value_type& v) noexcept
     {
         m_min = std::min(v, GetMin());
         m_max = std::max(v, GetMax());
@@ -155,7 +155,7 @@ public:
     /// @param v Value to "include" into this value.
     /// @post This value's "min" is the minimum of the given value's "min" and
     ///   this value's "min".
-    PLAYRHO_CONSTEXPR inline Interval& Include(const Interval& v) noexcept
+    PLAYRHO_CONSTEXPR Interval& Include(const Interval& v) noexcept
     {
         m_min = std::min(v.GetMin(), GetMin());
         m_max = std::max(v.GetMax(), GetMax());
@@ -163,7 +163,7 @@ public:
     }
     
     /// @brief Intersects this interval with the given interval.
-    PLAYRHO_CONSTEXPR inline Interval& Intersect(const Interval& v) noexcept
+    PLAYRHO_CONSTEXPR Interval& Intersect(const Interval& v) noexcept
     {
         const auto min = std::max(v.GetMin(), GetMin());
         const auto max = std::min(v.GetMax(), GetMax());
@@ -178,7 +178,7 @@ public:
     /// @param v Amount to expand this interval by.
     /// @warning Behavior is undefined if expanding the range by
     ///   the given amount overflows the range of the <code>value_type</code>,
-    PLAYRHO_CONSTEXPR inline Interval& Expand(const value_type& v) noexcept
+    PLAYRHO_CONSTEXPR Interval& Expand(const value_type& v) noexcept
     {
         if (v < value_type{})
         {
@@ -198,7 +198,7 @@ public:
     /// @param v Amount to expand both ends of this interval by.
     /// @warning Behavior is undefined if expanding the range by
     ///   the given amount overflows the range of the <code>value_type</code>,
-    PLAYRHO_CONSTEXPR inline Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
+    PLAYRHO_CONSTEXPR Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
     {
         const auto amount = value_type{v};
         m_min -= amount;
@@ -213,7 +213,7 @@ private:
     using pair_type = std::pair<value_type, value_type>;
     
     /// @brief Internal pair type accepting constructor.
-    PLAYRHO_CONSTEXPR inline explicit Interval(pair_type pair) noexcept:
+    PLAYRHO_CONSTEXPR explicit Interval(pair_type pair) noexcept:
         m_min{std::get<0>(pair)}, m_max{std::get<1>(pair)}
     {
         // Intentionally empty.
@@ -229,7 +229,7 @@ private:
 ///   max and min values overflows the range of the <code>Interval::value_type</code>.
 /// @return Non-negative value unless the given interval is "unset" or invalid.
 template <typename T>
-PLAYRHO_CONSTEXPR inline T GetSize(const Interval<T>& v) noexcept
+PLAYRHO_CONSTEXPR T GetSize(const Interval<T>& v) noexcept
 {
     return v.GetMax() - v.GetMin();
 }
@@ -239,7 +239,7 @@ PLAYRHO_CONSTEXPR inline T GetSize(const Interval<T>& v) noexcept
 ///   max and min values overflows the range of the <code>Interval::value_type</code>.
 /// @relatedalso Interval
 template <typename T>
-PLAYRHO_CONSTEXPR inline T GetCenter(const Interval<T>& v) noexcept
+PLAYRHO_CONSTEXPR T GetCenter(const Interval<T>& v) noexcept
 {
     // Rounding may cause issues...
     return (v.GetMin() + v.GetMax()) / 2;
@@ -248,7 +248,7 @@ PLAYRHO_CONSTEXPR inline T GetCenter(const Interval<T>& v) noexcept
 /// @brief Checks whether two value ranges have any intersection/overlap at all.
 /// @relatedalso Interval
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
+PLAYRHO_CONSTEXPR bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
 {
     const auto maxOfMins = std::max(a.GetMin(), b.GetMin());
     const auto minOfMaxs = std::min(a.GetMax(), b.GetMax());
@@ -258,28 +258,28 @@ PLAYRHO_CONSTEXPR inline bool IsIntersecting(const Interval<T>& a, const Interva
 /// @brief Gets the intersecting interval of two given ranges.
 /// @relatedalso Interval
 template <typename T>
-PLAYRHO_CONSTEXPR inline Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
+PLAYRHO_CONSTEXPR Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
 {
     return a.Intersect(b);
 }
 
 /// @brief Determines whether the first range is entirely before the second range.
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
+PLAYRHO_CONSTEXPR bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
 {
     return a.GetMax() < b.GetMin();
 }
 
 /// @brief Determines whether the first range is entirely after the second range.
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
+PLAYRHO_CONSTEXPR bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
 {
     return a.GetMin() > b.GetMax();
 }
 
 /// @brief Determines whether the first range entirely encloses the second.
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
+PLAYRHO_CONSTEXPR bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
 {
     return a.GetMin() <= b.GetMin() && a.GetMax() >= b.GetMax();
 }
@@ -289,7 +289,7 @@ PLAYRHO_CONSTEXPR inline bool IsEntirelyEnclosing(const Interval<T>& a, const In
 /// @relatedalso Interval
 /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
+PLAYRHO_CONSTEXPR bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
 {
     return (a.GetMin() == b.GetMin()) && (a.GetMax() == b.GetMax());
 }
@@ -299,7 +299,7 @@ PLAYRHO_CONSTEXPR inline bool operator== (const Interval<T>& a, const Interval<T
 /// @relatedalso Interval
 /// @sa http://en.cppreference.com/w/cpp/concept/EqualityComparable
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
+PLAYRHO_CONSTEXPR bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
 {
     return !(a == b);
 }
@@ -315,7 +315,7 @@ PLAYRHO_CONSTEXPR inline bool operator!= (const Interval<T>& a, const Interval<T
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 /// @sa http://en.cppreference.com/w/cpp/concept/LessThanComparable
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+PLAYRHO_CONSTEXPR bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() < rhs.GetMax());
@@ -327,7 +327,7 @@ PLAYRHO_CONSTEXPR inline bool operator< (const Interval<T>& lhs, const Interval<
 /// @relatedalso Interval
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+PLAYRHO_CONSTEXPR bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() <= rhs.GetMax());
@@ -339,7 +339,7 @@ PLAYRHO_CONSTEXPR inline bool operator<= (const Interval<T>& lhs, const Interval
 /// @relatedalso Interval
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+PLAYRHO_CONSTEXPR bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() > rhs.GetMax());
@@ -351,7 +351,7 @@ PLAYRHO_CONSTEXPR inline bool operator> (const Interval<T>& lhs, const Interval<
 /// @relatedalso Interval
 /// @sa https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+PLAYRHO_CONSTEXPR bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin()) ||
         (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() >= rhs.GetMax());

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -62,12 +62,12 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices)
         const auto e1 = p2 - p1;
         const auto e2 = p3 - p1;
         
-        PLAYRHO_CONSTEXPR const auto RealInverseOfTwo = Real{1} / Real{2};
+        constexpr const auto RealInverseOfTwo = Real{1} / Real{2};
         const auto triangleArea = Area{Cross(e1, e2) * RealInverseOfTwo};
         area += triangleArea;
         
         // Area weighted centroid
-        PLAYRHO_CONSTEXPR const auto RealInverseOfThree = Real{1} / Real{3};
+        constexpr const auto RealInverseOfThree = Real{1} / Real{3};
         const auto aveP = (p1 + p2 + p3) * RealInverseOfThree;
         c += triangleArea * aveP;
     }
@@ -131,7 +131,7 @@ NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices)
     
     // Note that using the absolute value isn't necessary for vertices in counter-clockwise
     // ordering; only needed for clockwise ordering.
-    PLAYRHO_CONSTEXPR const auto RealInverseOfTwo = Real{1} / Real{2};
+    constexpr const auto RealInverseOfTwo = Real{1} / Real{2};
     return abs(sum) * RealInverseOfTwo;
 }
 
@@ -164,7 +164,7 @@ SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices)
     }
     const auto secondMomentOfAreaX = SecondMomentOfArea{sum_x};
     const auto secondMomentOfAreaY = SecondMomentOfArea{sum_y};
-    PLAYRHO_CONSTEXPR const auto RealInverseOfTwelve = Real{1} / Real{12};
+    constexpr const auto RealInverseOfTwelve = Real{1} / Real{12};
     return (secondMomentOfAreaX + secondMomentOfAreaY) * RealInverseOfTwelve;
 }
 

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -63,42 +63,42 @@ using std::abs;
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-PLAYRHO_CONSTEXPR inline auto& GetX(T& value)
+constexpr inline auto& GetX(T& value)
 {
     return get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-PLAYRHO_CONSTEXPR inline auto& GetY(T& value)
+constexpr inline auto& GetY(T& value)
 {
     return get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-PLAYRHO_CONSTEXPR inline auto& GetZ(T& value)
+constexpr inline auto& GetZ(T& value)
 {
     return get<2>(value);
 }
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-PLAYRHO_CONSTEXPR inline auto GetX(const T& value)
+constexpr inline auto GetX(const T& value)
 {
     return get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-PLAYRHO_CONSTEXPR inline auto GetY(const T& value)
+constexpr inline auto GetY(const T& value)
 {
     return get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-PLAYRHO_CONSTEXPR inline auto GetZ(const T& value)
+constexpr inline auto GetZ(const T& value)
 {
     return get<2>(value);
 }
@@ -107,7 +107,7 @@ PLAYRHO_CONSTEXPR inline auto GetZ(const T& value)
 /// @note If the given value is negative, this will result in an unsigned value which is the
 ///   two's complement modulo-wrapped value.
 template <typename T>
-PLAYRHO_CONSTEXPR inline std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
+constexpr inline std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
 MakeUnsigned(const T& arg) noexcept
 {
     return static_cast<std::make_unsigned_t<T>>(arg);
@@ -115,7 +115,7 @@ MakeUnsigned(const T& arg) noexcept
 
 /// @brief Strips the unit from the given value.
 template <typename T, LoValueCheck lo, HiValueCheck hi>
-PLAYRHO_CONSTEXPR inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
+constexpr inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
 {
     return StripUnit(v.get());
 }
@@ -129,7 +129,7 @@ PLAYRHO_CONSTEXPR inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
 /// @brief Secant method.
 /// @sa https://en.wikipedia.org/wiki/Secant_method
 template <typename T, typename U>
-PLAYRHO_CONSTEXPR inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
+constexpr inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
 {
     static_assert(IsArithmetic<T>::value && IsArithmetic<U>::value, "Arithmetic types required.");
     return (a1 + (target - s1) * (a2 - a1) / (s2 - s1));
@@ -138,7 +138,7 @@ PLAYRHO_CONSTEXPR inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
 /// @brief Bisection method.
 /// @sa https://en.wikipedia.org/wiki/Bisection_method
 template <typename T>
-PLAYRHO_CONSTEXPR inline T Bisect(T a1, T a2) noexcept
+constexpr inline T Bisect(T a1, T a2) noexcept
 {
     return (a1 + a2) / 2;
 }
@@ -146,7 +146,7 @@ PLAYRHO_CONSTEXPR inline T Bisect(T a1, T a2) noexcept
 /// @brief Is-odd.
 /// @details Determines whether the given integral value is odd (as opposed to being even).
 template <typename T>
-PLAYRHO_CONSTEXPR inline bool IsOdd(T val) noexcept
+constexpr inline bool IsOdd(T val) noexcept
 {
     static_assert(std::is_integral<T>::value, "Integral type required.");
     return val % 2;
@@ -154,7 +154,7 @@ PLAYRHO_CONSTEXPR inline bool IsOdd(T val) noexcept
 
 /// @brief Squares the given value.
 template<class TYPE>
-PLAYRHO_CONSTEXPR inline auto Square(TYPE t) noexcept { return t * t; }
+constexpr inline auto Square(TYPE t) noexcept { return t * t; }
 
 /// @brief Computes the arc-tangent of the given y and x values.
 /// @return Normalized angle - an angle between -Pi and Pi inclusively.
@@ -175,7 +175,7 @@ inline auto Average(const T& span)
 
     // Relies on C++11 zero initialization to zero initialize value_type.
     // See: http://en.cppreference.com/w/cpp/language/zero_initialization
-    PLAYRHO_CONSTEXPR const auto zero = value_type{};
+    constexpr const auto zero = value_type{};
     assert(zero * Real{2} == zero);
     
     // For C++17, switch from using std::accumulate to using std::reduce.
@@ -201,7 +201,7 @@ inline Vec2 RoundOff(Vec2 value, std::uint32_t precision = 100000)
 /// @brief Absolute value function for vectors.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline Vector<T, N> abs(const Vector<T, N>& v) noexcept
+constexpr inline Vector<T, N> abs(const Vector<T, N>& v) noexcept
 {
     auto result = Vector<T, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -222,7 +222,7 @@ inline d2::UnitVec abs(const d2::UnitVec& v) noexcept
 /// odd results like a divide by zero trap occurring.
 /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
 template <typename T>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_arithmetic<T>::value, bool> AlmostZero(T value)
 {
     return abs(value) < std::numeric_limits<T>::min();
@@ -230,7 +230,7 @@ std::enable_if_t<std::is_arithmetic<T>::value, bool> AlmostZero(T value)
 
 /// @brief Determines whether the given two values are "almost equal".
 template <typename T>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_floating_point<T>::value, bool> AlmostEqual(T x, T y, int ulp = 2)
 {
     // From http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon :
@@ -269,7 +269,7 @@ inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
 /// @sa Atan2
 inline Angle GetNormalized(Angle value) noexcept
 {
-    PLAYRHO_CONSTEXPR const auto oneRotationInRadians = Real{2 * Pi};
+    constexpr const auto oneRotationInRadians = Real{2 * Pi};
     auto angleInRadians = Real{value / Radian};
 #if defined(NORMALIZE_ANGLE_VIA_FMOD)
     // Note: std::fmod appears slower than std::trunc.
@@ -305,7 +305,7 @@ inline Angle GetAngle(const Vector2<T> value)
 /// @note For performance, use this instead of <code>GetMagnitude(T value)</code> (if possible).
 /// @return Non-negative value from 0 to infinity, or NaN.
 template <typename T>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 auto GetMagnitudeSquared(T value) noexcept
 {
     using VT = typename T::value_type;
@@ -351,7 +351,7 @@ inline auto GetMagnitude(T value)
 /// @return Dot product of the vectors (0 means the two vectors are perpendicular).
 ///
 template <typename T1, typename T2>
-PLAYRHO_CONSTEXPR inline auto Dot(const T1 a, const T2 b) noexcept
+constexpr inline auto Dot(const T1 a, const T2 b) noexcept
 {
     static_assert(std::tuple_size<T1>::value == std::tuple_size<T2>::value,
                   "Dot only for same tuple-like sized types");
@@ -396,7 +396,7 @@ PLAYRHO_CONSTEXPR inline auto Dot(const T1 a, const T2 b) noexcept
 ///
 template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
-PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
+constexpr inline auto Cross(T1 a, T2 b) noexcept
 {
     assert(isfinite(StripUnit(get<0>(a))));
     assert(isfinite(StripUnit(get<1>(a))));
@@ -428,7 +428,7 @@ PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
 /// @return Cross product of the two values.
 template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 3 && std::tuple_size<T2>::value == 3, int> = 0>
-PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
+constexpr inline auto Cross(T1 a, T2 b) noexcept
 {
     assert(isfinite(get<0>(a)));
     assert(isfinite(get<1>(a)));
@@ -448,7 +448,7 @@ PLAYRHO_CONSTEXPR inline auto Cross(T1 a, T2 b) noexcept
 /// @brief Solves A * x = b, where b is a column vector.
 /// @note This is more efficient than computing the inverse in one-shot cases.
 template <typename T, typename U>
-PLAYRHO_CONSTEXPR inline auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
+constexpr inline auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
 {
     const auto cp = Cross(get<0>(mat), get<1>(mat));
     const auto inverseCp = Real{1} / cp;
@@ -462,7 +462,7 @@ PLAYRHO_CONSTEXPR inline auto Solve(const Matrix22<U> mat, const Vector2<T> b) n
 
 /// @brief Inverts the given value.
 template <class IN_TYPE>
-PLAYRHO_CONSTEXPR inline auto Invert(const Matrix22<IN_TYPE> value) noexcept
+constexpr inline auto Invert(const Matrix22<IN_TYPE> value) noexcept
 {
     const auto cp = Cross(get<0>(value), get<1>(value));
     using OutType = decltype(get<0>(value)[0] / cp);
@@ -477,7 +477,7 @@ PLAYRHO_CONSTEXPR inline auto Invert(const Matrix22<IN_TYPE> value) noexcept
 
 /// @brief Solves A * x = b, where b is a column vector.
 /// @note This is more efficient than computing the inverse in one-shot cases.
-PLAYRHO_CONSTEXPR inline Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
+constexpr inline Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
 {
     const auto dp = Dot(GetX(mat), Cross(GetY(mat), GetZ(mat)));
     const auto det = (dp != 0)? Real{1} / dp: dp;
@@ -491,7 +491,7 @@ PLAYRHO_CONSTEXPR inline Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
 /// @note This is more efficient than computing the inverse in one-shot cases.
 /// @note Solves only the upper 2-by-2 matrix equation.
 template <typename T>
-PLAYRHO_CONSTEXPR inline T Solve22(const Mat33& mat, const T b) noexcept
+constexpr inline T Solve22(const Mat33& mat, const T b) noexcept
 {
     const auto cp = GetX(GetX(mat)) * GetY(GetY(mat)) - GetX(GetY(mat)) * GetY(GetX(mat));
     const auto det = (cp != 0)? Real{1} / cp: cp;
@@ -502,7 +502,7 @@ PLAYRHO_CONSTEXPR inline T Solve22(const Mat33& mat, const T b) noexcept
 
 /// @brief Gets the inverse of the given matrix as a 2-by-2.
 /// @return Zero matrix if singular.
-PLAYRHO_CONSTEXPR inline Mat33 GetInverse22(const Mat33& value) noexcept
+constexpr inline Mat33 GetInverse22(const Mat33& value) noexcept
 {
     const auto a = GetX(GetX(value)), b = GetX(GetY(value)), c = GetY(GetX(value)), d = GetY(GetY(value));
     auto det = (a * d) - (b * c);
@@ -515,7 +515,7 @@ PLAYRHO_CONSTEXPR inline Mat33 GetInverse22(const Mat33& value) noexcept
     
 /// @brief Gets the symmetric inverse of this matrix as a 3-by-3.
 /// @return Zero matrix if singular.
-PLAYRHO_CONSTEXPR inline Mat33 GetSymInverse33(const Mat33& value) noexcept
+constexpr inline Mat33 GetSymInverse33(const Mat33& value) noexcept
 {
     auto det = Dot(GetX(value), Cross(GetY(value), GetZ(value)));
     if (det != Real{0})
@@ -544,7 +544,7 @@ PLAYRHO_CONSTEXPR inline Mat33 GetSymInverse33(const Mat33& value) noexcept
 /// @return A counter-clockwise 90-degree rotation of the given vector.
 /// @sa GetFwdPerpendicular.
 template <class T>
-PLAYRHO_CONSTEXPR inline auto GetRevPerpendicular(const T vector) noexcept
+constexpr inline auto GetRevPerpendicular(const T vector) noexcept
 {
     // See http://mathworld.wolfram.com/PerpendicularVector.html
     return T{-GetY(vector), GetX(vector)};
@@ -556,7 +556,7 @@ PLAYRHO_CONSTEXPR inline auto GetRevPerpendicular(const T vector) noexcept
 /// @return A clockwise 90-degree rotation of the given vector.
 /// @sa GetRevPerpendicular.
 template <class T>
-PLAYRHO_CONSTEXPR inline auto GetFwdPerpendicular(const T vector) noexcept
+constexpr inline auto GetFwdPerpendicular(const T vector) noexcept
 {
     // See http://mathworld.wolfram.com/PerpendicularVector.html
     return T{GetY(vector), -GetX(vector)};
@@ -567,13 +567,13 @@ PLAYRHO_CONSTEXPR inline auto GetFwdPerpendicular(const T vector) noexcept
 /// @param m An M-row by N-column *transformation matrix* to multiply the vector by.
 /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
 template <std::size_t M, typename T1, std::size_t N, typename T2>
-PLAYRHO_CONSTEXPR inline auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
+constexpr inline auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
 {
     return m * v;
 }
 
 /// @brief Multiplies a vector by a matrix.
-PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
+constexpr inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 {
     return Vec2{
         get<0>(get<0>(A)) * v[0] + get<0>(get<1>(A)) * v[1],
@@ -583,13 +583,13 @@ PLAYRHO_CONSTEXPR inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 
 /// Multiply a matrix transpose times a vector. If a rotation matrix is provided,
 /// then this transforms the vector from one frame to another (inverse transform).
-PLAYRHO_CONSTEXPR inline Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
+constexpr inline Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
 {
     return Vec2{Dot(v, GetX(A)), Dot(v, GetY(A))};
 }
 
 /// @brief Computes A^T * B.
-PLAYRHO_CONSTEXPR inline Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
+constexpr inline Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
 {
     const auto c1 = Vec2{Dot(GetX(A), GetX(B)), Dot(GetY(A), GetX(B))};
     const auto c2 = Vec2{Dot(GetX(A), GetY(B)), Dot(GetY(A), GetY(B))};
@@ -640,7 +640,7 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices);
 
 /// @brief Gets the modulo next value.
 template <typename T>
-PLAYRHO_CONSTEXPR inline T GetModuloNext(T value, T count) noexcept
+constexpr inline T GetModuloNext(T value, T count) noexcept
 {
     assert(value < count);
     return (value + 1) % count;
@@ -648,7 +648,7 @@ PLAYRHO_CONSTEXPR inline T GetModuloNext(T value, T count) noexcept
 
 /// @brief Gets the modulo previous value.
 template <typename T>
-PLAYRHO_CONSTEXPR inline T GetModuloPrev(T value, T count) noexcept
+constexpr inline T GetModuloPrev(T value, T count) noexcept
 {
     assert(value < count);
     return (value? value: count) - 1;
@@ -663,7 +663,7 @@ Angle GetDelta(Angle a1, Angle a2) noexcept;
 
 /// Gets the reverse (counter) clockwise rotational angle to go from angle 1 to angle 2.
 /// @return Angular rotation in the counter clockwise direction to go from angle 1 to angle 2.
-PLAYRHO_CONSTEXPR inline Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
+constexpr inline Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
 {
     return (a1 > a2)? 360_deg - (a1 - a2): a2 - a1;
 }
@@ -694,7 +694,7 @@ SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices);
 namespace d2 {
 
 /// @brief Gets a <code>Vec2</code> representation of the given value.
-PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const UnitVec value)
+constexpr inline Vec2 GetVec2(const UnitVec value)
 {
     return Vec2{get<0>(value), get<1>(value)};
 }
@@ -707,34 +707,34 @@ inline Angle GetAngle(const UnitVec value)
 
 /// @brief Multiplication operator.
 template <class T, LoValueCheck lo, HiValueCheck hi>
-PLAYRHO_CONSTEXPR inline Vector2<T> operator* (BoundedValue<T, lo, hi> s, UnitVec u) noexcept
+constexpr inline Vector2<T> operator* (BoundedValue<T, lo, hi> s, UnitVec u) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * T{s}};
 }
 
 /// @brief Multiplication operator.
 template <class T>
-PLAYRHO_CONSTEXPR inline Vector2<T> operator* (const T s, const UnitVec u) noexcept
+constexpr inline Vector2<T> operator* (const T s, const UnitVec u) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * s};
 }
 
 /// @brief Multiplication operator.
 template <class T, LoValueCheck lo, HiValueCheck hi>
-PLAYRHO_CONSTEXPR inline Vector2<T> operator* (UnitVec u, BoundedValue<T, lo, hi> s) noexcept
+constexpr inline Vector2<T> operator* (UnitVec u, BoundedValue<T, lo, hi> s) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * T{s}};
 }
 
 /// @brief Multiplication operator.
 template <class T>
-PLAYRHO_CONSTEXPR inline Vector2<T> operator* (const UnitVec u, const T s) noexcept
+constexpr inline Vector2<T> operator* (const UnitVec u, const T s) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * s};
 }
 
 /// @brief Division operator.
-PLAYRHO_CONSTEXPR inline Vec2 operator/ (const UnitVec u, const UnitVec::value_type s) noexcept
+constexpr inline Vec2 operator/ (const UnitVec u, const UnitVec::value_type s) noexcept
 {
     const auto inverseS = Real{1} / s;
     return Vec2{GetX(u) * inverseS, GetY(u) * inverseS};
@@ -746,7 +746,7 @@ PLAYRHO_CONSTEXPR inline Vec2 operator/ (const UnitVec u, const UnitVec::value_t
 /// @param angle Expresses the angle to forward rotate the given vector by.
 /// @sa InverseRotate.
 template <class T>
-PLAYRHO_CONSTEXPR inline auto Rotate(const Vector2<T> vector, const UnitVec& angle) noexcept
+constexpr inline auto Rotate(const Vector2<T> vector, const UnitVec& angle) noexcept
 {
     const auto newX = (GetX(angle) * GetX(vector)) - (GetY(angle) * GetY(vector));
     const auto newY = (GetY(angle) * GetX(vector)) + (GetX(angle) * GetY(vector));
@@ -761,7 +761,7 @@ PLAYRHO_CONSTEXPR inline auto Rotate(const Vector2<T> vector, const UnitVec& ang
 /// @param angle Expresses the angle to reverse rotate the given vector by.
 /// @sa Rotate.
 template <class T>
-PLAYRHO_CONSTEXPR inline auto InverseRotate(const Vector2<T> vector, const UnitVec& angle) noexcept
+constexpr inline auto InverseRotate(const Vector2<T> vector, const UnitVec& angle) noexcept
 {
     const auto newX = (GetX(angle) * GetX(vector)) + (GetY(angle) * GetY(vector));
     const auto newY = (GetX(angle) * GetY(vector)) - (GetY(angle) * GetX(vector));
@@ -813,7 +813,7 @@ inline Sweep GetNormalized(Sweep sweep) noexcept
 /// @param v 2-D position to transform (to rotate and then translate).
 /// @param xfm Transformation (a translation and rotation) to apply to the given vector.
 /// @return Rotated and translated vector.
-PLAYRHO_CONSTEXPR inline Length2 Transform(const Length2 v, const Transformation xfm) noexcept
+constexpr inline Length2 Transform(const Length2 v, const Transformation xfm) noexcept
 {
     return Rotate(v, xfm.q) + xfm.p;
 }
@@ -828,7 +828,7 @@ PLAYRHO_CONSTEXPR inline Length2 Transform(const Length2 v, const Transformation
 /// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
 /// @param xfm Transformation (a translation and rotation) to inversely apply to the given vector.
 /// @return Inverse transformed vector.
-PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transformation xfm) noexcept
+constexpr inline Length2 InverseTransform(const Length2 v, const Transformation xfm) noexcept
 {
     return InverseRotate(v - xfm.p, xfm.q);
 }
@@ -836,7 +836,7 @@ PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transfo
 /// @brief Multiplies a given transformation by another given transformation.
 /// @note <code>v2 = A.q.Rot(B.q.Rot(v1) + B.p) + A.p
 ///                = (A.q * B.q).Rot(v1) + A.q.Rot(B.p) + A.p</code>
-PLAYRHO_CONSTEXPR inline Transformation Mul(const Transformation& A, const Transformation& B) noexcept
+constexpr inline Transformation Mul(const Transformation& A, const Transformation& B) noexcept
 {
     return Transformation{A.p + Rotate(B.p, A.q), A.q.Rotate(B.q)};
 }
@@ -844,14 +844,14 @@ PLAYRHO_CONSTEXPR inline Transformation Mul(const Transformation& A, const Trans
 /// @brief Inverse multiplies a given transformation by another given transformation.
 /// @note <code>v2 = A.q' * (B.q * v1 + B.p - A.p)
 ///                = A.q' * B.q * v1 + A.q' * (B.p - A.p)</code>
-PLAYRHO_CONSTEXPR inline Transformation MulT(const Transformation& A, const Transformation& B) noexcept
+constexpr inline Transformation MulT(const Transformation& A, const Transformation& B) noexcept
 {
     const auto dp = B.p - A.p;
     return Transformation{InverseRotate(dp, A.q), B.q.Rotate(A.q.FlipY())};
 }
 
 /// @brief Gets the transformation for the given values.
-PLAYRHO_CONSTEXPR inline Transformation GetTransformation(const Length2 ctr, const UnitVec rot,
+constexpr inline Transformation GetTransformation(const Length2 ctr, const UnitVec rot,
                                                             const Length2 localCtr) noexcept
 {
     assert(IsValid(rot));
@@ -915,7 +915,7 @@ inline bool IsUnderActive(Velocity velocity,
 /// @brief Gets the reflection matrix for the given unit vector that defines the normal of
 ///   the line through the origin that points should be reflected against.
 /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
-PLAYRHO_CONSTEXPR inline auto GetReflectionMatrix(UnitVec axis)
+constexpr inline auto GetReflectionMatrix(UnitVec axis)
 {
     constexpr auto TupleSize = std::tuple_size<decltype(axis)>::value;
     constexpr auto NumRows = TupleSize;

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -63,42 +63,42 @@ using std::abs;
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-constexpr inline auto& GetX(T& value)
+constexpr auto& GetX(T& value)
 {
     return get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-constexpr inline auto& GetY(T& value)
+constexpr auto& GetY(T& value)
 {
     return get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-constexpr inline auto& GetZ(T& value)
+constexpr auto& GetZ(T& value)
 {
     return get<2>(value);
 }
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-constexpr inline auto GetX(const T& value)
+constexpr auto GetX(const T& value)
 {
     return get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-constexpr inline auto GetY(const T& value)
+constexpr auto GetY(const T& value)
 {
     return get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-constexpr inline auto GetZ(const T& value)
+constexpr auto GetZ(const T& value)
 {
     return get<2>(value);
 }
@@ -107,7 +107,7 @@ constexpr inline auto GetZ(const T& value)
 /// @note If the given value is negative, this will result in an unsigned value which is the
 ///   two's complement modulo-wrapped value.
 template <typename T>
-constexpr inline std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
+constexpr std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
 MakeUnsigned(const T& arg) noexcept
 {
     return static_cast<std::make_unsigned_t<T>>(arg);
@@ -115,7 +115,7 @@ MakeUnsigned(const T& arg) noexcept
 
 /// @brief Strips the unit from the given value.
 template <typename T, LoValueCheck lo, HiValueCheck hi>
-constexpr inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
+constexpr auto StripUnit(const BoundedValue<T, lo, hi>& v)
 {
     return StripUnit(v.get());
 }
@@ -129,7 +129,7 @@ constexpr inline auto StripUnit(const BoundedValue<T, lo, hi>& v)
 /// @brief Secant method.
 /// @sa https://en.wikipedia.org/wiki/Secant_method
 template <typename T, typename U>
-constexpr inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
+constexpr U Secant(T target, U a1, T s1, U a2, T s2) noexcept
 {
     static_assert(IsArithmetic<T>::value && IsArithmetic<U>::value, "Arithmetic types required.");
     return (a1 + (target - s1) * (a2 - a1) / (s2 - s1));
@@ -138,7 +138,7 @@ constexpr inline U Secant(T target, U a1, T s1, U a2, T s2) noexcept
 /// @brief Bisection method.
 /// @sa https://en.wikipedia.org/wiki/Bisection_method
 template <typename T>
-constexpr inline T Bisect(T a1, T a2) noexcept
+constexpr T Bisect(T a1, T a2) noexcept
 {
     return (a1 + a2) / 2;
 }
@@ -146,7 +146,7 @@ constexpr inline T Bisect(T a1, T a2) noexcept
 /// @brief Is-odd.
 /// @details Determines whether the given integral value is odd (as opposed to being even).
 template <typename T>
-constexpr inline bool IsOdd(T val) noexcept
+constexpr bool IsOdd(T val) noexcept
 {
     static_assert(std::is_integral<T>::value, "Integral type required.");
     return val % 2;
@@ -154,7 +154,7 @@ constexpr inline bool IsOdd(T val) noexcept
 
 /// @brief Squares the given value.
 template<class TYPE>
-constexpr inline auto Square(TYPE t) noexcept { return t * t; }
+constexpr auto Square(TYPE t) noexcept { return t * t; }
 
 /// @brief Computes the arc-tangent of the given y and x values.
 /// @return Normalized angle - an angle between -Pi and Pi inclusively.
@@ -201,7 +201,7 @@ inline Vec2 RoundOff(Vec2 value, std::uint32_t precision = 100000)
 /// @brief Absolute value function for vectors.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline Vector<T, N> abs(const Vector<T, N>& v) noexcept
+constexpr Vector<T, N> abs(const Vector<T, N>& v) noexcept
 {
     auto result = Vector<T, N>{};
     for (auto i = decltype(N){0}; i < N; ++i)
@@ -222,7 +222,7 @@ inline d2::UnitVec abs(const d2::UnitVec& v) noexcept
 /// odd results like a divide by zero trap occurring.
 /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
 template <typename T>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_arithmetic<T>::value, bool> AlmostZero(T value)
 {
     return abs(value) < std::numeric_limits<T>::min();
@@ -230,7 +230,7 @@ std::enable_if_t<std::is_arithmetic<T>::value, bool> AlmostZero(T value)
 
 /// @brief Determines whether the given two values are "almost equal".
 template <typename T>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_floating_point<T>::value, bool> AlmostEqual(T x, T y, int ulp = 2)
 {
     // From http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon :
@@ -305,7 +305,7 @@ inline Angle GetAngle(const Vector2<T> value)
 /// @note For performance, use this instead of <code>GetMagnitude(T value)</code> (if possible).
 /// @return Non-negative value from 0 to infinity, or NaN.
 template <typename T>
-constexpr inline
+constexpr
 auto GetMagnitudeSquared(T value) noexcept
 {
     using VT = typename T::value_type;
@@ -351,7 +351,7 @@ inline auto GetMagnitude(T value)
 /// @return Dot product of the vectors (0 means the two vectors are perpendicular).
 ///
 template <typename T1, typename T2>
-constexpr inline auto Dot(const T1 a, const T2 b) noexcept
+constexpr auto Dot(const T1 a, const T2 b) noexcept
 {
     static_assert(std::tuple_size<T1>::value == std::tuple_size<T2>::value,
                   "Dot only for same tuple-like sized types");
@@ -396,7 +396,7 @@ constexpr inline auto Dot(const T1 a, const T2 b) noexcept
 ///
 template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
-constexpr inline auto Cross(T1 a, T2 b) noexcept
+constexpr auto Cross(T1 a, T2 b) noexcept
 {
     assert(isfinite(StripUnit(get<0>(a))));
     assert(isfinite(StripUnit(get<1>(a))));
@@ -428,7 +428,7 @@ constexpr inline auto Cross(T1 a, T2 b) noexcept
 /// @return Cross product of the two values.
 template <class T1, class T2, std::enable_if_t<
     std::tuple_size<T1>::value == 3 && std::tuple_size<T2>::value == 3, int> = 0>
-constexpr inline auto Cross(T1 a, T2 b) noexcept
+constexpr auto Cross(T1 a, T2 b) noexcept
 {
     assert(isfinite(get<0>(a)));
     assert(isfinite(get<1>(a)));
@@ -448,7 +448,7 @@ constexpr inline auto Cross(T1 a, T2 b) noexcept
 /// @brief Solves A * x = b, where b is a column vector.
 /// @note This is more efficient than computing the inverse in one-shot cases.
 template <typename T, typename U>
-constexpr inline auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
+constexpr auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
 {
     const auto cp = Cross(get<0>(mat), get<1>(mat));
     const auto inverseCp = Real{1} / cp;
@@ -462,7 +462,7 @@ constexpr inline auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
 
 /// @brief Inverts the given value.
 template <class IN_TYPE>
-constexpr inline auto Invert(const Matrix22<IN_TYPE> value) noexcept
+constexpr auto Invert(const Matrix22<IN_TYPE> value) noexcept
 {
     const auto cp = Cross(get<0>(value), get<1>(value));
     using OutType = decltype(get<0>(value)[0] / cp);
@@ -477,7 +477,7 @@ constexpr inline auto Invert(const Matrix22<IN_TYPE> value) noexcept
 
 /// @brief Solves A * x = b, where b is a column vector.
 /// @note This is more efficient than computing the inverse in one-shot cases.
-constexpr inline Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
+constexpr Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
 {
     const auto dp = Dot(GetX(mat), Cross(GetY(mat), GetZ(mat)));
     const auto det = (dp != 0)? Real{1} / dp: dp;
@@ -491,7 +491,7 @@ constexpr inline Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
 /// @note This is more efficient than computing the inverse in one-shot cases.
 /// @note Solves only the upper 2-by-2 matrix equation.
 template <typename T>
-constexpr inline T Solve22(const Mat33& mat, const T b) noexcept
+constexpr T Solve22(const Mat33& mat, const T b) noexcept
 {
     const auto cp = GetX(GetX(mat)) * GetY(GetY(mat)) - GetX(GetY(mat)) * GetY(GetX(mat));
     const auto det = (cp != 0)? Real{1} / cp: cp;
@@ -502,7 +502,7 @@ constexpr inline T Solve22(const Mat33& mat, const T b) noexcept
 
 /// @brief Gets the inverse of the given matrix as a 2-by-2.
 /// @return Zero matrix if singular.
-constexpr inline Mat33 GetInverse22(const Mat33& value) noexcept
+constexpr Mat33 GetInverse22(const Mat33& value) noexcept
 {
     const auto a = GetX(GetX(value)), b = GetX(GetY(value)), c = GetY(GetX(value)), d = GetY(GetY(value));
     auto det = (a * d) - (b * c);
@@ -515,7 +515,7 @@ constexpr inline Mat33 GetInverse22(const Mat33& value) noexcept
     
 /// @brief Gets the symmetric inverse of this matrix as a 3-by-3.
 /// @return Zero matrix if singular.
-constexpr inline Mat33 GetSymInverse33(const Mat33& value) noexcept
+constexpr Mat33 GetSymInverse33(const Mat33& value) noexcept
 {
     auto det = Dot(GetX(value), Cross(GetY(value), GetZ(value)));
     if (det != Real{0})
@@ -544,7 +544,7 @@ constexpr inline Mat33 GetSymInverse33(const Mat33& value) noexcept
 /// @return A counter-clockwise 90-degree rotation of the given vector.
 /// @sa GetFwdPerpendicular.
 template <class T>
-constexpr inline auto GetRevPerpendicular(const T vector) noexcept
+constexpr auto GetRevPerpendicular(const T vector) noexcept
 {
     // See http://mathworld.wolfram.com/PerpendicularVector.html
     return T{-GetY(vector), GetX(vector)};
@@ -556,7 +556,7 @@ constexpr inline auto GetRevPerpendicular(const T vector) noexcept
 /// @return A clockwise 90-degree rotation of the given vector.
 /// @sa GetRevPerpendicular.
 template <class T>
-constexpr inline auto GetFwdPerpendicular(const T vector) noexcept
+constexpr auto GetFwdPerpendicular(const T vector) noexcept
 {
     // See http://mathworld.wolfram.com/PerpendicularVector.html
     return T{GetY(vector), -GetX(vector)};
@@ -567,13 +567,13 @@ constexpr inline auto GetFwdPerpendicular(const T vector) noexcept
 /// @param m An M-row by N-column *transformation matrix* to multiply the vector by.
 /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
 template <std::size_t M, typename T1, std::size_t N, typename T2>
-constexpr inline auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
+constexpr auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
 {
     return m * v;
 }
 
 /// @brief Multiplies a vector by a matrix.
-constexpr inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
+constexpr Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 {
     return Vec2{
         get<0>(get<0>(A)) * v[0] + get<0>(get<1>(A)) * v[1],
@@ -583,13 +583,13 @@ constexpr inline Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
 
 /// Multiply a matrix transpose times a vector. If a rotation matrix is provided,
 /// then this transforms the vector from one frame to another (inverse transform).
-constexpr inline Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
+constexpr Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
 {
     return Vec2{Dot(v, GetX(A)), Dot(v, GetY(A))};
 }
 
 /// @brief Computes A^T * B.
-constexpr inline Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
+constexpr Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
 {
     const auto c1 = Vec2{Dot(GetX(A), GetX(B)), Dot(GetY(A), GetX(B))};
     const auto c2 = Vec2{Dot(GetX(A), GetY(B)), Dot(GetY(A), GetY(B))};
@@ -640,7 +640,7 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices);
 
 /// @brief Gets the modulo next value.
 template <typename T>
-constexpr inline T GetModuloNext(T value, T count) noexcept
+constexpr T GetModuloNext(T value, T count) noexcept
 {
     assert(value < count);
     return (value + 1) % count;
@@ -648,7 +648,7 @@ constexpr inline T GetModuloNext(T value, T count) noexcept
 
 /// @brief Gets the modulo previous value.
 template <typename T>
-constexpr inline T GetModuloPrev(T value, T count) noexcept
+constexpr T GetModuloPrev(T value, T count) noexcept
 {
     assert(value < count);
     return (value? value: count) - 1;
@@ -663,7 +663,7 @@ Angle GetDelta(Angle a1, Angle a2) noexcept;
 
 /// Gets the reverse (counter) clockwise rotational angle to go from angle 1 to angle 2.
 /// @return Angular rotation in the counter clockwise direction to go from angle 1 to angle 2.
-constexpr inline Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
+constexpr Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
 {
     return (a1 > a2)? 360_deg - (a1 - a2): a2 - a1;
 }
@@ -694,7 +694,7 @@ SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices);
 namespace d2 {
 
 /// @brief Gets a <code>Vec2</code> representation of the given value.
-constexpr inline Vec2 GetVec2(const UnitVec value)
+constexpr Vec2 GetVec2(const UnitVec value)
 {
     return Vec2{get<0>(value), get<1>(value)};
 }
@@ -707,34 +707,34 @@ inline Angle GetAngle(const UnitVec value)
 
 /// @brief Multiplication operator.
 template <class T, LoValueCheck lo, HiValueCheck hi>
-constexpr inline Vector2<T> operator* (BoundedValue<T, lo, hi> s, UnitVec u) noexcept
+constexpr Vector2<T> operator* (BoundedValue<T, lo, hi> s, UnitVec u) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * T{s}};
 }
 
 /// @brief Multiplication operator.
 template <class T>
-constexpr inline Vector2<T> operator* (const T s, const UnitVec u) noexcept
+constexpr Vector2<T> operator* (const T s, const UnitVec u) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * s};
 }
 
 /// @brief Multiplication operator.
 template <class T, LoValueCheck lo, HiValueCheck hi>
-constexpr inline Vector2<T> operator* (UnitVec u, BoundedValue<T, lo, hi> s) noexcept
+constexpr Vector2<T> operator* (UnitVec u, BoundedValue<T, lo, hi> s) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * T{s}};
 }
 
 /// @brief Multiplication operator.
 template <class T>
-constexpr inline Vector2<T> operator* (const UnitVec u, const T s) noexcept
+constexpr Vector2<T> operator* (const UnitVec u, const T s) noexcept
 {
     return Vector2<T>{u.GetX() * s, u.GetY() * s};
 }
 
 /// @brief Division operator.
-constexpr inline Vec2 operator/ (const UnitVec u, const UnitVec::value_type s) noexcept
+constexpr Vec2 operator/ (const UnitVec u, const UnitVec::value_type s) noexcept
 {
     const auto inverseS = Real{1} / s;
     return Vec2{GetX(u) * inverseS, GetY(u) * inverseS};
@@ -746,7 +746,7 @@ constexpr inline Vec2 operator/ (const UnitVec u, const UnitVec::value_type s) n
 /// @param angle Expresses the angle to forward rotate the given vector by.
 /// @sa InverseRotate.
 template <class T>
-constexpr inline auto Rotate(const Vector2<T> vector, const UnitVec& angle) noexcept
+constexpr auto Rotate(const Vector2<T> vector, const UnitVec& angle) noexcept
 {
     const auto newX = (GetX(angle) * GetX(vector)) - (GetY(angle) * GetY(vector));
     const auto newY = (GetY(angle) * GetX(vector)) + (GetX(angle) * GetY(vector));
@@ -761,7 +761,7 @@ constexpr inline auto Rotate(const Vector2<T> vector, const UnitVec& angle) noex
 /// @param angle Expresses the angle to reverse rotate the given vector by.
 /// @sa Rotate.
 template <class T>
-constexpr inline auto InverseRotate(const Vector2<T> vector, const UnitVec& angle) noexcept
+constexpr auto InverseRotate(const Vector2<T> vector, const UnitVec& angle) noexcept
 {
     const auto newX = (GetX(angle) * GetX(vector)) + (GetY(angle) * GetY(vector));
     const auto newY = (GetX(angle) * GetY(vector)) - (GetY(angle) * GetX(vector));
@@ -813,7 +813,7 @@ inline Sweep GetNormalized(Sweep sweep) noexcept
 /// @param v 2-D position to transform (to rotate and then translate).
 /// @param xfm Transformation (a translation and rotation) to apply to the given vector.
 /// @return Rotated and translated vector.
-constexpr inline Length2 Transform(const Length2 v, const Transformation xfm) noexcept
+constexpr Length2 Transform(const Length2 v, const Transformation xfm) noexcept
 {
     return Rotate(v, xfm.q) + xfm.p;
 }
@@ -828,7 +828,7 @@ constexpr inline Length2 Transform(const Length2 v, const Transformation xfm) no
 /// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
 /// @param xfm Transformation (a translation and rotation) to inversely apply to the given vector.
 /// @return Inverse transformed vector.
-constexpr inline Length2 InverseTransform(const Length2 v, const Transformation xfm) noexcept
+constexpr Length2 InverseTransform(const Length2 v, const Transformation xfm) noexcept
 {
     return InverseRotate(v - xfm.p, xfm.q);
 }
@@ -836,7 +836,7 @@ constexpr inline Length2 InverseTransform(const Length2 v, const Transformation 
 /// @brief Multiplies a given transformation by another given transformation.
 /// @note <code>v2 = A.q.Rot(B.q.Rot(v1) + B.p) + A.p
 ///                = (A.q * B.q).Rot(v1) + A.q.Rot(B.p) + A.p</code>
-constexpr inline Transformation Mul(const Transformation& A, const Transformation& B) noexcept
+constexpr Transformation Mul(const Transformation& A, const Transformation& B) noexcept
 {
     return Transformation{A.p + Rotate(B.p, A.q), A.q.Rotate(B.q)};
 }
@@ -844,14 +844,14 @@ constexpr inline Transformation Mul(const Transformation& A, const Transformatio
 /// @brief Inverse multiplies a given transformation by another given transformation.
 /// @note <code>v2 = A.q' * (B.q * v1 + B.p - A.p)
 ///                = A.q' * B.q * v1 + A.q' * (B.p - A.p)</code>
-constexpr inline Transformation MulT(const Transformation& A, const Transformation& B) noexcept
+constexpr Transformation MulT(const Transformation& A, const Transformation& B) noexcept
 {
     const auto dp = B.p - A.p;
     return Transformation{InverseRotate(dp, A.q), B.q.Rotate(A.q.FlipY())};
 }
 
 /// @brief Gets the transformation for the given values.
-constexpr inline Transformation GetTransformation(const Length2 ctr, const UnitVec rot,
+constexpr Transformation GetTransformation(const Length2 ctr, const UnitVec rot,
                                                             const Length2 localCtr) noexcept
 {
     assert(IsValid(rot));
@@ -915,7 +915,7 @@ inline bool IsUnderActive(Velocity velocity,
 /// @brief Gets the reflection matrix for the given unit vector that defines the normal of
 ///   the line through the origin that points should be reflected against.
 /// @sa https://en.wikipedia.org/wiki/Transformation_matrix
-constexpr inline auto GetReflectionMatrix(UnitVec axis)
+constexpr auto GetReflectionMatrix(UnitVec axis)
 {
     constexpr auto TupleSize = std::tuple_size<decltype(axis)>::value;
     constexpr auto NumRows = TupleSize;

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -826,12 +826,11 @@ PLAYRHO_CONSTEXPR inline Length2 Transform(const Length2 v, const Transformation
 /// transformation again) will result in the original vector being returned.
 /// @sa <code>Transform</code>.
 /// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
-/// @param T Transformation (a translation and rotation) to inversely apply to the given vector.
+/// @param xfm Transformation (a translation and rotation) to inversely apply to the given vector.
 /// @return Inverse transformed vector.
-PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transformation T) noexcept
+PLAYRHO_CONSTEXPR inline Length2 InverseTransform(const Length2 v, const Transformation xfm) noexcept
 {
-    const auto v2 = v - T.p;
-    return InverseRotate(v2, T.q);
+    return InverseRotate(v - xfm.p, xfm.q);
 }
 
 /// @brief Multiplies a given transformation by another given transformation.

--- a/PlayRho/Common/Matrix.hpp
+++ b/PlayRho/Common/Matrix.hpp
@@ -98,7 +98,7 @@ struct IsSquareMatrix<Vector<Vector<T, M>, M>>: std::true_type {};
 /// @sa https://en.wikipedia.org/wiki/Identity_matrix
 /// @sa Matrix, IsMatrix, IsSquareMatrix
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<!IsVector<T>::value, Matrix<T, N, N>> GetIdentityMatrix()
 {
     auto result = Matrix<Real, N, N>{};
@@ -113,14 +113,14 @@ std::enable_if_t<!IsVector<T>::value, Matrix<T, N, N>> GetIdentityMatrix()
 /// @sa https://en.wikipedia.org/wiki/Identity_matrix
 /// @sa Matrix, IsMatrix, IsSquareMatrix
 template <typename T>
-PLAYRHO_CONSTEXPR inline std::enable_if_t<IsSquareMatrix<T>::value, T> GetIdentity()
+constexpr inline std::enable_if_t<IsSquareMatrix<T>::value, T> GetIdentity()
 {
     return GetIdentityMatrix<typename T::value_type::value_type, std::tuple_size<T>::value>();
 }
 
 /// @brief Gets the specified row of the given matrix as a row matrix.
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, N>, 1>> GetRowMatrix(Vector<T, N> arg)
 {
     return Vector<Vector<T, N>, 1>{arg};
@@ -128,7 +128,7 @@ std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, N>, 1>> GetRowMatrix(Vect
 
 /// @brief Gets the specified column of the given matrix as a column matrix.
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, 1>, N>> GetColumnMatrix(Vector<T, N> arg)
 {
     auto result = Vector<Vector<T, 1>, N>{};
@@ -142,7 +142,7 @@ std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, 1>, N>> GetColumnMatrix(V
 /// @brief Matrix addition operator for two same-type, same-sized matrices.
 /// @sa https://en.wikipedia.org/wiki/Matrix_addition
 template <typename T, std::size_t M, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 auto operator+ (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
 {
     auto result = Matrix<T, M, N>{};
@@ -159,7 +159,7 @@ auto operator+ (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
 /// @brief Matrix subtraction operator for two same-type, same-sized matrices.
 /// @sa https://en.wikipedia.org/wiki/Matrix_addition
 template <typename T, std::size_t M, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 auto operator- (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
 {
     auto result = Matrix<T, M, N>{};
@@ -195,14 +195,14 @@ using Mat33 = Matrix33<Real>;
 
 /// @brief Determines if the given value is valid.
 template <>
-PLAYRHO_CONSTEXPR inline bool IsValid(const Mat22& value) noexcept
+constexpr inline bool IsValid(const Mat22& value) noexcept
 {
     return IsValid(get<0>(value)) && IsValid(get<1>(value));
 }
 
 /// @brief Gets an invalid value for a <code>Mat22</code>.
 template <>
-PLAYRHO_CONSTEXPR inline Mat22 GetInvalid() noexcept
+constexpr inline Mat22 GetInvalid() noexcept
 {
     return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
 }

--- a/PlayRho/Common/Matrix.hpp
+++ b/PlayRho/Common/Matrix.hpp
@@ -98,7 +98,7 @@ struct IsSquareMatrix<Vector<Vector<T, M>, M>>: std::true_type {};
 /// @sa https://en.wikipedia.org/wiki/Identity_matrix
 /// @sa Matrix, IsMatrix, IsSquareMatrix
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<!IsVector<T>::value, Matrix<T, N, N>> GetIdentityMatrix()
 {
     auto result = Matrix<Real, N, N>{};
@@ -113,14 +113,14 @@ std::enable_if_t<!IsVector<T>::value, Matrix<T, N, N>> GetIdentityMatrix()
 /// @sa https://en.wikipedia.org/wiki/Identity_matrix
 /// @sa Matrix, IsMatrix, IsSquareMatrix
 template <typename T>
-constexpr inline std::enable_if_t<IsSquareMatrix<T>::value, T> GetIdentity()
+constexpr std::enable_if_t<IsSquareMatrix<T>::value, T> GetIdentity()
 {
     return GetIdentityMatrix<typename T::value_type::value_type, std::tuple_size<T>::value>();
 }
 
 /// @brief Gets the specified row of the given matrix as a row matrix.
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, N>, 1>> GetRowMatrix(Vector<T, N> arg)
 {
     return Vector<Vector<T, N>, 1>{arg};
@@ -128,7 +128,7 @@ std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, N>, 1>> GetRowMatrix(Vect
 
 /// @brief Gets the specified column of the given matrix as a column matrix.
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, 1>, N>> GetColumnMatrix(Vector<T, N> arg)
 {
     auto result = Vector<Vector<T, 1>, N>{};
@@ -142,7 +142,7 @@ std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, 1>, N>> GetColumnMatrix(V
 /// @brief Matrix addition operator for two same-type, same-sized matrices.
 /// @sa https://en.wikipedia.org/wiki/Matrix_addition
 template <typename T, std::size_t M, std::size_t N>
-constexpr inline
+constexpr
 auto operator+ (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
 {
     auto result = Matrix<T, M, N>{};
@@ -159,7 +159,7 @@ auto operator+ (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
 /// @brief Matrix subtraction operator for two same-type, same-sized matrices.
 /// @sa https://en.wikipedia.org/wiki/Matrix_addition
 template <typename T, std::size_t M, std::size_t N>
-constexpr inline
+constexpr
 auto operator- (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
 {
     auto result = Matrix<T, M, N>{};
@@ -195,14 +195,14 @@ using Mat33 = Matrix33<Real>;
 
 /// @brief Determines if the given value is valid.
 template <>
-constexpr inline bool IsValid(const Mat22& value) noexcept
+constexpr bool IsValid(const Mat22& value) noexcept
 {
     return IsValid(get<0>(value)) && IsValid(get<1>(value));
 }
 
 /// @brief Gets an invalid value for a <code>Mat22</code>.
 template <>
-constexpr inline Mat22 GetInvalid() noexcept
+constexpr Mat22 GetInvalid() noexcept
 {
     return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
 }

--- a/PlayRho/Common/OptionalValue.hpp
+++ b/PlayRho/Common/OptionalValue.hpp
@@ -39,13 +39,13 @@ namespace playrho {
         /// @brief Value type.
         using value_type = T;
         
-        PLAYRHO_CONSTEXPR inline OptionalValue() = default;
+        constexpr inline OptionalValue() = default;
         
         /// @brief Copy constructor.
-        PLAYRHO_CONSTEXPR inline OptionalValue(const OptionalValue& other) = default;
+        constexpr inline OptionalValue(const OptionalValue& other) = default;
 
         /// @brief Move constructor.
-        PLAYRHO_CONSTEXPR inline OptionalValue(OptionalValue&& other) noexcept:
+        constexpr inline OptionalValue(OptionalValue&& other) noexcept:
             m_value{std::move(other.m_value)}, m_set{other.m_set}
         {
             // Intentionally empty.
@@ -54,27 +54,27 @@ namespace playrho {
         }
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline explicit OptionalValue(T v);
+        constexpr inline explicit OptionalValue(T v);
 
         ~OptionalValue() = default;
 
         /// @brief Indirection operator.
-        PLAYRHO_CONSTEXPR const T& operator* () const;
+        constexpr const T& operator* () const;
 
         /// @brief Indirection operator.
-        PLAYRHO_CONSTEXPR inline T& operator* ();
+        constexpr inline T& operator* ();
         
         /// @brief Member of pointer operator.
-        PLAYRHO_CONSTEXPR const T* operator-> () const;
+        constexpr const T* operator-> () const;
         
         /// @brief Member of pointer operator.
-        PLAYRHO_CONSTEXPR inline T* operator-> ();
+        constexpr inline T* operator-> ();
 
         /// @brief Boolean operator.
-        PLAYRHO_CONSTEXPR inline explicit operator bool() const noexcept;
+        constexpr inline explicit operator bool() const noexcept;
 
         /// @brief Whether this optional value has a value.
-        PLAYRHO_CONSTEXPR inline bool has_value() const noexcept;
+        constexpr inline bool has_value() const noexcept;
         
         /// @brief Assignment operator.
         OptionalValue& operator= (const OptionalValue& other) = default;
@@ -93,13 +93,13 @@ namespace playrho {
         OptionalValue& operator= (T v);
 
         /// @brief Accesses the value.
-        PLAYRHO_CONSTEXPR inline T& value();
+        constexpr inline T& value();
 
         /// @brief Accesses the value.
-        PLAYRHO_CONSTEXPR const T& value() const;
+        constexpr const T& value() const;
         
         /// @brief Gets the value or provides the alternate given value instead.
-        PLAYRHO_CONSTEXPR inline T value_or(const T& alt) const;
+        constexpr inline T value_or(const T& alt) const;
         
         /// @brief Resets the optional value back to its default constructed state.
         void reset() noexcept
@@ -114,16 +114,16 @@ namespace playrho {
     };
     
     template<typename T>
-    PLAYRHO_CONSTEXPR inline OptionalValue<T>::OptionalValue(T v): m_value{v}, m_set{true} {}
+    constexpr inline OptionalValue<T>::OptionalValue(T v): m_value{v}, m_set{true} {}
     
     template<typename T>
-    PLAYRHO_CONSTEXPR inline bool OptionalValue<T>::has_value() const noexcept
+    constexpr inline bool OptionalValue<T>::has_value() const noexcept
     {
         return m_set;
     }
     
     template<typename T>
-    PLAYRHO_CONSTEXPR inline OptionalValue<T>::operator bool() const noexcept
+    constexpr inline OptionalValue<T>::operator bool() const noexcept
     {
         return m_set;
     }
@@ -137,47 +137,47 @@ namespace playrho {
     }
     
     template<typename T>
-    PLAYRHO_CONSTEXPR const T* OptionalValue<T>::operator->() const
+    constexpr const T* OptionalValue<T>::operator->() const
     {
         assert(m_set);
         return &m_value;
     }
     
     template<typename T>
-    PLAYRHO_CONSTEXPR inline T* OptionalValue<T>::operator->()
+    constexpr inline T* OptionalValue<T>::operator->()
     {
         assert(m_set);
         return &m_value;
     }
 
     template<typename T>
-    PLAYRHO_CONSTEXPR const T& OptionalValue<T>::operator*() const
+    constexpr const T& OptionalValue<T>::operator*() const
     {
         assert(m_set);
         return m_value;
     }
     
     template<typename T>
-    PLAYRHO_CONSTEXPR inline T& OptionalValue<T>::operator*()
+    constexpr inline T& OptionalValue<T>::operator*()
     {
         assert(m_set);
         return m_value;
     }
 
     template<typename T>
-    PLAYRHO_CONSTEXPR inline T& OptionalValue<T>::value()
+    constexpr inline T& OptionalValue<T>::value()
     {
         return m_value;
     }
     
     template<typename T>
-    PLAYRHO_CONSTEXPR const T& OptionalValue<T>::value() const
+    constexpr const T& OptionalValue<T>::value() const
     {
         return m_value;
     }
 
     template<typename T>
-    PLAYRHO_CONSTEXPR inline T OptionalValue<T>::value_or(const T& alt) const
+    constexpr inline T OptionalValue<T>::value_or(const T& alt) const
     {
         return m_set? m_value: alt;
     }

--- a/PlayRho/Common/OptionalValue.hpp
+++ b/PlayRho/Common/OptionalValue.hpp
@@ -39,13 +39,13 @@ namespace playrho {
         /// @brief Value type.
         using value_type = T;
         
-        constexpr inline OptionalValue() = default;
+        constexpr OptionalValue() = default;
         
         /// @brief Copy constructor.
-        constexpr inline OptionalValue(const OptionalValue& other) = default;
+        constexpr OptionalValue(const OptionalValue& other) = default;
 
         /// @brief Move constructor.
-        constexpr inline OptionalValue(OptionalValue&& other) noexcept:
+        constexpr OptionalValue(OptionalValue&& other) noexcept:
             m_value{std::move(other.m_value)}, m_set{other.m_set}
         {
             // Intentionally empty.
@@ -54,7 +54,7 @@ namespace playrho {
         }
 
         /// @brief Initializing constructor.
-        constexpr inline explicit OptionalValue(T v);
+        constexpr explicit OptionalValue(T v);
 
         ~OptionalValue() = default;
 
@@ -62,19 +62,19 @@ namespace playrho {
         constexpr const T& operator* () const;
 
         /// @brief Indirection operator.
-        constexpr inline T& operator* ();
+        constexpr T& operator* ();
         
         /// @brief Member of pointer operator.
         constexpr const T* operator-> () const;
         
         /// @brief Member of pointer operator.
-        constexpr inline T* operator-> ();
+        constexpr T* operator-> ();
 
         /// @brief Boolean operator.
-        constexpr inline explicit operator bool() const noexcept;
+        constexpr explicit operator bool() const noexcept;
 
         /// @brief Whether this optional value has a value.
-        constexpr inline bool has_value() const noexcept;
+        constexpr bool has_value() const noexcept;
         
         /// @brief Assignment operator.
         OptionalValue& operator= (const OptionalValue& other) = default;
@@ -93,13 +93,13 @@ namespace playrho {
         OptionalValue& operator= (T v);
 
         /// @brief Accesses the value.
-        constexpr inline T& value();
+        constexpr T& value();
 
         /// @brief Accesses the value.
         constexpr const T& value() const;
         
         /// @brief Gets the value or provides the alternate given value instead.
-        constexpr inline T value_or(const T& alt) const;
+        constexpr T value_or(const T& alt) const;
         
         /// @brief Resets the optional value back to its default constructed state.
         void reset() noexcept
@@ -114,16 +114,16 @@ namespace playrho {
     };
     
     template<typename T>
-    constexpr inline OptionalValue<T>::OptionalValue(T v): m_value{v}, m_set{true} {}
+    constexpr OptionalValue<T>::OptionalValue(T v): m_value{v}, m_set{true} {}
     
     template<typename T>
-    constexpr inline bool OptionalValue<T>::has_value() const noexcept
+    constexpr bool OptionalValue<T>::has_value() const noexcept
     {
         return m_set;
     }
     
     template<typename T>
-    constexpr inline OptionalValue<T>::operator bool() const noexcept
+    constexpr OptionalValue<T>::operator bool() const noexcept
     {
         return m_set;
     }
@@ -144,7 +144,7 @@ namespace playrho {
     }
     
     template<typename T>
-    constexpr inline T* OptionalValue<T>::operator->()
+    constexpr T* OptionalValue<T>::operator->()
     {
         assert(m_set);
         return &m_value;
@@ -158,14 +158,14 @@ namespace playrho {
     }
     
     template<typename T>
-    constexpr inline T& OptionalValue<T>::operator*()
+    constexpr T& OptionalValue<T>::operator*()
     {
         assert(m_set);
         return m_value;
     }
 
     template<typename T>
-    constexpr inline T& OptionalValue<T>::value()
+    constexpr T& OptionalValue<T>::value()
     {
         return m_value;
     }
@@ -177,7 +177,7 @@ namespace playrho {
     }
 
     template<typename T>
-    constexpr inline T OptionalValue<T>::value_or(const T& alt) const
+    constexpr T OptionalValue<T>::value_or(const T& alt) const
     {
         return m_set? m_value: alt;
     }

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -41,35 +41,35 @@ struct Position
 
 /// @brief Equality operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline bool operator==(const Position& lhs, const Position& rhs)
+constexpr inline bool operator==(const Position& lhs, const Position& rhs)
 {
     return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
 }
 
 /// @brief Inequality operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline bool operator!=(const Position& lhs, const Position& rhs)
+constexpr inline bool operator!=(const Position& lhs, const Position& rhs)
 {
     return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
 }
 
 /// @brief Negation operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position operator- (const Position& value)
+constexpr inline Position operator- (const Position& value)
 {
     return Position{-value.linear, -value.angular};
 }
 
 /// @brief Positive operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position operator+ (const Position& value)
+constexpr inline Position operator+ (const Position& value)
 {
     return value;
 }
 
 /// @brief Addition assignment operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position& operator+= (Position& lhs, const Position& rhs)
+constexpr inline Position& operator+= (Position& lhs, const Position& rhs)
 {
     lhs.linear += rhs.linear;
     lhs.angular += rhs.angular;
@@ -78,14 +78,14 @@ PLAYRHO_CONSTEXPR inline Position& operator+= (Position& lhs, const Position& rh
 
 /// @brief Addition operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position operator+ (const Position& lhs, const Position& rhs)
+constexpr inline Position operator+ (const Position& lhs, const Position& rhs)
 {
     return Position{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
 }
 
 /// @brief Subtraction assignment operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position& operator-= (Position& lhs, const Position& rhs)
+constexpr inline Position& operator-= (Position& lhs, const Position& rhs)
 {
     lhs.linear -= rhs.linear;
     lhs.angular -= rhs.angular;
@@ -94,20 +94,20 @@ PLAYRHO_CONSTEXPR inline Position& operator-= (Position& lhs, const Position& rh
 
 /// @brief Subtraction operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position operator- (const Position& lhs, const Position& rhs)
+constexpr inline Position operator- (const Position& lhs, const Position& rhs)
 {
     return Position{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
 }
 
 /// @brief Multiplication operator.
-PLAYRHO_CONSTEXPR inline Position operator* (const Position& pos, const Real scalar)
+constexpr inline Position operator* (const Position& pos, const Real scalar)
 {
     return Position{pos.linear * scalar, pos.angular * scalar};
 }
 
 /// @brief Multiplication operator.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position operator* (const Real scalar, const Position& pos)
+constexpr inline Position operator* (const Real scalar, const Position& pos)
 {
     return Position{pos.linear * scalar, pos.angular * scalar};
 }
@@ -117,7 +117,7 @@ PLAYRHO_CONSTEXPR inline Position operator* (const Real scalar, const Position& 
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Position
 template <>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 bool IsValid(const d2::Position& value) noexcept
 {
     return IsValid(value.linear) && IsValid(value.angular);
@@ -134,7 +134,7 @@ namespace d2 {
 ///   position 1 if <code>beta == 1</code>, or at the given unit interval value
 ///   between position 0 and position 1.
 /// @relatedalso Position
-PLAYRHO_CONSTEXPR inline Position GetPosition(const Position pos0, const Position pos1,
+constexpr inline Position GetPosition(const Position pos0, const Position pos1,
                                               const Real beta) noexcept
 {
     assert(IsValid(pos0));

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -41,35 +41,35 @@ struct Position
 
 /// @brief Equality operator.
 /// @relatedalso Position
-constexpr inline bool operator==(const Position& lhs, const Position& rhs)
+constexpr bool operator==(const Position& lhs, const Position& rhs)
 {
     return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
 }
 
 /// @brief Inequality operator.
 /// @relatedalso Position
-constexpr inline bool operator!=(const Position& lhs, const Position& rhs)
+constexpr bool operator!=(const Position& lhs, const Position& rhs)
 {
     return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
 }
 
 /// @brief Negation operator.
 /// @relatedalso Position
-constexpr inline Position operator- (const Position& value)
+constexpr Position operator- (const Position& value)
 {
     return Position{-value.linear, -value.angular};
 }
 
 /// @brief Positive operator.
 /// @relatedalso Position
-constexpr inline Position operator+ (const Position& value)
+constexpr Position operator+ (const Position& value)
 {
     return value;
 }
 
 /// @brief Addition assignment operator.
 /// @relatedalso Position
-constexpr inline Position& operator+= (Position& lhs, const Position& rhs)
+constexpr Position& operator+= (Position& lhs, const Position& rhs)
 {
     lhs.linear += rhs.linear;
     lhs.angular += rhs.angular;
@@ -78,14 +78,14 @@ constexpr inline Position& operator+= (Position& lhs, const Position& rhs)
 
 /// @brief Addition operator.
 /// @relatedalso Position
-constexpr inline Position operator+ (const Position& lhs, const Position& rhs)
+constexpr Position operator+ (const Position& lhs, const Position& rhs)
 {
     return Position{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
 }
 
 /// @brief Subtraction assignment operator.
 /// @relatedalso Position
-constexpr inline Position& operator-= (Position& lhs, const Position& rhs)
+constexpr Position& operator-= (Position& lhs, const Position& rhs)
 {
     lhs.linear -= rhs.linear;
     lhs.angular -= rhs.angular;
@@ -94,20 +94,20 @@ constexpr inline Position& operator-= (Position& lhs, const Position& rhs)
 
 /// @brief Subtraction operator.
 /// @relatedalso Position
-constexpr inline Position operator- (const Position& lhs, const Position& rhs)
+constexpr Position operator- (const Position& lhs, const Position& rhs)
 {
     return Position{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
 }
 
 /// @brief Multiplication operator.
-constexpr inline Position operator* (const Position& pos, const Real scalar)
+constexpr Position operator* (const Position& pos, const Real scalar)
 {
     return Position{pos.linear * scalar, pos.angular * scalar};
 }
 
 /// @brief Multiplication operator.
 /// @relatedalso Position
-constexpr inline Position operator* (const Real scalar, const Position& pos)
+constexpr Position operator* (const Real scalar, const Position& pos)
 {
     return Position{pos.linear * scalar, pos.angular * scalar};
 }
@@ -117,7 +117,7 @@ constexpr inline Position operator* (const Real scalar, const Position& pos)
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Position
 template <>
-constexpr inline
+constexpr
 bool IsValid(const d2::Position& value) noexcept
 {
     return IsValid(value.linear) && IsValid(value.angular);
@@ -134,7 +134,7 @@ namespace d2 {
 ///   position 1 if <code>beta == 1</code>, or at the given unit interval value
 ///   between position 0 and position 1.
 /// @relatedalso Position
-constexpr inline Position GetPosition(const Position pos0, const Position pos1,
+constexpr Position GetPosition(const Position pos0, const Position pos1,
                                               const Real beta) noexcept
 {
     assert(IsValid(pos0));

--- a/PlayRho/Common/Range.hpp
+++ b/PlayRho/Common/Range.hpp
@@ -36,26 +36,26 @@ namespace playrho {
         using iterator_type = IT;
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Range(iterator_type iter_begin, iterator_type iter_end) noexcept:
+        constexpr inline Range(iterator_type iter_begin, iterator_type iter_end) noexcept:
         	m_begin{iter_begin}, m_end{iter_end}
         {
             // Intentionally empty.
         }
 
         /// @brief Gets the "begin" index value.
-        PLAYRHO_CONSTEXPR iterator_type begin() const noexcept
+        constexpr iterator_type begin() const noexcept
         {
             return m_begin;
         }
 
         /// @brief Gets the "end" index value.
-        PLAYRHO_CONSTEXPR iterator_type end() const noexcept
+        constexpr iterator_type end() const noexcept
         {
             return m_end;
         }
 
         /// @brief Whether this range is empty.
-        PLAYRHO_CONSTEXPR bool empty() const noexcept
+        constexpr bool empty() const noexcept
         {
             return m_begin == m_end;
         }
@@ -74,7 +74,7 @@ namespace playrho {
         using size_type = std::size_t;
 
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline SizedRange(typename Range<IT>::iterator_type iter_begin,
+        constexpr inline SizedRange(typename Range<IT>::iterator_type iter_begin,
                              typename Range<IT>::iterator_type iter_end,
                              size_type size) noexcept:
         	Range<IT>{iter_begin, iter_end}, m_size{size}
@@ -83,7 +83,7 @@ namespace playrho {
         }
 
         /// @brief Gets the size of this range.
-        PLAYRHO_CONSTEXPR size_type size() const noexcept
+        constexpr size_type size() const noexcept
         {
             return m_size;
         }

--- a/PlayRho/Common/Range.hpp
+++ b/PlayRho/Common/Range.hpp
@@ -36,7 +36,7 @@ namespace playrho {
         using iterator_type = IT;
 
         /// @brief Initializing constructor.
-        constexpr inline Range(iterator_type iter_begin, iterator_type iter_end) noexcept:
+        constexpr Range(iterator_type iter_begin, iterator_type iter_end) noexcept:
         	m_begin{iter_begin}, m_end{iter_end}
         {
             // Intentionally empty.
@@ -74,7 +74,7 @@ namespace playrho {
         using size_type = std::size_t;
 
         /// @brief Initializing constructor.
-        constexpr inline SizedRange(typename Range<IT>::iterator_type iter_begin,
+        constexpr SizedRange(typename Range<IT>::iterator_type iter_begin,
                              typename Range<IT>::iterator_type iter_end,
                              size_type size) noexcept:
         	Range<IT>{iter_begin, iter_end}, m_size{size}

--- a/PlayRho/Common/RealConstants.hpp
+++ b/PlayRho/Common/RealConstants.hpp
@@ -51,13 +51,13 @@ namespace playrho {
 ///
 /// @sa https://en.wikipedia.org/wiki/Pi
 ///
-PLAYRHO_CONSTEXPR const auto Pi = Real(3.14159265358979323846264338327950288);
+constexpr const auto Pi = Real(3.14159265358979323846264338327950288);
 
 /// @brief Square root of two.
 ///
 /// @sa https://en.wikipedia.org/wiki/Square_root_of_2
 ///
-PLAYRHO_CONSTEXPR const auto SquareRootTwo =
+constexpr const auto SquareRootTwo =
     Real(1.414213562373095048801688724209698078569671875376948073176679737990732478462);
 
 /// @defgroup DecimalUnitPrefices Decimal Unit Prefices
@@ -70,35 +70,35 @@ PLAYRHO_CONSTEXPR const auto SquareRootTwo =
 
 /// @brief Centi- (1 x 10^-2).
 /// @sa https://en.wikipedia.org/wiki/Centi-
-PLAYRHO_CONSTEXPR const auto Centi = Real(1e-2);
+constexpr const auto Centi = Real(1e-2);
 
 /// @brief Deci- (1 x 10^-1).
 /// @sa https://en.wikipedia.org/wiki/Deci-
-PLAYRHO_CONSTEXPR const auto Deci = Real(1e-1);
+constexpr const auto Deci = Real(1e-1);
 
 /// @brief Kilo- (1 x 10^3).
 /// @sa https://en.wikipedia.org/wiki/Kilo-
-PLAYRHO_CONSTEXPR const auto Kilo = Real(1e3);
+constexpr const auto Kilo = Real(1e3);
 
 /// @brief Mega- (1 x 10^6).
 /// @sa https://en.wikipedia.org/wiki/Mega-
-PLAYRHO_CONSTEXPR const auto Mega = Real(1e6);
+constexpr const auto Mega = Real(1e6);
 
 /// @brief Giga- (1 x 10^9).
 /// @sa https://en.wikipedia.org/wiki/Giga-
-PLAYRHO_CONSTEXPR const auto Giga = Real(1e9);
+constexpr const auto Giga = Real(1e9);
 
 /// @brief Tera- (1 x 10^12).
 /// @sa https://en.wikipedia.org/wiki/Tera-
-PLAYRHO_CONSTEXPR const auto Tera = Real(1e12);
+constexpr const auto Tera = Real(1e12);
 
 /// @brief Peta- (1 x 10^15).
 /// @sa https://en.wikipedia.org/wiki/Peta-
-PLAYRHO_CONSTEXPR const auto Peta = Real(1e15);
+constexpr const auto Peta = Real(1e15);
 
 /// @brief Yotta- (1 x 10^24).
 /// @sa https://en.wikipedia.org/wiki/Yotta-
-PLAYRHO_CONSTEXPR const auto Yotta = Real(1e24);
+constexpr const auto Yotta = Real(1e24);
 
 /// @}
 

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -47,14 +47,14 @@ template <typename T>
 struct Defaults
 {
     /// @brief Gets the linear slop.
-    static PLAYRHO_CONSTEXPR inline auto GetLinearSlop() noexcept
+    static constexpr inline auto GetLinearSlop() noexcept
     {
         // Return the value used by Box2D 2.3.2 b2_linearSlop define....
         return 0.005_m;
     }
     
     /// @brief Gets the max vertex radius.
-    static PLAYRHO_CONSTEXPR inline auto GetMaxVertexRadius() noexcept
+    static constexpr inline auto GetMaxVertexRadius() noexcept
     {
         // DefaultLinearSlop * Real{2 * 1024 * 1024};
         // linearSlop * 2550000
@@ -67,7 +67,7 @@ template <unsigned int FRACTION_BITS>
 struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
 {
     /// @brief Gets the linear slop.
-    static PLAYRHO_CONSTEXPR inline auto GetLinearSlop() noexcept
+    static constexpr inline auto GetLinearSlop() noexcept
     {
         // Needs to be big enough that the step tolerance doesn't go to zero.
         // ex: FRACTION_BITS==10, then divisor==256
@@ -75,7 +75,7 @@ struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
     }
     
     /// @brief Gets the max vertex radius.
-    static PLAYRHO_CONSTEXPR inline auto GetMaxVertexRadius() noexcept
+    static constexpr inline auto GetMaxVertexRadius() noexcept
     {
         // linearSlop * 2550000
         return Length{Real(1u << (28 - FRACTION_BITS)) * 1_m};
@@ -85,10 +85,10 @@ struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
 } // namespace detail
 
 /// @brief Maximum number of supportable edges in a simplex.
-PLAYRHO_CONSTEXPR const auto MaxSimplexEdges = std::uint8_t{3};
+constexpr const auto MaxSimplexEdges = std::uint8_t{3};
 
 /// @brief Max child count.
-PLAYRHO_CONSTEXPR const auto MaxChildCount = std::numeric_limits<std::uint32_t>::max() >> 6;
+constexpr const auto MaxChildCount = std::numeric_limits<std::uint32_t>::max() >> 6;
 
 /// @brief Child counter type.
 /// @details Relating to "children" of shape where each child is a convex shape possibly
@@ -101,7 +101,7 @@ using ChildCounter = std::remove_const<decltype(MaxChildCount)>::type;
 using TimestepIters = std::uint8_t;
 
 /// @brief Maximum float value.
-PLAYRHO_CONSTEXPR const auto MaxFloat = std::numeric_limits<Real>::max(); // FLT_MAX
+constexpr const auto MaxFloat = std::numeric_limits<Real>::max(); // FLT_MAX
 
 // Collision
 
@@ -109,12 +109,12 @@ PLAYRHO_CONSTEXPR const auto MaxFloat = std::numeric_limits<Real>::max(); // FLT
 /// This is the maximum number of contact points between two convex shapes.
 /// Do not change this value.
 /// @note For memory efficiency, uses the smallest integral type that can hold the value. 
-PLAYRHO_CONSTEXPR const auto MaxManifoldPoints = std::uint8_t{2};
+constexpr const auto MaxManifoldPoints = std::uint8_t{2};
 
 /// @brief Maximum number of vertices for any shape type.
 /// @note For memory efficiency, uses the smallest integral type that can hold the value minus
 ///   one that's left out as a sentinel value.
-PLAYRHO_CONSTEXPR const auto MaxShapeVertices = std::uint8_t{254};
+constexpr const auto MaxShapeVertices = std::uint8_t{254};
 
 /// @brief Vertex count type.
 /// @note This type must not support more than 255 vertices as that would conflict
@@ -122,7 +122,7 @@ PLAYRHO_CONSTEXPR const auto MaxShapeVertices = std::uint8_t{254};
 using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
 
 /// @brief Invalid vertex index.
-PLAYRHO_CONSTEXPR const auto InvalidVertex = static_cast<VertexCounter>(-1);
+constexpr const auto InvalidVertex = static_cast<VertexCounter>(-1);
 
 /// @brief Default linear slop.
 /// @details Length used as a collision and constraint tolerance.
@@ -131,53 +131,53 @@ PLAYRHO_CONSTEXPR const auto InvalidVertex = static_cast<VertexCounter>(-1);
 ///   between bodies at rest.
 /// @note Smaller values relative to sizes of bodies increases the time it takes
 ///   for bodies to come to rest.
-PLAYRHO_CONSTEXPR const auto DefaultLinearSlop = detail::Defaults<Real>::GetLinearSlop();
+constexpr const auto DefaultLinearSlop = detail::Defaults<Real>::GetLinearSlop();
 
 /// @brief Default minimum vertex radius.
-PLAYRHO_CONSTEXPR const auto DefaultMinVertexRadius = DefaultLinearSlop * Real{2};
+constexpr const auto DefaultMinVertexRadius = DefaultLinearSlop * Real{2};
 
 /// @brief Default maximum vertex radius.
-PLAYRHO_CONSTEXPR const auto DefaultMaxVertexRadius = detail::Defaults<Real>::GetMaxVertexRadius();
+constexpr const auto DefaultMaxVertexRadius = detail::Defaults<Real>::GetMaxVertexRadius();
 
 /// @brief Default AABB extension amount.
-PLAYRHO_CONSTEXPR const auto DefaultAabbExtension = DefaultLinearSlop * Real{20};
+constexpr const auto DefaultAabbExtension = DefaultLinearSlop * Real{20};
 
 /// @brief Default distance multiplier.
-PLAYRHO_CONSTEXPR const auto DefaultDistanceMultiplier = Real{2};
+constexpr const auto DefaultDistanceMultiplier = Real{2};
 
 /// @brief Default angular slop.
 /// @details
 /// A small angle used as a collision and constraint tolerance. Usually it is
 /// chosen to be numerically significant, but visually insignificant.
-PLAYRHO_CONSTEXPR const auto DefaultAngularSlop = (Pi * 2_rad) / Real{180};
+constexpr const auto DefaultAngularSlop = (Pi * 2_rad) / Real{180};
 
 /// @brief Default maximum linear correction.
 /// @details The maximum linear position correction used when solving constraints.
 ///   This helps to prevent overshoot.
 /// @note This value should be greater than the linear slop value.
-PLAYRHO_CONSTEXPR const auto DefaultMaxLinearCorrection = 0.2_m;
+constexpr const auto DefaultMaxLinearCorrection = 0.2_m;
 
 /// @brief Default maximum angular correction.
 /// @note This value should be greater than the angular slop value.
-PLAYRHO_CONSTEXPR const auto DefaultMaxAngularCorrection = Real(8.0f / 180.0f) * Pi * 1_rad;
+constexpr const auto DefaultMaxAngularCorrection = Real(8.0f / 180.0f) * Pi * 1_rad;
 
 /// @brief Default maximum translation amount.
-PLAYRHO_CONSTEXPR const auto DefaultMaxTranslation = 2_m;
+constexpr const auto DefaultMaxTranslation = 2_m;
 
 /// @brief Default maximum rotation per world step.
 /// @warning This value should be less than Pi * Radian.
 /// @note This limit is meant to prevent numerical problems. Adjusting this value isn't advised.
 /// @sa StepConf::maxRotation.
-PLAYRHO_CONSTEXPR const auto DefaultMaxRotation = Angle{Pi * 1_rad / Real(2)};
+constexpr const auto DefaultMaxRotation = Angle{Pi * 1_rad / Real(2)};
 
 /// @brief Default maximum time of impact iterations.
-PLAYRHO_CONSTEXPR const auto DefaultMaxToiIters = std::uint8_t{20};
+constexpr const auto DefaultMaxToiIters = std::uint8_t{20};
 
 /// Default maximum time of impact root iterator count.
-PLAYRHO_CONSTEXPR const auto DefaultMaxToiRootIters = std::uint8_t{30};
+constexpr const auto DefaultMaxToiRootIters = std::uint8_t{30};
 
 /// Default max number of distance iterations.
-PLAYRHO_CONSTEXPR const auto DefaultMaxDistanceIters = std::uint8_t{20};
+constexpr const auto DefaultMaxDistanceIters = std::uint8_t{20};
 
 /// Default maximum number of sub steps.
 /// @details
@@ -185,22 +185,22 @@ PLAYRHO_CONSTEXPR const auto DefaultMaxDistanceIters = std::uint8_t{20};
 /// In other words, this is the default maximum number of times in a world step that a contact will
 /// have continuous collision resolution done for it.
 /// @note Used in the TOI phase of step processing.
-PLAYRHO_CONSTEXPR const auto DefaultMaxSubSteps = std::uint8_t{8};
+constexpr const auto DefaultMaxSubSteps = std::uint8_t{8};
     
 // Dynamics
 
 /// @brief Default velocity threshold.
-PLAYRHO_CONSTEXPR const auto DefaultVelocityThreshold = 1_mps;
+constexpr const auto DefaultVelocityThreshold = 1_mps;
 
 /// @brief Default regular-phase minimum momentum.
-PLAYRHO_CONSTEXPR const auto DefaultRegMinMomentum = Momentum{0_Ns / 100};
+constexpr const auto DefaultRegMinMomentum = Momentum{0_Ns / 100};
 
 /// @brief Default TOI-phase minimum momentum.
-PLAYRHO_CONSTEXPR const auto DefaultToiMinMomentum = Momentum{0_Ns / 100};
+constexpr const auto DefaultToiMinMomentum = Momentum{0_Ns / 100};
 
 /// @brief Maximum number of bodies in a world.
 /// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
-PLAYRHO_CONSTEXPR const auto MaxBodies = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
+constexpr const auto MaxBodies = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
                                                       std::uint16_t{1});
 
 /// @brief Body count type.
@@ -212,17 +212,17 @@ using BodyCounter = std::remove_const<decltype(MaxBodies)>::type;
 using ContactCounter = Wider<BodyCounter>::type;
 
 /// @brief Invalid contact index.
-PLAYRHO_CONSTEXPR const auto InvalidContactIndex = static_cast<ContactCounter>(-1);
+constexpr const auto InvalidContactIndex = static_cast<ContactCounter>(-1);
 
 /// @brief Maximum number of contacts in a world (2147319811).
 /// @details Uses the formula for the maximum number of edges in an unidirectional graph of
 ///   <code>MaxBodies</code> nodes.
 /// This occurs when every possible body is connected to every other body.
-PLAYRHO_CONSTEXPR const auto MaxContacts = ContactCounter{MaxBodies} * ContactCounter{MaxBodies - 1} / ContactCounter{2};
+constexpr const auto MaxContacts = ContactCounter{MaxBodies} * ContactCounter{MaxBodies - 1} / ContactCounter{2};
 
 /// @brief Maximum number of joints in a world.
 /// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
-PLAYRHO_CONSTEXPR const auto MaxJoints = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
+constexpr const auto MaxJoints = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
                                                       std::uint16_t{1});
 
 /// @brief Joint count type.
@@ -230,29 +230,29 @@ PLAYRHO_CONSTEXPR const auto MaxJoints = static_cast<std::uint16_t>(std::numeric
 using JointCounter = std::remove_const<decltype(MaxJoints)>::type;
 
 /// @brief Default step time.
-PLAYRHO_CONSTEXPR const auto DefaultStepTime = Time{1_s / 60};
+constexpr const auto DefaultStepTime = Time{1_s / 60};
 
 /// @brief Default step frequency.
-PLAYRHO_CONSTEXPR const auto DefaultStepFrequency = 60_Hz;
+constexpr const auto DefaultStepFrequency = 60_Hz;
 
 // Sleep
 
 /// Default minimum still time to sleep.
 /// @details The default minimum time bodies must be still for bodies to be put to sleep.
-PLAYRHO_CONSTEXPR const auto DefaultMinStillTimeToSleep = Time{1_s / 2}; // aka 0.5 secs
+constexpr const auto DefaultMinStillTimeToSleep = Time{1_s / 2}; // aka 0.5 secs
 
 /// Default linear sleep tolerance.
 /// @details A body cannot sleep if the magnitude of its linear velocity is above this amount.
-PLAYRHO_CONSTEXPR const auto DefaultLinearSleepTolerance = 0.01_mps; // aka 0.01
+constexpr const auto DefaultLinearSleepTolerance = 0.01_mps; // aka 0.01
 
 /// Default angular sleep tolerance.
 /// @details A body cannot sleep if its angular velocity is above this amount.
-PLAYRHO_CONSTEXPR const auto DefaultAngularSleepTolerance = Real{(Pi * 2) / 180} * RadianPerSecond;
+constexpr const auto DefaultAngularSleepTolerance = Real{(Pi * 2) / 180} * RadianPerSecond;
 
 /// Default circles ratio.
 /// @details Ratio used for switching between rounded-corner collisions and closest-face
 ///   biased normal collisions.
-PLAYRHO_CONSTEXPR const auto DefaultCirclesRatio = Real{10};
+constexpr const auto DefaultCirclesRatio = Real{10};
 
 } // namespace playrho
 

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -47,14 +47,14 @@ template <typename T>
 struct Defaults
 {
     /// @brief Gets the linear slop.
-    static constexpr inline auto GetLinearSlop() noexcept
+    static constexpr auto GetLinearSlop() noexcept
     {
         // Return the value used by Box2D 2.3.2 b2_linearSlop define....
         return 0.005_m;
     }
     
     /// @brief Gets the max vertex radius.
-    static constexpr inline auto GetMaxVertexRadius() noexcept
+    static constexpr auto GetMaxVertexRadius() noexcept
     {
         // DefaultLinearSlop * Real{2 * 1024 * 1024};
         // linearSlop * 2550000
@@ -67,7 +67,7 @@ template <unsigned int FRACTION_BITS>
 struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
 {
     /// @brief Gets the linear slop.
-    static constexpr inline auto GetLinearSlop() noexcept
+    static constexpr auto GetLinearSlop() noexcept
     {
         // Needs to be big enough that the step tolerance doesn't go to zero.
         // ex: FRACTION_BITS==10, then divisor==256
@@ -75,7 +75,7 @@ struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
     }
     
     /// @brief Gets the max vertex radius.
-    static constexpr inline auto GetMaxVertexRadius() noexcept
+    static constexpr auto GetMaxVertexRadius() noexcept
     {
         // linearSlop * 2550000
         return Length{Real(1u << (28 - FRACTION_BITS)) * 1_m};

--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -58,22 +58,22 @@ namespace playrho {
         Span(const Span& copy) = default;
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Span(pointer array, size_type size) noexcept:
+        constexpr inline Span(pointer array, size_type size) noexcept:
             m_array{array}, m_size{size}
         {
         }
         
         /// @brief Initializing constructor.
         template <std::size_t SIZE>
-        PLAYRHO_CONSTEXPR inline Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
+        constexpr inline Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
         
         /// @brief Initializing constructor.
         template <typename U, typename = std::enable_if_t< !std::is_array<U>::value > >
-        PLAYRHO_CONSTEXPR inline Span(U& value) noexcept:
+        constexpr inline Span(U& value) noexcept:
         m_array{detail::Data(value)}, m_size{detail::Size(value)} {}
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline Span(std::initializer_list<T> list) noexcept:
+        constexpr inline Span(std::initializer_list<T> list) noexcept:
             m_array{list.begin()}, m_size{list.size()} {}
 
         /// @brief Gets the "begin" iterator value.
@@ -103,13 +103,13 @@ namespace playrho {
         }
 
         /// @brief Gets the size of this span.
-        PLAYRHO_CONSTEXPR size_type size() const noexcept { return m_size; }
+        constexpr size_type size() const noexcept { return m_size; }
         
         /// @brief Direct access to data.
         pointer data() const noexcept { return m_array; }
         
         /// @brief Checks whether this span is empty.
-        PLAYRHO_CONSTEXPR bool empty() const noexcept { return m_size == 0; }
+        constexpr bool empty() const noexcept { return m_size == 0; }
 
     private:
         pointer m_array = nullptr; ///< Pointer to array of data.

--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -58,22 +58,22 @@ namespace playrho {
         Span(const Span& copy) = default;
         
         /// @brief Initializing constructor.
-        constexpr inline Span(pointer array, size_type size) noexcept:
+        constexpr Span(pointer array, size_type size) noexcept:
             m_array{array}, m_size{size}
         {
         }
         
         /// @brief Initializing constructor.
         template <std::size_t SIZE>
-        constexpr inline Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
+        constexpr Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
         
         /// @brief Initializing constructor.
         template <typename U, typename = std::enable_if_t< !std::is_array<U>::value > >
-        constexpr inline Span(U& value) noexcept:
+        constexpr Span(U& value) noexcept:
         m_array{detail::Data(value)}, m_size{detail::Size(value)} {}
         
         /// @brief Initializing constructor.
-        constexpr inline Span(std::initializer_list<T> list) noexcept:
+        constexpr Span(std::initializer_list<T> list) noexcept:
             m_array{list.begin()}, m_size{list.size()} {}
 
         /// @brief Gets the "begin" iterator value.

--- a/PlayRho/Common/StackAllocator.cpp
+++ b/PlayRho/Common/StackAllocator.cpp
@@ -29,7 +29,7 @@ namespace {
 
 inline std::size_t alignment_size(std::size_t size)
 {
-    PLAYRHO_CONSTEXPR const auto one = static_cast<std::size_t>(1u);
+    constexpr const auto one = static_cast<std::size_t>(1u);
     return (size < one)? one: (size < sizeof(std::max_align_t))?
         static_cast<std::size_t>(NextPowerOfTwo(size - one)): alignof(std::max_align_t);
 };

--- a/PlayRho/Common/StackAllocator.hpp
+++ b/PlayRho/Common/StackAllocator.hpp
@@ -46,7 +46,7 @@ public:
     };
 
     /// @brief Gets the default configuration.
-    static PLAYRHO_CONSTEXPR inline Conf GetDefaultConf()
+    static constexpr inline Conf GetDefaultConf()
     {
         return Conf{};
     }

--- a/PlayRho/Common/StackAllocator.hpp
+++ b/PlayRho/Common/StackAllocator.hpp
@@ -46,7 +46,7 @@ public:
     };
 
     /// @brief Gets the default configuration.
-    static constexpr inline Conf GetDefaultConf()
+    static constexpr Conf GetDefaultConf()
     {
         return Conf{};
     }

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -46,10 +46,10 @@ public:
     Sweep() = default;
     
     /// @brief Copy constructor.
-    PLAYRHO_CONSTEXPR inline Sweep(const Sweep& copy) = default;
+    constexpr inline Sweep(const Sweep& copy) = default;
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline Sweep(const Position p0, const Position p1,
+    constexpr inline Sweep(const Position p0, const Position p1,
                     const Length2 lc = Length2{0_m, 0_m},
                     Real a0 = 0) noexcept:
         pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
@@ -59,7 +59,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit Sweep(const Position p,
+    constexpr inline explicit Sweep(const Position p,
                              const Length2 lc = Length2{0_m, 0_m}):
         Sweep{p, p, lc, 0}
     {
@@ -132,7 +132,7 @@ inline void Sweep::ResetAlpha0() noexcept
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Transformation
 template <>
-PLAYRHO_CONSTEXPR inline bool IsValid(const d2::Sweep& value) noexcept
+constexpr inline bool IsValid(const d2::Sweep& value) noexcept
 {
     return IsValid(value.pos0) && IsValid(value.pos1)
     && IsValid(value.GetLocalCenter()) && IsValid(value.GetAlpha0());

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -46,10 +46,10 @@ public:
     Sweep() = default;
     
     /// @brief Copy constructor.
-    constexpr inline Sweep(const Sweep& copy) = default;
+    constexpr Sweep(const Sweep& copy) = default;
     
     /// @brief Initializing constructor.
-    constexpr inline Sweep(const Position p0, const Position p1,
+    constexpr Sweep(const Position p0, const Position p1,
                     const Length2 lc = Length2{0_m, 0_m},
                     Real a0 = 0) noexcept:
         pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
@@ -59,7 +59,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr inline explicit Sweep(const Position p,
+    constexpr explicit Sweep(const Position p,
                              const Length2 lc = Length2{0_m, 0_m}):
         Sweep{p, p, lc, 0}
     {
@@ -132,7 +132,7 @@ inline void Sweep::ResetAlpha0() noexcept
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Transformation
 template <>
-constexpr inline bool IsValid(const d2::Sweep& value) noexcept
+constexpr bool IsValid(const d2::Sweep& value) noexcept
 {
     return IsValid(value.pos0) && IsValid(value.pos1)
     && IsValid(value.GetLocalCenter()) && IsValid(value.GetAlpha0());

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -72,14 +72,14 @@ struct IsIterableImpl<T, VoidT<
 
 /// @brief Gets the maximum size of the given container.
 template <class T>
-constexpr inline auto max_size(const T& arg) -> decltype(arg.max_size())
+constexpr auto max_size(const T& arg) -> decltype(arg.max_size())
 {
     return arg.max_size();
 }
 
 /// @brief Checks whether the given container is full.
 template <class T>
-constexpr inline auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
+constexpr auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
 {
     return size(arg) == max_size(arg);
 }
@@ -109,16 +109,16 @@ static auto Size(T& v)
 
     /// @brief Gets an invalid value for the type.
     template <typename T>
-    constexpr inline T GetInvalid() noexcept
+    constexpr T GetInvalid() noexcept
     {
         static_assert(sizeof(T) == 0, "No available specialization");
     }
 
     /// @brief Determines if the given value is valid.
     template <typename T>
-    constexpr inline bool IsValid(const T& value) noexcept
+    constexpr bool IsValid(const T& value) noexcept
     {
-        // Note: This is not necessarily a no-op!! But it is a "constexpr inline".
+        // Note: This is not necessarily a no-op!! But it is a "constexpr".
         //
         // From http://en.cppreference.com/w/cpp/numeric/math/isnan:
         //   "Another way to test if a floating-point value is NaN is
@@ -135,28 +135,28 @@ static auto Size(T& v)
     
     /// @brief Gets an invalid value for the float type.
     template <>
-    constexpr inline float GetInvalid() noexcept
+    constexpr float GetInvalid() noexcept
     {
         return std::numeric_limits<float>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the double type.
     template <>
-    constexpr inline double GetInvalid() noexcept
+    constexpr double GetInvalid() noexcept
     {
         return std::numeric_limits<double>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the long double type.
     template <>
-    constexpr inline long double GetInvalid() noexcept
+    constexpr long double GetInvalid() noexcept
     {
         return std::numeric_limits<long double>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the std::size_t type.
     template <>
-    constexpr inline std::size_t GetInvalid() noexcept
+    constexpr std::size_t GetInvalid() noexcept
     {
         return static_cast<std::size_t>(-1);
     }
@@ -165,7 +165,7 @@ static auto Size(T& v)
     
     /// @brief Determines if the given value is valid.
     template <>
-    constexpr inline bool IsValid(const std::size_t& value) noexcept
+    constexpr bool IsValid(const std::size_t& value) noexcept
     {
         return value != GetInvalid<std::size_t>();
     }
@@ -181,7 +181,7 @@ static auto Size(T& v)
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    constexpr inline T* GetPtr(T* value) noexcept
+    constexpr T* GetPtr(T* value) noexcept
     {
         return value;
     }
@@ -195,7 +195,7 @@ static auto Size(T& v)
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    constexpr inline T* GetPtr(T& value) noexcept
+    constexpr T* GetPtr(T& value) noexcept
     {
         return &value;
     }
@@ -209,7 +209,7 @@ static auto Size(T& v)
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    constexpr inline T& GetRef(T* value) noexcept
+    constexpr T& GetRef(T* value) noexcept
     {
         return *value;
     }
@@ -223,7 +223,7 @@ static auto Size(T& v)
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    constexpr inline T& GetRef(T& value) noexcept
+    constexpr T& GetRef(T& value) noexcept
     {
         return value;
     }

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -72,14 +72,14 @@ struct IsIterableImpl<T, VoidT<
 
 /// @brief Gets the maximum size of the given container.
 template <class T>
-PLAYRHO_CONSTEXPR inline auto max_size(const T& arg) -> decltype(arg.max_size())
+constexpr inline auto max_size(const T& arg) -> decltype(arg.max_size())
 {
     return arg.max_size();
 }
 
 /// @brief Checks whether the given container is full.
 template <class T>
-PLAYRHO_CONSTEXPR inline auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
+constexpr inline auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
 {
     return size(arg) == max_size(arg);
 }
@@ -109,16 +109,16 @@ static auto Size(T& v)
 
     /// @brief Gets an invalid value for the type.
     template <typename T>
-    PLAYRHO_CONSTEXPR inline T GetInvalid() noexcept
+    constexpr inline T GetInvalid() noexcept
     {
         static_assert(sizeof(T) == 0, "No available specialization");
     }
 
     /// @brief Determines if the given value is valid.
     template <typename T>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const T& value) noexcept
+    constexpr inline bool IsValid(const T& value) noexcept
     {
-        // Note: This is not necessarily a no-op!! But it is a "PLAYRHO_CONSTEXPR inline".
+        // Note: This is not necessarily a no-op!! But it is a "constexpr inline".
         //
         // From http://en.cppreference.com/w/cpp/numeric/math/isnan:
         //   "Another way to test if a floating-point value is NaN is
@@ -135,28 +135,28 @@ static auto Size(T& v)
     
     /// @brief Gets an invalid value for the float type.
     template <>
-    PLAYRHO_CONSTEXPR inline float GetInvalid() noexcept
+    constexpr inline float GetInvalid() noexcept
     {
         return std::numeric_limits<float>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the double type.
     template <>
-    PLAYRHO_CONSTEXPR inline double GetInvalid() noexcept
+    constexpr inline double GetInvalid() noexcept
     {
         return std::numeric_limits<double>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the long double type.
     template <>
-    PLAYRHO_CONSTEXPR inline long double GetInvalid() noexcept
+    constexpr inline long double GetInvalid() noexcept
     {
         return std::numeric_limits<long double>::signaling_NaN();
     }
     
     /// @brief Gets an invalid value for the std::size_t type.
     template <>
-    PLAYRHO_CONSTEXPR inline std::size_t GetInvalid() noexcept
+    constexpr inline std::size_t GetInvalid() noexcept
     {
         return static_cast<std::size_t>(-1);
     }
@@ -165,7 +165,7 @@ static auto Size(T& v)
     
     /// @brief Determines if the given value is valid.
     template <>
-    PLAYRHO_CONSTEXPR inline bool IsValid(const std::size_t& value) noexcept
+    constexpr inline bool IsValid(const std::size_t& value) noexcept
     {
         return value != GetInvalid<std::size_t>();
     }
@@ -174,56 +174,56 @@ static auto Size(T& v)
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR const T* GetPtr(const T* value) noexcept
+    constexpr const T* GetPtr(const T* value) noexcept
     {
         return value;
     }
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR inline T* GetPtr(T* value) noexcept
+    constexpr inline T* GetPtr(T* value) noexcept
     {
         return value;
     }
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR const T* GetPtr(const T& value) noexcept
+    constexpr const T* GetPtr(const T& value) noexcept
     {
         return &value;
     }
     
     /// @brief Gets a pointer for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR inline T* GetPtr(T& value) noexcept
+    constexpr inline T* GetPtr(T& value) noexcept
     {
         return &value;
     }
 
     /// @brief Gets a reference for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR const T& GetRef(const T* value) noexcept
+    constexpr const T& GetRef(const T* value) noexcept
     {
         return *value;
     }
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR inline T& GetRef(T* value) noexcept
+    constexpr inline T& GetRef(T* value) noexcept
     {
         return *value;
     }
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR const T& GetRef(const T& value) noexcept
+    constexpr const T& GetRef(const T& value) noexcept
     {
         return value;
     }
     
     /// @brief Gets a reference for the given variable.
     template <class T>
-    PLAYRHO_CONSTEXPR inline T& GetRef(T& value) noexcept
+    constexpr inline T& GetRef(T& value) noexcept
     {
         return value;
     }

--- a/PlayRho/Common/Transformation.hpp
+++ b/PlayRho/Common/Transformation.hpp
@@ -51,14 +51,14 @@ constexpr const auto Transform_identity = Transformation{
 
 /// @brief Equality operator.
 /// @relatedalso Transformation
-constexpr inline bool operator== (Transformation lhs, Transformation rhs) noexcept
+constexpr bool operator== (Transformation lhs, Transformation rhs) noexcept
 {
     return (lhs.p == rhs.p) && (lhs.q == rhs.q);
 }
 
 /// @brief Inequality operator.
 /// @relatedalso Transformation
-constexpr inline bool operator!= (Transformation lhs, Transformation rhs) noexcept
+constexpr bool operator!= (Transformation lhs, Transformation rhs) noexcept
 {
     return (lhs.p != rhs.p) || (lhs.q != rhs.q);
 }
@@ -68,7 +68,7 @@ constexpr inline bool operator!= (Transformation lhs, Transformation rhs) noexce
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Transformation
 template <>
-constexpr inline bool IsValid(const d2::Transformation& value) noexcept
+constexpr bool IsValid(const d2::Transformation& value) noexcept
 {
     return IsValid(value.p) && IsValid(value.q);
 }

--- a/PlayRho/Common/Transformation.hpp
+++ b/PlayRho/Common/Transformation.hpp
@@ -45,20 +45,20 @@ struct Transformation
 };
 
 /// @brief Identity transformation value.
-PLAYRHO_CONSTEXPR const auto Transform_identity = Transformation{
+constexpr const auto Transform_identity = Transformation{
     Length2{0_m, 0_m}, UnitVec::GetRight()
 };
 
 /// @brief Equality operator.
 /// @relatedalso Transformation
-PLAYRHO_CONSTEXPR inline bool operator== (Transformation lhs, Transformation rhs) noexcept
+constexpr inline bool operator== (Transformation lhs, Transformation rhs) noexcept
 {
     return (lhs.p == rhs.p) && (lhs.q == rhs.q);
 }
 
 /// @brief Inequality operator.
 /// @relatedalso Transformation
-PLAYRHO_CONSTEXPR inline bool operator!= (Transformation lhs, Transformation rhs) noexcept
+constexpr inline bool operator!= (Transformation lhs, Transformation rhs) noexcept
 {
     return (lhs.p != rhs.p) || (lhs.q != rhs.q);
 }
@@ -68,7 +68,7 @@ PLAYRHO_CONSTEXPR inline bool operator!= (Transformation lhs, Transformation rhs
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Transformation
 template <>
-PLAYRHO_CONSTEXPR inline bool IsValid(const d2::Transformation& value) noexcept
+constexpr inline bool IsValid(const d2::Transformation& value) noexcept
 {
     return IsValid(value.p) && IsValid(value.q);
 }

--- a/PlayRho/Common/UnitVec.hpp
+++ b/PlayRho/Common/UnitVec.hpp
@@ -71,32 +71,32 @@ public:
     /// @note This is the value for the 0/4 turned (0 angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the bottom oriented vector.
     /// @note This is the forward perpendicular unit vector of the top oriented vector.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetRight() noexcept { return UnitVec{1, 0}; }
+    static constexpr inline UnitVec GetRight() noexcept { return UnitVec{1, 0}; }
 
     /// @brief Gets the top-ward oriented unit vector.
     /// @note This is the actual value for the 1/4 turned (90 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the right oriented vector.
     /// @note This is the forward perpendicular unit vector of the left oriented vector.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetTop() noexcept { return UnitVec{0, 1}; }
+    static constexpr inline UnitVec GetTop() noexcept { return UnitVec{0, 1}; }
 
     /// @brief Gets the left-ward oriented unit vector.
     /// @note This is the actual value for the 2/4 turned (180 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the top oriented vector.
     /// @note This is the forward perpendicular unit vector of the bottom oriented vector.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetLeft() noexcept { return UnitVec{-1, 0}; }
+    static constexpr inline UnitVec GetLeft() noexcept { return UnitVec{-1, 0}; }
 
     /// @brief Gets the bottom-ward oriented unit vector.
     /// @note This is the actual value for the 3/4 turned (270 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the left oriented vector.
     /// @note This is the forward perpendicular unit vector of the right oriented vector.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetBottom() noexcept { return UnitVec{0, -1}; }
+    static constexpr inline UnitVec GetBottom() noexcept { return UnitVec{0, -1}; }
 
     /// @brief Gets the non-oriented unit vector.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetZero() noexcept { return UnitVec{0, 0}; }
+    static constexpr inline UnitVec GetZero() noexcept { return UnitVec{0, 0}; }
 
     /// @brief Gets the 45 degree unit vector.
     /// @details This is the unit vector in the positive X and Y quadrant where X == Y.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetTopRight() noexcept
+    static constexpr inline UnitVec GetTopRight() noexcept
     {
         // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
         return UnitVec{+SquareRootTwo/Real(2), +SquareRootTwo/Real(2)};
@@ -105,14 +105,14 @@ public:
     /// @brief Gets the -45 degree unit vector.
     /// @details This is the unit vector in the positive X and negative Y quadrant
     ///   where |X| == |Y|.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetBottomRight() noexcept
+    static constexpr inline UnitVec GetBottomRight() noexcept
     {
         // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
         return UnitVec{+SquareRootTwo/Real(2), -SquareRootTwo/Real(2)};
     }
     
     /// @brief Gets the default fallback.
-    static PLAYRHO_CONSTEXPR inline UnitVec GetDefaultFallback() noexcept { return UnitVec{}; }
+    static constexpr inline UnitVec GetDefaultFallback() noexcept { return UnitVec{}; }
 
     /// @brief Polar coordinate.
     /// @details This is a direction and magnitude pair defined by the unit vector class.
@@ -155,17 +155,17 @@ public:
     ///
     static UnitVec Get(const Angle angle) noexcept;
 
-    PLAYRHO_CONSTEXPR inline UnitVec() noexcept = default;
+    constexpr inline UnitVec() noexcept = default;
     
     /// @brief Gets the max size.
-    PLAYRHO_CONSTEXPR inline size_type max_size() const noexcept { return size_type{2}; }
+    constexpr inline size_type max_size() const noexcept { return size_type{2}; }
     
     /// @brief Gets the size.
-    PLAYRHO_CONSTEXPR inline size_type size() const noexcept { return size_type{2}; }
+    constexpr inline size_type size() const noexcept { return size_type{2}; }
     
     /// @brief Whether empty.
     /// @note Always false for N > 0.
-    PLAYRHO_CONSTEXPR inline bool empty() const noexcept { return false; }
+    constexpr inline bool empty() const noexcept { return false; }
     
     /// @brief Gets a "begin" iterator.
     const_iterator begin() const noexcept { return const_iterator(m_elems); }
@@ -206,7 +206,7 @@ public:
     /// @brief Gets a constant reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    PLAYRHO_CONSTEXPR inline const_reference operator[](size_type pos) const noexcept
+    constexpr inline const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
         return m_elems[pos];
@@ -214,7 +214,7 @@ public:
     
     /// @brief Gets a constant reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    PLAYRHO_CONSTEXPR inline const_reference at(size_type pos) const
+    constexpr inline const_reference at(size_type pos) const
     {
         if (pos >= size())
         {
@@ -224,25 +224,25 @@ public:
     }
     
     /// @brief Direct access to data.
-    PLAYRHO_CONSTEXPR inline const_pointer data() const noexcept
+    constexpr inline const_pointer data() const noexcept
     {
         return m_elems;
     }
     
     /// @brief Gets the "X" value.
-    PLAYRHO_CONSTEXPR inline auto GetX() const noexcept { return m_elems[0]; }
+    constexpr inline auto GetX() const noexcept { return m_elems[0]; }
 
     /// @brief Gets the "Y" value.
-    PLAYRHO_CONSTEXPR inline auto GetY() const noexcept { return m_elems[1]; }
+    constexpr inline auto GetY() const noexcept { return m_elems[1]; }
     
     /// @brief Flips the X and Y values.
-    PLAYRHO_CONSTEXPR inline UnitVec FlipXY() const noexcept { return UnitVec{-GetX(), -GetY()}; }
+    constexpr inline UnitVec FlipXY() const noexcept { return UnitVec{-GetX(), -GetY()}; }
 
     /// @brief Flips the X value.
-    PLAYRHO_CONSTEXPR inline UnitVec FlipX() const noexcept { return UnitVec{-GetX(), GetY()}; }
+    constexpr inline UnitVec FlipX() const noexcept { return UnitVec{-GetX(), GetY()}; }
 
     /// @brief Flips the Y value.
-    PLAYRHO_CONSTEXPR inline UnitVec FlipY() const noexcept { return UnitVec{GetX(), -GetY()}; }
+    constexpr inline UnitVec FlipY() const noexcept { return UnitVec{GetX(), -GetY()}; }
 
     /// @brief Rotates the unit vector by the given amount.
     ///
@@ -251,7 +251,7 @@ public:
     ///
     /// @return Result of rotating this unit vector by the given amount.
     ///
-    PLAYRHO_CONSTEXPR inline UnitVec Rotate(UnitVec amount) const noexcept
+    constexpr inline UnitVec Rotate(UnitVec amount) const noexcept
     {
         return UnitVec{GetX() * amount.GetX() - GetY() * amount.GetY(),
                         GetY() * amount.GetX() + GetX() * amount.GetY()};
@@ -261,7 +261,7 @@ public:
     /// @details This returns the unit vector (-y, x).
     /// @return A counter-clockwise 90-degree rotation of this vector.
     /// @sa GetFwdPerpendicular.
-    PLAYRHO_CONSTEXPR inline UnitVec GetRevPerpendicular() const noexcept
+    constexpr inline UnitVec GetRevPerpendicular() const noexcept
     {
         // See http://mathworld.wolfram.com/PerpendicularVector.html
         return UnitVec{-GetY(), GetX()};
@@ -271,20 +271,20 @@ public:
     /// @details This returns the unit vector (y, -x).
     /// @return A clockwise 90-degree rotation of this vector.
     /// @sa GetRevPerpendicular.
-    PLAYRHO_CONSTEXPR inline UnitVec GetFwdPerpendicular() const noexcept
+    constexpr inline UnitVec GetFwdPerpendicular() const noexcept
     {
         // See http://mathworld.wolfram.com/PerpendicularVector.html
         return UnitVec{GetY(), -GetX()};
     }
 
     /// @brief Negation operator.
-    PLAYRHO_CONSTEXPR inline UnitVec operator-() const noexcept { return UnitVec{-GetX(), -GetY()}; }
+    constexpr inline UnitVec operator-() const noexcept { return UnitVec{-GetX(), -GetY()}; }
 
     /// @brief Positive operator.
-    PLAYRHO_CONSTEXPR inline UnitVec operator+() const noexcept { return UnitVec{+GetX(), +GetY()}; }
+    constexpr inline UnitVec operator+() const noexcept { return UnitVec{+GetX(), +GetY()}; }
 
     /// @brief Gets the absolute value.
-    PLAYRHO_CONSTEXPR inline UnitVec Absolute() const noexcept
+    constexpr inline UnitVec Absolute() const noexcept
     {
         return UnitVec{abs(GetX()), abs(GetY())};
     }
@@ -292,7 +292,7 @@ public:
 private:
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline UnitVec(value_type x, value_type y) noexcept : m_elems{x, y}
+    constexpr inline UnitVec(value_type x, value_type y) noexcept : m_elems{x, y}
     {
         // Intentionally empty.
     }
@@ -303,20 +303,20 @@ private:
 // Free functions...
 
 /// @brief Gets the "X-axis".
-PLAYRHO_CONSTEXPR inline UnitVec GetXAxis(UnitVec rot) noexcept { return rot; }
+constexpr inline UnitVec GetXAxis(UnitVec rot) noexcept { return rot; }
 
 /// @brief Gets the "Y-axis".
 /// @note This is the reverse perpendicular vector of the given unit vector.
-PLAYRHO_CONSTEXPR inline UnitVec GetYAxis(UnitVec rot) noexcept { return rot.GetRevPerpendicular(); }
+constexpr inline UnitVec GetYAxis(UnitVec rot) noexcept { return rot.GetRevPerpendicular(); }
 
 /// @brief Equality operator.
-PLAYRHO_CONSTEXPR inline bool operator==(const UnitVec a, const UnitVec b) noexcept
+constexpr inline bool operator==(const UnitVec a, const UnitVec b) noexcept
 {
     return (a.GetX() == b.GetX()) && (a.GetY() == b.GetY());
 }
 
 /// @brief Inequality operator.
-PLAYRHO_CONSTEXPR inline bool operator!=(const UnitVec a, const UnitVec b) noexcept
+constexpr inline bool operator!=(const UnitVec a, const UnitVec b) noexcept
 {
     return (a.GetX() != b.GetX()) || (a.GetY() != b.GetY());
 }
@@ -327,7 +327,7 @@ PLAYRHO_CONSTEXPR inline bool operator!=(const UnitVec a, const UnitVec b) noexc
 /// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
 /// @return A counter-clockwise 90-degree rotation of the given vector.
 /// @sa GetFwdPerpendicular.
-PLAYRHO_CONSTEXPR inline UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
+constexpr inline UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
 {
     return vector.GetRevPerpendicular();
 }
@@ -337,7 +337,7 @@ PLAYRHO_CONSTEXPR inline UnitVec GetRevPerpendicular(const UnitVec vector) noexc
 /// @param vector Vector to return a clockwise perpendicular equivalent for.
 /// @return A clockwise 90-degree rotation of the given vector.
 /// @sa GetRevPerpendicular.
-PLAYRHO_CONSTEXPR inline UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
+constexpr inline UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
 {
     return vector.GetFwdPerpendicular();
 }
@@ -345,20 +345,20 @@ PLAYRHO_CONSTEXPR inline UnitVec GetFwdPerpendicular(const UnitVec vector) noexc
 /// @brief Rotates a unit vector by the angle expressed by the second unit vector.
 /// @return Unit vector for the angle that's the sum of the two angles expressed by
 ///   the input unit vectors.
-PLAYRHO_CONSTEXPR inline UnitVec Rotate(const UnitVec vector, const UnitVec& angle) noexcept
+constexpr inline UnitVec Rotate(const UnitVec vector, const UnitVec& angle) noexcept
 {
     return vector.Rotate(angle);
 }
 
 /// @brief Inverse rotates a vector.
-PLAYRHO_CONSTEXPR inline UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noexcept
+constexpr inline UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noexcept
 {
     return vector.Rotate(angle.FlipY());
 }
 
 /// @brief Gets the specified element of the given collection.
 template <std::size_t I>
-PLAYRHO_CONSTEXPR inline UnitVec::value_type get(UnitVec v) noexcept
+constexpr inline UnitVec::value_type get(UnitVec v) noexcept
 {
     static_assert(I < 2, "Index out of bounds in playrho::get<> (playrho::UnitVec)");
     switch (I)
@@ -370,14 +370,14 @@ PLAYRHO_CONSTEXPR inline UnitVec::value_type get(UnitVec v) noexcept
 
 /// @brief Gets element 0 of the given collection.
 template <>
-PLAYRHO_CONSTEXPR inline UnitVec::value_type get<0>(UnitVec v) noexcept
+constexpr inline UnitVec::value_type get<0>(UnitVec v) noexcept
 {
     return v.GetX();
 }
 
 /// @brief Gets element 1 of the given collection.
 template <>
-PLAYRHO_CONSTEXPR inline UnitVec::value_type get<1>(UnitVec v) noexcept
+constexpr inline UnitVec::value_type get<1>(UnitVec v) noexcept
 {
     return v.GetY();
 }
@@ -391,10 +391,10 @@ inline ::std::ostream& operator<<(::std::ostream& os, const UnitVec& value)
 } // namespace d2
 
 /// @brief Gets an invalid value for the <code>UnitVec</code> type.
-template <> PLAYRHO_CONSTEXPR inline d2::UnitVec GetInvalid() noexcept { return d2::UnitVec{}; }
+template <> constexpr inline d2::UnitVec GetInvalid() noexcept { return d2::UnitVec{}; }
 
 /// @brief Determines if the given value is valid.
-template <> PLAYRHO_CONSTEXPR inline bool IsValid(const d2::UnitVec& value) noexcept
+template <> constexpr inline bool IsValid(const d2::UnitVec& value) noexcept
 {
     return IsValid(value.GetX()) && IsValid(value.GetY()) && (value != d2::UnitVec::GetZero());
 }

--- a/PlayRho/Common/UnitVec.hpp
+++ b/PlayRho/Common/UnitVec.hpp
@@ -71,32 +71,32 @@ public:
     /// @note This is the value for the 0/4 turned (0 angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the bottom oriented vector.
     /// @note This is the forward perpendicular unit vector of the top oriented vector.
-    static constexpr inline UnitVec GetRight() noexcept { return UnitVec{1, 0}; }
+    static constexpr UnitVec GetRight() noexcept { return UnitVec{1, 0}; }
 
     /// @brief Gets the top-ward oriented unit vector.
     /// @note This is the actual value for the 1/4 turned (90 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the right oriented vector.
     /// @note This is the forward perpendicular unit vector of the left oriented vector.
-    static constexpr inline UnitVec GetTop() noexcept { return UnitVec{0, 1}; }
+    static constexpr UnitVec GetTop() noexcept { return UnitVec{0, 1}; }
 
     /// @brief Gets the left-ward oriented unit vector.
     /// @note This is the actual value for the 2/4 turned (180 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the top oriented vector.
     /// @note This is the forward perpendicular unit vector of the bottom oriented vector.
-    static constexpr inline UnitVec GetLeft() noexcept { return UnitVec{-1, 0}; }
+    static constexpr UnitVec GetLeft() noexcept { return UnitVec{-1, 0}; }
 
     /// @brief Gets the bottom-ward oriented unit vector.
     /// @note This is the actual value for the 3/4 turned (270 degree angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the left oriented vector.
     /// @note This is the forward perpendicular unit vector of the right oriented vector.
-    static constexpr inline UnitVec GetBottom() noexcept { return UnitVec{0, -1}; }
+    static constexpr UnitVec GetBottom() noexcept { return UnitVec{0, -1}; }
 
     /// @brief Gets the non-oriented unit vector.
-    static constexpr inline UnitVec GetZero() noexcept { return UnitVec{0, 0}; }
+    static constexpr UnitVec GetZero() noexcept { return UnitVec{0, 0}; }
 
     /// @brief Gets the 45 degree unit vector.
     /// @details This is the unit vector in the positive X and Y quadrant where X == Y.
-    static constexpr inline UnitVec GetTopRight() noexcept
+    static constexpr UnitVec GetTopRight() noexcept
     {
         // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
         return UnitVec{+SquareRootTwo/Real(2), +SquareRootTwo/Real(2)};
@@ -105,14 +105,14 @@ public:
     /// @brief Gets the -45 degree unit vector.
     /// @details This is the unit vector in the positive X and negative Y quadrant
     ///   where |X| == |Y|.
-    static constexpr inline UnitVec GetBottomRight() noexcept
+    static constexpr UnitVec GetBottomRight() noexcept
     {
         // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
         return UnitVec{+SquareRootTwo/Real(2), -SquareRootTwo/Real(2)};
     }
     
     /// @brief Gets the default fallback.
-    static constexpr inline UnitVec GetDefaultFallback() noexcept { return UnitVec{}; }
+    static constexpr UnitVec GetDefaultFallback() noexcept { return UnitVec{}; }
 
     /// @brief Polar coordinate.
     /// @details This is a direction and magnitude pair defined by the unit vector class.
@@ -155,17 +155,17 @@ public:
     ///
     static UnitVec Get(const Angle angle) noexcept;
 
-    constexpr inline UnitVec() noexcept = default;
+    constexpr UnitVec() noexcept = default;
     
     /// @brief Gets the max size.
-    constexpr inline size_type max_size() const noexcept { return size_type{2}; }
+    constexpr size_type max_size() const noexcept { return size_type{2}; }
     
     /// @brief Gets the size.
-    constexpr inline size_type size() const noexcept { return size_type{2}; }
+    constexpr size_type size() const noexcept { return size_type{2}; }
     
     /// @brief Whether empty.
     /// @note Always false for N > 0.
-    constexpr inline bool empty() const noexcept { return false; }
+    constexpr bool empty() const noexcept { return false; }
     
     /// @brief Gets a "begin" iterator.
     const_iterator begin() const noexcept { return const_iterator(m_elems); }
@@ -206,7 +206,7 @@ public:
     /// @brief Gets a constant reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr inline const_reference operator[](size_type pos) const noexcept
+    constexpr const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
         return m_elems[pos];
@@ -214,7 +214,7 @@ public:
     
     /// @brief Gets a constant reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    constexpr inline const_reference at(size_type pos) const
+    constexpr const_reference at(size_type pos) const
     {
         if (pos >= size())
         {
@@ -224,25 +224,25 @@ public:
     }
     
     /// @brief Direct access to data.
-    constexpr inline const_pointer data() const noexcept
+    constexpr const_pointer data() const noexcept
     {
         return m_elems;
     }
     
     /// @brief Gets the "X" value.
-    constexpr inline auto GetX() const noexcept { return m_elems[0]; }
+    constexpr auto GetX() const noexcept { return m_elems[0]; }
 
     /// @brief Gets the "Y" value.
-    constexpr inline auto GetY() const noexcept { return m_elems[1]; }
+    constexpr auto GetY() const noexcept { return m_elems[1]; }
     
     /// @brief Flips the X and Y values.
-    constexpr inline UnitVec FlipXY() const noexcept { return UnitVec{-GetX(), -GetY()}; }
+    constexpr UnitVec FlipXY() const noexcept { return UnitVec{-GetX(), -GetY()}; }
 
     /// @brief Flips the X value.
-    constexpr inline UnitVec FlipX() const noexcept { return UnitVec{-GetX(), GetY()}; }
+    constexpr UnitVec FlipX() const noexcept { return UnitVec{-GetX(), GetY()}; }
 
     /// @brief Flips the Y value.
-    constexpr inline UnitVec FlipY() const noexcept { return UnitVec{GetX(), -GetY()}; }
+    constexpr UnitVec FlipY() const noexcept { return UnitVec{GetX(), -GetY()}; }
 
     /// @brief Rotates the unit vector by the given amount.
     ///
@@ -251,7 +251,7 @@ public:
     ///
     /// @return Result of rotating this unit vector by the given amount.
     ///
-    constexpr inline UnitVec Rotate(UnitVec amount) const noexcept
+    constexpr UnitVec Rotate(UnitVec amount) const noexcept
     {
         return UnitVec{GetX() * amount.GetX() - GetY() * amount.GetY(),
                         GetY() * amount.GetX() + GetX() * amount.GetY()};
@@ -261,7 +261,7 @@ public:
     /// @details This returns the unit vector (-y, x).
     /// @return A counter-clockwise 90-degree rotation of this vector.
     /// @sa GetFwdPerpendicular.
-    constexpr inline UnitVec GetRevPerpendicular() const noexcept
+    constexpr UnitVec GetRevPerpendicular() const noexcept
     {
         // See http://mathworld.wolfram.com/PerpendicularVector.html
         return UnitVec{-GetY(), GetX()};
@@ -271,20 +271,20 @@ public:
     /// @details This returns the unit vector (y, -x).
     /// @return A clockwise 90-degree rotation of this vector.
     /// @sa GetRevPerpendicular.
-    constexpr inline UnitVec GetFwdPerpendicular() const noexcept
+    constexpr UnitVec GetFwdPerpendicular() const noexcept
     {
         // See http://mathworld.wolfram.com/PerpendicularVector.html
         return UnitVec{GetY(), -GetX()};
     }
 
     /// @brief Negation operator.
-    constexpr inline UnitVec operator-() const noexcept { return UnitVec{-GetX(), -GetY()}; }
+    constexpr UnitVec operator-() const noexcept { return UnitVec{-GetX(), -GetY()}; }
 
     /// @brief Positive operator.
-    constexpr inline UnitVec operator+() const noexcept { return UnitVec{+GetX(), +GetY()}; }
+    constexpr UnitVec operator+() const noexcept { return UnitVec{+GetX(), +GetY()}; }
 
     /// @brief Gets the absolute value.
-    constexpr inline UnitVec Absolute() const noexcept
+    constexpr UnitVec Absolute() const noexcept
     {
         return UnitVec{abs(GetX()), abs(GetY())};
     }
@@ -292,7 +292,7 @@ public:
 private:
     
     /// @brief Initializing constructor.
-    constexpr inline UnitVec(value_type x, value_type y) noexcept : m_elems{x, y}
+    constexpr UnitVec(value_type x, value_type y) noexcept : m_elems{x, y}
     {
         // Intentionally empty.
     }
@@ -303,20 +303,20 @@ private:
 // Free functions...
 
 /// @brief Gets the "X-axis".
-constexpr inline UnitVec GetXAxis(UnitVec rot) noexcept { return rot; }
+constexpr UnitVec GetXAxis(UnitVec rot) noexcept { return rot; }
 
 /// @brief Gets the "Y-axis".
 /// @note This is the reverse perpendicular vector of the given unit vector.
-constexpr inline UnitVec GetYAxis(UnitVec rot) noexcept { return rot.GetRevPerpendicular(); }
+constexpr UnitVec GetYAxis(UnitVec rot) noexcept { return rot.GetRevPerpendicular(); }
 
 /// @brief Equality operator.
-constexpr inline bool operator==(const UnitVec a, const UnitVec b) noexcept
+constexpr bool operator==(const UnitVec a, const UnitVec b) noexcept
 {
     return (a.GetX() == b.GetX()) && (a.GetY() == b.GetY());
 }
 
 /// @brief Inequality operator.
-constexpr inline bool operator!=(const UnitVec a, const UnitVec b) noexcept
+constexpr bool operator!=(const UnitVec a, const UnitVec b) noexcept
 {
     return (a.GetX() != b.GetX()) || (a.GetY() != b.GetY());
 }
@@ -327,7 +327,7 @@ constexpr inline bool operator!=(const UnitVec a, const UnitVec b) noexcept
 /// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
 /// @return A counter-clockwise 90-degree rotation of the given vector.
 /// @sa GetFwdPerpendicular.
-constexpr inline UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
+constexpr UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
 {
     return vector.GetRevPerpendicular();
 }
@@ -337,7 +337,7 @@ constexpr inline UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
 /// @param vector Vector to return a clockwise perpendicular equivalent for.
 /// @return A clockwise 90-degree rotation of the given vector.
 /// @sa GetRevPerpendicular.
-constexpr inline UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
+constexpr UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
 {
     return vector.GetFwdPerpendicular();
 }
@@ -345,20 +345,20 @@ constexpr inline UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
 /// @brief Rotates a unit vector by the angle expressed by the second unit vector.
 /// @return Unit vector for the angle that's the sum of the two angles expressed by
 ///   the input unit vectors.
-constexpr inline UnitVec Rotate(const UnitVec vector, const UnitVec& angle) noexcept
+constexpr UnitVec Rotate(const UnitVec vector, const UnitVec& angle) noexcept
 {
     return vector.Rotate(angle);
 }
 
 /// @brief Inverse rotates a vector.
-constexpr inline UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noexcept
+constexpr UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noexcept
 {
     return vector.Rotate(angle.FlipY());
 }
 
 /// @brief Gets the specified element of the given collection.
 template <std::size_t I>
-constexpr inline UnitVec::value_type get(UnitVec v) noexcept
+constexpr UnitVec::value_type get(UnitVec v) noexcept
 {
     static_assert(I < 2, "Index out of bounds in playrho::get<> (playrho::UnitVec)");
     switch (I)
@@ -370,14 +370,14 @@ constexpr inline UnitVec::value_type get(UnitVec v) noexcept
 
 /// @brief Gets element 0 of the given collection.
 template <>
-constexpr inline UnitVec::value_type get<0>(UnitVec v) noexcept
+constexpr UnitVec::value_type get<0>(UnitVec v) noexcept
 {
     return v.GetX();
 }
 
 /// @brief Gets element 1 of the given collection.
 template <>
-constexpr inline UnitVec::value_type get<1>(UnitVec v) noexcept
+constexpr UnitVec::value_type get<1>(UnitVec v) noexcept
 {
     return v.GetY();
 }
@@ -391,10 +391,10 @@ inline ::std::ostream& operator<<(::std::ostream& os, const UnitVec& value)
 } // namespace d2
 
 /// @brief Gets an invalid value for the <code>UnitVec</code> type.
-template <> constexpr inline d2::UnitVec GetInvalid() noexcept { return d2::UnitVec{}; }
+template <> constexpr d2::UnitVec GetInvalid() noexcept { return d2::UnitVec{}; }
 
 /// @brief Determines if the given value is valid.
-template <> constexpr inline bool IsValid(const d2::UnitVec& value) noexcept
+template <> constexpr bool IsValid(const d2::UnitVec& value) noexcept
 {
     return IsValid(value.GetX()) && IsValid(value.GetY()) && (value != d2::UnitVec::GetZero());
 }

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -398,14 +398,14 @@ namespace playrho
 
     /// @brief SI unit symbol for a gram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Gram
-    constexpr inline Mass operator"" _g(unsigned long long int v) noexcept
+    constexpr Mass operator"" _g(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * (Kilogram / Kilo);
     }
     
     /// @brief SI unit symbol for a gram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Gram
-    constexpr inline Mass operator"" _g(long double v) noexcept
+    constexpr Mass operator"" _g(long double v) noexcept
     {
         return static_cast<Real>(v) * (Kilogram / Kilo);
     }
@@ -413,7 +413,7 @@ namespace playrho
     /// @brief SI unit symbol for a kilogram unit of Mass.
     /// @sa Kilogram
     /// @sa https://en.wikipedia.org/wiki/Kilogram
-    constexpr inline Mass operator"" _kg(unsigned long long int v) noexcept
+    constexpr Mass operator"" _kg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilogram;
     }
@@ -421,35 +421,35 @@ namespace playrho
     /// @brief SI unit symbol for a kilogram unit of Mass.
     /// @sa Kilogram
     /// @sa https://en.wikipedia.org/wiki/Kilogram
-    constexpr inline Mass operator"" _kg(long double v) noexcept
+    constexpr Mass operator"" _kg(long double v) noexcept
     {
         return static_cast<Real>(v) * Kilogram;
     }
     
     /// @brief SI unit symbol for a petagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    constexpr inline Mass operator"" _Pg(unsigned long long int v) noexcept
+    constexpr Mass operator"" _Pg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Peta * (Kilogram / Kilo);
     }
 
     /// @brief SI unit symbol for a petagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    constexpr inline Mass operator"" _Pg(long double v) noexcept
+    constexpr Mass operator"" _Pg(long double v) noexcept
     {
         return static_cast<Real>(v) * Peta * (Kilogram / Kilo);
     }
 
     /// @brief SI unit symbol for a yottagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    constexpr inline Mass operator"" _Yg(unsigned long long int v) noexcept
+    constexpr Mass operator"" _Yg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
     
     /// @brief SI unit symbol for a yottagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    constexpr inline Mass operator"" _Yg(long double v) noexcept
+    constexpr Mass operator"" _Yg(long double v) noexcept
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
@@ -457,7 +457,7 @@ namespace playrho
     /// @brief SI unit symbol for a meter of Length.
     /// @sa Meter
     /// @sa https://en.wikipedia.org/wiki/Metre
-    constexpr inline Length operator"" _m(unsigned long long int v) noexcept
+    constexpr Length operator"" _m(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Meter;
     }
@@ -465,77 +465,77 @@ namespace playrho
     /// @brief SI unit symbol for a meter of Length.
     /// @sa Meter
     /// @sa https://en.wikipedia.org/wiki/Metre
-    constexpr inline Length operator"" _m(long double v) noexcept
+    constexpr Length operator"" _m(long double v) noexcept
     {
         return static_cast<Real>(v) * Meter;
     }
     
     /// @brief SI unit symbol for a decimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Decimetre
-    constexpr inline Length operator"" _dm(unsigned long long int v) noexcept
+    constexpr Length operator"" _dm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
     
     /// @brief SI unit symbol for a decimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Decimetre
-    constexpr inline Length operator"" _dm(long double v) noexcept
+    constexpr Length operator"" _dm(long double v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
     
     /// @brief SI unit symbol for a centimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Centimetre
-    constexpr inline Length operator"" _cm(unsigned long long int v) noexcept
+    constexpr Length operator"" _cm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
     
     /// @brief SI unit symbol for a centimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Centimetre
-    constexpr inline Length operator"" _cm(long double v) noexcept
+    constexpr Length operator"" _cm(long double v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
     
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Gigametre
-    constexpr inline Length operator"" _Gm (unsigned long long int v) noexcept
+    constexpr Length operator"" _Gm (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
     
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Gigametre
-    constexpr inline Length operator"" _Gm (long double v) noexcept
+    constexpr Length operator"" _Gm (long double v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
     
     /// @brief SI unit symbol for a megameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Megametre
-    constexpr inline Length operator"" _Mm (unsigned long long int v) noexcept
+    constexpr Length operator"" _Mm (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Mega * Meter;
     }
 
     /// @brief SI unit symbol for a megameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Megametre
-    constexpr inline Length operator"" _Mm (long double v) noexcept
+    constexpr Length operator"" _Mm (long double v) noexcept
     {
         return static_cast<Real>(v) * Mega * Meter;
     }
 
     /// @brief SI symbol for a kilometer unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Kilometre
-    constexpr inline Length operator"" _km (unsigned long long int v) noexcept
+    constexpr Length operator"" _km (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
     
     /// @brief SI symbol for a kilometer unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Kilometre
-    constexpr inline Length operator"" _km (long double v) noexcept
+    constexpr Length operator"" _km (long double v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
@@ -543,7 +543,7 @@ namespace playrho
     /// @brief SI symbol for a second unit of Time.
     /// @sa Second
     /// @sa https://en.wikipedia.org/wiki/Second
-    constexpr inline Time operator"" _s(unsigned long long int v) noexcept
+    constexpr Time operator"" _s(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Second;
     }
@@ -551,49 +551,49 @@ namespace playrho
     /// @brief SI symbol for a second unit of Time.
     /// @sa Second
     /// @sa https://en.wikipedia.org/wiki/Second
-    constexpr inline Time operator"" _s(long double v) noexcept
+    constexpr Time operator"" _s(long double v) noexcept
     {
         return static_cast<Real>(v) * Second;
     }
     
     /// @brief SI symbol for a minute unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Minute
-    constexpr inline Time operator"" _min(unsigned long long int v) noexcept
+    constexpr Time operator"" _min(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
     
     /// @brief SI symbol for a minute unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Minute
-    constexpr inline Time operator"" _min(long double v) noexcept
+    constexpr Time operator"" _min(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
     
     /// @brief Symbol for an hour unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Hour
-    constexpr inline Time operator"" _h(unsigned long long int v) noexcept
+    constexpr Time operator"" _h(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
     
     /// @brief Symbol for an hour unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Hour
-    constexpr inline Time operator"" _h(long double v) noexcept
+    constexpr Time operator"" _h(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
     
     /// @brief Symbol for a day unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Day
-    constexpr inline Time operator"" _d(unsigned long long int v) noexcept
+    constexpr Time operator"" _d(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * 24 * Second;
     }
     
     /// @brief Symbol for a day unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Day
-    constexpr inline Time operator"" _d(long double v) noexcept
+    constexpr Time operator"" _d(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * 24 * Second;
     }
@@ -601,7 +601,7 @@ namespace playrho
     /// @brief SI symbol for a radian unit of Angle.
     /// @sa Radian.
     /// @sa https://en.wikipedia.org/wiki/Radian
-    constexpr inline Angle operator"" _rad(unsigned long long int v) noexcept
+    constexpr Angle operator"" _rad(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Radian;
     }
@@ -609,7 +609,7 @@ namespace playrho
     /// @brief SI symbol for a radian unit of Angle.
     /// @sa Radian.
     /// @sa https://en.wikipedia.org/wiki/Radian
-    constexpr inline Angle operator"" _rad(long double v) noexcept
+    constexpr Angle operator"" _rad(long double v) noexcept
     {
         return static_cast<Real>(v) * Radian;
     }
@@ -617,7 +617,7 @@ namespace playrho
     /// @brief Abbreviation for a degree unit of Angle.
     /// @sa Degree.
     /// @sa https://en.wikipedia.org/wiki/Degree_(angle)
-    constexpr inline Angle operator"" _deg(unsigned long long int v) noexcept
+    constexpr Angle operator"" _deg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Degree;
     }
@@ -625,7 +625,7 @@ namespace playrho
     /// @brief Abbreviation for a degree unit of Angle.
     /// @sa Degree.
     /// @sa https://en.wikipedia.org/wiki/Degree_(angle)
-    constexpr inline Angle operator"" _deg(long double v) noexcept
+    constexpr Angle operator"" _deg(long double v) noexcept
     {
         return static_cast<Real>(v) * Degree;
     }
@@ -633,7 +633,7 @@ namespace playrho
     /// @brief SI symbol for a newton unit of Force.
     /// @sa Newton
     /// @sa https://en.wikipedia.org/wiki/Newton_(unit)
-    constexpr inline Force operator"" _N(unsigned long long int v) noexcept
+    constexpr Force operator"" _N(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Newton;
     }
@@ -641,21 +641,21 @@ namespace playrho
     /// @brief SI symbol for a newton unit of Force.
     /// @sa Newton
     /// @sa https://en.wikipedia.org/wiki/Newton_(unit)
-    constexpr inline Force operator"" _N(long double v) noexcept
+    constexpr Force operator"" _N(long double v) noexcept
     {
         return static_cast<Real>(v) * Newton;
     }
     
     /// @brief Abbreviation for meter squared unit of Area.
     /// @sa SquareMeter
-    constexpr inline Area operator"" _m2(unsigned long long int v) noexcept
+    constexpr Area operator"" _m2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * SquareMeter;
     }
     
     /// @brief Abbreviation for meter squared unit of Area.
     /// @sa SquareMeter
-    constexpr inline Area operator"" _m2(long double v) noexcept
+    constexpr Area operator"" _m2(long double v) noexcept
     {
         return static_cast<Real>(v) * SquareMeter;
     }
@@ -665,7 +665,7 @@ namespace playrho
     /// @sa Meter
     /// @sa Second
     /// @sa MeterPerSecond
-    constexpr inline LinearVelocity operator"" _mps(unsigned long long int v) noexcept
+    constexpr LinearVelocity operator"" _mps(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSecond;
     }
@@ -675,7 +675,7 @@ namespace playrho
     /// @sa Meter
     /// @sa Second
     /// @sa MeterPerSecond
-    constexpr inline LinearVelocity operator"" _mps(long double v) noexcept
+    constexpr LinearVelocity operator"" _mps(long double v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSecond;
     }
@@ -683,7 +683,7 @@ namespace playrho
     /// @brief Abbreviation for kilometer per second.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second
     /// @sa Second
-    constexpr inline LinearVelocity operator"" _kps(unsigned long long int v) noexcept
+    constexpr LinearVelocity operator"" _kps(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
@@ -691,7 +691,7 @@ namespace playrho
     /// @brief Abbreviation for kilometer per second.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second
     /// @sa Second
-    constexpr inline LinearVelocity operator"" _kps(long double v) noexcept
+    constexpr LinearVelocity operator"" _kps(long double v) noexcept
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
@@ -699,7 +699,7 @@ namespace playrho
     /// @brief Abbreviation for meter per second squared.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @sa MeterPerSquareSecond
-    constexpr inline LinearAcceleration operator"" _mps2(unsigned long long int v) noexcept
+    constexpr LinearAcceleration operator"" _mps2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
@@ -707,7 +707,7 @@ namespace playrho
     /// @brief Abbreviation for meter per second squared.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @sa MeterPerSquareSecond
-    constexpr inline LinearAcceleration operator"" _mps2(long double v) noexcept
+    constexpr LinearAcceleration operator"" _mps2(long double v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
@@ -715,7 +715,7 @@ namespace playrho
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @sa Hertz
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    constexpr inline Frequency operator"" _Hz(unsigned long long int v) noexcept
+    constexpr Frequency operator"" _Hz(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Hertz;
     }
@@ -723,7 +723,7 @@ namespace playrho
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @sa Hertz
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    constexpr inline Frequency operator"" _Hz(long double v) noexcept
+    constexpr Frequency operator"" _Hz(long double v) noexcept
     {
         return static_cast<Real>(v) * Hertz;
     }
@@ -731,7 +731,7 @@ namespace playrho
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @sa NewtonMeter
     /// @sa https://en.wikipedia.org/wiki/Newton_metre
-    constexpr inline Torque operator"" _Nm(unsigned long long int v) noexcept
+    constexpr Torque operator"" _Nm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
@@ -739,7 +739,7 @@ namespace playrho
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @sa NewtonMeter
     /// @sa https://en.wikipedia.org/wiki/Newton_metre
-    constexpr inline Torque operator"" _Nm(long double v) noexcept
+    constexpr Torque operator"" _Nm(long double v) noexcept
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
@@ -747,7 +747,7 @@ namespace playrho
     /// @brief SI symbol for a newton second of impulse.
     /// @sa NewtonSecond
     /// @sa https://en.wikipedia.org/wiki/Newton_second
-    constexpr inline Momentum operator"" _Ns(unsigned long long int v) noexcept
+    constexpr Momentum operator"" _Ns(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
@@ -755,33 +755,33 @@ namespace playrho
     /// @brief SI symbol for a newton second of impulse.
     /// @sa NewtonSecond
     /// @sa https://en.wikipedia.org/wiki/Newton_second
-    constexpr inline Momentum operator"" _Ns(long double v) noexcept
+    constexpr Momentum operator"" _Ns(long double v) noexcept
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    constexpr inline AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
+    constexpr AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    constexpr inline AreaDensity operator"" _kgpm2(long double v) noexcept
+    constexpr AreaDensity operator"" _kgpm2(long double v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
 
     /// @brief Abbreviation for revolutions per minute.
     /// @sa RevolutionsPerMinute
-    constexpr inline AngularVelocity operator"" _rpm(unsigned long long int v) noexcept
+    constexpr AngularVelocity operator"" _rpm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * RevolutionsPerMinute;
     }
 
     /// @brief Abbreviation for revolutions per minute.
     /// @sa RevolutionsPerMinute
-    constexpr inline AngularVelocity operator"" _rpm(long double v) noexcept
+    constexpr AngularVelocity operator"" _rpm(long double v) noexcept
     {
         return static_cast<Real>(v) * RevolutionsPerMinute;
     }
@@ -789,7 +789,7 @@ namespace playrho
     /// @}
     
     /// @brief Strips the units off of the given value.
-    constexpr inline Real StripUnit(const Real value)
+    constexpr Real StripUnit(const Real value)
     {
         return value;
     }
@@ -865,105 +865,105 @@ namespace playrho
 
     /// @brief Strips the units off of the given value.
     template<class Unit,class Y>
-    constexpr inline auto StripUnit(const boost::units::quantity<Unit, Y> source)
+    constexpr auto StripUnit(const boost::units::quantity<Unit, Y> source)
     {
         return source.value();
     }
 
     /// @brief Gets an invalid value for the Angle type.
     template <>
-    constexpr inline Angle GetInvalid() noexcept
+    constexpr Angle GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Radian;
     }
     
     /// @brief Gets an invalid value for the Frequency type.
     template <>
-    constexpr inline Frequency GetInvalid() noexcept
+    constexpr Frequency GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Hertz;
     }
     
     /// @brief Gets an invalid value for the AngularVelocity type.
     template <>
-    constexpr inline AngularVelocity GetInvalid() noexcept
+    constexpr AngularVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSecond;
     }
     
     /// @brief Gets an invalid value for the Time type.
     template <>
-    constexpr inline Time GetInvalid() noexcept
+    constexpr Time GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Second;
     }
     
     /// @brief Gets an invalid value for the Length type.
     template <>
-    constexpr inline Length GetInvalid() noexcept
+    constexpr Length GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Meter;
     }
     
     /// @brief Gets an invalid value for the Mass type.
     template <>
-    constexpr inline Mass GetInvalid() noexcept
+    constexpr Mass GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram;
     }
     
     /// @brief Gets an invalid value for the InvMass type.
     template <>
-    constexpr inline InvMass GetInvalid() noexcept
+    constexpr InvMass GetInvalid() noexcept
     {
         return GetInvalid<Real>() / Kilogram;
     }
     
     /// @brief Gets an invalid value for the Momentum type.
     template <>
-    constexpr inline Momentum GetInvalid() noexcept
+    constexpr Momentum GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram * MeterPerSecond;
     }
     
     /// @brief Gets an invalid value for the Force type.
     template <>
-    constexpr inline Force GetInvalid() noexcept
+    constexpr Force GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Newton;
     }
     
     /// @brief Gets an invalid value for the Torque type.
     template <>
-    constexpr inline Torque GetInvalid() noexcept
+    constexpr Torque GetInvalid() noexcept
     {
         return GetInvalid<Real>() * NewtonMeter;
     }
     
     /// @brief Gets an invalid value for the LinearVelocity type.
     template <>
-    constexpr inline LinearVelocity GetInvalid() noexcept
+    constexpr LinearVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSecond;
     }
     
     /// @brief Gets an invalid value for the LinearAcceleration type.
     template <>
-    constexpr inline LinearAcceleration GetInvalid() noexcept
+    constexpr LinearAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSquareSecond;
     }
     
     /// @brief Gets an invalid value for the AngularAcceleration type.
     template <>
-    constexpr inline AngularAcceleration GetInvalid() noexcept
+    constexpr AngularAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSquareSecond;
     }
     
     /// @brief Gets an invalid value for the RotInertia type.
     template <>
-    constexpr inline RotInertia GetInvalid() noexcept
+    constexpr RotInertia GetInvalid() noexcept
     {
         // RotInertia is L^2  M    QP^-2
         return GetInvalid<Real>() * SquareMeter * Kilogram / SquareRadian;
@@ -998,7 +998,7 @@ template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} / X{}), playrho::Real>::value >
 >
-constexpr inline auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
+constexpr auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
 {
     return lhs / playrho::Real(rhs);
 }
@@ -1007,7 +1007,7 @@ template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(X{} / playrho::Real{}), playrho::Real>::value >
 >
-constexpr inline auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
+constexpr auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
 {
     return playrho::Real(lhs) / rhs;
 }
@@ -1023,7 +1023,7 @@ constexpr inline auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
 template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-constexpr inline auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
+constexpr auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
 {
     return lhs * playrho::Real(rhs);
 }
@@ -1039,7 +1039,7 @@ constexpr inline auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
 template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-constexpr inline auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
+constexpr auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
 {
     return playrho::Real(lhs) * rhs;
 }

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -280,112 +280,112 @@ namespace playrho
     /// @note This is the SI base unit of time.
     /// @sa Time.
     /// @sa https://en.wikipedia.org/wiki/Second
-    PLAYRHO_CONSTEXPR const auto Second = PLAYRHO_UNIT(Time, boost::units::si::second);
+    constexpr const auto Second = PLAYRHO_UNIT(Time, boost::units::si::second);
 
     /// @brief Square second unit.
     /// @sa Second
-    PLAYRHO_CONSTEXPR const auto SquareSecond = Second * Second;
+    constexpr const auto SquareSecond = Second * Second;
 
     /// @brief Hertz unit of Frequency.
     /// @details Represents the hertz unit of frequency (Hz).
     /// @sa Frequency.
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    PLAYRHO_CONSTEXPR const auto Hertz = PLAYRHO_UNIT(Frequency, boost::units::si::hertz);
+    constexpr const auto Hertz = PLAYRHO_UNIT(Frequency, boost::units::si::hertz);
 
     /// @brief Meter unit of Length.
     /// @details A unit of the length quantity.
     /// @note This is the SI base unit of length.
     /// @sa Length.
     /// @sa https://en.wikipedia.org/wiki/Metre
-    PLAYRHO_CONSTEXPR const auto Meter = PLAYRHO_UNIT(Length, boost::units::si::meter);
+    constexpr const auto Meter = PLAYRHO_UNIT(Length, boost::units::si::meter);
 
     /// @brief Meter per second unit of linear velocity.
     /// @sa LinearVelocity.
-    PLAYRHO_CONSTEXPR const auto MeterPerSecond = PLAYRHO_UNIT(LinearVelocity,
+    constexpr const auto MeterPerSecond = PLAYRHO_UNIT(LinearVelocity,
         boost::units::si::meter_per_second);
 
     /// @brief Meter per square second unit of linear acceleration.
     /// @sa LinearAcceleration.
-    PLAYRHO_CONSTEXPR const auto MeterPerSquareSecond = PLAYRHO_UNIT(LinearAcceleration,
+    constexpr const auto MeterPerSquareSecond = PLAYRHO_UNIT(LinearAcceleration,
         boost::units::si::meter_per_second_squared);
 
     /// @brief Kilogram unit of mass.
     /// @note This is the SI base unit of mass.
     /// @sa Mass.
     /// @sa https://en.wikipedia.org/wiki/Kilogram
-    PLAYRHO_CONSTEXPR const auto Kilogram = PLAYRHO_UNIT(Mass, boost::units::si::kilogram);
+    constexpr const auto Kilogram = PLAYRHO_UNIT(Mass, boost::units::si::kilogram);
 
     /// @brief Square meter unit of area.
     /// @sa Area.
-    PLAYRHO_CONSTEXPR const auto SquareMeter = PLAYRHO_UNIT(Area, boost::units::si::square_meter);
+    constexpr const auto SquareMeter = PLAYRHO_UNIT(Area, boost::units::si::square_meter);
 
     /// @brief Cubic meter unit of volume.
-    PLAYRHO_CONSTEXPR const auto CubicMeter = Meter * Meter * Meter;
+    constexpr const auto CubicMeter = Meter * Meter * Meter;
 
     /// @brief Kilogram per square meter unit of area density.
     /// @sa AreaDensity.
-    PLAYRHO_CONSTEXPR const auto KilogramPerSquareMeter = PLAYRHO_UNIT(AreaDensity,
+    constexpr const auto KilogramPerSquareMeter = PLAYRHO_UNIT(AreaDensity,
         boost::units::si::kilogram_per_square_meter);
 
     /// @brief Radian unit of angle.
     /// @sa Angle.
     /// @sa Degree.
-    PLAYRHO_CONSTEXPR const auto Radian = PLAYRHO_UNIT(Angle, boost::units::si::radian);
+    constexpr const auto Radian = PLAYRHO_UNIT(Angle, boost::units::si::radian);
     
     /// @brief Degree unit of angle quantity.
     /// @sa Angle.
     /// @sa Radian.
-    PLAYRHO_CONSTEXPR const auto Degree = Angle{Radian * Pi / Real{180}};
+    constexpr const auto Degree = Angle{Radian * Pi / Real{180}};
     
     /// @brief Square radian unit type.
     /// @sa Angle.
     /// @sa Radian.
-    PLAYRHO_CONSTEXPR const auto SquareRadian = Radian * Radian;
+    constexpr const auto SquareRadian = Radian * Radian;
 
     /// @brief Radian per second unit of angular velocity.
     /// @sa AngularVelocity.
     /// @sa Radian, Second.
-    PLAYRHO_CONSTEXPR const auto RadianPerSecond = PLAYRHO_UNIT(AngularVelocity,
+    constexpr const auto RadianPerSecond = PLAYRHO_UNIT(AngularVelocity,
         boost::units::si::radian_per_second);
     
     /// @brief Degree per second unit of angular velocity.
     /// @sa AngularVelocity.
     /// @sa Degree, Second.
-    PLAYRHO_CONSTEXPR const auto DegreePerSecond = AngularVelocity{RadianPerSecond * Degree / Radian};
+    constexpr const auto DegreePerSecond = AngularVelocity{RadianPerSecond * Degree / Radian};
 
     /// @brief Radian per square second unit of angular acceleration.
     /// @sa AngularAcceleration.
     /// @sa Radian, Second.
-    PLAYRHO_CONSTEXPR const auto RadianPerSquareSecond = Radian / (Second * Second);
+    constexpr const auto RadianPerSquareSecond = Radian / (Second * Second);
 
     /// @brief Degree per square second unit of angular acceleration.
     /// @sa AngularAcceleration.
     /// @sa Degree, Second.
-    PLAYRHO_CONSTEXPR const auto DegreePerSquareSecond = Degree / (Second * Second);
+    constexpr const auto DegreePerSquareSecond = Degree / (Second * Second);
 
     /// @brief Newton unit of force.
     /// @sa Force.
-    PLAYRHO_CONSTEXPR const auto Newton = PLAYRHO_UNIT(Force, boost::units::si::newton);
+    constexpr const auto Newton = PLAYRHO_UNIT(Force, boost::units::si::newton);
 
     /// @brief Newton meter unit of torque.
     /// @sa Torque.
     /// @sa Newton, Meter.
-    PLAYRHO_CONSTEXPR const auto NewtonMeter = PLAYRHO_UNIT(Torque, boost::units::si::newton_meter);
+    constexpr const auto NewtonMeter = PLAYRHO_UNIT(Torque, boost::units::si::newton_meter);
 
     /// @brief Newton second unit of momentum.
     /// @sa Momentum.
     /// @sa Newton, Second.
-    PLAYRHO_CONSTEXPR const auto NewtonSecond = Newton * Second;
+    constexpr const auto NewtonSecond = Newton * Second;
     
     /// @brief Newton meter second unit of angular momentum.
     /// @sa AngularMomentum.
     /// @sa Newton, Meter, Second.
-    PLAYRHO_CONSTEXPR const auto NewtonMeterSecond = NewtonMeter * Second;
+    constexpr const auto NewtonMeterSecond = NewtonMeter * Second;
     
     /// @brief Revolutions per minute units of angular velocity.
     /// @sa AngularVelocity, Time
     /// @sa Minute.
-    PLAYRHO_CONSTEXPR const auto RevolutionsPerMinute = 2 * Pi * Radian / (Real{60} * Second);
+    constexpr const auto RevolutionsPerMinute = 2 * Pi * Radian / (Real{60} * Second);
     
     /// @}
     
@@ -398,14 +398,14 @@ namespace playrho
 
     /// @brief SI unit symbol for a gram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Gram
-    PLAYRHO_CONSTEXPR inline Mass operator"" _g(unsigned long long int v) noexcept
+    constexpr inline Mass operator"" _g(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * (Kilogram / Kilo);
     }
     
     /// @brief SI unit symbol for a gram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Gram
-    PLAYRHO_CONSTEXPR inline Mass operator"" _g(long double v) noexcept
+    constexpr inline Mass operator"" _g(long double v) noexcept
     {
         return static_cast<Real>(v) * (Kilogram / Kilo);
     }
@@ -413,7 +413,7 @@ namespace playrho
     /// @brief SI unit symbol for a kilogram unit of Mass.
     /// @sa Kilogram
     /// @sa https://en.wikipedia.org/wiki/Kilogram
-    PLAYRHO_CONSTEXPR inline Mass operator"" _kg(unsigned long long int v) noexcept
+    constexpr inline Mass operator"" _kg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilogram;
     }
@@ -421,35 +421,35 @@ namespace playrho
     /// @brief SI unit symbol for a kilogram unit of Mass.
     /// @sa Kilogram
     /// @sa https://en.wikipedia.org/wiki/Kilogram
-    PLAYRHO_CONSTEXPR inline Mass operator"" _kg(long double v) noexcept
+    constexpr inline Mass operator"" _kg(long double v) noexcept
     {
         return static_cast<Real>(v) * Kilogram;
     }
     
     /// @brief SI unit symbol for a petagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    PLAYRHO_CONSTEXPR inline Mass operator"" _Pg(unsigned long long int v) noexcept
+    constexpr inline Mass operator"" _Pg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Peta * (Kilogram / Kilo);
     }
 
     /// @brief SI unit symbol for a petagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    PLAYRHO_CONSTEXPR inline Mass operator"" _Pg(long double v) noexcept
+    constexpr inline Mass operator"" _Pg(long double v) noexcept
     {
         return static_cast<Real>(v) * Peta * (Kilogram / Kilo);
     }
 
     /// @brief SI unit symbol for a yottagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    PLAYRHO_CONSTEXPR inline Mass operator"" _Yg(unsigned long long int v) noexcept
+    constexpr inline Mass operator"" _Yg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
     
     /// @brief SI unit symbol for a yottagram unit of Mass.
     /// @sa https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
-    PLAYRHO_CONSTEXPR inline Mass operator"" _Yg(long double v) noexcept
+    constexpr inline Mass operator"" _Yg(long double v) noexcept
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
@@ -457,7 +457,7 @@ namespace playrho
     /// @brief SI unit symbol for a meter of Length.
     /// @sa Meter
     /// @sa https://en.wikipedia.org/wiki/Metre
-    PLAYRHO_CONSTEXPR inline Length operator"" _m(unsigned long long int v) noexcept
+    constexpr inline Length operator"" _m(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Meter;
     }
@@ -465,77 +465,77 @@ namespace playrho
     /// @brief SI unit symbol for a meter of Length.
     /// @sa Meter
     /// @sa https://en.wikipedia.org/wiki/Metre
-    PLAYRHO_CONSTEXPR inline Length operator"" _m(long double v) noexcept
+    constexpr inline Length operator"" _m(long double v) noexcept
     {
         return static_cast<Real>(v) * Meter;
     }
     
     /// @brief SI unit symbol for a decimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Decimetre
-    PLAYRHO_CONSTEXPR inline Length operator"" _dm(unsigned long long int v) noexcept
+    constexpr inline Length operator"" _dm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
     
     /// @brief SI unit symbol for a decimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Decimetre
-    PLAYRHO_CONSTEXPR inline Length operator"" _dm(long double v) noexcept
+    constexpr inline Length operator"" _dm(long double v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
     
     /// @brief SI unit symbol for a centimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Centimetre
-    PLAYRHO_CONSTEXPR inline Length operator"" _cm(unsigned long long int v) noexcept
+    constexpr inline Length operator"" _cm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
     
     /// @brief SI unit symbol for a centimeter of Length.
     /// @sa https://en.wikipedia.org/wiki/Centimetre
-    PLAYRHO_CONSTEXPR inline Length operator"" _cm(long double v) noexcept
+    constexpr inline Length operator"" _cm(long double v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
     
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Gigametre
-    PLAYRHO_CONSTEXPR inline Length operator"" _Gm (unsigned long long int v) noexcept
+    constexpr inline Length operator"" _Gm (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
     
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Gigametre
-    PLAYRHO_CONSTEXPR inline Length operator"" _Gm (long double v) noexcept
+    constexpr inline Length operator"" _Gm (long double v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
     
     /// @brief SI unit symbol for a megameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Megametre
-    PLAYRHO_CONSTEXPR inline Length operator"" _Mm (unsigned long long int v) noexcept
+    constexpr inline Length operator"" _Mm (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Mega * Meter;
     }
 
     /// @brief SI unit symbol for a megameter unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Megametre
-    PLAYRHO_CONSTEXPR inline Length operator"" _Mm (long double v) noexcept
+    constexpr inline Length operator"" _Mm (long double v) noexcept
     {
         return static_cast<Real>(v) * Mega * Meter;
     }
 
     /// @brief SI symbol for a kilometer unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Kilometre
-    PLAYRHO_CONSTEXPR inline Length operator"" _km (unsigned long long int v) noexcept
+    constexpr inline Length operator"" _km (unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
     
     /// @brief SI symbol for a kilometer unit of Length.
     /// @sa https://en.wikipedia.org/wiki/Kilometre
-    PLAYRHO_CONSTEXPR inline Length operator"" _km (long double v) noexcept
+    constexpr inline Length operator"" _km (long double v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
@@ -543,7 +543,7 @@ namespace playrho
     /// @brief SI symbol for a second unit of Time.
     /// @sa Second
     /// @sa https://en.wikipedia.org/wiki/Second
-    PLAYRHO_CONSTEXPR inline Time operator"" _s(unsigned long long int v) noexcept
+    constexpr inline Time operator"" _s(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Second;
     }
@@ -551,49 +551,49 @@ namespace playrho
     /// @brief SI symbol for a second unit of Time.
     /// @sa Second
     /// @sa https://en.wikipedia.org/wiki/Second
-    PLAYRHO_CONSTEXPR inline Time operator"" _s(long double v) noexcept
+    constexpr inline Time operator"" _s(long double v) noexcept
     {
         return static_cast<Real>(v) * Second;
     }
     
     /// @brief SI symbol for a minute unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Minute
-    PLAYRHO_CONSTEXPR inline Time operator"" _min(unsigned long long int v) noexcept
+    constexpr inline Time operator"" _min(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
     
     /// @brief SI symbol for a minute unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Minute
-    PLAYRHO_CONSTEXPR inline Time operator"" _min(long double v) noexcept
+    constexpr inline Time operator"" _min(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
     
     /// @brief Symbol for an hour unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Hour
-    PLAYRHO_CONSTEXPR inline Time operator"" _h(unsigned long long int v) noexcept
+    constexpr inline Time operator"" _h(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
     
     /// @brief Symbol for an hour unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Hour
-    PLAYRHO_CONSTEXPR inline Time operator"" _h(long double v) noexcept
+    constexpr inline Time operator"" _h(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
     
     /// @brief Symbol for a day unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Day
-    PLAYRHO_CONSTEXPR inline Time operator"" _d(unsigned long long int v) noexcept
+    constexpr inline Time operator"" _d(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * 24 * Second;
     }
     
     /// @brief Symbol for a day unit of Time.
     /// @sa https://en.wikipedia.org/wiki/Day
-    PLAYRHO_CONSTEXPR inline Time operator"" _d(long double v) noexcept
+    constexpr inline Time operator"" _d(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * 24 * Second;
     }
@@ -601,7 +601,7 @@ namespace playrho
     /// @brief SI symbol for a radian unit of Angle.
     /// @sa Radian.
     /// @sa https://en.wikipedia.org/wiki/Radian
-    PLAYRHO_CONSTEXPR inline Angle operator"" _rad(unsigned long long int v) noexcept
+    constexpr inline Angle operator"" _rad(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Radian;
     }
@@ -609,7 +609,7 @@ namespace playrho
     /// @brief SI symbol for a radian unit of Angle.
     /// @sa Radian.
     /// @sa https://en.wikipedia.org/wiki/Radian
-    PLAYRHO_CONSTEXPR inline Angle operator"" _rad(long double v) noexcept
+    constexpr inline Angle operator"" _rad(long double v) noexcept
     {
         return static_cast<Real>(v) * Radian;
     }
@@ -617,7 +617,7 @@ namespace playrho
     /// @brief Abbreviation for a degree unit of Angle.
     /// @sa Degree.
     /// @sa https://en.wikipedia.org/wiki/Degree_(angle)
-    PLAYRHO_CONSTEXPR inline Angle operator"" _deg(unsigned long long int v) noexcept
+    constexpr inline Angle operator"" _deg(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Degree;
     }
@@ -625,7 +625,7 @@ namespace playrho
     /// @brief Abbreviation for a degree unit of Angle.
     /// @sa Degree.
     /// @sa https://en.wikipedia.org/wiki/Degree_(angle)
-    PLAYRHO_CONSTEXPR inline Angle operator"" _deg(long double v) noexcept
+    constexpr inline Angle operator"" _deg(long double v) noexcept
     {
         return static_cast<Real>(v) * Degree;
     }
@@ -633,7 +633,7 @@ namespace playrho
     /// @brief SI symbol for a newton unit of Force.
     /// @sa Newton
     /// @sa https://en.wikipedia.org/wiki/Newton_(unit)
-    PLAYRHO_CONSTEXPR inline Force operator"" _N(unsigned long long int v) noexcept
+    constexpr inline Force operator"" _N(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Newton;
     }
@@ -641,21 +641,21 @@ namespace playrho
     /// @brief SI symbol for a newton unit of Force.
     /// @sa Newton
     /// @sa https://en.wikipedia.org/wiki/Newton_(unit)
-    PLAYRHO_CONSTEXPR inline Force operator"" _N(long double v) noexcept
+    constexpr inline Force operator"" _N(long double v) noexcept
     {
         return static_cast<Real>(v) * Newton;
     }
     
     /// @brief Abbreviation for meter squared unit of Area.
     /// @sa SquareMeter
-    PLAYRHO_CONSTEXPR inline Area operator"" _m2(unsigned long long int v) noexcept
+    constexpr inline Area operator"" _m2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * SquareMeter;
     }
     
     /// @brief Abbreviation for meter squared unit of Area.
     /// @sa SquareMeter
-    PLAYRHO_CONSTEXPR inline Area operator"" _m2(long double v) noexcept
+    constexpr inline Area operator"" _m2(long double v) noexcept
     {
         return static_cast<Real>(v) * SquareMeter;
     }
@@ -665,7 +665,7 @@ namespace playrho
     /// @sa Meter
     /// @sa Second
     /// @sa MeterPerSecond
-    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _mps(unsigned long long int v) noexcept
+    constexpr inline LinearVelocity operator"" _mps(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSecond;
     }
@@ -675,7 +675,7 @@ namespace playrho
     /// @sa Meter
     /// @sa Second
     /// @sa MeterPerSecond
-    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _mps(long double v) noexcept
+    constexpr inline LinearVelocity operator"" _mps(long double v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSecond;
     }
@@ -683,7 +683,7 @@ namespace playrho
     /// @brief Abbreviation for kilometer per second.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second
     /// @sa Second
-    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _kps(unsigned long long int v) noexcept
+    constexpr inline LinearVelocity operator"" _kps(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
@@ -691,7 +691,7 @@ namespace playrho
     /// @brief Abbreviation for kilometer per second.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second
     /// @sa Second
-    PLAYRHO_CONSTEXPR inline LinearVelocity operator"" _kps(long double v) noexcept
+    constexpr inline LinearVelocity operator"" _kps(long double v) noexcept
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
@@ -699,7 +699,7 @@ namespace playrho
     /// @brief Abbreviation for meter per second squared.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @sa MeterPerSquareSecond
-    PLAYRHO_CONSTEXPR inline LinearAcceleration operator"" _mps2(unsigned long long int v) noexcept
+    constexpr inline LinearAcceleration operator"" _mps2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
@@ -707,7 +707,7 @@ namespace playrho
     /// @brief Abbreviation for meter per second squared.
     /// @sa https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @sa MeterPerSquareSecond
-    PLAYRHO_CONSTEXPR inline LinearAcceleration operator"" _mps2(long double v) noexcept
+    constexpr inline LinearAcceleration operator"" _mps2(long double v) noexcept
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
@@ -715,7 +715,7 @@ namespace playrho
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @sa Hertz
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    PLAYRHO_CONSTEXPR inline Frequency operator"" _Hz(unsigned long long int v) noexcept
+    constexpr inline Frequency operator"" _Hz(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Hertz;
     }
@@ -723,7 +723,7 @@ namespace playrho
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @sa Hertz
     /// @sa https://en.wikipedia.org/wiki/Hertz
-    PLAYRHO_CONSTEXPR inline Frequency operator"" _Hz(long double v) noexcept
+    constexpr inline Frequency operator"" _Hz(long double v) noexcept
     {
         return static_cast<Real>(v) * Hertz;
     }
@@ -731,7 +731,7 @@ namespace playrho
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @sa NewtonMeter
     /// @sa https://en.wikipedia.org/wiki/Newton_metre
-    PLAYRHO_CONSTEXPR inline Torque operator"" _Nm(unsigned long long int v) noexcept
+    constexpr inline Torque operator"" _Nm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
@@ -739,7 +739,7 @@ namespace playrho
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @sa NewtonMeter
     /// @sa https://en.wikipedia.org/wiki/Newton_metre
-    PLAYRHO_CONSTEXPR inline Torque operator"" _Nm(long double v) noexcept
+    constexpr inline Torque operator"" _Nm(long double v) noexcept
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
@@ -747,7 +747,7 @@ namespace playrho
     /// @brief SI symbol for a newton second of impulse.
     /// @sa NewtonSecond
     /// @sa https://en.wikipedia.org/wiki/Newton_second
-    PLAYRHO_CONSTEXPR inline Momentum operator"" _Ns(unsigned long long int v) noexcept
+    constexpr inline Momentum operator"" _Ns(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
@@ -755,33 +755,33 @@ namespace playrho
     /// @brief SI symbol for a newton second of impulse.
     /// @sa NewtonSecond
     /// @sa https://en.wikipedia.org/wiki/Newton_second
-    PLAYRHO_CONSTEXPR inline Momentum operator"" _Ns(long double v) noexcept
+    constexpr inline Momentum operator"" _Ns(long double v) noexcept
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    PLAYRHO_CONSTEXPR inline AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
+    constexpr inline AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
     
     /// @brief Abbreviation for kilogram per square meter.
-    PLAYRHO_CONSTEXPR inline AreaDensity operator"" _kgpm2(long double v) noexcept
+    constexpr inline AreaDensity operator"" _kgpm2(long double v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
 
     /// @brief Abbreviation for revolutions per minute.
     /// @sa RevolutionsPerMinute
-    PLAYRHO_CONSTEXPR inline AngularVelocity operator"" _rpm(unsigned long long int v) noexcept
+    constexpr inline AngularVelocity operator"" _rpm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * RevolutionsPerMinute;
     }
 
     /// @brief Abbreviation for revolutions per minute.
     /// @sa RevolutionsPerMinute
-    PLAYRHO_CONSTEXPR inline AngularVelocity operator"" _rpm(long double v) noexcept
+    constexpr inline AngularVelocity operator"" _rpm(long double v) noexcept
     {
         return static_cast<Real>(v) * RevolutionsPerMinute;
     }
@@ -789,7 +789,7 @@ namespace playrho
     /// @}
     
     /// @brief Strips the units off of the given value.
-    PLAYRHO_CONSTEXPR inline Real StripUnit(const Real value)
+    constexpr inline Real StripUnit(const Real value)
     {
         return value;
     }
@@ -806,13 +806,13 @@ namespace playrho
     /// @note This constant is only appropriate for use for objects of low mass and close
     ///   distance relative to the Earth.
     /// @sa https://en.wikipedia.org/wiki/Gravity_of_Earth
-    PLAYRHO_CONSTEXPR const auto EarthlyLinearAcceleration = Real{-9.8f} * MeterPerSquareSecond;
+    constexpr const auto EarthlyLinearAcceleration = Real{-9.8f} * MeterPerSquareSecond;
     
     /// @brief Big "G".
     /// @details Gravitational constant used in calculating the attractive force on a mass
     ///   to another mass at a given distance due to gravity.
     /// @sa https://en.wikipedia.org/wiki/Gravitational_constant
-    PLAYRHO_CONSTEXPR const auto BigG = Real{6.67408e-11f} * CubicMeter / (Kilogram * SquareSecond);
+    constexpr const auto BigG = Real{6.67408e-11f} * CubicMeter / (Kilogram * SquareSecond);
     
     /// @}
 
@@ -865,105 +865,105 @@ namespace playrho
 
     /// @brief Strips the units off of the given value.
     template<class Unit,class Y>
-    PLAYRHO_CONSTEXPR inline auto StripUnit(const boost::units::quantity<Unit, Y> source)
+    constexpr inline auto StripUnit(const boost::units::quantity<Unit, Y> source)
     {
         return source.value();
     }
 
     /// @brief Gets an invalid value for the Angle type.
     template <>
-    PLAYRHO_CONSTEXPR inline Angle GetInvalid() noexcept
+    constexpr inline Angle GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Radian;
     }
     
     /// @brief Gets an invalid value for the Frequency type.
     template <>
-    PLAYRHO_CONSTEXPR inline Frequency GetInvalid() noexcept
+    constexpr inline Frequency GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Hertz;
     }
     
     /// @brief Gets an invalid value for the AngularVelocity type.
     template <>
-    PLAYRHO_CONSTEXPR inline AngularVelocity GetInvalid() noexcept
+    constexpr inline AngularVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSecond;
     }
     
     /// @brief Gets an invalid value for the Time type.
     template <>
-    PLAYRHO_CONSTEXPR inline Time GetInvalid() noexcept
+    constexpr inline Time GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Second;
     }
     
     /// @brief Gets an invalid value for the Length type.
     template <>
-    PLAYRHO_CONSTEXPR inline Length GetInvalid() noexcept
+    constexpr inline Length GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Meter;
     }
     
     /// @brief Gets an invalid value for the Mass type.
     template <>
-    PLAYRHO_CONSTEXPR inline Mass GetInvalid() noexcept
+    constexpr inline Mass GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram;
     }
     
     /// @brief Gets an invalid value for the InvMass type.
     template <>
-    PLAYRHO_CONSTEXPR inline InvMass GetInvalid() noexcept
+    constexpr inline InvMass GetInvalid() noexcept
     {
         return GetInvalid<Real>() / Kilogram;
     }
     
     /// @brief Gets an invalid value for the Momentum type.
     template <>
-    PLAYRHO_CONSTEXPR inline Momentum GetInvalid() noexcept
+    constexpr inline Momentum GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram * MeterPerSecond;
     }
     
     /// @brief Gets an invalid value for the Force type.
     template <>
-    PLAYRHO_CONSTEXPR inline Force GetInvalid() noexcept
+    constexpr inline Force GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Newton;
     }
     
     /// @brief Gets an invalid value for the Torque type.
     template <>
-    PLAYRHO_CONSTEXPR inline Torque GetInvalid() noexcept
+    constexpr inline Torque GetInvalid() noexcept
     {
         return GetInvalid<Real>() * NewtonMeter;
     }
     
     /// @brief Gets an invalid value for the LinearVelocity type.
     template <>
-    PLAYRHO_CONSTEXPR inline LinearVelocity GetInvalid() noexcept
+    constexpr inline LinearVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSecond;
     }
     
     /// @brief Gets an invalid value for the LinearAcceleration type.
     template <>
-    PLAYRHO_CONSTEXPR inline LinearAcceleration GetInvalid() noexcept
+    constexpr inline LinearAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSquareSecond;
     }
     
     /// @brief Gets an invalid value for the AngularAcceleration type.
     template <>
-    PLAYRHO_CONSTEXPR inline AngularAcceleration GetInvalid() noexcept
+    constexpr inline AngularAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSquareSecond;
     }
     
     /// @brief Gets an invalid value for the RotInertia type.
     template <>
-    PLAYRHO_CONSTEXPR inline RotInertia GetInvalid() noexcept
+    constexpr inline RotInertia GetInvalid() noexcept
     {
         // RotInertia is L^2  M    QP^-2
         return GetInvalid<Real>() * SquareMeter * Kilogram / SquareRadian;
@@ -998,7 +998,7 @@ template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} / X{}), playrho::Real>::value >
 >
-PLAYRHO_CONSTEXPR inline auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
+constexpr inline auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
 {
     return lhs / playrho::Real(rhs);
 }
@@ -1007,7 +1007,7 @@ template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(X{} / playrho::Real{}), playrho::Real>::value >
 >
-PLAYRHO_CONSTEXPR inline auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
+constexpr inline auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
 {
     return playrho::Real(lhs) / rhs;
 }
@@ -1023,7 +1023,7 @@ PLAYRHO_CONSTEXPR inline auto operator/ (X lhs, quantity<Dimension, playrho::Rea
 template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-PLAYRHO_CONSTEXPR inline auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
+constexpr inline auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
 {
     return lhs * playrho::Real(rhs);
 }
@@ -1039,7 +1039,7 @@ PLAYRHO_CONSTEXPR inline auto operator* (quantity<Dimension, playrho::Real> lhs,
 template <class Dimension, typename X, typename = std::enable_if_t<
     playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
     std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-PLAYRHO_CONSTEXPR inline auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
+constexpr inline auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
 {
     return playrho::Real(lhs) * rhs;
 }

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -36,7 +36,7 @@
 namespace playrho {
 
 /// @brief Vector.
-/// @details This is a <code>PLAYRHO_CONSTEXPR inline</code> and constructor enhanced
+/// @details This is a <code>constexpr inline</code> and constructor enhanced
 ///   <code>std::array</code>-like template class for types supporting the +, -, *, /
 ///   arithmetic operators ("arithmetic types" as defined by the <code>IsArithmetic</code>
 ///   type trait) that itself comes with non-member arithmetic operator support making
@@ -83,25 +83,25 @@ struct Vector
     /// @brief Default constructor.
     /// @note Defaulted explicitly.
     /// @note This constructor performs no action.
-    PLAYRHO_CONSTEXPR inline Vector() = default;
+    constexpr inline Vector() = default;
     
     /// @brief Initializing constructor.
     template<typename... Tail>
-    PLAYRHO_CONSTEXPR inline Vector(std::enable_if_t<sizeof...(Tail)+1 == N, T> head,
+    constexpr inline Vector(std::enable_if_t<sizeof...(Tail)+1 == N, T> head,
                                     Tail... tail) noexcept: elements{head, T(tail)...}
     {
         // Intentionally empty.
     }
 
     /// @brief Gets the max size.
-    PLAYRHO_CONSTEXPR inline size_type max_size() const noexcept { return N; }
+    constexpr inline size_type max_size() const noexcept { return N; }
     
     /// @brief Gets the size.
-    PLAYRHO_CONSTEXPR inline size_type size() const noexcept { return N; }
+    constexpr inline size_type size() const noexcept { return N; }
     
     /// @brief Whether empty.
     /// @note Always false for N > 0.
-    PLAYRHO_CONSTEXPR inline bool empty() const noexcept { return N == 0; }
+    constexpr inline bool empty() const noexcept { return N == 0; }
     
     /// @brief Gets a "begin" iterator.
     iterator begin() noexcept { return iterator(elements); }
@@ -154,7 +154,7 @@ struct Vector
     /// @brief Gets a reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    PLAYRHO_CONSTEXPR inline reference operator[](size_type pos) noexcept
+    constexpr inline reference operator[](size_type pos) noexcept
     {
         assert(pos < size());
         return elements[pos];
@@ -163,7 +163,7 @@ struct Vector
     /// @brief Gets a constant reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    PLAYRHO_CONSTEXPR inline const_reference operator[](size_type pos) const noexcept
+    constexpr inline const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
         return elements[pos];
@@ -171,7 +171,7 @@ struct Vector
     
     /// @brief Gets a reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    PLAYRHO_CONSTEXPR inline reference at(size_type pos)
+    constexpr inline reference at(size_type pos)
     {
         if (pos >= size())
         {
@@ -182,7 +182,7 @@ struct Vector
     
     /// @brief Gets a constant reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    PLAYRHO_CONSTEXPR inline const_reference at(size_type pos) const
+    constexpr inline const_reference at(size_type pos) const
     {
         if (pos >= size())
         {
@@ -192,13 +192,13 @@ struct Vector
     }
     
     /// @brief Direct access to data.
-    PLAYRHO_CONSTEXPR inline pointer data() noexcept
+    constexpr inline pointer data() noexcept
     {
         return elements;
     }
     
     /// @brief Direct access to data.
-    PLAYRHO_CONSTEXPR inline const_pointer data() const noexcept
+    constexpr inline const_pointer data() const noexcept
     {
         return elements;
     }
@@ -242,7 +242,7 @@ struct IsVector<Vector<T, N>>: std::true_type {};
 /// @brief Equality operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+constexpr inline bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -257,7 +257,7 @@ PLAYRHO_CONSTEXPR inline bool operator== (const Vector<T, N>& lhs, const Vector<
 /// @brief Inequality operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+constexpr inline bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     return !(lhs == rhs);
 }
@@ -265,7 +265,7 @@ PLAYRHO_CONSTEXPR inline bool operator!= (const Vector<T, N>& lhs, const Vector<
 /// @brief Unary plus operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T, decltype(+T{})>::value, Vector<T, N>>
 operator+ (Vector<T, N> v) noexcept
 {
@@ -275,7 +275,7 @@ operator+ (Vector<T, N> v) noexcept
 /// @brief Unary negation operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T, decltype(-T{})>::value, Vector<T, N>>
 operator- (Vector<T, N> v) noexcept
 {
@@ -289,7 +289,7 @@ operator- (Vector<T, N> v) noexcept
 /// @brief Increments the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>&>
 operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
@@ -303,7 +303,7 @@ operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 /// @brief Decrements the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>&>
 operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
@@ -317,7 +317,7 @@ operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 /// @brief Adds two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>>
 operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
@@ -327,7 +327,7 @@ operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 /// @brief Subtracts two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>>
 operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
@@ -337,7 +337,7 @@ operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 /// @brief Multiplication assignment operator.
 /// @relatedalso Vector
 template <typename T1, typename T2, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T1, decltype(T1{} * T2{})>::value, Vector<T1, N>&>
 operator*= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
@@ -351,7 +351,7 @@ operator*= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 /// @brief Division assignment operator.
 /// @relatedalso Vector
 template <typename T1, typename T2, std::size_t N>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<std::is_same<T1, decltype(T1{} / T2{})>::value, Vector<T1, N>&>
 operator/= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
@@ -383,7 +383,7 @@ operator/= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 /// @relatedalso Vector
 template <typename T1, typename T2, std::size_t A, std::size_t B, std::size_t C,
     typename OT = decltype(T1{} * T2{})>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<IsMultipliable<T1, T2>::value, Vector<Vector<OT, C>, A>>
 operator* (const Vector<Vector<T1, B>, A>& lhs, const Vector<Vector<T2, C>, B>& rhs) noexcept
 {
@@ -419,7 +419,7 @@ operator* (const Vector<Vector<T1, B>, A>& lhs, const Vector<Vector<T2, C>, B>& 
 /// @return B-element vector product.
 template <typename T1, typename T2, std::size_t A, std::size_t B,
     typename OT = decltype(T1{} * T2{})>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, B>>
 operator* (const Vector<T1, A>& lhs, const Vector<Vector<T2, B>, A>& rhs) noexcept
 {
@@ -445,7 +445,7 @@ operator* (const Vector<T1, A>& lhs, const Vector<Vector<T2, B>, A>& rhs) noexce
 /// @return B-element vector product.
 template <typename T1, typename T2, std::size_t A, std::size_t B,
     typename OT = decltype(T1{} * T2{})>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, B>>
 operator* (const Vector<Vector<T1, A>, B>& lhs, const Vector<T2, A>& rhs) noexcept
 {
@@ -467,7 +467,7 @@ operator* (const Vector<Vector<T1, A>, B>& lhs, const Vector<T2, A>& rhs) noexce
 /// @note Explicitly disabled for Vector * Vector to prevent this function from existing
 ///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, N>>
 operator* (const T1 s, Vector<T2, N> a) noexcept
 {
@@ -485,7 +485,7 @@ operator* (const T1 s, Vector<T2, N> a) noexcept
 /// @note Explicitly disabled for Vector * Vector to prevent this function from existing
 ///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
 operator* (Vector<T1, N> a, const T2 s) noexcept
 {
@@ -501,7 +501,7 @@ operator* (Vector<T1, N> a, const T2 s) noexcept
 /// @brief Division operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} / T2{})>
-PLAYRHO_CONSTEXPR inline
+constexpr inline
 std::enable_if_t<IsDivisable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
 operator/ (Vector<T1, N> a, const T2 s) noexcept
 {
@@ -518,7 +518,7 @@ operator/ (Vector<T1, N> a, const T2 s) noexcept
 /// @brief Gets the specified element of the given collection.
 /// @relatedalso Vector
 template <std::size_t I, std::size_t N, typename T>
-PLAYRHO_CONSTEXPR inline auto& get(Vector<T, N>& v) noexcept
+constexpr inline auto& get(Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
     return v[I];
@@ -526,7 +526,7 @@ PLAYRHO_CONSTEXPR inline auto& get(Vector<T, N>& v) noexcept
 
 /// @brief Gets the specified element of the given collection.
 template <std::size_t I, std::size_t N, typename T>
-PLAYRHO_CONSTEXPR inline auto get(const Vector<T, N>& v) noexcept
+constexpr inline auto get(const Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
     return v[I];

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -36,7 +36,7 @@
 namespace playrho {
 
 /// @brief Vector.
-/// @details This is a <code>constexpr inline</code> and constructor enhanced
+/// @details This is a <code>constexpr</code> and constructor enhanced
 ///   <code>std::array</code>-like template class for types supporting the +, -, *, /
 ///   arithmetic operators ("arithmetic types" as defined by the <code>IsArithmetic</code>
 ///   type trait) that itself comes with non-member arithmetic operator support making
@@ -83,25 +83,25 @@ struct Vector
     /// @brief Default constructor.
     /// @note Defaulted explicitly.
     /// @note This constructor performs no action.
-    constexpr inline Vector() = default;
+    constexpr Vector() = default;
     
     /// @brief Initializing constructor.
     template<typename... Tail>
-    constexpr inline Vector(std::enable_if_t<sizeof...(Tail)+1 == N, T> head,
+    constexpr Vector(std::enable_if_t<sizeof...(Tail)+1 == N, T> head,
                                     Tail... tail) noexcept: elements{head, T(tail)...}
     {
         // Intentionally empty.
     }
 
     /// @brief Gets the max size.
-    constexpr inline size_type max_size() const noexcept { return N; }
+    constexpr size_type max_size() const noexcept { return N; }
     
     /// @brief Gets the size.
-    constexpr inline size_type size() const noexcept { return N; }
+    constexpr size_type size() const noexcept { return N; }
     
     /// @brief Whether empty.
     /// @note Always false for N > 0.
-    constexpr inline bool empty() const noexcept { return N == 0; }
+    constexpr bool empty() const noexcept { return N == 0; }
     
     /// @brief Gets a "begin" iterator.
     iterator begin() noexcept { return iterator(elements); }
@@ -154,7 +154,7 @@ struct Vector
     /// @brief Gets a reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr inline reference operator[](size_type pos) noexcept
+    constexpr reference operator[](size_type pos) noexcept
     {
         assert(pos < size());
         return elements[pos];
@@ -163,7 +163,7 @@ struct Vector
     /// @brief Gets a constant reference to the requested element.
     /// @note No bounds checking is performed.
     /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr inline const_reference operator[](size_type pos) const noexcept
+    constexpr const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
         return elements[pos];
@@ -171,7 +171,7 @@ struct Vector
     
     /// @brief Gets a reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    constexpr inline reference at(size_type pos)
+    constexpr reference at(size_type pos)
     {
         if (pos >= size())
         {
@@ -182,7 +182,7 @@ struct Vector
     
     /// @brief Gets a constant reference to the requested element.
     /// @throws InvalidArgument if given a position that's >= size().
-    constexpr inline const_reference at(size_type pos) const
+    constexpr const_reference at(size_type pos) const
     {
         if (pos >= size())
         {
@@ -192,13 +192,13 @@ struct Vector
     }
     
     /// @brief Direct access to data.
-    constexpr inline pointer data() noexcept
+    constexpr pointer data() noexcept
     {
         return elements;
     }
     
     /// @brief Direct access to data.
-    constexpr inline const_pointer data() const noexcept
+    constexpr const_pointer data() const noexcept
     {
         return elements;
     }
@@ -242,7 +242,7 @@ struct IsVector<Vector<T, N>>: std::true_type {};
 /// @brief Equality operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+constexpr bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     for (auto i = decltype(N){0}; i < N; ++i)
     {
@@ -257,7 +257,7 @@ constexpr inline bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& r
 /// @brief Inequality operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+constexpr bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
 {
     return !(lhs == rhs);
 }
@@ -265,7 +265,7 @@ constexpr inline bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& r
 /// @brief Unary plus operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T, decltype(+T{})>::value, Vector<T, N>>
 operator+ (Vector<T, N> v) noexcept
 {
@@ -275,7 +275,7 @@ operator+ (Vector<T, N> v) noexcept
 /// @brief Unary negation operator.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T, decltype(-T{})>::value, Vector<T, N>>
 operator- (Vector<T, N> v) noexcept
 {
@@ -289,7 +289,7 @@ operator- (Vector<T, N> v) noexcept
 /// @brief Increments the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>&>
 operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
@@ -303,7 +303,7 @@ operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 /// @brief Decrements the left hand side value by the right hand side value.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>&>
 operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 {
@@ -317,7 +317,7 @@ operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
 /// @brief Adds two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>>
 operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
@@ -327,7 +327,7 @@ operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 /// @brief Subtracts two vectors component-wise.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>>
 operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 {
@@ -337,7 +337,7 @@ operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
 /// @brief Multiplication assignment operator.
 /// @relatedalso Vector
 template <typename T1, typename T2, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T1, decltype(T1{} * T2{})>::value, Vector<T1, N>&>
 operator*= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
@@ -351,7 +351,7 @@ operator*= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 /// @brief Division assignment operator.
 /// @relatedalso Vector
 template <typename T1, typename T2, std::size_t N>
-constexpr inline
+constexpr
 std::enable_if_t<std::is_same<T1, decltype(T1{} / T2{})>::value, Vector<T1, N>&>
 operator/= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 {
@@ -383,7 +383,7 @@ operator/= (Vector<T1, N>& lhs, const T2 rhs) noexcept
 /// @relatedalso Vector
 template <typename T1, typename T2, std::size_t A, std::size_t B, std::size_t C,
     typename OT = decltype(T1{} * T2{})>
-constexpr inline
+constexpr
 std::enable_if_t<IsMultipliable<T1, T2>::value, Vector<Vector<OT, C>, A>>
 operator* (const Vector<Vector<T1, B>, A>& lhs, const Vector<Vector<T2, C>, B>& rhs) noexcept
 {
@@ -419,7 +419,7 @@ operator* (const Vector<Vector<T1, B>, A>& lhs, const Vector<Vector<T2, C>, B>& 
 /// @return B-element vector product.
 template <typename T1, typename T2, std::size_t A, std::size_t B,
     typename OT = decltype(T1{} * T2{})>
-constexpr inline
+constexpr
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, B>>
 operator* (const Vector<T1, A>& lhs, const Vector<Vector<T2, B>, A>& rhs) noexcept
 {
@@ -445,7 +445,7 @@ operator* (const Vector<T1, A>& lhs, const Vector<Vector<T2, B>, A>& rhs) noexce
 /// @return B-element vector product.
 template <typename T1, typename T2, std::size_t A, std::size_t B,
     typename OT = decltype(T1{} * T2{})>
-constexpr inline
+constexpr
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, B>>
 operator* (const Vector<Vector<T1, A>, B>& lhs, const Vector<T2, A>& rhs) noexcept
 {
@@ -467,7 +467,7 @@ operator* (const Vector<Vector<T1, A>, B>& lhs, const Vector<T2, A>& rhs) noexce
 /// @note Explicitly disabled for Vector * Vector to prevent this function from existing
 ///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-constexpr inline
+constexpr
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, N>>
 operator* (const T1 s, Vector<T2, N> a) noexcept
 {
@@ -485,7 +485,7 @@ operator* (const T1 s, Vector<T2, N> a) noexcept
 /// @note Explicitly disabled for Vector * Vector to prevent this function from existing
 ///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-constexpr inline
+constexpr
 std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
 operator* (Vector<T1, N> a, const T2 s) noexcept
 {
@@ -501,7 +501,7 @@ operator* (Vector<T1, N> a, const T2 s) noexcept
 /// @brief Division operator.
 /// @relatedalso Vector
 template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} / T2{})>
-constexpr inline
+constexpr
 std::enable_if_t<IsDivisable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
 operator/ (Vector<T1, N> a, const T2 s) noexcept
 {
@@ -518,7 +518,7 @@ operator/ (Vector<T1, N> a, const T2 s) noexcept
 /// @brief Gets the specified element of the given collection.
 /// @relatedalso Vector
 template <std::size_t I, std::size_t N, typename T>
-constexpr inline auto& get(Vector<T, N>& v) noexcept
+constexpr auto& get(Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
     return v[I];
@@ -526,7 +526,7 @@ constexpr inline auto& get(Vector<T, N>& v) noexcept
 
 /// @brief Gets the specified element of the given collection.
 template <std::size_t I, std::size_t N, typename T>
-constexpr inline auto get(const Vector<T, N>& v) noexcept
+constexpr auto get(const Vector<T, N>& v) noexcept
 {
     static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
     return v[I];

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -65,21 +65,21 @@ using InvMass2 = Vector2<InvMass>;
 using Momentum2 = Vector2<Momentum>;
 
 /// @brief Gets the given value as a 2-element vector of reals (<code>Vec2</code>).
-constexpr inline Vec2 GetVec2(const Vector2<Real> value)
+constexpr Vec2 GetVec2(const Vector2<Real> value)
 {
     return value;
 }
 
 /// @brief Gets an invalid value for the <code>Vec2</code> type.
 template <>
-constexpr inline Vec2 GetInvalid() noexcept
+constexpr Vec2 GetInvalid() noexcept
 {
     return Vec2{GetInvalid<Vec2::value_type>(), GetInvalid<Vec2::value_type>()};
 }
 
 /// @brief Determines whether the given vector contains finite coordinates.
 template <typename TYPE>
-constexpr inline bool IsValid(const Vector2<TYPE>& value) noexcept
+constexpr bool IsValid(const Vector2<TYPE>& value) noexcept
 {
     return IsValid(get<0>(value)) && IsValid(get<1>(value));
 }
@@ -87,33 +87,33 @@ constexpr inline bool IsValid(const Vector2<TYPE>& value) noexcept
 #ifdef USE_BOOST_UNITS
 /// @brief Gets an invalid value for the Length2 type.
 template <>
-constexpr inline Length2 GetInvalid() noexcept
+constexpr Length2 GetInvalid() noexcept
 {
     return Length2{GetInvalid<Length>(), GetInvalid<Length>()};
 }
 
 /// @brief Gets an invalid value for the LinearVelocity2 type.
 template <>
-constexpr inline LinearVelocity2 GetInvalid() noexcept
+constexpr LinearVelocity2 GetInvalid() noexcept
 {
     return LinearVelocity2{GetInvalid<LinearVelocity>(), GetInvalid<LinearVelocity>()};
 }
 
 /// @brief Gets an invalid value for the Force2 type.
 template <>
-constexpr inline Force2 GetInvalid() noexcept
+constexpr Force2 GetInvalid() noexcept
 {
     return Force2{GetInvalid<Force>(), GetInvalid<Force>()};
 }
 
 /// @brief Gets an invalid value for the Momentum2 type.
 template <>
-constexpr inline Momentum2 GetInvalid() noexcept
+constexpr Momentum2 GetInvalid() noexcept
 {
     return Momentum2{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
 }
 
-constexpr inline Vec2 GetVec2(const Length2 value)
+constexpr Vec2 GetVec2(const Length2 value)
 {
     return Vec2{
         get<0>(value) / Meter,
@@ -121,7 +121,7 @@ constexpr inline Vec2 GetVec2(const Length2 value)
     };
 }
 
-constexpr inline Vec2 GetVec2(const LinearVelocity2 value)
+constexpr Vec2 GetVec2(const LinearVelocity2 value)
 {
     return Vec2{
         get<0>(value) / MeterPerSecond,
@@ -129,7 +129,7 @@ constexpr inline Vec2 GetVec2(const LinearVelocity2 value)
     };
 }
 
-constexpr inline Vec2 GetVec2(const Momentum2 value)
+constexpr Vec2 GetVec2(const Momentum2 value)
 {
     return Vec2{
         get<0>(value) / (Kilogram * MeterPerSecond),
@@ -137,7 +137,7 @@ constexpr inline Vec2 GetVec2(const Momentum2 value)
     };
 }
 
-constexpr inline Vec2 GetVec2(const Force2 value)
+constexpr Vec2 GetVec2(const Force2 value)
 {
     return Vec2{
         get<0>(value) / Newton,

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -65,21 +65,21 @@ using InvMass2 = Vector2<InvMass>;
 using Momentum2 = Vector2<Momentum>;
 
 /// @brief Gets the given value as a 2-element vector of reals (<code>Vec2</code>).
-PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Vector2<Real> value)
+constexpr inline Vec2 GetVec2(const Vector2<Real> value)
 {
     return value;
 }
 
 /// @brief Gets an invalid value for the <code>Vec2</code> type.
 template <>
-PLAYRHO_CONSTEXPR inline Vec2 GetInvalid() noexcept
+constexpr inline Vec2 GetInvalid() noexcept
 {
     return Vec2{GetInvalid<Vec2::value_type>(), GetInvalid<Vec2::value_type>()};
 }
 
 /// @brief Determines whether the given vector contains finite coordinates.
 template <typename TYPE>
-PLAYRHO_CONSTEXPR inline bool IsValid(const Vector2<TYPE>& value) noexcept
+constexpr inline bool IsValid(const Vector2<TYPE>& value) noexcept
 {
     return IsValid(get<0>(value)) && IsValid(get<1>(value));
 }
@@ -87,33 +87,33 @@ PLAYRHO_CONSTEXPR inline bool IsValid(const Vector2<TYPE>& value) noexcept
 #ifdef USE_BOOST_UNITS
 /// @brief Gets an invalid value for the Length2 type.
 template <>
-PLAYRHO_CONSTEXPR inline Length2 GetInvalid() noexcept
+constexpr inline Length2 GetInvalid() noexcept
 {
     return Length2{GetInvalid<Length>(), GetInvalid<Length>()};
 }
 
 /// @brief Gets an invalid value for the LinearVelocity2 type.
 template <>
-PLAYRHO_CONSTEXPR inline LinearVelocity2 GetInvalid() noexcept
+constexpr inline LinearVelocity2 GetInvalid() noexcept
 {
     return LinearVelocity2{GetInvalid<LinearVelocity>(), GetInvalid<LinearVelocity>()};
 }
 
 /// @brief Gets an invalid value for the Force2 type.
 template <>
-PLAYRHO_CONSTEXPR inline Force2 GetInvalid() noexcept
+constexpr inline Force2 GetInvalid() noexcept
 {
     return Force2{GetInvalid<Force>(), GetInvalid<Force>()};
 }
 
 /// @brief Gets an invalid value for the Momentum2 type.
 template <>
-PLAYRHO_CONSTEXPR inline Momentum2 GetInvalid() noexcept
+constexpr inline Momentum2 GetInvalid() noexcept
 {
     return Momentum2{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
 }
 
-PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Length2 value)
+constexpr inline Vec2 GetVec2(const Length2 value)
 {
     return Vec2{
         get<0>(value) / Meter,
@@ -121,7 +121,7 @@ PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Length2 value)
     };
 }
 
-PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const LinearVelocity2 value)
+constexpr inline Vec2 GetVec2(const LinearVelocity2 value)
 {
     return Vec2{
         get<0>(value) / MeterPerSecond,
@@ -129,7 +129,7 @@ PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const LinearVelocity2 value)
     };
 }
 
-PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Momentum2 value)
+constexpr inline Vec2 GetVec2(const Momentum2 value)
 {
     return Vec2{
         get<0>(value) / (Kilogram * MeterPerSecond),
@@ -137,7 +137,7 @@ PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Momentum2 value)
     };
 }
 
-PLAYRHO_CONSTEXPR inline Vec2 GetVec2(const Force2 value)
+constexpr inline Vec2 GetVec2(const Force2 value)
 {
     return Vec2{
         get<0>(value) / Newton,
@@ -151,7 +151,7 @@ namespace d2 {
     /// @brief Earthly gravity in 2-dimensions.
     /// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
     /// @sa EarthlyLinearAcceleration
-    PLAYRHO_CONSTEXPR const auto EarthlyGravity = LinearAcceleration2{
+    constexpr const auto EarthlyGravity = LinearAcceleration2{
         0_mps2, EarthlyLinearAcceleration};
 
 } // namespace d2

--- a/PlayRho/Common/Vector3.hpp
+++ b/PlayRho/Common/Vector3.hpp
@@ -45,14 +45,14 @@ using InvMass3 = Vector3<InvMass>;
 
 /// @brief Gets an invalid value for the 3-element vector of real (<code>Vec3</code>) type.
 template <>
-PLAYRHO_CONSTEXPR inline Vec3 GetInvalid() noexcept
+constexpr inline Vec3 GetInvalid() noexcept
 {
     return Vec3{GetInvalid<Real>(), GetInvalid<Real>(), GetInvalid<Real>()};
 }
 
 /// @brief Determines whether the given vector contains finite coordinates.
 template <>
-PLAYRHO_CONSTEXPR inline bool IsValid(const Vec3& value) noexcept
+constexpr inline bool IsValid(const Vec3& value) noexcept
 {
     return IsValid(get<0>(value)) && IsValid(get<1>(value)) && IsValid(get<2>(value));
 }

--- a/PlayRho/Common/Vector3.hpp
+++ b/PlayRho/Common/Vector3.hpp
@@ -45,14 +45,14 @@ using InvMass3 = Vector3<InvMass>;
 
 /// @brief Gets an invalid value for the 3-element vector of real (<code>Vec3</code>) type.
 template <>
-constexpr inline Vec3 GetInvalid() noexcept
+constexpr Vec3 GetInvalid() noexcept
 {
     return Vec3{GetInvalid<Real>(), GetInvalid<Real>(), GetInvalid<Real>()};
 }
 
 /// @brief Determines whether the given vector contains finite coordinates.
 template <>
-constexpr inline bool IsValid(const Vec3& value) noexcept
+constexpr bool IsValid(const Vec3& value) noexcept
 {
     return IsValid(get<0>(value)) && IsValid(get<1>(value)) && IsValid(get<2>(value));
 }

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -40,21 +40,21 @@ struct Velocity
 
 /// @brief Equality operator.
 /// @relatedalso Velocity
-constexpr inline bool operator==(const Velocity& lhs, const Velocity& rhs)
+constexpr bool operator==(const Velocity& lhs, const Velocity& rhs)
 {
     return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
 }
 
 /// @brief Inequality operator.
 /// @relatedalso Velocity
-constexpr inline bool operator!=(const Velocity& lhs, const Velocity& rhs)
+constexpr bool operator!=(const Velocity& lhs, const Velocity& rhs)
 {
     return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
 }
 
 /// @brief Multiplication assignment operator.
 /// @relatedalso Velocity
-constexpr inline Velocity& operator*= (Velocity& lhs, const Real rhs)
+constexpr Velocity& operator*= (Velocity& lhs, const Real rhs)
 {
     lhs.linear *= rhs;
     lhs.angular *= rhs;
@@ -63,7 +63,7 @@ constexpr inline Velocity& operator*= (Velocity& lhs, const Real rhs)
 
 /// @brief Division assignment operator.
 /// @relatedalso Velocity
-constexpr inline Velocity& operator/= (Velocity& lhs, const Real rhs)
+constexpr Velocity& operator/= (Velocity& lhs, const Real rhs)
 {
     lhs.linear /= rhs;
     lhs.angular /= rhs;
@@ -72,7 +72,7 @@ constexpr inline Velocity& operator/= (Velocity& lhs, const Real rhs)
 
 /// @brief Addition assignment operator.
 /// @relatedalso Velocity
-constexpr inline Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
+constexpr Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
 {
     lhs.linear += rhs.linear;
     lhs.angular += rhs.angular;
@@ -81,14 +81,14 @@ constexpr inline Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
 
 /// @brief Addition operator.
 /// @relatedalso Velocity
-constexpr inline Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
+constexpr Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
 {
     return Velocity{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
 }
 
 /// @brief Subtraction assignment operator.
 /// @relatedalso Velocity
-constexpr inline Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
+constexpr Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
 {
     lhs.linear -= rhs.linear;
     lhs.angular -= rhs.angular;
@@ -97,42 +97,42 @@ constexpr inline Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
 
 /// @brief Subtraction operator.
 /// @relatedalso Velocity
-constexpr inline Velocity operator- (const Velocity& lhs, const Velocity& rhs)
+constexpr Velocity operator- (const Velocity& lhs, const Velocity& rhs)
 {
     return Velocity{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
 }
 
 /// @brief Negation operator.
 /// @relatedalso Velocity
-constexpr inline Velocity operator- (const Velocity& value)
+constexpr Velocity operator- (const Velocity& value)
 {
     return Velocity{-value.linear, -value.angular};
 }
 
 /// @brief Positive operator.
 /// @relatedalso Velocity
-constexpr inline Velocity operator+ (const Velocity& value)
+constexpr Velocity operator+ (const Velocity& value)
 {
     return value;
 }
 
 /// @brief Multiplication operator.
 /// @relatedalso Velocity
-constexpr inline Velocity operator* (const Velocity& lhs, const Real rhs)
+constexpr Velocity operator* (const Velocity& lhs, const Real rhs)
 {
     return Velocity{lhs.linear * rhs, lhs.angular * rhs};
 }
 
 /// @brief Multiplication operator.
 /// @relatedalso Velocity
-constexpr inline Velocity operator* (const Real lhs, const Velocity& rhs)
+constexpr Velocity operator* (const Real lhs, const Velocity& rhs)
 {
     return Velocity{rhs.linear * lhs, rhs.angular * lhs};
 }
 
 /// @brief Division operator.
 /// @relatedalso Velocity
-constexpr inline Velocity operator/ (const Velocity& lhs, const Real rhs)
+constexpr Velocity operator/ (const Velocity& lhs, const Real rhs)
 {
     const auto inverseRhs = Real{1} / rhs;
     return Velocity{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
@@ -149,7 +149,7 @@ VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc);
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Velocity
 template <>
-constexpr inline bool IsValid(const d2::Velocity& value) noexcept
+constexpr bool IsValid(const d2::Velocity& value) noexcept
 {
     return IsValid(value.linear) && IsValid(value.angular);
 }

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -40,21 +40,21 @@ struct Velocity
 
 /// @brief Equality operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline bool operator==(const Velocity& lhs, const Velocity& rhs)
+constexpr inline bool operator==(const Velocity& lhs, const Velocity& rhs)
 {
     return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
 }
 
 /// @brief Inequality operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline bool operator!=(const Velocity& lhs, const Velocity& rhs)
+constexpr inline bool operator!=(const Velocity& lhs, const Velocity& rhs)
 {
     return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
 }
 
 /// @brief Multiplication assignment operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity& operator*= (Velocity& lhs, const Real rhs)
+constexpr inline Velocity& operator*= (Velocity& lhs, const Real rhs)
 {
     lhs.linear *= rhs;
     lhs.angular *= rhs;
@@ -63,7 +63,7 @@ PLAYRHO_CONSTEXPR inline Velocity& operator*= (Velocity& lhs, const Real rhs)
 
 /// @brief Division assignment operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity& operator/= (Velocity& lhs, const Real rhs)
+constexpr inline Velocity& operator/= (Velocity& lhs, const Real rhs)
 {
     lhs.linear /= rhs;
     lhs.angular /= rhs;
@@ -72,7 +72,7 @@ PLAYRHO_CONSTEXPR inline Velocity& operator/= (Velocity& lhs, const Real rhs)
 
 /// @brief Addition assignment operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
+constexpr inline Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
 {
     lhs.linear += rhs.linear;
     lhs.angular += rhs.angular;
@@ -81,14 +81,14 @@ PLAYRHO_CONSTEXPR inline Velocity& operator+= (Velocity& lhs, const Velocity& rh
 
 /// @brief Addition operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
+constexpr inline Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
 {
     return Velocity{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
 }
 
 /// @brief Subtraction assignment operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
+constexpr inline Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
 {
     lhs.linear -= rhs.linear;
     lhs.angular -= rhs.angular;
@@ -97,42 +97,42 @@ PLAYRHO_CONSTEXPR inline Velocity& operator-= (Velocity& lhs, const Velocity& rh
 
 /// @brief Subtraction operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity operator- (const Velocity& lhs, const Velocity& rhs)
+constexpr inline Velocity operator- (const Velocity& lhs, const Velocity& rhs)
 {
     return Velocity{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
 }
 
 /// @brief Negation operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity operator- (const Velocity& value)
+constexpr inline Velocity operator- (const Velocity& value)
 {
     return Velocity{-value.linear, -value.angular};
 }
 
 /// @brief Positive operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity operator+ (const Velocity& value)
+constexpr inline Velocity operator+ (const Velocity& value)
 {
     return value;
 }
 
 /// @brief Multiplication operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity operator* (const Velocity& lhs, const Real rhs)
+constexpr inline Velocity operator* (const Velocity& lhs, const Real rhs)
 {
     return Velocity{lhs.linear * rhs, lhs.angular * rhs};
 }
 
 /// @brief Multiplication operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity operator* (const Real lhs, const Velocity& rhs)
+constexpr inline Velocity operator* (const Real lhs, const Velocity& rhs)
 {
     return Velocity{rhs.linear * lhs, rhs.angular * lhs};
 }
 
 /// @brief Division operator.
 /// @relatedalso Velocity
-PLAYRHO_CONSTEXPR inline Velocity operator/ (const Velocity& lhs, const Real rhs)
+constexpr inline Velocity operator/ (const Velocity& lhs, const Real rhs)
 {
     const auto inverseRhs = Real{1} / rhs;
     return Velocity{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
@@ -149,7 +149,7 @@ VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc);
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Velocity
 template <>
-PLAYRHO_CONSTEXPR inline bool IsValid(const d2::Velocity& value) noexcept
+constexpr inline bool IsValid(const d2::Velocity& value) noexcept
 {
     return IsValid(value.linear) && IsValid(value.angular);
 }

--- a/PlayRho/Common/Version.hpp
+++ b/PlayRho/Common/Version.hpp
@@ -61,13 +61,13 @@ namespace playrho {
     };
     
     /// @brief Equality operator.
-    constexpr inline bool operator== (Version lhs, Version rhs)
+    constexpr bool operator== (Version lhs, Version rhs)
     {
         return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.revision == rhs.revision;
     }
     
     /// @brief Inequality operator.
-    constexpr inline bool operator!= (Version lhs, Version rhs)
+    constexpr bool operator!= (Version lhs, Version rhs)
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Common/Version.hpp
+++ b/PlayRho/Common/Version.hpp
@@ -61,13 +61,13 @@ namespace playrho {
     };
     
     /// @brief Equality operator.
-    PLAYRHO_CONSTEXPR inline bool operator== (Version lhs, Version rhs)
+    constexpr inline bool operator== (Version lhs, Version rhs)
     {
         return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.revision == rhs.revision;
     }
     
     /// @brief Inequality operator.
-    PLAYRHO_CONSTEXPR inline bool operator!= (Version lhs, Version rhs)
+    constexpr inline bool operator!= (Version lhs, Version rhs)
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Defines.hpp
+++ b/PlayRho/Defines.hpp
@@ -21,10 +21,6 @@
 #ifndef PLAYRHO_DEFINES_HPP
 #define PLAYRHO_DEFINES_HPP
 
-// Macro for constant expressions.
-// Value of this macro should either be 'constexpr' or empty.
-#define PLAYRHO_CONSTEXPR constexpr
-
 // Checks if platform supports 128-bit integer types and defines macros for them if so.
 // Note that these could use any <code>LiteralType</code> type that has full operator and
 // common mathemtical function support.

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -87,7 +87,7 @@ public:
     using Contacts = std::vector<KeyedContactPtr>;
 
     /// @brief Invalid island index.
-    static PLAYRHO_CONSTEXPR const auto InvalidIslandIndex = static_cast<BodyCounter>(-1);
+    static constexpr const auto InvalidIslandIndex = static_cast<BodyCounter>(-1);
 
     /// @brief Flags type.
     /// @note For internal use. Made public to facilitate unit testing.

--- a/PlayRho/Dynamics/BodyConf.hpp
+++ b/PlayRho/Dynamics/BodyConf.hpp
@@ -50,58 +50,58 @@ struct BodyConf
     // Builder-styled methods...
 
     /// @brief Use the given type.
-    constexpr inline BodyConf& UseType(BodyType t) noexcept;
+    constexpr BodyConf& UseType(BodyType t) noexcept;
 
     /// @brief Use the given location.
-    constexpr inline BodyConf& UseLocation(Length2 l) noexcept;
+    constexpr BodyConf& UseLocation(Length2 l) noexcept;
     
     /// @brief Use the given angle.
-    constexpr inline BodyConf& UseAngle(Angle a) noexcept;
+    constexpr BodyConf& UseAngle(Angle a) noexcept;
     
     /// @brief Use the given linear velocity.
-    constexpr inline BodyConf& UseLinearVelocity(LinearVelocity2 v) noexcept;
+    constexpr BodyConf& UseLinearVelocity(LinearVelocity2 v) noexcept;
     
     /// @brief Use the given angular velocity.
-    constexpr inline BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
+    constexpr BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
     
     /// @brief Use the given position for the linear and angular positions.
-    constexpr inline BodyConf& Use(Position v) noexcept;
+    constexpr BodyConf& Use(Position v) noexcept;
 
     /// @brief Use the given velocity for the linear and angular velocities.
-    constexpr inline BodyConf& Use(Velocity v) noexcept;
+    constexpr BodyConf& Use(Velocity v) noexcept;
     
     /// @brief Use the given linear acceleration.
-    constexpr inline BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
+    constexpr BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
     
     /// @brief Use the given angular acceleration.
-    constexpr inline BodyConf& UseAngularAcceleration(AngularAcceleration v) noexcept;
+    constexpr BodyConf& UseAngularAcceleration(AngularAcceleration v) noexcept;
     
     /// @brief Use the given linear damping.
-    constexpr inline BodyConf& UseLinearDamping(NonNegative<Frequency> v) noexcept;
+    constexpr BodyConf& UseLinearDamping(NonNegative<Frequency> v) noexcept;
     
     /// @brief Use the given angular damping.
-    constexpr inline BodyConf& UseAngularDamping(NonNegative<Frequency> v) noexcept;
+    constexpr BodyConf& UseAngularDamping(NonNegative<Frequency> v) noexcept;
     
     /// @brief Use the given under active time.
-    constexpr inline BodyConf& UseUnderActiveTime(Time v) noexcept;
+    constexpr BodyConf& UseUnderActiveTime(Time v) noexcept;
     
     /// @brief Use the given allow sleep value.
-    constexpr inline BodyConf& UseAllowSleep(bool value) noexcept;
+    constexpr BodyConf& UseAllowSleep(bool value) noexcept;
     
     /// @brief Use the given awake value.
-    constexpr inline BodyConf& UseAwake(bool value) noexcept;
+    constexpr BodyConf& UseAwake(bool value) noexcept;
     
     /// @brief Use the given fixed rotation state.
-    constexpr inline BodyConf& UseFixedRotation(bool value) noexcept;
+    constexpr BodyConf& UseFixedRotation(bool value) noexcept;
     
     /// @brief Use the given bullet state.
-    constexpr inline BodyConf& UseBullet(bool value) noexcept;
+    constexpr BodyConf& UseBullet(bool value) noexcept;
     
     /// @brief Use the given enabled state.
-    constexpr inline BodyConf& UseEnabled(bool value) noexcept;
+    constexpr BodyConf& UseEnabled(bool value) noexcept;
     
     /// @brief Use the given user data.
-    constexpr inline BodyConf& UseUserData(void* value) noexcept;
+    constexpr BodyConf& UseUserData(void* value) noexcept;
     
     // Public member variables...
     
@@ -168,111 +168,111 @@ struct BodyConf
     void* userData = nullptr;
 };
 
-constexpr inline BodyConf& BodyConf::UseType(BodyType t) noexcept
+constexpr BodyConf& BodyConf::UseType(BodyType t) noexcept
 {
     type = t;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseLocation(Length2 l) noexcept
+constexpr BodyConf& BodyConf::UseLocation(Length2 l) noexcept
 {
     location = l;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseAngle(Angle a) noexcept
+constexpr BodyConf& BodyConf::UseAngle(Angle a) noexcept
 {
     angle = a;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::Use(Position v) noexcept
+constexpr BodyConf& BodyConf::Use(Position v) noexcept
 {
     location = v.linear;
     angle = v.angular;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::Use(Velocity v) noexcept
+constexpr BodyConf& BodyConf::Use(Velocity v) noexcept
 {
     linearVelocity = v.linear;
     angularVelocity = v.angular;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseLinearVelocity(LinearVelocity2 v) noexcept
+constexpr BodyConf& BodyConf::UseLinearVelocity(LinearVelocity2 v) noexcept
 {
     linearVelocity = v;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseLinearAcceleration(LinearAcceleration2 v) noexcept
+constexpr BodyConf& BodyConf::UseLinearAcceleration(LinearAcceleration2 v) noexcept
 {
     linearAcceleration = v;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseAngularVelocity(AngularVelocity v) noexcept
+constexpr BodyConf& BodyConf::UseAngularVelocity(AngularVelocity v) noexcept
 {
     angularVelocity = v;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseAngularAcceleration(AngularAcceleration v) noexcept
+constexpr BodyConf& BodyConf::UseAngularAcceleration(AngularAcceleration v) noexcept
 {
     angularAcceleration = v;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseLinearDamping(NonNegative<Frequency> v) noexcept
+constexpr BodyConf& BodyConf::UseLinearDamping(NonNegative<Frequency> v) noexcept
 {
     linearDamping = v;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseAngularDamping(NonNegative<Frequency> v) noexcept
+constexpr BodyConf& BodyConf::UseAngularDamping(NonNegative<Frequency> v) noexcept
 {
     angularDamping = v;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseUnderActiveTime(Time v) noexcept
+constexpr BodyConf& BodyConf::UseUnderActiveTime(Time v) noexcept
 {
     underActiveTime = v;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseAllowSleep(bool value) noexcept
+constexpr BodyConf& BodyConf::UseAllowSleep(bool value) noexcept
 {
     allowSleep = value;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseAwake(bool value) noexcept
+constexpr BodyConf& BodyConf::UseAwake(bool value) noexcept
 {
     awake = value;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseFixedRotation(bool value) noexcept
+constexpr BodyConf& BodyConf::UseFixedRotation(bool value) noexcept
 {
     fixedRotation = value;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseBullet(bool value) noexcept
+constexpr BodyConf& BodyConf::UseBullet(bool value) noexcept
 {
     bullet = value;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseEnabled(bool value) noexcept
+constexpr BodyConf& BodyConf::UseEnabled(bool value) noexcept
 {
     enabled = value;
     return *this;
 }
 
-constexpr inline BodyConf& BodyConf::UseUserData(void* value) noexcept
+constexpr BodyConf& BodyConf::UseUserData(void* value) noexcept
 {
     userData = value;
     return *this;
@@ -280,7 +280,7 @@ constexpr inline BodyConf& BodyConf::UseUserData(void* value) noexcept
 
 /// @brief Gets the default body definition.
 /// @relatedalso BodyConf
-constexpr inline BodyConf GetDefaultBodyConf() noexcept
+constexpr BodyConf GetDefaultBodyConf() noexcept
 {
     return BodyConf{};
 }

--- a/PlayRho/Dynamics/BodyConf.hpp
+++ b/PlayRho/Dynamics/BodyConf.hpp
@@ -50,58 +50,58 @@ struct BodyConf
     // Builder-styled methods...
 
     /// @brief Use the given type.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseType(BodyType t) noexcept;
+    constexpr inline BodyConf& UseType(BodyType t) noexcept;
 
     /// @brief Use the given location.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseLocation(Length2 l) noexcept;
+    constexpr inline BodyConf& UseLocation(Length2 l) noexcept;
     
     /// @brief Use the given angle.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseAngle(Angle a) noexcept;
+    constexpr inline BodyConf& UseAngle(Angle a) noexcept;
     
     /// @brief Use the given linear velocity.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseLinearVelocity(LinearVelocity2 v) noexcept;
+    constexpr inline BodyConf& UseLinearVelocity(LinearVelocity2 v) noexcept;
     
     /// @brief Use the given angular velocity.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
+    constexpr inline BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
     
     /// @brief Use the given position for the linear and angular positions.
-    PLAYRHO_CONSTEXPR inline BodyConf& Use(Position v) noexcept;
+    constexpr inline BodyConf& Use(Position v) noexcept;
 
     /// @brief Use the given velocity for the linear and angular velocities.
-    PLAYRHO_CONSTEXPR inline BodyConf& Use(Velocity v) noexcept;
+    constexpr inline BodyConf& Use(Velocity v) noexcept;
     
     /// @brief Use the given linear acceleration.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
+    constexpr inline BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
     
     /// @brief Use the given angular acceleration.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseAngularAcceleration(AngularAcceleration v) noexcept;
+    constexpr inline BodyConf& UseAngularAcceleration(AngularAcceleration v) noexcept;
     
     /// @brief Use the given linear damping.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseLinearDamping(NonNegative<Frequency> v) noexcept;
+    constexpr inline BodyConf& UseLinearDamping(NonNegative<Frequency> v) noexcept;
     
     /// @brief Use the given angular damping.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseAngularDamping(NonNegative<Frequency> v) noexcept;
+    constexpr inline BodyConf& UseAngularDamping(NonNegative<Frequency> v) noexcept;
     
     /// @brief Use the given under active time.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseUnderActiveTime(Time v) noexcept;
+    constexpr inline BodyConf& UseUnderActiveTime(Time v) noexcept;
     
     /// @brief Use the given allow sleep value.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseAllowSleep(bool value) noexcept;
+    constexpr inline BodyConf& UseAllowSleep(bool value) noexcept;
     
     /// @brief Use the given awake value.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseAwake(bool value) noexcept;
+    constexpr inline BodyConf& UseAwake(bool value) noexcept;
     
     /// @brief Use the given fixed rotation state.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseFixedRotation(bool value) noexcept;
+    constexpr inline BodyConf& UseFixedRotation(bool value) noexcept;
     
     /// @brief Use the given bullet state.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseBullet(bool value) noexcept;
+    constexpr inline BodyConf& UseBullet(bool value) noexcept;
     
     /// @brief Use the given enabled state.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseEnabled(bool value) noexcept;
+    constexpr inline BodyConf& UseEnabled(bool value) noexcept;
     
     /// @brief Use the given user data.
-    PLAYRHO_CONSTEXPR inline BodyConf& UseUserData(void* value) noexcept;
+    constexpr inline BodyConf& UseUserData(void* value) noexcept;
     
     // Public member variables...
     
@@ -168,111 +168,111 @@ struct BodyConf
     void* userData = nullptr;
 };
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseType(BodyType t) noexcept
+constexpr inline BodyConf& BodyConf::UseType(BodyType t) noexcept
 {
     type = t;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseLocation(Length2 l) noexcept
+constexpr inline BodyConf& BodyConf::UseLocation(Length2 l) noexcept
 {
     location = l;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseAngle(Angle a) noexcept
+constexpr inline BodyConf& BodyConf::UseAngle(Angle a) noexcept
 {
     angle = a;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::Use(Position v) noexcept
+constexpr inline BodyConf& BodyConf::Use(Position v) noexcept
 {
     location = v.linear;
     angle = v.angular;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::Use(Velocity v) noexcept
+constexpr inline BodyConf& BodyConf::Use(Velocity v) noexcept
 {
     linearVelocity = v.linear;
     angularVelocity = v.angular;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseLinearVelocity(LinearVelocity2 v) noexcept
+constexpr inline BodyConf& BodyConf::UseLinearVelocity(LinearVelocity2 v) noexcept
 {
     linearVelocity = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseLinearAcceleration(LinearAcceleration2 v) noexcept
+constexpr inline BodyConf& BodyConf::UseLinearAcceleration(LinearAcceleration2 v) noexcept
 {
     linearAcceleration = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseAngularVelocity(AngularVelocity v) noexcept
+constexpr inline BodyConf& BodyConf::UseAngularVelocity(AngularVelocity v) noexcept
 {
     angularVelocity = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseAngularAcceleration(AngularAcceleration v) noexcept
+constexpr inline BodyConf& BodyConf::UseAngularAcceleration(AngularAcceleration v) noexcept
 {
     angularAcceleration = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseLinearDamping(NonNegative<Frequency> v) noexcept
+constexpr inline BodyConf& BodyConf::UseLinearDamping(NonNegative<Frequency> v) noexcept
 {
     linearDamping = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseAngularDamping(NonNegative<Frequency> v) noexcept
+constexpr inline BodyConf& BodyConf::UseAngularDamping(NonNegative<Frequency> v) noexcept
 {
     angularDamping = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseUnderActiveTime(Time v) noexcept
+constexpr inline BodyConf& BodyConf::UseUnderActiveTime(Time v) noexcept
 {
     underActiveTime = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseAllowSleep(bool value) noexcept
+constexpr inline BodyConf& BodyConf::UseAllowSleep(bool value) noexcept
 {
     allowSleep = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseAwake(bool value) noexcept
+constexpr inline BodyConf& BodyConf::UseAwake(bool value) noexcept
 {
     awake = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseFixedRotation(bool value) noexcept
+constexpr inline BodyConf& BodyConf::UseFixedRotation(bool value) noexcept
 {
     fixedRotation = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseBullet(bool value) noexcept
+constexpr inline BodyConf& BodyConf::UseBullet(bool value) noexcept
 {
     bullet = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseEnabled(bool value) noexcept
+constexpr inline BodyConf& BodyConf::UseEnabled(bool value) noexcept
 {
     enabled = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseUserData(void* value) noexcept
+constexpr inline BodyConf& BodyConf::UseUserData(void* value) noexcept
 {
     userData = value;
     return *this;
@@ -280,7 +280,7 @@ PLAYRHO_CONSTEXPR inline BodyConf& BodyConf::UseUserData(void* value) noexcept
 
 /// @brief Gets the default body definition.
 /// @relatedalso BodyConf
-PLAYRHO_CONSTEXPR inline BodyConf GetDefaultBodyConf() noexcept
+constexpr inline BodyConf GetDefaultBodyConf() noexcept
 {
     return BodyConf{};
 }

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -43,7 +43,7 @@ namespace d2 {
         BodyConstraint() = default;
         
         /// @brief Initializing constructor.
-        PLAYRHO_CONSTEXPR inline
+        constexpr inline
         BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
                          Position position, Velocity velocity) noexcept:
             m_position{position},

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -43,7 +43,7 @@ namespace d2 {
         BodyConstraint() = default;
         
         /// @brief Initializing constructor.
-        constexpr inline
+        constexpr
         BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
                          Position position, Velocity velocity) noexcept:
             m_position{position},

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -36,26 +36,26 @@ namespace playrho {
 class ContactKey
 {
 public:
-    PLAYRHO_CONSTEXPR inline ContactKey() noexcept
+    constexpr inline ContactKey() noexcept
     {
         // Intentionally empty
     }
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept:
+    constexpr inline ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept:
         m_ids{std::minmax(fp1, fp2)}
     {
         // Intentionally empty
     }
 
     /// @brief Gets the minimum index value.
-    PLAYRHO_CONSTEXPR inline ContactCounter GetMin() const noexcept
+    constexpr inline ContactCounter GetMin() const noexcept
     {
         return std::get<0>(m_ids);
     }
     
     /// @brief Gets the maximum index value.
-    PLAYRHO_CONSTEXPR inline ContactCounter GetMax() const noexcept
+    constexpr inline ContactCounter GetMax() const noexcept
     {
         return std::get<1>(m_ids);
     }
@@ -70,40 +70,40 @@ private:
 };
 
 /// @brief Equality operator.
-PLAYRHO_CONSTEXPR inline bool operator== (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr inline bool operator== (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return lhs.GetMin() == rhs.GetMin() && lhs.GetMax() == rhs.GetMax();
 }
 
 /// @brief Inequality operator.
-PLAYRHO_CONSTEXPR inline bool operator!= (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr inline bool operator!= (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return !(lhs == rhs);
 }
 
 /// @brief Less-than operator.
-PLAYRHO_CONSTEXPR inline bool operator< (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr inline bool operator< (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin())
         || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() < rhs.GetMax()));
 }
 
 /// @brief Less-than or equal-to operator.
-PLAYRHO_CONSTEXPR inline bool operator<= (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr inline bool operator<= (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin())
     || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() <= rhs.GetMax()));
 }
 
 /// @brief Greater-than operator.
-PLAYRHO_CONSTEXPR inline bool operator> (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr inline bool operator> (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin())
         || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() > rhs.GetMax()));
 }
 
 /// @brief Greater-than or equal-to operator.
-PLAYRHO_CONSTEXPR inline bool operator>= (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr inline bool operator>= (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin())
     || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() >= rhs.GetMax()));
@@ -146,7 +146,7 @@ namespace std
         using result_type = std::size_t;
 
         /// @brief Function object operator.
-        PLAYRHO_CONSTEXPR inline std::size_t operator()(const playrho::ContactKey& key) const
+        constexpr inline std::size_t operator()(const playrho::ContactKey& key) const
         {
             // Use simple and fast Knuth multiplicative hash...
             const auto a = std::size_t{key.GetMin()} * 2654435761u;

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -36,26 +36,26 @@ namespace playrho {
 class ContactKey
 {
 public:
-    constexpr inline ContactKey() noexcept
+    constexpr ContactKey() noexcept
     {
         // Intentionally empty
     }
     
     /// @brief Initializing constructor.
-    constexpr inline ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept:
+    constexpr ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept:
         m_ids{std::minmax(fp1, fp2)}
     {
         // Intentionally empty
     }
 
     /// @brief Gets the minimum index value.
-    constexpr inline ContactCounter GetMin() const noexcept
+    constexpr ContactCounter GetMin() const noexcept
     {
         return std::get<0>(m_ids);
     }
     
     /// @brief Gets the maximum index value.
-    constexpr inline ContactCounter GetMax() const noexcept
+    constexpr ContactCounter GetMax() const noexcept
     {
         return std::get<1>(m_ids);
     }
@@ -70,40 +70,40 @@ private:
 };
 
 /// @brief Equality operator.
-constexpr inline bool operator== (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr bool operator== (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return lhs.GetMin() == rhs.GetMin() && lhs.GetMax() == rhs.GetMax();
 }
 
 /// @brief Inequality operator.
-constexpr inline bool operator!= (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr bool operator!= (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return !(lhs == rhs);
 }
 
 /// @brief Less-than operator.
-constexpr inline bool operator< (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr bool operator< (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin())
         || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() < rhs.GetMax()));
 }
 
 /// @brief Less-than or equal-to operator.
-constexpr inline bool operator<= (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr bool operator<= (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() < rhs.GetMin())
     || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() <= rhs.GetMax()));
 }
 
 /// @brief Greater-than operator.
-constexpr inline bool operator> (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr bool operator> (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin())
         || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() > rhs.GetMax()));
 }
 
 /// @brief Greater-than or equal-to operator.
-constexpr inline bool operator>= (const ContactKey lhs, const ContactKey rhs) noexcept
+constexpr bool operator>= (const ContactKey lhs, const ContactKey rhs) noexcept
 {
     return (lhs.GetMin() > rhs.GetMin())
     || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() >= rhs.GetMax()));
@@ -146,7 +146,7 @@ namespace std
         using result_type = std::size_t;
 
         /// @brief Function object operator.
-        constexpr inline std::size_t operator()(const playrho::ContactKey& key) const
+        constexpr std::size_t operator()(const playrho::ContactKey& key) const
         {
             // Use simple and fast Knuth multiplicative hash...
             const auto a = std::size_t{key.GetMin()} * 2654435761u;

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -39,7 +39,7 @@ namespace d2 {
 namespace {
 
 #if defined(B2_DEBUG_SOLVER)
-static constexpr inline auto k_errorTol = 1e-3_mps; ///< error tolerance
+static constexpr auto k_errorTol = 1e-3_mps; ///< error tolerance
 #endif
 
 /// Impulse change.

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -39,7 +39,7 @@ namespace d2 {
 namespace {
 
 #if defined(B2_DEBUG_SOLVER)
-static PLAYRHO_CONSTEXPR inline auto k_errorTol = 1e-3_mps; ///< error tolerance
+static constexpr inline auto k_errorTol = 1e-3_mps; ///< error tolerance
 #endif
 
 /// Impulse change.

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
@@ -107,7 +107,7 @@ VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
         const auto k00_times_k11 = get<0>(k) * get<1>(k);
         const auto k01_squared = Square(get<2>(k));
         const auto k_diff = k00_times_k11 - k01_squared;
-        PLAYRHO_CONSTEXPR const auto maxCondNum = PLAYRHO_MAGIC(Real(1000.0f));
+        constexpr const auto maxCondNum = PLAYRHO_MAGIC(Real(1000.0f));
         if (k00_squared < maxCondNum * k_diff)
         {
             // K is safe to invert.

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -58,7 +58,7 @@ public:
     };
     
     /// @brief Gets the default configuration for a <code>VelocityConstraint</code>.
-    static PLAYRHO_CONSTEXPR inline Conf GetDefaultConf() noexcept
+    static constexpr inline Conf GetDefaultConf() noexcept
     {
         return Conf{};
     }

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -58,7 +58,7 @@ public:
     };
     
     /// @brief Gets the default configuration for a <code>VelocityConstraint</code>.
-    static constexpr inline Conf GetDefaultConf() noexcept
+    static constexpr Conf GetDefaultConf() noexcept
     {
         return Conf{};
     }

--- a/PlayRho/Dynamics/Filter.hpp
+++ b/PlayRho/Dynamics/Filter.hpp
@@ -63,7 +63,7 @@ namespace playrho {
     
     /// @brief Equality operator.
     /// @relatedalso Filter
-    PLAYRHO_CONSTEXPR inline bool operator== (const Filter lhs, const Filter rhs) noexcept
+    constexpr inline bool operator== (const Filter lhs, const Filter rhs) noexcept
     {
         return lhs.categoryBits == rhs.categoryBits
             && lhs.maskBits == rhs.maskBits
@@ -72,7 +72,7 @@ namespace playrho {
 
     /// @brief Inequality operator.
     /// @relatedalso Filter
-    PLAYRHO_CONSTEXPR inline bool operator!= (const Filter lhs, const Filter rhs) noexcept
+    constexpr inline bool operator!= (const Filter lhs, const Filter rhs) noexcept
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Dynamics/Filter.hpp
+++ b/PlayRho/Dynamics/Filter.hpp
@@ -63,7 +63,7 @@ namespace playrho {
     
     /// @brief Equality operator.
     /// @relatedalso Filter
-    constexpr inline bool operator== (const Filter lhs, const Filter rhs) noexcept
+    constexpr bool operator== (const Filter lhs, const Filter rhs) noexcept
     {
         return lhs.categoryBits == rhs.categoryBits
             && lhs.maskBits == rhs.maskBits
@@ -72,7 +72,7 @@ namespace playrho {
 
     /// @brief Inequality operator.
     /// @relatedalso Filter
-    constexpr inline bool operator!= (const Filter lhs, const Filter rhs) noexcept
+    constexpr bool operator!= (const Filter lhs, const Filter rhs) noexcept
     {
         return !(lhs == rhs);
     }

--- a/PlayRho/Dynamics/FixtureConf.hpp
+++ b/PlayRho/Dynamics/FixtureConf.hpp
@@ -41,13 +41,13 @@ struct FixtureConf
 {
     
     /// @brief Uses the given user data.
-    PLAYRHO_CONSTEXPR inline FixtureConf& UseUserData(void* value) noexcept;
+    constexpr inline FixtureConf& UseUserData(void* value) noexcept;
 
     /// @brief Uses the given sensor state value.
-    PLAYRHO_CONSTEXPR inline FixtureConf& UseIsSensor(bool value) noexcept;
+    constexpr inline FixtureConf& UseIsSensor(bool value) noexcept;
     
     /// @brief Uses the given filter value.
-    PLAYRHO_CONSTEXPR inline FixtureConf& UseFilter(Filter value) noexcept;
+    constexpr inline FixtureConf& UseFilter(Filter value) noexcept;
     
     /// Use this to store application specific fixture data.
     void* userData = nullptr;
@@ -60,19 +60,19 @@ struct FixtureConf
     Filter filter;
 };
 
-PLAYRHO_CONSTEXPR inline FixtureConf& FixtureConf::UseUserData(void* value) noexcept
+constexpr inline FixtureConf& FixtureConf::UseUserData(void* value) noexcept
 {
     userData = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline FixtureConf& FixtureConf::UseIsSensor(bool value) noexcept
+constexpr inline FixtureConf& FixtureConf::UseIsSensor(bool value) noexcept
 {
     isSensor = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline FixtureConf& FixtureConf::UseFilter(Filter value) noexcept
+constexpr inline FixtureConf& FixtureConf::UseFilter(Filter value) noexcept
 {
     filter = value;
     return *this;
@@ -80,7 +80,7 @@ PLAYRHO_CONSTEXPR inline FixtureConf& FixtureConf::UseFilter(Filter value) noexc
 
 /// @brief Gets the default fixture definition.
 /// @relatedalso FixtureConf
-PLAYRHO_CONSTEXPR inline FixtureConf GetDefaultFixtureConf() noexcept
+constexpr inline FixtureConf GetDefaultFixtureConf() noexcept
 {
     return FixtureConf{};
 }

--- a/PlayRho/Dynamics/FixtureConf.hpp
+++ b/PlayRho/Dynamics/FixtureConf.hpp
@@ -41,13 +41,13 @@ struct FixtureConf
 {
     
     /// @brief Uses the given user data.
-    constexpr inline FixtureConf& UseUserData(void* value) noexcept;
+    constexpr FixtureConf& UseUserData(void* value) noexcept;
 
     /// @brief Uses the given sensor state value.
-    constexpr inline FixtureConf& UseIsSensor(bool value) noexcept;
+    constexpr FixtureConf& UseIsSensor(bool value) noexcept;
     
     /// @brief Uses the given filter value.
-    constexpr inline FixtureConf& UseFilter(Filter value) noexcept;
+    constexpr FixtureConf& UseFilter(Filter value) noexcept;
     
     /// Use this to store application specific fixture data.
     void* userData = nullptr;
@@ -60,19 +60,19 @@ struct FixtureConf
     Filter filter;
 };
 
-constexpr inline FixtureConf& FixtureConf::UseUserData(void* value) noexcept
+constexpr FixtureConf& FixtureConf::UseUserData(void* value) noexcept
 {
     userData = value;
     return *this;
 }
 
-constexpr inline FixtureConf& FixtureConf::UseIsSensor(bool value) noexcept
+constexpr FixtureConf& FixtureConf::UseIsSensor(bool value) noexcept
 {
     isSensor = value;
     return *this;
 }
 
-constexpr inline FixtureConf& FixtureConf::UseFilter(Filter value) noexcept
+constexpr FixtureConf& FixtureConf::UseFilter(Filter value) noexcept
 {
     filter = value;
     return *this;
@@ -80,7 +80,7 @@ constexpr inline FixtureConf& FixtureConf::UseFilter(Filter value) noexcept
 
 /// @brief Gets the default fixture definition.
 /// @relatedalso FixtureConf
-constexpr inline FixtureConf GetDefaultFixtureConf() noexcept
+constexpr FixtureConf GetDefaultFixtureConf() noexcept
 {
     return FixtureConf{};
 }

--- a/PlayRho/Dynamics/FixtureProxy.hpp
+++ b/PlayRho/Dynamics/FixtureProxy.hpp
@@ -42,14 +42,14 @@ struct FixtureProxy
 
 /// @brief Equality operator
 /// @relatedalso FixtureProxy
-constexpr inline bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+constexpr bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
 {
     return lhs.treeId == rhs.treeId;
 }
 
 /// @brief Inequality operator
 /// @relatedalso FixtureProxy
-constexpr inline bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+constexpr bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
 {
     return !(lhs.treeId == rhs.treeId);
 }

--- a/PlayRho/Dynamics/FixtureProxy.hpp
+++ b/PlayRho/Dynamics/FixtureProxy.hpp
@@ -42,14 +42,14 @@ struct FixtureProxy
 
 /// @brief Equality operator
 /// @relatedalso FixtureProxy
-PLAYRHO_CONSTEXPR inline bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+constexpr inline bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
 {
     return lhs.treeId == rhs.treeId;
 }
 
 /// @brief Inequality operator
 /// @relatedalso FixtureProxy
-PLAYRHO_CONSTEXPR inline bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+constexpr inline bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
 {
     return !(lhs.treeId == rhs.treeId);
 }

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
@@ -44,7 +44,7 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf>
     /// @brief Super type.
     using super = JointBuilder<DistanceJointConf>;
     
-    PLAYRHO_CONSTEXPR inline DistanceJointConf() noexcept: super{JointType::Distance} {}
+    constexpr inline DistanceJointConf() noexcept: super{JointType::Distance} {}
     
     /// @brief Copy constructor.
     DistanceJointConf(const DistanceJointConf& copy) = default;
@@ -56,13 +56,13 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf>
                      Length2 anchorB = Length2{}) noexcept;
     
     /// @brief Uses the given length.
-    PLAYRHO_CONSTEXPR inline DistanceJointConf& UseLength(Length v) noexcept;
+    constexpr inline DistanceJointConf& UseLength(Length v) noexcept;
     
     /// @brief Uses the given frequency.
-    PLAYRHO_CONSTEXPR inline DistanceJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
+    constexpr inline DistanceJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
     
     /// @brief Uses the given damping ratio.
-    PLAYRHO_CONSTEXPR inline DistanceJointConf& UseDampingRatio(Real v) noexcept;
+    constexpr inline DistanceJointConf& UseDampingRatio(Real v) noexcept;
     
     /// @brief Local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -82,19 +82,19 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf>
     Real dampingRatio = 0;
 };
 
-PLAYRHO_CONSTEXPR inline DistanceJointConf& DistanceJointConf::UseLength(Length v) noexcept
+constexpr inline DistanceJointConf& DistanceJointConf::UseLength(Length v) noexcept
 {
     length = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline DistanceJointConf& DistanceJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
+constexpr inline DistanceJointConf& DistanceJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline DistanceJointConf& DistanceJointConf::UseDampingRatio(Real v) noexcept
+constexpr inline DistanceJointConf& DistanceJointConf::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
@@ -44,7 +44,7 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf>
     /// @brief Super type.
     using super = JointBuilder<DistanceJointConf>;
     
-    constexpr inline DistanceJointConf() noexcept: super{JointType::Distance} {}
+    constexpr DistanceJointConf() noexcept: super{JointType::Distance} {}
     
     /// @brief Copy constructor.
     DistanceJointConf(const DistanceJointConf& copy) = default;
@@ -56,13 +56,13 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf>
                      Length2 anchorB = Length2{}) noexcept;
     
     /// @brief Uses the given length.
-    constexpr inline DistanceJointConf& UseLength(Length v) noexcept;
+    constexpr DistanceJointConf& UseLength(Length v) noexcept;
     
     /// @brief Uses the given frequency.
-    constexpr inline DistanceJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
+    constexpr DistanceJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
     
     /// @brief Uses the given damping ratio.
-    constexpr inline DistanceJointConf& UseDampingRatio(Real v) noexcept;
+    constexpr DistanceJointConf& UseDampingRatio(Real v) noexcept;
     
     /// @brief Local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -82,19 +82,19 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf>
     Real dampingRatio = 0;
 };
 
-constexpr inline DistanceJointConf& DistanceJointConf::UseLength(Length v) noexcept
+constexpr DistanceJointConf& DistanceJointConf::UseLength(Length v) noexcept
 {
     length = v;
     return *this;
 }
 
-constexpr inline DistanceJointConf& DistanceJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
+constexpr DistanceJointConf& DistanceJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr inline DistanceJointConf& DistanceJointConf::UseDampingRatio(Real v) noexcept
+constexpr DistanceJointConf& DistanceJointConf::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
@@ -39,7 +39,7 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf>
     /// @brief Super type.
     using super = JointBuilder<FrictionJointConf>;
     
-    PLAYRHO_CONSTEXPR inline FrictionJointConf() noexcept: super{JointType::Friction} {}
+    constexpr inline FrictionJointConf() noexcept: super{JointType::Friction} {}
     
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, axis, and reference angle using the world
@@ -47,10 +47,10 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf>
     FrictionJointConf(Body* bodyA, Body* bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given maximum force value.
-    PLAYRHO_CONSTEXPR inline FrictionJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
+    constexpr inline FrictionJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
     
     /// @brief Uses the given maximum torque value.
-    PLAYRHO_CONSTEXPR inline FrictionJointConf& UseMaxTorque(NonNegative<Torque> v) noexcept;
+    constexpr inline FrictionJointConf& UseMaxTorque(NonNegative<Torque> v) noexcept;
     
     /// @brief Local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -65,13 +65,13 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf>
     NonNegative<Torque> maxTorque = NonNegative<Torque>{0_Nm};
 };
 
-PLAYRHO_CONSTEXPR inline FrictionJointConf& FrictionJointConf::UseMaxForce(NonNegative<Force> v) noexcept
+constexpr inline FrictionJointConf& FrictionJointConf::UseMaxForce(NonNegative<Force> v) noexcept
 {
     maxForce = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline FrictionJointConf& FrictionJointConf::UseMaxTorque(NonNegative<Torque> v) noexcept
+constexpr inline FrictionJointConf& FrictionJointConf::UseMaxTorque(NonNegative<Torque> v) noexcept
 {
     maxTorque = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
@@ -39,7 +39,7 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf>
     /// @brief Super type.
     using super = JointBuilder<FrictionJointConf>;
     
-    constexpr inline FrictionJointConf() noexcept: super{JointType::Friction} {}
+    constexpr FrictionJointConf() noexcept: super{JointType::Friction} {}
     
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, axis, and reference angle using the world
@@ -47,10 +47,10 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf>
     FrictionJointConf(Body* bodyA, Body* bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given maximum force value.
-    constexpr inline FrictionJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
+    constexpr FrictionJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
     
     /// @brief Uses the given maximum torque value.
-    constexpr inline FrictionJointConf& UseMaxTorque(NonNegative<Torque> v) noexcept;
+    constexpr FrictionJointConf& UseMaxTorque(NonNegative<Torque> v) noexcept;
     
     /// @brief Local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -65,13 +65,13 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf>
     NonNegative<Torque> maxTorque = NonNegative<Torque>{0_Nm};
 };
 
-constexpr inline FrictionJointConf& FrictionJointConf::UseMaxForce(NonNegative<Force> v) noexcept
+constexpr FrictionJointConf& FrictionJointConf::UseMaxForce(NonNegative<Force> v) noexcept
 {
     maxForce = v;
     return *this;
 }
 
-constexpr inline FrictionJointConf& FrictionJointConf::UseMaxTorque(NonNegative<Torque> v) noexcept
+constexpr FrictionJointConf& FrictionJointConf::UseMaxTorque(NonNegative<Torque> v) noexcept
 {
     maxTorque = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/JointConf.hpp
+++ b/PlayRho/Dynamics/Joints/JointConf.hpp
@@ -41,7 +41,7 @@ struct JointConf
     JointConf() = delete; // deleted to prevent direct instantiation.
     
     /// @brief Initializing constructor.
-    constexpr inline explicit JointConf(JointType t) noexcept : type{t}
+    constexpr explicit JointConf(JointType t) noexcept : type{t}
     {
         // Intentionally empty.
     }
@@ -82,34 +82,34 @@ struct JointBuilder : JointConf
     using reference = value_type&;
     
     /// @brief Initializing constructor.
-    constexpr inline explicit JointBuilder(JointType t) noexcept : JointConf{t}
+    constexpr explicit JointBuilder(JointType t) noexcept : JointConf{t}
     {
         // Intentionally empty.
     }
     
     /// @brief Use value for body A setting.
-    constexpr inline reference UseBodyA(Body* b) noexcept
+    constexpr reference UseBodyA(Body* b) noexcept
     {
         bodyA = b;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for body B setting.
-    constexpr inline reference UseBodyB(Body* b) noexcept
+    constexpr reference UseBodyB(Body* b) noexcept
     {
         bodyB = b;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for collide connected setting.
-    constexpr inline reference UseCollideConnected(bool v) noexcept
+    constexpr reference UseCollideConnected(bool v) noexcept
     {
         collideConnected = v;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for user data setting.
-    constexpr inline reference UseUserData(void* v) noexcept
+    constexpr reference UseUserData(void* v) noexcept
     {
         userData = v;
         return static_cast<reference>(*this);

--- a/PlayRho/Dynamics/Joints/JointConf.hpp
+++ b/PlayRho/Dynamics/Joints/JointConf.hpp
@@ -41,7 +41,7 @@ struct JointConf
     JointConf() = delete; // deleted to prevent direct instantiation.
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit JointConf(JointType t) noexcept : type{t}
+    constexpr inline explicit JointConf(JointType t) noexcept : type{t}
     {
         // Intentionally empty.
     }
@@ -82,34 +82,34 @@ struct JointBuilder : JointConf
     using reference = value_type&;
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline explicit JointBuilder(JointType t) noexcept : JointConf{t}
+    constexpr inline explicit JointBuilder(JointType t) noexcept : JointConf{t}
     {
         // Intentionally empty.
     }
     
     /// @brief Use value for body A setting.
-    PLAYRHO_CONSTEXPR inline reference UseBodyA(Body* b) noexcept
+    constexpr inline reference UseBodyA(Body* b) noexcept
     {
         bodyA = b;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for body B setting.
-    PLAYRHO_CONSTEXPR inline reference UseBodyB(Body* b) noexcept
+    constexpr inline reference UseBodyB(Body* b) noexcept
     {
         bodyB = b;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for collide connected setting.
-    PLAYRHO_CONSTEXPR inline reference UseCollideConnected(bool v) noexcept
+    constexpr inline reference UseCollideConnected(bool v) noexcept
     {
         collideConnected = v;
         return static_cast<reference>(*this);
     }
     
     /// @brief Use value for user data setting.
-    PLAYRHO_CONSTEXPR inline reference UseUserData(void* v) noexcept
+    constexpr inline reference UseUserData(void* v) noexcept
     {
         userData = v;
         return static_cast<reference>(*this);

--- a/PlayRho/Dynamics/Joints/JointKey.hpp
+++ b/PlayRho/Dynamics/Joints/JointKey.hpp
@@ -40,7 +40,7 @@ class JointKey
 public:
     
     /// @brief Gets the <code>JointKey</code> for the given bodies.
-    static constexpr inline JointKey Get(const Body* bodyA, const Body* bodyB) noexcept
+    static constexpr JointKey Get(const Body* bodyA, const Body* bodyB) noexcept
     {
         return (bodyA < bodyB)? JointKey{bodyA, bodyB}: JointKey{bodyB, bodyA};
     }
@@ -59,7 +59,7 @@ public:
 
 private:
     /// @brief Initializing constructor.
-    constexpr inline JointKey(const Body* body1, const Body* body2):
+    constexpr JointKey(const Body* body1, const Body* body2):
         m_body1(body1), m_body2(body2)
     {
         // Intentionally empty.
@@ -78,7 +78,7 @@ private:
 JointKey GetJointKey(const Joint& joint) noexcept;
 
 /// @brief Compares the given joint keys.
-constexpr inline int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
+constexpr int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
 {
     if (lhs.GetBody1() < rhs.GetBody1())
     {
@@ -101,7 +101,7 @@ constexpr inline int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
 
 /// @brief Determines whether the given key is for the given body.
 /// @relatedalso JointKey
-constexpr inline bool IsFor(const JointKey key, const Body* body) noexcept
+constexpr bool IsFor(const JointKey key, const Body* body) noexcept
 {
     return body == key.GetBody1() || body == key.GetBody2();
 }
@@ -122,7 +122,7 @@ namespace std
     struct less<playrho::d2::JointKey>
     {
         /// @brief Function object operator.
-        constexpr inline
+        constexpr
         bool operator()(const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs) const
         {
             return playrho::d2::Compare(lhs, rhs) < 0;
@@ -135,7 +135,7 @@ namespace std
     {
         
         /// @brief Function object operator.
-        constexpr inline
+        constexpr
         bool operator()( const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs ) const
         {
             return playrho::d2::Compare(lhs, rhs) == 0;

--- a/PlayRho/Dynamics/Joints/JointKey.hpp
+++ b/PlayRho/Dynamics/Joints/JointKey.hpp
@@ -40,26 +40,26 @@ class JointKey
 public:
     
     /// @brief Gets the <code>JointKey</code> for the given bodies.
-    static PLAYRHO_CONSTEXPR inline JointKey Get(const Body* bodyA, const Body* bodyB) noexcept
+    static constexpr inline JointKey Get(const Body* bodyA, const Body* bodyB) noexcept
     {
         return (bodyA < bodyB)? JointKey{bodyA, bodyB}: JointKey{bodyB, bodyA};
     }
     
     /// @brief Gets body 1.
-    PLAYRHO_CONSTEXPR const Body* GetBody1() const noexcept
+    constexpr const Body* GetBody1() const noexcept
     {
         return m_body1;
     }
     
     /// @brief Gets body 2.
-    PLAYRHO_CONSTEXPR const Body* GetBody2() const
+    constexpr const Body* GetBody2() const
     {
         return m_body2;
     }
 
 private:
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline JointKey(const Body* body1, const Body* body2):
+    constexpr inline JointKey(const Body* body1, const Body* body2):
         m_body1(body1), m_body2(body2)
     {
         // Intentionally empty.
@@ -78,7 +78,7 @@ private:
 JointKey GetJointKey(const Joint& joint) noexcept;
 
 /// @brief Compares the given joint keys.
-PLAYRHO_CONSTEXPR inline int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
+constexpr inline int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
 {
     if (lhs.GetBody1() < rhs.GetBody1())
     {
@@ -101,7 +101,7 @@ PLAYRHO_CONSTEXPR inline int Compare(const JointKey& lhs, const JointKey& rhs) n
 
 /// @brief Determines whether the given key is for the given body.
 /// @relatedalso JointKey
-PLAYRHO_CONSTEXPR inline bool IsFor(const JointKey key, const Body* body) noexcept
+constexpr inline bool IsFor(const JointKey key, const Body* body) noexcept
 {
     return body == key.GetBody1() || body == key.GetBody2();
 }
@@ -122,7 +122,7 @@ namespace std
     struct less<playrho::d2::JointKey>
     {
         /// @brief Function object operator.
-        PLAYRHO_CONSTEXPR inline
+        constexpr inline
         bool operator()(const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs) const
         {
             return playrho::d2::Compare(lhs, rhs) < 0;
@@ -135,7 +135,7 @@ namespace std
     {
         
         /// @brief Function object operator.
-        PLAYRHO_CONSTEXPR inline
+        constexpr inline
         bool operator()( const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs ) const
         {
             return playrho::d2::Compare(lhs, rhs) == 0;

--- a/PlayRho/Dynamics/Joints/MotorJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.hpp
@@ -38,7 +38,7 @@ struct MotorJointConf : public JointBuilder<MotorJointConf>
     /// @brief Super type.
     using super = JointBuilder<MotorJointConf>;
     
-    constexpr inline MotorJointConf() noexcept: super{JointType::Motor} {}
+    constexpr MotorJointConf() noexcept: super{JointType::Motor} {}
     
     /// @brief Initialize the bodies and offsets using the current transforms.
     MotorJointConf(NonNull<Body*> bodyA, NonNull<Body*> bodyB) noexcept;

--- a/PlayRho/Dynamics/Joints/MotorJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.hpp
@@ -38,7 +38,7 @@ struct MotorJointConf : public JointBuilder<MotorJointConf>
     /// @brief Super type.
     using super = JointBuilder<MotorJointConf>;
     
-    PLAYRHO_CONSTEXPR inline MotorJointConf() noexcept: super{JointType::Motor} {}
+    constexpr inline MotorJointConf() noexcept: super{JointType::Motor} {}
     
     /// @brief Initialize the bodies and offsets using the current transforms.
     MotorJointConf(NonNull<Body*> bodyA, NonNull<Body*> bodyB) noexcept;

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
@@ -43,7 +43,7 @@ struct PrismaticJointConf : public JointBuilder<PrismaticJointConf>
     /// @brief Super type.
     using super = JointBuilder<PrismaticJointConf>;
     
-    PLAYRHO_CONSTEXPR inline PrismaticJointConf() noexcept: super{JointType::Prismatic} {}
+    constexpr inline PrismaticJointConf() noexcept: super{JointType::Prismatic} {}
     
     /// @brief Copy constructor.
     PrismaticJointConf(const PrismaticJointConf& copy) = default;

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
@@ -43,7 +43,7 @@ struct PrismaticJointConf : public JointBuilder<PrismaticJointConf>
     /// @brief Super type.
     using super = JointBuilder<PrismaticJointConf>;
     
-    constexpr inline PrismaticJointConf() noexcept: super{JointType::Prismatic} {}
+    constexpr PrismaticJointConf() noexcept: super{JointType::Prismatic} {}
     
     /// @brief Copy constructor.
     PrismaticJointConf(const PrismaticJointConf& copy) = default;

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
@@ -48,22 +48,22 @@ struct RevoluteJointConf : public JointBuilder<RevoluteJointConf>
     /// @brief Super type.
     using super = JointBuilder<RevoluteJointConf>;
     
-    constexpr inline RevoluteJointConf() noexcept: super{JointType::Revolute} {}
+    constexpr RevoluteJointConf() noexcept: super{JointType::Revolute} {}
     
     /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
     RevoluteJointConf(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given enable limit state value.
-    constexpr inline RevoluteJointConf& UseEnableLimit(bool v) noexcept;
+    constexpr RevoluteJointConf& UseEnableLimit(bool v) noexcept;
     
     /// @brief Uses the given lower angle value.
-    constexpr inline RevoluteJointConf& UseLowerAngle(Angle v) noexcept;
+    constexpr RevoluteJointConf& UseLowerAngle(Angle v) noexcept;
     
     /// @brief Uses the given upper angle value.
-    constexpr inline RevoluteJointConf& UseUpperAngle(Angle v) noexcept;
+    constexpr RevoluteJointConf& UseUpperAngle(Angle v) noexcept;
     
     /// @brief Uses the given enable motor state value.
-    constexpr inline RevoluteJointConf& UseEnableMotor(bool v) noexcept;
+    constexpr RevoluteJointConf& UseEnableMotor(bool v) noexcept;
 
     /// @brief Local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -94,25 +94,25 @@ struct RevoluteJointConf : public JointBuilder<RevoluteJointConf>
     Torque maxMotorTorque = 0;
 };
 
-constexpr inline RevoluteJointConf& RevoluteJointConf::UseEnableLimit(bool v) noexcept
+constexpr RevoluteJointConf& RevoluteJointConf::UseEnableLimit(bool v) noexcept
 {
     enableLimit = v;
     return *this;
 }
 
-constexpr inline RevoluteJointConf& RevoluteJointConf::UseLowerAngle(Angle v) noexcept
+constexpr RevoluteJointConf& RevoluteJointConf::UseLowerAngle(Angle v) noexcept
 {
     lowerAngle = v;
     return *this;
 }
 
-constexpr inline RevoluteJointConf& RevoluteJointConf::UseUpperAngle(Angle v) noexcept
+constexpr RevoluteJointConf& RevoluteJointConf::UseUpperAngle(Angle v) noexcept
 {
     upperAngle = v;
     return *this;
 }
 
-constexpr inline RevoluteJointConf& RevoluteJointConf::UseEnableMotor(bool v) noexcept
+constexpr RevoluteJointConf& RevoluteJointConf::UseEnableMotor(bool v) noexcept
 {
     enableMotor = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
@@ -48,22 +48,22 @@ struct RevoluteJointConf : public JointBuilder<RevoluteJointConf>
     /// @brief Super type.
     using super = JointBuilder<RevoluteJointConf>;
     
-    PLAYRHO_CONSTEXPR inline RevoluteJointConf() noexcept: super{JointType::Revolute} {}
+    constexpr inline RevoluteJointConf() noexcept: super{JointType::Revolute} {}
     
     /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
     RevoluteJointConf(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given enable limit state value.
-    PLAYRHO_CONSTEXPR inline RevoluteJointConf& UseEnableLimit(bool v) noexcept;
+    constexpr inline RevoluteJointConf& UseEnableLimit(bool v) noexcept;
     
     /// @brief Uses the given lower angle value.
-    PLAYRHO_CONSTEXPR inline RevoluteJointConf& UseLowerAngle(Angle v) noexcept;
+    constexpr inline RevoluteJointConf& UseLowerAngle(Angle v) noexcept;
     
     /// @brief Uses the given upper angle value.
-    PLAYRHO_CONSTEXPR inline RevoluteJointConf& UseUpperAngle(Angle v) noexcept;
+    constexpr inline RevoluteJointConf& UseUpperAngle(Angle v) noexcept;
     
     /// @brief Uses the given enable motor state value.
-    PLAYRHO_CONSTEXPR inline RevoluteJointConf& UseEnableMotor(bool v) noexcept;
+    constexpr inline RevoluteJointConf& UseEnableMotor(bool v) noexcept;
 
     /// @brief Local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -94,25 +94,25 @@ struct RevoluteJointConf : public JointBuilder<RevoluteJointConf>
     Torque maxMotorTorque = 0;
 };
 
-PLAYRHO_CONSTEXPR inline RevoluteJointConf& RevoluteJointConf::UseEnableLimit(bool v) noexcept
+constexpr inline RevoluteJointConf& RevoluteJointConf::UseEnableLimit(bool v) noexcept
 {
     enableLimit = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline RevoluteJointConf& RevoluteJointConf::UseLowerAngle(Angle v) noexcept
+constexpr inline RevoluteJointConf& RevoluteJointConf::UseLowerAngle(Angle v) noexcept
 {
     lowerAngle = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline RevoluteJointConf& RevoluteJointConf::UseUpperAngle(Angle v) noexcept
+constexpr inline RevoluteJointConf& RevoluteJointConf::UseUpperAngle(Angle v) noexcept
 {
     upperAngle = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline RevoluteJointConf& RevoluteJointConf::UseEnableMotor(bool v) noexcept
+constexpr inline RevoluteJointConf& RevoluteJointConf::UseEnableMotor(bool v) noexcept
 {
     enableMotor = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/RopeJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.hpp
@@ -40,17 +40,17 @@ struct RopeJointConf : public JointBuilder<RopeJointConf>
     /// @brief Super type.
     using super = JointBuilder<RopeJointConf>;
     
-    PLAYRHO_CONSTEXPR inline RopeJointConf() noexcept: super{JointType::Rope} {}
+    constexpr inline RopeJointConf() noexcept: super{JointType::Rope} {}
     
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline RopeJointConf(Body* bodyA, Body* bodyB) noexcept:
+    constexpr inline RopeJointConf(Body* bodyA, Body* bodyB) noexcept:
         super{super{JointType::Rope}.UseBodyA(bodyA).UseBodyB(bodyB)}
     {
         // Intentionally empty.
     }
     
     /// @brief Uses the given max length value.
-    PLAYRHO_CONSTEXPR inline RopeJointConf& UseMaxLength(Length v) noexcept;
+    constexpr inline RopeJointConf& UseMaxLength(Length v) noexcept;
     
     /// The local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{-1_m, 0_m};
@@ -62,7 +62,7 @@ struct RopeJointConf : public JointBuilder<RopeJointConf>
     Length maxLength = 0_m;
 };
 
-PLAYRHO_CONSTEXPR inline RopeJointConf& RopeJointConf::UseMaxLength(Length v) noexcept
+constexpr inline RopeJointConf& RopeJointConf::UseMaxLength(Length v) noexcept
 {
     maxLength = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/RopeJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.hpp
@@ -40,17 +40,17 @@ struct RopeJointConf : public JointBuilder<RopeJointConf>
     /// @brief Super type.
     using super = JointBuilder<RopeJointConf>;
     
-    constexpr inline RopeJointConf() noexcept: super{JointType::Rope} {}
+    constexpr RopeJointConf() noexcept: super{JointType::Rope} {}
     
     /// @brief Initializing constructor.
-    constexpr inline RopeJointConf(Body* bodyA, Body* bodyB) noexcept:
+    constexpr RopeJointConf(Body* bodyA, Body* bodyB) noexcept:
         super{super{JointType::Rope}.UseBodyA(bodyA).UseBodyB(bodyB)}
     {
         // Intentionally empty.
     }
     
     /// @brief Uses the given max length value.
-    constexpr inline RopeJointConf& UseMaxLength(Length v) noexcept;
+    constexpr RopeJointConf& UseMaxLength(Length v) noexcept;
     
     /// The local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{-1_m, 0_m};
@@ -62,7 +62,7 @@ struct RopeJointConf : public JointBuilder<RopeJointConf>
     Length maxLength = 0_m;
 };
 
-constexpr inline RopeJointConf& RopeJointConf::UseMaxLength(Length v) noexcept
+constexpr RopeJointConf& RopeJointConf::UseMaxLength(Length v) noexcept
 {
     maxLength = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/TargetJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.hpp
@@ -39,25 +39,25 @@ struct TargetJointConf : public JointBuilder<TargetJointConf>
     /// @brief Super type.
     using super = JointBuilder<TargetJointConf>;
     
-    constexpr inline TargetJointConf() noexcept: super{JointType::Target} {}
+    constexpr TargetJointConf() noexcept: super{JointType::Target} {}
 
     /// @brief Initializing constructor.
-    constexpr inline TargetJointConf(NonNull<Body*> b) noexcept: super{super{JointType::Target}.UseBodyB(b)}
+    constexpr TargetJointConf(NonNull<Body*> b) noexcept: super{super{JointType::Target}.UseBodyB(b)}
     {
         // Intentionally empty.
     }
     
     /// @brief Use value for target.
-    constexpr inline TargetJointConf& UseTarget(Length2 v) noexcept;
+    constexpr TargetJointConf& UseTarget(Length2 v) noexcept;
 
     /// @brief Use value for max force.
-    constexpr inline TargetJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
+    constexpr TargetJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
 
     /// @brief Use value for frequency.
-    constexpr inline TargetJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
+    constexpr TargetJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
 
     /// @brief Use value for damping ratio.
-    constexpr inline TargetJointConf& UseDampingRatio(NonNegative<Real> v) noexcept;
+    constexpr TargetJointConf& UseDampingRatio(NonNegative<Real> v) noexcept;
 
     /// The initial world target point. This is assumed
     /// to coincide with the body anchor initially.
@@ -80,25 +80,25 @@ struct TargetJointConf : public JointBuilder<TargetJointConf>
     NonNegative<Real> dampingRatio = NonNegative<Real>(0.7f);
 };
 
-constexpr inline TargetJointConf& TargetJointConf::UseTarget(Length2 v) noexcept
+constexpr TargetJointConf& TargetJointConf::UseTarget(Length2 v) noexcept
 {
     target = v;
     return *this;
 }
 
-constexpr inline TargetJointConf& TargetJointConf::UseMaxForce(NonNegative<Force> v) noexcept
+constexpr TargetJointConf& TargetJointConf::UseMaxForce(NonNegative<Force> v) noexcept
 {
     maxForce = v;
     return *this;
 }
 
-constexpr inline TargetJointConf& TargetJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
+constexpr TargetJointConf& TargetJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr inline TargetJointConf& TargetJointConf::UseDampingRatio(NonNegative<Real> v) noexcept
+constexpr TargetJointConf& TargetJointConf::UseDampingRatio(NonNegative<Real> v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/TargetJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.hpp
@@ -39,25 +39,25 @@ struct TargetJointConf : public JointBuilder<TargetJointConf>
     /// @brief Super type.
     using super = JointBuilder<TargetJointConf>;
     
-    PLAYRHO_CONSTEXPR inline TargetJointConf() noexcept: super{JointType::Target} {}
+    constexpr inline TargetJointConf() noexcept: super{JointType::Target} {}
 
     /// @brief Initializing constructor.
-    PLAYRHO_CONSTEXPR inline TargetJointConf(NonNull<Body*> b) noexcept: super{super{JointType::Target}.UseBodyB(b)}
+    constexpr inline TargetJointConf(NonNull<Body*> b) noexcept: super{super{JointType::Target}.UseBodyB(b)}
     {
         // Intentionally empty.
     }
     
     /// @brief Use value for target.
-    PLAYRHO_CONSTEXPR inline TargetJointConf& UseTarget(Length2 v) noexcept;
+    constexpr inline TargetJointConf& UseTarget(Length2 v) noexcept;
 
     /// @brief Use value for max force.
-    PLAYRHO_CONSTEXPR inline TargetJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
+    constexpr inline TargetJointConf& UseMaxForce(NonNegative<Force> v) noexcept;
 
     /// @brief Use value for frequency.
-    PLAYRHO_CONSTEXPR inline TargetJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
+    constexpr inline TargetJointConf& UseFrequency(NonNegative<Frequency> v) noexcept;
 
     /// @brief Use value for damping ratio.
-    PLAYRHO_CONSTEXPR inline TargetJointConf& UseDampingRatio(NonNegative<Real> v) noexcept;
+    constexpr inline TargetJointConf& UseDampingRatio(NonNegative<Real> v) noexcept;
 
     /// The initial world target point. This is assumed
     /// to coincide with the body anchor initially.
@@ -80,25 +80,25 @@ struct TargetJointConf : public JointBuilder<TargetJointConf>
     NonNegative<Real> dampingRatio = NonNegative<Real>(0.7f);
 };
 
-PLAYRHO_CONSTEXPR inline TargetJointConf& TargetJointConf::UseTarget(Length2 v) noexcept
+constexpr inline TargetJointConf& TargetJointConf::UseTarget(Length2 v) noexcept
 {
     target = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline TargetJointConf& TargetJointConf::UseMaxForce(NonNegative<Force> v) noexcept
+constexpr inline TargetJointConf& TargetJointConf::UseMaxForce(NonNegative<Force> v) noexcept
 {
     maxForce = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline TargetJointConf& TargetJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
+constexpr inline TargetJointConf& TargetJointConf::UseFrequency(NonNegative<Frequency> v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline TargetJointConf& TargetJointConf::UseDampingRatio(NonNegative<Real> v) noexcept
+constexpr inline TargetJointConf& TargetJointConf::UseDampingRatio(NonNegative<Real> v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/WeldJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.hpp
@@ -43,7 +43,7 @@ struct WeldJointConf : public JointBuilder<WeldJointConf>
     /// @brief Super type.
     using super = JointBuilder<WeldJointConf>;
     
-    constexpr inline WeldJointConf() noexcept: super{JointType::Weld} {}
+    constexpr WeldJointConf() noexcept: super{JointType::Weld} {}
     
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, and reference angle using a world
@@ -54,10 +54,10 @@ struct WeldJointConf : public JointBuilder<WeldJointConf>
     WeldJointConf(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given frequency value.
-    constexpr inline WeldJointConf& UseFrequency(Frequency v) noexcept;
+    constexpr WeldJointConf& UseFrequency(Frequency v) noexcept;
     
     /// @brief Uses the given damping ratio.
-    constexpr inline WeldJointConf& UseDampingRatio(Real v) noexcept;
+    constexpr WeldJointConf& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -78,13 +78,13 @@ struct WeldJointConf : public JointBuilder<WeldJointConf>
     Real dampingRatio = 0;
 };
 
-constexpr inline WeldJointConf& WeldJointConf::UseFrequency(Frequency v) noexcept
+constexpr WeldJointConf& WeldJointConf::UseFrequency(Frequency v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr inline WeldJointConf& WeldJointConf::UseDampingRatio(Real v) noexcept
+constexpr WeldJointConf& WeldJointConf::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/WeldJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.hpp
@@ -43,7 +43,7 @@ struct WeldJointConf : public JointBuilder<WeldJointConf>
     /// @brief Super type.
     using super = JointBuilder<WeldJointConf>;
     
-    PLAYRHO_CONSTEXPR inline WeldJointConf() noexcept: super{JointType::Weld} {}
+    constexpr inline WeldJointConf() noexcept: super{JointType::Weld} {}
     
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, and reference angle using a world
@@ -54,10 +54,10 @@ struct WeldJointConf : public JointBuilder<WeldJointConf>
     WeldJointConf(NonNull<Body*> bodyA, NonNull<Body*> bodyB, const Length2 anchor) noexcept;
     
     /// @brief Uses the given frequency value.
-    PLAYRHO_CONSTEXPR inline WeldJointConf& UseFrequency(Frequency v) noexcept;
+    constexpr inline WeldJointConf& UseFrequency(Frequency v) noexcept;
     
     /// @brief Uses the given damping ratio.
-    PLAYRHO_CONSTEXPR inline WeldJointConf& UseDampingRatio(Real v) noexcept;
+    constexpr inline WeldJointConf& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -78,13 +78,13 @@ struct WeldJointConf : public JointBuilder<WeldJointConf>
     Real dampingRatio = 0;
 };
 
-PLAYRHO_CONSTEXPR inline WeldJointConf& WeldJointConf::UseFrequency(Frequency v) noexcept
+constexpr inline WeldJointConf& WeldJointConf::UseFrequency(Frequency v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline WeldJointConf& WeldJointConf::UseDampingRatio(Real v) noexcept
+constexpr inline WeldJointConf& WeldJointConf::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/WheelJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.hpp
@@ -43,7 +43,7 @@ struct WheelJointConf : public JointBuilder<WheelJointConf>
     /// @brief Super type.
     using super = JointBuilder<WheelJointConf>;
     
-    PLAYRHO_CONSTEXPR inline WheelJointConf() noexcept: super{JointType::Wheel} {}
+    constexpr inline WheelJointConf() noexcept: super{JointType::Wheel} {}
     
     /// Initialize the bodies, anchors, axis, and reference angle using the world
     /// anchor and world axis.
@@ -51,19 +51,19 @@ struct WheelJointConf : public JointBuilder<WheelJointConf>
                   const UnitVec axis) noexcept;
     
     /// @brief Uses the given enable motor state value.
-    PLAYRHO_CONSTEXPR inline WheelJointConf& UseEnableMotor(bool v) noexcept;
+    constexpr inline WheelJointConf& UseEnableMotor(bool v) noexcept;
     
     /// @brief Uses the given max motor toque value.
-    PLAYRHO_CONSTEXPR inline WheelJointConf& UseMaxMotorTorque(Torque v) noexcept;
+    constexpr inline WheelJointConf& UseMaxMotorTorque(Torque v) noexcept;
     
     /// @brief Uses the given motor speed value.
-    PLAYRHO_CONSTEXPR inline WheelJointConf& UseMotorSpeed(AngularVelocity v) noexcept;
+    constexpr inline WheelJointConf& UseMotorSpeed(AngularVelocity v) noexcept;
     
     /// @brief Uses the given frequency value.
-    PLAYRHO_CONSTEXPR inline WheelJointConf& UseFrequency(Frequency v) noexcept;
+    constexpr inline WheelJointConf& UseFrequency(Frequency v) noexcept;
     
     /// @brief Uses the given damping ratio value.
-    PLAYRHO_CONSTEXPR inline WheelJointConf& UseDampingRatio(Real v) noexcept;
+    constexpr inline WheelJointConf& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -90,31 +90,31 @@ struct WheelJointConf : public JointBuilder<WheelJointConf>
     Real dampingRatio = 0.7f;
 };
 
-PLAYRHO_CONSTEXPR inline WheelJointConf& WheelJointConf::UseEnableMotor(bool v) noexcept
+constexpr inline WheelJointConf& WheelJointConf::UseEnableMotor(bool v) noexcept
 {
     enableMotor = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline WheelJointConf& WheelJointConf::UseMaxMotorTorque(Torque v) noexcept
+constexpr inline WheelJointConf& WheelJointConf::UseMaxMotorTorque(Torque v) noexcept
 {
     maxMotorTorque = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline WheelJointConf& WheelJointConf::UseMotorSpeed(AngularVelocity v) noexcept
+constexpr inline WheelJointConf& WheelJointConf::UseMotorSpeed(AngularVelocity v) noexcept
 {
     motorSpeed = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline WheelJointConf& WheelJointConf::UseFrequency(Frequency v) noexcept
+constexpr inline WheelJointConf& WheelJointConf::UseFrequency(Frequency v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline WheelJointConf& WheelJointConf::UseDampingRatio(Real v) noexcept
+constexpr inline WheelJointConf& WheelJointConf::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/Joints/WheelJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.hpp
@@ -43,7 +43,7 @@ struct WheelJointConf : public JointBuilder<WheelJointConf>
     /// @brief Super type.
     using super = JointBuilder<WheelJointConf>;
     
-    constexpr inline WheelJointConf() noexcept: super{JointType::Wheel} {}
+    constexpr WheelJointConf() noexcept: super{JointType::Wheel} {}
     
     /// Initialize the bodies, anchors, axis, and reference angle using the world
     /// anchor and world axis.
@@ -51,19 +51,19 @@ struct WheelJointConf : public JointBuilder<WheelJointConf>
                   const UnitVec axis) noexcept;
     
     /// @brief Uses the given enable motor state value.
-    constexpr inline WheelJointConf& UseEnableMotor(bool v) noexcept;
+    constexpr WheelJointConf& UseEnableMotor(bool v) noexcept;
     
     /// @brief Uses the given max motor toque value.
-    constexpr inline WheelJointConf& UseMaxMotorTorque(Torque v) noexcept;
+    constexpr WheelJointConf& UseMaxMotorTorque(Torque v) noexcept;
     
     /// @brief Uses the given motor speed value.
-    constexpr inline WheelJointConf& UseMotorSpeed(AngularVelocity v) noexcept;
+    constexpr WheelJointConf& UseMotorSpeed(AngularVelocity v) noexcept;
     
     /// @brief Uses the given frequency value.
-    constexpr inline WheelJointConf& UseFrequency(Frequency v) noexcept;
+    constexpr WheelJointConf& UseFrequency(Frequency v) noexcept;
     
     /// @brief Uses the given damping ratio value.
-    constexpr inline WheelJointConf& UseDampingRatio(Real v) noexcept;
+    constexpr WheelJointConf& UseDampingRatio(Real v) noexcept;
     
     /// The local anchor point relative to body A's origin.
     Length2 localAnchorA = Length2{};
@@ -90,31 +90,31 @@ struct WheelJointConf : public JointBuilder<WheelJointConf>
     Real dampingRatio = 0.7f;
 };
 
-constexpr inline WheelJointConf& WheelJointConf::UseEnableMotor(bool v) noexcept
+constexpr WheelJointConf& WheelJointConf::UseEnableMotor(bool v) noexcept
 {
     enableMotor = v;
     return *this;
 }
 
-constexpr inline WheelJointConf& WheelJointConf::UseMaxMotorTorque(Torque v) noexcept
+constexpr WheelJointConf& WheelJointConf::UseMaxMotorTorque(Torque v) noexcept
 {
     maxMotorTorque = v;
     return *this;
 }
 
-constexpr inline WheelJointConf& WheelJointConf::UseMotorSpeed(AngularVelocity v) noexcept
+constexpr WheelJointConf& WheelJointConf::UseMotorSpeed(AngularVelocity v) noexcept
 {
     motorSpeed = v;
     return *this;
 }
 
-constexpr inline WheelJointConf& WheelJointConf::UseFrequency(Frequency v) noexcept
+constexpr WheelJointConf& WheelJointConf::UseFrequency(Frequency v) noexcept
 {
     frequency = v;
     return *this;
 }
 
-constexpr inline WheelJointConf& WheelJointConf::UseDampingRatio(Real v) noexcept
+constexpr WheelJointConf& WheelJointConf::UseDampingRatio(Real v) noexcept
 {
     dampingRatio = v;
     return *this;

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -47,7 +47,7 @@ public:
     using iteration_type = TimestepIters;
 
     /// @brief Invalid iteration value.
-    static PLAYRHO_CONSTEXPR const auto InvalidIteration = static_cast<iteration_type>(-1);
+    static constexpr const auto InvalidIteration = static_cast<iteration_type>(-1);
 
     /// @brief Gets the delta time (time amount for this time step).
     /// @sa SetTime(Real).
@@ -66,7 +66,7 @@ public:
     /// @sa GetTime().
     /// @sa GetInvTime().
     /// @param value Elapsed time amount.
-    PLAYRHO_CONSTEXPR inline StepConf& SetTime(Time value) noexcept
+    constexpr inline StepConf& SetTime(Time value) noexcept
     {
         time = value;
         invTime = (value != 0_s)? Real{1} / value: 0_Hz;
@@ -80,7 +80,7 @@ public:
     /// @sa GetTime().
     /// @sa GetInvTime().
     /// @param value Inverse time amount.
-    PLAYRHO_CONSTEXPR inline StepConf& SetInvTime(Frequency value) noexcept
+    constexpr inline StepConf& SetInvTime(Frequency value) noexcept
     {
         invTime = value;
         time = (value != 0_Hz)? Time{Real{1} / value}: 0_s;

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -66,7 +66,7 @@ public:
     /// @sa GetTime().
     /// @sa GetInvTime().
     /// @param value Elapsed time amount.
-    constexpr inline StepConf& SetTime(Time value) noexcept
+    constexpr StepConf& SetTime(Time value) noexcept
     {
         time = value;
         invTime = (value != 0_s)? Real{1} / value: 0_Hz;
@@ -80,7 +80,7 @@ public:
     /// @sa GetTime().
     /// @sa GetInvTime().
     /// @param value Inverse time amount.
-    constexpr inline StepConf& SetInvTime(Frequency value) noexcept
+    constexpr StepConf& SetInvTime(Frequency value) noexcept
     {
         invTime = value;
         time = (value != 0_Hz)? Time{Real{1} / value}: 0_s;

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -891,7 +891,7 @@ void World::AddToIsland(Island& island, Body& seed,
                   Contacts::size_type& remNumContacts,
                   Joints::size_type& remNumJoints)
 {
-    assert(!IsIslanded(&seed));
+    assert(!BodyAtty::IsIslanded(seed));
     assert(seed.IsSpeedable());
     assert(seed.IsAwake());
     assert(seed.IsEnabled());
@@ -1433,7 +1433,7 @@ IslandStats World::SolveToi(const StepConf& conf, Contact& contact)
     assert(!HasSensor(contact));
     assert(IsActive(contact));
     assert(IsImpenetrable(contact));
-    assert(!IsIslanded(&contact));
+    assert(!ContactAtty::IsIslanded(contact));
     
     const auto toi = contact.GetToi();
     const auto bA = contact.GetFixtureA()->GetBody();
@@ -1515,8 +1515,8 @@ IslandStats World::SolveToi(const StepConf& conf, Contact& contact)
     Island island(size(m_bodies), size(m_contacts), 0);
 
      // These asserts get triggered sometimes if contacts within TOI are iterated over.
-    assert(!IsIslanded(bA));
-    assert(!IsIslanded(bB));
+    assert(!BodyAtty::IsIslanded(*bA));
+    assert(!BodyAtty::IsIslanded(*bB));
     
     island.m_bodies.push_back(bA);
     BodyAtty::SetIslanded(*bA);
@@ -1705,7 +1705,7 @@ World::ProcessContactsOutput
 World::ProcessContactsForTOI(Island& island, Body& body, Real toi,
                              const StepConf& conf, ContactListener* contactListener)
 {
-    assert(IsIslanded(&body));
+    assert(BodyAtty::IsIslanded(body));
     assert(body.IsAccelerable());
     assert(toi >= 0 && toi <= 1);
 

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -2346,7 +2346,7 @@ void World::SetType(Body& body, playrho::BodyType type)
         body.SetAwake();
         const auto fixtures = body.GetFixtures();
         for_each(begin(fixtures), end(fixtures), [&](Body::Fixtures::value_type& f) {
-            InternalTouchProxies(GetRef(f));
+            InternalTouchProxies(m_proxies, GetRef(f));
         });
     }
 }
@@ -2504,15 +2504,13 @@ void World::DestroyProxies(ProxyQueue& proxies, DynamicTree& tree, Fixture& fixt
 void World::TouchProxies(Fixture& fixture) noexcept
 {
     assert(fixture.GetBody()->GetWorld() == this);
-    InternalTouchProxies(fixture);
+    InternalTouchProxies(m_proxies, fixture);
 }
 
-void World::InternalTouchProxies(Fixture& fixture) noexcept
+void World::InternalTouchProxies(ProxyQueue& proxies, Fixture& fixture) noexcept
 {
-    const auto proxyCount = fixture.GetProxyCount();
-    for (auto i = decltype(proxyCount){0}; i < proxyCount; ++i)
-    {
-        m_proxies.push_back(fixture.GetProxy(i).treeId);
+    for (const auto& proxy: fixture.GetProxies()) {
+        proxies.push_back(proxy.treeId);
     }
 }
 

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -1042,7 +1042,7 @@ RegStepStats World::SolveReg(const StepConf& conf)
     });
 
 #if defined(DO_THREADED)
-    std::vector<std::future<World::IslandSolverResults>> futures;
+    std::vector<std::future<IslandStats>> futures;
     futures.reserve(remNumBodies);
 #endif
     // Build and simulate all awake islands.

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -903,9 +903,8 @@ void World::AddToIsland(Island& island, Body& seed,
     // Create a stack for bodies to be is-in-island that aren't already in the island.
     auto stack = BodyStack{};
     stack.reserve(remNumBodies);
-
     stack.push_back(&seed);
-    SetIslanded(&seed);
+    BodyAtty::SetIslanded(seed);
     AddToIsland(island, stack, remNumBodies, remNumContacts, remNumJoints);
 }
 
@@ -959,7 +958,7 @@ void World::AddContactsToIsland(Island& island, BodyStack& stack, const Body* b)
     const auto contacts = b->GetContacts();
     for_each(cbegin(contacts), cend(contacts), [&](const KeyedContactPtr& ci) {
         const auto contact = GetContactPtr(ci);
-        if (!IsIslanded(contact) && contact->IsEnabled() && contact->IsTouching())
+        if (!ContactAtty::IsIslanded(*contact) && contact->IsEnabled() && contact->IsTouching())
         {
             const auto fA = contact->GetFixtureA();
             const auto fB = contact->GetFixtureB();
@@ -969,11 +968,11 @@ void World::AddContactsToIsland(Island& island, BodyStack& stack, const Body* b)
                 const auto bB = fB->GetBody();
                 const auto other = (bA != b)? bA: bB;
                 island.m_contacts.push_back(contact);
-                SetIslanded(contact);
-                if (!IsIslanded(other))
+                ContactAtty::SetIslanded(*contact);
+                if (!BodyAtty::IsIslanded(*other))
                 {
                     stack.push_back(other);
-                    SetIslanded(other);
+                    BodyAtty::SetIslanded(*other);
                 }
             }
         }
@@ -988,11 +987,12 @@ void World::AddJointsToIsland(Island& island, BodyStack& stack, const Body* b)
         const auto other = std::get<Body*>(ji);
         const auto joint = std::get<Joint*>(ji);
         assert(!other || other->IsEnabled() || !other->IsAwake());
-        if (!IsIslanded(joint) && (!other || other->IsEnabled()))
+        assert(joint);
+        if (!JointAtty::IsIslanded(*joint) && (!other || other->IsEnabled()))
         {
             island.m_joints.push_back(joint);
-            SetIslanded(joint);
-            if (other && !IsIslanded(other))
+            JointAtty::SetIslanded(*joint);
+            if (other && !BodyAtty::IsIslanded(*other))
             {
                 // Only now dereference ji's pointers.
                 const auto bodyA = joint->GetBodyA();
@@ -1000,7 +1000,7 @@ void World::AddJointsToIsland(Island& island, BodyStack& stack, const Body* b)
                 const auto rwOther = bodyA != b? bodyA: bodyB;
                 assert(rwOther == other);
                 stack.push_back(rwOther);
-                SetIslanded(rwOther);
+                BodyAtty::SetIslanded(*rwOther);
             }
         }
     });
@@ -1013,7 +1013,7 @@ World::Bodies::size_type World::RemoveUnspeedablesFromIslanded(const std::vector
         if (!body->IsSpeedable())
         {
             // Allow static bodies to participate in other islands.
-            UnsetIslanded(body);
+            BodyAtty::UnsetIslanded(*body);
             ++numRemoved;
         }
     });
@@ -1050,7 +1050,7 @@ RegStepStats World::SolveReg(const StepConf& conf)
     {
         auto& body = GetRef(b);
         assert(!body.IsAwake() || body.IsSpeedable());
-        if (!IsIslanded(&body) && body.IsAwake() && body.IsEnabled())
+        if (!BodyAtty::IsIslanded(body) && body.IsAwake() && body.IsEnabled())
         {
             ++stats.islandsFound;
 
@@ -1083,7 +1083,7 @@ RegStepStats World::SolveReg(const StepConf& conf)
     {
         auto& body = GetRef(b);
         // A non-static body that was in an island may have moved.
-        if (IsIslanded(&body) && body.IsSpeedable())
+        if (BodyAtty::IsIslanded(body) && body.IsSpeedable())
         {
             // Update fixtures (for broad-phase).
             stats.proxiesMoved += Synchronize(body, GetTransform0(body.GetSweep()), body.GetTransformation(),
@@ -1356,7 +1356,7 @@ ToiStepStats World::SolveToi(const StepConf& conf)
                                           static_cast<decltype(stats.maxSimulContacts)>(ncount));
         stats.contactsFound += ncount;
         auto islandsFound = 0u;
-        if (!IsIslanded(contact))
+        if (!ContactAtty::IsIslanded(*contact))
         {
             /*
              * Confirm that contact is as it's supposed to be according to contract of the
@@ -1386,9 +1386,9 @@ ToiStepStats World::SolveToi(const StepConf& conf)
         for (auto&& b: m_bodies)
         {
             auto& body = GetRef(b);
-            if (IsIslanded(&body))
+            if (BodyAtty::IsIslanded(body))
             {
-                UnsetIslanded(&body);
+                BodyAtty::UnsetIslanded(body);
                 if (body.IsAccelerable())
                 {
                     const auto xfm0 = GetTransform0(body.GetSweep());
@@ -1519,11 +1519,11 @@ IslandStats World::SolveToi(const StepConf& conf, Contact& contact)
     assert(!IsIslanded(bB));
     
     island.m_bodies.push_back(bA);
-    SetIslanded(bA);
+    BodyAtty::SetIslanded(*bA);
     island.m_bodies.push_back(bB);
-    SetIslanded(bB);
+    BodyAtty::SetIslanded(*bB);
     island.m_contacts.push_back(&contact);
-    SetIslanded(&contact);
+    ContactAtty::SetIslanded(contact);
 
     // Process the contacts of the two bodies, adding appropriate ones to the island,
     // adding appropriate other bodies of added contacts, and advancing those other
@@ -1696,7 +1696,7 @@ void World::ResetContactsForSolveTOI(Body& body) noexcept
     const auto contacts = body.GetContacts();
     for_each(cbegin(contacts), cend(contacts), [&](KeyedContactPtr ci) {
         const auto contact = GetContactPtr(ci);
-        UnsetIslanded(contact);
+        ContactAtty::UnsetIslanded(*contact);
         ContactAtty::UnsetToi(*contact);
     });
 }
@@ -1717,7 +1717,7 @@ World::ProcessContactsForTOI(Island& island, Body& body, Real toi,
 
     auto processContactFunc = [&](Contact* contact, Body* other)
     {
-        const auto otherIslanded = IsIslanded(other);
+        const auto otherIslanded = BodyAtty::IsIslanded(*other);
         {
             const auto backup = other->GetSweep();
             if (!otherIslanded /* && other->GetSweep().GetAlpha0() != toi */)
@@ -1745,7 +1745,7 @@ World::ProcessContactsForTOI(Island& island, Body& body, Real toi,
             }
         }
         island.m_contacts.push_back(contact);
-        SetIslanded(contact);
+        ContactAtty::SetIslanded(*contact);
         if (!otherIslanded)
         {
             if (other->IsSpeedable())
@@ -1753,7 +1753,7 @@ World::ProcessContactsForTOI(Island& island, Body& body, Real toi,
                 BodyAtty::SetAwakeFlag(*other);
             }
             island.m_bodies.push_back(other);
-            SetIslanded(other);
+            BodyAtty::SetIslanded(*other);
 #if 0
             if (other->IsAccelerable())
             {
@@ -1781,7 +1781,7 @@ World::ProcessContactsForTOI(Island& island, Body& body, Real toi,
     for (auto&& ci: body.GetContacts())
     {
         const auto contact = GetContactPtr(ci);
-        if (!IsIslanded(contact))
+        if (!ContactAtty::IsIslanded(*contact))
         {
             const auto fA = contact->GetFixtureA();
             const auto fB = contact->GetFixtureB();

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -771,33 +771,6 @@ private:
     /// @brief Synchronizes proxies of the bodies for proxies.
     PreStepStats::counter_type SynchronizeProxies(const StepConf& conf);
 
-    /// @brief Whether the given body is in an island.
-    bool IsIslanded(const Body* body) const noexcept;
-
-    /// @brief Whether the given contact is in an island.
-    bool IsIslanded(const Contact* contact) const noexcept;
-
-    /// @brief Whether the given joint is in an island.
-    bool IsIslanded(const Joint* joint) const noexcept;
-
-    /// @brief Sets the given body to the in an island state.
-    void SetIslanded(Body* body) noexcept;
-
-    /// @brief Sets the given contact to the in an island state.
-    void SetIslanded(Contact* contact) noexcept;
-
-    /// @brief Sets the given joint to the in an island state.
-    void SetIslanded(Joint* joint) noexcept;
-
-    /// @brief Unsets the given body's in island state.
-    void UnsetIslanded(Body* body) noexcept;
-
-    /// @brief Unsets the given contact's in island state.
-    void UnsetIslanded(Contact* contact) noexcept;
-    
-    /// @brief Unsets the given joint's in island state.
-    void UnsetIslanded(Joint* joint) noexcept;
-
     /******** Member variables. ********/
     
     DynamicTree m_tree; ///< Dynamic tree.
@@ -967,51 +940,6 @@ inline void World::SetDestructionListener(DestructionListener* listener) noexcep
 inline void World::SetContactListener(ContactListener* listener) noexcept
 {
     m_contactListener = listener;
-}
-
-inline bool World::IsIslanded(const Body* body) const noexcept
-{
-    return BodyAtty::IsIslanded(*body);
-}
-
-inline bool World::IsIslanded(const Contact* contact) const noexcept
-{
-    return ContactAtty::IsIslanded(*contact);
-}
-
-inline bool World::IsIslanded(const Joint* joint) const noexcept
-{
-    return JointAtty::IsIslanded(*joint);
-}
-
-inline void World::SetIslanded(Body* body) noexcept
-{
-    BodyAtty::SetIslanded(*body);
-}
-
-inline void World::SetIslanded(Contact* contact) noexcept
-{
-    ContactAtty::SetIslanded(*contact);
-}
-
-inline void World::SetIslanded(Joint* joint) noexcept
-{
-    JointAtty::SetIslanded(*joint);
-}
-
-inline void World::UnsetIslanded(Body* body) noexcept
-{
-    BodyAtty::UnsetIslanded(*body);
-}
-
-inline void World::UnsetIslanded(Contact* contact) noexcept
-{
-    ContactAtty::UnsetIslanded(*contact);
-}
-
-inline void World::UnsetIslanded(Joint* joint) noexcept
-{
-    JointAtty::UnsetIslanded(*joint);
 }
 
 // Free functions.

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -749,7 +749,7 @@ private:
 
     /// @brief Touches each proxy of the given fixture.
     /// @note This sets things up so that pairs may be created for potentially new contacts.
-    void InternalTouchProxies(Fixture& fixture) noexcept;
+    static void InternalTouchProxies(ProxyQueue& proxies, Fixture& fixture) noexcept;
     
     /// @brief Synchronizes the given body.
     /// @details This updates the broad phase dynamic tree data for all of the given

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -577,13 +577,13 @@ private:
     static void UpdateBody(Body& body, const Position& pos, const Velocity& vel);
 
     /// @brief Reset bodies for solve TOI.
-    void ResetBodiesForSolveTOI() noexcept;
+    static void ResetBodiesForSolveTOI(Bodies& bodies) noexcept;
 
     /// @brief Reset contacts for solve TOI.
-    void ResetContactsForSolveTOI() noexcept;
+    static void ResetContactsForSolveTOI(Contacts& contacts) noexcept;
     
     /// @brief Reset contacts for solve TOI.
-    void ResetContactsForSolveTOI(Body& body) noexcept;
+    static void ResetContactsForSolveTOI(Body& body) noexcept;
 
     /// @brief Process contacts output.
     struct ProcessContactsOutput
@@ -606,8 +606,8 @@ private:
     /// @param[in,out] body A dynamic/accelerable body.
     /// @param[in] toi Time of impact (TOI). Value between 0 and 1.
     /// @param[in] conf Step configuration data.
-    ProcessContactsOutput ProcessContactsForTOI(Island& island, Body& body, Real toi,
-                                                const StepConf& conf);
+    static ProcessContactsOutput ProcessContactsForTOI(Island& island, Body& body, Real toi,
+                                                       const StepConf& conf, ContactListener* contactListener);
 
     /// @brief Adds the given joint to this world.
     /// @note This also adds the joint to the bodies of the joint.
@@ -680,13 +680,13 @@ private:
     };
     
     /// @brief Updates the contact times of impact.
-    UpdateContactsData UpdateContactTOIs(const StepConf& conf);
+    static UpdateContactsData UpdateContactTOIs(Contacts& contacts, const StepConf& conf);
 
     /// @brief Gets the soonest contact.
     /// @details This finds the contact with the lowest (soonest) time of impact.
     /// @return Contact with the least time of impact and its time of impact, or null contact.
     ///  A non-null contact will be enabled, not have sensors, be active, and impenetrable.
-    ContactToiData GetSoonestContact() const noexcept;
+    static ContactToiData GetSoonestContact(const Contacts& contacts) noexcept;
 
     /// @brief Determines whether this world has new fixtures.
     bool HasNewFixtures() const noexcept;
@@ -754,19 +754,19 @@ private:
     /// @brief Synchronizes the given body.
     /// @details This updates the broad phase dynamic tree data for all of the given
     ///   body's fixtures.
-    ContactCounter Synchronize(Body& body,
-                               Transformation xfm1, Transformation xfm2,
+    ContactCounter Synchronize(const Body& body,
+                               const Transformation& xfm1, const Transformation& xfm2,
                                Real multiplier, Length extension);
 
     /// @brief Synchronizes the given fixture.
     /// @details This updates the broad phase dynamic tree data for all of the given
     ///   fixture shape's children.
-    ContactCounter Synchronize(Fixture& fixture,
-                               Transformation xfm1, Transformation xfm2,
+    ContactCounter Synchronize(const Fixture& fixture,
+                               const Transformation& xfm1, const Transformation& xfm2,
                                Length2 displacement, Length extension);
     
     /// @brief Creates and destroys proxies.
-    void CreateAndDestroyProxies(const StepConf& conf);
+    void CreateAndDestroyProxies(Length extension);
     
     /// @brief Synchronizes proxies of the bodies for proxies.
     PreStepStats::counter_type SynchronizeProxies(const StepConf& conf);

--- a/PlayRho/Dynamics/WorldConf.hpp
+++ b/PlayRho/Dynamics/WorldConf.hpp
@@ -34,13 +34,13 @@ namespace d2 {
 struct WorldConf
 {
     /// @brief Uses the given min vertex radius value.
-    constexpr inline WorldConf& UseMinVertexRadius(Positive<Length> value) noexcept;
+    constexpr WorldConf& UseMinVertexRadius(Positive<Length> value) noexcept;
     
     /// @brief Uses the given max vertex radius value.
-    constexpr inline WorldConf& UseMaxVertexRadius(Positive<Length> value) noexcept;
+    constexpr WorldConf& UseMaxVertexRadius(Positive<Length> value) noexcept;
     
     /// @brief Uses the given value as the initial dynamic tree size.
-    constexpr inline WorldConf& UseInitialTreeSize(ContactCounter value) noexcept;
+    constexpr WorldConf& UseInitialTreeSize(ContactCounter value) noexcept;
     
     /// @brief Minimum vertex radius.
     /// @details This is the minimum vertex radius that this world establishes which bodies
@@ -65,19 +65,19 @@ struct WorldConf
     ContactCounter initialTreeSize = 4096;
 };
 
-constexpr inline WorldConf& WorldConf::UseMinVertexRadius(Positive<Length> value) noexcept
+constexpr WorldConf& WorldConf::UseMinVertexRadius(Positive<Length> value) noexcept
 {
     minVertexRadius = value;
     return *this;
 }
 
-constexpr inline WorldConf& WorldConf::UseMaxVertexRadius(Positive<Length> value) noexcept
+constexpr WorldConf& WorldConf::UseMaxVertexRadius(Positive<Length> value) noexcept
 {
     maxVertexRadius = value;
     return *this;
 }
 
-constexpr inline WorldConf& WorldConf::UseInitialTreeSize(ContactCounter value) noexcept
+constexpr WorldConf& WorldConf::UseInitialTreeSize(ContactCounter value) noexcept
 {
     initialTreeSize = value;
     return *this;
@@ -89,7 +89,7 @@ constexpr inline WorldConf& WorldConf::UseInitialTreeSize(ContactCounter value) 
 ///     "cannot use defaulted constructor of '<code>Conf</code>' within '<code>World</code>'
 ///     outside of member functions because 'gravity' has an initializer"
 /// @relatedalso WorldConf
-constexpr inline WorldConf GetDefaultWorldConf() noexcept
+constexpr WorldConf GetDefaultWorldConf() noexcept
 {
     return WorldConf{};
 }

--- a/PlayRho/Dynamics/WorldConf.hpp
+++ b/PlayRho/Dynamics/WorldConf.hpp
@@ -34,13 +34,13 @@ namespace d2 {
 struct WorldConf
 {
     /// @brief Uses the given min vertex radius value.
-    PLAYRHO_CONSTEXPR inline WorldConf& UseMinVertexRadius(Positive<Length> value) noexcept;
+    constexpr inline WorldConf& UseMinVertexRadius(Positive<Length> value) noexcept;
     
     /// @brief Uses the given max vertex radius value.
-    PLAYRHO_CONSTEXPR inline WorldConf& UseMaxVertexRadius(Positive<Length> value) noexcept;
+    constexpr inline WorldConf& UseMaxVertexRadius(Positive<Length> value) noexcept;
     
     /// @brief Uses the given value as the initial dynamic tree size.
-    PLAYRHO_CONSTEXPR inline WorldConf& UseInitialTreeSize(ContactCounter value) noexcept;
+    constexpr inline WorldConf& UseInitialTreeSize(ContactCounter value) noexcept;
     
     /// @brief Minimum vertex radius.
     /// @details This is the minimum vertex radius that this world establishes which bodies
@@ -65,19 +65,19 @@ struct WorldConf
     ContactCounter initialTreeSize = 4096;
 };
 
-PLAYRHO_CONSTEXPR inline WorldConf& WorldConf::UseMinVertexRadius(Positive<Length> value) noexcept
+constexpr inline WorldConf& WorldConf::UseMinVertexRadius(Positive<Length> value) noexcept
 {
     minVertexRadius = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline WorldConf& WorldConf::UseMaxVertexRadius(Positive<Length> value) noexcept
+constexpr inline WorldConf& WorldConf::UseMaxVertexRadius(Positive<Length> value) noexcept
 {
     maxVertexRadius = value;
     return *this;
 }
 
-PLAYRHO_CONSTEXPR inline WorldConf& WorldConf::UseInitialTreeSize(ContactCounter value) noexcept
+constexpr inline WorldConf& WorldConf::UseInitialTreeSize(ContactCounter value) noexcept
 {
     initialTreeSize = value;
     return *this;
@@ -89,7 +89,7 @@ PLAYRHO_CONSTEXPR inline WorldConf& WorldConf::UseInitialTreeSize(ContactCounter
 ///     "cannot use defaulted constructor of '<code>Conf</code>' within '<code>World</code>'
 ///     outside of member functions because 'gravity' has an initializer"
 /// @relatedalso WorldConf
-PLAYRHO_CONSTEXPR inline WorldConf GetDefaultWorldConf() noexcept
+constexpr inline WorldConf GetDefaultWorldConf() noexcept
 {
     return WorldConf{};
 }

--- a/Testbed/Framework/Drawer.hpp
+++ b/Testbed/Framework/Drawer.hpp
@@ -31,7 +31,7 @@ struct Color
 {
     Color() = default;
     
-    constexpr inline Color(float ri, float gi, float bi, float ai = 1):
+    constexpr Color(float ri, float gi, float bi, float ai = 1):
         r(std::clamp(ri, 0.0f, 1.0f)),
         g(std::clamp(gi, 0.0f, 1.0f)),
         b(std::clamp(bi, 0.0f, 1.0f)),
@@ -40,7 +40,7 @@ struct Color
         // Intentionally empty.
     }
 
-    constexpr inline Color(Color copy, float new_a):
+    constexpr Color(Color copy, float new_a):
         Color{copy.r, copy.g, copy.b, new_a}
     {
         // Intentionally empty.

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -23,6 +23,7 @@
 #include <PlayRho/Dynamics/Joints/TypeJointVisitor.hpp>
 
 #if defined(__APPLE__)
+#define GL_SILENCE_DEPRECATION
 #include <OpenGL/gl3.h>
 #else
 #include <GL/glew.h>

--- a/UnitTests/ArrayList.cpp
+++ b/UnitTests/ArrayList.cpp
@@ -71,7 +71,7 @@ TEST(ArrayList, ArrayConstruction)
     }
     {
         constexpr const auto maxsize = std::size_t{10};
-        PLAYRHO_CONSTEXPR const auto list = std::array<int, maxsize>{{5, 4, 3}};
+        constexpr const auto list = std::array<int, maxsize>{{5, 4, 3}};
         EXPECT_EQ(list.size(), decltype(list.size()){maxsize});
         EXPECT_EQ(list.max_size(), maxsize);
         EXPECT_EQ(list[0], 5);
@@ -81,7 +81,7 @@ TEST(ArrayList, ArrayConstruction)
     {
         constexpr const auto maxsize = std::size_t{10};
         
-        // Note: list cannot be PLAYRHO_CONSTEXPR const.
+        // Note: list cannot be constexpr const.
         const auto list = ArrayList<int, maxsize>{1, 2, 3};
 
         EXPECT_EQ(list.size(), decltype(list.size()){3});
@@ -91,7 +91,7 @@ TEST(ArrayList, ArrayConstruction)
         EXPECT_EQ(list[2], 3);
     }
     {
-        PLAYRHO_CONSTEXPR const auto list = Vector<int, 3>{1, 2, 3};
+        constexpr const auto list = Vector<int, 3>{1, 2, 3};
         EXPECT_EQ(list.size(), decltype(list.size()){3});
         EXPECT_EQ(list[0], 1);
         EXPECT_EQ(list[1], 2);

--- a/UnitTests/BoundedValue.cpp
+++ b/UnitTests/BoundedValue.cpp
@@ -290,8 +290,8 @@ namespace playrho
 template <typename T>
 struct ValueCheckHelper<T, Fixed32>
 {
-    static PLAYRHO_CONSTEXPR inline bool has_one = true;
-    static PLAYRHO_CONSTEXPR inline T one() noexcept { return T(1); }
+    static constexpr inline bool has_one = true;
+    static constexpr inline T one() noexcept { return T(1); }
 };
 }
 

--- a/UnitTests/BoundedValue.cpp
+++ b/UnitTests/BoundedValue.cpp
@@ -290,8 +290,8 @@ namespace playrho
 template <typename T>
 struct ValueCheckHelper<T, Fixed32>
 {
-    static constexpr inline bool has_one = true;
-    static constexpr inline T one() noexcept { return T(1); }
+    static constexpr bool has_one = true;
+    static constexpr T one() noexcept { return T(1); }
 };
 }
 

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -27,7 +27,7 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-static PLAYRHO_CONSTEXPR const auto Baumgarte = Real{2} / Real{10};
+static constexpr const auto Baumgarte = Real{2} / Real{10};
 
 TEST(ContactSolver, SolvePosConstraintsForHorTouchingDoesntMove)
 {

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -662,7 +662,7 @@ struct Coords {
 #if 0
 TEST(Math, LengthFasterThanHypot)
 {
-    constexpr inline auto iterations = unsigned(5000000);
+    constexpr auto iterations = unsigned(5000000);
     
     std::chrono::duration<double> elapsed_secs_length;
     std::chrono::duration<double> elapsed_secs_hypot;

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -547,7 +547,7 @@ TEST(Math, NextPowerOfTwo)
         EXPECT_EQ(NextPowerOfTwo(val - 1u), val);
     }
 
-    PLAYRHO_CONSTEXPR const auto max = std::numeric_limits<std::uint32_t>::max() / 512;
+    constexpr const auto max = std::numeric_limits<std::uint32_t>::max() / 512;
     for (auto i = decltype(max){0}; i < max; ++i)
     {
         const auto next = std::pow(2, std::ceil(std::log(i + 1)/std::log(2)));

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1740,9 +1740,9 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
 
 TEST(World, HeavyOnLight)
 {
-    PLAYRHO_CONSTEXPR const auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
-    PLAYRHO_CONSTEXPR const auto LargerLinearSlop = playrho::Meter / playrho::Real(200);
-    PLAYRHO_CONSTEXPR const auto SmallerLinearSlop = playrho::Meter / playrho::Real(1000);
+    constexpr const auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
+    constexpr const auto LargerLinearSlop = playrho::Meter / playrho::Real(200);
+    constexpr const auto SmallerLinearSlop = playrho::Meter / playrho::Real(1000);
 
     const auto bd = BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity);
     const auto upperBodyConf = BodyConf(bd).UseLocation(Vec2(0.0f, 6.0f) * Meter);
@@ -2526,9 +2526,9 @@ TEST(World, CollidingDynamicBodies)
 
 TEST(World_Longer, TilesComesToRest)
 {
-    PLAYRHO_CONSTEXPR const auto LinearSlop = Meter / 1000;
-    PLAYRHO_CONSTEXPR const auto AngularSlop = (Pi * 2 * 1_rad) / 180;
-    PLAYRHO_CONSTEXPR const auto VertexRadius = LinearSlop * 2;
+    constexpr const auto LinearSlop = Meter / 1000;
+    constexpr const auto AngularSlop = (Pi * 2 * 1_rad) / 180;
+    constexpr const auto VertexRadius = LinearSlop * 2;
     auto conf = PolygonShapeConf{}.UseVertexRadius(VertexRadius);
     const auto world = std::make_unique<World>(WorldConf{}.UseMinVertexRadius(VertexRadius));
     
@@ -2752,9 +2752,9 @@ TEST(World_Longer, TilesComesToRest)
 
 TEST(World, SpeedingBulletBallWontTunnel)
 {
-    PLAYRHO_CONSTEXPR const auto LinearSlop = playrho::Meter / playrho::Real(1000);
-    PLAYRHO_CONSTEXPR const auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
-    PLAYRHO_CONSTEXPR const auto VertexRadius = playrho::Length{LinearSlop * playrho::Real(2)};
+    constexpr const auto LinearSlop = playrho::Meter / playrho::Real(1000);
+    constexpr const auto AngularSlop = (Pi * Real{2} * 1_rad) / Real{180};
+    constexpr const auto VertexRadius = playrho::Length{LinearSlop * playrho::Real(2)};
     
     World world{WorldConf{}.UseMinVertexRadius(VertexRadius)};
 


### PR DESCRIPTION
#### Description - What's this PR do?

- Reverts uses of `PLAYRHO_CONSTEXPR`.
- Removes extraneous `inline`.
- Shrinks the `World` class "surface area".

#### Impacts/Risks of These Changes?
- While theoretically unit test coverage % should stay the same, it might change due to less extraneous text.
- May speed up compile times with less macro processing happening.