### PR TITLE
Removes "user-data" from the design

### DIFF
--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -27,7 +27,6 @@
 #include <functional>
 #include <iterator>
 #include <limits>
-#include <typeinfo>
 #include <type_traits>
 #include <tuple>
 #include <utility>

--- a/PlayRho/Common/Version.cpp
+++ b/PlayRho/Common/Version.cpp
@@ -26,7 +26,6 @@
 #include <cstdio>
 #include <cstdarg>
 #include <cstdlib>
-#include <typeinfo>
 #include <sstream>
 
 namespace playrho {

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -91,7 +91,6 @@ Body::FlagsType Body::GetFlags(const BodyConf& bd) noexcept
 }
 
 Body::Body(const BodyConf& bd) noexcept:
-    m_userData{bd.userData},
     m_xf{::playrho::d2::GetTransformation(bd)},
     m_sweep{Position{bd.location, bd.angle}},
     m_flags{GetFlags(bd)},

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -299,12 +299,6 @@ public:
     ///   miss some collisions if you don't use <code>ContactListener</code>.
     SizedRange<Contacts::const_iterator> GetContacts() const noexcept;
 
-    /// @brief Gets the user data pointer that was provided in the body definition.
-    void* GetUserData() const noexcept;
-
-    /// @brief Sets the user data. Use this to store your application specific data.
-    void SetUserData(void* data) noexcept;
-
     /// @brief Gets whether the mass data for this body is "dirty".
     bool IsMassDataDirty() const noexcept;
 
@@ -516,8 +510,6 @@ private:
     mutable Fixtures m_fixtures; ///< Cache of associated fixtures (owned by world).
     mutable Contacts m_contacts; ///< Cache of associated contacts (owned by world).
     mutable Joints m_joints; ///< Cache of associated joints (owned by world).
-
-    void* m_userData = nullptr; ///< User data. 8-bytes.
 
     /// Transformation for body origin.
     /// @note Also availble from <code>GetTransform1(m_sweep)</code>.
@@ -806,16 +798,6 @@ inline SizedRange<Body::Joints::const_iterator> Body::GetJoints() const noexcept
 inline SizedRange<Body::Contacts::const_iterator> Body::GetContacts() const noexcept
 {
     return {begin(m_contacts), end(m_contacts), size(m_contacts)};
-}
-
-inline void Body::SetUserData(void* data) noexcept
-{
-    m_userData = data;
-}
-
-inline void* Body::GetUserData() const noexcept
-{
-    return m_userData;
 }
 
 inline LinearAcceleration2 Body::GetLinearAcceleration() const noexcept

--- a/PlayRho/Dynamics/BodyConf.cpp
+++ b/PlayRho/Dynamics/BodyConf.cpp
@@ -43,7 +43,6 @@ BodyConf GetBodyConf(const Body& body) noexcept
     def.fixedRotation = body.IsFixedRotation();
     def.bullet = body.IsAccelerable() && body.IsImpenetrable();
     def.enabled = body.IsEnabled();
-    def.userData = body.GetUserData();
     return def;
 }
 

--- a/PlayRho/Dynamics/BodyConf.hpp
+++ b/PlayRho/Dynamics/BodyConf.hpp
@@ -100,9 +100,6 @@ struct BodyConf
     /// @brief Use the given enabled state.
     constexpr BodyConf& UseEnabled(bool value) noexcept;
     
-    /// @brief Use the given user data.
-    constexpr BodyConf& UseUserData(void* value) noexcept;
-    
     // Public member variables...
     
     /// @brief Type of the body: static, kinematic, or dynamic.
@@ -163,9 +160,6 @@ struct BodyConf
     
     /// Does this body start out enabled?
     bool enabled = true;
-    
-    /// Use this to store application specific body data.
-    void* userData = nullptr;
 };
 
 constexpr BodyConf& BodyConf::UseType(BodyType t) noexcept
@@ -269,12 +263,6 @@ constexpr BodyConf& BodyConf::UseBullet(bool value) noexcept
 constexpr BodyConf& BodyConf::UseEnabled(bool value) noexcept
 {
     enabled = value;
-    return *this;
-}
-
-constexpr BodyConf& BodyConf::UseUserData(void* value) noexcept
-{
-    userData = value;
     return *this;
 }
 

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -77,7 +77,6 @@ public:
     ///    <code>AreaDensity</code> must be greater-than-or-equal-to zero.
     ///
     Fixture(BodyID body, const Shape& shape, const FixtureConf& def = GetDefaultFixtureConf()):
-        m_userData{def.userData},
         m_shape{shape},
         m_body{body},
         m_filter{def.filter},
@@ -110,14 +109,6 @@ public:
     /// @brief Sets the contact filtering data.
     void SetFilterData(Filter filter) noexcept;
 
-    /// Get the user data that was assigned in the fixture definition. Use this to
-    /// store your application specific data.
-    void* GetUserData() const noexcept;
-
-    /// @brief Sets the user data.
-    /// @note Use this to store your application specific data.
-    void SetUserData(void* data) noexcept;
-
     /// @brief Gets the density of this fixture.
     /// @return Non-negative density (in mass per area).
     AreaDensity GetDensity() const noexcept;
@@ -137,8 +128,6 @@ public:
 
 private:
     // Data ordered here for memory compaction.
-
-    void* m_userData = nullptr; ///< User data. 8-bytes.
 
     /// Shape (of fixture).
     /// @note Set on construction.
@@ -172,16 +161,6 @@ inline Filter Fixture::GetFilterData() const noexcept
 inline void Fixture::SetFilterData(Filter filter) noexcept
 {
     m_filter = filter;
-}
-
-inline void* Fixture::GetUserData() const noexcept
-{
-    return m_userData;
-}
-
-inline void Fixture::SetUserData(void* data) noexcept
-{
-    m_userData = data;
 }
 
 inline BodyID Fixture::GetBody() const noexcept

--- a/PlayRho/Dynamics/FixtureConf.cpp
+++ b/PlayRho/Dynamics/FixtureConf.cpp
@@ -27,7 +27,7 @@ namespace d2 {
 
 FixtureConf GetFixtureConf(const Fixture& fixture) noexcept
 {
-    return FixtureConf{fixture.GetUserData(), fixture.IsSensor(), fixture.GetFilterData()};
+    return FixtureConf{fixture.IsSensor(), fixture.GetFilterData()};
 }
 
 } // namespace d2

--- a/PlayRho/Dynamics/FixtureConf.hpp
+++ b/PlayRho/Dynamics/FixtureConf.hpp
@@ -39,18 +39,12 @@ class Fixture;
 ///
 struct FixtureConf
 {
-    /// @brief Uses the given user data.
-    constexpr FixtureConf& UseUserData(void* value) noexcept;
-
     /// @brief Uses the given sensor state value.
     constexpr FixtureConf& UseIsSensor(bool value) noexcept;
     
     /// @brief Uses the given filter value.
     constexpr FixtureConf& UseFilter(Filter value) noexcept;
-    
-    /// Use this to store application specific fixture data.
-    void* userData = nullptr;
-    
+
     /// A sensor shape collects contact information but never generates a collision
     /// response.
     bool isSensor = false;
@@ -58,12 +52,6 @@ struct FixtureConf
     /// Contact filtering data.
     Filter filter;
 };
-
-constexpr FixtureConf& FixtureConf::UseUserData(void* value) noexcept
-{
-    userData = value;
-    return *this;
-}
 
 constexpr FixtureConf& FixtureConf::UseIsSensor(bool value) noexcept
 {

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -61,12 +61,6 @@ bool GetCollideConnected(const Joint& object) noexcept;
 /// @return <code>true</code> if shift done, <code>false</code> otherwise.
 bool ShiftOrigin(Joint& object, Length2 value) noexcept;
 
-/// Gets the user data pointer.
-void* GetUserData(const Joint& object) noexcept;
-
-/// Sets the user data pointer.
-void SetUserData(Joint& object, void* data) noexcept;
-
 /// @brief Initializes velocity constraint data based on the given solver data.
 /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
 /// @see SolveVelocity.
@@ -176,16 +170,6 @@ public:
         return object.m_self? object.m_self->GetBodyB_(): InvalidBodyID;
     }
 
-    friend void* GetUserData(const Joint& object) noexcept
-    {
-        return object.m_self? object.m_self->GetUserData_(): nullptr;
-    }
-
-    friend void SetUserData(Joint& object, void* data) noexcept
-    {
-        if (object.m_self) object.m_self->SetUserData_(data);
-    }
-
     friend bool GetCollideConnected(const Joint& object) noexcept
     {
         return object.m_self? object.m_self->GetCollideConnected_(): false;
@@ -247,12 +231,6 @@ private:
 
         /// @brief Call to notify joint of a shift in the world origin.
         virtual bool ShiftOrigin_(Length2 value) noexcept = 0;
-
-        /// @brief Gets the user data for this joint.
-        virtual void* GetUserData_() const noexcept = 0;
-
-        /// @brief Sets the user data for this joint.
-        virtual void SetUserData_(void* value) noexcept = 0;
 
         /// @brief Initializes the velocities for this joint.
         virtual void InitVelocity_(BodyConstraintsMap& bodies,
@@ -321,18 +299,6 @@ private:
         bool ShiftOrigin_(Length2 value) noexcept override
         {
             return ShiftOrigin(data, value);
-        }
-
-        /// @copydoc Concept::GetUserData_
-        void* GetUserData_() const noexcept override
-        {
-            return GetUserData(data);
-        }
-
-        /// @copydoc Concept::SetUserData_
-        void SetUserData_(void* value) noexcept override
-        {
-            SetUserData(data, value);
         }
 
         /// @copydoc Concept::InitVelocity_

--- a/PlayRho/Dynamics/Joints/JointConf.cpp
+++ b/PlayRho/Dynamics/Joints/JointConf.cpp
@@ -40,7 +40,6 @@ static_assert(std::is_nothrow_destructible<JointConf>::value,
 
 void Set(JointConf& def, const Joint& joint) noexcept
 {
-    def.userData = GetUserData(joint);
     def.bodyA = GetBodyA(joint);
     def.bodyB = GetBodyB(joint);
     def.collideConnected = GetCollideConnected(joint);

--- a/PlayRho/Dynamics/Joints/JointConf.hpp
+++ b/PlayRho/Dynamics/Joints/JointConf.hpp
@@ -36,10 +36,6 @@ namespace d2 {
 ///   to be inherited from.
 struct JointConf
 {
-    /// @brief User data.
-    /// @details Use this to attach application specific data to your joints.
-    void* userData = nullptr;
-
     /// @brief 1st attached body.
     BodyID bodyA = InvalidBodyID;
     
@@ -50,16 +46,6 @@ struct JointConf
     /// @details Set this flag to true if the attached bodies should collide.
     bool collideConnected = false;
 };
-
-constexpr void* GetUserData(const JointConf& object) noexcept
-{
-    return object.userData;
-}
-
-constexpr void SetUserData(JointConf& object, void* value) noexcept
-{
-    object.userData = value;
-}
 
 /// @brief Gets the first body attached to this joint.
 constexpr BodyID GetBodyA(const JointConf& object) noexcept
@@ -93,13 +79,6 @@ struct JointBuilder : JointConf
 
     /// @brief Reference type.
     using reference = value_type&;
-
-    /// @brief Use value for user data setting.
-    constexpr reference UseUserData(void* v) noexcept
-    {
-        userData = v;
-        return static_cast<reference>(*this);
-    }
 
     /// @brief Use value for body A setting.
     constexpr reference UseBodyA(BodyID b) noexcept

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -173,16 +173,6 @@ SizedRange<World::Contacts::const_iterator> World::GetContacts(BodyID id) const
     return ::playrho::d2::GetContacts(*m_impl, id);
 }
 
-void* World::GetUserData(BodyID id) const
-{
-    return ::playrho::d2::GetUserData(*m_impl, id);
-}
-
-void World::SetUserData(BodyID id, void* value)
-{
-    return ::playrho::d2::SetUserData(*m_impl, id, value);
-}
-
 SizedRange<World::Contacts::const_iterator> World::GetContacts() const noexcept
 {
     return ::playrho::d2::GetContacts(*m_impl);
@@ -327,16 +317,6 @@ BodyConf World::GetBodyConf(BodyID id) const
 BodyID World::GetBody(FixtureID id) const
 {
     return ::playrho::d2::GetBody(*m_impl, id);
-}
-
-void* World::GetUserData(FixtureID id) const
-{
-    return ::playrho::d2::GetUserData(*m_impl, id);
-}
-
-void World::SetUserData(FixtureID id, void* value)
-{
-    return ::playrho::d2::SetUserData(*m_impl, id, value);
 }
 
 Shape World::GetShape(FixtureID id) const
@@ -507,16 +487,6 @@ void World::SetJoint(JointID id, const Joint& def)
 bool World::GetCollideConnected(JointID id) const
 {
     return ::playrho::d2::GetCollideConnected(*m_impl, id);
-}
-
-void* World::GetUserData(JointID id) const
-{
-    return ::playrho::d2::GetUserData(*m_impl, id);
-}
-
-void World::SetUserData(JointID id, void* value)
-{
-    return ::playrho::d2::SetUserData(*m_impl, id, value);
 }
 
 BodyID World::GetBodyA(JointID id) const

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -567,11 +567,6 @@ public:
     ///   miss some collisions if you don't use <code>ContactListener</code>.
     SizedRange<Contacts::const_iterator> GetContacts(BodyID id) const;
 
-    /// @brief Gets the user data associated with the identified body.
-    void* GetUserData(BodyID id) const;
-
-    void SetUserData(BodyID, void* value);
-
     /// @brief Gets the world joint range.
     /// @details Gets a range enumerating the joints currently existing within this world.
     ///   These are the joints that had been created from previous calls to the
@@ -627,12 +622,6 @@ public:
         }
         return *static_cast<std::add_pointer_t<std::add_const_t<T>>>(GetData(id));
     }
-
-    /// @brief Gets the user data associated with the identified joint.
-    void* GetUserData(JointID id) const;
-
-    /// @brief Sets the user data associated with the identified joint.
-    void SetUserData(JointID, void* value);
 
     BodyID GetBodyA(JointID id) const;
     BodyID GetBodyB(JointID id) const;
@@ -701,12 +690,6 @@ public:
 
     /// @brief Gets the identifier of the body associated with the specified fixture.
     BodyID GetBody(FixtureID id) const;
-
-    /// @brief Gets the user data associated with the identified fixture.
-    void* GetUserData(FixtureID id) const;
-
-    /// @brief Sets the user data associated with the identified fixture.
-    void SetUserData(FixtureID id, void* value);
 
     Shape GetShape(FixtureID id) const;
 

--- a/PlayRho/Dynamics/WorldBody.cpp
+++ b/PlayRho/Dynamics/WorldBody.cpp
@@ -366,16 +366,6 @@ GetContacts(const World& world, BodyID id)
     return world.GetContacts(id);
 }
 
-void* GetUserData(const World& world, BodyID id)
-{
-    return world.GetUserData(id);
-}
-
-void SetUserData(World& world, BodyID id, void* value)
-{
-    world.SetUserData(id, value);
-}
-
 bool ShouldCollide(const World& world, BodyID lhs, BodyID rhs)
 {
     // At least one body should be accelerable/dynamic.

--- a/PlayRho/Dynamics/WorldBody.hpp
+++ b/PlayRho/Dynamics/WorldBody.hpp
@@ -483,13 +483,6 @@ void SetSleepingAllowed(World& world, BodyID, bool value);
 SizedRange<std::vector<KeyedContactPtr>::const_iterator>
 GetContacts(const World& world, BodyID id);
 
-/// @brief Gets the user data associated with the identified body.
-/// @relatedalso World
-void* GetUserData(const World& world, BodyID id);
-
-/// @brief Sets the user data of the identified body.
-void SetUserData(World& world, BodyID id, void* value);
-
 /// @brief Gets the centripetal force necessary to put the body into an orbit having
 ///    the given radius.
 /// @relatedalso World

--- a/PlayRho/Dynamics/WorldFixture.cpp
+++ b/PlayRho/Dynamics/WorldFixture.cpp
@@ -58,16 +58,6 @@ BodyID GetBody(const World& world, FixtureID id)
     return world.GetBody(id);
 }
 
-void* GetUserData(const World& world, FixtureID id)
-{
-    return world.GetUserData(id);
-}
-
-void SetUserData(World& world, FixtureID id, void* value)
-{
-    return world.SetUserData(id, value);
-}
-
 Transformation GetTransformation(const World& world, FixtureID id)
 {
     return GetTransformation(world, GetBody(world, id));

--- a/PlayRho/Dynamics/WorldFixture.hpp
+++ b/PlayRho/Dynamics/WorldFixture.hpp
@@ -70,12 +70,6 @@ void Refilter(World& world, FixtureID id);
 /// @relatedalso World
 BodyID GetBody(const World& world, FixtureID id);
 
-/// @copydoc World::GetUserData(FixtureID)
-/// @relatedalso World
-void* GetUserData(const World& world, FixtureID id);
-
-void SetUserData(World& world, FixtureID id, void* value);
-
 /// @brief Gets the transformation associated with the given fixture.
 /// @warning Behavior is undefined if the fixture doesn't have an associated body - i.e.
 ///   behavior is undefined if the fixture has <code>nullptr</code> as its associated body.

--- a/PlayRho/Dynamics/WorldImplBody.cpp
+++ b/PlayRho/Dynamics/WorldImplBody.cpp
@@ -219,16 +219,6 @@ SizedRange<WorldImpl::Contacts::const_iterator> GetContacts(const WorldImpl& wor
     return world.GetBody(id).GetContacts();
 }
 
-void* GetUserData(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetUserData();
-}
-
-void SetUserData(WorldImpl& world, BodyID id, void* value)
-{
-    world.GetBody(id).SetUserData(value);
-}
-
 bool IsMassDataDirty(const WorldImpl& world, BodyID id)
 {
     return world.GetBody(id).IsMassDataDirty();

--- a/PlayRho/Dynamics/WorldImplBody.hpp
+++ b/PlayRho/Dynamics/WorldImplBody.hpp
@@ -294,13 +294,6 @@ bool IsAccelerable(const WorldImpl& world, BodyID id);
 SizedRange<std::vector<KeyedContactPtr>::const_iterator>
 GetContacts(const WorldImpl& world, BodyID id);
 
-/// @brief Gets the user data associated with the identified body.
-/// @relatedalso WorldImpl
-void* GetUserData(const WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-void SetUserData(WorldImpl& world, BodyID id, void* value);
-
 /// @brief Gets whether the body's mass-data is dirty.
 /// @relatedalso WorldImpl
 bool IsMassDataDirty(const WorldImpl& world, BodyID id);

--- a/PlayRho/Dynamics/WorldImplFixture.cpp
+++ b/PlayRho/Dynamics/WorldImplFixture.cpp
@@ -49,16 +49,6 @@ Transformation GetTransformation(const WorldImpl& world, FixtureID id)
     return GetTransformation(world, GetBody(world, id));
 }
 
-void* GetUserData(const WorldImpl& world, FixtureID id)
-{
-    return world.GetFixture(id).GetUserData();
-}
-
-void SetUserData(WorldImpl& world, FixtureID id, void* value)
-{
-    world.GetFixture(id).SetUserData(value);
-}
-
 Shape GetShape(const WorldImpl& world, FixtureID id)
 {
     return world.GetFixture(id).GetShape();

--- a/PlayRho/Dynamics/WorldImplFixture.hpp
+++ b/PlayRho/Dynamics/WorldImplFixture.hpp
@@ -54,12 +54,6 @@ bool Destroy(WorldImpl& world, FixtureID id, bool resetMassData);
 /// @relatedalso WorldImpl
 BodyID GetBody(const WorldImpl& world, FixtureID id);
 
-/// @brief Gets the user data associated with the identified fixture.
-/// @relatedalso WorldImpl
-void* GetUserData(const WorldImpl& world, FixtureID id);
-
-void SetUserData(WorldImpl& world, FixtureID id, void* value);
-
 /// @relatedalso WorldImpl
 Shape GetShape(const WorldImpl& world, FixtureID id);
 

--- a/PlayRho/Dynamics/WorldImplJoint.cpp
+++ b/PlayRho/Dynamics/WorldImplJoint.cpp
@@ -102,16 +102,6 @@ bool GetCollideConnected(const WorldImpl& world, JointID id)
     return GetCollideConnected(world.GetJoint(id));
 }
 
-void* GetUserData(const WorldImpl& world, JointID id)
-{
-    return GetUserData(world.GetJoint(id));
-}
-
-void SetUserData(WorldImpl& world, JointID id, void* value)
-{
-    SetUserData(world.GetJoint(id), value);
-}
-
 BodyID GetBodyA(const WorldImpl& world, JointID id)
 {
     return GetBodyA(world.GetJoint(id));

--- a/PlayRho/Dynamics/WorldImplJoint.hpp
+++ b/PlayRho/Dynamics/WorldImplJoint.hpp
@@ -70,17 +70,6 @@ void SetAwake(WorldImpl& world, JointID id);
 ///   the flag is only checked when fixture AABBs begin to overlap.
 bool GetCollideConnected(const WorldImpl& world, JointID id);
 
-/// @brief Gets the user data associated with the identified joint.
-/// @relatedalso WorldImpl
-void* GetUserData(const WorldImpl& world, JointID id);
-
-/// @relatedalso WorldImpl
-void SetUserData(WorldImpl& world, JointID id, void* value);
-
-/// @brief Sets the user data associated with the identified joint.
-/// @relatedalso WorldImpl
-void SetUserData(WorldImpl& world, JointID id, void* value);
-
 /// @relatedalso WorldImpl
 BodyID GetBodyA(const WorldImpl& world, JointID id);
 

--- a/PlayRho/Dynamics/WorldJoint.cpp
+++ b/PlayRho/Dynamics/WorldJoint.cpp
@@ -61,11 +61,6 @@ bool GetCollideConnected(const World& world, JointID id)
     return world.GetCollideConnected(id);
 }
 
-void* GetUserData(const World& world, JointID id)
-{
-    return world.GetUserData(id);
-}
-
 BodyID GetBodyA(const World& world, JointID id)
 {
     return world.GetBodyA(id);

--- a/PlayRho/Dynamics/WorldJoint.hpp
+++ b/PlayRho/Dynamics/WorldJoint.hpp
@@ -74,10 +74,6 @@ bool IsLimitEnabled(const World& world, JointID id);
 /// @relatedalso World
 void EnableLimit(World& world, JointID id, bool value);
 
-/// @copydoc World::GetUserData(JointID)
-/// @relatedalso World
-void* GetUserData(const World& world, JointID id);
-
 BodyID GetBodyA(const World& world, JointID id);
 
 BodyID GetBodyB(const World& world, JointID id);

--- a/Testbed/Tests/PolyShapes.hpp
+++ b/Testbed/Tests/PolyShapes.hpp
@@ -24,7 +24,6 @@
 
 #include <vector>
 #include <cstring>
-#include <typeinfo>
 
 /// This tests stacking. It also shows how to use World::Query
 /// and TestOverlap.

--- a/Testbed/Tests/Tumbler.hpp
+++ b/Testbed/Tests/Tumbler.hpp
@@ -22,6 +22,8 @@
 
 #include "../Framework/Test.hpp"
 
+#include <vector>
+
 namespace testbed {
 
 class Tumbler : public Test
@@ -65,15 +67,12 @@ public:
         });
         RegisterForKey(GLFW_KEY_C, GLFW_PRESS, 0, "Clear and re-emit shapes.", [&](KeyActionMods) {
             std::vector<BodyID> bodies;
-            for (const auto& b: m_world.GetBodies())
-            {
-                if (GetUserData(m_world, b) == reinterpret_cast<void*>(1))
-                {
+            for (const auto& b: m_world.GetBodies()) {
+                if ((b.get() < m_tumblee.size()) && m_tumblee[b.get()]) {
                     bodies.push_back(b);
                 }
             }
-            for (const auto& b: bodies)
-            {
+            for (const auto& b: bodies) {
                 Destroy(m_world, b);
             }
             m_count = 0;
@@ -128,8 +127,9 @@ public:
     void CreateTumblee(Length2 at)
     {
         const auto b = CreateBody(m_world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(at)
-                                          .UseLinearAcceleration(m_gravity)
-                                          .UseUserData(reinterpret_cast<void*>(1)));
+                                          .UseLinearAcceleration(m_gravity));
+        m_tumblee.resize(b.get() + 1u);
+        m_tumblee[b.get()] = true;
         CreateFixture(m_world, b, m_shape);
     }
 
@@ -152,6 +152,7 @@ public:
     const Shape m_disk = Shape{DiskShapeConf{}.UseRadius(0.125_m).UseFriction(0).UseDensity(0.1_kgpm2)};
     int m_count = 0;
     Shape m_shape = m_square;
+    std::vector<bool> m_tumblee;
 };
 
 } // namespace testbed

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -152,7 +152,7 @@ TEST(Body, ByteSize)
 #if !defined(NDEBUG)
             EXPECT_EQ(sizeof(Body), std::size_t(216));
 #else
-            EXPECT_EQ(sizeof(Body), std::size_t(184));
+            EXPECT_EQ(sizeof(Body), std::size_t(176));
 #endif
 #elif defined(_WIN32)
 #if !defined(NDEBUG)
@@ -160,14 +160,14 @@ TEST(Body, ByteSize)
             EXPECT_EQ(sizeof(Body), std::size_t(192));
 #else
             // Win32 release
-            EXPECT_EQ(sizeof(Body), std::size_t(140));
+            EXPECT_EQ(sizeof(Body), std::size_t(136));
 #endif
 #else
             EXPECT_EQ(sizeof(Body), std::size_t(176));
 #endif
             break;
         case  8:
-            EXPECT_EQ(sizeof(Body), std::size_t(280));
+            EXPECT_EQ(sizeof(Body), std::size_t(272));
             break;
         case 16:
             EXPECT_EQ(sizeof(Body), std::size_t(480));

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -163,7 +163,7 @@ TEST(Body, ByteSize)
             EXPECT_EQ(sizeof(Body), std::size_t(140));
 #endif
 #else
-            EXPECT_EQ(sizeof(Body), std::size_t(184));
+            EXPECT_EQ(sizeof(Body), std::size_t(176));
 #endif
             break;
         case  8:
@@ -183,7 +183,6 @@ TEST(Body, WorldCreated)
     const auto body = world.CreateBody();
     ASSERT_NE(body, InvalidBodyID);
 
-    EXPECT_EQ(GetUserData(world, body), nullptr);
     EXPECT_TRUE(IsEnabled(world, body));
     EXPECT_FALSE(IsAwake(world, body));
     EXPECT_FALSE(IsSpeedable(world, body));

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -22,7 +22,6 @@
 #include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <array>
-#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -22,7 +22,6 @@
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
 #include <PlayRho/Collision/AABB.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
-#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -42,7 +42,7 @@ TEST(DistanceJointConf, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(80));
 #else
-            EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(88));
+            EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(76));
 #endif
             break;
         case  8:
@@ -64,8 +64,7 @@ TEST(DistanceJointConf, DefaultConstruction)
     EXPECT_EQ(def.bodyA, InvalidBodyID);
     EXPECT_EQ(def.bodyB, InvalidBodyID);
     EXPECT_EQ(def.collideConnected, false);
-    EXPECT_EQ(def.userData, nullptr);
-    
+
     EXPECT_EQ(def.localAnchorA, (Length2{}));
     EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.length, 1_m);
@@ -113,7 +112,6 @@ TEST(DistanceJoint, Construction)
     EXPECT_EQ(GetBodyA(world, joint), def.bodyA);
     EXPECT_EQ(GetBodyB(world, joint), def.bodyB);
     EXPECT_EQ(GetCollideConnected(world, joint), def.collideConnected);
-    EXPECT_EQ(GetUserData(world, joint), def.userData);
     EXPECT_EQ(GetLinearReaction(world, joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(world, joint), AngularMomentum{0});
 
@@ -262,7 +260,6 @@ TEST(DistanceJointConf, GetDistanceJointDefFreeFunction)
     def.bodyA = bA;
     def.bodyB = bB;
     def.collideConnected = false;
-    def.userData = reinterpret_cast<void*>(71);
     def.localAnchorA = Length2(21_m, -2_m);
     def.localAnchorB = Length2(13_m, 12_m);
     def.length = 5_m;
@@ -274,7 +271,6 @@ TEST(DistanceJointConf, GetDistanceJointDefFreeFunction)
     
     EXPECT_EQ(def.bodyA, got.bodyA);
     EXPECT_EQ(def.bodyB, got.bodyB);
-    EXPECT_EQ(def.userData, got.userData);
     EXPECT_EQ(def.localAnchorA, got.localAnchorA);
     EXPECT_EQ(def.localAnchorB, got.localAnchorB);
     EXPECT_EQ(def.length, got.length);

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -40,13 +40,13 @@ TEST(DistanceJointConf, ByteSize)
         case  4:
             // why is there a difference between 32-bit Windows and others?
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(80));
+            EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(76));
 #else
             EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(76));
 #endif
             break;
         case  8:
-            EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(152));
+            EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(144));
             break;
         case 16:
             EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(288));

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -21,7 +21,6 @@
 #include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
-#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -41,7 +41,7 @@ TEST(Fixture, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(Fixture), std::size_t(36));
 #else
-            EXPECT_EQ(sizeof(Fixture), std::size_t(64));
+            EXPECT_EQ(sizeof(Fixture), std::size_t(56));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(Fixture), std::size_t(64)); break;
@@ -53,8 +53,6 @@ TEST(Fixture, ByteSize)
 TEST(Fixture, CreateMatchesConf)
 {
     const auto density = 2_kgpm2;
-    int variable;
-    const auto userData = &variable;
     const auto friction = Real(0.5);
     const auto restitution = Real(0.4);
     const auto isSensor = true;
@@ -62,7 +60,6 @@ TEST(Fixture, CreateMatchesConf)
     const auto shapeA = Shape(conf);
 
     auto def = FixtureConf{};
-    def.userData = userData;
     def.isSensor = isSensor;
 
     World world;
@@ -74,7 +71,6 @@ TEST(Fixture, CreateMatchesConf)
     EXPECT_EQ(GetDensity(world, fixture), density);
     EXPECT_EQ(GetFriction(world, fixture), friction);
     EXPECT_EQ(GetRestitution(world, fixture), restitution);
-    EXPECT_EQ(GetUserData(world, fixture), userData);
     EXPECT_EQ(IsSensor(world, fixture), isSensor);
     EXPECT_EQ(GetProxyCount(world, fixture), ChildCounter{0});
 }
@@ -123,14 +119,11 @@ TEST(Fixture, SetAwakeFreeFunction)
 TEST(Fixture, Proxies)
 {
     const auto density = 2_kgpm2;
-    auto variable = 0;
-    const auto userData = &variable;
     const auto friction = Real(0.5);
     const auto restitution = Real(0.4);
     const auto isSensor = true;
     
     auto def = FixtureConf{};
-    def.userData = userData;
     def.isSensor = isSensor;
     
     {
@@ -146,7 +139,6 @@ TEST(Fixture, Proxies)
         ASSERT_EQ(GetShape(world, fixture), shape);
         ASSERT_EQ(GetDensity(world, fixture), density);
         ASSERT_EQ(GetFriction(world, fixture), friction);
-        ASSERT_EQ(GetUserData(world, fixture), userData);
         ASSERT_EQ(GetRestitution(world, fixture), restitution);
         ASSERT_EQ(IsSensor(world, fixture), isSensor);
         ASSERT_EQ(GetProxyCount(world, fixture), ChildCounter{0});

--- a/UnitTests/Fixture.cpp
+++ b/UnitTests/Fixture.cpp
@@ -39,12 +39,12 @@ TEST(Fixture, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(Fixture), std::size_t(36));
+            EXPECT_EQ(sizeof(Fixture), std::size_t(32));
 #else
             EXPECT_EQ(sizeof(Fixture), std::size_t(56));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(Fixture), std::size_t(64)); break;
+        case  8: EXPECT_EQ(sizeof(Fixture), std::size_t(56)); break;
         case 16: EXPECT_EQ(sizeof(Fixture), std::size_t(64)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -42,7 +42,7 @@ TEST(FrictionJointConf, ByteSize)
 #elif defined(_WIN64)
             EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(88));
 #else
-            EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(88));
+            EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(80));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(160)); break;
@@ -58,8 +58,7 @@ TEST(FrictionJointConf, DefaultConstruction)
     EXPECT_EQ(def.bodyA, InvalidBodyID);
     EXPECT_EQ(def.bodyB, InvalidBodyID);
     EXPECT_EQ(def.collideConnected, false);
-    EXPECT_EQ(def.userData, nullptr);
-    
+
     EXPECT_EQ(def.localAnchorA, (Length2{}));
     EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.maxForce, 0_N);
@@ -94,7 +93,6 @@ TEST(FrictionJoint, Construction)
     EXPECT_EQ(GetBodyA(joint), def.bodyA);
     EXPECT_EQ(GetBodyB(joint), def.bodyB);
     EXPECT_EQ(GetCollideConnected(joint), def.collideConnected);
-    EXPECT_EQ(GetUserData(joint), def.userData);
     EXPECT_EQ(GetLinearReaction(joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(joint), AngularMomentum{0});
     
@@ -117,7 +115,6 @@ TEST(FrictionJoint, GetFrictionJointConf)
     ASSERT_EQ(GetBodyA(joint), def.bodyA);
     ASSERT_EQ(GetBodyB(joint), def.bodyB);
     ASSERT_EQ(GetCollideConnected(joint), def.collideConnected);
-    ASSERT_EQ(GetUserData(joint), def.userData);
 
     ASSERT_EQ(GetLocalAnchorA(joint), def.localAnchorA);
     ASSERT_EQ(GetLocalAnchorB(joint), def.localAnchorB);
@@ -128,7 +125,6 @@ TEST(FrictionJoint, GetFrictionJointConf)
     EXPECT_EQ(cdef.bodyA, b0);
     EXPECT_EQ(cdef.bodyB, b1);
     EXPECT_EQ(cdef.collideConnected, false);
-    EXPECT_EQ(cdef.userData, nullptr);
 
     EXPECT_EQ(cdef.localAnchorA, (Length2{}));
     EXPECT_EQ(cdef.localAnchorB, (Length2{}));

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -38,14 +38,14 @@ TEST(FrictionJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(84));
+            EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(80));
 #elif defined(_WIN64)
-            EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(88));
+            EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(80));
 #else
             EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(80));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(160)); break;
+        case  8: EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(152)); break;
         case 16: EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(304)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -49,7 +49,7 @@ TEST(GearJointConf, ByteSize)
             EXPECT_EQ(sizeof(GearJointConf), std::size_t(128));
 #endif
 #else
-            EXPECT_EQ(sizeof(GearJointConf), std::size_t(144));
+            EXPECT_EQ(sizeof(GearJointConf), std::size_t(136));
 #endif
             break;
         case  8:
@@ -106,7 +106,6 @@ TEST(GearJoint, Creation)
     EXPECT_EQ(GetBodyA(world, joint), def.bodyA);
     EXPECT_EQ(GetBodyB(world, joint), def.bodyB);
     EXPECT_EQ(GetCollideConnected(world, joint), def.collideConnected);
-    EXPECT_EQ(GetUserData(world, joint), def.userData);
     EXPECT_EQ(GetLinearReaction(world, joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(world, joint), AngularMomentum{0});
     
@@ -174,7 +173,6 @@ TEST(GearJoint, GetGearJointConf)
     ASSERT_EQ(GetBodyA(world, joint), def.bodyA);
     ASSERT_EQ(GetBodyB(world, joint), def.bodyB);
     ASSERT_EQ(GetCollideConnected(world, joint), def.collideConnected);
-    ASSERT_EQ(GetUserData(world, joint), def.userData);
     
     ASSERT_EQ(GetLocalAnchorA(world, joint), GetLocalAnchorB(world, revJoint1));
     ASSERT_EQ(GetLocalAnchorB(world, joint), GetLocalAnchorB(world, revJoint2));
@@ -187,7 +185,6 @@ TEST(GearJoint, GetGearJointConf)
     EXPECT_EQ(cdef.bodyA, def.bodyA);
     EXPECT_EQ(cdef.bodyB, def.bodyB);
     EXPECT_EQ(cdef.collideConnected, false);
-    EXPECT_EQ(cdef.userData, nullptr);
     
     EXPECT_EQ(cdef.type1, GetType(rdef1));
     EXPECT_EQ(cdef.type2, GetType(rdef2));

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -44,7 +44,7 @@ TEST(GearJointConf, ByteSize)
         case  4:
 #if defined(_WIN32)
 #if defined(_WIN64)
-            EXPECT_EQ(sizeof(GearJointConf), std::size_t(144));
+            EXPECT_EQ(sizeof(GearJointConf), std::size_t(136));
 #else
             EXPECT_EQ(sizeof(GearJointConf), std::size_t(124));
 #endif

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -46,14 +46,14 @@ TEST(GearJointConf, ByteSize)
 #if defined(_WIN64)
             EXPECT_EQ(sizeof(GearJointConf), std::size_t(144));
 #else
-            EXPECT_EQ(sizeof(GearJointConf), std::size_t(128));
+            EXPECT_EQ(sizeof(GearJointConf), std::size_t(124));
 #endif
 #else
             EXPECT_EQ(sizeof(GearJointConf), std::size_t(136));
 #endif
             break;
         case  8:
-            EXPECT_EQ(sizeof(GearJointConf), std::size_t(248));
+            EXPECT_EQ(sizeof(GearJointConf), std::size_t(240));
             break;
         case 16:
             EXPECT_EQ(sizeof(GearJointConf), std::size_t(464));

--- a/UnitTests/Joint.cpp
+++ b/UnitTests/Joint.cpp
@@ -36,7 +36,6 @@ TEST(JointBuilder, Construction)
     EXPECT_EQ(JointBuilder<JointConf>{}.bodyA, InvalidBodyID);
     EXPECT_EQ(JointBuilder<JointConf>{}.bodyB, InvalidBodyID);
     EXPECT_EQ(JointBuilder<JointConf>{}.collideConnected, false);
-    EXPECT_EQ(JointBuilder<JointConf>{}.userData, nullptr);
 }
 
 TEST(JointBuilder, UseBodyA)
@@ -59,13 +58,6 @@ TEST(JointBuilder, UseCollideConnected)
     EXPECT_NE(JointBuilder<JointConf>{}.collideConnected, value);
     EXPECT_EQ(JointBuilder<JointConf>{}.UseCollideConnected(value).collideConnected,
               value);
-}
-
-TEST(JointBuilder, UseUserData)
-{
-    const auto d = reinterpret_cast<void*>(318);
-    EXPECT_NE(JointBuilder<JointConf>{}.userData, d);
-    EXPECT_EQ(JointBuilder<JointConf>{}.UseUserData(d).userData, d);
 }
 
 TEST(Joint, ByteSize)

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -39,14 +39,14 @@ TEST(MotorJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN64)
-            EXPECT_EQ(sizeof(MotorJointConf), std::size_t(104));
+            EXPECT_EQ(sizeof(MotorJointConf), std::size_t(92));
 #elif defined(_WIN32)
-            EXPECT_EQ(sizeof(MotorJointConf), std::size_t(96));
+            EXPECT_EQ(sizeof(MotorJointConf), std::size_t(92));
 #else
             EXPECT_EQ(sizeof(MotorJointConf), std::size_t(92));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(MotorJointConf), std::size_t(184)); break;
+        case  8: EXPECT_EQ(sizeof(MotorJointConf), std::size_t(176)); break;
         case 16: EXPECT_EQ(sizeof(MotorJointConf), std::size_t(352)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -43,7 +43,7 @@ TEST(MotorJointConf, ByteSize)
 #elif defined(_WIN32)
             EXPECT_EQ(sizeof(MotorJointConf), std::size_t(96));
 #else
-            EXPECT_EQ(sizeof(MotorJointConf), std::size_t(104));
+            EXPECT_EQ(sizeof(MotorJointConf), std::size_t(92));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(MotorJointConf), std::size_t(184)); break;
@@ -59,8 +59,7 @@ TEST(MotorJointConf, DefaultConstruction)
     EXPECT_EQ(def.bodyA, InvalidBodyID);
     EXPECT_EQ(def.bodyB, InvalidBodyID);
     EXPECT_EQ(def.collideConnected, false);
-    EXPECT_EQ(def.userData, nullptr);
-    
+
     EXPECT_EQ(def.linearOffset, (Length2{}));
     EXPECT_EQ(def.angularOffset, 0_deg);
     EXPECT_EQ(def.maxForce, 1_N);
@@ -73,23 +72,20 @@ TEST(MotorJointConf, BuilderConstruction)
     const auto bodyA = static_cast<BodyID>(0x1);
     const auto bodyB = static_cast<BodyID>(0x2);
     const auto collideConnected = true;
-    int tmp;
-    const auto userData = &tmp;
     const auto linearOffset = Length2{2_m, 3_m};
     const auto angularOffset = 33_rad;
     const auto maxForce = 22_N;
     const auto maxTorque = 31_Nm;
     const auto correctionFactor = Real(0.44f);
     const auto def = MotorJointConf{}
-        .UseBodyA(bodyA).UseBodyB(bodyB).UseCollideConnected(collideConnected).UseUserData(userData)
+        .UseBodyA(bodyA).UseBodyB(bodyB).UseCollideConnected(collideConnected)
         .UseLinearOffset(linearOffset).UseAngularOffset(angularOffset)
         .UseMaxForce(maxForce).UseMaxTorque(maxTorque).UseCorrectionFactor(correctionFactor);
     
     EXPECT_EQ(def.bodyA, bodyA);
     EXPECT_EQ(def.bodyB, bodyB);
     EXPECT_EQ(def.collideConnected, collideConnected);
-    EXPECT_EQ(def.userData, userData);
-    
+
     EXPECT_EQ(def.linearOffset, linearOffset);
     EXPECT_EQ(def.angularOffset, angularOffset);
     EXPECT_EQ(def.maxForce, maxForce);
@@ -110,7 +106,6 @@ TEST(MotorJoint, Construction)
     EXPECT_EQ(GetBodyA(world, jointID), def.bodyA);
     EXPECT_EQ(GetBodyB(world, jointID), def.bodyB);
     EXPECT_EQ(GetCollideConnected(world, jointID), def.collideConnected);
-    EXPECT_EQ(GetUserData(world, jointID), def.userData);
     EXPECT_EQ(GetLinearReaction(world, jointID), Momentum2{});
     EXPECT_EQ(GetAngularReaction(world, jointID), AngularMomentum{0});
 
@@ -169,7 +164,6 @@ TEST(MotorJoint, GetMotorJointConf)
     ASSERT_EQ(GetBodyA(world, jointID), def.bodyA);
     ASSERT_EQ(GetBodyB(world, jointID), def.bodyB);
     ASSERT_EQ(GetCollideConnected(world, jointID), def.collideConnected);
-    ASSERT_EQ(GetUserData(world, jointID), def.userData);
     
     ASSERT_EQ(GetLinearOffset(world, jointID), def.linearOffset);
     ASSERT_EQ(GetAngularOffset(world, jointID), def.angularOffset);
@@ -182,7 +176,6 @@ TEST(MotorJoint, GetMotorJointConf)
     EXPECT_EQ(cdef.bodyA, b0);
     EXPECT_EQ(cdef.bodyB, b1);
     EXPECT_EQ(cdef.collideConnected, false);
-    EXPECT_EQ(cdef.userData, nullptr);
     
     EXPECT_EQ(cdef.linearOffset, (Length2{}));
     EXPECT_EQ(cdef.angularOffset, 0_deg);

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -23,7 +23,6 @@
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 #include <array>
-#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -21,7 +21,6 @@
 #include "UnitTests.hpp"
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
-#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -40,7 +40,7 @@ TEST(PrismaticJointConf, ByteSize)
 #elif defined(_WIN32)
             EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(164));
 #else
-            EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(168));
+            EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(160));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(320)); break;

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -36,14 +36,14 @@ TEST(PrismaticJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN64)
-            EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(168));
+            EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(160));
 #elif defined(_WIN32)
-            EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(164));
+            EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(160));
 #else
             EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(160));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(320)); break;
+        case  8: EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(312)); break;
         case 16: EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(624)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -42,7 +42,6 @@ TEST(PulleyJointConf, DefaultConstruction)
     EXPECT_EQ(def.bodyA, InvalidBodyID);
     EXPECT_EQ(def.bodyB, InvalidBodyID);
     EXPECT_EQ(def.collideConnected, true);
-    EXPECT_EQ(def.userData, nullptr);
     
     EXPECT_EQ(def.groundAnchorA, PulleyJointConf::DefaultGroundAnchorA);
     EXPECT_EQ(def.groundAnchorB, PulleyJointConf::DefaultGroundAnchorB);
@@ -141,7 +140,7 @@ TEST(PulleyJointConf, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(100));
 #else
-            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(104));
+            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(96));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(192)); break;
@@ -159,7 +158,6 @@ TEST(PulleyJoint, Construction)
     EXPECT_EQ(GetBodyA(joint), def.bodyA);
     EXPECT_EQ(GetBodyB(joint), def.bodyB);
     EXPECT_EQ(GetCollideConnected(joint), def.collideConnected);
-    EXPECT_EQ(GetUserData(joint), def.userData);
     EXPECT_EQ(GetLinearReaction(joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(joint), AngularMomentum{0});
 

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -138,12 +138,12 @@ TEST(PulleyJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(100));
+            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(96));
 #else
             EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(96));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(192)); break;
+        case  8: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(184)); break;
         case 16: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(368)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -43,12 +43,12 @@ TEST(RevoluteJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(132));
+            EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(128));
 #else
             EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(128));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(256)); break;
+        case  8: EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(248)); break;
         case 16: EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(496)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -45,7 +45,7 @@ TEST(RevoluteJointConf, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(132));
 #else
-            EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(136));
+            EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(128));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(256)); break;
@@ -65,7 +65,6 @@ TEST(RevoluteJoint, Construction)
     jd.bodyA = b0;
     jd.bodyB = b1;
     jd.collideConnected = true;
-    jd.userData = reinterpret_cast<void*>(0x011);
 
     jd.localAnchorA = Length2(4_m, 5_m);
     jd.localAnchorB = Length2(6_m, 7_m);
@@ -83,7 +82,6 @@ TEST(RevoluteJoint, Construction)
     EXPECT_EQ(GetBodyA(joint), jd.bodyA);
     EXPECT_EQ(GetBodyB(joint), jd.bodyB);
     EXPECT_EQ(GetCollideConnected(joint), jd.collideConnected);
-    EXPECT_EQ(GetUserData(joint), jd.userData);
     EXPECT_EQ(GetLinearReaction(joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(joint), AngularMomentum{0});
     EXPECT_EQ(GetLimitState(joint), LimitState::e_inactiveLimit);

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -41,7 +41,7 @@ TEST(RopeJointConf, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(RopeJointConf), std::size_t(72));
 #else
-            EXPECT_EQ(sizeof(RopeJointConf), std::size_t(80));
+            EXPECT_EQ(sizeof(RopeJointConf), std::size_t(68));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(RopeJointConf), std::size_t(136)); break;
@@ -57,7 +57,6 @@ TEST(RopeJointConf, DefaultConstruction)
     EXPECT_EQ(def.bodyA, InvalidBodyID);
     EXPECT_EQ(def.bodyB, InvalidBodyID);
     EXPECT_EQ(def.collideConnected, false);
-    EXPECT_EQ(def.userData, nullptr);
 
     EXPECT_EQ(def.localAnchorA, Length2(-1_m, 0_m));
     EXPECT_EQ(def.localAnchorB, Length2(+1_m, 0_m));
@@ -77,7 +76,6 @@ TEST(RopeJoint, Construction)
     EXPECT_EQ(GetBodyA(joint), def.bodyA);
     EXPECT_EQ(GetBodyB(joint), def.bodyB);
     EXPECT_EQ(GetCollideConnected(joint), def.collideConnected);
-    EXPECT_EQ(GetUserData(joint), def.userData);
     EXPECT_EQ(GetLinearReaction(joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(joint), AngularMomentum{0});
 
@@ -107,7 +105,6 @@ TEST(RopeJoint, GetRopeJointConf)
     ASSERT_EQ(GetBodyA(joint), def.bodyA);
     ASSERT_EQ(GetBodyB(joint), def.bodyB);
     ASSERT_EQ(GetCollideConnected(joint), def.collideConnected);
-    ASSERT_EQ(GetUserData(joint), def.userData);
     
     ASSERT_EQ(GetLocalAnchorA(joint), def.localAnchorA);
     ASSERT_EQ(GetLocalAnchorB(joint), def.localAnchorB);
@@ -118,7 +115,6 @@ TEST(RopeJoint, GetRopeJointConf)
     EXPECT_EQ(cdef.bodyA, bodyA);
     EXPECT_EQ(cdef.bodyB, bodyB);
     EXPECT_EQ(cdef.collideConnected, false);
-    EXPECT_EQ(cdef.userData, nullptr);
     
     EXPECT_EQ(cdef.localAnchorA, localAnchorA);
     EXPECT_EQ(cdef.localAnchorB, localAnchorB);

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -39,12 +39,12 @@ TEST(RopeJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(RopeJointConf), std::size_t(72));
+            EXPECT_EQ(sizeof(RopeJointConf), std::size_t(68));
 #else
             EXPECT_EQ(sizeof(RopeJointConf), std::size_t(68));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(RopeJointConf), std::size_t(136)); break;
+        case  8: EXPECT_EQ(sizeof(RopeJointConf), std::size_t(128)); break;
         case 16: EXPECT_EQ(sizeof(RopeJointConf), std::size_t(256)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -26,7 +26,6 @@
 #include <PlayRho/Collision/Distance.hpp>
 #include <PlayRho/Collision/Manifold.hpp>
 #include <chrono>
-#include <typeinfo>
 
 using namespace playrho;
 using namespace playrho::d2;

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -68,7 +68,7 @@ TEST(TargetJointConf, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(TargetJointConf), std::size_t(84));
 #else
-            EXPECT_EQ(sizeof(TargetJointConf), std::size_t(88));
+            EXPECT_EQ(sizeof(TargetJointConf), std::size_t(80));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(TargetJointConf), std::size_t(160)); break;
@@ -106,7 +106,6 @@ TEST(TargetJoint, DefaultInitialized)
     //EXPECT_FALSE(IsValid(joint.GetAnchorB()));
     EXPECT_EQ(GetLinearReaction(joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(joint), AngularMomentum{0});
-    EXPECT_EQ(GetUserData(joint), nullptr);
     EXPECT_FALSE(GetCollideConnected(joint));
     //EXPECT_FALSE(IsValid(GetLocalAnchorB(joint)));
     EXPECT_EQ(GetMaxForce(joint), def.maxForce);
@@ -125,7 +124,6 @@ TEST(TargetJoint, GetLocalAnchorB)
     auto def = TargetJointConf{};
     def.bodyA = bA;
     def.bodyB = bB;
-    def.userData = reinterpret_cast<void*>(71);
     def.localAnchorB = Length2(-1.4_m, -2_m);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
@@ -146,7 +144,6 @@ TEST(TargetJoint, GetAnchorB)
     auto def = TargetJointConf{};
     def.bodyA = bA;
     def.bodyB = bB;
-    def.userData = reinterpret_cast<void*>(71);
     def.localAnchorB = Length2(-1.4_m, -2_m);
     def.maxForce = 3_N;
     def.frequency = 67_Hz;
@@ -186,7 +183,6 @@ TEST(TargetJointConf, GetTargetJointDefFreeFunction)
     auto def = TargetJointConf{};
     def.bodyA = bA;
     def.bodyB = bB;
-    def.userData = reinterpret_cast<void*>(71);
     def.target = Length2(-1.4_m, -2_m);
     def.localAnchorB = Length2(+2.0_m, -1_m);
     def.maxForce = 3_N;
@@ -198,7 +194,6 @@ TEST(TargetJointConf, GetTargetJointDefFreeFunction)
 
     EXPECT_EQ(def.bodyA, got.bodyA);
     EXPECT_EQ(def.bodyB, got.bodyB);
-    EXPECT_EQ(def.userData, got.userData);
     EXPECT_EQ(def.target, got.target);
     EXPECT_EQ(def.localAnchorB, got.localAnchorB);
     EXPECT_EQ(def.maxForce, got.maxForce);

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -66,12 +66,12 @@ TEST(TargetJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(TargetJointConf), std::size_t(84));
+            EXPECT_EQ(sizeof(TargetJointConf), std::size_t(80));
 #else
             EXPECT_EQ(sizeof(TargetJointConf), std::size_t(80));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(TargetJointConf), std::size_t(160)); break;
+        case  8: EXPECT_EQ(sizeof(TargetJointConf), std::size_t(152)); break;
         case 16: EXPECT_EQ(sizeof(TargetJointConf), std::size_t(304)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -47,12 +47,12 @@ TEST(WeldJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(WeldJointConf), std::size_t(112));
+            EXPECT_EQ(sizeof(WeldJointConf), std::size_t(108));
 #else
             EXPECT_EQ(sizeof(WeldJointConf), std::size_t(108));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(WeldJointConf), std::size_t(216)); break;
+        case  8: EXPECT_EQ(sizeof(WeldJointConf), std::size_t(208)); break;
         case 16: EXPECT_EQ(sizeof(WeldJointConf), std::size_t(416)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -49,7 +49,7 @@ TEST(WeldJointConf, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(WeldJointConf), std::size_t(112));
 #else
-            EXPECT_EQ(sizeof(WeldJointConf), std::size_t(120));
+            EXPECT_EQ(sizeof(WeldJointConf), std::size_t(108));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(WeldJointConf), std::size_t(216)); break;
@@ -65,8 +65,7 @@ TEST(WeldJointConf, DefaultConstruction)
     EXPECT_EQ(def.bodyA, InvalidBodyID);
     EXPECT_EQ(def.bodyB, InvalidBodyID);
     EXPECT_EQ(def.collideConnected, false);
-    EXPECT_EQ(def.userData, nullptr);
-    
+
     EXPECT_EQ(def.localAnchorA, (Length2{}));
     EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.referenceAngle, 0_deg);
@@ -83,7 +82,6 @@ TEST(WeldJoint, Construction)
     EXPECT_EQ(GetBodyA(joint), def.bodyA);
     EXPECT_EQ(GetBodyB(joint), def.bodyB);
     EXPECT_EQ(GetCollideConnected(joint), def.collideConnected);
-    EXPECT_EQ(GetUserData(joint), def.userData);
     EXPECT_EQ(GetLinearReaction(joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(joint), AngularMomentum{0});
 
@@ -107,7 +105,6 @@ TEST(WeldJoint, GetWeldJointConf)
     ASSERT_EQ(GetBodyA(joint), def.bodyA);
     ASSERT_EQ(GetBodyB(joint), def.bodyB);
     ASSERT_EQ(GetCollideConnected(joint), def.collideConnected);
-    ASSERT_EQ(GetUserData(joint), def.userData);
     
     ASSERT_EQ(GetLocalAnchorA(joint), def.localAnchorA);
     ASSERT_EQ(GetLocalAnchorB(joint), def.localAnchorB);
@@ -119,7 +116,6 @@ TEST(WeldJoint, GetWeldJointConf)
     EXPECT_EQ(cdef.bodyA, bodyA);
     EXPECT_EQ(cdef.bodyB, bodyB);
     EXPECT_EQ(cdef.collideConnected, false);
-    EXPECT_EQ(cdef.userData, nullptr);
     
     EXPECT_EQ(cdef.localAnchorA, anchor);
     EXPECT_EQ(cdef.localAnchorB, anchor);

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -39,12 +39,12 @@ TEST(WheelJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(WheelJointConf), std::size_t(128));
+            EXPECT_EQ(sizeof(WheelJointConf), std::size_t(124));
 #else
             EXPECT_EQ(sizeof(WheelJointConf), std::size_t(124));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(WheelJointConf), std::size_t(248)); break;
+        case  8: EXPECT_EQ(sizeof(WheelJointConf), std::size_t(240)); break;
         case 16: EXPECT_EQ(sizeof(WheelJointConf), std::size_t(480)); break;
         default: FAIL(); break;
     }

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -41,7 +41,7 @@ TEST(WheelJointConf, ByteSize)
 #if defined(_WIN32) && !defined(_WIN64)
             EXPECT_EQ(sizeof(WheelJointConf), std::size_t(128));
 #else
-            EXPECT_EQ(sizeof(WheelJointConf), std::size_t(136));
+            EXPECT_EQ(sizeof(WheelJointConf), std::size_t(124));
 #endif
             break;
         case  8: EXPECT_EQ(sizeof(WheelJointConf), std::size_t(248)); break;
@@ -57,8 +57,7 @@ TEST(WheelJointConf, DefaultConstruction)
     EXPECT_EQ(def.bodyA, InvalidBodyID);
     EXPECT_EQ(def.bodyB, InvalidBodyID);
     EXPECT_EQ(def.collideConnected, false);
-    EXPECT_EQ(def.userData, nullptr);
-    
+
     EXPECT_EQ(def.localAnchorA, (Length2{}));
     EXPECT_EQ(def.localAnchorB, (Length2{}));
     EXPECT_EQ(def.localXAxisA, UnitVec::GetRight());
@@ -86,7 +85,6 @@ TEST(WheelJoint, Construction)
     EXPECT_EQ(GetBodyA(joint), def.bodyA);
     EXPECT_EQ(GetBodyB(joint), def.bodyB);
     EXPECT_EQ(GetCollideConnected(joint), def.collideConnected);
-    EXPECT_EQ(GetUserData(joint), def.userData);
     EXPECT_EQ(GetLinearReaction(joint), Momentum2{});
     EXPECT_EQ(GetAngularReaction(joint), AngularMomentum{0});
 
@@ -213,7 +211,6 @@ TEST(WheelJoint, GetWheelJointConf)
     ASSERT_EQ(GetBodyA(joint), def.bodyA);
     ASSERT_EQ(GetBodyB(joint), def.bodyB);
     ASSERT_EQ(GetCollideConnected(joint), def.collideConnected);
-    ASSERT_EQ(GetUserData(joint), def.userData);
 
     ASSERT_EQ(GetLocalAnchorA(joint), def.localAnchorA);
     ASSERT_EQ(GetLocalAnchorB(joint), def.localAnchorB);
@@ -228,7 +225,6 @@ TEST(WheelJoint, GetWheelJointConf)
     EXPECT_EQ(cdef.bodyA, InvalidBodyID);
     EXPECT_EQ(cdef.bodyB, InvalidBodyID);
     EXPECT_EQ(cdef.collideConnected, false);
-    EXPECT_EQ(cdef.userData, nullptr);
 
     EXPECT_EQ(cdef.localAnchorA, (Length2{}));
     EXPECT_EQ(cdef.localAnchorB, (Length2{}));

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -754,20 +754,6 @@ TEST(World, SetSleepingAllowed)
     EXPECT_FALSE(IsSleepingAllowed(world, body));
 }
 
-TEST(World, SetUserDataOnBody)
-{
-    auto world = World{};
-    auto value = reinterpret_cast<void*>(0u);
-    EXPECT_THROW(SetUserData(world, InvalidBodyID, value), std::out_of_range);
-    const auto body = CreateBody(world);
-    value = reinterpret_cast<void*>(1u);
-    EXPECT_NO_THROW(SetUserData(world, body, value));
-    EXPECT_EQ(GetUserData(world, body), value);
-    value = reinterpret_cast<void*>(2u);
-    EXPECT_NO_THROW(SetUserData(world, body, value));
-    EXPECT_EQ(GetUserData(world, body), value);
-}
-
 TEST(World, SetLinearDamping)
 {
     auto world = World{};


### PR DESCRIPTION
#### Description - What's this PR do?
Removes "user-data" from the design.

#### Impacts/Risks of These Changes?
Applications need to be updated to use their own data structures. See Testbed test files like `iforce2d_TopdownCar.hpp` for example of how user code can deal with this change.

#### Related Issues
- Structures wasting 8-bytes of space for only sometimes used "user-data" #347.
