### PR TITLE
Apply microsoft code style format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,7 @@ BasedOnStyle: Microsoft
 AccessModifierOffset: -3
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
-AlignOperands: true
+AlignOperands: Align
 AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,94 +1,67 @@
----
-Language:        Cpp
-AccessModifierOffset: -4
+# Generated from CLion C/C++ Code Style settings
+BasedOnStyle: Microsoft
+AccessModifierOffset: -3
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
-AlignOperands:   true
-AlignTrailingComments: false
-AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AlignOperands: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
-BinPackArguments: true
-BinPackParameters: true
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Custom
 BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
-  AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
-  IndentBraces:    false
-BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Allman
-BreakBeforeTernaryOperators: false
-BreakConstructorInitializersBeforeComma: false
-BreakAfterJavaFieldAnnotations: false
-BreakStringLiterals: true
-ColumnLimit:     100
-CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 0
+CompactNamespaces: false
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
-DerivePointerAlignment: false
-DisableFormat:   false
-ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        1
-IncludeIsMainRegex: '$'
 IndentCaseLabels: false
-IndentWidth:     4
-IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd:   ''
-MaxEmptyLinesToKeep: 2
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 4
-ObjCSpaceAfterProperty: true
+IndentPPDirectives: None
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: All
+ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakString: 1000
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-ReflowComments:  true
-SortIncludes:    false
+ReflowComments: false
 SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
-SpacesInContainerLiterals: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
-TabWidth:        8
-UseTab:          Never
-...
+Standard: c++17
+TabWidth: 4
+UseTab: Never

--- a/PlayRho/CMakeLists.txt
+++ b/PlayRho/CMakeLists.txt
@@ -1,106 +1,106 @@
-if(NOT PLAYRHO_REAL_TYPE)
-	set(PLAYRHO_REAL_TYPE float)
-endif()
+if (NOT PLAYRHO_REAL_TYPE)
+    set(PLAYRHO_REAL_TYPE float)
+endif ()
 message(STATUS "PLAYRHO_REAL_TYPE=${PLAYRHO_REAL_TYPE}")
 
 file(REMOVE "Common/Real.hpp")
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/Common/Real.hpp.in" "${CMAKE_CURRENT_SOURCE_DIR}/Common/Real.hpp")
 
 file(GLOB PLAYRHO_Collision_SRCS
-	"Collision/*.cpp"
-)
+        "Collision/*.cpp"
+        )
 file(GLOB PLAYRHO_Collision_HDRS
-	"Collision/*.hpp"
-)
+        "Collision/*.hpp"
+        )
 file(GLOB PLAYRHO_Shapes_SRCS
-	"Collision/Shapes/*.cpp"
-)
+        "Collision/Shapes/*.cpp"
+        )
 file(GLOB PLAYRHO_Shapes_HDRS
-	"Collision/Shapes/*.hpp"
-)
+        "Collision/Shapes/*.hpp"
+        )
 file(GLOB PLAYRHO_Common_SRCS
-	"Common/*.cpp"
-)
+        "Common/*.cpp"
+        )
 file(GLOB PLAYRHO_Common_HDRS
-	"Common/*.hpp"
-)
+        "Common/*.hpp"
+        )
 file(GLOB PLAYRHO_Dynamics_SRCS
-	"Dynamics/*.cpp"
-)
+        "Dynamics/*.cpp"
+        )
 file(GLOB PLAYRHO_Dynamics_HDRS
-	"Dynamics/*.hpp"
-)
+        "Dynamics/*.hpp"
+        )
 file(GLOB PLAYRHO_Contacts_SRCS
-	"Dynamics/Contacts/*.cpp"
-)
+        "Dynamics/Contacts/*.cpp"
+        )
 file(GLOB PLAYRHO_Contacts_HDRS
-	"Dynamics/Contacts/*.hpp"
-)
+        "Dynamics/Contacts/*.hpp"
+        )
 file(GLOB PLAYRHO_Joints_SRCS
-	"Dynamics/Joints/*.cpp"
-)
+        "Dynamics/Joints/*.cpp"
+        )
 file(GLOB PLAYRHO_Joints_HDRS
-	"Dynamics/Joints/*.hpp"
-)
+        "Dynamics/Joints/*.hpp"
+        )
 file(GLOB PLAYRHO_General_HDRS
-	"*.hpp"
-)
-include_directories( ../ )
+        "*.hpp"
+        )
+include_directories(../)
 
 
 if (${PLAYRHO_ENABLE_COVERAGE} AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-	message(STATUS "lib: Adding definitions for coverage analysis.")
-	add_definitions(--coverage)
-endif()
+    message(STATUS "lib: Adding definitions for coverage analysis.")
+    add_definitions(--coverage)
+endif ()
 
-if(PLAYRHO_BUILD_SHARED)
-	add_library(PlayRho_shared SHARED
-		${PLAYRHO_General_HDRS}
-		${PLAYRHO_Joints_SRCS}
-		${PLAYRHO_Joints_HDRS}
-		${PLAYRHO_Contacts_SRCS}
-		${PLAYRHO_Contacts_HDRS}
-		${PLAYRHO_Dynamics_SRCS}
-		${PLAYRHO_Dynamics_HDRS}
-		${PLAYRHO_Common_SRCS}
-		${PLAYRHO_Common_HDRS}
-		${PLAYRHO_Shapes_SRCS}
-		${PLAYRHO_Shapes_HDRS}
-		${PLAYRHO_Collision_SRCS}
-		${PLAYRHO_Collision_HDRS}
-		${PLAYRHO_Rope_SRCS}
-		${PLAYRHO_Rope_HDRS}
-	)
-	set_target_properties(PlayRho_shared PROPERTIES
-		OUTPUT_NAME "PlayRho"
-		CLEAN_DIRECT_OUTPUT 1
-		VERSION ${PLAYRHO_VERSION}
-	)
-endif()
+if (PLAYRHO_BUILD_SHARED)
+    add_library(PlayRho_shared SHARED
+            ${PLAYRHO_General_HDRS}
+            ${PLAYRHO_Joints_SRCS}
+            ${PLAYRHO_Joints_HDRS}
+            ${PLAYRHO_Contacts_SRCS}
+            ${PLAYRHO_Contacts_HDRS}
+            ${PLAYRHO_Dynamics_SRCS}
+            ${PLAYRHO_Dynamics_HDRS}
+            ${PLAYRHO_Common_SRCS}
+            ${PLAYRHO_Common_HDRS}
+            ${PLAYRHO_Shapes_SRCS}
+            ${PLAYRHO_Shapes_HDRS}
+            ${PLAYRHO_Collision_SRCS}
+            ${PLAYRHO_Collision_HDRS}
+            ${PLAYRHO_Rope_SRCS}
+            ${PLAYRHO_Rope_HDRS}
+            )
+    set_target_properties(PlayRho_shared PROPERTIES
+            OUTPUT_NAME "PlayRho"
+            CLEAN_DIRECT_OUTPUT 1
+            VERSION ${PLAYRHO_VERSION}
+            )
+endif ()
 
-if(PLAYRHO_BUILD_STATIC)
-	add_library(PlayRho STATIC
-		${PLAYRHO_General_HDRS}
-		${PLAYRHO_Joints_SRCS}
-		${PLAYRHO_Joints_HDRS}
-		${PLAYRHO_Contacts_SRCS}
-		${PLAYRHO_Contacts_HDRS}
-		${PLAYRHO_Dynamics_SRCS}
-		${PLAYRHO_Dynamics_HDRS}
-		${PLAYRHO_Common_SRCS}
-		${PLAYRHO_Common_HDRS}
-		${PLAYRHO_Shapes_SRCS}
-		${PLAYRHO_Shapes_HDRS}
-		${PLAYRHO_Collision_SRCS}
-		${PLAYRHO_Collision_HDRS}
-		${PLAYRHO_Rope_SRCS}
-		${PLAYRHO_Rope_HDRS}
-	)
-	set_target_properties(PlayRho PROPERTIES
-		CLEAN_DIRECT_OUTPUT 1
-		VERSION ${PLAYRHO_VERSION}
-	)
-endif()
+if (PLAYRHO_BUILD_STATIC)
+    add_library(PlayRho STATIC
+            ${PLAYRHO_General_HDRS}
+            ${PLAYRHO_Joints_SRCS}
+            ${PLAYRHO_Joints_HDRS}
+            ${PLAYRHO_Contacts_SRCS}
+            ${PLAYRHO_Contacts_HDRS}
+            ${PLAYRHO_Dynamics_SRCS}
+            ${PLAYRHO_Dynamics_HDRS}
+            ${PLAYRHO_Common_SRCS}
+            ${PLAYRHO_Common_HDRS}
+            ${PLAYRHO_Shapes_SRCS}
+            ${PLAYRHO_Shapes_HDRS}
+            ${PLAYRHO_Collision_SRCS}
+            ${PLAYRHO_Collision_HDRS}
+            ${PLAYRHO_Rope_SRCS}
+            ${PLAYRHO_Rope_HDRS}
+            )
+    set_target_properties(PlayRho PROPERTIES
+            CLEAN_DIRECT_OUTPUT 1
+            VERSION ${PLAYRHO_VERSION}
+            )
+endif ()
 
 # These are used to create visual studio folders.
 source_group(Collision FILES ${PLAYRHO_Collision_SRCS} ${PLAYRHO_Collision_HDRS})
@@ -111,36 +111,36 @@ source_group(Dynamics\\Contacts FILES ${PLAYRHO_Contacts_SRCS} ${PLAYRHO_Contact
 source_group(Dynamics\\Joints FILES ${PLAYRHO_Joints_SRCS} ${PLAYRHO_Joints_HDRS})
 source_group(Include FILES ${PLAYRHO_General_HDRS})
 
-if(PLAYRHO_INSTALL)
-	# install headers
-	install(FILES ${PLAYRHO_General_HDRS} DESTINATION include/PlayRho)
-	install(FILES ${PLAYRHO_Collision_HDRS} DESTINATION include/PlayRho/Collision)
-	install(FILES ${PLAYRHO_Shapes_HDRS} DESTINATION include/PlayRho/Collision/Shapes)
-	install(FILES ${PLAYRHO_Common_HDRS} DESTINATION include/PlayRho/Common)
-	install(FILES ${PLAYRHO_Dynamics_HDRS} DESTINATION include/PlayRho/Dynamics)
-	install(FILES ${PLAYRHO_Contacts_HDRS} DESTINATION include/PlayRho/Dynamics/Contacts)
-	install(FILES ${PLAYRHO_Joints_HDRS} DESTINATION include/PlayRho/Dynamics/Joints)
+if (PLAYRHO_INSTALL)
+    # install headers
+    install(FILES ${PLAYRHO_General_HDRS} DESTINATION include/PlayRho)
+    install(FILES ${PLAYRHO_Collision_HDRS} DESTINATION include/PlayRho/Collision)
+    install(FILES ${PLAYRHO_Shapes_HDRS} DESTINATION include/PlayRho/Collision/Shapes)
+    install(FILES ${PLAYRHO_Common_HDRS} DESTINATION include/PlayRho/Common)
+    install(FILES ${PLAYRHO_Dynamics_HDRS} DESTINATION include/PlayRho/Dynamics)
+    install(FILES ${PLAYRHO_Contacts_HDRS} DESTINATION include/PlayRho/Dynamics/Contacts)
+    install(FILES ${PLAYRHO_Joints_HDRS} DESTINATION include/PlayRho/Dynamics/Joints)
 
-	# install libraries
-	if(PLAYRHO_BUILD_SHARED)
-		install(TARGETS PlayRho_shared EXPORT PlayRho-targets
-                  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-                  ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
-                  RUNTIME DESTINATION bin)
-	endif()
-	if(PLAYRHO_BUILD_STATIC)
-		install(TARGETS PlayRho EXPORT PlayRho-targets DESTINATION ${LIB_INSTALL_DIR})
-	endif()
+    # install libraries
+    if (PLAYRHO_BUILD_SHARED)
+        install(TARGETS PlayRho_shared EXPORT PlayRho-targets
+                LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+                ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+                RUNTIME DESTINATION bin)
+    endif ()
+    if (PLAYRHO_BUILD_STATIC)
+        install(TARGETS PlayRho EXPORT PlayRho-targets DESTINATION ${LIB_INSTALL_DIR})
+    endif ()
 
-	# install build system hooks for third-party apps
-	install(EXPORT PlayRho-targets DESTINATION ${LIB_INSTALL_DIR}/PlayRho)
+    # install build system hooks for third-party apps
+    install(EXPORT PlayRho-targets DESTINATION ${LIB_INSTALL_DIR}/PlayRho)
 
-	set(PLAYRHO_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
-	set(PLAYRHO_INCLUDE_DIRS ${PLAYRHO_INCLUDE_DIR} )
-	set(PLAYRHO_LIBRARY_DIRS ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR})
-	set(PLAYRHO_LIBRARY PlayRho)
-	set(PLAYRHO_LIBRARIES ${PLAYRHO_LIBRARY})
-	set(PLAYRHO_USE_FILE ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/cmake/PlayRho/UsePlayRho.cmake)
-	configure_file(PlayRhoConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/PlayRhoConfig.cmake @ONLY ESCAPE_QUOTES)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PlayRhoConfig.cmake UsePlayRho.cmake DESTINATION ${LIB_INSTALL_DIR}/cmake/PlayRho)
-endif(PLAYRHO_INSTALL)
+    set(PLAYRHO_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include)
+    set(PLAYRHO_INCLUDE_DIRS ${PLAYRHO_INCLUDE_DIR})
+    set(PLAYRHO_LIBRARY_DIRS ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR})
+    set(PLAYRHO_LIBRARY PlayRho)
+    set(PLAYRHO_LIBRARIES ${PLAYRHO_LIBRARY})
+    set(PLAYRHO_USE_FILE ${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/cmake/PlayRho/UsePlayRho.cmake)
+    configure_file(PlayRhoConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/PlayRhoConfig.cmake @ONLY ESCAPE_QUOTES)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/PlayRhoConfig.cmake UsePlayRho.cmake DESTINATION ${LIB_INSTALL_DIR}/cmake/PlayRho)
+endif (PLAYRHO_INSTALL)

--- a/PlayRho/Collision/AABB.cpp
+++ b/PlayRho/Collision/AABB.cpp
@@ -20,109 +20,111 @@
  */
 
 #include <PlayRho/Collision/AABB.hpp>
-#include <PlayRho/Collision/RayCastInput.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
+#include <PlayRho/Collision/RayCastInput.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
-#include <PlayRho/Dynamics/WorldFixture.hpp>
 #include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/WorldFixture.hpp>
 
 /// @file
 /// Definitions for the AABB class.
 
-namespace playrho {
-namespace d2 {
-
-AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept
+namespace playrho
 {
-    assert(IsValid(xf));
-    auto result = AABB{};
-    for (const auto& vertex: proxy.GetVertices())
+    namespace d2
     {
-        Include(result, Transform(vertex, xf));
-    }
-    return GetFattenedAABB(result, proxy.GetVertexRadius());
-}
 
-AABB ComputeAABB(const DistanceProxy& proxy,
-                 const Transformation& xfm0, const Transformation& xfm1) noexcept
-{
-    assert(IsValid(xfm0));
-    assert(IsValid(xfm1));
-    auto result = AABB{};
-    for (const auto& vertex: proxy.GetVertices())
-    {
-        Include(result, Transform(vertex, xfm0));
-        Include(result, Transform(vertex, xfm1));
-    }
-    return GetFattenedAABB(result, proxy.GetVertexRadius());
-}
+        AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept
+        {
+            assert(IsValid(xf));
+            auto result = AABB{};
+            for (const auto& vertex : proxy.GetVertices())
+            {
+                Include(result, Transform(vertex, xf));
+            }
+            return GetFattenedAABB(result, proxy.GetVertexRadius());
+        }
 
-AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept
-{
-    auto sum = AABB{};
-    const auto childCount = GetChildCount(shape);
-    for (auto i = decltype(childCount){0}; i < childCount; ++i)
-    {
-        Include(sum, ComputeAABB(GetChild(shape, i), xf));
-    }
-    return sum;
-}
+        AABB ComputeAABB(const DistanceProxy& proxy,
+                         const Transformation& xfm0, const Transformation& xfm1) noexcept
+        {
+            assert(IsValid(xfm0));
+            assert(IsValid(xfm1));
+            auto result = AABB{};
+            for (const auto& vertex : proxy.GetVertices())
+            {
+                Include(result, Transform(vertex, xfm0));
+                Include(result, Transform(vertex, xfm1));
+            }
+            return GetFattenedAABB(result, proxy.GetVertexRadius());
+        }
 
-AABB ComputeAABB(const World& world, FixtureID id)
-{
-    return ComputeAABB(GetShape(world, id), GetTransformation(world, GetBody(world, id)));
-}
+        AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept
+        {
+            auto sum = AABB{};
+            const auto childCount = GetChildCount(shape);
+            for (auto i = decltype(childCount){0}; i < childCount; ++i)
+            {
+                Include(sum, ComputeAABB(GetChild(shape, i), xf));
+            }
+            return sum;
+        }
 
-AABB ComputeAABB(const World& world, const Body& body)
-{
-    auto sum = AABB{};
-    const auto xf = body.GetTransformation();
-    for (auto&& f: body.GetFixtures())
-    {
-        Include(sum, ComputeAABB(GetShape(world, f), xf));
-    }
-    return sum;
-}
+        AABB ComputeAABB(const World& world, FixtureID id)
+        {
+            return ComputeAABB(GetShape(world, id), GetTransformation(world, GetBody(world, id)));
+        }
 
-AABB ComputeAABB(const World& world, BodyID id)
-{
-    auto sum = AABB{};
-    const auto xf = GetTransformation(world, id);
-    for (const auto& f: GetFixtures(world, id))
-    {
-        Include(sum, ComputeAABB(GetShape(world, f), xf));
-    }
-    return sum;
-}
+        AABB ComputeAABB(const World& world, const Body& body)
+        {
+            auto sum = AABB{};
+            const auto xf = body.GetTransformation();
+            for (auto&& f : body.GetFixtures())
+            {
+                Include(sum, ComputeAABB(GetShape(world, f), xf));
+            }
+            return sum;
+        }
 
-AABB ComputeIntersectingAABB(const World& world,
-                             FixtureID fA, ChildCounter iA,
-                             FixtureID fB, ChildCounter iB) noexcept
-{
-    const auto xA = GetTransformation(GetBodyConf(world, GetBody(world, fA)));
-    const auto xB = GetTransformation(GetBodyConf(world, GetBody(world, fB)));
-    const auto childA = GetChild(GetShape(world, fA), iA);
-    const auto childB = GetChild(GetShape(world, fB), iB);
-    const auto aabbA = ComputeAABB(childA, xA);
-    const auto aabbB = ComputeAABB(childB, xB);
-    return GetIntersectingAABB(aabbA, aabbB);
-}
+        AABB ComputeAABB(const World& world, BodyID id)
+        {
+            auto sum = AABB{};
+            const auto xf = GetTransformation(world, id);
+            for (const auto& f : GetFixtures(world, id))
+            {
+                Include(sum, ComputeAABB(GetShape(world, f), xf));
+            }
+            return sum;
+        }
 
-AABB ComputeIntersectingAABB(const World& world, const Contact& contact)
-{
-    return ComputeIntersectingAABB(world,
-                                   contact.GetFixtureA(), contact.GetChildIndexA(),
-                                   contact.GetFixtureB(), contact.GetChildIndexB());
-}
+        AABB ComputeIntersectingAABB(const World& world,
+                                     FixtureID fA, ChildCounter iA,
+                                     FixtureID fB, ChildCounter iB) noexcept
+        {
+            const auto xA = GetTransformation(GetBodyConf(world, GetBody(world, fA)));
+            const auto xB = GetTransformation(GetBodyConf(world, GetBody(world, fB)));
+            const auto childA = GetChild(GetShape(world, fA), iA);
+            const auto childB = GetChild(GetShape(world, fB), iB);
+            const auto aabbA = ComputeAABB(childA, xA);
+            const auto aabbB = ComputeAABB(childB, xB);
+            return GetIntersectingAABB(aabbA, aabbB);
+        }
 
-AABB GetAABB(const RayCastInput& input) noexcept
-{
-    const auto totalDelta = input.p2 - input.p1;
-    const auto fractDelta = input.maxFraction * totalDelta;
-    return AABB{input.p1, input.p1 + fractDelta};
-}
+        AABB ComputeIntersectingAABB(const World& world, const Contact& contact)
+        {
+            return ComputeIntersectingAABB(world,
+                                           contact.GetFixtureA(), contact.GetChildIndexA(),
+                                           contact.GetFixtureB(), contact.GetChildIndexB());
+        }
 
-} // namespace d2
-} // namespace playrho
+        AABB GetAABB(const RayCastInput& input) noexcept
+        {
+            const auto totalDelta = input.p2 - input.p1;
+            const auto fractDelta = input.maxFraction * totalDelta;
+            return AABB{input.p1, input.p1 + fractDelta};
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -25,473 +25,477 @@
 /// @file
 /// Declaration of the AABB class and free functions that return instances of it.
 
-#include <PlayRho/Common/Intervals.hpp> // for LengthInterval, IsIntersecting
-#include <PlayRho/Common/Vector.hpp>
+#include <PlayRho/Common/Intervals.hpp>// for LengthInterval, IsIntersecting
 #include <PlayRho/Common/Settings.hpp> // for ChildCounter, etc.
 #include <PlayRho/Common/Templates.hpp>
+#include <PlayRho/Common/Vector.hpp>
 #include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/FixtureID.hpp>
 
-#include <algorithm> // for std::mismatch, lexicographical_compare, etc
-#include <utility> // for std::get
+#include <algorithm>// for std::mismatch, lexicographical_compare, etc
+#include <utility>  // for std::get
 
-namespace playrho {
-
-namespace detail {
-
-template <std::size_t N> struct RayCastInput;
-
-/// @brief N-dimensional Axis Aligned Bounding Box.
-///
-/// @details This is a concrete value class template for an N-dimensional axis aligned
-///   bounding box (AABB) which is a type of bounding volume.
-///
-/// @note This class satisfies at least the following named requirement: all the basic named
-///   requirements, <code>EqualityComparable</code>, and <code>Swappable</code>.
-/// @note This class is composed of &mdash; as in contains and owns &mdash; N
-///   <code>LengthInterval</code> variables.
-/// @note Non-defaulted methods of this class are marked <code>noexcept</code> and expect
-///   that the Length type doesn't throw.
-///
-/// @see https://en.wikipedia.org/wiki/Bounding_volume
-/// @see https://en.cppreference.com/w/cpp/named_req
-///
-template <std::size_t N>
-struct AABB
+namespace playrho
 {
-    /// @brief Alias for the location type.
-    using Location = Vector<Length, N>;
 
-    /// @brief Default constructor.
-    /// @details Constructs an "unset" AABB.
-    /// @note If an unset AABB is added to another AABB, the result will be the other AABB.
-    constexpr AABB() = default;
-    
-    /// @brief Initializing constructor.
-    /// @details Initializing constructor supporting construction by the same number of elements
-    ///   as this AABB template type is defined for.
-    /// @note For example this enables a 2-dimensional AABB to be constructed as:
-    /// @code{.cpp}
-    /// const auto aabb = AABB<2>{LengthInterval{1_m, 4_m}, LengthInterval{-3_m, 3_m}};
-    /// @endcode
-    template<typename... Tail>
-    constexpr AABB(std::enable_if_t<sizeof...(Tail)+1 == N, LengthInterval> head,
-                                  Tail... tail) noexcept:
-        ranges{head, LengthInterval(tail)...}
+    namespace detail
     {
-        // Intentionally empty.
-    }
 
-    /// @brief Initializing constructor for a single point.
-    /// @param p Point location to initialize this AABB with.
-    /// @post <code>rangeX</code> will have its min and max values both set to the
-    ///   given point's X value.
-    /// @post <code>rangeY</code> will have its min and max values both set to the
-    ///   given point's Y value.
-    constexpr explicit AABB(const Location p) noexcept
-    {
-        for (auto i = decltype(N){0}; i < N; ++i)
+        template<std::size_t N>
+        struct RayCastInput;
+
+        /// @brief N-dimensional Axis Aligned Bounding Box.
+        ///
+        /// @details This is a concrete value class template for an N-dimensional axis aligned
+        ///   bounding box (AABB) which is a type of bounding volume.
+        ///
+        /// @note This class satisfies at least the following named requirement: all the basic named
+        ///   requirements, <code>EqualityComparable</code>, and <code>Swappable</code>.
+        /// @note This class is composed of &mdash; as in contains and owns &mdash; N
+        ///   <code>LengthInterval</code> variables.
+        /// @note Non-defaulted methods of this class are marked <code>noexcept</code> and expect
+        ///   that the Length type doesn't throw.
+        ///
+        /// @see https://en.wikipedia.org/wiki/Bounding_volume
+        /// @see https://en.cppreference.com/w/cpp/named_req
+        ///
+        template<std::size_t N>
+        struct AABB
         {
-            ranges[i] = LengthInterval{p[i]};
-        }
-    }
+            /// @brief Alias for the location type.
+            using Location = Vector<Length, N>;
 
-    /// @brief Initializing constructor for two points.
-    /// @param a Point location "A" to initialize this AABB with.
-    /// @param b Point location "B" to initialize this AABB with.
-    constexpr AABB(const Location a, const Location b) noexcept
-    {
-        for (auto i = decltype(N){0}; i < N; ++i)
+            /// @brief Default constructor.
+            /// @details Constructs an "unset" AABB.
+            /// @note If an unset AABB is added to another AABB, the result will be the other AABB.
+            constexpr AABB() = default;
+
+            /// @brief Initializing constructor.
+            /// @details Initializing constructor supporting construction by the same number of elements
+            ///   as this AABB template type is defined for.
+            /// @note For example this enables a 2-dimensional AABB to be constructed as:
+            /// @code{.cpp}
+            /// const auto aabb = AABB<2>{LengthInterval{1_m, 4_m}, LengthInterval{-3_m, 3_m}};
+            /// @endcode
+            template<typename... Tail>
+            constexpr AABB(std::enable_if_t<sizeof...(Tail) + 1 == N, LengthInterval> head,
+                           Tail... tail) noexcept
+                : ranges{head, LengthInterval(tail)...}
+            {
+                // Intentionally empty.
+            }
+
+            /// @brief Initializing constructor for a single point.
+            /// @param p Point location to initialize this AABB with.
+            /// @post <code>rangeX</code> will have its min and max values both set to the
+            ///   given point's X value.
+            /// @post <code>rangeY</code> will have its min and max values both set to the
+            ///   given point's Y value.
+            constexpr explicit AABB(const Location p) noexcept
+            {
+                for (auto i = decltype(N){0}; i < N; ++i)
+                {
+                    ranges[i] = LengthInterval{p[i]};
+                }
+            }
+
+            /// @brief Initializing constructor for two points.
+            /// @param a Point location "A" to initialize this AABB with.
+            /// @param b Point location "B" to initialize this AABB with.
+            constexpr AABB(const Location a, const Location b) noexcept
+            {
+                for (auto i = decltype(N){0}; i < N; ++i)
+                {
+                    ranges[i] = LengthInterval{a[i], b[i]};
+                }
+            }
+
+            /// @brief Holds the value range of each dimension from 0 to N-1.
+            LengthInterval ranges[N];
+        };
+
+        /// @brief Gets whether the two AABB objects are equal.
+        /// @return <code>true</code> if the two values are equal, <code>false</code> otherwise.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr bool operator==(const AABB<N>& lhs, const AABB<N>& rhs) noexcept
         {
-            ranges[i] = LengthInterval{a[i], b[i]};
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                if (lhs.ranges[i] != rhs.ranges[i])
+                {
+                    return false;
+                }
+            }
+            return true;
         }
-    }
 
-    /// @brief Holds the value range of each dimension from 0 to N-1.
-    LengthInterval ranges[N];
-};
-
-/// @brief Gets whether the two AABB objects are equal.
-/// @return <code>true</code> if the two values are equal, <code>false</code> otherwise.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr bool operator== (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        if (lhs.ranges[i] != rhs.ranges[i])
+        /// @brief Gets whether the two AABB objects are not equal.
+        /// @return <code>true</code> if the two values are not equal, <code>false</code> otherwise.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr bool operator!=(const AABB<N>& lhs, const AABB<N>& rhs) noexcept
         {
-            return false;
+            return !(lhs == rhs);
         }
-    }
-    return true;
-}
 
-/// @brief Gets whether the two AABB objects are not equal.
-/// @return <code>true</code> if the two values are not equal, <code>false</code> otherwise.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr bool operator!= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
-/// @brief Less-than operator.
-/// @relatedalso AABB
-template <std::size_t N>
-inline bool operator< (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
-{
-    return std::lexicographical_compare(cbegin(lhs.ranges), cend(lhs.ranges),
-                                        cbegin(rhs.ranges), cend(rhs.ranges),
-                                        std::less<LengthInterval>{});
-}
-
-/// @brief Less-than or equal-to operator.
-/// @relatedalso AABB
-template <std::size_t N>
-inline bool operator<= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
-{
-    const auto lhsEnd = cend(lhs.ranges);
-    const auto rhsEnd = cend(rhs.ranges);
-    const auto diff = std::mismatch(cbegin(lhs.ranges), lhsEnd,
-                                    cbegin(rhs.ranges), rhsEnd);
-    return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) < *std::get<1>(diff));
-}
-
-/// @brief Greater-than operator.
-/// @relatedalso AABB
-template <std::size_t N>
-inline bool operator> (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
-{
-    return std::lexicographical_compare(cbegin(lhs.ranges), cend(lhs.ranges),
-                                        cbegin(rhs.ranges), cend(rhs.ranges),
-                                        std::greater<LengthInterval>{});
-}
-
-/// @brief Greater-than or equal-to operator.
-/// @relatedalso AABB
-template <std::size_t N>
-inline bool operator>= (const AABB<N>& lhs, const AABB<N>& rhs) noexcept
-{
-    const auto lhsEnd = cend(lhs.ranges);
-    const auto rhsEnd = cend(rhs.ranges);
-    const auto diff = std::mismatch(cbegin(lhs.ranges), lhsEnd,
-                                    cbegin(rhs.ranges), rhsEnd);
-    return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) > *std::get<1>(diff));
-}
-
-/// @brief Tests for overlap between two axis aligned bounding boxes.
-/// @note This function's complexity is constant.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        if (!IsIntersecting(a.ranges[i], b.ranges[i]))
+        /// @brief Less-than operator.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        inline bool operator<(const AABB<N>& lhs, const AABB<N>& rhs) noexcept
         {
-            return false;
+            return std::lexicographical_compare(cbegin(lhs.ranges), cend(lhs.ranges),
+                                                cbegin(rhs.ranges), cend(rhs.ranges),
+                                                std::less<LengthInterval>{});
         }
-    }
-    return true;
-}
 
-/// @brief Gets the intersecting AABB of the two given AABBs'.
-template <std::size_t N>
-constexpr AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
-{
-    auto result = AABB<N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        result.ranges[i] = GetIntersection(a.ranges[i], b.ranges[i]);
-    }
-    return result;
-}
-
-/// @brief Gets the center of the AABB.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
-{
-    auto result = Vector<Length, N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        result[i] = GetCenter(aabb.ranges[i]);
-    }
-    return result;
-}
-
-/// @brief Gets dimensions of the given AABB.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
-{
-    auto result = Vector<Length, N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        result[i] = GetSize(aabb.ranges[i]);
-    }
-    return result;
-}
-
-/// @brief Gets the extents of the AABB (half-widths).
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
-{
-    constexpr auto RealInverseOfTwo = Real{1} / Real{2};
-    return GetDimensions(aabb) * RealInverseOfTwo;
-}
-
-/// @brief Checks whether the first AABB fully contains the second AABB.
-/// @details Whether the first AABB contains the entirety of the second AABB where
-///   containment is defined as being equal-to or within an AABB.
-/// @note The "unset" AABB is contained by all valid AABBs including the "unset"
-///   AABB itself.
-/// @param a AABB to test whether it contains the second AABB.
-/// @param b AABB to test whether it's contained by the first AABB.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        if (!IsEntirelyEnclosing(a.ranges[i], b.ranges[i]))
+        /// @brief Less-than or equal-to operator.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        inline bool operator<=(const AABB<N>& lhs, const AABB<N>& rhs) noexcept
         {
-            return false;
+            const auto lhsEnd = cend(lhs.ranges);
+            const auto rhsEnd = cend(rhs.ranges);
+            const auto diff = std::mismatch(cbegin(lhs.ranges), lhsEnd,
+                                            cbegin(rhs.ranges), rhsEnd);
+            return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) < *std::get<1>(diff));
         }
-    }
-    return true;
-}
 
-/// @brief Includes the given location into the given AABB.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        var.ranges[i].Include(value[i]);
-    }
-    return var;
-}
-
-/// @brief Includes the second AABB into the first one.
-/// @note If an unset AABB is added to the first AABB, the result will be the first AABB.
-/// @note If the first AABB is unset and another AABB is added to it, the result will be
-///   the other AABB.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        var.ranges[i].Include(val.ranges[i]);
-    }
-    return var;
-}
-
-/// @brief Moves the given AABB by the given value.
-template <std::size_t N>
-constexpr AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        var.ranges[i].Move(value[i]);
-    }
-    return var;
-}
-
-/// @brief Fattens an AABB by the given amount.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        var.ranges[i].ExpandEqually(amount);
-    }
-    return var;
-}
-
-/// @brief Gets the AABB that the result of displacing the given AABB by the given
-///   displacement amount.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        aabb.ranges[i].Expand(displacement[i]);
-    }
-    return aabb;
-}
-
-/// @brief Gets the fattened AABB result.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
-{
-    return Fatten(aabb, amount);
-}
-
-/// @brief Gets the result of moving the given AABB by the given value.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
-{
-    return Move(aabb, value);
-}
-
-/// @brief Gets the AABB that minimally encloses the given AABBs.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
-{
-    return Include(a, b);
-}
-
-/// @brief Gets the lower bound.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
-{
-    auto result = Vector<Length, N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        result[i] = aabb.ranges[i].GetMin();
-    }
-    return result;
-}
-
-/// @brief Gets the upper bound.
-/// @relatedalso AABB
-template <std::size_t N>
-constexpr Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
-{
-    auto result = Vector<Length, N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        result[i] = aabb.ranges[i].GetMax();
-    }
-    return result;
-}
-
-/// @brief Output stream operator.
-template <std::size_t N>
-inline ::std::ostream& operator<< (::std::ostream& os, const AABB<N>& value)
-{
-    os << "{";
-    auto multiple = false;
-    for (const auto& range: value.ranges)
-    {
-        if (multiple)
+        /// @brief Greater-than operator.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        inline bool operator>(const AABB<N>& lhs, const AABB<N>& rhs) noexcept
         {
-            os << ',';
+            return std::lexicographical_compare(cbegin(lhs.ranges), cend(lhs.ranges),
+                                                cbegin(rhs.ranges), cend(rhs.ranges),
+                                                std::greater<LengthInterval>{});
         }
-        else
+
+        /// @brief Greater-than or equal-to operator.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        inline bool operator>=(const AABB<N>& lhs, const AABB<N>& rhs) noexcept
         {
-            multiple = true;
+            const auto lhsEnd = cend(lhs.ranges);
+            const auto rhsEnd = cend(rhs.ranges);
+            const auto diff = std::mismatch(cbegin(lhs.ranges), lhsEnd,
+                                            cbegin(rhs.ranges), rhsEnd);
+            return (std::get<0>(diff) == lhsEnd) || (*std::get<0>(diff) > *std::get<1>(diff));
         }
-        os << range;
+
+        /// @brief Tests for overlap between two axis aligned bounding boxes.
+        /// @note This function's complexity is constant.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr bool TestOverlap(const AABB<N>& a, const AABB<N>& b) noexcept
+        {
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                if (!IsIntersecting(a.ranges[i], b.ranges[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// @brief Gets the intersecting AABB of the two given AABBs'.
+        template<std::size_t N>
+        constexpr AABB<N> GetIntersectingAABB(const AABB<N>& a, const AABB<N>& b) noexcept
+        {
+            auto result = AABB<N>{};
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                result.ranges[i] = GetIntersection(a.ranges[i], b.ranges[i]);
+            }
+            return result;
+        }
+
+        /// @brief Gets the center of the AABB.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr Vector<Length, N> GetCenter(const AABB<N>& aabb) noexcept
+        {
+            auto result = Vector<Length, N>{};
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                result[i] = GetCenter(aabb.ranges[i]);
+            }
+            return result;
+        }
+
+        /// @brief Gets dimensions of the given AABB.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr Vector<Length, N> GetDimensions(const AABB<N>& aabb) noexcept
+        {
+            auto result = Vector<Length, N>{};
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                result[i] = GetSize(aabb.ranges[i]);
+            }
+            return result;
+        }
+
+        /// @brief Gets the extents of the AABB (half-widths).
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr Vector<Length, N> GetExtents(const AABB<N>& aabb) noexcept
+        {
+            constexpr auto RealInverseOfTwo = Real{1} / Real{2};
+            return GetDimensions(aabb) * RealInverseOfTwo;
+        }
+
+        /// @brief Checks whether the first AABB fully contains the second AABB.
+        /// @details Whether the first AABB contains the entirety of the second AABB where
+        ///   containment is defined as being equal-to or within an AABB.
+        /// @note The "unset" AABB is contained by all valid AABBs including the "unset"
+        ///   AABB itself.
+        /// @param a AABB to test whether it contains the second AABB.
+        /// @param b AABB to test whether it's contained by the first AABB.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr bool Contains(const AABB<N>& a, const AABB<N>& b) noexcept
+        {
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                if (!IsEntirelyEnclosing(a.ranges[i], b.ranges[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// @brief Includes the given location into the given AABB.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr AABB<N>& Include(AABB<N>& var, const Vector<Length, N>& value) noexcept
+        {
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                var.ranges[i].Include(value[i]);
+            }
+            return var;
+        }
+
+        /// @brief Includes the second AABB into the first one.
+        /// @note If an unset AABB is added to the first AABB, the result will be the first AABB.
+        /// @note If the first AABB is unset and another AABB is added to it, the result will be
+        ///   the other AABB.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr AABB<N>& Include(AABB<N>& var, const AABB<N>& val) noexcept
+        {
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                var.ranges[i].Include(val.ranges[i]);
+            }
+            return var;
+        }
+
+        /// @brief Moves the given AABB by the given value.
+        template<std::size_t N>
+        constexpr AABB<N>& Move(AABB<N>& var, const Vector<Length, N> value) noexcept
+        {
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                var.ranges[i].Move(value[i]);
+            }
+            return var;
+        }
+
+        /// @brief Fattens an AABB by the given amount.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr AABB<N>& Fatten(AABB<N>& var, const NonNegative<Length> amount) noexcept
+        {
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                var.ranges[i].ExpandEqually(amount);
+            }
+            return var;
+        }
+
+        /// @brief Gets the AABB that the result of displacing the given AABB by the given
+        ///   displacement amount.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr AABB<N> GetDisplacedAABB(AABB<N> aabb, const Vector<Length, N> displacement)
+        {
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                aabb.ranges[i].Expand(displacement[i]);
+            }
+            return aabb;
+        }
+
+        /// @brief Gets the fattened AABB result.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr AABB<N> GetFattenedAABB(AABB<N> aabb, const Length amount)
+        {
+            return Fatten(aabb, amount);
+        }
+
+        /// @brief Gets the result of moving the given AABB by the given value.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr AABB<N> GetMovedAABB(AABB<N> aabb, const Vector<Length, N> value) noexcept
+        {
+            return Move(aabb, value);
+        }
+
+        /// @brief Gets the AABB that minimally encloses the given AABBs.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr AABB<N> GetEnclosingAABB(AABB<N> a, const AABB<N>& b)
+        {
+            return Include(a, b);
+        }
+
+        /// @brief Gets the lower bound.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr Vector<Length, N> GetLowerBound(const AABB<N>& aabb) noexcept
+        {
+            auto result = Vector<Length, N>{};
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                result[i] = aabb.ranges[i].GetMin();
+            }
+            return result;
+        }
+
+        /// @brief Gets the upper bound.
+        /// @relatedalso AABB
+        template<std::size_t N>
+        constexpr Vector<Length, N> GetUpperBound(const AABB<N>& aabb) noexcept
+        {
+            auto result = Vector<Length, N>{};
+            for (auto i = decltype(N){0}; i < N; ++i)
+            {
+                result[i] = aabb.ranges[i].GetMax();
+            }
+            return result;
+        }
+
+        /// @brief Output stream operator.
+        template<std::size_t N>
+        inline ::std::ostream& operator<<(::std::ostream& os, const AABB<N>& value)
+        {
+            os << "{";
+            auto multiple = false;
+            for (const auto& range : value.ranges)
+            {
+                if (multiple)
+                {
+                    os << ',';
+                }
+                else
+                {
+                    multiple = true;
+                }
+                os << range;
+            }
+            os << "}";
+            return os;
+        }
+
+    }// namespace detail
+
+    namespace d2
+    {
+
+        class Shape;
+        class Fixture;
+        class Body;
+        class Contact;
+        class DistanceProxy;
+        struct Transformation;
+        class World;
+
+        using detail::Contains;
+        using detail::TestOverlap;
+
+        /// @brief 2-Dimensional Axis Aligned Bounding Box.
+        /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
+        using AABB = detail::AABB<2>;
+
+        /// @brief Gets the perimeter length of the 2-dimensional AABB.
+        /// @warning Behavior is undefined for an invalid AABB.
+        /// @return Twice the sum of the width and height.
+        /// @relatedalso playrho::detail::AABB
+        /// @see https://en.wikipedia.org/wiki/Perimeter
+        constexpr Length GetPerimeter(const AABB& aabb) noexcept
+        {
+            return (GetSize(aabb.ranges[0]) + GetSize(aabb.ranges[1])) * 2;
+        }
+
+        /// @brief Computes the AABB.
+        /// @details Computes the Axis Aligned Bounding Box (AABB) for the given child shape
+        ///   at a given a transform.
+        /// @warning Behavior is undefined if the given transformation is invalid.
+        /// @param proxy Distance proxy for the child shape.
+        /// @param xf World transform of the shape.
+        /// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
+        /// @relatedalso DistanceProxy
+        AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept;
+
+        /// @brief Computes the AABB.
+        /// @details Computes the Axis Aligned Bounding Box (AABB) for the given child shape
+        ///   at the given transforms.
+        /// @warning Behavior is undefined if a given transformation is invalid.
+        /// @param proxy Distance proxy for the child shape.
+        /// @param xfm0 World transform 0 of the shape.
+        /// @param xfm1 World transform 1 of the shape.
+        /// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
+        /// @relatedalso DistanceProxy
+        AABB ComputeAABB(const DistanceProxy& proxy,
+                         const Transformation& xfm0, const Transformation& xfm1) noexcept;
+
+        /// @brief Computes the AABB for the given shape with the given transformation.
+        /// @relatedalso Shape
+        AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept;
+
+        /// @brief Computes the AABB for the identified fixture within the given world.
+        /// @relatedalso World
+        AABB ComputeAABB(const World& world, FixtureID id);
+
+        /// @brief Computes the AABB for the given body.
+        /// @relatedalso World
+        AABB ComputeAABB(const World& world, const Body& body);
+
+        /// @brief Computes the AABB for the identified body within the given world.
+        /// @relatedalso World
+        AABB ComputeAABB(const World& world, BodyID id);
+
+        /// @brief Computes the intersecting AABB for the given pair of fixtures and indexes.
+        /// @details The intersecting AABB for the given pair of fixtures is the intersection
+        ///   of the AABB for child A of the shape of fixture A with the AABB for child B of
+        ///   the shape of fixture B.
+        AABB ComputeIntersectingAABB(const World& world,
+                                     FixtureID fA, ChildCounter iA,
+                                     FixtureID fB, ChildCounter iB) noexcept;
+
+        /// @brief Computes the intersecting AABB for the given contact.
+        /// @relatedalso Contact
+        AABB ComputeIntersectingAABB(const World& world, const Contact& contact);
+
+        /// @brief Gets the AABB for the given ray cast input data.
+        /// @relatedalso playrho::detail::RayCastInput<2>
+        AABB GetAABB(const playrho::detail::RayCastInput<2>& input) noexcept;
+
+    }// namespace d2
+
+    /// @brief Gets an invalid AABB value.
+    /// @relatedalso detail::AABB
+    template<>
+    constexpr d2::AABB GetInvalid() noexcept
+    {
+        return d2::AABB{LengthInterval{GetInvalid<Length>()}, LengthInterval{GetInvalid<Length>()}};
     }
-    os << "}";
-    return os;
-}
 
-} // namespace detail
+}// namespace playrho
 
-namespace d2 {
-
-class Shape;
-class Fixture;
-class Body;
-class Contact;
-class DistanceProxy;
-struct Transformation;
-class World;
-
-using detail::TestOverlap;
-using detail::Contains;
-
-/// @brief 2-Dimensional Axis Aligned Bounding Box.
-/// @note This data structure is 16-bytes large (on at least one 64-bit platform).
-using AABB = detail::AABB<2>;
-
-/// @brief Gets the perimeter length of the 2-dimensional AABB.
-/// @warning Behavior is undefined for an invalid AABB.
-/// @return Twice the sum of the width and height.
-/// @relatedalso playrho::detail::AABB
-/// @see https://en.wikipedia.org/wiki/Perimeter
-constexpr Length GetPerimeter(const AABB& aabb) noexcept
-{
-    return (GetSize(aabb.ranges[0]) + GetSize(aabb.ranges[1])) * 2;
-}
-
-/// @brief Computes the AABB.
-/// @details Computes the Axis Aligned Bounding Box (AABB) for the given child shape
-///   at a given a transform.
-/// @warning Behavior is undefined if the given transformation is invalid.
-/// @param proxy Distance proxy for the child shape.
-/// @param xf World transform of the shape.
-/// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
-/// @relatedalso DistanceProxy
-AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xf) noexcept;
-
-/// @brief Computes the AABB.
-/// @details Computes the Axis Aligned Bounding Box (AABB) for the given child shape
-///   at the given transforms.
-/// @warning Behavior is undefined if a given transformation is invalid.
-/// @param proxy Distance proxy for the child shape.
-/// @param xfm0 World transform 0 of the shape.
-/// @param xfm1 World transform 1 of the shape.
-/// @return AABB for the proxy shape or the default AABB if the proxy has a zero vertex count.
-/// @relatedalso DistanceProxy
-AABB ComputeAABB(const DistanceProxy& proxy,
-                 const Transformation& xfm0, const Transformation& xfm1) noexcept;
-
-/// @brief Computes the AABB for the given shape with the given transformation.
-/// @relatedalso Shape
-AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept;
-
-/// @brief Computes the AABB for the identified fixture within the given world.
-/// @relatedalso World
-AABB ComputeAABB(const World& world, FixtureID id);
-
-/// @brief Computes the AABB for the given body.
-/// @relatedalso World
-AABB ComputeAABB(const World& world, const Body& body);
-
-/// @brief Computes the AABB for the identified body within the given world.
-/// @relatedalso World
-AABB ComputeAABB(const World& world, BodyID id);
-
-/// @brief Computes the intersecting AABB for the given pair of fixtures and indexes.
-/// @details The intersecting AABB for the given pair of fixtures is the intersection
-///   of the AABB for child A of the shape of fixture A with the AABB for child B of
-///   the shape of fixture B.
-AABB ComputeIntersectingAABB(const World& world,
-                             FixtureID fA, ChildCounter iA,
-                             FixtureID fB, ChildCounter iB) noexcept;
-
-/// @brief Computes the intersecting AABB for the given contact.
-/// @relatedalso Contact
-AABB ComputeIntersectingAABB(const World& world, const Contact& contact);
-    
-/// @brief Gets the AABB for the given ray cast input data.
-/// @relatedalso playrho::detail::RayCastInput<2>
-AABB GetAABB(const playrho::detail::RayCastInput<2>& input) noexcept;
-
-} // namespace d2
-
-/// @brief Gets an invalid AABB value.
-/// @relatedalso detail::AABB
-template <>
-constexpr d2::AABB GetInvalid() noexcept
-{
-    return d2::AABB{LengthInterval{GetInvalid<Length>()}, LengthInterval{GetInvalid<Length>()}};
-}
-
-} // namespace playrho
-
-#endif // PLAYRHO_COLLISION_AABB_HPP
+#endif// PLAYRHO_COLLISION_AABB_HPP

--- a/PlayRho/Collision/Collision.cpp
+++ b/PlayRho/Collision/Collision.cpp
@@ -21,92 +21,94 @@
 #include <PlayRho/Collision/Manifold.hpp>
 #include <cmath>
 
-namespace playrho {
-namespace d2 {
-
-PointStates GetPointStates(const Manifold& manifold1, const Manifold& manifold2) noexcept
+namespace playrho
 {
-    auto retval = PointStates{};
-
-    // Detect persists and removes.
-    for (auto i = decltype(manifold1.GetPointCount()){0}; i < manifold1.GetPointCount(); ++i)
+    namespace d2
     {
-        const auto cf = manifold1.GetContactFeature(i);
 
-        retval.state1[i] = PointState::RemoveState;
-
-        for (auto j = decltype(manifold2.GetPointCount()){0}; j < manifold2.GetPointCount(); ++j)
+        PointStates GetPointStates(const Manifold& manifold1, const Manifold& manifold2) noexcept
         {
-            if (manifold2.GetContactFeature(j) == cf)
+            auto retval = PointStates{};
+
+            // Detect persists and removes.
+            for (auto i = decltype(manifold1.GetPointCount()){0}; i < manifold1.GetPointCount(); ++i)
             {
-                retval.state1[i] = PointState::PersistState;
-                break;
+                const auto cf = manifold1.GetContactFeature(i);
+
+                retval.state1[i] = PointState::RemoveState;
+
+                for (auto j = decltype(manifold2.GetPointCount()){0}; j < manifold2.GetPointCount(); ++j)
+                {
+                    if (manifold2.GetContactFeature(j) == cf)
+                    {
+                        retval.state1[i] = PointState::PersistState;
+                        break;
+                    }
+                }
             }
-        }
-    }
 
-    // Detect persists and adds.
-    for (auto i = decltype(manifold2.GetPointCount()){0}; i < manifold2.GetPointCount(); ++i)
-    {
-        const auto cf = manifold2.GetContactFeature(i);
-
-        retval.state2[i] = PointState::AddState;
-
-        for (auto j = decltype(manifold1.GetPointCount()){0}; j < manifold1.GetPointCount(); ++j)
-        {
-            if (manifold1.GetContactFeature(j) == cf)
+            // Detect persists and adds.
+            for (auto i = decltype(manifold2.GetPointCount()){0}; i < manifold2.GetPointCount(); ++i)
             {
-                retval.state2[i] = PointState::PersistState;
-                break;
+                const auto cf = manifold2.GetContactFeature(i);
+
+                retval.state2[i] = PointState::AddState;
+
+                for (auto j = decltype(manifold1.GetPointCount()){0}; j < manifold1.GetPointCount(); ++j)
+                {
+                    if (manifold1.GetContactFeature(j) == cf)
+                    {
+                        retval.state2[i] = PointState::PersistState;
+                        break;
+                    }
+                }
             }
+
+            return retval;
         }
-    }
-    
-    return retval;
-}
 
-ClipList ClipSegmentToLine(const ClipList& vIn, const UnitVec& normal, Length offset,
-                           ContactFeature::Index indexA)
-{
-    ClipList vOut;
-
-    if (size(vIn) == 2) // must have two points (for a segment)
-    {
-        // Use Sutherland-Hodgman clipping:
-        //   (https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm ).
-
-        // Calculate the distance of end points to the line
-        const auto distance0 = Dot(normal, vIn[0].v) - offset;
-        const auto distance1 = Dot(normal, vIn[1].v) - offset;
-
-        // If the points are behind the plane...
-        // Ideally they are. Then we get face-vertex contact features which are simpler to
-        // calculate. Note that it also helps to avoid changing the contact feature from the
-        // given clip vertices. So the code here also accepts distances that are just slightly
-        // over zero.
-        if (distance0 <= 0_m || AlmostZero(StripUnit(distance0)))
+        ClipList ClipSegmentToLine(const ClipList& vIn, const UnitVec& normal, Length offset,
+                                   ContactFeature::Index indexA)
         {
-            vOut.push_back(vIn[0]);
-        }
-        if (distance1 <= 0_m || AlmostZero(StripUnit(distance1)))
-        {
-            vOut.push_back(vIn[1]);
+            ClipList vOut;
+
+            if (size(vIn) == 2)// must have two points (for a segment)
+            {
+                // Use Sutherland-Hodgman clipping:
+                //   (https://en.wikipedia.org/wiki/Sutherland%E2%80%93Hodgman_algorithm ).
+
+                // Calculate the distance of end points to the line
+                const auto distance0 = Dot(normal, vIn[0].v) - offset;
+                const auto distance1 = Dot(normal, vIn[1].v) - offset;
+
+                // If the points are behind the plane...
+                // Ideally they are. Then we get face-vertex contact features which are simpler to
+                // calculate. Note that it also helps to avoid changing the contact feature from the
+                // given clip vertices. So the code here also accepts distances that are just slightly
+                // over zero.
+                if (distance0 <= 0_m || AlmostZero(StripUnit(distance0)))
+                {
+                    vOut.push_back(vIn[0]);
+                }
+                if (distance1 <= 0_m || AlmostZero(StripUnit(distance1)))
+                {
+                    vOut.push_back(vIn[1]);
+                }
+
+                // If we didn't already find two points & the points are on different sides of the plane...
+                if (size(vOut) < 2 && signbit(StripUnit(distance0)) != signbit(StripUnit(distance1)))
+                {
+                    // Neither distance0 nor distance1 is 0 and either one or the other is negative (but not both).
+                    // Find intersection point of edge and plane
+                    // Vertex A is hitting edge B.
+                    const auto interp = distance0 / (distance0 - distance1);
+                    const auto vertex = vIn[0].v + (vIn[1].v - vIn[0].v) * interp;
+                    vOut.push_back(ClipVertex{vertex, GetVertexFaceContactFeature(indexA, vIn[0].cf.indexB)});
+                }
+            }
+
+            return vOut;
         }
 
-        // If we didn't already find two points & the points are on different sides of the plane...
-        if (size(vOut) < 2 && signbit(StripUnit(distance0)) != signbit(StripUnit(distance1)))
-        {
-            // Neither distance0 nor distance1 is 0 and either one or the other is negative (but not both).
-            // Find intersection point of edge and plane
-            // Vertex A is hitting edge B.
-            const auto interp = distance0 / (distance0 - distance1);
-            const auto vertex = vIn[0].v + (vIn[1].v - vIn[0].v) * interp;
-            vOut.push_back(ClipVertex{vertex, GetVertexFaceContactFeature(indexA, vIn[0].cf.indexB)});
-        }
-    }
-
-    return vOut;
-}
-
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Collision.hpp
+++ b/PlayRho/Collision/Collision.hpp
@@ -24,70 +24,72 @@
 /// Structures and functions used for computing contact points, distance
 /// queries, and TOI queries.
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/ArrayList.hpp>
 #include <PlayRho/Collision/ContactFeature.hpp>
+#include <PlayRho/Common/ArrayList.hpp>
+#include <PlayRho/Common/Math.hpp>
 
 #include <array>
 #include <type_traits>
 
-namespace playrho {
-
-/// @brief Point state enumeration.
-/// @note This is used for determining the state of contact points.
-enum class PointState
+namespace playrho
 {
-    NullState, ///< point does not exist
-    AddState, ///< point was added in the update
-    PersistState, ///< point persisted across the update
-    RemoveState ///< point was removed in the update
-};
 
-/// @brief Point states.
-/// @details The states pertain to the transition from an old manifold to a new manifold.
-///   So state 1 is either persist or remove while state 2 is either add or persist.
-struct PointStates
-{
-    /// @brief State 1.
-    PointState state1[MaxManifoldPoints] = {PointState::NullState, PointState::NullState};
-    
-    /// @brief State 2.
-    PointState state2[MaxManifoldPoints] = {PointState::NullState, PointState::NullState};
-};
+    /// @brief Point state enumeration.
+    /// @note This is used for determining the state of contact points.
+    enum class PointState
+    {
+        NullState,   ///< point does not exist
+        AddState,    ///< point was added in the update
+        PersistState,///< point persisted across the update
+        RemoveState  ///< point was removed in the update
+    };
 
-namespace d2 {
+    /// @brief Point states.
+    /// @details The states pertain to the transition from an old manifold to a new manifold.
+    ///   So state 1 is either persist or remove while state 2 is either add or persist.
+    struct PointStates
+    {
+        /// @brief State 1.
+        PointState state1[MaxManifoldPoints] = {PointState::NullState, PointState::NullState};
 
-class Manifold;
+        /// @brief State 2.
+        PointState state2[MaxManifoldPoints] = {PointState::NullState, PointState::NullState};
+    };
 
-/// @brief Computes the point states given two manifolds.
-PointStates GetPointStates(const Manifold& manifold1, const Manifold& manifold2) noexcept;
+    namespace d2
+    {
 
-/// @brief Clip vertex.
-/// @details Used for computing contact manifolds.
-/// @note This data structure is 12-bytes large (on at least one 64-bit platform).
-struct ClipVertex
-{
-    Length2 v; ///< Vertex of edge or polygon. 8-bytes.
-    ContactFeature cf; ///< Contact feature information. 4-bytes.
-};
+        class Manifold;
 
-/// @brief Clip list for <code>ClipSegmentToLine</code>.
-/// @see ClipSegmentToLine.
-/// @note This data structure is at least 24-bytes large.
-using ClipList = ArrayList<ClipVertex, MaxManifoldPoints>;
+        /// @brief Computes the point states given two manifolds.
+        PointStates GetPointStates(const Manifold& manifold1, const Manifold& manifold2) noexcept;
 
-/// Clipping for contact manifolds.
-/// @details This returns an array of points from the given line that are inside of the plane as
-///   defined by a given normal and offset.
-/// @param vIn Clip list of two points defining the line.
-/// @param normal Normal of the plane with which to determine intersection.
-/// @param offset Offset of the plane with which to determine intersection.
-/// @param indexA Index of vertex A.
-/// @return List of zero one or two clip points.
-ClipList ClipSegmentToLine(const ClipList& vIn, const UnitVec& normal, Length offset,
-                           ContactFeature::Index indexA);
+        /// @brief Clip vertex.
+        /// @details Used for computing contact manifolds.
+        /// @note This data structure is 12-bytes large (on at least one 64-bit platform).
+        struct ClipVertex
+        {
+            Length2 v;        ///< Vertex of edge or polygon. 8-bytes.
+            ContactFeature cf;///< Contact feature information. 4-bytes.
+        };
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Clip list for <code>ClipSegmentToLine</code>.
+        /// @see ClipSegmentToLine.
+        /// @note This data structure is at least 24-bytes large.
+        using ClipList = ArrayList<ClipVertex, MaxManifoldPoints>;
 
-#endif // PLAYRHO_COLLISION_COLLISION_HPP
+        /// Clipping for contact manifolds.
+        /// @details This returns an array of points from the given line that are inside of the plane as
+        ///   defined by a given normal and offset.
+        /// @param vIn Clip list of two points defining the line.
+        /// @param normal Normal of the plane with which to determine intersection.
+        /// @param offset Offset of the plane with which to determine intersection.
+        /// @param indexA Index of vertex A.
+        /// @return List of zero one or two clip points.
+        ClipList ClipSegmentToLine(const ClipList& vIn, const UnitVec& normal, Length offset,
+                                   ContactFeature::Index indexA);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_COLLISION_HPP

--- a/PlayRho/Collision/ContactFeature.hpp
+++ b/PlayRho/Collision/ContactFeature.hpp
@@ -25,116 +25,119 @@
 #include <PlayRho/Common/Math.hpp>
 #include <ostream>
 
-namespace playrho {
-
-/// @brief Contact Feature.
-/// @details The features that intersect to form the contact point.
-/// @note This structure is designed to be compact and passed-by-value.
-/// @note This data structure is 4-bytes large.
-/// @note Possible type combinations are:
-///   vertex-vertex,
-///   vertex-face,
-///   face-vertex, or
-///   face-face.
-struct ContactFeature
+namespace playrho
 {
-    using Index = std::uint8_t; ///< Index type.
 
-    /// @brief Type of the associated index value.
-    enum Type : std::uint8_t
+    /// @brief Contact Feature.
+    /// @details The features that intersect to form the contact point.
+    /// @note This structure is designed to be compact and passed-by-value.
+    /// @note This data structure is 4-bytes large.
+    /// @note Possible type combinations are:
+    ///   vertex-vertex,
+    ///   vertex-face,
+    ///   face-vertex, or
+    ///   face-face.
+    struct ContactFeature
     {
-        e_vertex = 0,
-        e_face = 1
+        using Index = std::uint8_t;///< Index type.
+
+        /// @brief Type of the associated index value.
+        enum Type : std::uint8_t
+        {
+            e_vertex = 0,
+            e_face = 1
+        };
+
+        // Fit data into 4-byte large structure...
+
+        Type typeA;  ///< The feature type on shape A
+        Index indexA;///< Feature index on shape A
+        Type typeB;  ///< The feature type on shape B
+        Index indexB;///< Feature index on shape B
     };
 
-    // Fit data into 4-byte large structure...
-
-    Type typeA; ///< The feature type on shape A
-    Index indexA; ///< Feature index on shape A
-    Type typeB; ///< The feature type on shape B
-    Index indexB; ///< Feature index on shape B
-};
-
-/// @brief Gets the vertex vertex contact feature for the given indices.
-/// @relatedalso ContactFeature
-constexpr ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
-                                                       ContactFeature::Index b) noexcept
-{
-    return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_vertex, b};
-}
-
-/// @brief Gets the vertex face contact feature for the given indices.
-/// @relatedalso ContactFeature
-constexpr ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
-                                                     ContactFeature::Index b) noexcept
-{
-    return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_face, b};
-}
-
-/// @brief Gets the face vertex contact feature for the given indices.
-/// @relatedalso ContactFeature
-constexpr ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
-                                                     ContactFeature::Index b) noexcept
-{
-    return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_vertex, b};
-}
-
-/// @brief Gets the face face contact feature for the given indices.
-/// @relatedalso ContactFeature
-constexpr ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
-                                                   ContactFeature::Index b) noexcept
-{
-    return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_face, b};
-}
-
-/// @brief Flips contact features information.
-/// @relatedalso ContactFeature
-constexpr ContactFeature Flip(ContactFeature val) noexcept
-{
-    return ContactFeature{val.typeB, val.indexB, val.typeA, val.indexA};
-}
-
-/// @brief Determines if the given two contact features are equal.
-/// @relatedalso ContactFeature
-constexpr bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
-{
-    return (lhs.typeA == rhs.typeA) && (lhs.indexA == rhs.indexA)
-        && (lhs.typeB == rhs.typeB) && (lhs.indexB == rhs.indexB);
-}
-
-/// @brief Determines if the given two contact features are not equal.
-/// @relatedalso ContactFeature
-constexpr bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
-/// @brief Gets the human readable name for the given contact feature type.
-inline const char* GetName(ContactFeature::Type type) noexcept
-{
-    switch (type)
+    /// @brief Gets the vertex vertex contact feature for the given indices.
+    /// @relatedalso ContactFeature
+    constexpr ContactFeature GetVertexVertexContactFeature(ContactFeature::Index a,
+                                                           ContactFeature::Index b) noexcept
     {
-        case ContactFeature::e_face: return "face";
-        case ContactFeature::e_vertex: return "vertex";
+        return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_vertex, b};
     }
-    return "unknown";
-}
 
-/// @brief Stream output operator.
-inline ::std::ostream& operator<<(::std::ostream& os, const ContactFeature& value)
-{
-    os << "{";
-    os << GetName(value.typeA);
-    os << ",";
-    os << unsigned(value.indexA);
-    os << ",";
-    os << GetName(value.typeB);
-    os << ",";
-    os << unsigned(value.indexB);
-    os << "}";
-    return os;
-}
+    /// @brief Gets the vertex face contact feature for the given indices.
+    /// @relatedalso ContactFeature
+    constexpr ContactFeature GetVertexFaceContactFeature(ContactFeature::Index a,
+                                                         ContactFeature::Index b) noexcept
+    {
+        return ContactFeature{ContactFeature::e_vertex, a, ContactFeature::e_face, b};
+    }
 
-}; // namespace playrho
+    /// @brief Gets the face vertex contact feature for the given indices.
+    /// @relatedalso ContactFeature
+    constexpr ContactFeature GetFaceVertexContactFeature(ContactFeature::Index a,
+                                                         ContactFeature::Index b) noexcept
+    {
+        return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_vertex, b};
+    }
 
-#endif // PLAYRHO_COLLISION_CONTACTFEATURE_HPP
+    /// @brief Gets the face face contact feature for the given indices.
+    /// @relatedalso ContactFeature
+    constexpr ContactFeature GetFaceFaceContactFeature(ContactFeature::Index a,
+                                                       ContactFeature::Index b) noexcept
+    {
+        return ContactFeature{ContactFeature::e_face, a, ContactFeature::e_face, b};
+    }
+
+    /// @brief Flips contact features information.
+    /// @relatedalso ContactFeature
+    constexpr ContactFeature Flip(ContactFeature val) noexcept
+    {
+        return ContactFeature{val.typeB, val.indexB, val.typeA, val.indexA};
+    }
+
+    /// @brief Determines if the given two contact features are equal.
+    /// @relatedalso ContactFeature
+    constexpr bool operator==(ContactFeature lhs, ContactFeature rhs) noexcept
+    {
+        return (lhs.typeA == rhs.typeA) && (lhs.indexA == rhs.indexA)
+               && (lhs.typeB == rhs.typeB) && (lhs.indexB == rhs.indexB);
+    }
+
+    /// @brief Determines if the given two contact features are not equal.
+    /// @relatedalso ContactFeature
+    constexpr bool operator!=(ContactFeature lhs, ContactFeature rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+    /// @brief Gets the human readable name for the given contact feature type.
+    inline const char* GetName(ContactFeature::Type type) noexcept
+    {
+        switch (type)
+        {
+        case ContactFeature::e_face:
+            return "face";
+        case ContactFeature::e_vertex:
+            return "vertex";
+        }
+        return "unknown";
+    }
+
+    /// @brief Stream output operator.
+    inline ::std::ostream& operator<<(::std::ostream& os, const ContactFeature& value)
+    {
+        os << "{";
+        os << GetName(value.typeA);
+        os << ",";
+        os << unsigned(value.indexA);
+        os << ",";
+        os << GetName(value.typeB);
+        os << ",";
+        os << unsigned(value.indexB);
+        os << "}";
+        return os;
+    }
+
+};// namespace playrho
+
+#endif// PLAYRHO_COLLISION_CONTACTFEATURE_HPP

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -25,84 +25,87 @@
 
 #include <PlayRho/Dynamics/StepConf.hpp>
 
-namespace playrho {
-namespace d2 {
-namespace {
-
-inline bool HasKey(IndexPair3 pairs, IndexPair key)
+namespace playrho
 {
-    return pairs[0] == key || pairs[1] == key || pairs[2] == key;
-}
-
-inline SimplexEdge GetSimplexEdge(const DistanceProxy& proxyA,
-                                  const Transformation& xfA,
-                                  VertexCounter idxA,
-                                  const DistanceProxy& proxyB,
-                                  const Transformation& xfB,
-                                  VertexCounter idxB)
-{
-    const auto wA = Transform(proxyA.GetVertex(idxA), xfA);
-    const auto wB = Transform(proxyB.GetVertex(idxB), xfB);
-    return SimplexEdge{wA, idxA, wB, idxB};
-}
-
-inline SimplexEdges GetSimplexEdges(const IndexPair3 indexPairs,
-                                    const DistanceProxy& proxyA, const Transformation& xfA,
-                                    const DistanceProxy& proxyB, const Transformation& xfB)
-{
-    /// @brief Size type.
-    using size_type = std::remove_const<decltype(MaxSimplexEdges)>::type;
-
-    auto simplexEdges = SimplexEdges{};
-    const auto count = GetNumValidIndices(indexPairs);
-    switch (count)
+    namespace d2
     {
-        case 3:
-            simplexEdges[2] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[2]),
-                                             proxyB, xfB, std::get<1>(indexPairs[2]));
-            [[fallthrough]];
-        case 2:
-            simplexEdges[1] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[1]),
-                                             proxyB, xfB, std::get<1>(indexPairs[1]));
-            [[fallthrough]];
-        case 1:
-            simplexEdges[0] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[0]),
-                                             proxyB, xfB, std::get<1>(indexPairs[0]));
-    }
-    simplexEdges.size(static_cast<size_type>(count));
-    return simplexEdges;
-}
+        namespace
+        {
 
-} // namespace
+            inline bool HasKey(IndexPair3 pairs, IndexPair key)
+            {
+                return pairs[0] == key || pairs[1] == key || pairs[2] == key;
+            }
 
-DistanceConf GetDistanceConf(const ToiConf& conf) noexcept
-{
-    auto distanceConf = DistanceConf{};
-    distanceConf.maxIterations = conf.maxDistIters;
-    return distanceConf;
-}
+            inline SimplexEdge GetSimplexEdge(const DistanceProxy& proxyA,
+                                              const Transformation& xfA,
+                                              VertexCounter idxA,
+                                              const DistanceProxy& proxyB,
+                                              const Transformation& xfB,
+                                              VertexCounter idxB)
+            {
+                const auto wA = Transform(proxyA.GetVertex(idxA), xfA);
+                const auto wB = Transform(proxyB.GetVertex(idxB), xfB);
+                return SimplexEdge{wA, idxA, wB, idxB};
+            }
 
-DistanceConf GetDistanceConf(const StepConf& conf) noexcept
-{
-    DistanceConf distanceConf;
-    distanceConf.maxIterations = conf.maxDistanceIters;
-    return distanceConf;
-}
+            inline SimplexEdges GetSimplexEdges(const IndexPair3 indexPairs,
+                                                const DistanceProxy& proxyA, const Transformation& xfA,
+                                                const DistanceProxy& proxyB, const Transformation& xfB)
+            {
+                /// @brief Size type.
+                using size_type = std::remove_const<decltype(MaxSimplexEdges)>::type;
 
-PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept
-{
-    auto pointA = Length2{};
-    auto pointB = Length2{};
+                auto simplexEdges = SimplexEdges{};
+                const auto count = GetNumValidIndices(indexPairs);
+                switch (count)
+                {
+                case 3:
+                    simplexEdges[2] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[2]),
+                                                     proxyB, xfB, std::get<1>(indexPairs[2]));
+                    [[fallthrough]];
+                case 2:
+                    simplexEdges[1] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[1]),
+                                                     proxyB, xfB, std::get<1>(indexPairs[1]));
+                    [[fallthrough]];
+                case 1:
+                    simplexEdges[0] = GetSimplexEdge(proxyA, xfA, std::get<0>(indexPairs[0]),
+                                                     proxyB, xfB, std::get<1>(indexPairs[0]));
+                }
+                simplexEdges.size(static_cast<size_type>(count));
+                return simplexEdges;
+            }
 
-    const auto numEdges = size(simplex);
-    for (auto i = decltype(numEdges){0}; i < numEdges; ++i)
-    {
-        const auto e = simplex.GetSimplexEdge(i);
-        const auto c = simplex.GetCoefficient(i);
+        }// namespace
 
-        pointA += e.GetPointA() * c;
-        pointB += e.GetPointB() * c;
-    }
+        DistanceConf GetDistanceConf(const ToiConf& conf) noexcept
+        {
+            auto distanceConf = DistanceConf{};
+            distanceConf.maxIterations = conf.maxDistIters;
+            return distanceConf;
+        }
+
+        DistanceConf GetDistanceConf(const StepConf& conf) noexcept
+        {
+            DistanceConf distanceConf;
+            distanceConf.maxIterations = conf.maxDistanceIters;
+            return distanceConf;
+        }
+
+        PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept
+        {
+            auto pointA = Length2{};
+            auto pointB = Length2{};
+
+            const auto numEdges = size(simplex);
+            for (auto i = decltype(numEdges){0}; i < numEdges; ++i)
+            {
+                const auto e = simplex.GetSimplexEdge(i);
+                const auto c = simplex.GetCoefficient(i);
+
+                pointA += e.GetPointA() * c;
+                pointB += e.GetPointB() * c;
+            }
 #if 0
     // In the 3-simplex case, pointA and pointB are usually equal.
     // XXX: Sometimes in the 3-simplex case, pointA is slightly different than pointB. Why??
@@ -112,130 +115,130 @@ PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept
         std::cout << std::endl;
     }
 #endif
-    return PairLength2{pointA, pointB};
-}
-
-DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& transformA,
-                        const DistanceProxy& proxyB, const Transformation& transformB,
-                        DistanceConf conf)
-{
-    using playrho::IsFull;
-    
-    assert(proxyA.GetVertexCount() > 0);
-    assert(IsValid(transformA.p));
-    assert(proxyB.GetVertexCount() > 0);
-    assert(IsValid(transformB.p));
-
-    auto savedIndices = conf.cache.indices;
-
-    // Initialize the simplex.
-    auto simplexEdges = GetSimplexEdges(savedIndices, proxyA, transformA, proxyB, transformB);
-
-    // Compute the new simplex metric, if it is substantially different than
-    // old metric then flush the simplex.
-    if (size(simplexEdges) > 1)
-    {
-        const auto metric1 = conf.cache.metric;
-        const auto metric2 = Simplex::CalcMetric(simplexEdges);
-        if ((metric2 < (metric1 / 2)) || (metric2 > (metric1 * 2)) || (metric2 < 0) || AlmostZero(metric2))
-        {
-            simplexEdges.clear();
+            return PairLength2{pointA, pointB};
         }
-    }
 
-    if (empty(simplexEdges))
-    {
-        simplexEdges.push_back(GetSimplexEdge(proxyA, transformA, 0, proxyB, transformB, 0));
-        savedIndices = IndexPair3{{IndexPair{0, 0}, InvalidIndexPair, InvalidIndexPair}};
-    }
+        DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& transformA,
+                                const DistanceProxy& proxyB, const Transformation& transformB,
+                                DistanceConf conf)
+        {
+            using playrho::IsFull;
 
-    auto simplex = Simplex{};
-    auto state = DistanceOutput::HitMaxIters;
+            assert(proxyA.GetVertexCount() > 0);
+            assert(IsValid(transformA.p));
+            assert(proxyB.GetVertexCount() > 0);
+            assert(IsValid(transformB.p));
+
+            auto savedIndices = conf.cache.indices;
+
+            // Initialize the simplex.
+            auto simplexEdges = GetSimplexEdges(savedIndices, proxyA, transformA, proxyB, transformB);
+
+            // Compute the new simplex metric, if it is substantially different than
+            // old metric then flush the simplex.
+            if (size(simplexEdges) > 1)
+            {
+                const auto metric1 = conf.cache.metric;
+                const auto metric2 = Simplex::CalcMetric(simplexEdges);
+                if ((metric2 < (metric1 / 2)) || (metric2 > (metric1 * 2)) || (metric2 < 0) || AlmostZero(metric2))
+                {
+                    simplexEdges.clear();
+                }
+            }
+
+            if (empty(simplexEdges))
+            {
+                simplexEdges.push_back(GetSimplexEdge(proxyA, transformA, 0, proxyB, transformB, 0));
+                savedIndices = IndexPair3{{IndexPair{0, 0}, InvalidIndexPair, InvalidIndexPair}};
+            }
+
+            auto simplex = Simplex{};
+            auto state = DistanceOutput::HitMaxIters;
 
 #if defined(DO_COMPUTE_CLOSEST_POINT)
-    auto distanceSqr1 = MaxFloat;
+            auto distanceSqr1 = MaxFloat;
 #endif
 
-    // Main iteration loop.
-    auto iter = decltype(conf.maxIterations){0};
-    while (iter < conf.maxIterations)
-    {
-        ++iter;
-        
-        simplex = Simplex::Get(simplexEdges);
-        simplexEdges = simplex.GetEdges();
+            // Main iteration loop.
+            auto iter = decltype(conf.maxIterations){0};
+            while (iter < conf.maxIterations)
+            {
+                ++iter;
 
-        // If have max simplex edges (3), then the origin is in corresponding triangle.
-        if (IsFull(simplexEdges))
-        {
-            state = DistanceOutput::MaxPoints;
-            break;
-        }
+                simplex = Simplex::Get(simplexEdges);
+                simplexEdges = simplex.GetEdges();
+
+                // If have max simplex edges (3), then the origin is in corresponding triangle.
+                if (IsFull(simplexEdges))
+                {
+                    state = DistanceOutput::MaxPoints;
+                    break;
+                }
 
 #if defined(DO_COMPUTE_CLOSEST_POINT)
-        // Compute closest point.
-        const auto p = GetClosestPoint(simplexEdges);
-        const auto distanceSqr2 = GetMagnitudeSquared(p);
+                // Compute closest point.
+                const auto p = GetClosestPoint(simplexEdges);
+                const auto distanceSqr2 = GetMagnitudeSquared(p);
 
-        // Ensure progress
-        if (distanceSqr2 >= distanceSqr1)
-        {
-            //break;
-        }
-        distanceSqr1 = distanceSqr2;
+                // Ensure progress
+                if (distanceSqr2 >= distanceSqr1)
+                {
+                    //break;
+                }
+                distanceSqr1 = distanceSqr2;
 #endif
-        // Get search direction.
-        const auto d = CalcSearchDirection(simplexEdges);
-        assert(IsValid(d));
+                // Get search direction.
+                const auto d = CalcSearchDirection(simplexEdges);
+                assert(IsValid(d));
 
-        // Ensure the search direction is numerically fit.
-        if (AlmostZero(StripUnit(GetMagnitudeSquared(d))))
-        {
-            state = DistanceOutput::UnfitSearchDir;
+                // Ensure the search direction is numerically fit.
+                if (AlmostZero(StripUnit(GetMagnitudeSquared(d))))
+                {
+                    state = DistanceOutput::UnfitSearchDir;
 
-            // The origin is probably contained by a line segment
-            // or triangle. Thus the shapes are overlapped.
+                    // The origin is probably contained by a line segment
+                    // or triangle. Thus the shapes are overlapped.
 
-            // We can't return zero here even though there may be overlap.
-            // In case the simplex is a point, segment, or triangle it is difficult
-            // to determine if the origin is contained in the CSO or very close to it.
-            break;
+                    // We can't return zero here even though there may be overlap.
+                    // In case the simplex is a point, segment, or triangle it is difficult
+                    // to determine if the origin is contained in the CSO or very close to it.
+                    break;
+                }
+
+                // Compute a tentative new simplex edge using support points.
+                const auto indexA = GetSupportIndex(proxyA, InverseRotate(-d, transformA.q));
+                const auto indexB = GetSupportIndex(proxyB, InverseRotate(d, transformB.q));
+
+                // Check for duplicate support points. This is the main termination criteria.
+                // If there's a duplicate support point, code must exit loop to avoid cycling.
+                if (HasKey(savedIndices, IndexPair{indexA, indexB}))
+                {
+                    state = DistanceOutput::DuplicateIndexPair;
+                    break;
+                }
+
+                // New edge is ok and needed.
+                simplexEdges.push_back(GetSimplexEdge(proxyA, transformA, indexA, proxyB, transformB, indexB));
+                savedIndices = GetIndexPairs(simplexEdges);
+            }
+
+            // Note: simplexEdges is same here as simplex.GetSimplexEdges().
+            // GetWitnessPoints(simplex), iter, Simplex::GetCache(simplexEdges)
+            return DistanceOutput{simplex, iter, state};
         }
 
-        // Compute a tentative new simplex edge using support points.
-        const auto indexA = GetSupportIndex(proxyA, InverseRotate(-d, transformA.q));
-        const auto indexB = GetSupportIndex(proxyB, InverseRotate(d, transformB.q));
-
-        // Check for duplicate support points. This is the main termination criteria.
-        // If there's a duplicate support point, code must exit loop to avoid cycling.
-        if (HasKey(savedIndices, IndexPair{indexA, indexB}))
+        Area TestOverlap(const DistanceProxy& proxyA, const Transformation& xfA,
+                         const DistanceProxy& proxyB, const Transformation& xfB,
+                         DistanceConf conf)
         {
-            state = DistanceOutput::DuplicateIndexPair;
-            break;
+            const auto distanceInfo = Distance(proxyA, xfA, proxyB, xfB, conf);
+            assert(distanceInfo.state != DistanceOutput::Unknown && distanceInfo.state != DistanceOutput::HitMaxIters);
+
+            const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
+            const auto distanceSquared = GetMagnitudeSquared(GetDelta(witnessPoints));
+            const auto totalRadiusSquared = Square(proxyA.GetVertexRadius() + proxyB.GetVertexRadius());
+            return totalRadiusSquared - distanceSquared;
         }
 
-        // New edge is ok and needed.
-        simplexEdges.push_back(GetSimplexEdge(proxyA, transformA, indexA, proxyB, transformB, indexB));
-        savedIndices = GetIndexPairs(simplexEdges);
-    }
-
-    // Note: simplexEdges is same here as simplex.GetSimplexEdges().
-    // GetWitnessPoints(simplex), iter, Simplex::GetCache(simplexEdges)
-    return DistanceOutput{simplex, iter, state};
-}
-
-Area TestOverlap(const DistanceProxy& proxyA, const Transformation& xfA,
-                 const DistanceProxy& proxyB, const Transformation& xfB,
-                 DistanceConf conf)
-{
-    const auto distanceInfo = Distance(proxyA, xfA, proxyB, xfB, conf);
-    assert(distanceInfo.state != DistanceOutput::Unknown && distanceInfo.state != DistanceOutput::HitMaxIters);
-    
-    const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
-    const auto distanceSquared = GetMagnitudeSquared(GetDelta(witnessPoints));
-    const auto totalRadiusSquared = Square(proxyA.GetVertexRadius() + proxyB.GetVertexRadius());
-    return totalRadiusSquared - distanceSquared;
-}
-
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Distance.hpp
+++ b/PlayRho/Collision/Distance.hpp
@@ -20,100 +20,102 @@
 #ifndef PLAYRHO_COLLISION_DISTANCE_HPP
 #define PLAYRHO_COLLISION_DISTANCE_HPP
 
-#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Collision/Simplex.hpp>
+#include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-/// @brief Pair of <code>Length2</code> values.
-/// @note Uses <code>std::pair</code> because this is a pair and also because
-///   <code>std::pair</code> has more support for constant expressions.
-using PairLength2 = std::pair<Length2, Length2>;
-
-struct ToiConf;
-struct StepConf;
-
-namespace d2 {
-
-class DistanceProxy;
-
-/// @brief Gets the witness points of the given simplex.
-PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept;
-
-/// @brief Gets the delta to go from the first element to the second.
-constexpr Length2 GetDelta(PairLength2 arg) noexcept
+namespace playrho
 {
-    return std::get<1>(arg) - std::get<0>(arg);
-}
 
-/// @brief Distance Configuration.
-/// @details Configuration information for calling the <code>Distance</code> function.
-struct DistanceConf
-{
-    /// @brief Iteration type.
-    using iteration_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+    /// @brief Pair of <code>Length2</code> values.
+    /// @note Uses <code>std::pair</code> because this is a pair and also because
+    ///   <code>std::pair</code> has more support for constant expressions.
+    using PairLength2 = std::pair<Length2, Length2>;
 
-    Simplex::Cache cache; ///< Cache.
-    iteration_type maxIterations = DefaultMaxDistanceIters; ///< Max iterations.
-};
+    struct ToiConf;
+    struct StepConf;
 
-/// @brief Gets the distance configuration for the given time of impact configuration.
-/// @relatedalso DistanceConf
-DistanceConf GetDistanceConf(const ToiConf& conf) noexcept;
-
-/// @brief Gets the distance configuration for the given step configuration.
-/// @relatedalso DistanceConf
-DistanceConf GetDistanceConf(const StepConf& conf) noexcept;
-
-/// @brief Distance Output.
-struct DistanceOutput
-{
-    /// @brief State of the distance output.
-    enum State: std::uint8_t
+    namespace d2
     {
-        Unknown,
-        MaxPoints,
-        UnfitSearchDir,
-        DuplicateIndexPair,
-        HitMaxIters
-    };
 
-    /// @brief Iteration type.
-    using iteration_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+        class DistanceProxy;
 
-    Simplex simplex; ///< Simplex.
-    iteration_type iterations = 0; ///< Count of iterations performed to return result.
-    State state = Unknown; ///< Termination state.
-};
+        /// @brief Gets the witness points of the given simplex.
+        PairLength2 GetWitnessPoints(const Simplex& simplex) noexcept;
 
-/// @brief Determines the closest points between two shapes.
-/// @note Supports any combination of shapes.
-/// @note On the first call, the Simplex::Cache.count should be set to zero.
-/// @image html distance.png
-/// @param proxyA Proxy A.
-/// @param transformA Transform of A.
-/// @param proxyB Proxy B.
-/// @param transformB Transform of B.
-/// @param conf Configuration to use including the simplex cache for assisting the determination.
-/// @relatedalso DistanceConf
-/// @return Closest points between the two shapes and the count of iterations it took to
-///   determine them. The iteration count will always be greater than zero unless
-///   <code>DefaultMaxDistanceIters</code> is zero.
-DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& transformA,
-                        const DistanceProxy& proxyB, const Transformation& transformB,
-                        DistanceConf conf = DistanceConf{});
+        /// @brief Gets the delta to go from the first element to the second.
+        constexpr Length2 GetDelta(PairLength2 arg) noexcept
+        {
+            return std::get<1>(arg) - std::get<0>(arg);
+        }
 
-/// @brief Determine if two generic shapes overlap.
-///
-/// @note The returned touching state information typically agrees with that returned from
-///   the <code>CollideShapes</code> function. This is not always the case however
-///   especially when the separation or overlap distance is closer to zero.
-///
-Area TestOverlap(const DistanceProxy& proxyA, const Transformation& xfA,
-                 const DistanceProxy& proxyB, const Transformation& xfB,
-                 DistanceConf conf = DistanceConf{});
+        /// @brief Distance Configuration.
+        /// @details Configuration information for calling the <code>Distance</code> function.
+        struct DistanceConf
+        {
+            /// @brief Iteration type.
+            using iteration_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
 
-} // namespace d2
-} // namespace playrho
+            Simplex::Cache cache;                                  ///< Cache.
+            iteration_type maxIterations = DefaultMaxDistanceIters;///< Max iterations.
+        };
 
-#endif // PLAYRHO_COLLISION_DISTANCE_HPP
+        /// @brief Gets the distance configuration for the given time of impact configuration.
+        /// @relatedalso DistanceConf
+        DistanceConf GetDistanceConf(const ToiConf& conf) noexcept;
+
+        /// @brief Gets the distance configuration for the given step configuration.
+        /// @relatedalso DistanceConf
+        DistanceConf GetDistanceConf(const StepConf& conf) noexcept;
+
+        /// @brief Distance Output.
+        struct DistanceOutput
+        {
+            /// @brief State of the distance output.
+            enum State : std::uint8_t
+            {
+                Unknown,
+                MaxPoints,
+                UnfitSearchDir,
+                DuplicateIndexPair,
+                HitMaxIters
+            };
+
+            /// @brief Iteration type.
+            using iteration_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+
+            Simplex simplex;              ///< Simplex.
+            iteration_type iterations = 0;///< Count of iterations performed to return result.
+            State state = Unknown;        ///< Termination state.
+        };
+
+        /// @brief Determines the closest points between two shapes.
+        /// @note Supports any combination of shapes.
+        /// @note On the first call, the Simplex::Cache.count should be set to zero.
+        /// @image html distance.png
+        /// @param proxyA Proxy A.
+        /// @param transformA Transform of A.
+        /// @param proxyB Proxy B.
+        /// @param transformB Transform of B.
+        /// @param conf Configuration to use including the simplex cache for assisting the determination.
+        /// @relatedalso DistanceConf
+        /// @return Closest points between the two shapes and the count of iterations it took to
+        ///   determine them. The iteration count will always be greater than zero unless
+        ///   <code>DefaultMaxDistanceIters</code> is zero.
+        DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& transformA,
+                                const DistanceProxy& proxyB, const Transformation& transformB,
+                                DistanceConf conf = DistanceConf{});
+
+        /// @brief Determine if two generic shapes overlap.
+        ///
+        /// @note The returned touching state information typically agrees with that returned from
+        ///   the <code>CollideShapes</code> function. This is not always the case however
+        ///   especially when the separation or overlap distance is closer to zero.
+        ///
+        Area TestOverlap(const DistanceProxy& proxyA, const Transformation& xfA,
+                         const DistanceProxy& proxyB, const Transformation& xfB,
+                         DistanceConf conf = DistanceConf{});
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_DISTANCE_HPP

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -22,148 +22,149 @@
 #include <algorithm>
 #include <iterator>
 
-namespace playrho {
-namespace d2 {
-
-bool operator== (const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept
+namespace playrho
 {
-    if (lhs.GetVertexRadius() != rhs.GetVertexRadius())
+    namespace d2
     {
-        return false;
-    }
 
-    // No need to compare normals since they should be invariant to the vertices.
-    const auto lhr = lhs.GetVertices();
-    const auto rhr = rhs.GetVertices();
-    return std::equal(cbegin(lhr), cend(lhr), cbegin(rhr), cend(rhr));
-}
-
-std::size_t FindLowestRightMostVertex(Span<const Length2> vertices)
-{
-    if (const auto numVertices = size(vertices); numVertices > 0)
-    {
-        auto i0 = decltype(numVertices){0};
-        auto max_x = GetX(vertices[0]);
-        for (auto i = decltype(numVertices){1}; i < numVertices; ++i)
+        bool operator==(const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept
         {
-            const auto x = GetX(vertices[i]);
-            if ((max_x < x) || ((max_x == x) && (GetY(vertices[i]) < GetY(vertices[i0]))))
+            if (lhs.GetVertexRadius() != rhs.GetVertexRadius())
             {
-                max_x = x;
-                i0 = i;
+                return false;
             }
+
+            // No need to compare normals since they should be invariant to the vertices.
+            const auto lhr = lhs.GetVertices();
+            const auto rhr = rhs.GetVertices();
+            return std::equal(cbegin(lhr), cend(lhr), cbegin(rhr), cend(rhr));
         }
-        return i0;
-    }
-    return GetInvalid<std::size_t>();
-}
 
-std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices)
-{
-    auto result = std::vector<Length2>{};
-    
-    // Create the convex hull using the Gift wrapping algorithm
-    // http://en.wikipedia.org/wiki/Gift_wrapping_algorithm
-    
-    const auto index0 = FindLowestRightMostVertex(vertices);
-    if (index0 != GetInvalid<std::size_t>())
-    {
-        const auto numVertices = size(vertices);
-        auto hull = std::vector<decltype(size(vertices))>();
-        
-        auto ih = index0;
-        for (;;)
+        std::size_t FindLowestRightMostVertex(Span<const Length2> vertices)
         {
-            hull.push_back(ih);
-            
-            auto ie = decltype(numVertices){0};
-            for (auto j = decltype(numVertices){1}; j < numVertices; ++j)
+            if (const auto numVertices = size(vertices); numVertices > 0)
             {
-                if (ie == ih)
+                auto i0 = decltype(numVertices){0};
+                auto max_x = GetX(vertices[0]);
+                for (auto i = decltype(numVertices){1}; i < numVertices; ++i)
                 {
-                    ie = j;
-                    continue;
+                    const auto x = GetX(vertices[i]);
+                    if ((max_x < x) || ((max_x == x) && (GetY(vertices[i]) < GetY(vertices[i0]))))
+                    {
+                        max_x = x;
+                        i0 = i;
+                    }
                 }
-                
-                const auto r = vertices[ie] - vertices[ih];
-                const auto v = vertices[j] - vertices[ih];
-                const auto c = Cross(r, v);
-                if ((c < 0_m2) || ((c == 0_m2) && (GetMagnitudeSquared(v) > GetMagnitudeSquared(r))))
+                return i0;
+            }
+            return GetInvalid<std::size_t>();
+        }
+
+        std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices)
+        {
+            auto result = std::vector<Length2>{};
+
+            // Create the convex hull using the Gift wrapping algorithm
+            // http://en.wikipedia.org/wiki/Gift_wrapping_algorithm
+
+            const auto index0 = FindLowestRightMostVertex(vertices);
+            if (index0 != GetInvalid<std::size_t>())
+            {
+                const auto numVertices = size(vertices);
+                auto hull = std::vector<decltype(size(vertices))>();
+
+                auto ih = index0;
+                for (;;)
                 {
-                    ie = j;
+                    hull.push_back(ih);
+
+                    auto ie = decltype(numVertices){0};
+                    for (auto j = decltype(numVertices){1}; j < numVertices; ++j)
+                    {
+                        if (ie == ih)
+                        {
+                            ie = j;
+                            continue;
+                        }
+
+                        const auto r = vertices[ie] - vertices[ih];
+                        const auto v = vertices[j] - vertices[ih];
+                        const auto c = Cross(r, v);
+                        if ((c < 0_m2) || ((c == 0_m2) && (GetMagnitudeSquared(v) > GetMagnitudeSquared(r))))
+                        {
+                            ie = j;
+                        }
+                    }
+
+                    ih = ie;
+                    if (ie == index0)
+                    {
+                        break;
+                    }
+                }
+
+                const auto count = size(hull);
+                for (auto i = decltype(count){0}; i < count; ++i)
+                {
+                    result.emplace_back(vertices[hull[i]]);
                 }
             }
-            
-            ih = ie;
-            if (ie == index0)
+
+            return result;
+        }
+
+        bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept
+        {
+            const auto count = proxy.GetVertexCount();
+            const auto vr = proxy.GetVertexRadius();
+
+            switch (count)
             {
+            case 0:
+                return false;
+            case 1: {
+                const auto v0 = proxy.GetVertex(0);
+                const auto delta = point - v0;
+                return GetMagnitudeSquared(delta) <= Square(vr);
+            }
+            default:
                 break;
             }
-        }
-        
-        const auto count = size(hull);
-        for (auto i = decltype(count){0}; i < count; ++i)
-        {
-            result.emplace_back(vertices[hull[i]]);
-        }
-    }
-    
-    return result;
-}
 
-bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept
-{
-    const auto count = proxy.GetVertexCount();
-    const auto vr = proxy.GetVertexRadius();
+            auto maxDot = -MaxFloat * Meter;
+            auto maxIdx = static_cast<decltype(count)>(-1);
+            for (auto i = decltype(count){0}; i < count; ++i)
+            {
+                const auto vi = proxy.GetVertex(i);
+                const auto delta = point - vi;
+                const auto dot = Dot(proxy.GetNormal(i), delta);
+                if (dot > vr)
+                {
+                    return false;
+                }
+                if (maxDot < dot)
+                {
+                    maxDot = dot;
+                    maxIdx = i;
+                }
+            }
+            assert(maxIdx < count);
 
-    switch (count)
-    {
-        case 0:
-            return false;
-        case 1:
-        {
-            const auto v0 = proxy.GetVertex(0);
-            const auto delta = point - v0;
-            return GetMagnitudeSquared(delta) <= Square(vr);
+            const auto v0 = proxy.GetVertex(maxIdx);
+            const auto v1 = proxy.GetVertex(GetModuloNext(maxIdx, count));
+            const auto edge = v1 - v0;
+            if (const auto delta0 = v0 - point; Dot(edge, delta0) >= 0_m2)
+            {
+                // point is nearest v0 and not within edge
+                return GetMagnitudeSquared(delta0) <= Square(vr);
+            }
+            if (const auto delta1 = point - v1; Dot(edge, delta1) >= 0_m2)
+            {
+                // point is nearest v1 and not within edge
+                return GetMagnitudeSquared(delta1) <= Square(vr);
+            }
+            return true;
         }
-        default:
-            break;
-    }
-    
-    auto maxDot = -MaxFloat * Meter;
-    auto maxIdx = static_cast<decltype(count)>(-1);
-    for (auto i = decltype(count){0}; i < count; ++i)
-    {
-        const auto vi = proxy.GetVertex(i);
-        const auto delta = point - vi;
-        const auto dot = Dot(proxy.GetNormal(i), delta);
-        if (dot > vr)
-        {
-            return false;
-        }
-        if (maxDot < dot)
-        {
-            maxDot = dot;
-            maxIdx = i;
-        }
-    }
-    assert(maxIdx < count);
-    
-    const auto v0 = proxy.GetVertex(maxIdx);
-    const auto v1 = proxy.GetVertex(GetModuloNext(maxIdx, count));
-    const auto edge = v1 - v0;
-    if (const auto delta0 = v0 - point; Dot(edge, delta0) >= 0_m2)
-    {
-        // point is nearest v0 and not within edge
-        return GetMagnitudeSquared(delta0) <= Square(vr);
-    }
-    if (const auto delta1 = point - v1; Dot(edge, delta1) >= 0_m2)
-    {
-        // point is nearest v1 and not within edge
-        return GetMagnitudeSquared(delta1) <= Square(vr);
-    }
-    return true;
-}
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -22,8 +22,8 @@
 
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/Range.hpp>
-#include <vector>
 #include <algorithm>
+#include <vector>
 
 // Define IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS to implement the DistanceProxy class
 // using buffers instead of pointers. Note that timing tests suggest implementing with
@@ -31,229 +31,239 @@
 // easier though so a buffering code alternative is kept in the source code for now.
 // #define IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
 
-namespace playrho {
-namespace d2 {
-
-    class Shape;
-
-    /// @brief Distance Proxy.
-    ///
-    /// @details A distance proxy aggregates a convex set of vertices and a vertex radius of
-    ///   those vertices. This can be visualized as a convex N-sided polygon with rounded corners.
-    ///   It's meant to represent any single portion of a shape identified by its child-index.
-    ///   These are used by the G.J.K. algorithm: "a method for determining the minimum distance
-    ///   between two convex sets".
-    ///
-    /// @note This data structure is 24-bytes.
-    ///
-    /// @see https://en.wikipedia.org/wiki/Gilbert%2DJohnson%2DKeerthi_distance_algorithm
-    ///
-    class DistanceProxy
+namespace playrho
+{
+    namespace d2
     {
-    public:
-        /// @brief Constant vertex pointer.
-        using ConstVertexPointer = const Length2*;
-        
-        /// @brief Constant vertex iterator.
-        using ConstVertexIterator = ConstVertexPointer;
-        
-        /// @brief Constant normal pointer.
-        using ConstNormalPointer = const UnitVec*;
-        
-        /// @brief Constant normal iterator.
-        using ConstNormalIterator = ConstNormalPointer;
 
-        DistanceProxy() = default;
-        
-        /// @brief Copy constructor.
-        DistanceProxy(const DistanceProxy& copy) noexcept:
+        class Shape;
+
+        /// @brief Distance Proxy.
+        ///
+        /// @details A distance proxy aggregates a convex set of vertices and a vertex radius of
+        ///   those vertices. This can be visualized as a convex N-sided polygon with rounded corners.
+        ///   It's meant to represent any single portion of a shape identified by its child-index.
+        ///   These are used by the G.J.K. algorithm: "a method for determining the minimum distance
+        ///   between two convex sets".
+        ///
+        /// @note This data structure is 24-bytes.
+        ///
+        /// @see https://en.wikipedia.org/wiki/Gilbert%2DJohnson%2DKeerthi_distance_algorithm
+        ///
+        class DistanceProxy
+        {
+         public:
+            /// @brief Constant vertex pointer.
+            using ConstVertexPointer = const Length2*;
+
+            /// @brief Constant vertex iterator.
+            using ConstVertexIterator = ConstVertexPointer;
+
+            /// @brief Constant normal pointer.
+            using ConstNormalPointer = const UnitVec*;
+
+            /// @brief Constant normal iterator.
+            using ConstNormalIterator = ConstNormalPointer;
+
+            DistanceProxy() = default;
+
+            /// @brief Copy constructor.
+            DistanceProxy(const DistanceProxy& copy) noexcept
+                :
 #ifndef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
-            m_vertices{copy.m_vertices},
-            m_normals{copy.m_normals},
+                  m_vertices{copy.m_vertices},
+                  m_normals{copy.m_normals},
 #endif
-            m_count{copy.m_count},
-            m_vertexRadius{copy.m_vertexRadius}
-        {
+                  m_count{copy.m_count},
+                  m_vertexRadius{copy.m_vertexRadius}
+            {
 #ifdef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
-            const auto count = copy.m_count;
-            std::copy(copy.m_vertices, copy.m_vertices + count, m_vertices);
-            std::copy(copy.m_normals, copy.m_normals + count, m_normals);
+                const auto count = copy.m_count;
+                std::copy(copy.m_vertices, copy.m_vertices + count, m_vertices);
+                std::copy(copy.m_normals, copy.m_normals + count, m_normals);
 #else
-            // Intentionall empty.
+                // Intentionall empty.
 #endif
-       }
+            }
 
-        /// @brief Initializing constructor.
-        ///
-        /// @details Constructs a distance proxy for n-point shape (like a polygon).
-        ///
-        /// @param vertexRadius Radius of the given vertices.
-        /// @param count Count of elements of the vertices and normals arrays.
-        /// @param vertices Collection of vertices of the shape (relative to the shape's origin).
-        /// @param normals Collection of normals of the shape.
-        ///
-        /// @note The vertices collection must have more than zero elements and no more than
-        ///    <code>MaxShapeVertices</code> elements.
-        /// @warning Behavior is undefined if the vertices collection has less than one element or
-        ///   more than <code>MaxShapeVertices</code> elements.
-        /// @warning Behavior is undefined if the vertices are not in counter-clockwise order.
-        /// @warning Behavior is undefined if the shape defined by the vertices is not convex.
-        /// @warning Behavior is undefined if the normals aren't normals for adjacent vertices.
-        /// @warning Behavior is undefined if any normal is not unique.
-        ///
-        DistanceProxy(const NonNegative<Length> vertexRadius, const VertexCounter count,
-                      const Length2* vertices, const UnitVec* normals) noexcept:
+            /// @brief Initializing constructor.
+            ///
+            /// @details Constructs a distance proxy for n-point shape (like a polygon).
+            ///
+            /// @param vertexRadius Radius of the given vertices.
+            /// @param count Count of elements of the vertices and normals arrays.
+            /// @param vertices Collection of vertices of the shape (relative to the shape's origin).
+            /// @param normals Collection of normals of the shape.
+            ///
+            /// @note The vertices collection must have more than zero elements and no more than
+            ///    <code>MaxShapeVertices</code> elements.
+            /// @warning Behavior is undefined if the vertices collection has less than one element or
+            ///   more than <code>MaxShapeVertices</code> elements.
+            /// @warning Behavior is undefined if the vertices are not in counter-clockwise order.
+            /// @warning Behavior is undefined if the shape defined by the vertices is not convex.
+            /// @warning Behavior is undefined if the normals aren't normals for adjacent vertices.
+            /// @warning Behavior is undefined if any normal is not unique.
+            ///
+            DistanceProxy(const NonNegative<Length> vertexRadius, const VertexCounter count,
+                          const Length2* vertices, const UnitVec* normals) noexcept
+                :
 #ifndef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
-            m_vertices{vertices},
-            m_normals{normals},
+                  m_vertices{vertices},
+                  m_normals{normals},
 #endif
-            m_count{count},
-            m_vertexRadius{vertexRadius}
-        {
-            assert(vertexRadius >= 0_m);
-            assert(count >= 0);
-            assert(count < 1 || vertices);
-            assert(count < 2 || normals);
+                  m_count{count},
+                  m_vertexRadius{vertexRadius}
+            {
+                assert(vertexRadius >= 0_m);
+                assert(count >= 0);
+                assert(count < 1 || vertices);
+                assert(count < 2 || normals);
 #ifdef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
-            if (vertices)
-            {
-                std::copy(vertices, vertices + count, m_vertices);
-            }
-            if (normals)
-            {
-                std::copy(normals, normals + count, m_normals);
-            }
+                if (vertices)
+                {
+                    std::copy(vertices, vertices + count, m_vertices);
+                }
+                if (normals)
+                {
+                    std::copy(normals, normals + count, m_normals);
+                }
 #endif
-        }
-        
-        /// Gets the vertex radius of the vertices of the associated shape.
-        /// @return Non-negative distance.
-        auto GetVertexRadius() const noexcept { return m_vertexRadius; }
-        
-        /// @brief Gets the range of vertices.
-        Range<ConstVertexIterator> GetVertices() const noexcept
-        {
-            return {m_vertices, m_vertices + m_count};
-        }
-        
-        /// @brief Gets the range of normal.
-        Range<ConstNormalIterator> GetNormals() const noexcept
-        {
-            return {m_normals, m_normals + m_count};
-        }
+            }
 
-        /// Gets the vertex count.
-        /// @details This is the count of valid vertex elements that this object provides.
-        /// @return Value between 0 and <code>MaxShapeVertices</code>.
-        /// @note This only returns 0 if this proxy was default constructed.
-        auto GetVertexCount() const noexcept { return m_count; }
-        
-        /// Gets a vertex by index.
-        ///
-        /// @param index Index value less than the count of vertices represented by this proxy.
-        ///
-        /// @warning Behavior is undefined if the index given is not less than the count of
-        ///   vertices represented by this proxy.
-        /// @warning Behavior is undefined if <code>InvalidVertex</code> is given as the index
-        ///   value.
-        ///
-        /// @return Vertex linear position (relative to the shape's origin) at the given index.
-        ///
-        /// @see Distance.
-        ///
-        auto GetVertex(VertexCounter index) const noexcept
-        {
-            assert(index != InvalidVertex);
-            assert(index < m_count);
-            return *(m_vertices + index);
-        }
-        
-        /// @brief Gets the normal for the given index.
-        auto GetNormal(VertexCounter index) const noexcept
-        {
-            assert(index != InvalidVertex);
-            assert(index < m_count);
-            return *(m_normals + index);
-        }
+            /// Gets the vertex radius of the vertices of the associated shape.
+            /// @return Non-negative distance.
+            auto GetVertexRadius() const noexcept
+            {
+                return m_vertexRadius;
+            }
 
-    private:
+            /// @brief Gets the range of vertices.
+            Range<ConstVertexIterator> GetVertices() const noexcept
+            {
+                return {m_vertices, m_vertices + m_count};
+            }
+
+            /// @brief Gets the range of normal.
+            Range<ConstNormalIterator> GetNormals() const noexcept
+            {
+                return {m_normals, m_normals + m_count};
+            }
+
+            /// Gets the vertex count.
+            /// @details This is the count of valid vertex elements that this object provides.
+            /// @return Value between 0 and <code>MaxShapeVertices</code>.
+            /// @note This only returns 0 if this proxy was default constructed.
+            auto GetVertexCount() const noexcept
+            {
+                return m_count;
+            }
+
+            /// Gets a vertex by index.
+            ///
+            /// @param index Index value less than the count of vertices represented by this proxy.
+            ///
+            /// @warning Behavior is undefined if the index given is not less than the count of
+            ///   vertices represented by this proxy.
+            /// @warning Behavior is undefined if <code>InvalidVertex</code> is given as the index
+            ///   value.
+            ///
+            /// @return Vertex linear position (relative to the shape's origin) at the given index.
+            ///
+            /// @see Distance.
+            ///
+            auto GetVertex(VertexCounter index) const noexcept
+            {
+                assert(index != InvalidVertex);
+                assert(index < m_count);
+                return *(m_vertices + index);
+            }
+
+            /// @brief Gets the normal for the given index.
+            auto GetNormal(VertexCounter index) const noexcept
+            {
+                assert(index != InvalidVertex);
+                assert(index < m_count);
+                return *(m_normals + index);
+            }
+
+         private:
 #ifdef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
-        Length2 m_vertices[MaxShapeVertices]; ///< Vertices.
-        UnitVec m_normals[MaxShapeVertices]; ///< Normals.
+            Length2 m_vertices[MaxShapeVertices];///< Vertices.
+            UnitVec m_normals[MaxShapeVertices]; ///< Normals.
 #else
-        const Length2* m_vertices = nullptr; ///< Vertices.
-        const UnitVec* m_normals = nullptr; ///< Normals.
+            const Length2* m_vertices = nullptr;///< Vertices.
+            const UnitVec* m_normals = nullptr; ///< Normals.
 #endif
-        VertexCounter m_count = 0; ///< Count of valid elements of m_vertices.
-        NonNegative<Length> m_vertexRadius = 0_m; ///< Radius of the vertices of the associated shape.
-    };
-    
-    // Free functions...
-    
-    /// @brief Determines with the two given distance proxies are equal.
-    /// @relatedalso DistanceProxy
-    bool operator== (const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept;
-    
-    /// @brief Determines with the two given distance proxies are not equal.
-    /// @relatedalso DistanceProxy
-    inline bool operator!= (const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
-    
-    /// @brief Gets the vertex radius property of a given distance proxy.
-    inline NonNegative<Length> GetVertexRadius(const DistanceProxy& arg) noexcept
-    {
-        return arg.GetVertexRadius();
-    }
-    
-    /// @brief Gets the supporting vertex index in the given direction for the given distance proxy.
-    /// @details This finds the vertex that's most significantly in the direction of the given
-    ///   vector and returns its index.
-    /// @note 0 is returned for a given zero length direction vector.
-    /// @param proxy Distance proxy object to find index in if a valid index exists for it.
-    /// @param dir Direction vector to find index for.
-    /// @return <code>InvalidVertex</code> if d is invalid or the count of vertices is zero,
-    ///   otherwise a value from 0 to one less than count.
-    /// @see GetVertexCount().
-    /// @relatedalso DistanceProxy
-    template <class T>
-    inline VertexCounter GetSupportIndex(const DistanceProxy& proxy, T dir) noexcept
-    {
-        using VT = typename T::value_type;
-        using OT = decltype(VT{} * 0_m);
+            VertexCounter m_count = 0;               ///< Count of valid elements of m_vertices.
+            NonNegative<Length> m_vertexRadius = 0_m;///< Radius of the vertices of the associated shape.
+        };
 
-        auto index = InvalidVertex; // Index of vertex that when dotted with dir has the max value.
-        auto maxValue = -std::numeric_limits<OT>::infinity(); // Max dot value.
-        auto i = VertexCounter{0};
-        for (const auto& vertex: proxy.GetVertices())
+        // Free functions...
+
+        /// @brief Determines with the two given distance proxies are equal.
+        /// @relatedalso DistanceProxy
+        bool operator==(const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept;
+
+        /// @brief Determines with the two given distance proxies are not equal.
+        /// @relatedalso DistanceProxy
+        inline bool operator!=(const DistanceProxy& lhs, const DistanceProxy& rhs) noexcept
         {
-            const auto value = Dot(vertex, dir);
-            if (maxValue < value)
-            {
-                maxValue = value;
-                index = i;
-            }
-            ++i;
+            return !(lhs == rhs);
         }
-        return index;
-    }
 
-    /// @brief Finds the lowest right most vertex in the given collection.
-    std::size_t FindLowestRightMostVertex(Span<const Length2> vertices);
-    
-    /// @brief Gets the convex hull for the given collection of vertices as a vector.
-    std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices);
+        /// @brief Gets the vertex radius property of a given distance proxy.
+        inline NonNegative<Length> GetVertexRadius(const DistanceProxy& arg) noexcept
+        {
+            return arg.GetVertexRadius();
+        }
 
-    /// @brief Tests a point for containment in the given distance proxy.
-    /// @param proxy Distance proxy to check if point is within.
-    /// @param point Point in local coordinates.
-    /// @return <code>true</code> if point is contained in the proxy, <code>false</code> otherwise.
-    /// @relatedalso DistanceProxy
-    /// @ingroup TestPointGroup
-    bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept;
-    
-} // namespace d2
-} // namespace playrho
+        /// @brief Gets the supporting vertex index in the given direction for the given distance proxy.
+        /// @details This finds the vertex that's most significantly in the direction of the given
+        ///   vector and returns its index.
+        /// @note 0 is returned for a given zero length direction vector.
+        /// @param proxy Distance proxy object to find index in if a valid index exists for it.
+        /// @param dir Direction vector to find index for.
+        /// @return <code>InvalidVertex</code> if d is invalid or the count of vertices is zero,
+        ///   otherwise a value from 0 to one less than count.
+        /// @see GetVertexCount().
+        /// @relatedalso DistanceProxy
+        template<class T>
+        inline VertexCounter GetSupportIndex(const DistanceProxy& proxy, T dir) noexcept
+        {
+            using VT = typename T::value_type;
+            using OT = decltype(VT{} * 0_m);
 
-#endif // PLAYRHO_COLLISION_DISTANCEPROXY_HPP
+            auto index = InvalidVertex;                          // Index of vertex that when dotted with dir has the max value.
+            auto maxValue = -std::numeric_limits<OT>::infinity();// Max dot value.
+            auto i = VertexCounter{0};
+            for (const auto& vertex : proxy.GetVertices())
+            {
+                const auto value = Dot(vertex, dir);
+                if (maxValue < value)
+                {
+                    maxValue = value;
+                    index = i;
+                }
+                ++i;
+            }
+            return index;
+        }
+
+        /// @brief Finds the lowest right most vertex in the given collection.
+        std::size_t FindLowestRightMostVertex(Span<const Length2> vertices);
+
+        /// @brief Gets the convex hull for the given collection of vertices as a vector.
+        std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices);
+
+        /// @brief Tests a point for containment in the given distance proxy.
+        /// @param proxy Distance proxy to check if point is within.
+        /// @param point Point in local coordinates.
+        /// @return <code>true</code> if point is contained in the proxy, <code>false</code> otherwise.
+        /// @relatedalso DistanceProxy
+        /// @ingroup TestPointGroup
+        bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept;
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_DISTANCEPROXY_HPP

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -20,8 +20,8 @@
  */
 
 #include <PlayRho/Collision/DynamicTree.hpp>
-#include <PlayRho/Common/GrowableStack.hpp>
 #include <PlayRho/Common/DynamicMemory.hpp>
+#include <PlayRho/Common/GrowableStack.hpp>
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/Templates.hpp>
 
@@ -31,864 +31,864 @@
 #include <numeric>
 #include <utility>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_nothrow_default_constructible<DynamicTree>::value,
-              "DynamicTree must be nothrow default constructible!");
-static_assert(std::is_copy_constructible<DynamicTree>::value,
-              "DynamicTree must be copy constructible!");
-static_assert(std::is_nothrow_move_constructible<DynamicTree>::value,
-              "DynamicTree must be nothrow move constructible!");
-static_assert(std::is_copy_assignable<DynamicTree>::value,
-              "DynamicTree must be copy assignable!");
-static_assert(std::is_nothrow_move_assignable<DynamicTree>::value,
-              "DynamicTree must be move assignable!");
-
-static_assert(std::is_nothrow_default_constructible<DynamicTree::LeafData>::value,
-              "DynamicTree::LeafData must be nothrow default constructible!");
-static_assert(std::is_copy_constructible<DynamicTree::LeafData>::value,
-              "DynamicTree::LeafData must be copy constructible!");
-static_assert(std::is_nothrow_move_constructible<DynamicTree::LeafData>::value,
-              "DynamicTree::LeafData must be nothrow move constructible!");
-static_assert(std::is_copy_assignable<DynamicTree::LeafData>::value,
-              "DynamicTree::LeafData must be copy assignable!");
-static_assert(std::is_nothrow_move_assignable<DynamicTree::LeafData>::value,
-              "DynamicTree::LeafData must be move assignable!");
-
-namespace {
-
-inline DynamicTree::TreeNode
-MakeNode(DynamicTree::Size c1, const AABB& aabb1, DynamicTree::Height h1,
-         DynamicTree::Size c2, const AABB& aabb2, DynamicTree::Height h2,
-         DynamicTree::Size parent) noexcept
+namespace playrho
 {
-    return DynamicTree::TreeNode{
-        DynamicTree::BranchData{c1, c2}, GetEnclosingAABB(aabb1, aabb2), 1 + std::max(h1, h2), parent
-    };
-}
+    namespace d2
+    {
 
-std::pair<DynamicTree::Size, DynamicTree::Size>
-MakeMoveStay(const DynamicTree::TreeNode& nodeA, DynamicTree::Size indexA,
-             const DynamicTree::TreeNode& nodeB, DynamicTree::Size indexB,
-             const AABB& toBox) noexcept
-{
-    if (nodeA.GetHeight() < nodeB.GetHeight())
-    {
-        return std::make_pair(indexA, indexB);
-    }
-    if (nodeB.GetHeight() < nodeA.GetHeight())
-    {
-        return std::make_pair(indexB, indexA);
-    }
-    const auto perimA = GetPerimeter(GetEnclosingAABB(toBox, nodeA.GetAABB()));
-    const auto perimB = GetPerimeter(GetEnclosingAABB(toBox, nodeB.GetAABB()));
-    if (perimA < perimB)
-    {
-        return std::make_pair(indexA, indexB);
-    }
-    if (perimB < perimA)
-    {
-        return std::make_pair(indexB, indexA);
-    }
-    return std::make_pair(indexA, indexB);
-}
+        static_assert(std::is_nothrow_default_constructible<DynamicTree>::value,
+                      "DynamicTree must be nothrow default constructible!");
+        static_assert(std::is_copy_constructible<DynamicTree>::value,
+                      "DynamicTree must be copy constructible!");
+        static_assert(std::is_nothrow_move_constructible<DynamicTree>::value,
+                      "DynamicTree must be nothrow move constructible!");
+        static_assert(std::is_copy_assignable<DynamicTree>::value,
+                      "DynamicTree must be copy assignable!");
+        static_assert(std::is_nothrow_move_assignable<DynamicTree>::value,
+                      "DynamicTree must be move assignable!");
 
-DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i) noexcept
-{
-    //assert(index < GetNodeCapacity());
-    assert(DynamicTree::IsBranch(nodes[i].GetHeight()));
-    
-    //          o
-    //          |
-    //          i
-    //         / \
+        static_assert(std::is_nothrow_default_constructible<DynamicTree::LeafData>::value,
+                      "DynamicTree::LeafData must be nothrow default constructible!");
+        static_assert(std::is_copy_constructible<DynamicTree::LeafData>::value,
+                      "DynamicTree::LeafData must be copy constructible!");
+        static_assert(std::is_nothrow_move_constructible<DynamicTree::LeafData>::value,
+                      "DynamicTree::LeafData must be nothrow move constructible!");
+        static_assert(std::is_copy_assignable<DynamicTree::LeafData>::value,
+                      "DynamicTree::LeafData must be copy assignable!");
+        static_assert(std::is_nothrow_move_assignable<DynamicTree::LeafData>::value,
+                      "DynamicTree::LeafData must be move assignable!");
+
+        namespace
+        {
+
+            inline DynamicTree::TreeNode
+            MakeNode(DynamicTree::Size c1, const AABB& aabb1, DynamicTree::Height h1,
+                     DynamicTree::Size c2, const AABB& aabb2, DynamicTree::Height h2,
+                     DynamicTree::Size parent) noexcept
+            {
+                return DynamicTree::TreeNode{
+                    DynamicTree::BranchData{c1, c2}, GetEnclosingAABB(aabb1, aabb2), 1 + std::max(h1, h2), parent};
+            }
+
+            std::pair<DynamicTree::Size, DynamicTree::Size>
+            MakeMoveStay(const DynamicTree::TreeNode& nodeA, DynamicTree::Size indexA,
+                         const DynamicTree::TreeNode& nodeB, DynamicTree::Size indexB,
+                         const AABB& toBox) noexcept
+            {
+                if (nodeA.GetHeight() < nodeB.GetHeight())
+                {
+                    return std::make_pair(indexA, indexB);
+                }
+                if (nodeB.GetHeight() < nodeA.GetHeight())
+                {
+                    return std::make_pair(indexB, indexA);
+                }
+                const auto perimA = GetPerimeter(GetEnclosingAABB(toBox, nodeA.GetAABB()));
+                const auto perimB = GetPerimeter(GetEnclosingAABB(toBox, nodeB.GetAABB()));
+                if (perimA < perimB)
+                {
+                    return std::make_pair(indexA, indexB);
+                }
+                if (perimB < perimA)
+                {
+                    return std::make_pair(indexB, indexA);
+                }
+                return std::make_pair(indexA, indexB);
+            }
+
+            DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i) noexcept
+            {
+                //assert(index < GetNodeCapacity());
+                assert(DynamicTree::IsBranch(nodes[i].GetHeight()));
+
+                //          o
+                //          |
+                //          i
+                //         / \
     //      *-c1  c2-*
-    //     /   |  |   \
+                //     /   |  |   \
     // c1c1 c1c2  c2c1 c2c2
-    const auto oldNodeI = nodes[i];
-    const auto o = oldNodeI.GetOther();
-    const auto c1 = oldNodeI.AsBranch().child1;
-    const auto c2 = oldNodeI.AsBranch().child2;
-    auto c1Node = nodes[c1];
-    auto c2Node = nodes[c2];
-    const auto c1Height = c1Node.GetHeight();
-    const auto c2Height = c2Node.GetHeight();
-    
-    if (c2Height > (c1Height + 1))
-    {
-        // child 2 heavier than child 1, child 2 must be branch, rotate it up.
-        const auto c2c1 = c2Node.AsBranch().child1;
-        const auto c2c2 = c2Node.AsBranch().child2;
-        const auto c2c1Node = nodes[c2c1];
-        const auto c2c2Node = nodes[c2c2];
+                const auto oldNodeI = nodes[i];
+                const auto o = oldNodeI.GetOther();
+                const auto c1 = oldNodeI.AsBranch().child1;
+                const auto c2 = oldNodeI.AsBranch().child2;
+                auto c1Node = nodes[c1];
+                auto c2Node = nodes[c2];
+                const auto c1Height = c1Node.GetHeight();
+                const auto c2Height = c2Node.GetHeight();
 
-        // From:
-        //          *i*
-        //         /   \
+                if (c2Height > (c1Height + 1))
+                {
+                    // child 2 heavier than child 1, child 2 must be branch, rotate it up.
+                    const auto c2c1 = c2Node.AsBranch().child1;
+                    const auto c2c2 = c2Node.AsBranch().child2;
+                    const auto c2c1Node = nodes[c2c1];
+                    const auto c2c2Node = nodes[c2c2];
+
+                    // From:
+                    //          *i*
+                    //         /   \
         //        c1   c2*
-        //            /   \
+                    //            /   \
         //         c2c1   c2c2
-        //    where c2c1 or c2c2 is also a branch node
-        //
-        // To:
-        //           c2*
-        //          /   \
+                    //    where c2c1 or c2c2 is also a branch node
+                    //
+                    // To:
+                    //           c2*
+                    //          /   \
         //       *i*     c2cY
-        //      /   \
+                    //      /   \
         //    c1    c2cX
-        //
-        // Rotate left and pick the taller of c2c1 or c2c2 or the better fitting to move to the new i node.
-        const auto ms = MakeMoveStay(c2c1Node, c2c1, c2c2Node, c2c2, c1Node.GetAABB());
-        const auto newNodeI = MakeNode(c1, c1Node.GetAABB(), c1Height,
-                                       ms.first, nodes[ms.first].GetAABB(), nodes[ms.first].GetHeight(),
-                                       c2);
-        c2Node = MakeNode(i, newNodeI.GetAABB(), newNodeI.GetHeight(),
-                          ms.second, nodes[ms.second].GetAABB(), nodes[ms.second].GetHeight(),
-                          o);
-        nodes[ms.first].SetOther(i);
-        nodes[i] = newNodeI;
-        nodes[c2] = c2Node;
-        if (o != DynamicTree::GetInvalidSize())
-        {
-            const auto oNode = nodes[o];
-            const auto oNodeBD = oNode.AsBranch();
-            assert(oNodeBD.child1 == i || oNodeBD.child2 == i);
-            nodes[o] = (oNodeBD.child1 == i)?
-                MakeNode(c2, c2Node.GetAABB(), c2Node.GetHeight(),
-                         oNodeBD.child2, nodes[oNodeBD.child2].GetAABB(), nodes[oNodeBD.child2].GetHeight(),
-                         oNode.GetOther()):
-                MakeNode(oNodeBD.child1, nodes[oNodeBD.child1].GetAABB(), nodes[oNodeBD.child1].GetHeight(),
-                         c2, c2Node.GetAABB(), c2Node.GetHeight(),
-                         oNode.GetOther());
-        }
-        return c2;
-    }
-    
-    if (c1Height > (c2Height + 1))
-    {
-        // child1 must be a branch, rotate it up.
-        const auto c1c1 = c1Node.AsBranch().child1;
-        const auto c1c2 = c1Node.AsBranch().child2;
-        const auto c1c1Node = nodes[c1c1];
-        const auto c1c2Node = nodes[c1c2];
-        
-        // From:
-        //          *i*
-        //         /   \
-        //       *c1   c2*
-        //      /   \
-        //   c1c1   c1c2
-        //    where c1c1 or c1c2 is also a branch node
-        //
-        // To:
-        //           c1*
-        //          /   \
-        //       c1cX    *i*
-        //              /   \
-        //           c1cY    c2
-        //
-        // Rotate right and pick the taller of c1c1 or c1c2 or the better fitting to move to the new i node.
-        const auto ms = MakeMoveStay(c1c1Node, c1c1, c1c2Node, c1c2, c2Node.GetAABB());
-        const auto newNodeI = MakeNode(ms.first, nodes[ms.first].GetAABB(), nodes[ms.first].GetHeight(),
-                                       c2, c2Node.GetAABB(), c2Height,
-                                       c1);
-        c1Node = MakeNode(ms.second, nodes[ms.second].GetAABB(), nodes[ms.second].GetHeight(),
-                          i, newNodeI.GetAABB(), newNodeI.GetHeight(),
-                          o);
-        nodes[ms.first].SetOther(i);
-        nodes[i] = newNodeI;
-        nodes[c1] = c1Node;
-        if (o != DynamicTree::GetInvalidSize())
-        {
-            const auto oNode = nodes[o];
-            const auto oNodeBD = oNode.AsBranch();
-            assert(oNodeBD.child1 == i || oNodeBD.child2 == i);
-            nodes[o] = (oNodeBD.child1 == i)?
-                MakeNode(c1, c1Node.GetAABB(), c1Node.GetHeight(),
-                         oNodeBD.child2, nodes[oNodeBD.child2].GetAABB(), nodes[oNodeBD.child2].GetHeight(),
-                         oNode.GetOther()):
-                MakeNode(oNodeBD.child1, nodes[oNodeBD.child1].GetAABB(), nodes[oNodeBD.child1].GetHeight(),
-                         c1, c1Node.GetAABB(), c1Node.GetHeight(),
-                         oNode.GetOther());
-        }
-        return c1;
-    }
-    
-    nodes[i] = MakeNode(c1, c1Node.GetAABB(), c1Node.GetHeight(), c2, c2Node.GetAABB(), c2Height, o);
-    return i;
-}
-
-/// @brief Updates upward from location in tree.
-/// @note In addition to updating the heights & AABBs of branch nodes, this also rebalances
-///  the tree.
-DynamicTree::Size UpdateUpwardFrom(DynamicTree::TreeNode nodes[], DynamicTree::Size start) noexcept
-{
-    assert(DynamicTree::IsBranch(nodes[start].GetHeight()));
-    auto rootIndex = DynamicTree::GetInvalidSize();
-    for (auto index = start; index != DynamicTree::GetInvalidSize(); index = nodes[index].GetOther())
-    {
-        assert(DynamicTree::IsBranch(nodes[index].GetHeight()));
-        assert(nodes[nodes[index].AsBranch().child1].GetOther() == index);
-        assert(nodes[nodes[index].AsBranch().child2].GetOther() == index);
-        if (nodes[index].GetHeight() >= 2)
-        {
-            index = RebalanceAt(nodes, index);
-        }
-        rootIndex = index;
-    }
-    return rootIndex;
-}
-
-/// @brief Finds the lowest cost node to associate the given AABB with
-///   starting from the given index.
-/// @details Finds the index of the "lowest cost" node using a surface area heuristic
-///   (S.A.H.) for two dimensions.
-/// @warning Behavior is undefined if the given index is invalid or for an unused node.
-DynamicTree::Size FindLowestCostNode(const DynamicTree::TreeNode nodes[],
-                                     AABB leafAABB, DynamicTree::Size index) noexcept
-{
-    assert(IsValid(leafAABB));
-    assert(index != DynamicTree::GetInvalidSize());
-    assert(!playrho::d2::IsUnused(nodes[index]));
-    
-    // Cost function to calculate cost of descending into specified child
-    const auto costFunc = [leafAABB](const DynamicTree::TreeNode& childNode, Length inheritCost) {
-        const auto childAabb = playrho::d2::GetAABB(childNode);
-        const auto isLeaf = playrho::d2::IsLeaf(childNode);
-        const auto leafCost = GetPerimeter(GetEnclosingAABB(leafAABB, childAabb)) + inheritCost;
-        return isLeaf? leafCost: (leafCost - GetPerimeter(childAabb));
-    };
-    
-    while (playrho::d2::IsBranch(nodes[index]))
-    {
-        const auto& node = nodes[index];
-        const auto branch = node.AsBranch();
-        const auto child1 = branch.child1;
-        const auto child2 = branch.child2;
-        assert(nodes[child1].GetOther() == index);
-        assert(nodes[child2].GetOther() == index);
-        const auto aabb = node.GetAABB();
-        const auto perimeter = GetPerimeter(aabb);
-        const auto combinedPerimeter = GetPerimeter(GetEnclosingAABB(aabb, leafAABB));
-        
-        assert(combinedPerimeter >= perimeter);
-        assert(child1 != DynamicTree::GetInvalidSize());
-        assert(child2 != DynamicTree::GetInvalidSize());
-        
-        // Cost of creating a new parent for this node and the new leaf
-        const auto cost = combinedPerimeter * 2;
-        
-        // Minimum cost of pushing the leaf further down the tree
-        const auto inheritanceCost = (combinedPerimeter - perimeter) * 2;
-        
-        const auto cost1 = costFunc(nodes[child1], inheritanceCost);
-        const auto cost2 = costFunc(nodes[child2], inheritanceCost);
-        
-        if ((cost < cost1) && (cost < cost2))
-        {
-            // Cheaper to create a new parent for this node and the new leaf
-            break;
-        }
-        
-        // Descend into child with least cost.
-        index = (cost1 < cost2)? child1: child2;
-    }
-    return index;
-}
-
-std::pair<DynamicTree::Size, DynamicTree::Size>
-RemoveParent(DynamicTree::TreeNode nodes[], DynamicTree::Size index) noexcept
-{
-    const auto parent = nodes[index].GetOther();
-    const auto grandParent = nodes[parent].GetOther();
-    const auto parentBD = nodes[parent].AsBranch();
-    const auto sibling = (parentBD.child1 == index)? parentBD.child2: parentBD.child1;
-    
-    nodes[index].SetOther(DynamicTree::GetInvalidSize());
-    nodes[sibling].SetOther(grandParent);
-    if (grandParent != DynamicTree::GetInvalidSize())
-    {
-        const auto newBD = ReplaceChild(nodes[grandParent].AsBranch(), parent, sibling);
-        const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
-        const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
-        nodes[grandParent].Assign(newBD, newAabb, newHeight);
-        nodes[parent].SetOther(DynamicTree::GetInvalidSize());
-        return std::make_pair(UpdateUpwardFrom(nodes, grandParent), parent);
-    }
-    return std::make_pair(sibling, parent);
-}
-
-DynamicTree::Size InsertParent(DynamicTree::TreeNode nodes[],
-                               DynamicTree::Size newParent,
-                               const AABB& aabb,
-                               DynamicTree::Size index,
-                               DynamicTree::Size rootIndex) noexcept
-{
-    const auto sibling = FindLowestCostNode(nodes, aabb, rootIndex);
-    const auto oldParent = nodes[sibling].GetOther();
-    
-    // std::max of leaf height and sibling height + 1 = sibling height + 1
-    nodes[newParent] = DynamicTree::TreeNode{DynamicTree::BranchData{sibling, index},
-        GetEnclosingAABB(aabb, nodes[sibling].GetAABB()), 1 + nodes[sibling].GetHeight(), oldParent};
-    nodes[sibling].SetOther(newParent);
-    nodes[index].SetOther(newParent);
-    if (oldParent != DynamicTree::GetInvalidSize())
-    {
-        const auto newBD = ReplaceChild(nodes[oldParent].AsBranch(), sibling, newParent);
-        const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
-        const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
-        nodes[oldParent].Assign(newBD, newAabb, newHeight);
-        assert(nodes[nodes[oldParent].AsBranch().child1].GetOther() == oldParent);
-        assert(nodes[nodes[oldParent].AsBranch().child2].GetOther() == oldParent);
-        return UpdateUpwardFrom(nodes, oldParent);
-    }
-    return newParent;
-}
-
-DynamicTree::Size UpdateNonRoot(DynamicTree::TreeNode nodes[],
-                                DynamicTree::Size index, const AABB& aabb) noexcept
-{
-    assert(nodes[index].GetOther() != DynamicTree::GetInvalidSize());
-    
-    const auto parent = nodes[index].GetOther();
-    const auto grandParent = nodes[parent].GetOther();
-    const auto parentBD = nodes[parent].AsBranch();
-    assert(parentBD.child1 == index || parentBD.child2 == index);
-    const auto sibling = (parentBD.child1 == index)? parentBD.child2: parentBD.child1;
-
-    nodes[sibling].SetOther(grandParent);
-    nodes[index].SetAABB(aabb);
-    auto rootIndex = DynamicTree::GetInvalidSize();
-    if (grandParent != DynamicTree::GetInvalidSize())
-    {
-        assert(nodes[grandParent].AsBranch().child1 == parent || nodes[grandParent].AsBranch().child2 == parent);
-        const auto newBD = ReplaceChild(nodes[grandParent].AsBranch(), parent, sibling);
-        const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
-        const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
-        nodes[grandParent].Assign(newBD, newAabb, newHeight);
-        nodes[parent].SetOther(DynamicTree::GetInvalidSize());
-        assert(nodes[nodes[grandParent].AsBranch().child1].GetOther() == grandParent);
-        assert(nodes[nodes[grandParent].AsBranch().child2].GetOther() == grandParent);
-        rootIndex = UpdateUpwardFrom(nodes, grandParent);
-    }
-    else // grandParent == GetInvalidSize()
-    {
-        rootIndex = sibling;
-    }
-    
-    const auto cheapest = FindLowestCostNode(nodes, aabb, rootIndex);
-    const auto cheapestParent = nodes[cheapest].GetOther();
-    
-    // std::max of leaf height and cheapest height + 1 = cheapest height + 1
-    nodes[parent] = DynamicTree::TreeNode{
-        DynamicTree::BranchData{cheapest, index},
-        GetEnclosingAABB(aabb, nodes[cheapest].GetAABB()),
-        1 + nodes[cheapest].GetHeight(), cheapestParent
-    };
-    if (cheapestParent != DynamicTree::GetInvalidSize())
-    {
-        const auto newBD = ReplaceChild(nodes[cheapestParent].AsBranch(), cheapest, parent);
-        const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
-        const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
-        nodes[cheapestParent].Assign(newBD, newAabb, newHeight);
-    }
-    nodes[cheapest].SetOther(parent);
-    return UpdateUpwardFrom(nodes, parent);
-}
-
-} // anonymous namespace
-
-DynamicTree::DynamicTree() noexcept = default;
-
-DynamicTree::DynamicTree(Size nodeCapacity):
-    m_nodes{nodeCapacity? AllocArray<TreeNode>(nodeCapacity): nullptr},
-    m_freeIndex{nodeCapacity? 0: GetInvalidSize()},
-    m_nodeCapacity{nodeCapacity}
-{
-    if (nodeCapacity)
-    {
-        // Build a linked list for the free list.
-        const auto endCapacity = nodeCapacity - Size{1};
-        for (auto i = decltype(nodeCapacity){0}; i < endCapacity; ++i)
-        {
-            new (&m_nodes[i]) TreeNode{i + 1};
-        }
-        new (&m_nodes[endCapacity]) TreeNode{};
-    }
-}
-
-DynamicTree::DynamicTree(const DynamicTree& other):
-    m_nodes{AllocArray<TreeNode>(other.m_nodeCapacity)},
-    m_rootIndex{other.m_rootIndex},
-    m_freeIndex{other.m_freeIndex},
-    m_nodeCount{other.m_nodeCount},
-    m_nodeCapacity{other.m_nodeCapacity},
-    m_leafCount{other.m_leafCount}
-{
-    std::copy(&other.m_nodes[0], &other.m_nodes[other.m_nodeCapacity], &m_nodes[0]);
-}
-
-DynamicTree::DynamicTree(DynamicTree&& other) noexcept:
-    DynamicTree{}
-{
-    swap(*this, other);
-}
-
-DynamicTree& DynamicTree::operator= (DynamicTree other) noexcept
-{
-    // Leverages the "copy-and-swap" idiom.
-    // For details, see https://stackoverflow.com/a/3279550/7410358
-    swap(*this, other);
-    return *this;
-}
-
-DynamicTree::~DynamicTree() noexcept
-{
-    // This frees the entire tree in one shot.
-    Free(m_nodes);
-}
-
-void DynamicTree::SetNodeCapacity(Size value)
-{
-    assert(value > m_nodeCapacity);
-
-    // The free list is empty. Rebuild a bigger pool.
-    // Call Realloc first in case it throws so this code doesn't have to restore any state
-    // and so this function will have no effect.
-    m_nodes = ReallocArray<TreeNode>(m_nodes, value);
-    m_nodeCapacity = value;
-
-    // Build a linked list for the free list. The parent
-    // pointer becomes the "next" pointer.
-    const auto endCapacity = m_nodeCapacity - 1;
-    for (auto i = m_nodeCount; i < endCapacity; ++i)
-    {
-        new (m_nodes + i) TreeNode{i + 1};
-    }
-    new (m_nodes + endCapacity) TreeNode{};
-    m_freeIndex = m_nodeCount;
-}
-
-DynamicTree::Size DynamicTree::AllocateNode(const LeafData& data, AABB aabb)
-{
-    const auto index = AllocateNode();
-    m_nodes[index] = TreeNode{data, aabb};
-    return index;
-}
-
-DynamicTree::Size DynamicTree::AllocateNode(const BranchData& data, AABB aabb,
-                                            Height height, Size parent)
-{
-    assert(height > 0);
-    const auto index = AllocateNode();
-    m_nodes[index] = TreeNode{data, aabb, height, parent};
-    return index;
-}
-
-DynamicTree::Size DynamicTree::AllocateNode()
-{
-    // Expand the node pool as needed.
-    if (m_freeIndex == GetInvalidSize())
-    {
-        assert(m_nodeCount == m_nodeCapacity);
-        
-        // The free list is empty. Rebuild a bigger pool.
-        SetNodeCapacity(m_nodeCapacity? m_nodeCapacity * 2: GetDefaultInitialNodeCapacity());
-    }
-    
-    // Peel a node off the free list.
-    const auto index = m_freeIndex;
-    m_freeIndex = m_nodes[index].GetOther();
-    ++m_nodeCount;
-    return index;
-}
-
-void DynamicTree::FreeNode(Size index) noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < GetNodeCapacity());
-    assert(index != GetFreeIndex());
-    assert(m_nodeCount > 0); // index is not necessarily less than m_nodeCount.
-    assert(!IsUnused(m_nodes[index].GetHeight()));
-    assert(m_nodes[index].GetOther() == GetInvalidSize());
-
-    m_nodes[index] = TreeNode{m_freeIndex};
-    m_freeIndex = index;
-    --m_nodeCount;
-}
-
-void DynamicTree::Clear() noexcept
-{
-    m_nodeCount = Size{0u};
-    m_leafCount = Size{0u};
-    m_rootIndex = GetInvalidSize();
-    if (m_nodeCapacity && m_nodes) {
-        m_freeIndex = Size{0u};
-        const auto endCapacity = m_nodeCapacity - 1;
-        for (auto i = Size{0u}; i < endCapacity; ++i)
-        {
-            m_nodes[i] = TreeNode{i + 1};
-        }
-        m_nodes[endCapacity] = TreeNode{};
-    }
-    else {
-        Free(m_nodes);
-        m_nodes = nullptr;
-        m_nodeCapacity = Size{0u};
-        m_freeIndex = GetInvalidSize();
-    }
-}
-
-DynamicTree::Size DynamicTree::FindReference(Size index) const noexcept
-{
-    const auto it = std::find_if(m_nodes, m_nodes + m_nodeCapacity, [&](TreeNode& node) {
-        if (node.GetOther() == index)
-        {
-            return true;
-        }
-        if (IsBranch(node.GetHeight()))
-        {
-            const auto bd = node.AsBranch();
-            if (bd.child1 == index || bd.child2 == index)
-            {
-                return true;
-            }
-        }
-        return false;
-    });
-    return (it != m_nodes + m_nodeCapacity)? static_cast<Size>(it - m_nodes): GetInvalidSize();
-}
-
-DynamicTree::Size DynamicTree::CreateLeaf(const AABB& aabb, const LeafData& data)
-{
-    assert(IsValid(aabb));
-    const auto index = AllocateNode(data, aabb);
-    if (m_rootIndex != GetInvalidSize())
-    {
-        const auto newParent = AllocateNode(); // Note: may change m_nodes!
-        m_rootIndex = InsertParent(m_nodes, newParent, aabb, index, m_rootIndex);
-    }
-    else
-    {
-        m_rootIndex = index;
-    }
-    ++m_leafCount;
-    return index;
-}
-
-void DynamicTree::DestroyLeaf(Size index) noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index].GetHeight()));
-    assert(m_leafCount > 0);
-
-    --m_leafCount;
-
-    if (m_rootIndex != index)
-    {
-        const auto result = RemoveParent(m_nodes, index);
-        m_rootIndex = std::get<0>(result);
-        const auto parent = std::get<1>(result);
-#ifndef NDEBUG
-        const auto found = FindReference(parent);
-        assert(found == GetInvalidSize());
-#endif
-        FreeNode(parent);
-    }
-    else
-    {
-        assert(m_nodes[index].GetOther() == GetInvalidSize());
-        m_rootIndex = GetInvalidSize();
-    }
-
-#ifndef NDEBUG
-    const auto found = FindReference(index);
-    assert(found == GetInvalidSize());
-#endif
-    FreeNode(index);
-}
-
-void DynamicTree::UpdateLeaf(Size index, const AABB& aabb)
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index].GetHeight()));
-
-    if (m_rootIndex != index)
-    {
-        m_rootIndex = UpdateNonRoot(m_nodes, index, aabb);
-    }
-    else
-    {
-        assert(m_nodes[index].GetOther() == GetInvalidSize());
-        m_nodes[index].SetAABB(aabb);
-    }
-}
-
-void DynamicTree::RebuildBottomUp()
-{
-    const auto nodes = AllocArray<Size>(m_nodeCount);
-    auto count = Size{0};
-
-    // Build array of leaves. Free the rest.
-    for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)
-    {
-        const auto height = m_nodes[i].GetHeight();
-        if (IsLeaf(height))
-        {
-            m_nodes[i].SetOther(GetInvalidSize());
-            nodes[count] = i;
-            ++count;
-        }
-        else if (IsBranch(height))
-        {
-            m_nodes[i].SetOther(GetInvalidSize());
-            FreeNode(i);
-        }
-    }
-
-    while (count > 1)
-    {
-        auto minCost = std::numeric_limits<Length>::infinity();
-        auto iMin = GetInvalidSize();
-        auto jMin = GetInvalidSize();
-        for (auto i = decltype(count){0}; i < count; ++i)
-        {
-            const auto& aabbi = m_nodes[nodes[i]].GetAABB();
-
-            for (auto j = i + 1; j < count; ++j)
-            {
-                const auto& aabbj = m_nodes[nodes[j]].GetAABB();
-                const auto b = GetEnclosingAABB(aabbi, aabbj);
-                const auto cost = GetPerimeter(b);
-                if (minCost > cost)
-                {
-                    iMin = i;
-                    jMin = j;
-                    minCost = cost;
-                }
-            }
-        }
-
-        assert((iMin < m_nodeCount) && (jMin < m_nodeCount));
-
-        const auto index1 = nodes[iMin];
-        const auto index2 = nodes[jMin];
-        assert(!IsUnused(m_nodes[index1].GetHeight()));
-        assert(!IsUnused(m_nodes[index2].GetHeight()));
-
-        const auto aabb = GetEnclosingAABB(m_nodes[index1].GetAABB(), m_nodes[index2].GetAABB());
-        const auto height = 1 + std::max(m_nodes[index1].GetHeight(), m_nodes[index2].GetHeight());
-        
-        // Warning: the following may change value of m_nodes!
-        const auto parent = AllocateNode(BranchData{index1, index2}, aabb, height);
-        m_nodes[index1].SetOther(parent);
-        m_nodes[index2].SetOther(parent);
-
-        nodes[jMin] = nodes[count-1];
-        nodes[iMin] = parent;
-        --count;
-    }
-
-    m_rootIndex = nodes[0];
-    Free(nodes);
-}
-
-void DynamicTree::ShiftOrigin(Length2 newOrigin)
-{
-    // Build array of leaves. Free the rest.
-    for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)
-    {
-        if (!IsUnused(m_nodes[i].GetHeight()))
-        {
-            m_nodes[i].SetAABB(GetMovedAABB(m_nodes[i].GetAABB(), -newOrigin));
-        }
-    }
-}
-
-// Free functions...
-
-void swap(DynamicTree& lhs, DynamicTree& rhs) noexcept
-{
-    using playrho::swap;
-    swap(lhs.m_nodes, rhs.m_nodes);
-    swap(lhs.m_rootIndex, rhs.m_rootIndex);
-    swap(lhs.m_freeIndex, rhs.m_freeIndex);
-    swap(lhs.m_nodeCount, rhs.m_nodeCount);
-    swap(lhs.m_nodeCapacity, rhs.m_nodeCapacity);
-    swap(lhs.m_leafCount, rhs.m_leafCount);
-}
-
-void Query(const DynamicTree& tree, const AABB& aabb, const DynamicTreeSizeCB& callback)
-{    
-    GrowableStack<DynamicTree::Size, 256> stack;
-    stack.push(tree.GetRootIndex());
-    
-    while (!empty(stack))
-    {
-        const auto index = stack.top();
-        stack.pop();
-        if (index != DynamicTree::GetInvalidSize())
-        {
-            if (TestOverlap(tree.GetAABB(index), aabb))
-            {
-                const auto height = tree.GetHeight(index);
-                if (DynamicTree::IsBranch(height))
-                {
-                    const auto branchData = tree.GetBranchData(index);
-                    stack.push(branchData.child1);
-                    stack.push(branchData.child2);
-                }
-                else
-                {
-                    assert(DynamicTree::IsLeaf(height));
-                    const auto sc = callback(index);
-                    if (sc == DynamicTreeOpcode::End)
+                    //
+                    // Rotate left and pick the taller of c2c1 or c2c2 or the better fitting to move to the new i node.
+                    const auto ms = MakeMoveStay(c2c1Node, c2c1, c2c2Node, c2c2, c1Node.GetAABB());
+                    const auto newNodeI = MakeNode(c1, c1Node.GetAABB(), c1Height,
+                                                   ms.first, nodes[ms.first].GetAABB(), nodes[ms.first].GetHeight(),
+                                                   c2);
+                    c2Node = MakeNode(i, newNodeI.GetAABB(), newNodeI.GetHeight(),
+                                      ms.second, nodes[ms.second].GetAABB(), nodes[ms.second].GetHeight(),
+                                      o);
+                    nodes[ms.first].SetOther(i);
+                    nodes[i] = newNodeI;
+                    nodes[c2] = c2Node;
+                    if (o != DynamicTree::GetInvalidSize())
                     {
-                        return;
+                        const auto oNode = nodes[o];
+                        const auto oNodeBD = oNode.AsBranch();
+                        assert(oNodeBD.child1 == i || oNodeBD.child2 == i);
+                        nodes[o] = (oNodeBD.child1 == i) ? MakeNode(c2, c2Node.GetAABB(), c2Node.GetHeight(),
+                                                                    oNodeBD.child2, nodes[oNodeBD.child2].GetAABB(), nodes[oNodeBD.child2].GetHeight(),
+                                                                    oNode.GetOther())
+                                                         : MakeNode(oNodeBD.child1, nodes[oNodeBD.child1].GetAABB(), nodes[oNodeBD.child1].GetHeight(),
+                                                                    c2, c2Node.GetAABB(), c2Node.GetHeight(),
+                                                                    oNode.GetOther());
+                    }
+                    return c2;
+                }
+
+                if (c1Height > (c2Height + 1))
+                {
+                    // child1 must be a branch, rotate it up.
+                    const auto c1c1 = c1Node.AsBranch().child1;
+                    const auto c1c2 = c1Node.AsBranch().child2;
+                    const auto c1c1Node = nodes[c1c1];
+                    const auto c1c2Node = nodes[c1c2];
+
+                    // From:
+                    //          *i*
+                    //         /   \
+        //       *c1   c2*
+                    //      /   \
+        //   c1c1   c1c2
+                    //    where c1c1 or c1c2 is also a branch node
+                    //
+                    // To:
+                    //           c1*
+                    //          /   \
+        //       c1cX    *i*
+                    //              /   \
+        //           c1cY    c2
+                    //
+                    // Rotate right and pick the taller of c1c1 or c1c2 or the better fitting to move to the new i node.
+                    const auto ms = MakeMoveStay(c1c1Node, c1c1, c1c2Node, c1c2, c2Node.GetAABB());
+                    const auto newNodeI = MakeNode(ms.first, nodes[ms.first].GetAABB(), nodes[ms.first].GetHeight(),
+                                                   c2, c2Node.GetAABB(), c2Height,
+                                                   c1);
+                    c1Node = MakeNode(ms.second, nodes[ms.second].GetAABB(), nodes[ms.second].GetHeight(),
+                                      i, newNodeI.GetAABB(), newNodeI.GetHeight(),
+                                      o);
+                    nodes[ms.first].SetOther(i);
+                    nodes[i] = newNodeI;
+                    nodes[c1] = c1Node;
+                    if (o != DynamicTree::GetInvalidSize())
+                    {
+                        const auto oNode = nodes[o];
+                        const auto oNodeBD = oNode.AsBranch();
+                        assert(oNodeBD.child1 == i || oNodeBD.child2 == i);
+                        nodes[o] = (oNodeBD.child1 == i) ? MakeNode(c1, c1Node.GetAABB(), c1Node.GetHeight(),
+                                                                    oNodeBD.child2, nodes[oNodeBD.child2].GetAABB(), nodes[oNodeBD.child2].GetHeight(),
+                                                                    oNode.GetOther())
+                                                         : MakeNode(oNodeBD.child1, nodes[oNodeBD.child1].GetAABB(), nodes[oNodeBD.child1].GetHeight(),
+                                                                    c1, c1Node.GetAABB(), c1Node.GetHeight(),
+                                                                    oNode.GetOther());
+                    }
+                    return c1;
+                }
+
+                nodes[i] = MakeNode(c1, c1Node.GetAABB(), c1Node.GetHeight(), c2, c2Node.GetAABB(), c2Height, o);
+                return i;
+            }
+
+            /// @brief Updates upward from location in tree.
+            /// @note In addition to updating the heights & AABBs of branch nodes, this also rebalances
+            ///  the tree.
+            DynamicTree::Size UpdateUpwardFrom(DynamicTree::TreeNode nodes[], DynamicTree::Size start) noexcept
+            {
+                assert(DynamicTree::IsBranch(nodes[start].GetHeight()));
+                auto rootIndex = DynamicTree::GetInvalidSize();
+                for (auto index = start; index != DynamicTree::GetInvalidSize(); index = nodes[index].GetOther())
+                {
+                    assert(DynamicTree::IsBranch(nodes[index].GetHeight()));
+                    assert(nodes[nodes[index].AsBranch().child1].GetOther() == index);
+                    assert(nodes[nodes[index].AsBranch().child2].GetOther() == index);
+                    if (nodes[index].GetHeight() >= 2)
+                    {
+                        index = RebalanceAt(nodes, index);
+                    }
+                    rootIndex = index;
+                }
+                return rootIndex;
+            }
+
+            /// @brief Finds the lowest cost node to associate the given AABB with
+            ///   starting from the given index.
+            /// @details Finds the index of the "lowest cost" node using a surface area heuristic
+            ///   (S.A.H.) for two dimensions.
+            /// @warning Behavior is undefined if the given index is invalid or for an unused node.
+            DynamicTree::Size FindLowestCostNode(const DynamicTree::TreeNode nodes[],
+                                                 AABB leafAABB, DynamicTree::Size index) noexcept
+            {
+                assert(IsValid(leafAABB));
+                assert(index != DynamicTree::GetInvalidSize());
+                assert(!playrho::d2::IsUnused(nodes[index]));
+
+                // Cost function to calculate cost of descending into specified child
+                const auto costFunc = [leafAABB](const DynamicTree::TreeNode& childNode, Length inheritCost) {
+                    const auto childAabb = playrho::d2::GetAABB(childNode);
+                    const auto isLeaf = playrho::d2::IsLeaf(childNode);
+                    const auto leafCost = GetPerimeter(GetEnclosingAABB(leafAABB, childAabb)) + inheritCost;
+                    return isLeaf ? leafCost : (leafCost - GetPerimeter(childAabb));
+                };
+
+                while (playrho::d2::IsBranch(nodes[index]))
+                {
+                    const auto& node = nodes[index];
+                    const auto branch = node.AsBranch();
+                    const auto child1 = branch.child1;
+                    const auto child2 = branch.child2;
+                    assert(nodes[child1].GetOther() == index);
+                    assert(nodes[child2].GetOther() == index);
+                    const auto aabb = node.GetAABB();
+                    const auto perimeter = GetPerimeter(aabb);
+                    const auto combinedPerimeter = GetPerimeter(GetEnclosingAABB(aabb, leafAABB));
+
+                    assert(combinedPerimeter >= perimeter);
+                    assert(child1 != DynamicTree::GetInvalidSize());
+                    assert(child2 != DynamicTree::GetInvalidSize());
+
+                    // Cost of creating a new parent for this node and the new leaf
+                    const auto cost = combinedPerimeter * 2;
+
+                    // Minimum cost of pushing the leaf further down the tree
+                    const auto inheritanceCost = (combinedPerimeter - perimeter) * 2;
+
+                    const auto cost1 = costFunc(nodes[child1], inheritanceCost);
+                    const auto cost2 = costFunc(nodes[child2], inheritanceCost);
+
+                    if ((cost < cost1) && (cost < cost2))
+                    {
+                        // Cheaper to create a new parent for this node and the new leaf
+                        break;
+                    }
+
+                    // Descend into child with least cost.
+                    index = (cost1 < cost2) ? child1 : child2;
+                }
+                return index;
+            }
+
+            std::pair<DynamicTree::Size, DynamicTree::Size>
+            RemoveParent(DynamicTree::TreeNode nodes[], DynamicTree::Size index) noexcept
+            {
+                const auto parent = nodes[index].GetOther();
+                const auto grandParent = nodes[parent].GetOther();
+                const auto parentBD = nodes[parent].AsBranch();
+                const auto sibling = (parentBD.child1 == index) ? parentBD.child2 : parentBD.child1;
+
+                nodes[index].SetOther(DynamicTree::GetInvalidSize());
+                nodes[sibling].SetOther(grandParent);
+                if (grandParent != DynamicTree::GetInvalidSize())
+                {
+                    const auto newBD = ReplaceChild(nodes[grandParent].AsBranch(), parent, sibling);
+                    const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
+                    const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
+                    nodes[grandParent].Assign(newBD, newAabb, newHeight);
+                    nodes[parent].SetOther(DynamicTree::GetInvalidSize());
+                    return std::make_pair(UpdateUpwardFrom(nodes, grandParent), parent);
+                }
+                return std::make_pair(sibling, parent);
+            }
+
+            DynamicTree::Size InsertParent(DynamicTree::TreeNode nodes[],
+                                           DynamicTree::Size newParent,
+                                           const AABB& aabb,
+                                           DynamicTree::Size index,
+                                           DynamicTree::Size rootIndex) noexcept
+            {
+                const auto sibling = FindLowestCostNode(nodes, aabb, rootIndex);
+                const auto oldParent = nodes[sibling].GetOther();
+
+                // std::max of leaf height and sibling height + 1 = sibling height + 1
+                nodes[newParent] = DynamicTree::TreeNode{DynamicTree::BranchData{sibling, index},
+                                                         GetEnclosingAABB(aabb, nodes[sibling].GetAABB()), 1 + nodes[sibling].GetHeight(), oldParent};
+                nodes[sibling].SetOther(newParent);
+                nodes[index].SetOther(newParent);
+                if (oldParent != DynamicTree::GetInvalidSize())
+                {
+                    const auto newBD = ReplaceChild(nodes[oldParent].AsBranch(), sibling, newParent);
+                    const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
+                    const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
+                    nodes[oldParent].Assign(newBD, newAabb, newHeight);
+                    assert(nodes[nodes[oldParent].AsBranch().child1].GetOther() == oldParent);
+                    assert(nodes[nodes[oldParent].AsBranch().child2].GetOther() == oldParent);
+                    return UpdateUpwardFrom(nodes, oldParent);
+                }
+                return newParent;
+            }
+
+            DynamicTree::Size UpdateNonRoot(DynamicTree::TreeNode nodes[],
+                                            DynamicTree::Size index, const AABB& aabb) noexcept
+            {
+                assert(nodes[index].GetOther() != DynamicTree::GetInvalidSize());
+
+                const auto parent = nodes[index].GetOther();
+                const auto grandParent = nodes[parent].GetOther();
+                const auto parentBD = nodes[parent].AsBranch();
+                assert(parentBD.child1 == index || parentBD.child2 == index);
+                const auto sibling = (parentBD.child1 == index) ? parentBD.child2 : parentBD.child1;
+
+                nodes[sibling].SetOther(grandParent);
+                nodes[index].SetAABB(aabb);
+                auto rootIndex = DynamicTree::GetInvalidSize();
+                if (grandParent != DynamicTree::GetInvalidSize())
+                {
+                    assert(nodes[grandParent].AsBranch().child1 == parent || nodes[grandParent].AsBranch().child2 == parent);
+                    const auto newBD = ReplaceChild(nodes[grandParent].AsBranch(), parent, sibling);
+                    const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
+                    const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
+                    nodes[grandParent].Assign(newBD, newAabb, newHeight);
+                    nodes[parent].SetOther(DynamicTree::GetInvalidSize());
+                    assert(nodes[nodes[grandParent].AsBranch().child1].GetOther() == grandParent);
+                    assert(nodes[nodes[grandParent].AsBranch().child2].GetOther() == grandParent);
+                    rootIndex = UpdateUpwardFrom(nodes, grandParent);
+                }
+                else// grandParent == GetInvalidSize()
+                {
+                    rootIndex = sibling;
+                }
+
+                const auto cheapest = FindLowestCostNode(nodes, aabb, rootIndex);
+                const auto cheapestParent = nodes[cheapest].GetOther();
+
+                // std::max of leaf height and cheapest height + 1 = cheapest height + 1
+                nodes[parent] = DynamicTree::TreeNode{
+                    DynamicTree::BranchData{cheapest, index},
+                    GetEnclosingAABB(aabb, nodes[cheapest].GetAABB()),
+                    1 + nodes[cheapest].GetHeight(), cheapestParent};
+                if (cheapestParent != DynamicTree::GetInvalidSize())
+                {
+                    const auto newBD = ReplaceChild(nodes[cheapestParent].AsBranch(), cheapest, parent);
+                    const auto newAabb = GetEnclosingAABB(nodes[newBD.child1].GetAABB(), nodes[newBD.child2].GetAABB());
+                    const auto newHeight = 1 + std::max(nodes[newBD.child1].GetHeight(), nodes[newBD.child2].GetHeight());
+                    nodes[cheapestParent].Assign(newBD, newAabb, newHeight);
+                }
+                nodes[cheapest].SetOther(parent);
+                return UpdateUpwardFrom(nodes, parent);
+            }
+
+        }// anonymous namespace
+
+        DynamicTree::DynamicTree() noexcept = default;
+
+        DynamicTree::DynamicTree(Size nodeCapacity)
+            : m_nodes{nodeCapacity ? AllocArray<TreeNode>(nodeCapacity) : nullptr},
+              m_freeIndex{nodeCapacity ? 0 : GetInvalidSize()},
+              m_nodeCapacity{nodeCapacity}
+        {
+            if (nodeCapacity)
+            {
+                // Build a linked list for the free list.
+                const auto endCapacity = nodeCapacity - Size{1};
+                for (auto i = decltype(nodeCapacity){0}; i < endCapacity; ++i)
+                {
+                    new (&m_nodes[i]) TreeNode{i + 1};
+                }
+                new (&m_nodes[endCapacity]) TreeNode{};
+            }
+        }
+
+        DynamicTree::DynamicTree(const DynamicTree& other)
+            : m_nodes{AllocArray<TreeNode>(other.m_nodeCapacity)},
+              m_rootIndex{other.m_rootIndex},
+              m_freeIndex{other.m_freeIndex},
+              m_nodeCount{other.m_nodeCount},
+              m_nodeCapacity{other.m_nodeCapacity},
+              m_leafCount{other.m_leafCount}
+        {
+            std::copy(&other.m_nodes[0], &other.m_nodes[other.m_nodeCapacity], &m_nodes[0]);
+        }
+
+        DynamicTree::DynamicTree(DynamicTree&& other) noexcept
+            : DynamicTree{}
+        {
+            swap(*this, other);
+        }
+
+        DynamicTree& DynamicTree::operator=(DynamicTree other) noexcept
+        {
+            // Leverages the "copy-and-swap" idiom.
+            // For details, see https://stackoverflow.com/a/3279550/7410358
+            swap(*this, other);
+            return *this;
+        }
+
+        DynamicTree::~DynamicTree() noexcept
+        {
+            // This frees the entire tree in one shot.
+            Free(m_nodes);
+        }
+
+        void DynamicTree::SetNodeCapacity(Size value)
+        {
+            assert(value > m_nodeCapacity);
+
+            // The free list is empty. Rebuild a bigger pool.
+            // Call Realloc first in case it throws so this code doesn't have to restore any state
+            // and so this function will have no effect.
+            m_nodes = ReallocArray<TreeNode>(m_nodes, value);
+            m_nodeCapacity = value;
+
+            // Build a linked list for the free list. The parent
+            // pointer becomes the "next" pointer.
+            const auto endCapacity = m_nodeCapacity - 1;
+            for (auto i = m_nodeCount; i < endCapacity; ++i)
+            {
+                new (m_nodes + i) TreeNode{i + 1};
+            }
+            new (m_nodes + endCapacity) TreeNode{};
+            m_freeIndex = m_nodeCount;
+        }
+
+        DynamicTree::Size DynamicTree::AllocateNode(const LeafData& data, AABB aabb)
+        {
+            const auto index = AllocateNode();
+            m_nodes[index] = TreeNode{data, aabb};
+            return index;
+        }
+
+        DynamicTree::Size DynamicTree::AllocateNode(const BranchData& data, AABB aabb,
+                                                    Height height, Size parent)
+        {
+            assert(height > 0);
+            const auto index = AllocateNode();
+            m_nodes[index] = TreeNode{data, aabb, height, parent};
+            return index;
+        }
+
+        DynamicTree::Size DynamicTree::AllocateNode()
+        {
+            // Expand the node pool as needed.
+            if (m_freeIndex == GetInvalidSize())
+            {
+                assert(m_nodeCount == m_nodeCapacity);
+
+                // The free list is empty. Rebuild a bigger pool.
+                SetNodeCapacity(m_nodeCapacity ? m_nodeCapacity * 2 : GetDefaultInitialNodeCapacity());
+            }
+
+            // Peel a node off the free list.
+            const auto index = m_freeIndex;
+            m_freeIndex = m_nodes[index].GetOther();
+            ++m_nodeCount;
+            return index;
+        }
+
+        void DynamicTree::FreeNode(Size index) noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < GetNodeCapacity());
+            assert(index != GetFreeIndex());
+            assert(m_nodeCount > 0);// index is not necessarily less than m_nodeCount.
+            assert(!IsUnused(m_nodes[index].GetHeight()));
+            assert(m_nodes[index].GetOther() == GetInvalidSize());
+
+            m_nodes[index] = TreeNode{m_freeIndex};
+            m_freeIndex = index;
+            --m_nodeCount;
+        }
+
+        void DynamicTree::Clear() noexcept
+        {
+            m_nodeCount = Size{0u};
+            m_leafCount = Size{0u};
+            m_rootIndex = GetInvalidSize();
+            if (m_nodeCapacity && m_nodes)
+            {
+                m_freeIndex = Size{0u};
+                const auto endCapacity = m_nodeCapacity - 1;
+                for (auto i = Size{0u}; i < endCapacity; ++i)
+                {
+                    m_nodes[i] = TreeNode{i + 1};
+                }
+                m_nodes[endCapacity] = TreeNode{};
+            }
+            else
+            {
+                Free(m_nodes);
+                m_nodes = nullptr;
+                m_nodeCapacity = Size{0u};
+                m_freeIndex = GetInvalidSize();
+            }
+        }
+
+        DynamicTree::Size DynamicTree::FindReference(Size index) const noexcept
+        {
+            const auto it = std::find_if(m_nodes, m_nodes + m_nodeCapacity, [&](TreeNode& node) {
+                if (node.GetOther() == index)
+                {
+                    return true;
+                }
+                if (IsBranch(node.GetHeight()))
+                {
+                    const auto bd = node.AsBranch();
+                    if (bd.child1 == index || bd.child2 == index)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            });
+            return (it != m_nodes + m_nodeCapacity) ? static_cast<Size>(it - m_nodes) : GetInvalidSize();
+        }
+
+        DynamicTree::Size DynamicTree::CreateLeaf(const AABB& aabb, const LeafData& data)
+        {
+            assert(IsValid(aabb));
+            const auto index = AllocateNode(data, aabb);
+            if (m_rootIndex != GetInvalidSize())
+            {
+                const auto newParent = AllocateNode();// Note: may change m_nodes!
+                m_rootIndex = InsertParent(m_nodes, newParent, aabb, index, m_rootIndex);
+            }
+            else
+            {
+                m_rootIndex = index;
+            }
+            ++m_leafCount;
+            return index;
+        }
+
+        void DynamicTree::DestroyLeaf(Size index) noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            assert(IsLeaf(m_nodes[index].GetHeight()));
+            assert(m_leafCount > 0);
+
+            --m_leafCount;
+
+            if (m_rootIndex != index)
+            {
+                const auto result = RemoveParent(m_nodes, index);
+                m_rootIndex = std::get<0>(result);
+                const auto parent = std::get<1>(result);
+#ifndef NDEBUG
+                const auto found = FindReference(parent);
+                assert(found == GetInvalidSize());
+#endif
+                FreeNode(parent);
+            }
+            else
+            {
+                assert(m_nodes[index].GetOther() == GetInvalidSize());
+                m_rootIndex = GetInvalidSize();
+            }
+
+#ifndef NDEBUG
+            const auto found = FindReference(index);
+            assert(found == GetInvalidSize());
+#endif
+            FreeNode(index);
+        }
+
+        void DynamicTree::UpdateLeaf(Size index, const AABB& aabb)
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            assert(IsLeaf(m_nodes[index].GetHeight()));
+
+            if (m_rootIndex != index)
+            {
+                m_rootIndex = UpdateNonRoot(m_nodes, index, aabb);
+            }
+            else
+            {
+                assert(m_nodes[index].GetOther() == GetInvalidSize());
+                m_nodes[index].SetAABB(aabb);
+            }
+        }
+
+        void DynamicTree::RebuildBottomUp()
+        {
+            const auto nodes = AllocArray<Size>(m_nodeCount);
+            auto count = Size{0};
+
+            // Build array of leaves. Free the rest.
+            for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)
+            {
+                const auto height = m_nodes[i].GetHeight();
+                if (IsLeaf(height))
+                {
+                    m_nodes[i].SetOther(GetInvalidSize());
+                    nodes[count] = i;
+                    ++count;
+                }
+                else if (IsBranch(height))
+                {
+                    m_nodes[i].SetOther(GetInvalidSize());
+                    FreeNode(i);
+                }
+            }
+
+            while (count > 1)
+            {
+                auto minCost = std::numeric_limits<Length>::infinity();
+                auto iMin = GetInvalidSize();
+                auto jMin = GetInvalidSize();
+                for (auto i = decltype(count){0}; i < count; ++i)
+                {
+                    const auto& aabbi = m_nodes[nodes[i]].GetAABB();
+
+                    for (auto j = i + 1; j < count; ++j)
+                    {
+                        const auto& aabbj = m_nodes[nodes[j]].GetAABB();
+                        const auto b = GetEnclosingAABB(aabbi, aabbj);
+                        const auto cost = GetPerimeter(b);
+                        if (minCost > cost)
+                        {
+                            iMin = i;
+                            jMin = j;
+                            minCost = cost;
+                        }
+                    }
+                }
+
+                assert((iMin < m_nodeCount) && (jMin < m_nodeCount));
+
+                const auto index1 = nodes[iMin];
+                const auto index2 = nodes[jMin];
+                assert(!IsUnused(m_nodes[index1].GetHeight()));
+                assert(!IsUnused(m_nodes[index2].GetHeight()));
+
+                const auto aabb = GetEnclosingAABB(m_nodes[index1].GetAABB(), m_nodes[index2].GetAABB());
+                const auto height = 1 + std::max(m_nodes[index1].GetHeight(), m_nodes[index2].GetHeight());
+
+                // Warning: the following may change value of m_nodes!
+                const auto parent = AllocateNode(BranchData{index1, index2}, aabb, height);
+                m_nodes[index1].SetOther(parent);
+                m_nodes[index2].SetOther(parent);
+
+                nodes[jMin] = nodes[count - 1];
+                nodes[iMin] = parent;
+                --count;
+            }
+
+            m_rootIndex = nodes[0];
+            Free(nodes);
+        }
+
+        void DynamicTree::ShiftOrigin(Length2 newOrigin)
+        {
+            // Build array of leaves. Free the rest.
+            for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i)
+            {
+                if (!IsUnused(m_nodes[i].GetHeight()))
+                {
+                    m_nodes[i].SetAABB(GetMovedAABB(m_nodes[i].GetAABB(), -newOrigin));
+                }
+            }
+        }
+
+        // Free functions...
+
+        void swap(DynamicTree& lhs, DynamicTree& rhs) noexcept
+        {
+            using playrho::swap;
+            swap(lhs.m_nodes, rhs.m_nodes);
+            swap(lhs.m_rootIndex, rhs.m_rootIndex);
+            swap(lhs.m_freeIndex, rhs.m_freeIndex);
+            swap(lhs.m_nodeCount, rhs.m_nodeCount);
+            swap(lhs.m_nodeCapacity, rhs.m_nodeCapacity);
+            swap(lhs.m_leafCount, rhs.m_leafCount);
+        }
+
+        void Query(const DynamicTree& tree, const AABB& aabb, const DynamicTreeSizeCB& callback)
+        {
+            GrowableStack<DynamicTree::Size, 256> stack;
+            stack.push(tree.GetRootIndex());
+
+            while (!empty(stack))
+            {
+                const auto index = stack.top();
+                stack.pop();
+                if (index != DynamicTree::GetInvalidSize())
+                {
+                    if (TestOverlap(tree.GetAABB(index), aabb))
+                    {
+                        const auto height = tree.GetHeight(index);
+                        if (DynamicTree::IsBranch(height))
+                        {
+                            const auto branchData = tree.GetBranchData(index);
+                            stack.push(branchData.child1);
+                            stack.push(branchData.child2);
+                        }
+                        else
+                        {
+                            assert(DynamicTree::IsLeaf(height));
+                            const auto sc = callback(index);
+                            if (sc == DynamicTreeOpcode::End)
+                            {
+                                return;
+                            }
+                        }
                     }
                 }
             }
         }
-    }
-}
 
-void Query(const DynamicTree& tree, const AABB& aabb, QueryFixtureCallback callback)
-{
-    Query(tree, aabb, [&](DynamicTree::Size treeId) {
-        const auto leafData = tree.GetLeafData(treeId);
-        return callback(leafData.fixture, leafData.childIndex)?
-        DynamicTreeOpcode::Continue: DynamicTreeOpcode::End;
-    });
-}
-
-Length ComputeTotalPerimeter(const DynamicTree& tree) noexcept
-{
-    auto total = 0_m;
-    const auto nodeCapacity = tree.GetNodeCapacity();
-    for (auto i = decltype(nodeCapacity){0}; i < nodeCapacity; ++i)
-    {
-        if (!DynamicTree::IsUnused(tree.GetHeight(i)))
+        void Query(const DynamicTree& tree, const AABB& aabb, QueryFixtureCallback callback)
         {
-            total += GetPerimeter(tree.GetAABB(i));
+            Query(tree, aabb, [&](DynamicTree::Size treeId) {
+                const auto leafData = tree.GetLeafData(treeId);
+                return callback(leafData.fixture, leafData.childIndex) ? DynamicTreeOpcode::Continue : DynamicTreeOpcode::End;
+            });
         }
-    }
-    return total;
-}
 
-Real ComputePerimeterRatio(const DynamicTree& tree) noexcept
-{
-    const auto root = tree.GetRootIndex();
-    if (root != DynamicTree::GetInvalidSize())
-    {
-        const auto rootPerimeter = GetPerimeter(tree.GetAABB(root));
-        const auto total = ComputeTotalPerimeter(tree);
-        return total / rootPerimeter;
-    }
-    return 0;
-}
-
-DynamicTree::Height ComputeHeight(const DynamicTree& tree, DynamicTree::Size index) noexcept
-{
-    assert(index < tree.GetNodeCapacity());
-    if (DynamicTree::IsBranch(tree.GetHeight(index)))
-    {
-        const auto bd = tree.GetBranchData(index);
-        const auto height1 = ComputeHeight(tree, bd.child1);
-        const auto height2 = ComputeHeight(tree, bd.child2);
-        return 1 + std::max(height1, height2);
-    }
-    return 0;
-}
-
-DynamicTree::Height GetMaxImbalance(const DynamicTree& tree) noexcept
-{
-    auto maxImbalance = DynamicTree::Height{0};
-    const auto nodeCapacity = tree.GetNodeCapacity();
-    for (auto i = decltype(nodeCapacity){0}; i < nodeCapacity; ++i)
-    {
-        if (DynamicTree::IsBranch(tree.GetHeight(i)))
+        Length ComputeTotalPerimeter(const DynamicTree& tree) noexcept
         {
-            const auto bd = tree.GetBranchData(i);
-            const auto height1 = tree.GetHeight(bd.child1);
-            const auto height2 = tree.GetHeight(bd.child2);
-            const auto imbalance = (height2 >= height1)? height2 - height1: height1 - height2;
-            maxImbalance = std::max(maxImbalance, imbalance);
+            auto total = 0_m;
+            const auto nodeCapacity = tree.GetNodeCapacity();
+            for (auto i = decltype(nodeCapacity){0}; i < nodeCapacity; ++i)
+            {
+                if (!DynamicTree::IsUnused(tree.GetHeight(i)))
+                {
+                    total += GetPerimeter(tree.GetAABB(i));
+                }
+            }
+            return total;
         }
-    }
-    return maxImbalance;
-}
 
-bool ValidateStructure(const DynamicTree& tree, DynamicTree::Size index) noexcept
-{
-    if (index == DynamicTree::GetInvalidSize())
-    {
-        return true;
-    }
-    
-    // DynamicTree enforces this invariant, so can't setup instance in this state to runtime test.
-    assert((index != tree.GetRootIndex()) || (tree.GetOther(index) == DynamicTree::GetInvalidSize()));
+        Real ComputePerimeterRatio(const DynamicTree& tree) noexcept
+        {
+            const auto root = tree.GetRootIndex();
+            if (root != DynamicTree::GetInvalidSize())
+            {
+                const auto rootPerimeter = GetPerimeter(tree.GetAABB(root));
+                const auto total = ComputeTotalPerimeter(tree);
+                return total / rootPerimeter;
+            }
+            return 0;
+        }
 
-    const auto nodeCapacity = tree.GetNodeCapacity();
-    if (index >= nodeCapacity)
-    {
-        return false;
-    }
-    
-    const auto height = tree.GetHeight(index);
-    
-    if (DynamicTree::IsLeaf(height))
-    {
-        return true;
-    }
-    
-    if (DynamicTree::IsBranch(height))
-    {
-        const auto bd = tree.GetBranchData(index);
-        const auto child1 = bd.child1;
-        const auto child2 = bd.child2;
-        assert(tree.GetOther(child1) == index);
-        assert(tree.GetOther(child2) == index);
-        return ValidateStructure(tree, child1) && ValidateStructure(tree, child2);
-    }
-    
-    assert(DynamicTree::IsUnused(height));
-    return ValidateStructure(tree, tree.GetOther(index));
-}
+        DynamicTree::Height ComputeHeight(const DynamicTree& tree, DynamicTree::Size index) noexcept
+        {
+            assert(index < tree.GetNodeCapacity());
+            if (DynamicTree::IsBranch(tree.GetHeight(index)))
+            {
+                const auto bd = tree.GetBranchData(index);
+                const auto height1 = ComputeHeight(tree, bd.child1);
+                const auto height2 = ComputeHeight(tree, bd.child2);
+                return 1 + std::max(height1, height2);
+            }
+            return 0;
+        }
 
-bool ValidateMetrics(const DynamicTree& tree, DynamicTree::Size index) noexcept
-{
-    if (index == DynamicTree::GetInvalidSize())
-    {
-        return true;
-    }
-    
-    const auto nodeCapacity = tree.GetNodeCapacity();
-    if (index >= nodeCapacity)
-    {
-        return false;
-    }
-    
-    const auto height = tree.GetHeight(index);
-    if (!DynamicTree::IsBranch(height))
-    {
-        return true;
-    }
-    
-    const auto bd = tree.GetBranchData(index);
-    const auto child1 = bd.child1;
-    const auto child2 = bd.child2;
-    
-    // DynamicTree doesn't provide way to set up the following states so only assertable...
-    assert(tree.GetOther(child1) == index);
-    assert(tree.GetOther(child2) == index);
-    assert(height == (1 + std::max(tree.GetHeight(child1), tree.GetHeight(child2))));
-    assert(tree.GetAABB(index) == GetEnclosingAABB(tree.GetAABB(child1), tree.GetAABB(child2)));
+        DynamicTree::Height GetMaxImbalance(const DynamicTree& tree) noexcept
+        {
+            auto maxImbalance = DynamicTree::Height{0};
+            const auto nodeCapacity = tree.GetNodeCapacity();
+            for (auto i = decltype(nodeCapacity){0}; i < nodeCapacity; ++i)
+            {
+                if (DynamicTree::IsBranch(tree.GetHeight(i)))
+                {
+                    const auto bd = tree.GetBranchData(i);
+                    const auto height1 = tree.GetHeight(bd.child1);
+                    const auto height2 = tree.GetHeight(bd.child2);
+                    const auto imbalance = (height2 >= height1) ? height2 - height1 : height1 - height2;
+                    maxImbalance = std::max(maxImbalance, imbalance);
+                }
+            }
+            return maxImbalance;
+        }
 
-    return ValidateMetrics(tree, child1) && ValidateMetrics(tree, child2);
-}
+        bool ValidateStructure(const DynamicTree& tree, DynamicTree::Size index) noexcept
+        {
+            if (index == DynamicTree::GetInvalidSize())
+            {
+                return true;
+            }
 
-} // namespace d2
-} // namespace playrho
+            // DynamicTree enforces this invariant, so can't setup instance in this state to runtime test.
+            assert((index != tree.GetRootIndex()) || (tree.GetOther(index) == DynamicTree::GetInvalidSize()));
+
+            const auto nodeCapacity = tree.GetNodeCapacity();
+            if (index >= nodeCapacity)
+            {
+                return false;
+            }
+
+            const auto height = tree.GetHeight(index);
+
+            if (DynamicTree::IsLeaf(height))
+            {
+                return true;
+            }
+
+            if (DynamicTree::IsBranch(height))
+            {
+                const auto bd = tree.GetBranchData(index);
+                const auto child1 = bd.child1;
+                const auto child2 = bd.child2;
+                assert(tree.GetOther(child1) == index);
+                assert(tree.GetOther(child2) == index);
+                return ValidateStructure(tree, child1) && ValidateStructure(tree, child2);
+            }
+
+            assert(DynamicTree::IsUnused(height));
+            return ValidateStructure(tree, tree.GetOther(index));
+        }
+
+        bool ValidateMetrics(const DynamicTree& tree, DynamicTree::Size index) noexcept
+        {
+            if (index == DynamicTree::GetInvalidSize())
+            {
+                return true;
+            }
+
+            const auto nodeCapacity = tree.GetNodeCapacity();
+            if (index >= nodeCapacity)
+            {
+                return false;
+            }
+
+            const auto height = tree.GetHeight(index);
+            if (!DynamicTree::IsBranch(height))
+            {
+                return true;
+            }
+
+            const auto bd = tree.GetBranchData(index);
+            const auto child1 = bd.child1;
+            const auto child2 = bd.child2;
+
+            // DynamicTree doesn't provide way to set up the following states so only assertable...
+            assert(tree.GetOther(child1) == index);
+            assert(tree.GetOther(child2) == index);
+            assert(height == (1 + std::max(tree.GetHeight(child1), tree.GetHeight(child2))));
+            assert(tree.GetAABB(index) == GetEnclosingAABB(tree.GetAABB(child1), tree.GetAABB(child2)));
+
+            return ValidateMetrics(tree, child1) && ValidateMetrics(tree, child2);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -35,771 +35,780 @@
 #include <type_traits>
 #include <utility>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief A dynamic AABB tree broad-phase.
-///
-/// @details A dynamic tree arranges data in a binary tree to accelerate
-///   queries such as volume queries and ray casts. Leafs are proxies
-///   with an AABB.
-///
-/// @invariant A dynamic tree with a capacity of N nodes will always have N minus M "free"
-///   nodes and M "allocated" nodes where M is never more than N.
-/// @invariant Freed nodes' "other" nodes are valid "next" older freed nodes, or they
-///   have the invalid size value indicating that they are the oldest freed node.
-/// @invariant Allocated nodes' "other" nodes are valid "parent" nodes, or they
-///   have the invalid size value indicating that they are parentless.
-/// @invariant The root node's index is either the index to the node at the root of the tree
-///   or it's the invalid size value indicating that this tree is empty.
-/// @invariant The root node's "other" index will be the invalid size value.
-/// @invariant Allocated nodes can only be "branch" or "leaf" nodes.
-/// @invariant Branch nodes always have two valid "child" nodes.
-/// @invariant Branch nodes always have a "height" of 1 plus the maximum height of its children.
-/// @invariant Branch nodes' AABBs are always the AABB which minimally encloses its children.
-/// @invariant Leaf nodes always have a "height" of zero.
-/// @invariant Freed nodes always have a "height" of the maximum value of the height type.
-///
-/// @note This code was inspired by Nathanael Presson's <code>btDbvt</code>.
-/// @note Nodes are pooled and relocatable, so we use node indices rather than pointers.
-/// @note This data structure is 32-bytes large (on at least one 64-bit platform).
-///
-/// @see http://www.randygaul.net/2013/08/06/dynamic-aabb-tree/
-/// @see http://www.cs.utah.edu/~thiago/papers/rotations.pdf ("Fast, Effective
-///    BVH Updates for Animated Scenes")
-///
-class DynamicTree
+namespace playrho
 {
-public:
-    /// @brief Size type.
-    using Size = ContactCounter;
-
-    class TreeNode;
-    struct UnusedData;
-    struct BranchData;
-    struct LeafData;
-    union VariantData;
-
-    /// @brief Gets the invalid size value.
-    static constexpr Size GetInvalidSize() noexcept
+    namespace d2
     {
-        return static_cast<Size>(-1);
-    }
-
-    /// @brief Type for heights.
-    /// @note The maximum height of a tree can never exceed half of the max value of the
-    ///   <code>Size</code> type due to the binary nature of this tree structure.
-    using Height = ContactCounter;
-
-    /// @brief Invalid height constant value.
-    static constexpr auto InvalidHeight = static_cast<Height>(-1);
-
-    /// @brief Gets the invalid height value.
-    static constexpr Height GetInvalidHeight() noexcept
-    {
-        return InvalidHeight;
-    }
-
-    /// @brief Gets whether the given height is the height for an "unused" node.
-    static constexpr bool IsUnused(Height value) noexcept
-    {
-        return value == GetInvalidHeight();
-    }
-
-    /// @brief Gets whether the given height is the height for a "leaf" node.
-    static constexpr bool IsLeaf(Height value) noexcept
-    {
-        return value == 0;
-    }
-
-    /// @brief Gets whether the given height is a height for a "branch" node.
-    static constexpr bool IsBranch(Height value) noexcept
-    {
-        return !IsUnused(value) && !IsLeaf(value);
-    }
-
-    /// @brief Gets the default initial node capacity.
-    static constexpr Size GetDefaultInitialNodeCapacity() noexcept;
-
-    /// @brief Non-throwing default constructor.
-    DynamicTree() noexcept;
-
-    /// @brief Size initializing constructor.
-    /// @param nodeCapacity Node capacity. If zero, this is the same as calling
-    ///   the default constructor except this isn't recognized as non-throwing.
-    explicit DynamicTree(Size nodeCapacity);
-
-    /// @brief Destroys the tree, freeing the node pool.
-    ~DynamicTree() noexcept;
-
-    /// @brief Copy constructor.
-    DynamicTree(const DynamicTree& other);
-
-    /// @brief Move constructor.
-    DynamicTree(DynamicTree&& other) noexcept;
-
-    /// @brief Unifying assignment operator.
-    /// @note This intentionally takes the argument by-value. Along with the move constructor,
-    ///   this assignment method effectively doubles up as both copy assignment and move
-    ///   assignment support.
-    /// @see https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Copy-and-swap
-    /// @see https://stackoverflow.com/a/3279550/7410358
-    DynamicTree& operator= (DynamicTree other) noexcept;
-
-    /// @brief Clears the dynamic tree.
-    /// @details Clears the leafs and branches from this tree. This does not deallocate any
-    ///    memory nor reduce this tree's capacity; this only reduces this tree's usage of that
-    ///    capacity.
-    /// @post <code>GetLeafCount()</code> will return 0.
-    /// @post <code>GetNodeCount()</code> will return 0.
-    /// @post <code>GetRootIndex()</code> will return <code>GetInvalidSize()</code>.
-    /// @post <code>GetFreeIndex()</code> will return 0 if this tree had any node capacity,
-    ///   else the value of <code>GetInvalidSize()</code>.
-    void Clear() noexcept;
-
-    /// @brief Creates a new leaf node.
-    /// @details Creates a leaf node for a tight fitting AABB and the given data.
-    /// @warning Behavior is undefined unless the number of nodes already allocated (as reported by
-    ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
-    /// @note The indices of leaf nodes that have been destroyed get reused for new nodes.
-    /// @post If the root index had been the <code>GetInvalidSize()</code>, then it will
-    ///   be set to the index returned from this method.
-    /// @post The leaf count (as reported by <code>GetLeafCount()</code>) will be incremented by one.
-    /// @post The node count (as reported by <code>GetNodeCount()</code>) will be incremented by one
-    ///   or two (if the root index had not been <code>GetInvalidSize()</code>).
-    /// @return The index of the created leaf node. This will be a value not equal to
-    ///   <code>GetInvalidSize()</code>.
-    /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
-    ///   thrown, this function has no effect.
-    /// @see GetLeafCount(), GetNodeCount()
-    Size CreateLeaf(const AABB& aabb, const LeafData& data);
-
-    /// @brief Destroys a leaf node.
-    /// @post The leaf count will be decremented by one.
-    /// @warning Behavior is undefined if the given index is not valid.
-    void DestroyLeaf(Size index) noexcept;
-
-    /// @brief Updates a leaf node with a new AABB value.
-    /// @warning Behavior is undefined if the given index is not valid.
-    /// @param index Leaf node's ID. Behavior is undefined if this is not a valid ID.
-    /// @param aabb New axis aligned bounding box for the leaf node.
-    void UpdateLeaf(Size index, const AABB& aabb);
-
-    /// @brief Gets the leaf data for the node identified by the given identifier.
-    /// @warning Behavior is undefined if the given index is not valid.
-    /// @param index Identifier of node to get the leaf data for.
-    /// @return Leaf data for the specified node.
-    LeafData GetLeafData(Size index) const noexcept;
-
-    /// @brief Sets the leaf data for the element at the given index to the given value.
-    void SetLeafData(Size index, LeafData value) noexcept;
-
-    /// @brief Gets the AABB for a leaf or branch (a non-unused node).
-    /// @warning Behavior is undefined if the given index is not valid.
-    /// @param index Leaf or branch node's ID. Must be a valid ID.
-    AABB GetAABB(Size index) const noexcept;
-
-    /// @brief Gets the height value for the identified node.
-    /// @warning Behavior is undefined if the given index is not valid.
-    Height GetHeight(Size index) const noexcept;
-
-    /// @brief Gets the "other" index for the node at the given index.
-    /// @note For unused nodes, this is the index to the "next" unused node.
-    /// @note For used nodes (leaf or branch nodes), this is the index to the "parent" node.
-    /// @warning Behavior is undefined if the given index is not valid.
-    /// @pre This tree has a node capacity greater than the given index.
-    /// @return The invalid index value or a value less than the node capacity.
-    Size GetOther(Size index) const noexcept;
-
-    /// @brief Gets the branch data for the identified node.
-    /// @warning Behavior is undefined if the given index in not a valid branch node.
-    BranchData GetBranchData(Size index) const noexcept;
-
-    /// @brief Gets the index of the "root" node if this tree has one.
-    /// @note If the tree has a root node, then the "other" property of this node will be
-    ///   the invalid size.
-    /// @return <code>GetInvalidSize()</code> if this tree is "empty", else index to "root" node.
-    Size GetRootIndex() const noexcept;
-
-    /// @brief Gets the free index.
-    Size GetFreeIndex() const noexcept;
-
-    /// @brief Builds an optimal tree.
-    /// @note This operation is very expensive.
-    /// @note Meant for testing.
-    /// @throws std::bad_alloc If unable to allocate necessary memory.
-    void RebuildBottomUp();
-
-    /// @brief Shifts the world origin.
-    /// @note Useful for large worlds.
-    /// @note The shift formula is: <code>position -= newOrigin</code>.
-    /// @param newOrigin the new origin with respect to the old origin.
-    void ShiftOrigin(Length2 newOrigin);
-
-    /// @brief Gets the current node capacity of this tree.
-    Size GetNodeCapacity() const noexcept;
-
-    /// @brief Gets the current count of allocated nodes.
-    /// @return Count of existing proxies (count of nodes currently allocated).
-    Size GetNodeCount() const noexcept;
-
-    /// @brief Gets the current leaf node count.
-    /// @details Gets the current leaf node count.
-    Size GetLeafCount() const noexcept;
-
-    /// @brief Finds first node which references the given index.
-    /// @note Primarily intended for unit testing and/or debugging.
-    /// @return Index of node referencing the given index, or the value of
-    ///   <code>GetInvalidSize()</code>.
-    Size FindReference(Size index) const noexcept;
-
-    /// @brief Customized swap function for <code>DynamicTree</code> objects.
-    /// @note This satisfies the <code>Swappable</code> named requirement.
-    /// @see https://en.cppreference.com/w/cpp/named_req/Swappable
-    friend void swap(DynamicTree& lhs, DynamicTree& rhs) noexcept;
-
-private:
-    
-    /// @brief Sets the node capacity to the given value.
-    /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
-    ///   thrown, this function has no effect.
-    void SetNodeCapacity(Size value);
-
-    /// @brief Allocates a node.
-    /// @details This allocates a node from the free list that can be used as either a leaf
-    ///   node or a branch node.
-    /// @warning Behavior is undefined unless the number of nodes allocated (as reported by
-    ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
-    /// @return Value not equal to <code>GetInvalidSize()</code>.
-    /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
-    ///   thrown, this function has no effect.
-    /// @see GetNodeCount()
-    Size AllocateNode();
-
-    /// @brief Allocates a leaf node.
-    /// @details This allocates a node from the free list as a leaf node.
-    /// @warning Behavior is undefined unless the number of nodes allocated (as reported by
-    ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
-    /// @return Value not equal to <code>GetInvalidSize()</code>.
-    /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
-    ///   thrown, this function has no effect.
-    /// @see GetNodeCount()
-    Size AllocateNode(const LeafData& data, AABB aabb);
-
-    /// @brief Allocates a branch node.
-    /// @details This allocates a node from the free list as a branch node.
-    /// @warning Behavior is undefined unless the number of nodes allocated (as reported by
-    ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
-    /// @post The free list no longer references the returned index.
-    /// @return Value not equal to <code>GetInvalidSize()</code>.
-    /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
-    ///   thrown, this function has no effect.
-    /// @see GetNodeCount()
-    Size AllocateNode(const BranchData& data, AABB aabb, Height height,
-                      Size parent = GetInvalidSize());
- 
-    /// @brief Frees the specified node.
-    ///
-    /// @warning Behavior is undefined if the given index is not valid.
-    /// @warning Specified node must be a "leaf" or "branch" node.
-    ///
-    /// @pre Specified node's other index is the invalid size index.
-    /// @pre Specified node isn't referenced by any other nodes.
-    /// @post The free list links to the given index.
-    ///
-    void FreeNode(Size index) noexcept;
-    
-    TreeNode* m_nodes{nullptr}; ///< Nodes. @details Initialized on construction.
-    Size m_rootIndex{GetInvalidSize()}; ///< Index of root element in m_nodes or <code>GetInvalidSize()</code>.
-    Size m_freeIndex{GetInvalidSize()}; ///< Free list. @details Index to free nodes.
-    Size m_nodeCount{0u}; ///< Node count. @details Count of currently allocated nodes.
-    Size m_nodeCapacity{0u}; ///< Node capacity. @details Size of buffer allocated for nodes.
-    Size m_leafCount{0u}; ///< Leaf count. @details Count of currently allocated leaf nodes.
-};
-
-/// @brief Unused data of a tree node.
-/// @note This exists for symmetry and as placeholder in case this needs to later be used.
-struct DynamicTree::UnusedData
-{
-    // Intentionally empty.
-};
-
-/// @brief Branch data of a tree node.
-struct DynamicTree::BranchData
-{
-    Size child1; ///< @brief Child 1.
-    Size child2; ///< @brief Child 2.
-};
-
-/// @brief Leaf data of a tree node.
-/// @details This is the leaf node specific data for a <code>DynamicTree::TreeNode</code>.
-///   It's data that only pertains to leaf nodes.
-/// @note This class is used in the <code>DynamicTree::VariantData</code> union within a
-///   <code>DynamicTree::TreeNode</code>.
-///   This has ramifications on this class's data contents and size.
-struct DynamicTree::LeafData
-{
-    // In terms of what needs to be in this structure, it minimally needs to have enough
-    // information in it to identify the child shape for which the node's AABB represents,
-    // and its associated body. A pointer to the fixture and the index of the child in
-    // its shape could suffice for this. Meanwhile, a Contact is defined to be the
-    // recognition of an overlap between two child shapes having different bodies making
-    // the caching of the bodies a potential speed-up opportunity.
-
-    /// @brief Identifier of the associated body.
-    /// @note This field serves merely to potentially avoid the lookup of the body through
-    ///   the fixture.
-    BodyID body;
-    
-    /// @brief Identifier of the associated Fixture.
-    FixtureID fixture;
-
-    /// @brief Child index of related Shape.
-    ChildCounter childIndex;
-};
-
-/// @brief Equality operator.
-/// @relatedalso DynamicTree::LeafData
-constexpr bool operator== (const DynamicTree::LeafData& lhs,
-                           const DynamicTree::LeafData& rhs) noexcept
-{
-    return lhs.fixture == rhs.fixture && lhs.childIndex == rhs.childIndex;
-}
-
-/// @brief Inequality operator.
-/// @relatedalso DynamicTree::LeafData
-constexpr bool operator!= (const DynamicTree::LeafData& lhs,
-                           const DynamicTree::LeafData& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
-/// @brief Variant data.
-/// @note A union is used intentionally to save space.
-union DynamicTree::VariantData
-{
-    /// @brief Unused/free-list specific data.
-    UnusedData unused;
-    
-    /// @brief Leaf specific data.
-    LeafData leaf;
-    
-    /// @brief Branch specific data.
-    BranchData branch;
-    
-    /// @brief Default constructor.
-    VariantData() noexcept {}
-    
-    /// @brief Initializing constructor.
-    constexpr VariantData(UnusedData value) noexcept: unused{value} {}
-    
-    /// @brief Initializing constructor.
-    constexpr VariantData(LeafData value) noexcept: leaf{value} {}
-    
-    /// @brief Initializing constructor.
-    constexpr VariantData(BranchData value) noexcept: branch{value} {}
-};
-
-/// @brief Is unused.
-/// @details Determines whether the given dynamic tree node is an unused node.
-/// @relatedalso DynamicTree::TreeNode
-constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
-
-/// @brief Is leaf.
-/// @details Determines whether the given dynamic tree node is a leaf node.
-/// @relatedalso DynamicTree::TreeNode
-constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
-
-/// @brief Is branch.
-/// @details Determines whether the given dynamic tree node is a branch node.
-///   Branch nodes have 2 indices to child nodes.
-/// @relatedalso DynamicTree::TreeNode
-constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
-
-/// @brief A node in the dynamic tree.
-/// @note Users do not interact with this directly.
-/// @note By using indexes to other tree nodes, these don't need to be updated
-///   if the memory for other nodes is relocated.
-/// @note On some 64-bit architectures, pointers are 8-bytes, while indices need only be
-///   4-bytes. So using indices can also save 4-bytes.
-/// @note This data structure is 48-bytes large on at least one 64-bit platform.
-class DynamicTree::TreeNode
-{
-public:
-    ~TreeNode() = default;
-
-    /// @brief Copy constructor.
-    constexpr TreeNode(const TreeNode& other) = default;
-
-    /// @brief Move constructor.
-    constexpr TreeNode(TreeNode&& other) = default;
-
-    /// @brief Initializing constructor.
-    constexpr explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept:
-        m_other{other}
-    {
-        assert(IsUnused(m_height));
-    }
-
-    /// @brief Initializing constructor.
-    constexpr TreeNode(const LeafData& value, AABB aabb,
-                                      Size other = DynamicTree::GetInvalidSize()) noexcept:
-        m_aabb{aabb}, m_variant{value}, m_height{0}, m_other{other}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr TreeNode(const BranchData& value, AABB aabb, Height height,
-                       Size other = DynamicTree::GetInvalidSize()) noexcept:
-        m_aabb{aabb}, m_variant{value}, m_height{height}, m_other{other}
-    {
-        assert(IsBranch(height));
-        assert(value.child1 != GetInvalidSize());
-        assert(value.child2 != GetInvalidSize());
-    }
-
-    /// @brief Copy assignment operator.
-    TreeNode& operator= (const TreeNode& other) = default;
-
-    /// @brief Gets the node "height".
-    constexpr Height GetHeight() const noexcept
-    {
-        return m_height;
-    }
-    
-    /// @brief Gets the node's "other" index.
-    constexpr Size GetOther() const noexcept
-    {
-        return m_other;
-    }
-                
-    /// @brief Sets the node's "other" index to the given value.
-    constexpr void SetOther(Size other) noexcept
-    {
-        m_other = other;
-    }
-
-    /// @brief Gets the node's AABB.
-    /// @warning Behavior is undefined if called on a free/unused node!
-    constexpr AABB GetAABB() const noexcept
-    {
-        assert(!IsUnused(m_height));
-        return m_aabb;
-    }
-
-    /// @brief Sets the node's AABB.
-    /// @warning Behavior is undefined if called on a free/unused node!
-    constexpr void SetAABB(AABB value) noexcept
-    {
-        assert(!IsUnused(m_height));
-        m_aabb = value;
-    }
-    
-    /// @brief Gets the node as an "unused" value.
-    /// @warning Behavior is undefined unless called on a free/unused node!
-    constexpr UnusedData AsUnused() const noexcept
-    {
-        assert(IsUnused(m_height));
-        return m_variant.unused;
-    }
-    
-    /// @brief Gets the node as a "leaf" value.
-    /// @warning Behavior is undefined unless called on a leaf node!
-    constexpr LeafData AsLeaf() const noexcept
-    {
-        assert(IsLeaf(m_height));
-        return m_variant.leaf;
-    }
-    
-    /// @brief Gets the node as a "branch" value.
-    /// @warning Behavior is undefined unless called on a branch node!
-    constexpr BranchData AsBranch() const noexcept
-    {
-        assert(IsBranch(m_height));
-        return m_variant.branch;
-    }
-
-    /// @brief Gets the node as an "unused" value.
-    constexpr void Assign(const UnusedData& v) noexcept
-    {
-        m_variant.unused = v;
-        m_height = static_cast<Height>(-1);
-    }
-    
-    /// @brief Gets the node as a "leaf" value.
-    constexpr void Assign(const LeafData& v) noexcept
-    {
-        m_variant.leaf = v;
-        m_height = 0;
-    }
-    
-    /// @brief Assigns the node as a "branch" value.
-    constexpr void Assign(const BranchData& v, const AABB& bb, Height h) noexcept
-    {
-        assert(v.child1 != GetInvalidSize());
-        assert(v.child2 != GetInvalidSize());
-        assert(IsBranch(h));
-        m_variant.branch = v;
-        m_aabb = bb;
-        m_height = h;
-    }
-
-private:
-    /// @brief AABB.
-    /// @note This field is unused for free nodes, else it's the minimally enclosing AABB
-    ///   for the node.
-    AABB m_aabb;
-
-    /// @brief Variant data for the node.
-    VariantData m_variant{UnusedData{}};
-
-    /// @brief Height.
-    /// @details "Height" for tree balancing.
-    /// @note 0 if leaf node, <code>DynamicTree::GetInvalidHeight()</code> if free (unallocated)
-    ///   node, else branch node.
-    Height m_height = GetInvalidHeight();
-
-    /// @brief Index to "other" node.
-    /// @note This is an index to the next node for a free node, else this is the index to the
-    ///   parent node.
-    Size m_other = DynamicTree::GetInvalidSize(); ///< Index of another node.
-};
-
-constexpr DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
-{
-    return Size{64};
-}
-
-inline DynamicTree::Size DynamicTree::GetRootIndex() const noexcept
-{
-    assert((m_rootIndex == GetInvalidSize() && (m_leafCount == 0)) ||
-           ((m_rootIndex < m_nodeCapacity) && (m_leafCount > 0) && (GetOther(m_rootIndex) == GetInvalidSize())));
-    return m_rootIndex;
-}
-
-inline DynamicTree::Size DynamicTree::GetFreeIndex() const noexcept
-{
-    return m_freeIndex;
-}
-
-inline DynamicTree::Size DynamicTree::GetNodeCapacity() const noexcept
-{
-    return m_nodeCapacity;
-}
-
-inline DynamicTree::Size DynamicTree::GetNodeCount() const noexcept
-{
-    return m_nodeCount;
-}
-
-inline DynamicTree::Size DynamicTree::GetLeafCount() const noexcept
-{
-    assert(((m_leafCount == 0) && (m_rootIndex == GetInvalidSize())) ||
-           ((m_leafCount > 0) && (m_rootIndex != GetInvalidSize()) && (GetOther(m_rootIndex) == GetInvalidSize())));
-    return m_leafCount;
-}
-
-inline DynamicTree::Height DynamicTree::GetHeight(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    return m_nodes[index].GetHeight();
-}
-
-inline DynamicTree::Size DynamicTree::GetOther(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    return m_nodes[index].GetOther();
-}
-
-inline AABB DynamicTree::GetAABB(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(!IsUnused(m_nodes[index].GetHeight()));
-    return m_nodes[index].GetAABB();
-}
-
-inline DynamicTree::BranchData DynamicTree::GetBranchData(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(IsBranch(m_nodes[index].GetHeight()));
-    return m_nodes[index].AsBranch();
-}
-
-inline DynamicTree::LeafData DynamicTree::GetLeafData(Size index) const noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index].GetHeight()));
-    return m_nodes[index].AsLeaf();
-}
-
-inline void DynamicTree::SetLeafData(Size index, LeafData value) noexcept
-{
-    assert(index != GetInvalidSize());
-    assert(index < m_nodeCapacity);
-    assert(IsLeaf(m_nodes[index].GetHeight()));
-    m_nodes[index].AsLeaf() = value;
-}
-
-// Free functions...
-
-/// @brief Replaces the old child with the new child.
-constexpr DynamicTree::BranchData
-ReplaceChild(DynamicTree::BranchData bd, DynamicTree::Size oldChild, DynamicTree::Size newChild)
-{
-    assert(bd.child1 == oldChild || bd.child2 == oldChild);
-    return (bd.child1 == oldChild)?
-        DynamicTree::BranchData{newChild, bd.child2}: DynamicTree::BranchData{bd.child1, newChild};
-}
-
-/// @brief Whether this node is free (or allocated).
-/// @relatedalso DynamicTree::TreeNode
-constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept
-{
-    return DynamicTree::IsUnused(node.GetHeight());
-}
-
-/// @brief Whether or not this node is a leaf node.
-/// @note This has constant complexity.
-/// @return <code>true</code> if this is a leaf node, <code>false</code> otherwise.
-/// @relatedalso DynamicTree::TreeNode
-constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
-{
-    return DynamicTree::IsLeaf(node.GetHeight());
-}
-
-/// @brief Is branch.
-/// @details Determines whether the given node is a "branch" node.
-/// @relatedalso DynamicTree::TreeNode
-constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept
-{
-    return DynamicTree::IsBranch(node.GetHeight());
-}
-
-/// @brief Gets the AABB of the given dynamic tree node.
-/// @relatedalso DynamicTree::TreeNode
-constexpr AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
-{
-    assert(!IsUnused(node));
-    return node.GetAABB();
-}
-
-/// @brief Gets the next index of the given node.
-/// @warning Behavior is undefined if the given node is not an "unused" node.
-/// @relatedalso DynamicTree::TreeNode
-constexpr DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
-{
-    assert(IsUnused(node));
-    return node.GetOther();
-}
-
-/// @brief Gets the height of the binary tree.
-/// @return Height of the tree (as stored in the root node) or 0 if the root node is not valid.
-/// @relatedalso DynamicTree
-inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
-{
-    const auto index = tree.GetRootIndex();
-    return (index != DynamicTree::GetInvalidSize())? tree.GetHeight(index): DynamicTree::Height{0};
-}
-
-/// @brief Gets the AABB for the given dynamic tree.
-/// @details Gets the AABB that encloses all other AABB instances that are within the
-///   given dynamic tree.
-/// @return Enclosing AABB or the "unset" AABB.
-/// @relatedalso DynamicTree
-inline AABB GetAABB(const DynamicTree& tree) noexcept
-{
-    const auto index = tree.GetRootIndex();
-    return (index != DynamicTree::GetInvalidSize())? tree.GetAABB(index): AABB{};
-}
-
-/// @brief Tests for overlap of the elements identified in the given dynamic tree.
-/// @relatedalso DynamicTree
-inline bool TestOverlap(const DynamicTree& tree,
-                        DynamicTree::Size leafIdA, DynamicTree::Size leafIdB) noexcept
-{
-    return TestOverlap(tree.GetAABB(leafIdA), tree.GetAABB(leafIdB));
-}
-
-/// @brief Gets the sum of the perimeters of nodes.
-/// @note Zero is returned if no proxies exist at the time of the call.
-/// @return Value of zero or more.
-Length ComputeTotalPerimeter(const DynamicTree& tree) noexcept;
-
-/// @brief Gets the ratio of the sum of the perimeters of nodes to the root perimeter.
-/// @note Zero is returned if no proxies exist at the time of the call.
-/// @return Value of zero or more.
-Real ComputePerimeterRatio(const DynamicTree& tree) noexcept;
-
-/// @brief Computes the height of the tree from a given node.
-/// @warning Behavior is undefined if the given index is not valid.
-/// @param tree Tree to compute the height at the given node for.
-/// @param index ID of node to compute height from.
-/// @return 0 unless the given index is to a branch node.
-DynamicTree::Height ComputeHeight(const DynamicTree& tree, DynamicTree::Size index) noexcept;
-
-/// @brief Computes the height of the given dynamic tree.
-inline DynamicTree::Height ComputeHeight(const DynamicTree& tree) noexcept
-{
-    return ComputeHeight(tree, tree.GetRootIndex());
-}
-
-/// @brief Validates the structure of the given tree from the given index.
-/// @note Meant for testing.
-/// @return <code>true</code> if valid, <code>false</code> otherwise.
-bool ValidateStructure(const DynamicTree& tree, DynamicTree::Size index) noexcept;
-
-/// @brief Validates the metrics of the given tree from the given index.
-/// @note Meant for testing.
-/// @return <code>true</code> if valid, <code>false</code> otherwise.
-bool ValidateMetrics(const DynamicTree& tree, DynamicTree::Size index) noexcept;
-
-/// @brief Gets the maximum imbalance.
-/// @details This gets the maximum imbalance of nodes in the given tree.
-/// @note The imbalance is the difference in height of the two children of a node.
-DynamicTree::Height GetMaxImbalance(const DynamicTree& tree) noexcept;
-
-/// @brief Opcodes for dynamic tree callbacks.
-enum class DynamicTreeOpcode
-{
-    End,
-    Continue,
-};
-
-/// @brief Query callback type.
-using DynamicTreeSizeCB = std::function<DynamicTreeOpcode(DynamicTree::Size)>;
-
-/// @brief Query the given dynamic tree and find nodes overlapping the given AABB.
-/// @note The callback instance is called for each leaf node that overlaps the supplied AABB.
-void Query(const DynamicTree& tree, const AABB& aabb,
-           const DynamicTreeSizeCB& callback);
-
-/// @brief Query AABB for fixtures callback function type.
-/// @note Returning true will continue the query. Returning false will terminate the query.
-using QueryFixtureCallback = std::function<bool(FixtureID fixture, ChildCounter child)>;
-
-/// @brief Queries the world for all fixtures that potentially overlap the provided AABB.
-/// @param tree Dynamic tree to do the query over.
-/// @param aabb The query box.
-/// @param callback User implemented callback function.
-void Query(const DynamicTree& tree, const AABB& aabb, QueryFixtureCallback callback);
-
-/// @brief Gets the "size" of the given tree.
-/// @note Size in this context is defined as the leaf count.
-/// @note This provides ancillary support for the container named requirement's size method.
-/// @see DynamicTree::GetLeafCount()
-/// @see https://en.cppreference.com/w/cpp/named_req/Container
-inline std::size_t size(const DynamicTree& tree) noexcept
-{
-    return tree.GetLeafCount();
-}
-
-} // namespace d2
-} // namespace playrho
-
-#endif // PLAYRHO_COLLISION_DYNAMICTREE_HPP
+
+        /// @brief A dynamic AABB tree broad-phase.
+        ///
+        /// @details A dynamic tree arranges data in a binary tree to accelerate
+        ///   queries such as volume queries and ray casts. Leafs are proxies
+        ///   with an AABB.
+        ///
+        /// @invariant A dynamic tree with a capacity of N nodes will always have N minus M "free"
+        ///   nodes and M "allocated" nodes where M is never more than N.
+        /// @invariant Freed nodes' "other" nodes are valid "next" older freed nodes, or they
+        ///   have the invalid size value indicating that they are the oldest freed node.
+        /// @invariant Allocated nodes' "other" nodes are valid "parent" nodes, or they
+        ///   have the invalid size value indicating that they are parentless.
+        /// @invariant The root node's index is either the index to the node at the root of the tree
+        ///   or it's the invalid size value indicating that this tree is empty.
+        /// @invariant The root node's "other" index will be the invalid size value.
+        /// @invariant Allocated nodes can only be "branch" or "leaf" nodes.
+        /// @invariant Branch nodes always have two valid "child" nodes.
+        /// @invariant Branch nodes always have a "height" of 1 plus the maximum height of its children.
+        /// @invariant Branch nodes' AABBs are always the AABB which minimally encloses its children.
+        /// @invariant Leaf nodes always have a "height" of zero.
+        /// @invariant Freed nodes always have a "height" of the maximum value of the height type.
+        ///
+        /// @note This code was inspired by Nathanael Presson's <code>btDbvt</code>.
+        /// @note Nodes are pooled and relocatable, so we use node indices rather than pointers.
+        /// @note This data structure is 32-bytes large (on at least one 64-bit platform).
+        ///
+        /// @see http://www.randygaul.net/2013/08/06/dynamic-aabb-tree/
+        /// @see http://www.cs.utah.edu/~thiago/papers/rotations.pdf ("Fast, Effective
+        ///    BVH Updates for Animated Scenes")
+        ///
+        class DynamicTree
+        {
+         public:
+            /// @brief Size type.
+            using Size = ContactCounter;
+
+            class TreeNode;
+            struct UnusedData;
+            struct BranchData;
+            struct LeafData;
+            union VariantData;
+
+            /// @brief Gets the invalid size value.
+            static constexpr Size GetInvalidSize() noexcept
+            {
+                return static_cast<Size>(-1);
+            }
+
+            /// @brief Type for heights.
+            /// @note The maximum height of a tree can never exceed half of the max value of the
+            ///   <code>Size</code> type due to the binary nature of this tree structure.
+            using Height = ContactCounter;
+
+            /// @brief Invalid height constant value.
+            static constexpr auto InvalidHeight = static_cast<Height>(-1);
+
+            /// @brief Gets the invalid height value.
+            static constexpr Height GetInvalidHeight() noexcept
+            {
+                return InvalidHeight;
+            }
+
+            /// @brief Gets whether the given height is the height for an "unused" node.
+            static constexpr bool IsUnused(Height value) noexcept
+            {
+                return value == GetInvalidHeight();
+            }
+
+            /// @brief Gets whether the given height is the height for a "leaf" node.
+            static constexpr bool IsLeaf(Height value) noexcept
+            {
+                return value == 0;
+            }
+
+            /// @brief Gets whether the given height is a height for a "branch" node.
+            static constexpr bool IsBranch(Height value) noexcept
+            {
+                return !IsUnused(value) && !IsLeaf(value);
+            }
+
+            /// @brief Gets the default initial node capacity.
+            static constexpr Size GetDefaultInitialNodeCapacity() noexcept;
+
+            /// @brief Non-throwing default constructor.
+            DynamicTree() noexcept;
+
+            /// @brief Size initializing constructor.
+            /// @param nodeCapacity Node capacity. If zero, this is the same as calling
+            ///   the default constructor except this isn't recognized as non-throwing.
+            explicit DynamicTree(Size nodeCapacity);
+
+            /// @brief Destroys the tree, freeing the node pool.
+            ~DynamicTree() noexcept;
+
+            /// @brief Copy constructor.
+            DynamicTree(const DynamicTree& other);
+
+            /// @brief Move constructor.
+            DynamicTree(DynamicTree&& other) noexcept;
+
+            /// @brief Unifying assignment operator.
+            /// @note This intentionally takes the argument by-value. Along with the move constructor,
+            ///   this assignment method effectively doubles up as both copy assignment and move
+            ///   assignment support.
+            /// @see https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Copy-and-swap
+            /// @see https://stackoverflow.com/a/3279550/7410358
+            DynamicTree& operator=(DynamicTree other) noexcept;
+
+            /// @brief Clears the dynamic tree.
+            /// @details Clears the leafs and branches from this tree. This does not deallocate any
+            ///    memory nor reduce this tree's capacity; this only reduces this tree's usage of that
+            ///    capacity.
+            /// @post <code>GetLeafCount()</code> will return 0.
+            /// @post <code>GetNodeCount()</code> will return 0.
+            /// @post <code>GetRootIndex()</code> will return <code>GetInvalidSize()</code>.
+            /// @post <code>GetFreeIndex()</code> will return 0 if this tree had any node capacity,
+            ///   else the value of <code>GetInvalidSize()</code>.
+            void Clear() noexcept;
+
+            /// @brief Creates a new leaf node.
+            /// @details Creates a leaf node for a tight fitting AABB and the given data.
+            /// @warning Behavior is undefined unless the number of nodes already allocated (as reported by
+            ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
+            /// @note The indices of leaf nodes that have been destroyed get reused for new nodes.
+            /// @post If the root index had been the <code>GetInvalidSize()</code>, then it will
+            ///   be set to the index returned from this method.
+            /// @post The leaf count (as reported by <code>GetLeafCount()</code>) will be incremented by one.
+            /// @post The node count (as reported by <code>GetNodeCount()</code>) will be incremented by one
+            ///   or two (if the root index had not been <code>GetInvalidSize()</code>).
+            /// @return The index of the created leaf node. This will be a value not equal to
+            ///   <code>GetInvalidSize()</code>.
+            /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
+            ///   thrown, this function has no effect.
+            /// @see GetLeafCount(), GetNodeCount()
+            Size CreateLeaf(const AABB& aabb, const LeafData& data);
+
+            /// @brief Destroys a leaf node.
+            /// @post The leaf count will be decremented by one.
+            /// @warning Behavior is undefined if the given index is not valid.
+            void DestroyLeaf(Size index) noexcept;
+
+            /// @brief Updates a leaf node with a new AABB value.
+            /// @warning Behavior is undefined if the given index is not valid.
+            /// @param index Leaf node's ID. Behavior is undefined if this is not a valid ID.
+            /// @param aabb New axis aligned bounding box for the leaf node.
+            void UpdateLeaf(Size index, const AABB& aabb);
+
+            /// @brief Gets the leaf data for the node identified by the given identifier.
+            /// @warning Behavior is undefined if the given index is not valid.
+            /// @param index Identifier of node to get the leaf data for.
+            /// @return Leaf data for the specified node.
+            LeafData GetLeafData(Size index) const noexcept;
+
+            /// @brief Sets the leaf data for the element at the given index to the given value.
+            void SetLeafData(Size index, LeafData value) noexcept;
+
+            /// @brief Gets the AABB for a leaf or branch (a non-unused node).
+            /// @warning Behavior is undefined if the given index is not valid.
+            /// @param index Leaf or branch node's ID. Must be a valid ID.
+            AABB GetAABB(Size index) const noexcept;
+
+            /// @brief Gets the height value for the identified node.
+            /// @warning Behavior is undefined if the given index is not valid.
+            Height GetHeight(Size index) const noexcept;
+
+            /// @brief Gets the "other" index for the node at the given index.
+            /// @note For unused nodes, this is the index to the "next" unused node.
+            /// @note For used nodes (leaf or branch nodes), this is the index to the "parent" node.
+            /// @warning Behavior is undefined if the given index is not valid.
+            /// @pre This tree has a node capacity greater than the given index.
+            /// @return The invalid index value or a value less than the node capacity.
+            Size GetOther(Size index) const noexcept;
+
+            /// @brief Gets the branch data for the identified node.
+            /// @warning Behavior is undefined if the given index in not a valid branch node.
+            BranchData GetBranchData(Size index) const noexcept;
+
+            /// @brief Gets the index of the "root" node if this tree has one.
+            /// @note If the tree has a root node, then the "other" property of this node will be
+            ///   the invalid size.
+            /// @return <code>GetInvalidSize()</code> if this tree is "empty", else index to "root" node.
+            Size GetRootIndex() const noexcept;
+
+            /// @brief Gets the free index.
+            Size GetFreeIndex() const noexcept;
+
+            /// @brief Builds an optimal tree.
+            /// @note This operation is very expensive.
+            /// @note Meant for testing.
+            /// @throws std::bad_alloc If unable to allocate necessary memory.
+            void RebuildBottomUp();
+
+            /// @brief Shifts the world origin.
+            /// @note Useful for large worlds.
+            /// @note The shift formula is: <code>position -= newOrigin</code>.
+            /// @param newOrigin the new origin with respect to the old origin.
+            void ShiftOrigin(Length2 newOrigin);
+
+            /// @brief Gets the current node capacity of this tree.
+            Size GetNodeCapacity() const noexcept;
+
+            /// @brief Gets the current count of allocated nodes.
+            /// @return Count of existing proxies (count of nodes currently allocated).
+            Size GetNodeCount() const noexcept;
+
+            /// @brief Gets the current leaf node count.
+            /// @details Gets the current leaf node count.
+            Size GetLeafCount() const noexcept;
+
+            /// @brief Finds first node which references the given index.
+            /// @note Primarily intended for unit testing and/or debugging.
+            /// @return Index of node referencing the given index, or the value of
+            ///   <code>GetInvalidSize()</code>.
+            Size FindReference(Size index) const noexcept;
+
+            /// @brief Customized swap function for <code>DynamicTree</code> objects.
+            /// @note This satisfies the <code>Swappable</code> named requirement.
+            /// @see https://en.cppreference.com/w/cpp/named_req/Swappable
+            friend void swap(DynamicTree& lhs, DynamicTree& rhs) noexcept;
+
+         private:
+            /// @brief Sets the node capacity to the given value.
+            /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
+            ///   thrown, this function has no effect.
+            void SetNodeCapacity(Size value);
+
+            /// @brief Allocates a node.
+            /// @details This allocates a node from the free list that can be used as either a leaf
+            ///   node or a branch node.
+            /// @warning Behavior is undefined unless the number of nodes allocated (as reported by
+            ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
+            /// @return Value not equal to <code>GetInvalidSize()</code>.
+            /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
+            ///   thrown, this function has no effect.
+            /// @see GetNodeCount()
+            Size AllocateNode();
+
+            /// @brief Allocates a leaf node.
+            /// @details This allocates a node from the free list as a leaf node.
+            /// @warning Behavior is undefined unless the number of nodes allocated (as reported by
+            ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
+            /// @return Value not equal to <code>GetInvalidSize()</code>.
+            /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
+            ///   thrown, this function has no effect.
+            /// @see GetNodeCount()
+            Size AllocateNode(const LeafData& data, AABB aabb);
+
+            /// @brief Allocates a branch node.
+            /// @details This allocates a node from the free list as a branch node.
+            /// @warning Behavior is undefined unless the number of nodes allocated (as reported by
+            ///   <code>GetNodeCount()</code>) is less than <code>std::numeric_limits<Size>::max()</code>.
+            /// @post The free list no longer references the returned index.
+            /// @return Value not equal to <code>GetInvalidSize()</code>.
+            /// @throws std::bad_alloc If unable to allocate necessary memory. If this exception is
+            ///   thrown, this function has no effect.
+            /// @see GetNodeCount()
+            Size AllocateNode(const BranchData& data, AABB aabb, Height height,
+                              Size parent = GetInvalidSize());
+
+            /// @brief Frees the specified node.
+            ///
+            /// @warning Behavior is undefined if the given index is not valid.
+            /// @warning Specified node must be a "leaf" or "branch" node.
+            ///
+            /// @pre Specified node's other index is the invalid size index.
+            /// @pre Specified node isn't referenced by any other nodes.
+            /// @post The free list links to the given index.
+            ///
+            void FreeNode(Size index) noexcept;
+
+            TreeNode* m_nodes{nullptr};        ///< Nodes. @details Initialized on construction.
+            Size m_rootIndex{GetInvalidSize()};///< Index of root element in m_nodes or <code>GetInvalidSize()</code>.
+            Size m_freeIndex{GetInvalidSize()};///< Free list. @details Index to free nodes.
+            Size m_nodeCount{0u};              ///< Node count. @details Count of currently allocated nodes.
+            Size m_nodeCapacity{0u};           ///< Node capacity. @details Size of buffer allocated for nodes.
+            Size m_leafCount{0u};              ///< Leaf count. @details Count of currently allocated leaf nodes.
+        };
+
+        /// @brief Unused data of a tree node.
+        /// @note This exists for symmetry and as placeholder in case this needs to later be used.
+        struct DynamicTree::UnusedData
+        {
+            // Intentionally empty.
+        };
+
+        /// @brief Branch data of a tree node.
+        struct DynamicTree::BranchData
+        {
+            Size child1;///< @brief Child 1.
+            Size child2;///< @brief Child 2.
+        };
+
+        /// @brief Leaf data of a tree node.
+        /// @details This is the leaf node specific data for a <code>DynamicTree::TreeNode</code>.
+        ///   It's data that only pertains to leaf nodes.
+        /// @note This class is used in the <code>DynamicTree::VariantData</code> union within a
+        ///   <code>DynamicTree::TreeNode</code>.
+        ///   This has ramifications on this class's data contents and size.
+        struct DynamicTree::LeafData
+        {
+            // In terms of what needs to be in this structure, it minimally needs to have enough
+            // information in it to identify the child shape for which the node's AABB represents,
+            // and its associated body. A pointer to the fixture and the index of the child in
+            // its shape could suffice for this. Meanwhile, a Contact is defined to be the
+            // recognition of an overlap between two child shapes having different bodies making
+            // the caching of the bodies a potential speed-up opportunity.
+
+            /// @brief Identifier of the associated body.
+            /// @note This field serves merely to potentially avoid the lookup of the body through
+            ///   the fixture.
+            BodyID body;
+
+            /// @brief Identifier of the associated Fixture.
+            FixtureID fixture;
+
+            /// @brief Child index of related Shape.
+            ChildCounter childIndex;
+        };
+
+        /// @brief Equality operator.
+        /// @relatedalso DynamicTree::LeafData
+        constexpr bool operator==(const DynamicTree::LeafData& lhs,
+                                  const DynamicTree::LeafData& rhs) noexcept
+        {
+            return lhs.fixture == rhs.fixture && lhs.childIndex == rhs.childIndex;
+        }
+
+        /// @brief Inequality operator.
+        /// @relatedalso DynamicTree::LeafData
+        constexpr bool operator!=(const DynamicTree::LeafData& lhs,
+                                  const DynamicTree::LeafData& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
+
+        /// @brief Variant data.
+        /// @note A union is used intentionally to save space.
+        union DynamicTree::VariantData
+        {
+            /// @brief Unused/free-list specific data.
+            UnusedData unused;
+
+            /// @brief Leaf specific data.
+            LeafData leaf;
+
+            /// @brief Branch specific data.
+            BranchData branch;
+
+            /// @brief Default constructor.
+            VariantData() noexcept
+            {
+            }
+
+            /// @brief Initializing constructor.
+            constexpr VariantData(UnusedData value) noexcept
+                : unused{value}
+            {
+            }
+
+            /// @brief Initializing constructor.
+            constexpr VariantData(LeafData value) noexcept
+                : leaf{value}
+            {
+            }
+
+            /// @brief Initializing constructor.
+            constexpr VariantData(BranchData value) noexcept
+                : branch{value}
+            {
+            }
+        };
+
+        /// @brief Is unused.
+        /// @details Determines whether the given dynamic tree node is an unused node.
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept;
+
+        /// @brief Is leaf.
+        /// @details Determines whether the given dynamic tree node is a leaf node.
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept;
+
+        /// @brief Is branch.
+        /// @details Determines whether the given dynamic tree node is a branch node.
+        ///   Branch nodes have 2 indices to child nodes.
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept;
+
+        /// @brief A node in the dynamic tree.
+        /// @note Users do not interact with this directly.
+        /// @note By using indexes to other tree nodes, these don't need to be updated
+        ///   if the memory for other nodes is relocated.
+        /// @note On some 64-bit architectures, pointers are 8-bytes, while indices need only be
+        ///   4-bytes. So using indices can also save 4-bytes.
+        /// @note This data structure is 48-bytes large on at least one 64-bit platform.
+        class DynamicTree::TreeNode
+        {
+         public:
+            ~TreeNode() = default;
+
+            /// @brief Copy constructor.
+            constexpr TreeNode(const TreeNode& other) = default;
+
+            /// @brief Move constructor.
+            constexpr TreeNode(TreeNode&& other) = default;
+
+            /// @brief Initializing constructor.
+            constexpr explicit TreeNode(Size other = DynamicTree::GetInvalidSize()) noexcept
+                : m_other{other}
+            {
+                assert(IsUnused(m_height));
+            }
+
+            /// @brief Initializing constructor.
+            constexpr TreeNode(const LeafData& value, AABB aabb,
+                               Size other = DynamicTree::GetInvalidSize()) noexcept
+                : m_aabb{aabb}, m_variant{value}, m_height{0}, m_other{other}
+            {
+                // Intentionally empty.
+            }
+
+            /// @brief Initializing constructor.
+            constexpr TreeNode(const BranchData& value, AABB aabb, Height height,
+                               Size other = DynamicTree::GetInvalidSize()) noexcept
+                : m_aabb{aabb}, m_variant{value}, m_height{height}, m_other{other}
+            {
+                assert(IsBranch(height));
+                assert(value.child1 != GetInvalidSize());
+                assert(value.child2 != GetInvalidSize());
+            }
+
+            /// @brief Copy assignment operator.
+            TreeNode& operator=(const TreeNode& other) = default;
+
+            /// @brief Gets the node "height".
+            constexpr Height GetHeight() const noexcept
+            {
+                return m_height;
+            }
+
+            /// @brief Gets the node's "other" index.
+            constexpr Size GetOther() const noexcept
+            {
+                return m_other;
+            }
+
+            /// @brief Sets the node's "other" index to the given value.
+            constexpr void SetOther(Size other) noexcept
+            {
+                m_other = other;
+            }
+
+            /// @brief Gets the node's AABB.
+            /// @warning Behavior is undefined if called on a free/unused node!
+            constexpr AABB GetAABB() const noexcept
+            {
+                assert(!IsUnused(m_height));
+                return m_aabb;
+            }
+
+            /// @brief Sets the node's AABB.
+            /// @warning Behavior is undefined if called on a free/unused node!
+            constexpr void SetAABB(AABB value) noexcept
+            {
+                assert(!IsUnused(m_height));
+                m_aabb = value;
+            }
+
+            /// @brief Gets the node as an "unused" value.
+            /// @warning Behavior is undefined unless called on a free/unused node!
+            constexpr UnusedData AsUnused() const noexcept
+            {
+                assert(IsUnused(m_height));
+                return m_variant.unused;
+            }
+
+            /// @brief Gets the node as a "leaf" value.
+            /// @warning Behavior is undefined unless called on a leaf node!
+            constexpr LeafData AsLeaf() const noexcept
+            {
+                assert(IsLeaf(m_height));
+                return m_variant.leaf;
+            }
+
+            /// @brief Gets the node as a "branch" value.
+            /// @warning Behavior is undefined unless called on a branch node!
+            constexpr BranchData AsBranch() const noexcept
+            {
+                assert(IsBranch(m_height));
+                return m_variant.branch;
+            }
+
+            /// @brief Gets the node as an "unused" value.
+            constexpr void Assign(const UnusedData& v) noexcept
+            {
+                m_variant.unused = v;
+                m_height = static_cast<Height>(-1);
+            }
+
+            /// @brief Gets the node as a "leaf" value.
+            constexpr void Assign(const LeafData& v) noexcept
+            {
+                m_variant.leaf = v;
+                m_height = 0;
+            }
+
+            /// @brief Assigns the node as a "branch" value.
+            constexpr void Assign(const BranchData& v, const AABB& bb, Height h) noexcept
+            {
+                assert(v.child1 != GetInvalidSize());
+                assert(v.child2 != GetInvalidSize());
+                assert(IsBranch(h));
+                m_variant.branch = v;
+                m_aabb = bb;
+                m_height = h;
+            }
+
+         private:
+            /// @brief AABB.
+            /// @note This field is unused for free nodes, else it's the minimally enclosing AABB
+            ///   for the node.
+            AABB m_aabb;
+
+            /// @brief Variant data for the node.
+            VariantData m_variant{UnusedData{}};
+
+            /// @brief Height.
+            /// @details "Height" for tree balancing.
+            /// @note 0 if leaf node, <code>DynamicTree::GetInvalidHeight()</code> if free (unallocated)
+            ///   node, else branch node.
+            Height m_height = GetInvalidHeight();
+
+            /// @brief Index to "other" node.
+            /// @note This is an index to the next node for a free node, else this is the index to the
+            ///   parent node.
+            Size m_other = DynamicTree::GetInvalidSize();///< Index of another node.
+        };
+
+        constexpr DynamicTree::Size DynamicTree::GetDefaultInitialNodeCapacity() noexcept
+        {
+            return Size{64};
+        }
+
+        inline DynamicTree::Size DynamicTree::GetRootIndex() const noexcept
+        {
+            assert((m_rootIndex == GetInvalidSize() && (m_leafCount == 0)) || ((m_rootIndex < m_nodeCapacity) && (m_leafCount > 0) && (GetOther(m_rootIndex) == GetInvalidSize())));
+            return m_rootIndex;
+        }
+
+        inline DynamicTree::Size DynamicTree::GetFreeIndex() const noexcept
+        {
+            return m_freeIndex;
+        }
+
+        inline DynamicTree::Size DynamicTree::GetNodeCapacity() const noexcept
+        {
+            return m_nodeCapacity;
+        }
+
+        inline DynamicTree::Size DynamicTree::GetNodeCount() const noexcept
+        {
+            return m_nodeCount;
+        }
+
+        inline DynamicTree::Size DynamicTree::GetLeafCount() const noexcept
+        {
+            assert(((m_leafCount == 0) && (m_rootIndex == GetInvalidSize())) || ((m_leafCount > 0) && (m_rootIndex != GetInvalidSize()) && (GetOther(m_rootIndex) == GetInvalidSize())));
+            return m_leafCount;
+        }
+
+        inline DynamicTree::Height DynamicTree::GetHeight(Size index) const noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            return m_nodes[index].GetHeight();
+        }
+
+        inline DynamicTree::Size DynamicTree::GetOther(Size index) const noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            return m_nodes[index].GetOther();
+        }
+
+        inline AABB DynamicTree::GetAABB(Size index) const noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            assert(!IsUnused(m_nodes[index].GetHeight()));
+            return m_nodes[index].GetAABB();
+        }
+
+        inline DynamicTree::BranchData DynamicTree::GetBranchData(Size index) const noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            assert(IsBranch(m_nodes[index].GetHeight()));
+            return m_nodes[index].AsBranch();
+        }
+
+        inline DynamicTree::LeafData DynamicTree::GetLeafData(Size index) const noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            assert(IsLeaf(m_nodes[index].GetHeight()));
+            return m_nodes[index].AsLeaf();
+        }
+
+        inline void DynamicTree::SetLeafData(Size index, LeafData value) noexcept
+        {
+            assert(index != GetInvalidSize());
+            assert(index < m_nodeCapacity);
+            assert(IsLeaf(m_nodes[index].GetHeight()));
+            m_nodes[index].AsLeaf() = value;
+        }
+
+        // Free functions...
+
+        /// @brief Replaces the old child with the new child.
+        constexpr DynamicTree::BranchData
+        ReplaceChild(DynamicTree::BranchData bd, DynamicTree::Size oldChild, DynamicTree::Size newChild)
+        {
+            assert(bd.child1 == oldChild || bd.child2 == oldChild);
+            return (bd.child1 == oldChild) ? DynamicTree::BranchData{newChild, bd.child2} : DynamicTree::BranchData{bd.child1, newChild};
+        }
+
+        /// @brief Whether this node is free (or allocated).
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr bool IsUnused(const DynamicTree::TreeNode& node) noexcept
+        {
+            return DynamicTree::IsUnused(node.GetHeight());
+        }
+
+        /// @brief Whether or not this node is a leaf node.
+        /// @note This has constant complexity.
+        /// @return <code>true</code> if this is a leaf node, <code>false</code> otherwise.
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr bool IsLeaf(const DynamicTree::TreeNode& node) noexcept
+        {
+            return DynamicTree::IsLeaf(node.GetHeight());
+        }
+
+        /// @brief Is branch.
+        /// @details Determines whether the given node is a "branch" node.
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr bool IsBranch(const DynamicTree::TreeNode& node) noexcept
+        {
+            return DynamicTree::IsBranch(node.GetHeight());
+        }
+
+        /// @brief Gets the AABB of the given dynamic tree node.
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr AABB GetAABB(const DynamicTree::TreeNode& node) noexcept
+        {
+            assert(!IsUnused(node));
+            return node.GetAABB();
+        }
+
+        /// @brief Gets the next index of the given node.
+        /// @warning Behavior is undefined if the given node is not an "unused" node.
+        /// @relatedalso DynamicTree::TreeNode
+        constexpr DynamicTree::Size GetNext(const DynamicTree::TreeNode& node) noexcept
+        {
+            assert(IsUnused(node));
+            return node.GetOther();
+        }
+
+        /// @brief Gets the height of the binary tree.
+        /// @return Height of the tree (as stored in the root node) or 0 if the root node is not valid.
+        /// @relatedalso DynamicTree
+        inline DynamicTree::Height GetHeight(const DynamicTree& tree) noexcept
+        {
+            const auto index = tree.GetRootIndex();
+            return (index != DynamicTree::GetInvalidSize()) ? tree.GetHeight(index) : DynamicTree::Height{0};
+        }
+
+        /// @brief Gets the AABB for the given dynamic tree.
+        /// @details Gets the AABB that encloses all other AABB instances that are within the
+        ///   given dynamic tree.
+        /// @return Enclosing AABB or the "unset" AABB.
+        /// @relatedalso DynamicTree
+        inline AABB GetAABB(const DynamicTree& tree) noexcept
+        {
+            const auto index = tree.GetRootIndex();
+            return (index != DynamicTree::GetInvalidSize()) ? tree.GetAABB(index) : AABB{};
+        }
+
+        /// @brief Tests for overlap of the elements identified in the given dynamic tree.
+        /// @relatedalso DynamicTree
+        inline bool TestOverlap(const DynamicTree& tree,
+                                DynamicTree::Size leafIdA, DynamicTree::Size leafIdB) noexcept
+        {
+            return TestOverlap(tree.GetAABB(leafIdA), tree.GetAABB(leafIdB));
+        }
+
+        /// @brief Gets the sum of the perimeters of nodes.
+        /// @note Zero is returned if no proxies exist at the time of the call.
+        /// @return Value of zero or more.
+        Length ComputeTotalPerimeter(const DynamicTree& tree) noexcept;
+
+        /// @brief Gets the ratio of the sum of the perimeters of nodes to the root perimeter.
+        /// @note Zero is returned if no proxies exist at the time of the call.
+        /// @return Value of zero or more.
+        Real ComputePerimeterRatio(const DynamicTree& tree) noexcept;
+
+        /// @brief Computes the height of the tree from a given node.
+        /// @warning Behavior is undefined if the given index is not valid.
+        /// @param tree Tree to compute the height at the given node for.
+        /// @param index ID of node to compute height from.
+        /// @return 0 unless the given index is to a branch node.
+        DynamicTree::Height ComputeHeight(const DynamicTree& tree, DynamicTree::Size index) noexcept;
+
+        /// @brief Computes the height of the given dynamic tree.
+        inline DynamicTree::Height ComputeHeight(const DynamicTree& tree) noexcept
+        {
+            return ComputeHeight(tree, tree.GetRootIndex());
+        }
+
+        /// @brief Validates the structure of the given tree from the given index.
+        /// @note Meant for testing.
+        /// @return <code>true</code> if valid, <code>false</code> otherwise.
+        bool ValidateStructure(const DynamicTree& tree, DynamicTree::Size index) noexcept;
+
+        /// @brief Validates the metrics of the given tree from the given index.
+        /// @note Meant for testing.
+        /// @return <code>true</code> if valid, <code>false</code> otherwise.
+        bool ValidateMetrics(const DynamicTree& tree, DynamicTree::Size index) noexcept;
+
+        /// @brief Gets the maximum imbalance.
+        /// @details This gets the maximum imbalance of nodes in the given tree.
+        /// @note The imbalance is the difference in height of the two children of a node.
+        DynamicTree::Height GetMaxImbalance(const DynamicTree& tree) noexcept;
+
+        /// @brief Opcodes for dynamic tree callbacks.
+        enum class DynamicTreeOpcode
+        {
+            End,
+            Continue,
+        };
+
+        /// @brief Query callback type.
+        using DynamicTreeSizeCB = std::function<DynamicTreeOpcode(DynamicTree::Size)>;
+
+        /// @brief Query the given dynamic tree and find nodes overlapping the given AABB.
+        /// @note The callback instance is called for each leaf node that overlaps the supplied AABB.
+        void Query(const DynamicTree& tree, const AABB& aabb,
+                   const DynamicTreeSizeCB& callback);
+
+        /// @brief Query AABB for fixtures callback function type.
+        /// @note Returning true will continue the query. Returning false will terminate the query.
+        using QueryFixtureCallback = std::function<bool(FixtureID fixture, ChildCounter child)>;
+
+        /// @brief Queries the world for all fixtures that potentially overlap the provided AABB.
+        /// @param tree Dynamic tree to do the query over.
+        /// @param aabb The query box.
+        /// @param callback User implemented callback function.
+        void Query(const DynamicTree& tree, const AABB& aabb, QueryFixtureCallback callback);
+
+        /// @brief Gets the "size" of the given tree.
+        /// @note Size in this context is defined as the leaf count.
+        /// @note This provides ancillary support for the container named requirement's size method.
+        /// @see DynamicTree::GetLeafCount()
+        /// @see https://en.cppreference.com/w/cpp/named_req/Container
+        inline std::size_t size(const DynamicTree& tree) noexcept
+        {
+            return tree.GetLeafCount();
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_DYNAMICTREE_HPP

--- a/PlayRho/Collision/IndexPair.hpp
+++ b/PlayRho/Collision/IndexPair.hpp
@@ -26,127 +26,127 @@
 #include <array>
 #include <utility>
 
-namespace playrho {
-
-/// @brief Index pair.
-/// @note This data structure is at least 2-bytes large.
-/// @note Using <code>std::array</code> would make more sense if it weren't for the
-///   fact that <code>std::pair</code>, but not <code>std::array</code>, has
-///   <code>constexpr</code> equality and inequality operators.
-using IndexPair = std::pair<VertexCounter, VertexCounter>;
-
-/// @brief Invalid index-pair value.
-constexpr auto InvalidIndexPair = IndexPair{
-    InvalidVertex, InvalidVertex
-};
-
-/// @brief Array of three index-pair elements.
-/// @note An element having the <code>InvalidIndexPair</code> value, denotes an
-///   unused or invalid elements.
-/// @note This data type is 6-bytes large (on at least one 64-bit platform).
-using IndexPair3 = std::array<IndexPair, MaxSimplexEdges>;
-
-/// @brief Invalid array of three index-pair elements.
-constexpr auto InvalidIndexPair3 = IndexPair3{{
-    InvalidIndexPair, InvalidIndexPair, InvalidIndexPair
-}};
-
-static_assert(MaxSimplexEdges == 3, "Invalid assumption about size of MaxSimplexEdges");
-
-/// @brief Gets the number of valid indices in the given collection of index pairs.
-/// @note Any element with a value of <code>InvalidIndexPair</code> is interpreted
-///   as being invalid in this context.
-/// @return Value between 0 and 3 inclusive.
-constexpr std::size_t GetNumValidIndices(IndexPair3 pairs) noexcept
+namespace playrho
 {
-    return std::size_t{3}
-    - ((std::get<0>(pairs) == InvalidIndexPair)? 1u: 0u)
-    - ((std::get<1>(pairs) == InvalidIndexPair)? 1u: 0u)
-    - ((std::get<2>(pairs) == InvalidIndexPair)? 1u: 0u);
-}
 
-/// @brief Checks whether the given collection of index pairs is empty.
-constexpr bool empty(IndexPair3 pairs) noexcept
-{
-    return GetNumValidIndices(pairs) == 0;
-}
+    /// @brief Index pair.
+    /// @note This data structure is at least 2-bytes large.
+    /// @note Using <code>std::array</code> would make more sense if it weren't for the
+    ///   fact that <code>std::pair</code>, but not <code>std::array</code>, has
+    ///   <code>constexpr</code> equality and inequality operators.
+    using IndexPair = std::pair<VertexCounter, VertexCounter>;
 
-/// @brief Gets the dynamic size of the given collection of index pairs.
-/// @note This just calls <code>GetNumValidIndices</code>.
-/// @see GetNumValidIndices
-constexpr auto size(IndexPair3 pairs) -> decltype(GetNumValidIndices(pairs))
-{
-    return GetNumValidIndices(pairs);
-}
+    /// @brief Invalid index-pair value.
+    constexpr auto InvalidIndexPair = IndexPair{
+        InvalidVertex, InvalidVertex};
 
-/// @brief Gets the maximum size of the given container of index pairs.
-/// @return Always returns 3.
-constexpr auto max_size(IndexPair3 pairs) -> decltype(pairs.max_size())
-{
-    return pairs.max_size();
-}
+    /// @brief Array of three index-pair elements.
+    /// @note An element having the <code>InvalidIndexPair</code> value, denotes an
+    ///   unused or invalid elements.
+    /// @note This data type is 6-bytes large (on at least one 64-bit platform).
+    using IndexPair3 = std::array<IndexPair, MaxSimplexEdges>;
 
-/// @brief Vertex counter array template alias.
-template <std::size_t N>
-using VertexCounterArray = std::array<VertexCounter, N>;
+    /// @brief Invalid array of three index-pair elements.
+    constexpr auto InvalidIndexPair3 = IndexPair3{{InvalidIndexPair, InvalidIndexPair, InvalidIndexPair}};
 
-/// @brief 2-element vertex counter array.
-using VertexCounter2 = VertexCounterArray<2>;
+    static_assert(MaxSimplexEdges == 3, "Invalid assumption about size of MaxSimplexEdges");
 
-namespace detail {
+    /// @brief Gets the number of valid indices in the given collection of index pairs.
+    /// @note Any element with a value of <code>InvalidIndexPair</code> is interpreted
+    ///   as being invalid in this context.
+    /// @return Value between 0 and 3 inclusive.
+    constexpr std::size_t GetNumValidIndices(IndexPair3 pairs) noexcept
+    {
+        return std::size_t{3}
+               - ((std::get<0>(pairs) == InvalidIndexPair) ? 1u : 0u)
+               - ((std::get<1>(pairs) == InvalidIndexPair) ? 1u : 0u)
+               - ((std::get<2>(pairs) == InvalidIndexPair) ? 1u : 0u);
+    }
 
-/// @brief Length and vertex counter array of indices.
-template <std::size_t N>
-struct LengthIndices
-{
-    Length distance; ///< Distance.
-    VertexCounterArray<N> indices; ///< Array of vertex indices.
-};
+    /// @brief Checks whether the given collection of index pairs is empty.
+    constexpr bool empty(IndexPair3 pairs) noexcept
+    {
+        return GetNumValidIndices(pairs) == 0;
+    }
 
-/// @brief Separation information.
-template <std::size_t N>
-struct SeparationInfo
-{
-    Length distance; ///< Distance.
-    VertexCounter firstShape; ///< First shape vertex index.
-    VertexCounterArray<N> secondShape; ///< Second shape vertex indices.
-};
+    /// @brief Gets the dynamic size of the given collection of index pairs.
+    /// @note This just calls <code>GetNumValidIndices</code>.
+    /// @see GetNumValidIndices
+    constexpr auto size(IndexPair3 pairs) -> decltype(GetNumValidIndices(pairs))
+    {
+        return GetNumValidIndices(pairs);
+    }
 
-} // namespace detail
+    /// @brief Gets the maximum size of the given container of index pairs.
+    /// @return Always returns 3.
+    constexpr auto max_size(IndexPair3 pairs) -> decltype(pairs.max_size())
+    {
+        return pairs.max_size();
+    }
 
-/// @brief Gets first shape vertex index.
-template <std::size_t N>
-VertexCounter GetFirstShapeVertexIdx(const detail::SeparationInfo<N>& info) noexcept
-{
-    return info.firstShape;
-}
+    /// @brief Vertex counter array template alias.
+    template<std::size_t N>
+    using VertexCounterArray = std::array<VertexCounter, N>;
 
-/// @brief Gets second shape vertex indices.
-template <VertexCounter M, std::size_t N>
-VertexCounter GetSecondShapeVertexIdx(const detail::SeparationInfo<N>& info) noexcept
-{
-    return std::get<M>(info.secondShape);
-}
+    /// @brief 2-element vertex counter array.
+    using VertexCounter2 = VertexCounterArray<2>;
 
-/// @brief A length associated with two vertex counter indices.
-/// @details This structure is used to keep track of the best separating axis.
-/// @note Any element can be invalid as indicated by the use of the invalid sentinel
-///   for the type.
-struct LengthIndexPair
-{
-    Length distance = GetInvalid<Length>(); ///< Separation.
-    IndexPair indices = InvalidIndexPair; ///< Index pair.
-};
+    namespace detail
+    {
 
-namespace d2 {
+        /// @brief Length and vertex counter array of indices.
+        template<std::size_t N>
+        struct LengthIndices
+        {
+            Length distance;              ///< Distance.
+            VertexCounterArray<N> indices;///< Array of vertex indices.
+        };
 
-/// @brief Length and vertex counter array of indices for 2-D space.
-using LengthIndices = detail::LengthIndices<2>;
+        /// @brief Separation information.
+        template<std::size_t N>
+        struct SeparationInfo
+        {
+            Length distance;                  ///< Distance.
+            VertexCounter firstShape;         ///< First shape vertex index.
+            VertexCounterArray<N> secondShape;///< Second shape vertex indices.
+        };
 
-/// @brief Separation information alias for 2-D space.
-using SeparationInfo = detail::SeparationInfo<2>;
+    }// namespace detail
 
-} // namespace 2d
-} // namespace playrho
+    /// @brief Gets first shape vertex index.
+    template<std::size_t N>
+    VertexCounter GetFirstShapeVertexIdx(const detail::SeparationInfo<N>& info) noexcept
+    {
+        return info.firstShape;
+    }
 
-#endif // PLAYRHO_COLLISION_INDEXPAIR_HPP
+    /// @brief Gets second shape vertex indices.
+    template<VertexCounter M, std::size_t N>
+    VertexCounter GetSecondShapeVertexIdx(const detail::SeparationInfo<N>& info) noexcept
+    {
+        return std::get<M>(info.secondShape);
+    }
+
+    /// @brief A length associated with two vertex counter indices.
+    /// @details This structure is used to keep track of the best separating axis.
+    /// @note Any element can be invalid as indicated by the use of the invalid sentinel
+    ///   for the type.
+    struct LengthIndexPair
+    {
+        Length distance = GetInvalid<Length>();///< Separation.
+        IndexPair indices = InvalidIndexPair;  ///< Index pair.
+    };
+
+    namespace d2
+    {
+
+        /// @brief Length and vertex counter array of indices for 2-D space.
+        using LengthIndices = detail::LengthIndices<2>;
+
+        /// @brief Separation information alias for 2-D space.
+        using SeparationInfo = detail::SeparationInfo<2>;
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_INDEXPAIR_HPP

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -21,439 +21,438 @@
 
 #include <PlayRho/Collision/Manifold.hpp>
 
-#include <PlayRho/Collision/Simplex.hpp>
+#include <PlayRho/Collision/Collision.hpp>
 #include <PlayRho/Collision/Distance.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
-#include <PlayRho/Collision/Collision.hpp>
 #include <PlayRho/Collision/ShapeSeparation.hpp>
+#include <PlayRho/Collision/Simplex.hpp>
 
 #include <PlayRho/Defines.hpp>
 
 #include <PlayRho/Dynamics/StepConf.hpp>
 
+#include <algorithm>
 #include <array>
 #include <bitset>
-#include <algorithm>
 
 #define PLAYRHO_MAGIC(x) (x)
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-namespace {
+        namespace
+        {
 
 #ifdef DEFINE_GET_MANIFOLD
-inline index_type GetEdgeIndex(VertexCounter i1, VertexCounter i2, VertexCounter count)
-{
-    if (GetModuloNext(i1, count) == i2)
-    {
-        return i1;
-    }
-    if (GetModuloNext(i2, count) == i1)
-    {
-        return i2;
-    }
-    return InvalidVertex;
-}
+            inline index_type GetEdgeIndex(VertexCounter i1, VertexCounter i2, VertexCounter count)
+            {
+                if (GetModuloNext(i1, count) == i2)
+                {
+                    return i1;
+                }
+                if (GetModuloNext(i2, count) == i1)
+                {
+                    return i2;
+                }
+                return InvalidVertex;
+            }
 #endif
 
-using VertexCounterPair = std::pair<VertexCounter, VertexCounter>;
-    
-VertexCounterPair
-GetMostAntiParallelEdge(UnitVec shape0_rel_n0, const Transformation& xf0,
-                        const DistanceProxy& shape1, const Transformation& xf1,
-                        const VertexCounter2 indices1) noexcept
-{
-    const auto firstIdx = std::get<0>(indices1);
-    const auto secondIdx = std::get<1>(indices1);
-    if (secondIdx == InvalidVertex)
-    {
-        // Gets most anti-parallel edge of either prevIdx or firstIdx.
-        const auto normal = InverseRotate(Rotate(shape0_rel_n0, xf0.q), xf1.q);
-        const auto count = shape1.GetVertexCount();
-        const auto prevIdx = GetModuloPrev(firstIdx, count);
-        const auto prevDot = Dot(normal, shape1.GetNormal(prevIdx));
-        const auto currDot = Dot(normal, shape1.GetNormal(firstIdx));
-        return (prevDot < currDot)?
-            std::make_pair(prevIdx, firstIdx):
-            std::make_pair(firstIdx, GetModuloNext(firstIdx, count));
-    }
-    return ((secondIdx > firstIdx) && ((firstIdx + 1) == secondIdx))?
-        std::make_pair(firstIdx, secondIdx): std::make_pair(secondIdx, firstIdx);
-}
+            using VertexCounterPair = std::pair<VertexCounter, VertexCounter>;
 
-ClipList GetClipPoints(Length2 shape0_abs_v0, Length2 shape0_abs_v1, VertexCounterPair shape0_e,
-                       UnitVec shape0_abs_e0_dir,
-                       Length2 shape1_abs_v0, Length2 shape1_abs_v1, VertexCounterPair shape1_e)
-{
-    // Gets the two vertices in world coordinates and their face-vertex contact features
-    // of the incident edge of shape1
-    const auto ie = ClipList{
-        ClipVertex{shape1_abs_v0, GetFaceVertexContactFeature(shape0_e.first, shape1_e.first)},
-        ClipVertex{shape1_abs_v1, GetFaceVertexContactFeature(shape0_e.first, shape1_e.second)}
-    };
-    const auto shape0_dp_v0_e0 = -Dot(shape0_abs_e0_dir, shape0_abs_v0);
-    const auto shape0_dp_v1_e0 = +Dot(shape0_abs_e0_dir, shape0_abs_v1);
-
-    const auto points = ClipSegmentToLine(ie, -shape0_abs_e0_dir, shape0_dp_v0_e0, shape0_e.first);
-    return ClipSegmentToLine(points, +shape0_abs_e0_dir, shape0_dp_v1_e0, shape0_e.second);
-}
-
-} // anonymous namespace
-
-Manifold::Conf GetManifoldConf(const StepConf& conf) noexcept
-{
-    auto manifoldConf = Manifold::Conf{};
-    manifoldConf.linearSlop = conf.linearSlop;
-    manifoldConf.tolerance = conf.tolerance;
-    manifoldConf.targetDepth = conf.targetDepth;
-    manifoldConf.maxCirclesRatio = conf.maxCirclesRatio;
-    return manifoldConf;
-}
-
-Manifold GetManifold(bool flipped,
-                     const DistanceProxy& shape0, const Transformation& xf0,
-                     const VertexCounter idx0,
-                     const DistanceProxy& shape1, const Transformation& xf1,
-                     const VertexCounter2 indices1,
-                     const Manifold::Conf conf)
-{
-    assert(shape0.GetVertexCount() > 1 && shape1.GetVertexCount() > 1);
-    
-    const auto r0 = shape0.GetVertexRadius();
-    const auto r1 = shape1.GetVertexRadius();
-    const auto totalRadius = Length{r0 + r1};
-    
-    const auto idx0Next = GetModuloNext(idx0, shape0.GetVertexCount());
-    
-    const auto shape0_rel_v0 = shape0.GetVertex(idx0);
-    const auto shape0_rel_v1 = shape0.GetVertex(idx0Next);
-    const auto shape0_abs_v0 = Transform(shape0_rel_v0, xf0);
-    const auto shape0_abs_v1 = Transform(shape0_rel_v1, xf0);
-    
-    auto shape0_len_edge0 = GetMagnitudeSquared(shape0_rel_v1 - shape0_rel_v0);
-
-    // Clip incident edge against extruded edge1 side edges.
-    // Side offsets, extended by polytope skin thickness.
-    
-    const auto shape0_rel_n0 = shape0.GetNormal(idx0);
-    const auto shape0_rel_e0_dir = GetRevPerpendicular(shape0_rel_n0);
-    const auto shape1_e = GetMostAntiParallelEdge(shape0_rel_n0, xf0, shape1, xf1, indices1);
-    const auto shape1_rel_v0 = shape1.GetVertex(shape1_e.first);
-    const auto shape1_abs_v0 = Transform(shape1_rel_v0, xf1);
-    const auto shape1_rel_v1 = shape1.GetVertex(shape1_e.second);
-    const auto shape1_abs_v1 = Transform(shape1_rel_v1, xf1);
-    {
-        const auto shape0_abs_e0_dir = Rotate(shape0_rel_e0_dir, xf0.q);
-        const auto clipPoints = GetClipPoints(shape0_abs_v0, shape0_abs_v1, std::make_pair(idx0, idx0Next),
-                                              shape0_abs_e0_dir,
-                                              shape1_abs_v0, shape1_abs_v1, shape1_e);
-        if (size(clipPoints) == 2)
-        {
-            const auto abs_normal = GetFwdPerpendicular(shape0_abs_e0_dir);
-            const auto rel_midpoint = (shape0_rel_v0 + shape0_rel_v1) / Real{2};
-            const auto abs_offset = Dot(abs_normal, shape0_abs_v0); ///< Face offset.
-            
-            auto manifold = Manifold{};
-            if (!flipped)
+            VertexCounterPair
+            GetMostAntiParallelEdge(UnitVec shape0_rel_n0, const Transformation& xf0,
+                                    const DistanceProxy& shape1, const Transformation& xf1,
+                                    const VertexCounter2 indices1) noexcept
             {
-                manifold = Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), rel_midpoint);
-                for (auto&& cp: clipPoints)
+                const auto firstIdx = std::get<0>(indices1);
+                const auto secondIdx = std::get<1>(indices1);
+                if (secondIdx == InvalidVertex)
                 {
-                    if ((Dot(abs_normal, cp.v) - abs_offset) <= totalRadius)
+                    // Gets most anti-parallel edge of either prevIdx or firstIdx.
+                    const auto normal = InverseRotate(Rotate(shape0_rel_n0, xf0.q), xf1.q);
+                    const auto count = shape1.GetVertexCount();
+                    const auto prevIdx = GetModuloPrev(firstIdx, count);
+                    const auto prevDot = Dot(normal, shape1.GetNormal(prevIdx));
+                    const auto currDot = Dot(normal, shape1.GetNormal(firstIdx));
+                    return (prevDot < currDot) ? std::make_pair(prevIdx, firstIdx) : std::make_pair(firstIdx, GetModuloNext(firstIdx, count));
+                }
+                return ((secondIdx > firstIdx) && ((firstIdx + 1) == secondIdx)) ? std::make_pair(firstIdx, secondIdx) : std::make_pair(secondIdx, firstIdx);
+            }
+
+            ClipList GetClipPoints(Length2 shape0_abs_v0, Length2 shape0_abs_v1, VertexCounterPair shape0_e,
+                                   UnitVec shape0_abs_e0_dir,
+                                   Length2 shape1_abs_v0, Length2 shape1_abs_v1, VertexCounterPair shape1_e)
+            {
+                // Gets the two vertices in world coordinates and their face-vertex contact features
+                // of the incident edge of shape1
+                const auto ie = ClipList{
+                    ClipVertex{shape1_abs_v0, GetFaceVertexContactFeature(shape0_e.first, shape1_e.first)},
+                    ClipVertex{shape1_abs_v1, GetFaceVertexContactFeature(shape0_e.first, shape1_e.second)}};
+                const auto shape0_dp_v0_e0 = -Dot(shape0_abs_e0_dir, shape0_abs_v0);
+                const auto shape0_dp_v1_e0 = +Dot(shape0_abs_e0_dir, shape0_abs_v1);
+
+                const auto points = ClipSegmentToLine(ie, -shape0_abs_e0_dir, shape0_dp_v0_e0, shape0_e.first);
+                return ClipSegmentToLine(points, +shape0_abs_e0_dir, shape0_dp_v1_e0, shape0_e.second);
+            }
+
+        }// anonymous namespace
+
+        Manifold::Conf GetManifoldConf(const StepConf& conf) noexcept
+        {
+            auto manifoldConf = Manifold::Conf{};
+            manifoldConf.linearSlop = conf.linearSlop;
+            manifoldConf.tolerance = conf.tolerance;
+            manifoldConf.targetDepth = conf.targetDepth;
+            manifoldConf.maxCirclesRatio = conf.maxCirclesRatio;
+            return manifoldConf;
+        }
+
+        Manifold GetManifold(bool flipped,
+                             const DistanceProxy& shape0, const Transformation& xf0,
+                             const VertexCounter idx0,
+                             const DistanceProxy& shape1, const Transformation& xf1,
+                             const VertexCounter2 indices1,
+                             const Manifold::Conf conf)
+        {
+            assert(shape0.GetVertexCount() > 1 && shape1.GetVertexCount() > 1);
+
+            const auto r0 = shape0.GetVertexRadius();
+            const auto r1 = shape1.GetVertexRadius();
+            const auto totalRadius = Length{r0 + r1};
+
+            const auto idx0Next = GetModuloNext(idx0, shape0.GetVertexCount());
+
+            const auto shape0_rel_v0 = shape0.GetVertex(idx0);
+            const auto shape0_rel_v1 = shape0.GetVertex(idx0Next);
+            const auto shape0_abs_v0 = Transform(shape0_rel_v0, xf0);
+            const auto shape0_abs_v1 = Transform(shape0_rel_v1, xf0);
+
+            auto shape0_len_edge0 = GetMagnitudeSquared(shape0_rel_v1 - shape0_rel_v0);
+
+            // Clip incident edge against extruded edge1 side edges.
+            // Side offsets, extended by polytope skin thickness.
+
+            const auto shape0_rel_n0 = shape0.GetNormal(idx0);
+            const auto shape0_rel_e0_dir = GetRevPerpendicular(shape0_rel_n0);
+            const auto shape1_e = GetMostAntiParallelEdge(shape0_rel_n0, xf0, shape1, xf1, indices1);
+            const auto shape1_rel_v0 = shape1.GetVertex(shape1_e.first);
+            const auto shape1_abs_v0 = Transform(shape1_rel_v0, xf1);
+            const auto shape1_rel_v1 = shape1.GetVertex(shape1_e.second);
+            const auto shape1_abs_v1 = Transform(shape1_rel_v1, xf1);
+            {
+                const auto shape0_abs_e0_dir = Rotate(shape0_rel_e0_dir, xf0.q);
+                const auto clipPoints = GetClipPoints(shape0_abs_v0, shape0_abs_v1, std::make_pair(idx0, idx0Next),
+                                                      shape0_abs_e0_dir,
+                                                      shape1_abs_v0, shape1_abs_v1, shape1_e);
+                if (size(clipPoints) == 2)
+                {
+                    const auto abs_normal = GetFwdPerpendicular(shape0_abs_e0_dir);
+                    const auto rel_midpoint = (shape0_rel_v0 + shape0_rel_v1) / Real{2};
+                    const auto abs_offset = Dot(abs_normal, shape0_abs_v0);///< Face offset.
+
+                    auto manifold = Manifold{};
+                    if (!flipped)
                     {
-                        manifold.AddPoint(Manifold::Point{InverseTransform(cp.v, xf1), cp.cf});
+                        manifold = Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), rel_midpoint);
+                        for (auto&& cp : clipPoints)
+                        {
+                            if ((Dot(abs_normal, cp.v) - abs_offset) <= totalRadius)
+                            {
+                                manifold.AddPoint(Manifold::Point{InverseTransform(cp.v, xf1), cp.cf});
+                            }
+                        }
+                    }
+                    else
+                    {
+                        manifold = Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), rel_midpoint);
+                        for (auto&& cp : clipPoints)
+                        {
+                            if ((Dot(abs_normal, cp.v) - abs_offset) <= totalRadius)
+                            {
+                                manifold.AddPoint(Manifold::Point{InverseTransform(cp.v, xf1), Flip(cp.cf)});
+                            }
+                        }
+                    }
+                    if (manifold.GetPointCount() > 0)
+                    {
+                        return manifold;
                     }
                 }
             }
-            else
+
+            // If the shapes are colliding, then they're colliding with each others corners.
+            // Using a circles manifold, means these corners will repell each other with a normal
+            // that's in the direction between the two vertices.
+            // That's problematic though for things like polygons sliding over edges where a face
+            // manifold that favors the primary edge can work better.
+            // Use a threshold against the ratio of the square of the vertex radius to the square
+            // of the length of the primary edge to determine whether to return a circles manifold
+            // or a face manifold.
+            const auto totalRadiusSquared = Square(totalRadius);
+            const auto mustUseFaceManifold = shape0_len_edge0 > Square(conf.maxCirclesRatio * r0);
+            if (GetMagnitudeSquared(shape0_abs_v0 - shape1_abs_v0) <= totalRadiusSquared)
             {
-                manifold = Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), rel_midpoint);
-                for (auto&& cp: clipPoints)
+                // shape 1 vertex 1 is colliding with shape 2 vertex 1
+                // shape 1 vertex 1 is the vertex at index idx0, or one before idx0Next.
+                // shape 2 vertex 1 is the vertex at index shape1_e.first, or one before shape1_e.second.
+                if (!flipped)// face A
                 {
-                    if ((Dot(abs_normal, cp.v) - abs_offset) <= totalRadius)
+                    // shape 1 is shape A.
+                    if (mustUseFaceManifold)
                     {
-                        manifold.AddPoint(Manifold::Point{InverseTransform(cp.v, xf1), Flip(cp.cf)});
+                        return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
+                                                     shape0_rel_v0, ContactFeature::e_vertex,
+                                                     shape1_e.first, shape1_rel_v0);
+                    }
+                    return Manifold::GetForCircles(shape0_rel_v0, idx0, shape1_rel_v0, shape1_e.first);
+                }
+                // shape 2 is shape A.
+                if (mustUseFaceManifold)
+                {
+                    return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
+                                                 shape0_rel_v0, ContactFeature::e_vertex,
+                                                 shape1_e.first, shape1_rel_v0);
+                }
+                return Manifold::GetForCircles(shape1_rel_v0, shape1_e.first, shape0_rel_v0, idx0);
+            }
+            else if (GetMagnitudeSquared(shape0_abs_v0 - shape1_abs_v1) <= totalRadiusSquared)
+            {
+                // shape 1 vertex 1 is colliding with shape 2 vertex 2
+                if (!flipped)
+                {
+                    if (mustUseFaceManifold)
+                    {
+                        return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
+                                                     shape0_rel_v0, ContactFeature::e_vertex,
+                                                     shape1_e.second, shape1_rel_v1);
+                    }
+                    return Manifold::GetForCircles(shape0_rel_v0, idx0, shape1_rel_v1, shape1_e.second);
+                }
+                if (mustUseFaceManifold)
+                {
+                    return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
+                                                 shape0_rel_v0, ContactFeature::e_vertex,
+                                                 shape1_e.second, shape1_rel_v1);
+                }
+                return Manifold::GetForCircles(shape1_rel_v1, shape1_e.second, shape0_rel_v0, idx0);
+            }
+            else if (GetMagnitudeSquared(shape0_abs_v1 - shape1_abs_v1) <= totalRadiusSquared)
+            {
+                // shape 1 vertex 2 is colliding with shape 2 vertex 2
+                if (!flipped)
+                {
+                    if (mustUseFaceManifold)
+                    {
+                        return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
+                                                     shape0_rel_v1, ContactFeature::e_vertex,
+                                                     shape1_e.second, shape1_rel_v1);
+                    }
+                    return Manifold::GetForCircles(shape0_rel_v1, idx0Next, shape1_rel_v1, shape1_e.second);
+                }
+                if (mustUseFaceManifold)
+                {
+                    return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
+                                                 shape0_rel_v1, ContactFeature::e_vertex,
+                                                 shape1_e.second, shape1_rel_v1);
+                }
+                return Manifold::GetForCircles(shape1_rel_v1, shape1_e.second, shape0_rel_v1, idx0Next);
+            }
+            else if (GetMagnitudeSquared(shape0_abs_v1 - shape1_abs_v0) <= totalRadiusSquared)
+            {
+                // shape 1 vertex 2 is colliding with shape 2 vertex 1
+                if (!flipped)
+                {
+                    if (mustUseFaceManifold)
+                    {
+                        return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
+                                                     shape0_rel_v1, ContactFeature::e_vertex,
+                                                     shape1_e.first, shape1_rel_v0);
+                    }
+                    return Manifold::GetForCircles(shape0_rel_v1, idx0Next, shape1_rel_v0, shape1_e.first);
+                }
+                if (mustUseFaceManifold)
+                {
+                    return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
+                                                 shape0_rel_v1, ContactFeature::e_vertex,
+                                                 shape1_e.first, shape1_rel_v0);
+                }
+                return Manifold::GetForCircles(shape1_rel_v0, shape1_e.first, shape0_rel_v1, idx0Next);
+            }
+            return Manifold{};
+        }
+
+        Manifold GetManifold(bool flipped, Length totalRadius,
+                             const DistanceProxy& shape, const Transformation& sxf,
+                             Length2 point, const Transformation& xfm)
+        {
+            // Computes the center of the circle in the frame of the polygon.
+            const auto cLocal = InverseTransform(Transform(point, xfm), sxf);///< Center of circle in frame of polygon.
+
+            const auto vertexCount = shape.GetVertexCount();
+
+            // Find edge that circle is closest to.
+            auto indexOfMax = decltype(vertexCount){0};
+            auto maxSeparation = -MaxFloat * Meter;
+            {
+                for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
+                {
+                    // Get circle's distance from vertex[i] in direction of normal[i].
+                    const auto s = Dot(shape.GetNormal(i), cLocal - shape.GetVertex(i));
+                    if (s > totalRadius)
+                    {
+                        // Early out - no contact.
+                        return Manifold{};
+                    }
+                    if (maxSeparation < s)
+                    {
+                        maxSeparation = s;
+                        indexOfMax = i;
                     }
                 }
             }
-            if (manifold.GetPointCount() > 0)
-            {
-                return manifold;
-            }
-        }
-    }
-    
-    // If the shapes are colliding, then they're colliding with each others corners.
-    // Using a circles manifold, means these corners will repell each other with a normal
-    // that's in the direction between the two vertices.
-    // That's problematic though for things like polygons sliding over edges where a face
-    // manifold that favors the primary edge can work better.
-    // Use a threshold against the ratio of the square of the vertex radius to the square
-    // of the length of the primary edge to determine whether to return a circles manifold
-    // or a face manifold.
-    const auto totalRadiusSquared = Square(totalRadius);
-    const auto mustUseFaceManifold = shape0_len_edge0 > Square(conf.maxCirclesRatio * r0);
-    if (GetMagnitudeSquared(shape0_abs_v0 - shape1_abs_v0) <= totalRadiusSquared)
-    {
-        // shape 1 vertex 1 is colliding with shape 2 vertex 1
-        // shape 1 vertex 1 is the vertex at index idx0, or one before idx0Next.
-        // shape 2 vertex 1 is the vertex at index shape1_e.first, or one before shape1_e.second.
-        if (!flipped) // face A
-        {
-            // shape 1 is shape A.
-            if (mustUseFaceManifold)
-            {
-                return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
-                                             shape0_rel_v0, ContactFeature::e_vertex,
-                                             shape1_e.first, shape1_rel_v0);
-            }
-            return Manifold::GetForCircles(shape0_rel_v0, idx0, shape1_rel_v0, shape1_e.first);
-        }
-        // shape 2 is shape A.
-        if (mustUseFaceManifold)
-        {
-            return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
-                                         shape0_rel_v0, ContactFeature::e_vertex,
-                                         shape1_e.first, shape1_rel_v0);
-        }
-        return Manifold::GetForCircles(shape1_rel_v0, shape1_e.first, shape0_rel_v0, idx0);
-    }
-    else if (GetMagnitudeSquared(shape0_abs_v0 - shape1_abs_v1) <= totalRadiusSquared)
-    {
-        // shape 1 vertex 1 is colliding with shape 2 vertex 2
-        if (!flipped)
-        {
-            if (mustUseFaceManifold)
-            {
-                return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
-                                             shape0_rel_v0, ContactFeature::e_vertex,
-                                             shape1_e.second, shape1_rel_v1);
-            }
-            return Manifold::GetForCircles(shape0_rel_v0, idx0, shape1_rel_v1, shape1_e.second);
-        }
-        if (mustUseFaceManifold)
-        {
-            return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0,
-                                         shape0_rel_v0, ContactFeature::e_vertex,
-                                         shape1_e.second, shape1_rel_v1);
-        }
-        return Manifold::GetForCircles(shape1_rel_v1, shape1_e.second, shape0_rel_v0, idx0);
-    }
-    else if (GetMagnitudeSquared(shape0_abs_v1 - shape1_abs_v1) <= totalRadiusSquared)
-    {
-        // shape 1 vertex 2 is colliding with shape 2 vertex 2
-        if (!flipped)
-        {
-            if (mustUseFaceManifold)
-            {
-                return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
-                                             shape0_rel_v1, ContactFeature::e_vertex,
-                                             shape1_e.second, shape1_rel_v1);
-            }
-            return Manifold::GetForCircles(shape0_rel_v1, idx0Next, shape1_rel_v1, shape1_e.second);
-        }
-        if (mustUseFaceManifold)
-        {
-            return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
-                                         shape0_rel_v1, ContactFeature::e_vertex,
-                                         shape1_e.second, shape1_rel_v1);
-        }
-        return Manifold::GetForCircles(shape1_rel_v1, shape1_e.second, shape0_rel_v1, idx0Next);
-    }
-    else if (GetMagnitudeSquared(shape0_abs_v1 - shape1_abs_v0) <= totalRadiusSquared)
-    {
-        // shape 1 vertex 2 is colliding with shape 2 vertex 1
-        if (!flipped)
-        {
-            if (mustUseFaceManifold)
-            {
-                return Manifold::GetForFaceA(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
-                                             shape0_rel_v1, ContactFeature::e_vertex,
-                                             shape1_e.first, shape1_rel_v0);
-            }
-            return Manifold::GetForCircles(shape0_rel_v1, idx0Next, shape1_rel_v0, shape1_e.first);
-        }
-        if (mustUseFaceManifold)
-        {
-            return Manifold::GetForFaceB(GetFwdPerpendicular(shape0_rel_e0_dir), idx0Next,
-                                         shape0_rel_v1, ContactFeature::e_vertex,
-                                         shape1_e.first, shape1_rel_v0);
-        }
-        return Manifold::GetForCircles(shape1_rel_v0, shape1_e.first, shape0_rel_v1, idx0Next);
-    }
-    return Manifold{};
-}
+            const auto indexOfMax2 = GetModuloNext(indexOfMax, vertexCount);
+            assert(maxSeparation <= totalRadius);
 
-Manifold GetManifold(bool flipped, Length totalRadius,
-                     const DistanceProxy& shape, const Transformation& sxf,
-                     Length2 point, const Transformation& xfm)
-{
-    // Computes the center of the circle in the frame of the polygon.
-    const auto cLocal = InverseTransform(Transform(point, xfm), sxf); ///< Center of circle in frame of polygon.
-    
-    const auto vertexCount = shape.GetVertexCount();
-    
-    // Find edge that circle is closest to.
-    auto indexOfMax = decltype(vertexCount){0};
-    auto maxSeparation = -MaxFloat * Meter;
-    {
-        for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
-        {
-            // Get circle's distance from vertex[i] in direction of normal[i].
-            const auto s = Dot(shape.GetNormal(i), cLocal - shape.GetVertex(i));
-            if (s > totalRadius)
+            // Vertices that subtend the incident face.
+            const auto v1 = shape.GetVertex(indexOfMax);
+            const auto v2 = shape.GetVertex(indexOfMax2);
+
+            if (maxSeparation < 0_m)
             {
-                // Early out - no contact.
+                const auto faceCenter = (v1 + v2) / Real{2};
+                // Circle's center is inside the polygon and closest to edge[indexOfMax].
+                if (!flipped)
+                {
+                    return Manifold::GetForFaceA(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
+                                                 ContactFeature::e_vertex, 0, point);
+                }
+                return Manifold::GetForFaceB(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
+                                             ContactFeature::e_vertex, 0, point);
+            }
+
+            // Circle's center is outside polygon and closest to edge[indexOfMax].
+            // Compute barycentric coordinates.
+
+            const auto cLocalV1 = cLocal - v1;
+            if (Dot(cLocalV1, v2 - v1) <= 0_m2)
+            {
+                // Circle's center right of v1 (in direction of v1 to v2).
+                if (GetMagnitudeSquared(cLocalV1) > Square(totalRadius))
+                {
+                    return Manifold{};
+                }
+                if (!flipped)
+                {
+                    return Manifold::GetForCircles(v1, indexOfMax, point, 0);
+                }
+                return Manifold::GetForCircles(point, 0, v1, indexOfMax);
+            }
+
+            const auto ClocalV2 = cLocal - v2;
+            if (Dot(ClocalV2, v1 - v2) <= 0_m2)
+            {
+                // Circle's center left of v2 (in direction of v2 to v1).
+                if (GetMagnitudeSquared(ClocalV2) > Square(totalRadius))
+                {
+                    return Manifold{};
+                }
+                if (!flipped)
+                {
+                    return Manifold::GetForCircles(v2, indexOfMax2, point, 0);
+                }
+                return Manifold::GetForCircles(point, 0, v2, indexOfMax2);
+            }
+
+            // Circle's center is between v1 and v2.
+            const auto faceCenter = (v1 + v2) / Real{2};
+            if (Dot(cLocal - faceCenter, shape.GetNormal(indexOfMax)) > totalRadius)
+            {
                 return Manifold{};
             }
-            if (maxSeparation < s)
+            if (!flipped)
             {
-                maxSeparation = s;
-                indexOfMax = i;
+                return Manifold::GetForFaceA(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
+                                             ContactFeature::e_vertex, 0, point);
             }
-        }
-    }
-    const auto indexOfMax2 = GetModuloNext(indexOfMax, vertexCount);
-    assert(maxSeparation <= totalRadius);
-    
-    // Vertices that subtend the incident face.
-    const auto v1 = shape.GetVertex(indexOfMax);
-    const auto v2 = shape.GetVertex(indexOfMax2);
-    
-    if (maxSeparation < 0_m)
-    {
-        const auto faceCenter = (v1 + v2) / Real{2};
-        // Circle's center is inside the polygon and closest to edge[indexOfMax].
-        if (!flipped)
-        {
-            return Manifold::GetForFaceA(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
+            return Manifold::GetForFaceB(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
                                          ContactFeature::e_vertex, 0, point);
         }
-        return Manifold::GetForFaceB(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
-                                     ContactFeature::e_vertex, 0, point);
-    }
-    
-    // Circle's center is outside polygon and closest to edge[indexOfMax].
-    // Compute barycentric coordinates.
-    
-    const auto cLocalV1 = cLocal - v1;
-    if (Dot(cLocalV1, v2 - v1) <= 0_m2)
-    {
-        // Circle's center right of v1 (in direction of v1 to v2).
-        if (GetMagnitudeSquared(cLocalV1) > Square(totalRadius))
-        {
-            return Manifold{};
-        }
-        if (!flipped)
-        {
-            return Manifold::GetForCircles(v1, indexOfMax, point, 0);
-        }
-        return Manifold::GetForCircles(point, 0, v1, indexOfMax);
-    }
-    
-    const auto ClocalV2 = cLocal - v2;
-    if (Dot(ClocalV2, v1 - v2) <= 0_m2)
-    {
-        // Circle's center left of v2 (in direction of v2 to v1).
-        if (GetMagnitudeSquared(ClocalV2) > Square(totalRadius))
-        {
-            return Manifold{};
-        }
-        if (!flipped)
-        {
-            return Manifold::GetForCircles(v2, indexOfMax2, point, 0);
-        }
-        return Manifold::GetForCircles(point, 0, v2, indexOfMax2);
-    }
-    
-    // Circle's center is between v1 and v2.
-    const auto faceCenter = (v1 + v2) / Real{2};
-    if (Dot(cLocal - faceCenter, shape.GetNormal(indexOfMax)) > totalRadius)
-    {
-        return Manifold{};
-    }
-    if (!flipped)
-    {
-        return Manifold::GetForFaceA(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
-                                     ContactFeature::e_vertex, 0, point);
-    }
-    return Manifold::GetForFaceB(shape.GetNormal(indexOfMax), indexOfMax, faceCenter,
-                                 ContactFeature::e_vertex, 0, point);
-}
 
-Manifold GetManifold(Length2 locationA, const Transformation& xfA,
-                     Length2 locationB, const Transformation& xfB,
-                     Length totalRadius) noexcept
-{
-    const auto pA = Transform(locationA, xfA);
-    const auto pB = Transform(locationB, xfB);
-    // Intermediary results here for debugging...
-    const auto lenSq = GetMagnitudeSquared(pB - pA);
-    const auto totSq = Square(totalRadius);
-    return (lenSq > totSq)? Manifold{}: Manifold::GetForCircles(locationA, 0, locationB, 0);
-}
+        Manifold GetManifold(Length2 locationA, const Transformation& xfA,
+                             Length2 locationB, const Transformation& xfB,
+                             Length totalRadius) noexcept
+        {
+            const auto pA = Transform(locationA, xfA);
+            const auto pB = Transform(locationB, xfB);
+            // Intermediary results here for debugging...
+            const auto lenSq = GetMagnitudeSquared(pB - pA);
+            const auto totSq = Square(totalRadius);
+            return (lenSq > totSq) ? Manifold{} : Manifold::GetForCircles(locationA, 0, locationB, 0);
+        }
 
-/*
+        /*
  * Definition of public CollideShapes functions.
  * All CollideShapes functions return a Manifold object.
  */
 
-Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA,
-                       const DistanceProxy& shapeB, const Transformation& xfB,
-                       Manifold::Conf conf)
-{
-    // Assumes called after detecting AABB overlap.
-    // Find edge normal of max separation on A - return if separating axis is found
-    // Find edge normal of max separation on B - return if separation axis is found
-    // Choose reference edge as min(minA, minB)
-    // Find incident edge
-    // Clip
-    
-    const auto totalRadius = shapeA.GetVertexRadius() + shapeB.GetVertexRadius();
-    const auto countA = shapeA.GetVertexCount();
-    const auto countB = shapeB.GetVertexCount();
-    
-    enum: unsigned { ZeroOneVert = 0x0u, OneVertA = 0x1u, OneVertB = 0x2u };
-    switch (((countA == 1)? OneVertA: ZeroOneVert) | ((countB == 1)? OneVertB: ZeroOneVert))
-    {
-        case OneVertA|OneVertB:
-            return GetManifold(shapeA.GetVertex(0), xfA, shapeB.GetVertex(0), xfB, totalRadius);
-        case OneVertA:
-            return GetManifold(true, totalRadius, shapeB, xfB, shapeA.GetVertex(0), xfA);
-        case OneVertB:
-            return GetManifold(false, totalRadius, shapeA, xfA, shapeB.GetVertex(0), xfB);
-    }
-    
-    const auto do4x4 = (countA == 4) && (countB == 4);
-    
-    const auto edgeSepA = do4x4?
-        GetMaxSeparation4x4(shapeA, xfA, shapeB, xfB):
-        GetMaxSeparation(shapeA, xfA, shapeB, xfB);
-    if (edgeSepA.distance > totalRadius)
-    {
-        return Manifold{};
-    }
-    
-    const auto edgeSepB = do4x4?
-        GetMaxSeparation4x4(shapeB, xfB, shapeA, xfA):
-        GetMaxSeparation(shapeB, xfB, shapeA, xfA);
-    if (edgeSepB.distance > totalRadius)
-    {
-        return Manifold{};
-    }
-    
-    const auto k_tol = PLAYRHO_MAGIC(conf.linearSlop / 10);
-    return (edgeSepB.distance > (edgeSepA.distance + k_tol))?
-        GetManifold(true,
-                        shapeB, xfB, edgeSepB.firstShape,
-                        shapeA, xfA, edgeSepB.secondShape,
-                        conf):
-        GetManifold(false,
-                        shapeA, xfA, edgeSepA.firstShape,
-                        shapeB, xfB, edgeSepA.secondShape,
-                        conf);
-}
+        Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA,
+                               const DistanceProxy& shapeB, const Transformation& xfB,
+                               Manifold::Conf conf)
+        {
+            // Assumes called after detecting AABB overlap.
+            // Find edge normal of max separation on A - return if separating axis is found
+            // Find edge normal of max separation on B - return if separation axis is found
+            // Choose reference edge as min(minA, minB)
+            // Find incident edge
+            // Clip
+
+            const auto totalRadius = shapeA.GetVertexRadius() + shapeB.GetVertexRadius();
+            const auto countA = shapeA.GetVertexCount();
+            const auto countB = shapeB.GetVertexCount();
+
+            enum : unsigned
+            {
+                ZeroOneVert = 0x0u,
+                OneVertA = 0x1u,
+                OneVertB = 0x2u
+            };
+            switch (((countA == 1) ? OneVertA : ZeroOneVert) | ((countB == 1) ? OneVertB : ZeroOneVert))
+            {
+            case OneVertA | OneVertB:
+                return GetManifold(shapeA.GetVertex(0), xfA, shapeB.GetVertex(0), xfB, totalRadius);
+            case OneVertA:
+                return GetManifold(true, totalRadius, shapeB, xfB, shapeA.GetVertex(0), xfA);
+            case OneVertB:
+                return GetManifold(false, totalRadius, shapeA, xfA, shapeB.GetVertex(0), xfB);
+            }
+
+            const auto do4x4 = (countA == 4) && (countB == 4);
+
+            const auto edgeSepA = do4x4 ? GetMaxSeparation4x4(shapeA, xfA, shapeB, xfB) : GetMaxSeparation(shapeA, xfA, shapeB, xfB);
+            if (edgeSepA.distance > totalRadius)
+            {
+                return Manifold{};
+            }
+
+            const auto edgeSepB = do4x4 ? GetMaxSeparation4x4(shapeB, xfB, shapeA, xfA) : GetMaxSeparation(shapeB, xfB, shapeA, xfA);
+            if (edgeSepB.distance > totalRadius)
+            {
+                return Manifold{};
+            }
+
+            const auto k_tol = PLAYRHO_MAGIC(conf.linearSlop / 10);
+            return (edgeSepB.distance > (edgeSepA.distance + k_tol)) ? GetManifold(true,
+                                                                                   shapeB, xfB, edgeSepB.firstShape,
+                                                                                   shapeA, xfA, edgeSepB.secondShape,
+                                                                                   conf)
+                                                                     : GetManifold(false,
+                                                                                   shapeA, xfA, edgeSepA.firstShape,
+                                                                                   shapeB, xfB, edgeSepA.secondShape,
+                                                                                   conf);
+        }
 
 #if 0
 Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
@@ -562,349 +561,347 @@ Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
 #endif
 
 #ifdef DEFINE_GET_MANIFOLD
-Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transformA,
-                     const DistanceProxy& proxyB, const Transformation& transformB)
-{
-    const auto distanceInfo = Distance(proxyA, transformA, proxyB, transformB);
-    const auto totalRadius = proxyA.GetVertexRadius() + proxyB.GetVertexRadius();
-    const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
-
-    const auto distance = sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
-    if (distance > totalRadius)
-    {
-        // no collision
-        return Manifold{};
-    }
-
-    const auto a_count = proxyA.GetVertexCount();
-    const auto b_count = proxyB.GetVertexCount();
-
-    index_type a_indices_array[Simplex::MaxEdges];
-    index_type b_indices_array[Simplex::MaxEdges];
-    auto uniqA = std::size_t{0};
-    auto uniqB = std::size_t{0};
-    {
-        std::bitset<MaxShapeVertices> a_indices_set;
-        std::bitset<MaxShapeVertices> b_indices_set;
-        for (auto&& e: distanceInfo.simplex.GetEdges())
+        Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transformA,
+                             const DistanceProxy& proxyB, const Transformation& transformB)
         {
-            const auto indexA = e.GetIndexA();
-            if (!a_indices_set[indexA])
-            {
-                a_indices_set[indexA] = true;
-                a_indices_array[uniqA] = indexA;
-                ++uniqA;
-            }
-            const auto indexB = e.GetIndexB();
-            if (!b_indices_set[indexB])
-            {
-                b_indices_set[indexB] = true;
-                b_indices_array[uniqB] = indexB;
-                ++uniqB;
-            }
-        }
-    }
+            const auto distanceInfo = Distance(proxyA, transformA, proxyB, transformB);
+            const auto totalRadius = proxyA.GetVertexRadius() + proxyB.GetVertexRadius();
+            const auto witnessPoints = GetWitnessPoints(distanceInfo.simplex);
 
-    assert(uniqA > 0 && uniqB > 0);
-
-    std::sort(a_indices_array, a_indices_array + uniqA);
-    std::sort(b_indices_array, b_indices_array + uniqB);
-
-    if (uniqA < uniqB)
-    {
-        switch (uniqA)
-        {
-            case 1: // uniqB must be 2 or 3
+            const auto distance = sqrt(GetMagnitudeSquared(witnessPoints.a - witnessPoints.b));
+            if (distance > totalRadius)
             {
-                const auto b_idx0 = GetEdgeIndex(b_indices_array[0], b_indices_array[1], b_count);
-                assert(b_idx0 != InvalidVertex);
-                const auto b_idx1 = GetModuloNext(b_idx0, b_count);
-                const auto b_v0 = proxyB.GetVertex(b_idx0);
-                const auto b_v1 = proxyB.GetVertex(b_idx1);
-                const auto lp = (b_v0 + b_v1) / Real{2};
-                const auto ln = GetFwdPerpendicular(GetUnitVector(b_v1 - b_v0));
-                const auto mp0 = Manifold::Point{
-                    proxyA.GetVertex(a_indices_array[0]),
-                    ContactFeature{
-                        ContactFeature::e_vertex,
-                        a_indices_array[0],
-                        ContactFeature::e_face,
-                        b_idx0,
-                    }
-                };
-                return Manifold::GetForFaceB(ln, lp, mp0);
-            }
-            case 2: // uniqB must be 3
-            {
-                auto mp0 = Manifold::Point{};
-                auto mp1 = Manifold::Point{};
-                mp0.contactFeature.typeA = ContactFeature::e_face;
-                mp1.contactFeature.typeA = ContactFeature::e_face;
-                const auto v0 = proxyA.GetVertex(a_indices_array[0]);
-                const auto v1 = proxyA.GetVertex(a_indices_array[1]);
-                const auto lp = (v0 + v1) / Real{2};
-                const auto count = proxyA.GetVertexCount();
-                if ((a_indices_array[1] - a_indices_array[0]) == 1)
-                {
-                    mp0.contactFeature.indexA = a_indices_array[0];
-                    mp1.contactFeature.indexA = a_indices_array[0];
-                    const auto ln = GetFwdPerpendicular(GetUnitVector(v1 - v0));
-                    return Manifold::GetForFaceA(ln, lp, mp0, mp1);
-                }
-                else if (GetModuloNext(a_indices_array[1], count) == a_indices_array[0])
-                {
-                    mp0.contactFeature.indexA = a_indices_array[1];
-                    mp1.contactFeature.indexA = a_indices_array[1];
-                    const auto ln = GetFwdPerpendicular(GetUnitVector(v0 - v1));
-                    return Manifold::GetForFaceA(ln, lp, mp0, mp1);
-                }
-                else
-                {
-                    //assert(false);
-                }
+                // no collision
                 return Manifold{};
             }
-            default:
-                break;
-        }
-    }
-    else if (uniqB < uniqA)
-    {
-        switch (uniqB)
-        {
-            case 1: // uniqA must be 2 or 3
+
+            const auto a_count = proxyA.GetVertexCount();
+            const auto b_count = proxyB.GetVertexCount();
+
+            index_type a_indices_array[Simplex::MaxEdges];
+            index_type b_indices_array[Simplex::MaxEdges];
+            auto uniqA = std::size_t{0};
+            auto uniqB = std::size_t{0};
             {
-                const auto a_idx0 = GetEdgeIndex(a_indices_array[0],a_indices_array[1], a_count);
-                assert(a_idx0 != InvalidVertex);
-                const auto a_idx1 = GetModuloNext(a_idx0, a_count);
-                const auto a_v0 = proxyA.GetVertex(a_idx0);
-                const auto a_v1 = proxyA.GetVertex(a_idx1);
-                const auto lp = (a_v0 + a_v1) / Real{2};
-                const auto ln = GetFwdPerpendicular(GetUnitVector(a_v1 - a_v0));
-                const auto mp0 = Manifold::Point{
-                    proxyB.GetVertex(b_indices_array[0]),
-                    ContactFeature{
-                        ContactFeature::e_face,
-                        a_idx0,
-                        ContactFeature::e_vertex,
-                        b_indices_array[0]
-                    }
-                };
-                return Manifold::GetForFaceA(ln, lp, mp0);
-            }
-            case 2: // uniqA must be 3
-            {
-                auto mp0 = Manifold::Point{};
-                auto mp1 = Manifold::Point{};
-                mp0.contactFeature.typeB = ContactFeature::e_face;
-                mp1.contactFeature.typeB = ContactFeature::e_face;
-                const auto v0 = proxyB.GetVertex(b_indices_array[0]);
-                const auto v1 = proxyB.GetVertex(b_indices_array[1]);
-                const auto lp = (v0 + v1) / Real{2};
-                const auto count = proxyB.GetVertexCount();
-                if ((b_indices_array[1] - b_indices_array[0]) == 1)
+                std::bitset<MaxShapeVertices> a_indices_set;
+                std::bitset<MaxShapeVertices> b_indices_set;
+                for (auto&& e : distanceInfo.simplex.GetEdges())
                 {
+                    const auto indexA = e.GetIndexA();
+                    if (!a_indices_set[indexA])
+                    {
+                        a_indices_set[indexA] = true;
+                        a_indices_array[uniqA] = indexA;
+                        ++uniqA;
+                    }
+                    const auto indexB = e.GetIndexB();
+                    if (!b_indices_set[indexB])
+                    {
+                        b_indices_set[indexB] = true;
+                        b_indices_array[uniqB] = indexB;
+                        ++uniqB;
+                    }
+                }
+            }
+
+            assert(uniqA > 0 && uniqB > 0);
+
+            std::sort(a_indices_array, a_indices_array + uniqA);
+            std::sort(b_indices_array, b_indices_array + uniqB);
+
+            if (uniqA < uniqB)
+            {
+                switch (uniqA)
+                {
+                case 1:// uniqB must be 2 or 3
+                {
+                    const auto b_idx0 = GetEdgeIndex(b_indices_array[0], b_indices_array[1], b_count);
+                    assert(b_idx0 != InvalidVertex);
+                    const auto b_idx1 = GetModuloNext(b_idx0, b_count);
+                    const auto b_v0 = proxyB.GetVertex(b_idx0);
+                    const auto b_v1 = proxyB.GetVertex(b_idx1);
+                    const auto lp = (b_v0 + b_v1) / Real{2};
+                    const auto ln = GetFwdPerpendicular(GetUnitVector(b_v1 - b_v0));
+                    const auto mp0 = Manifold::Point{
+                        proxyA.GetVertex(a_indices_array[0]),
+                        ContactFeature{
+                            ContactFeature::e_vertex,
+                            a_indices_array[0],
+                            ContactFeature::e_face,
+                            b_idx0,
+                        }};
+                    return Manifold::GetForFaceB(ln, lp, mp0);
+                }
+                case 2:// uniqB must be 3
+                {
+                    auto mp0 = Manifold::Point{};
+                    auto mp1 = Manifold::Point{};
+                    mp0.contactFeature.typeA = ContactFeature::e_face;
+                    mp1.contactFeature.typeA = ContactFeature::e_face;
+                    const auto v0 = proxyA.GetVertex(a_indices_array[0]);
+                    const auto v1 = proxyA.GetVertex(a_indices_array[1]);
+                    const auto lp = (v0 + v1) / Real{2};
+                    const auto count = proxyA.GetVertexCount();
+                    if ((a_indices_array[1] - a_indices_array[0]) == 1)
+                    {
+                        mp0.contactFeature.indexA = a_indices_array[0];
+                        mp1.contactFeature.indexA = a_indices_array[0];
+                        const auto ln = GetFwdPerpendicular(GetUnitVector(v1 - v0));
+                        return Manifold::GetForFaceA(ln, lp, mp0, mp1);
+                    }
+                    else if (GetModuloNext(a_indices_array[1], count) == a_indices_array[0])
+                    {
+                        mp0.contactFeature.indexA = a_indices_array[1];
+                        mp1.contactFeature.indexA = a_indices_array[1];
+                        const auto ln = GetFwdPerpendicular(GetUnitVector(v0 - v1));
+                        return Manifold::GetForFaceA(ln, lp, mp0, mp1);
+                    }
+                    else
+                    {
+                        //assert(false);
+                    }
+                    return Manifold{};
+                }
+                default:
+                    break;
+                }
+            }
+            else if (uniqB < uniqA)
+            {
+                switch (uniqB)
+                {
+                case 1:// uniqA must be 2 or 3
+                {
+                    const auto a_idx0 = GetEdgeIndex(a_indices_array[0], a_indices_array[1], a_count);
+                    assert(a_idx0 != InvalidVertex);
+                    const auto a_idx1 = GetModuloNext(a_idx0, a_count);
+                    const auto a_v0 = proxyA.GetVertex(a_idx0);
+                    const auto a_v1 = proxyA.GetVertex(a_idx1);
+                    const auto lp = (a_v0 + a_v1) / Real{2};
+                    const auto ln = GetFwdPerpendicular(GetUnitVector(a_v1 - a_v0));
+                    const auto mp0 = Manifold::Point{
+                        proxyB.GetVertex(b_indices_array[0]),
+                        ContactFeature{
+                            ContactFeature::e_face,
+                            a_idx0,
+                            ContactFeature::e_vertex,
+                            b_indices_array[0]}};
+                    return Manifold::GetForFaceA(ln, lp, mp0);
+                }
+                case 2:// uniqA must be 3
+                {
+                    auto mp0 = Manifold::Point{};
+                    auto mp1 = Manifold::Point{};
+                    mp0.contactFeature.typeB = ContactFeature::e_face;
+                    mp1.contactFeature.typeB = ContactFeature::e_face;
+                    const auto v0 = proxyB.GetVertex(b_indices_array[0]);
+                    const auto v1 = proxyB.GetVertex(b_indices_array[1]);
+                    const auto lp = (v0 + v1) / Real{2};
+                    const auto count = proxyB.GetVertexCount();
+                    if ((b_indices_array[1] - b_indices_array[0]) == 1)
+                    {
+                        mp0.contactFeature.indexB = b_indices_array[0];
+                        mp1.contactFeature.indexB = b_indices_array[0];
+                        const auto ln = GetFwdPerpendicular(GetUnitVector(v1 - v0));
+                        return Manifold::GetForFaceB(ln, lp, mp0, mp1);
+                    }
+                    else if (GetModuloNext(b_indices_array[1], count) == b_indices_array[0])
+                    {
+                        mp0.contactFeature.indexB = b_indices_array[1];
+                        mp1.contactFeature.indexB = b_indices_array[1];
+                        const auto ln = GetFwdPerpendicular(GetUnitVector(v0 - v1));
+                        return Manifold::GetForFaceB(ln, lp, mp0, mp1);
+                    }
+                    else
+                    {
+                        //assert(false);
+                    }
+                    return Manifold{};
+                }
+                default:
+                    break;
+                }
+            }
+            else// uniqA == uniqB
+            {
+                switch (uniqA)
+                {
+                case 1: {
+                    return Manifold::GetForCircles(proxyA.GetVertex(a_indices_array[0]), a_indices_array[0],
+                                                   proxyB.GetVertex(b_indices_array[0]), b_indices_array[0]);
+                }
+                case 2: {
+                    const auto v0 = proxyA.GetVertex(a_indices_array[0]);
+                    const auto v1 = proxyA.GetVertex(a_indices_array[1]);
+                    const auto lp = (v0 + v1) / Real{2};
+                    const auto count = proxyA.GetVertexCount();
+                    auto mp0 = Manifold::Point{};
+                    auto mp1 = Manifold::Point{};
+                    mp0.contactFeature.typeB = ContactFeature::e_vertex;
                     mp0.contactFeature.indexB = b_indices_array[0];
-                    mp1.contactFeature.indexB = b_indices_array[0];
-                    const auto ln = GetFwdPerpendicular(GetUnitVector(v1 - v0));
-                    return Manifold::GetForFaceB(ln, lp, mp0, mp1);
-                }
-                else if (GetModuloNext(b_indices_array[1], count) == b_indices_array[0])
-                {
-                    mp0.contactFeature.indexB = b_indices_array[1];
+                    mp0.localPoint = proxyB.GetVertex(mp0.contactFeature.indexB);
+                    mp1.contactFeature.typeB = ContactFeature::e_vertex;
                     mp1.contactFeature.indexB = b_indices_array[1];
-                    const auto ln = GetFwdPerpendicular(GetUnitVector(v0 - v1));
-                    return Manifold::GetForFaceB(ln, lp, mp0, mp1);
+                    mp1.localPoint = proxyB.GetVertex(mp1.contactFeature.indexB);
+                    if ((a_indices_array[1] - a_indices_array[0]) == 1)
+                    {
+                        mp0.contactFeature.typeA = ContactFeature::e_face;
+                        mp0.contactFeature.indexA = a_indices_array[0];
+                        mp1.contactFeature.typeA = ContactFeature::e_face;
+                        mp1.contactFeature.indexA = a_indices_array[0];
+                        const auto ln = GetFwdPerpendicular(GetUnitVector(v1 - v0));
+                        return Manifold::GetForFaceA(ln, lp, mp0, mp1);
+                    }
+                    if (GetModuloNext(a_indices_array[1], count) == a_indices_array[0])
+                    {
+                        mp0.contactFeature.typeA = ContactFeature::e_face;
+                        mp0.contactFeature.indexA = a_indices_array[1];
+                        mp1.contactFeature.typeA = ContactFeature::e_face;
+                        mp1.contactFeature.indexA = a_indices_array[1];
+                        const auto ln = GetFwdPerpendicular(GetUnitVector(v0 - v1));
+                        return Manifold::GetForFaceA(ln, lp, mp0, mp1);
+                    }
+                    assert(false);
+                    break;
                 }
-                else
-                {
-                    //assert(false);
+                case 3: {
+                    const auto ln = UnitVec::GetLeft();
+                    const auto lp = Length2{};
+                    return Manifold::GetForFaceA(ln, lp);
                 }
-                return Manifold{};
-            }
-            default:
-                break;
-        }
-    }
-    else // uniqA == uniqB
-    {
-        switch (uniqA)
-        {
-            case 1:
-            {
-                return Manifold::GetForCircles(proxyA.GetVertex(a_indices_array[0]), a_indices_array[0],
-                                               proxyB.GetVertex(b_indices_array[0]), b_indices_array[0]);
-            }
-            case 2:
-            {
-                const auto v0 = proxyA.GetVertex(a_indices_array[0]);
-                const auto v1 = proxyA.GetVertex(a_indices_array[1]);
-                const auto lp = (v0 + v1) / Real{2};
-                const auto count = proxyA.GetVertexCount();
-                auto mp0 = Manifold::Point{};
-                auto mp1 = Manifold::Point{};
-                mp0.contactFeature.typeB = ContactFeature::e_vertex;
-                mp0.contactFeature.indexB = b_indices_array[0];
-                mp0.localPoint = proxyB.GetVertex(mp0.contactFeature.indexB);
-                mp1.contactFeature.typeB = ContactFeature::e_vertex;
-                mp1.contactFeature.indexB = b_indices_array[1];
-                mp1.localPoint = proxyB.GetVertex(mp1.contactFeature.indexB);
-                if ((a_indices_array[1] - a_indices_array[0]) == 1)
-                {
-                    mp0.contactFeature.typeA = ContactFeature::e_face;
-                    mp0.contactFeature.indexA = a_indices_array[0];
-                    mp1.contactFeature.typeA = ContactFeature::e_face;
-                    mp1.contactFeature.indexA = a_indices_array[0];
-                    const auto ln = GetFwdPerpendicular(GetUnitVector(v1 - v0));
-                    return Manifold::GetForFaceA(ln, lp, mp0, mp1);
+                default:
+                    break;
                 }
-                if (GetModuloNext(a_indices_array[1], count) == a_indices_array[0])
-                {
-                    mp0.contactFeature.typeA = ContactFeature::e_face;
-                    mp0.contactFeature.indexA = a_indices_array[1];
-                    mp1.contactFeature.typeA = ContactFeature::e_face;
-                    mp1.contactFeature.indexA = a_indices_array[1];
-                    const auto ln = GetFwdPerpendicular(GetUnitVector(v0 - v1));
-                    return Manifold::GetForFaceA(ln, lp, mp0, mp1);
-                }
-                assert(false);
-                break;
             }
-            case 3:
-            {
-                const auto ln = UnitVec::GetLeft();
-                const auto lp = Length2{};
-                return Manifold::GetForFaceA(ln, lp);
-            }
-            default:
-                break;
-        }
-    }
 
-    return Manifold{};
-}
+            return Manifold{};
+        }
 #endif
 
-const char* GetName(Manifold::Type type) noexcept
-{
-    switch (type)
-    {
-        case Manifold::e_unset: break;
-        case Manifold::e_circles: return "circles";
-        case Manifold::e_faceA: return "face-a";
-        case Manifold::e_faceB: return "face-b";
-    }
-    assert(type == Manifold::e_unset);
-    return "unset";
-}
+        const char* GetName(Manifold::Type type) noexcept
+        {
+            switch (type)
+            {
+            case Manifold::e_unset:
+                break;
+            case Manifold::e_circles:
+                return "circles";
+            case Manifold::e_faceA:
+                return "face-a";
+            case Manifold::e_faceB:
+                return "face-b";
+            }
+            assert(type == Manifold::e_unset);
+            return "unset";
+        }
 
-bool operator==(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept
-{
-    if (lhs.localPoint != rhs.localPoint)
-    {
-        return false;
-    }
-    if (lhs.contactFeature != rhs.contactFeature)
-    {
-        return false;
-    }
-    if (lhs.normalImpulse != rhs.normalImpulse)
-    {
-        return false;
-    }
-    if (lhs.tangentImpulse != rhs.tangentImpulse)
-    {
-        return false;
-    }
-    return true;
-}
+        bool operator==(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept
+        {
+            if (lhs.localPoint != rhs.localPoint)
+            {
+                return false;
+            }
+            if (lhs.contactFeature != rhs.contactFeature)
+            {
+                return false;
+            }
+            if (lhs.normalImpulse != rhs.normalImpulse)
+            {
+                return false;
+            }
+            if (lhs.tangentImpulse != rhs.tangentImpulse)
+            {
+                return false;
+            }
+            return true;
+        }
 
-bool operator!=(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+        bool operator!=(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
 
-bool operator==(const Manifold& lhs, const Manifold& rhs) noexcept
-{
-    if (lhs.GetType() != rhs.GetType())
-    {
-        return false;
-    }
-    if (lhs.GetPointCount() != rhs.GetPointCount())
-    {
-        return false;
-    }
+        bool operator==(const Manifold& lhs, const Manifold& rhs) noexcept
+        {
+            if (lhs.GetType() != rhs.GetType())
+            {
+                return false;
+            }
+            if (lhs.GetPointCount() != rhs.GetPointCount())
+            {
+                return false;
+            }
 
-    switch (lhs.GetType())
-    {
-        case Manifold::e_unset:
-            break;
-        case Manifold::e_circles:
-            if (lhs.GetLocalPoint() != rhs.GetLocalPoint())
+            switch (lhs.GetType())
             {
-                return false;
-            }
-            break;
-        case Manifold::e_faceA:
-            if (lhs.GetLocalPoint() != rhs.GetLocalPoint())
-            {
-                return false;
-            }
-            if (lhs.GetLocalNormal() != rhs.GetLocalNormal())
-            {
-                return false;
-            }
-            break;
-        case Manifold::e_faceB:
-            if (lhs.GetLocalPoint() != rhs.GetLocalPoint())
-            {
-                return false;
-            }
-            if (lhs.GetLocalNormal() != rhs.GetLocalNormal())
-            {
-                return false;
-            }
-            break;
-    }
-
-    const auto count = lhs.GetPointCount();
-    assert(count <= 2);
-    switch (count)
-    {
-        case 0:
-            break;
-        case 1:
-            if (lhs.GetPoint(0) != rhs.GetPoint(0))
-            {
-                return false;
-            }
-            break;
-        case 2:
-            if (lhs.GetPoint(0) != rhs.GetPoint(0))
-            {
-                if (lhs.GetPoint(0) != rhs.GetPoint(1))
+            case Manifold::e_unset:
+                break;
+            case Manifold::e_circles:
+                if (lhs.GetLocalPoint() != rhs.GetLocalPoint())
                 {
                     return false;
                 }
-                if (lhs.GetPoint(1) != rhs.GetPoint(0))
+                break;
+            case Manifold::e_faceA:
+                if (lhs.GetLocalPoint() != rhs.GetLocalPoint())
                 {
                     return false;
                 }
+                if (lhs.GetLocalNormal() != rhs.GetLocalNormal())
+                {
+                    return false;
+                }
+                break;
+            case Manifold::e_faceB:
+                if (lhs.GetLocalPoint() != rhs.GetLocalPoint())
+                {
+                    return false;
+                }
+                if (lhs.GetLocalNormal() != rhs.GetLocalNormal())
+                {
+                    return false;
+                }
+                break;
             }
-            else if (lhs.GetPoint(1) != rhs.GetPoint(1))
-            {
-                return false;
-            }
-            break;
-    }
-    
-    return true;
-}
 
-bool operator!=(const Manifold& lhs, const Manifold& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+            const auto count = lhs.GetPointCount();
+            assert(count <= 2);
+            switch (count)
+            {
+            case 0:
+                break;
+            case 1:
+                if (lhs.GetPoint(0) != rhs.GetPoint(0))
+                {
+                    return false;
+                }
+                break;
+            case 2:
+                if (lhs.GetPoint(0) != rhs.GetPoint(0))
+                {
+                    if (lhs.GetPoint(0) != rhs.GetPoint(1))
+                    {
+                        return false;
+                    }
+                    if (lhs.GetPoint(1) != rhs.GetPoint(0))
+                    {
+                        return false;
+                    }
+                }
+                else if (lhs.GetPoint(1) != rhs.GetPoint(1))
+                {
+                    return false;
+                }
+                break;
+            }
+
+            return true;
+        }
+
+        bool operator!=(const Manifold& lhs, const Manifold& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
 
 #if 0
 Length2 GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
@@ -923,5 +920,5 @@ Length2 GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
 }
 #endif
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -20,586 +20,578 @@
 #ifndef PLAYRHO_COLLISION_MANIFOLD_HPP
 #define PLAYRHO_COLLISION_MANIFOLD_HPP
 
-#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Collision/ContactFeature.hpp>
 #include <PlayRho/Collision/IndexPair.hpp>
+#include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-struct StepConf;
-
-namespace d2 {
-
-class DistanceProxy;
-struct Transformation;
-
-/// @brief A collision response oriented description of the intersection of two convex shapes.
-///
-/// @details
-/// This describes zero, one, or two points of contact for which impulses should be applied to
-/// most naturally resolve those contacts. Ideally the manifold is calculated at the earliest
-/// point in time of contact occurring. The further past that time, the less natural contact
-/// resolution of solid bodies will be - eventually resulting in oddities like tunneling.
-///
-/// Multiple types of contact are supported: clip point versus plane with radius, point versus
-/// point with radius (circles). Contacts are stored in this way so that position correction can
-/// account for movement, which is critical for continuous physics. All contact scenarios must
-/// be expressed in one of these types.
-///
-/// Conceptually, a manifold represents the intersection of two convex sets (which is itself
-/// a convex set) and a solution for moving the sets away from each other to eliminate the
-/// intersection.
-///
-/// @note The local point and local normal usage depends on the manifold type. For details, see
-///   the documentation associated with the different manifold types.
-/// @note Every point adds computational overhead to the collision response calculation - so
-///   express collision manifolds with one point if possible instead of two.
-/// @note While this data structure is at least 58-bytes large (60-bytes on one 64-bit
-///   platform), it is intentionally 64-byte aligned making it 64-byte large (on 64-bit
-///   platforms with 4-byte Real).
-///
-/// @image html manifolds.png
-///
-/// @see Contact, PositionConstraint, VelocityConstraint
-/// @see https://en.wikipedia.org/wiki/Convex_set
-/// @see http://box2d.org/files/GDC2007/GDC2007_Catto_Erin_Physics2.ppt
-///
-class alignas(64) Manifold
+namespace playrho
 {
-public:
-    
-    /// @brief Size type.
-    using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
 
-    /// Contact feature index.
-    using CfIndex = ContactFeature::Index;
-    
-    /// @brief Contact feature type.
-    using CfType = ContactFeature::Type;
+    struct StepConf;
 
-    struct Conf;
-
-    /// Manifold type.
-    /// @note This is by design a 1-byte sized type.
-    enum Type: std::uint8_t
+    namespace d2
     {
-        /// Unset type.
-        /// @details Manifold is unset. For manifolds of this type: the point count is zero,
-        ///   point data is undefined, and all other properties are invalid.
-        e_unset,
-        
-        /// Circles type.
-        /// @details Manifold is for circle-to-circle like collisions.
-        /// @note For manifolds of this type: the local point is local center of "circle-A"
-        ///     (where shape A wasn't necessarily a circle but treating it as such is useful),
-        ///     the local normal is invalid (and unused) and, the point count will be zero or
-        ///     one where the contact feature will be
-        ///               <code>ContactFeature{e_vertex, i, e_vertex, j}</code>
-        ///     where i and j are indexes of the vertexes of shapes A and B respectively.
-        e_circles,
 
-        /// Face-A type.
-        /// @details Indicates: local point is center of face A, local normal is normal on shape A, and the
-        ///   local points of Point instances are the local center of circle B or a clip point of polygon B
-        ///   where the contact feature will be <code>ContactFeature{e_face, i, e_vertex, j}</code> or
-        ///   <code>ContactFeature{e_face, i, e_face, j} where i and j are indexes for the vertex or edge
-        ///   of shapes A and B respectively.</code>.
-        e_faceA,
+        class DistanceProxy;
+        struct Transformation;
 
-        /// Face-B type.
-        /// @details Indicates: local point is center of face B, local normal is normal on shape B, and the
-        ///   local points of Point instances are the local center of circle A or a clip point of polygon A
-        ///   where the contact feature will be <code>ContactFeature{e_face, i, e_vertex, j}</code> or
-        ///   <code>ContactFeature{e_face, i, e_face, j} where i and j are indexes for the vertex or edge
-        ///   of shapes A and B respectively.</code>.
-        e_faceB
-    };
-    
-    /// @brief Data for a point of collision in a Manifold.
-    ///
-    /// @details This is a contact point belonging to a contact manifold. It holds details
-    /// related to the geometry and dynamics of the contact points.
-    ///
-    /// @note The impulses are used for internal caching and may not provide reliable contact
-    ///    forces especially for high speed collisions.
-    ///
-    /// @note This structure is at least 20-bytes large.
-    ///
-    struct Point
-    {
-        /// @brief Local point.
-        /// @details Usage depends on manifold type.
-        /// @note For circles type manifolds, this is the local center of circle B.
-        /// @note For face-A type manifolds, this is the local center of "circle" B or a clip
-        /// point of shape B. It is also the point at which impulse forces should be relatively
-        /// applied for position resolution.
-        /// @note For face-B type manifolds, this is the local center of "circle" A or a clip
-        /// point of shape A. It is also the point at which impulse forces should be relatively
-        /// applied for position resolution.
-        /// @note 8-bytes.
-        Length2 localPoint;
+        /// @brief A collision response oriented description of the intersection of two convex shapes.
+        ///
+        /// @details
+        /// This describes zero, one, or two points of contact for which impulses should be applied to
+        /// most naturally resolve those contacts. Ideally the manifold is calculated at the earliest
+        /// point in time of contact occurring. The further past that time, the less natural contact
+        /// resolution of solid bodies will be - eventually resulting in oddities like tunneling.
+        ///
+        /// Multiple types of contact are supported: clip point versus plane with radius, point versus
+        /// point with radius (circles). Contacts are stored in this way so that position correction can
+        /// account for movement, which is critical for continuous physics. All contact scenarios must
+        /// be expressed in one of these types.
+        ///
+        /// Conceptually, a manifold represents the intersection of two convex sets (which is itself
+        /// a convex set) and a solution for moving the sets away from each other to eliminate the
+        /// intersection.
+        ///
+        /// @note The local point and local normal usage depends on the manifold type. For details, see
+        ///   the documentation associated with the different manifold types.
+        /// @note Every point adds computational overhead to the collision response calculation - so
+        ///   express collision manifolds with one point if possible instead of two.
+        /// @note While this data structure is at least 58-bytes large (60-bytes on one 64-bit
+        ///   platform), it is intentionally 64-byte aligned making it 64-byte large (on 64-bit
+        ///   platforms with 4-byte Real).
+        ///
+        /// @image html manifolds.png
+        ///
+        /// @see Contact, PositionConstraint, VelocityConstraint
+        /// @see https://en.wikipedia.org/wiki/Convex_set
+        /// @see http://box2d.org/files/GDC2007/GDC2007_Catto_Erin_Physics2.ppt
+        ///
+        class alignas(64) Manifold
+        {
+         public:
+            /// @brief Size type.
+            using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
 
-        /// @brief Contact feature.
-        /// @details Uniquely identifies a contact point between two shapes - A and B.
-        /// @note This field is 4-bytes.
-        /// @see GetPointStates.
-        ContactFeature contactFeature;
-        
-        /// @brief Normal impulse.
-        /// @details This is the non-penetration impulse.
-        /// @note This is only used for velocity constraint resolution.
-        /// @note 4-bytes.
-        Momentum normalImpulse = 0_Ns;
-        
-        /// @brief Tangent impulse.
-        /// @details This is the friction impulse.
-        /// @note This is only used for velocity constraint resolution.
-        /// @note 4-bytes.
-        Momentum tangentImpulse = 0_Ns;
-    };
-    
-    // For Circles type manifolds...
-    
-    /// Gets a circles-typed manifold with one point.
-    /// @param vA Local center of "circle" A.
-    /// @param iA Index of vertex from shape A representing the local center of "circle" A.
-    /// @param vB Local center of "circle" B.
-    /// @param iB Index of vertex from shape B representing the local center of "circle" B.
-    static inline Manifold GetForCircles(Length2 vA, CfIndex iA, Length2 vB, CfIndex iB) noexcept
-    {
-        return Manifold{e_circles, GetInvalid<UnitVec>(), vA, 1, {{
-            Point{vB, GetVertexVertexContactFeature(iA, iB)}
-        }}};
-    }
+            /// Contact feature index.
+            using CfIndex = ContactFeature::Index;
 
-    // For Face A type manifolds...
-    
-    /// Gets a face A typed manifold.
-    /// @param normalA Local normal of the face from polygon A.
-    /// @param faceA Any point in local coordinates on the face whose normal was provided.
-    static inline Manifold GetForFaceA(UnitVec normalA, Length2 faceA) noexcept
-    {
-        return Manifold{e_faceA, normalA, faceA, 0, {{}}};
-    }
-    
-    /// Gets a face A typed manifold.
-    /// @param ln Normal on polygon A.
-    /// @param lp Center of face A.
-    /// @param mp1 Manifold point 1 (of 1).
-    static inline Manifold GetForFaceA(UnitVec ln, Length2 lp,
-                                       const Point& mp1) noexcept
-    {
-        //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
-        return Manifold{e_faceA, ln, lp, 1, {{mp1}}};
-    }
-    
-    /// Gets a face A typed manifold.
-    /// @param ln Normal on polygon A.
-    /// @param lp Center of face A.
-    /// @param mp1 Manifold point 1 (of 2).
-    /// @param mp2 Manifold point 2 (of 2).
-    static inline Manifold GetForFaceA(UnitVec ln, Length2 lp,
-                                       const Point& mp1, const Point& mp2) noexcept
-    {
-        //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
-        //assert(mp2.contactFeature.typeA == ContactFeature::e_face || mp2.contactFeature.typeB == ContactFeature::e_face);
-        //assert(mp1.contactFeature != mp2.contactFeature);
-        return Manifold{e_faceA, ln, lp, 2, {{mp1, mp2}}};
-    }
-    
-    // For Face B...
-    
-    /// Gets a face B typed manifold.
-    /// @param ln Normal on polygon B.
-    /// @param lp Center of face B.
-    static inline Manifold GetForFaceB(UnitVec ln, Length2 lp) noexcept
-    {
-        return Manifold{e_faceB, ln, lp, 0, {{}}};
-    }
-    
-    /// Gets a face B typed manifold.
-    /// @param ln Normal on polygon B.
-    /// @param lp Center of face B.
-    /// @param mp1 Manifold point 1.
-    static inline Manifold GetForFaceB(UnitVec ln, Length2 lp,
-                                       const Point& mp1) noexcept
-    {
-        //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
-        return Manifold{e_faceB, ln, lp, 1, {{mp1}}};
-    }
-    
-    /// Gets a face B typed manifold.
-    /// @param ln Normal on polygon B.
-    /// @param lp Center of face B.
-    /// @param mp1 Manifold point 1 (of 2).
-    /// @param mp2 Manifold point 2 (of 2).
-    static inline Manifold GetForFaceB(UnitVec ln, Length2 lp,
-                                       const Point& mp1, const Point& mp2) noexcept
-    {
-        //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
-        //assert(mp2.contactFeature.typeA == ContactFeature::e_face || mp2.contactFeature.typeB == ContactFeature::e_face);
-        //assert(mp1.contactFeature != mp2.contactFeature);
-        return Manifold{e_faceB, ln, lp, 2, {{mp1, mp2}}};
-    }
-    
-    /// @brief Gets the face A manifold for the given data.
-    static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa) noexcept
-    {
-        return Manifold{e_faceA, na, pa, 0, {{
-            Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}},
-            Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}}
-        }}};
-    }
-    
-    /// @brief Gets the face B manifold for the given data.
-    static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb) noexcept
-    {
-        return Manifold{e_faceB, nb, pb, 0, {{
-            Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}},
-            Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}}
-        }}};
-    }
+            /// @brief Contact feature type.
+            using CfType = ContactFeature::Type;
 
-    /// @brief Gets the face A manifold for the given data.
-    static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa,
-                                          CfType tb0, CfIndex ib0, Length2 pb0) noexcept
-    {
-        return Manifold{e_faceA, na, pa, 1, {{
-            Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}},
-            Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}}
-        }}};
-    }
-    
-    /// @brief Gets the face B manifold for the given data.
-    static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb,
-                                          CfType ta0, CfIndex ia0, Length2 pa0) noexcept
-    {
-        return Manifold{e_faceB, nb, pb, 1, {{
-            Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}},
-            Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}}
-        }}};
-    }
-    
-    /// @brief Gets the face A manifold for the given data.
-    static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa,
-                                          CfType tb0, CfIndex ib0, Length2 pb0,
-                                          CfType tb1, CfIndex ib1, Length2 pb1) noexcept
-    {
-        return Manifold{e_faceA, na, pa, 2, {{
-            Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}},
-            Point{pb1, ContactFeature{ContactFeature::e_face, ia, tb1, ib1}}
-        }}};
-    }
+            struct Conf;
 
-    /// @brief Gets the face B manifold for the given data.
-    static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb,
-                                          CfType ta0, CfIndex ia0, Length2 pa0,
-                                          CfType ta1, CfIndex ia1, Length2 pa1) noexcept
-    {
-        return Manifold{e_faceB, nb, pb, 2, {{
-            Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}},
-            Point{pa1, ContactFeature{ta1, ia1, ContactFeature::e_face, ib}}
-        }}};
-    }
+            /// Manifold type.
+            /// @note This is by design a 1-byte sized type.
+            enum Type : std::uint8_t
+            {
+                /// Unset type.
+                /// @details Manifold is unset. For manifolds of this type: the point count is zero,
+                ///   point data is undefined, and all other properties are invalid.
+                e_unset,
 
-    /// Default constructor.
-    /// @details
-    /// Constructs an unset-type manifold.
-    /// For an unset-type manifold:
-    /// point count is zero, point data is undefined, and all other properties are invalid.
-    Manifold() = default;
-    
-    /// @brief Copy constructor.
-    Manifold(const Manifold& copy) = default;
-    
-    /// Gets the type of this manifold.
-    ///
-    /// @note This must be a constant expression in order to use it in the context
-    ///   of the <code>IsValid</code> specialized template function for it.
-    ///
-    constexpr Type GetType() const noexcept { return m_type; }
-    
-    /// Gets the manifold point count.
-    ///
-    /// @details This is the count of contact points for this manifold.
-    ///   Only up to this many points can be validly accessed using the
-    ///   <code>GetPoint()</code> method.
-    /// @note Non-zero values indicate that the two shapes are touching.
-    ///
-    /// @return Value between 0 and <code>MaxManifoldPoints</code>.
-    ///
-    /// @see MaxManifoldPoints.
-    /// @see AddPoint().
-    /// @see GetPoint().
-    ///
-    constexpr size_type GetPointCount() const noexcept { return m_pointCount; }
-    
-    /// @brief Gets the contact feature for the given index.
-    constexpr ContactFeature GetContactFeature(size_type index) const noexcept
-    {
-        assert(index < m_pointCount);
-        return m_points[index].contactFeature;
-    }
+                /// Circles type.
+                /// @details Manifold is for circle-to-circle like collisions.
+                /// @note For manifolds of this type: the local point is local center of "circle-A"
+                ///     (where shape A wasn't necessarily a circle but treating it as such is useful),
+                ///     the local normal is invalid (and unused) and, the point count will be zero or
+                ///     one where the contact feature will be
+                ///               <code>ContactFeature{e_vertex, i, e_vertex, j}</code>
+                ///     where i and j are indexes of the vertexes of shapes A and B respectively.
+                e_circles,
 
-    /// @brief Gets the contact impulses for the given index.
-    /// @return Pair of impulses where the first impulse is the "normal impulse"
-    ///   and the second impulse is the "tangent impulse".
-    constexpr Momentum2 GetContactImpulses(size_type index) const noexcept
-    {
-        assert(index < m_pointCount);
-        return Momentum2{m_points[index].normalImpulse, m_points[index].tangentImpulse};
-    }
+                /// Face-A type.
+                /// @details Indicates: local point is center of face A, local normal is normal on shape A, and the
+                ///   local points of Point instances are the local center of circle B or a clip point of polygon B
+                ///   where the contact feature will be <code>ContactFeature{e_face, i, e_vertex, j}</code> or
+                ///   <code>ContactFeature{e_face, i, e_face, j} where i and j are indexes for the vertex or edge
+                ///   of shapes A and B respectively.</code>.
+                e_faceA,
 
-    /// @brief Sets the contact impulses for the given index.
-    /// @details Sets the contact impulses for the given index where the first impulse
-    ///   is the "normal impulse" and the second impulse is the "tangent impulse".
-    void SetContactImpulses(size_type index, Momentum2 value) noexcept
-    {
-        assert(index < m_pointCount);
-        m_points[index].normalImpulse = get<0>(value);
-        m_points[index].tangentImpulse = get<1>(value);
-    }
+                /// Face-B type.
+                /// @details Indicates: local point is center of face B, local normal is normal on shape B, and the
+                ///   local points of Point instances are the local center of circle A or a clip point of polygon A
+                ///   where the contact feature will be <code>ContactFeature{e_face, i, e_vertex, j}</code> or
+                ///   <code>ContactFeature{e_face, i, e_face, j} where i and j are indexes for the vertex or edge
+                ///   of shapes A and B respectively.</code>.
+                e_faceB
+            };
 
-    /// @brief Gets the point identified by the given index.
-    const Point& GetPoint(size_type index) const noexcept
-    {
-        assert((0 <= index) && (index < m_pointCount));
-        return m_points[index];
-    }
-    
-    /// @brief Sets the point impulses for the given index.
-    void SetPointImpulses(size_type index, Momentum n, Momentum t)
-    {
-        assert((index < m_pointCount) || (index < MaxManifoldPoints && n == 0_Ns && t == 0_Ns));
-        m_points[index].normalImpulse = n;
-        m_points[index].tangentImpulse = t;
-    }
-    
-    /// Adds a new point.
-    /// @details This can be called once for circle type manifolds,
-    ///   and up to twice for face-A or face-B type manifolds. <code>GetPointCount()</code>
-    ///   can be called to find out how many points have already been added.
-    /// @warning Behavior is undefined if this object's type is e_unset.
-    /// @warning Behavior is undefined if this is called more than twice.
-    void AddPoint(const Point& mp) noexcept;
+            /// @brief Data for a point of collision in a Manifold.
+            ///
+            /// @details This is a contact point belonging to a contact manifold. It holds details
+            /// related to the geometry and dynamics of the contact points.
+            ///
+            /// @note The impulses are used for internal caching and may not provide reliable contact
+            ///    forces especially for high speed collisions.
+            ///
+            /// @note This structure is at least 20-bytes large.
+            ///
+            struct Point
+            {
+                /// @brief Local point.
+                /// @details Usage depends on manifold type.
+                /// @note For circles type manifolds, this is the local center of circle B.
+                /// @note For face-A type manifolds, this is the local center of "circle" B or a clip
+                /// point of shape B. It is also the point at which impulse forces should be relatively
+                /// applied for position resolution.
+                /// @note For face-B type manifolds, this is the local center of "circle" A or a clip
+                /// point of shape A. It is also the point at which impulse forces should be relatively
+                /// applied for position resolution.
+                /// @note 8-bytes.
+                Length2 localPoint;
 
-    /// @brief Adds a new point with the given data.
-    void AddPoint(CfType type, CfIndex index, Length2 point) noexcept;
+                /// @brief Contact feature.
+                /// @details Uniquely identifies a contact point between two shapes - A and B.
+                /// @note This field is 4-bytes.
+                /// @see GetPointStates.
+                ContactFeature contactFeature;
 
-    /// @brief Gets the local normal for a face-type manifold.
-    /// @note Only valid for face-A or face-B type manifolds.
-    /// @warning Behavior is undefined for unset (e_unset) type manifolds.
-    /// @warning Behavior is undefined for circles (e_circles) type manifolds.
-    /// @return Local normal if the manifold type is face A or face B, else invalid value.
-    constexpr UnitVec GetLocalNormal() const noexcept
-    {
-        assert(m_type != e_unset);
-        assert(m_type != e_circles);
-        return m_localNormal;
-    }
-    
-    /// @brief Gets the local point.
-    /// @details
-    /// This is the: local center of "circle" A for circles-type manifolds;
-    /// the center of face A for face-A-type manifolds; or
-    /// the center of face B for face-B-type manifolds.
-    /// @note Only valid for circle, face-A, or face-B type manifolds.
-    /// @warning Behavior is undefined for unset (e_unset) type manifolds.
-    /// @return Local point.
-    constexpr Length2 GetLocalPoint() const noexcept
-    {
-        assert(m_type != e_unset);
-        return m_localPoint;
-    }
-    
-    /// @brief Gets the opposing point.
-    constexpr Length2 GetOpposingPoint(size_type index) const noexcept
-    {
-        assert((0 <= index) && (index < m_pointCount));
-        return m_points[index].localPoint;
-    }
+                /// @brief Normal impulse.
+                /// @details This is the non-penetration impulse.
+                /// @note This is only used for velocity constraint resolution.
+                /// @note 4-bytes.
+                Momentum normalImpulse = 0_Ns;
 
-private:
-    
-    /// @brief Point array structure.
-    struct PointArray
-    {
-        Point elements[MaxManifoldPoints]; ///< Elements.
+                /// @brief Tangent impulse.
+                /// @details This is the friction impulse.
+                /// @note This is only used for velocity constraint resolution.
+                /// @note 4-bytes.
+                Momentum tangentImpulse = 0_Ns;
+            };
 
-        /// @brief Array indexing operator.
-        constexpr Point& operator[](std::size_t i) { return elements[i]; }
-        
-        /// @brief Array indexing operator.
-        constexpr const Point& operator[](std::size_t i) const { return elements[i]; }
-    };
+            // For Circles type manifolds...
 
-    /// Constructs manifold with array of points using the given values.
-    /// @param t Manifold type.
-    /// @param ln Local normal.
-    /// @param lp Local point.
-    /// @param n number of points defined in array.
-    /// @param mpa Manifold point array.
-    constexpr Manifold(Type t, UnitVec ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
-    
-    Type m_type = e_unset; ///< Type of collision this manifold is associated with (1-byte).
-    size_type m_pointCount = 0; ///< Number of defined manifold points (1-byte).
-    
-    /// Local normal.
-    /// @details Exact usage depends on manifold type (8-bytes).
-    /// @note Invalid for the unset and circle manifold types.
-    UnitVec m_localNormal = GetInvalid<decltype(m_localNormal)>();
+            /// Gets a circles-typed manifold with one point.
+            /// @param vA Local center of "circle" A.
+            /// @param iA Index of vertex from shape A representing the local center of "circle" A.
+            /// @param vB Local center of "circle" B.
+            /// @param iB Index of vertex from shape B representing the local center of "circle" B.
+            static inline Manifold GetForCircles(Length2 vA, CfIndex iA, Length2 vB, CfIndex iB) noexcept
+            {
+                return Manifold{e_circles, GetInvalid<UnitVec>(), vA, 1, {{Point{vB, GetVertexVertexContactFeature(iA, iB)}}}};
+            }
 
-    /// Local point.
-    /// @details Exact usage depends on manifold type (8-bytes).
-    /// @note Invalid for the unset manifold type.
-    Length2 m_localPoint = GetInvalid<Length2>();
-    
-    PointArray m_points; ///< Points of contact (at least 40-bytes). @see pointCount.
-};
+            // For Face A type manifolds...
 
-/// @brief Configuration data for manifold calculation.
-struct Manifold::Conf
-{
-    /// @brief Linear slop.
-    Length linearSlop = DefaultLinearSlop;
+            /// Gets a face A typed manifold.
+            /// @param normalA Local normal of the face from polygon A.
+            /// @param faceA Any point in local coordinates on the face whose normal was provided.
+            static inline Manifold GetForFaceA(UnitVec normalA, Length2 faceA) noexcept
+            {
+                return Manifold{e_faceA, normalA, faceA, 0, {{}}};
+            }
 
-    /// @brief Targeted depth of impact.
-    /// @note Value must be less than twice the minimum vertex radius of any shape.
-    Length targetDepth = DefaultLinearSlop * Real{3};
-    
-    /// @brief Tolerance.
-    Length tolerance = DefaultLinearSlop / Real{4}; ///< Tolerance.
-    
-    /// Max. circles ratio.
-    /// @details When the ratio of the closest face's length to the vertex radius is
-    ///   more than this amount, then face-manifolds are forced, else circles-manifolds
-    ///   may be computed for new contact manifolds.
-    Real maxCirclesRatio = DefaultCirclesRatio;
-};
+            /// Gets a face A typed manifold.
+            /// @param ln Normal on polygon A.
+            /// @param lp Center of face A.
+            /// @param mp1 Manifold point 1 (of 1).
+            static inline Manifold GetForFaceA(UnitVec ln, Length2 lp,
+                                               const Point& mp1) noexcept
+            {
+                //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
+                return Manifold{e_faceA, ln, lp, 1, {{mp1}}};
+            }
 
-/// @brief Gets the default manifold configuration.
-/// @relatedalso Manifold::Conf
-constexpr Manifold::Conf GetDefaultManifoldConf() noexcept
-{
-    return Manifold::Conf{};
-}
+            /// Gets a face A typed manifold.
+            /// @param ln Normal on polygon A.
+            /// @param lp Center of face A.
+            /// @param mp1 Manifold point 1 (of 2).
+            /// @param mp2 Manifold point 2 (of 2).
+            static inline Manifold GetForFaceA(UnitVec ln, Length2 lp,
+                                               const Point& mp1, const Point& mp2) noexcept
+            {
+                //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
+                //assert(mp2.contactFeature.typeA == ContactFeature::e_face || mp2.contactFeature.typeB == ContactFeature::e_face);
+                //assert(mp1.contactFeature != mp2.contactFeature);
+                return Manifold{e_faceA, ln, lp, 2, {{mp1, mp2}}};
+            }
 
-/// @brief Gets the manifold configuration for the given step configuration.
-/// @relatedalso Manifold::Conf
-Manifold::Conf GetManifoldConf(const StepConf& conf) noexcept;
+            // For Face B...
 
-constexpr Manifold::Manifold(Type t, UnitVec ln, Length2 lp, size_type n,
-                                          const PointArray& mpa) noexcept:
-    m_type{t}, m_pointCount{n}, m_localNormal{ln}, m_localPoint{lp}, m_points{mpa}
-{
-    assert(t != e_unset || n == 0);
-    assert(t == e_unset || IsValid(lp));
-    assert((t == e_unset) || (t == e_circles) || IsValid(ln));
-    assert((t != e_circles) || (n == 1 && !IsValid(ln)));
-    //assert((t != e_circles) || (n == 1 && !IsValid(ln) && mpa[0].contactFeature.typeA == ContactFeature::e_vertex && mpa[0].contactFeature.typeB == ContactFeature::e_vertex));
-}
+            /// Gets a face B typed manifold.
+            /// @param ln Normal on polygon B.
+            /// @param lp Center of face B.
+            static inline Manifold GetForFaceB(UnitVec ln, Length2 lp) noexcept
+            {
+                return Manifold{e_faceB, ln, lp, 0, {{}}};
+            }
 
-inline void Manifold::AddPoint(const Point& mp) noexcept
-{
-    assert(m_type != e_unset);
-    assert(m_type != e_circles || m_pointCount == 0);
-    assert(m_pointCount < MaxManifoldPoints);
-    // assert((m_pointCount == 0) || (mp.contactFeature != m_points[0].contactFeature));
-    //assert((m_type != e_circles) || (mp.contactFeature.typeA == ContactFeature::e_vertex || mp.contactFeature.typeB == ContactFeature::e_vertex));
-    //assert((m_type != e_faceA) || ((mp.contactFeature.typeA == ContactFeature::e_face) && (m_pointCount == 0 || mp.contactFeature.indexA == m_points[0].contactFeature.indexA)));
-    //assert((m_type != e_faceB) || (mp.contactFeature.typeB == ContactFeature::e_face));
-    m_points[m_pointCount] = mp;
-    ++m_pointCount;
-}
+            /// Gets a face B typed manifold.
+            /// @param ln Normal on polygon B.
+            /// @param lp Center of face B.
+            /// @param mp1 Manifold point 1.
+            static inline Manifold GetForFaceB(UnitVec ln, Length2 lp,
+                                               const Point& mp1) noexcept
+            {
+                //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
+                return Manifold{e_faceB, ln, lp, 1, {{mp1}}};
+            }
 
-inline void Manifold::AddPoint(CfType type, CfIndex index, Length2 point) noexcept
-{
-    assert(m_pointCount < MaxManifoldPoints);
-    switch (m_type)
-    {
-        case e_unset:
-            break;
-        case e_circles:
-            break;
-        case e_faceA:
-            m_points[m_pointCount].localPoint = point;
-            m_points[m_pointCount].contactFeature.typeB = type;
-            m_points[m_pointCount].contactFeature.indexB = index;
+            /// Gets a face B typed manifold.
+            /// @param ln Normal on polygon B.
+            /// @param lp Center of face B.
+            /// @param mp1 Manifold point 1 (of 2).
+            /// @param mp2 Manifold point 2 (of 2).
+            static inline Manifold GetForFaceB(UnitVec ln, Length2 lp,
+                                               const Point& mp1, const Point& mp2) noexcept
+            {
+                //assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB == ContactFeature::e_face);
+                //assert(mp2.contactFeature.typeA == ContactFeature::e_face || mp2.contactFeature.typeB == ContactFeature::e_face);
+                //assert(mp1.contactFeature != mp2.contactFeature);
+                return Manifold{e_faceB, ln, lp, 2, {{mp1, mp2}}};
+            }
+
+            /// @brief Gets the face A manifold for the given data.
+            static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa) noexcept
+            {
+                return Manifold{e_faceA, na, pa, 0, {{Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}}, Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, ia, ContactFeature::e_face, 0}}}}};
+            }
+
+            /// @brief Gets the face B manifold for the given data.
+            static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb) noexcept
+            {
+                return Manifold{e_faceB, nb, pb, 0, {{Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}}, Point{GetInvalid<Length2>(), ContactFeature{ContactFeature::e_face, 0, ContactFeature::e_face, ib}}}}};
+            }
+
+            /// @brief Gets the face A manifold for the given data.
+            static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa,
+                                               CfType tb0, CfIndex ib0, Length2 pb0) noexcept
+            {
+                return Manifold{e_faceA, na, pa, 1, {{Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}}, Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}}}}};
+            }
+
+            /// @brief Gets the face B manifold for the given data.
+            static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb,
+                                               CfType ta0, CfIndex ia0, Length2 pa0) noexcept
+            {
+                return Manifold{e_faceB, nb, pb, 1, {{Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}}, Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}}}}};
+            }
+
+            /// @brief Gets the face A manifold for the given data.
+            static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa,
+                                               CfType tb0, CfIndex ib0, Length2 pb0,
+                                               CfType tb1, CfIndex ib1, Length2 pb1) noexcept
+            {
+                return Manifold{e_faceA, na, pa, 2, {{Point{pb0, ContactFeature{ContactFeature::e_face, ia, tb0, ib0}}, Point{pb1, ContactFeature{ContactFeature::e_face, ia, tb1, ib1}}}}};
+            }
+
+            /// @brief Gets the face B manifold for the given data.
+            static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb,
+                                               CfType ta0, CfIndex ia0, Length2 pa0,
+                                               CfType ta1, CfIndex ia1, Length2 pa1) noexcept
+            {
+                return Manifold{e_faceB, nb, pb, 2, {{Point{pa0, ContactFeature{ta0, ia0, ContactFeature::e_face, ib}}, Point{pa1, ContactFeature{ta1, ia1, ContactFeature::e_face, ib}}}}};
+            }
+
+            /// Default constructor.
+            /// @details
+            /// Constructs an unset-type manifold.
+            /// For an unset-type manifold:
+            /// point count is zero, point data is undefined, and all other properties are invalid.
+            Manifold() = default;
+
+            /// @brief Copy constructor.
+            Manifold(const Manifold& copy) = default;
+
+            /// Gets the type of this manifold.
+            ///
+            /// @note This must be a constant expression in order to use it in the context
+            ///   of the <code>IsValid</code> specialized template function for it.
+            ///
+            constexpr Type GetType() const noexcept
+            {
+                return m_type;
+            }
+
+            /// Gets the manifold point count.
+            ///
+            /// @details This is the count of contact points for this manifold.
+            ///   Only up to this many points can be validly accessed using the
+            ///   <code>GetPoint()</code> method.
+            /// @note Non-zero values indicate that the two shapes are touching.
+            ///
+            /// @return Value between 0 and <code>MaxManifoldPoints</code>.
+            ///
+            /// @see MaxManifoldPoints.
+            /// @see AddPoint().
+            /// @see GetPoint().
+            ///
+            constexpr size_type GetPointCount() const noexcept
+            {
+                return m_pointCount;
+            }
+
+            /// @brief Gets the contact feature for the given index.
+            constexpr ContactFeature GetContactFeature(size_type index) const noexcept
+            {
+                assert(index < m_pointCount);
+                return m_points[index].contactFeature;
+            }
+
+            /// @brief Gets the contact impulses for the given index.
+            /// @return Pair of impulses where the first impulse is the "normal impulse"
+            ///   and the second impulse is the "tangent impulse".
+            constexpr Momentum2 GetContactImpulses(size_type index) const noexcept
+            {
+                assert(index < m_pointCount);
+                return Momentum2{m_points[index].normalImpulse, m_points[index].tangentImpulse};
+            }
+
+            /// @brief Sets the contact impulses for the given index.
+            /// @details Sets the contact impulses for the given index where the first impulse
+            ///   is the "normal impulse" and the second impulse is the "tangent impulse".
+            void SetContactImpulses(size_type index, Momentum2 value) noexcept
+            {
+                assert(index < m_pointCount);
+                m_points[index].normalImpulse = get<0>(value);
+                m_points[index].tangentImpulse = get<1>(value);
+            }
+
+            /// @brief Gets the point identified by the given index.
+            const Point& GetPoint(size_type index) const noexcept
+            {
+                assert((0 <= index) && (index < m_pointCount));
+                return m_points[index];
+            }
+
+            /// @brief Sets the point impulses for the given index.
+            void SetPointImpulses(size_type index, Momentum n, Momentum t)
+            {
+                assert((index < m_pointCount) || (index < MaxManifoldPoints && n == 0_Ns && t == 0_Ns));
+                m_points[index].normalImpulse = n;
+                m_points[index].tangentImpulse = t;
+            }
+
+            /// Adds a new point.
+            /// @details This can be called once for circle type manifolds,
+            ///   and up to twice for face-A or face-B type manifolds. <code>GetPointCount()</code>
+            ///   can be called to find out how many points have already been added.
+            /// @warning Behavior is undefined if this object's type is e_unset.
+            /// @warning Behavior is undefined if this is called more than twice.
+            void AddPoint(const Point& mp) noexcept;
+
+            /// @brief Adds a new point with the given data.
+            void AddPoint(CfType type, CfIndex index, Length2 point) noexcept;
+
+            /// @brief Gets the local normal for a face-type manifold.
+            /// @note Only valid for face-A or face-B type manifolds.
+            /// @warning Behavior is undefined for unset (e_unset) type manifolds.
+            /// @warning Behavior is undefined for circles (e_circles) type manifolds.
+            /// @return Local normal if the manifold type is face A or face B, else invalid value.
+            constexpr UnitVec GetLocalNormal() const noexcept
+            {
+                assert(m_type != e_unset);
+                assert(m_type != e_circles);
+                return m_localNormal;
+            }
+
+            /// @brief Gets the local point.
+            /// @details
+            /// This is the: local center of "circle" A for circles-type manifolds;
+            /// the center of face A for face-A-type manifolds; or
+            /// the center of face B for face-B-type manifolds.
+            /// @note Only valid for circle, face-A, or face-B type manifolds.
+            /// @warning Behavior is undefined for unset (e_unset) type manifolds.
+            /// @return Local point.
+            constexpr Length2 GetLocalPoint() const noexcept
+            {
+                assert(m_type != e_unset);
+                return m_localPoint;
+            }
+
+            /// @brief Gets the opposing point.
+            constexpr Length2 GetOpposingPoint(size_type index) const noexcept
+            {
+                assert((0 <= index) && (index < m_pointCount));
+                return m_points[index].localPoint;
+            }
+
+         private:
+            /// @brief Point array structure.
+            struct PointArray
+            {
+                Point elements[MaxManifoldPoints];///< Elements.
+
+                /// @brief Array indexing operator.
+                constexpr Point& operator[](std::size_t i)
+                {
+                    return elements[i];
+                }
+
+                /// @brief Array indexing operator.
+                constexpr const Point& operator[](std::size_t i) const
+                {
+                    return elements[i];
+                }
+            };
+
+            /// Constructs manifold with array of points using the given values.
+            /// @param t Manifold type.
+            /// @param ln Local normal.
+            /// @param lp Local point.
+            /// @param n number of points defined in array.
+            /// @param mpa Manifold point array.
+            constexpr Manifold(Type t, UnitVec ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
+
+            Type m_type = e_unset;     ///< Type of collision this manifold is associated with (1-byte).
+            size_type m_pointCount = 0;///< Number of defined manifold points (1-byte).
+
+            /// Local normal.
+            /// @details Exact usage depends on manifold type (8-bytes).
+            /// @note Invalid for the unset and circle manifold types.
+            UnitVec m_localNormal = GetInvalid<decltype(m_localNormal)>();
+
+            /// Local point.
+            /// @details Exact usage depends on manifold type (8-bytes).
+            /// @note Invalid for the unset manifold type.
+            Length2 m_localPoint = GetInvalid<Length2>();
+
+            PointArray m_points;///< Points of contact (at least 40-bytes). @see pointCount.
+        };
+
+        /// @brief Configuration data for manifold calculation.
+        struct Manifold::Conf
+        {
+            /// @brief Linear slop.
+            Length linearSlop = DefaultLinearSlop;
+
+            /// @brief Targeted depth of impact.
+            /// @note Value must be less than twice the minimum vertex radius of any shape.
+            Length targetDepth = DefaultLinearSlop * Real{3};
+
+            /// @brief Tolerance.
+            Length tolerance = DefaultLinearSlop / Real{4};///< Tolerance.
+
+            /// Max. circles ratio.
+            /// @details When the ratio of the closest face's length to the vertex radius is
+            ///   more than this amount, then face-manifolds are forced, else circles-manifolds
+            ///   may be computed for new contact manifolds.
+            Real maxCirclesRatio = DefaultCirclesRatio;
+        };
+
+        /// @brief Gets the default manifold configuration.
+        /// @relatedalso Manifold::Conf
+        constexpr Manifold::Conf GetDefaultManifoldConf() noexcept
+        {
+            return Manifold::Conf{};
+        }
+
+        /// @brief Gets the manifold configuration for the given step configuration.
+        /// @relatedalso Manifold::Conf
+        Manifold::Conf GetManifoldConf(const StepConf& conf) noexcept;
+
+        constexpr Manifold::Manifold(Type t, UnitVec ln, Length2 lp, size_type n,
+                                     const PointArray& mpa) noexcept
+            : m_type{t}, m_pointCount{n}, m_localNormal{ln}, m_localPoint{lp}, m_points{mpa}
+        {
+            assert(t != e_unset || n == 0);
+            assert(t == e_unset || IsValid(lp));
+            assert((t == e_unset) || (t == e_circles) || IsValid(ln));
+            assert((t != e_circles) || (n == 1 && !IsValid(ln)));
+            //assert((t != e_circles) || (n == 1 && !IsValid(ln) && mpa[0].contactFeature.typeA == ContactFeature::e_vertex && mpa[0].contactFeature.typeB == ContactFeature::e_vertex));
+        }
+
+        inline void Manifold::AddPoint(const Point& mp) noexcept
+        {
+            assert(m_type != e_unset);
+            assert(m_type != e_circles || m_pointCount == 0);
+            assert(m_pointCount < MaxManifoldPoints);
+            // assert((m_pointCount == 0) || (mp.contactFeature != m_points[0].contactFeature));
+            //assert((m_type != e_circles) || (mp.contactFeature.typeA == ContactFeature::e_vertex || mp.contactFeature.typeB == ContactFeature::e_vertex));
+            //assert((m_type != e_faceA) || ((mp.contactFeature.typeA == ContactFeature::e_face) && (m_pointCount == 0 || mp.contactFeature.indexA == m_points[0].contactFeature.indexA)));
+            //assert((m_type != e_faceB) || (mp.contactFeature.typeB == ContactFeature::e_face));
+            m_points[m_pointCount] = mp;
             ++m_pointCount;
-            break;
-        case e_faceB:
-            m_points[m_pointCount].localPoint = point;
-            m_points[m_pointCount].contactFeature.typeA = type;
-            m_points[m_pointCount].contactFeature.indexA = index;
-            ++m_pointCount;
-            break;
-    }
-}
+        }
 
-// Free functions...
+        inline void Manifold::AddPoint(CfType type, CfIndex index, Length2 point) noexcept
+        {
+            assert(m_pointCount < MaxManifoldPoints);
+            switch (m_type)
+            {
+            case e_unset:
+                break;
+            case e_circles:
+                break;
+            case e_faceA:
+                m_points[m_pointCount].localPoint = point;
+                m_points[m_pointCount].contactFeature.typeB = type;
+                m_points[m_pointCount].contactFeature.indexB = index;
+                ++m_pointCount;
+                break;
+            case e_faceB:
+                m_points[m_pointCount].localPoint = point;
+                m_points[m_pointCount].contactFeature.typeA = type;
+                m_points[m_pointCount].contactFeature.indexA = index;
+                ++m_pointCount;
+                break;
+            }
+        }
 
-/// @brief Determines whether the two given manifold points are equal.
-/// @relatedalso Manifold::Point
-bool operator==(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept;
+        // Free functions...
 
-/// @brief Determines whether the two given manifold points are not equal.
-/// @relatedalso Manifold::Point
-bool operator!=(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept;
+        /// @brief Determines whether the two given manifold points are equal.
+        /// @relatedalso Manifold::Point
+        bool operator==(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept;
 
-/// @brief Manifold equality operator.
-/// @note In-so-far as manifold points are concerned, order doesn't matter;
-///    only whether the two manifolds have the same point set.
-/// @relatedalso Manifold
-bool operator==(const Manifold& lhs, const Manifold& rhs) noexcept;
+        /// @brief Determines whether the two given manifold points are not equal.
+        /// @relatedalso Manifold::Point
+        bool operator!=(const Manifold::Point& lhs, const Manifold::Point& rhs) noexcept;
 
-/// @brief Manifold inequality operator.
-/// @details Determines whether the two given manifolds are not equal.
-/// @relatedalso Manifold
-bool operator!=(const Manifold& lhs, const Manifold& rhs) noexcept;
+        /// @brief Manifold equality operator.
+        /// @note In-so-far as manifold points are concerned, order doesn't matter;
+        ///    only whether the two manifolds have the same point set.
+        /// @relatedalso Manifold
+        bool operator==(const Manifold& lhs, const Manifold& rhs) noexcept;
 
-/// @brief Gets a face-to-face based manifold.
-/// @param flipped Whether to flip the resulting manifold (between face-A and face-B).
-/// @param shape0 Shape 0. This should be shape A for face-A type manifold or shape B for face-B
-///   type manifold.
-/// @param xf0 Transform 0. This should be transform A for face-A type manifold or transform B
-///   for face-B type manifold.
-/// @param idx0 Index 0. This should be the index of the vertex and normal of shape0 that had
-///   the maximal separation distance from any vertex in shape1.
-/// @param shape1 Shape 1. This should be shape B for face-A type manifold or shape A for face-B
-///   type manifold.
-/// @param xf1 Transform 1. This should be transform B for face-A type manifold or transform A
-///   for face-B type manifold.
-/// @param indices1 Index 1. This is the first and possibly second index of the vertex of shape1
-///   that had the maximal separation distance from the edge of shape0 identified by idx0.
-/// @param conf Manifold configuration data.
-Manifold GetManifold(bool flipped,
-                     const DistanceProxy& shape0, const Transformation& xf0,
-                     const VertexCounter idx0,
-                     const DistanceProxy& shape1, const Transformation& xf1,
-                     const VertexCounter2 indices1,
-                     const Manifold::Conf conf);
+        /// @brief Manifold inequality operator.
+        /// @details Determines whether the two given manifolds are not equal.
+        /// @relatedalso Manifold
+        bool operator!=(const Manifold& lhs, const Manifold& rhs) noexcept;
 
-/// @brief Computes manifolds for face-to-point collision.
-Manifold GetManifold(bool flipped, Length totalRadius,
-                     const DistanceProxy& shape, const Transformation& sxf,
-                     Length2 point, const Transformation& xfm);
+        /// @brief Gets a face-to-face based manifold.
+        /// @param flipped Whether to flip the resulting manifold (between face-A and face-B).
+        /// @param shape0 Shape 0. This should be shape A for face-A type manifold or shape B for face-B
+        ///   type manifold.
+        /// @param xf0 Transform 0. This should be transform A for face-A type manifold or transform B
+        ///   for face-B type manifold.
+        /// @param idx0 Index 0. This should be the index of the vertex and normal of shape0 that had
+        ///   the maximal separation distance from any vertex in shape1.
+        /// @param shape1 Shape 1. This should be shape B for face-A type manifold or shape A for face-B
+        ///   type manifold.
+        /// @param xf1 Transform 1. This should be transform B for face-A type manifold or transform A
+        ///   for face-B type manifold.
+        /// @param indices1 Index 1. This is the first and possibly second index of the vertex of shape1
+        ///   that had the maximal separation distance from the edge of shape0 identified by idx0.
+        /// @param conf Manifold configuration data.
+        Manifold GetManifold(bool flipped,
+                             const DistanceProxy& shape0, const Transformation& xf0,
+                             const VertexCounter idx0,
+                             const DistanceProxy& shape1, const Transformation& xf1,
+                             const VertexCounter2 indices1,
+                             const Manifold::Conf conf);
 
-/// @brief Gets a point-to-point based manifold.
-Manifold GetManifold(Length2 locationA, const Transformation& xfA,
-                     Length2 locationB, const Transformation& xfB,
-                     Length totalRadius) noexcept;
+        /// @brief Computes manifolds for face-to-point collision.
+        Manifold GetManifold(bool flipped, Length totalRadius,
+                             const DistanceProxy& shape, const Transformation& sxf,
+                             Length2 point, const Transformation& xfm);
 
-/// @brief Calculates the relevant collision manifold.
-///
-/// @note The returned touching state information typically agrees with that returned from
-///   the distance-proxy-based <code>TestOverlap</code> function. This is not always the
-///   case however especially when the separation or overlap distance is closer to zero.
-///
-/// @relatedalso Manifold
-///
-Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA,
-                       const DistanceProxy& shapeB, const Transformation& xfB,
-                       Manifold::Conf conf = GetDefaultManifoldConf());
+        /// @brief Gets a point-to-point based manifold.
+        Manifold GetManifold(Length2 locationA, const Transformation& xfA,
+                             Length2 locationB, const Transformation& xfB,
+                             Length totalRadius) noexcept;
+
+        /// @brief Calculates the relevant collision manifold.
+        ///
+        /// @note The returned touching state information typically agrees with that returned from
+        ///   the distance-proxy-based <code>TestOverlap</code> function. This is not always the
+        ///   case however especially when the separation or overlap distance is closer to zero.
+        ///
+        /// @relatedalso Manifold
+        ///
+        Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA,
+                               const DistanceProxy& shapeB, const Transformation& xfB,
+                               Manifold::Conf conf = GetDefaultManifoldConf());
 #if 0
 Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
                        const DistanceProxy& shapeB, const Transformation& xfB,
@@ -607,8 +599,8 @@ Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
 #endif
 
 #ifdef DEFINE_GET_MANIFOLD
-Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transformA,
-                     const DistanceProxy& proxyB, const Transformation& transformB);
+        Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transformA,
+                             const DistanceProxy& proxyB, const Transformation& transformB);
 #endif
 
 #if 0
@@ -616,19 +608,19 @@ Length2 GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
                        ContactFeature::Index index);
 #endif
 
-/// @brief Gets a unique name for the given manifold type.
-const char* GetName(Manifold::Type type) noexcept;
+        /// @brief Gets a unique name for the given manifold type.
+        const char* GetName(Manifold::Type type) noexcept;
 
-} // namespace d2
+    }// namespace d2
 
-/// @brief Gets whether the given manifold is valid.
-/// @relatedalso d2::Manifold
-template <>
-constexpr bool IsValid(const d2::Manifold& value) noexcept
-{
-    return value.GetType() != d2::Manifold::e_unset;
-}
+    /// @brief Gets whether the given manifold is valid.
+    /// @relatedalso d2::Manifold
+    template<>
+    constexpr bool IsValid(const d2::Manifold& value) noexcept
+    {
+        return value.GetType() != d2::Manifold::e_unset;
+    }
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COLLISION_MANIFOLD_HPP
+#endif// PLAYRHO_COLLISION_MANIFOLD_HPP

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -19,165 +19,167 @@
 
 #include <PlayRho/Collision/MassData.hpp>
 
-#include <PlayRho/Collision/Shapes/Shape.hpp>
-#include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
-#include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
+#include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
+#include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
+#include <PlayRho/Collision/Shapes/Shape.hpp>
 
-namespace playrho {
-namespace d2 {
-
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location)
+namespace playrho
 {
-    // Uses parallel axis theorem, perpendicular axis theorem, and the second moment of area.
-    // See: https://en.wikipedia.org/wiki/Second_moment_of_area
-    //
-    // Ixp = Ix + A * dx^2
-    // Iyp = Iy + A * dy^2
-    // Iz = Ixp + Iyp = Ix + A * dx^2 + Iy + A * dy^2
-    // Ix = Pi * r^4 / 4
-    // Iy = Pi * r^4 / 4
-    // Iz = (Pi * r^4 / 4) + (Pi * r^4 / 4) + (A * dx^2) + (A * dy^2)
-    //    = (Pi * r^4 / 2) + (A * (dx^2 + dy^2))
-    // A = Pi * r^2
-    // Iz = (Pi * r^4 / 2) + (2 * (Pi * r^2) * (dx^2 + dy^2))
-    // Iz = Pi * r^2 * ((r^2 / 2) + (dx^2 + dy^2))
-    const auto r_squared = r * r;
-    const auto area = r_squared * Pi;
-    const auto mass = Mass{AreaDensity{density} * area};
-    const auto Iz = SecondMomentOfArea{area * ((r_squared / Real{2}) + GetMagnitudeSquared(location))};
-    const auto I = RotInertia{Iz * AreaDensity{density} / SquareRadian};
-    return MassData{location, mass, I};
-}
-
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1)
-{
-    const auto r_squared = Area{r * r};
-    const auto circle_area = r_squared * Pi;
-    const auto circle_mass = density * circle_area;
-    const auto d = v1 - v0;
-    const auto offset = GetRevPerpendicular(GetUnitVector(d, UnitVec::GetZero())) * r;
-    const auto b = GetMagnitude(d);
-    const auto h = r * Real{2};
-    const auto rect_mass = density * b * h;
-    const auto totalMass = circle_mass + rect_mass;
-    const auto center = (v0 + v1) / Real{2};
-
-    /// Use the fixture's areal mass density times the shape's second moment of area to derive I.
-    /// @see https://en.wikipedia.org/wiki/Second_moment_of_area
-    const auto halfCircleArea = circle_area / 2;
-    const auto halfRSquared = r_squared / 2;
-    
-    const auto vertices = Vector<const Length2, 4>{
-        Length2{v0 + offset},
-        Length2{v0 - offset},
-        Length2{v1 - offset},
-        Length2{v1 + offset}
-    };
-    const auto I_z = GetPolarMoment(vertices);
-    const auto I0 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v0))};
-    const auto I1 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v1))};
-    assert(I0 >= SecondMomentOfArea{0});
-    assert(I1 >= SecondMomentOfArea{0});
-    assert(I_z >= SecondMomentOfArea{0});
-    const auto I = RotInertia{(I0 + I1 + I_z) * density / SquareRadian};
-    return MassData{center, totalMass, I};
-}
-
-MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
-                     Span<const Length2> vertices)
-{    
-    // See: https://en.wikipedia.org/wiki/Centroid#Centroid_of_polygon
-    
-    // Polygon mass, centroid, and inertia.
-    // Let rho be the polygon density in mass per unit area.
-    // Then:
-    // mass = rho * int(dA)
-    // centroid.x = (1/mass) * rho * int(x * dA)
-    // centroid.y = (1/mass) * rho * int(y * dA)
-    // I = rho * int((x*x + y*y) * dA)
-    //
-    // We can compute these integrals by summing all the integrals
-    // for each triangle of the polygon. To evaluate the integral
-    // for a single triangle, we make a change of variables to
-    // the (u,v) coordinates of the triangle:
-    // x = x0 + e1x * u + e2x * v
-    // y = y0 + e1y * u + e2y * v
-    // where 0 <= u && 0 <= v && u + v <= 1.
-    //
-    // We integrate u from [0,1-v] and then v from [0,1].
-    // We also need to use the Jacobian of the transformation:
-    // D = cross(e1, e2)
-    //
-    // Simplification: triangle centroid = (1/3) * (p1 + p2 + p3)
-    //
-    // The rest of the derivation is handled by computer algebra.
-    
-    const auto count = size(vertices);
-    switch (count)
+    namespace d2
     {
-        case 0:
-            return MassData{};
-        case 1:
-            return playrho::d2::GetMassData(vertexRadius, density, vertices[0]);
-        case 2:
-            return playrho::d2::GetMassData(vertexRadius, density, vertices[0], vertices[1]);
-        default:
-            break;
-    }
-    
-    auto center = Length2{};
-    auto area = 0_m2;
-    auto I = SecondMomentOfArea{0};
-    
-    // s is the reference point for forming triangles.
-    // It's location doesn't change the result (except for rounding error).
-    // This code puts the reference point inside the polygon.
-    const auto s = Average(vertices);
-    
-    for (auto i = decltype(count){0}; i < count; ++i)
-    {
-        // Triangle vertices.
-        const auto e1 = vertices[i] - s;
-        const auto e2 = vertices[GetModuloNext(i, count)] - s;
-        
-        const auto D = Cross(e1, e2);
-        
-        constexpr auto RealReciprocalOfTwo = Real{1} / Real{2}; // .5
-        const auto triangleArea = D * RealReciprocalOfTwo;
-        area += triangleArea;
-        
-        // Area weighted centroid
-        constexpr auto RealReciprocalOfThree = Real{1} / Real{3}; // .3333333...
-        center += StripUnit(triangleArea) * (e1 + e2) * RealReciprocalOfThree;
-        
-        const auto intx2 = Square(GetX(e1)) + GetX(e2) * GetX(e1) + Square(GetX(e2));
-        const auto inty2 = Square(GetY(e1)) + GetY(e2) * GetY(e1) + Square(GetY(e2));
-        
-        constexpr auto RealReciprocalOfTwelve = Real{1} / Real{3 * 4}; // .083333..
-        const auto triangleI = D * (intx2 + inty2) * RealReciprocalOfTwelve;
-        I += triangleI;
-    }
-    
-    // Total mass
-    const auto mass = Mass{AreaDensity{density} * area};
-    
-    // Center of mass
-    assert(area >= 0_m2);
-    center = ((area > 0_m2) && !AlmostZero(StripUnit(area)))
-        ? center / StripUnit(area): Length2{};
-    const auto massDataCenter = center + s;
-    
-    // Inertia tensor relative to the local origin (point s).
-    // Shift to center of mass then to original body origin.
-    const auto massCenterOffset = GetMagnitudeSquared(massDataCenter);
-    const auto centerOffset = GetMagnitudeSquared(center);
-    const auto inertialLever = massCenterOffset - centerOffset;
-    const auto massDataI = RotInertia{((AreaDensity{density} * I) + (mass * inertialLever)) / SquareRadian};
-    
-    return MassData{massDataCenter, mass, massDataI};
-}
 
-} // namespace d2
-} // namespace playrho
+        MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location)
+        {
+            // Uses parallel axis theorem, perpendicular axis theorem, and the second moment of area.
+            // See: https://en.wikipedia.org/wiki/Second_moment_of_area
+            //
+            // Ixp = Ix + A * dx^2
+            // Iyp = Iy + A * dy^2
+            // Iz = Ixp + Iyp = Ix + A * dx^2 + Iy + A * dy^2
+            // Ix = Pi * r^4 / 4
+            // Iy = Pi * r^4 / 4
+            // Iz = (Pi * r^4 / 4) + (Pi * r^4 / 4) + (A * dx^2) + (A * dy^2)
+            //    = (Pi * r^4 / 2) + (A * (dx^2 + dy^2))
+            // A = Pi * r^2
+            // Iz = (Pi * r^4 / 2) + (2 * (Pi * r^2) * (dx^2 + dy^2))
+            // Iz = Pi * r^2 * ((r^2 / 2) + (dx^2 + dy^2))
+            const auto r_squared = r * r;
+            const auto area = r_squared * Pi;
+            const auto mass = Mass{AreaDensity{density} * area};
+            const auto Iz = SecondMomentOfArea{area * ((r_squared / Real{2}) + GetMagnitudeSquared(location))};
+            const auto I = RotInertia{Iz * AreaDensity{density} / SquareRadian};
+            return MassData{location, mass, I};
+        }
+
+        MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1)
+        {
+            const auto r_squared = Area{r * r};
+            const auto circle_area = r_squared * Pi;
+            const auto circle_mass = density * circle_area;
+            const auto d = v1 - v0;
+            const auto offset = GetRevPerpendicular(GetUnitVector(d, UnitVec::GetZero())) * r;
+            const auto b = GetMagnitude(d);
+            const auto h = r * Real{2};
+            const auto rect_mass = density * b * h;
+            const auto totalMass = circle_mass + rect_mass;
+            const auto center = (v0 + v1) / Real{2};
+
+            /// Use the fixture's areal mass density times the shape's second moment of area to derive I.
+            /// @see https://en.wikipedia.org/wiki/Second_moment_of_area
+            const auto halfCircleArea = circle_area / 2;
+            const auto halfRSquared = r_squared / 2;
+
+            const auto vertices = Vector<const Length2, 4>{
+                Length2{v0 + offset},
+                Length2{v0 - offset},
+                Length2{v1 - offset},
+                Length2{v1 + offset}};
+            const auto I_z = GetPolarMoment(vertices);
+            const auto I0 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v0))};
+            const auto I1 = SecondMomentOfArea{halfCircleArea * (halfRSquared + GetMagnitudeSquared(v1))};
+            assert(I0 >= SecondMomentOfArea{0});
+            assert(I1 >= SecondMomentOfArea{0});
+            assert(I_z >= SecondMomentOfArea{0});
+            const auto I = RotInertia{(I0 + I1 + I_z) * density / SquareRadian};
+            return MassData{center, totalMass, I};
+        }
+
+        MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
+                             Span<const Length2> vertices)
+        {
+            // See: https://en.wikipedia.org/wiki/Centroid#Centroid_of_polygon
+
+            // Polygon mass, centroid, and inertia.
+            // Let rho be the polygon density in mass per unit area.
+            // Then:
+            // mass = rho * int(dA)
+            // centroid.x = (1/mass) * rho * int(x * dA)
+            // centroid.y = (1/mass) * rho * int(y * dA)
+            // I = rho * int((x*x + y*y) * dA)
+            //
+            // We can compute these integrals by summing all the integrals
+            // for each triangle of the polygon. To evaluate the integral
+            // for a single triangle, we make a change of variables to
+            // the (u,v) coordinates of the triangle:
+            // x = x0 + e1x * u + e2x * v
+            // y = y0 + e1y * u + e2y * v
+            // where 0 <= u && 0 <= v && u + v <= 1.
+            //
+            // We integrate u from [0,1-v] and then v from [0,1].
+            // We also need to use the Jacobian of the transformation:
+            // D = cross(e1, e2)
+            //
+            // Simplification: triangle centroid = (1/3) * (p1 + p2 + p3)
+            //
+            // The rest of the derivation is handled by computer algebra.
+
+            const auto count = size(vertices);
+            switch (count)
+            {
+            case 0:
+                return MassData{};
+            case 1:
+                return playrho::d2::GetMassData(vertexRadius, density, vertices[0]);
+            case 2:
+                return playrho::d2::GetMassData(vertexRadius, density, vertices[0], vertices[1]);
+            default:
+                break;
+            }
+
+            auto center = Length2{};
+            auto area = 0_m2;
+            auto I = SecondMomentOfArea{0};
+
+            // s is the reference point for forming triangles.
+            // It's location doesn't change the result (except for rounding error).
+            // This code puts the reference point inside the polygon.
+            const auto s = Average(vertices);
+
+            for (auto i = decltype(count){0}; i < count; ++i)
+            {
+                // Triangle vertices.
+                const auto e1 = vertices[i] - s;
+                const auto e2 = vertices[GetModuloNext(i, count)] - s;
+
+                const auto D = Cross(e1, e2);
+
+                constexpr auto RealReciprocalOfTwo = Real{1} / Real{2};// .5
+                const auto triangleArea = D * RealReciprocalOfTwo;
+                area += triangleArea;
+
+                // Area weighted centroid
+                constexpr auto RealReciprocalOfThree = Real{1} / Real{3};// .3333333...
+                center += StripUnit(triangleArea) * (e1 + e2) * RealReciprocalOfThree;
+
+                const auto intx2 = Square(GetX(e1)) + GetX(e2) * GetX(e1) + Square(GetX(e2));
+                const auto inty2 = Square(GetY(e1)) + GetY(e2) * GetY(e1) + Square(GetY(e2));
+
+                constexpr auto RealReciprocalOfTwelve = Real{1} / Real{3 * 4};// .083333..
+                const auto triangleI = D * (intx2 + inty2) * RealReciprocalOfTwelve;
+                I += triangleI;
+            }
+
+            // Total mass
+            const auto mass = Mass{AreaDensity{density} * area};
+
+            // Center of mass
+            assert(area >= 0_m2);
+            center = ((area > 0_m2) && !AlmostZero(StripUnit(area)))
+                         ? center / StripUnit(area)
+                         : Length2{};
+            const auto massDataCenter = center + s;
+
+            // Inertia tensor relative to the local origin (point s).
+            // Shift to center of mass then to original body origin.
+            const auto massCenterOffset = GetMagnitudeSquared(massDataCenter);
+            const auto centerOffset = GetMagnitudeSquared(center);
+            const auto inertialLever = massCenterOffset - centerOffset;
+            const auto massDataI = RotInertia{((AreaDensity{density} * I) + (mass * inertialLever)) / SquareRadian};
+
+            return MassData{massDataCenter, mass, massDataI};
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -31,74 +31,77 @@
 #include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/FixtureID.hpp>
 
-namespace playrho {
-namespace detail {
-
-/// @brief Mass data.
-/// @details This holds the mass data computed for a shape.
-template <std::size_t N>
-struct MassData
+namespace playrho
 {
-    /// @brief Position of the shape's centroid relative to the shape's origin.
-    Vector<Length, N> center = Vector<Length, N>{};
-    
-    /// @brief Mass of the shape in kilograms.
-    NonNegative<Mass> mass = NonNegative<Mass>{0_kg};
-    
-    /// @brief Rotational inertia, a.k.a. moment of inertia.
-    /// @details This is the rotational inertia of the shape about the local origin.
-    /// @see https://en.wikipedia.org/wiki/Moment_of_inertia
-    NonNegative<RotInertia> I = NonNegative<RotInertia>{0 * 1_m2 * 1_kg / SquareRadian};
-};
+    namespace detail
+    {
 
-// Free functions...
+        /// @brief Mass data.
+        /// @details This holds the mass data computed for a shape.
+        template<std::size_t N>
+        struct MassData
+        {
+            /// @brief Position of the shape's centroid relative to the shape's origin.
+            Vector<Length, N> center = Vector<Length, N>{};
 
-/// @brief Equality operator for mass data.
-/// @relatedalso MassData
-template <std::size_t N>
-constexpr bool operator== (MassData<N> lhs, MassData<N> rhs)
-{
-    return lhs.center == rhs.center && lhs.mass == rhs.mass && lhs.I == rhs.I;
-}
+            /// @brief Mass of the shape in kilograms.
+            NonNegative<Mass> mass = NonNegative<Mass>{0_kg};
 
-/// @brief Inequality operator for mass data.
-/// @relatedalso MassData
-template <std::size_t N>
-constexpr bool operator!= (MassData<N> lhs, MassData<N> rhs)
-{
-    return !(lhs == rhs);
-}
-} // namespace detail
+            /// @brief Rotational inertia, a.k.a. moment of inertia.
+            /// @details This is the rotational inertia of the shape about the local origin.
+            /// @see https://en.wikipedia.org/wiki/Moment_of_inertia
+            NonNegative<RotInertia> I = NonNegative<RotInertia>{0 * 1_m2 * 1_kg / SquareRadian};
+        };
 
-namespace d2 {
+        // Free functions...
 
-/// @brief Mass data alias for 2-D objects.
-/// @note This data structure is 16-bytes large (on at least one 64-bit platform).
-using MassData = detail::MassData<2>;
+        /// @brief Equality operator for mass data.
+        /// @relatedalso MassData
+        template<std::size_t N>
+        constexpr bool operator==(MassData<N> lhs, MassData<N> rhs)
+        {
+            return lhs.center == rhs.center && lhs.mass == rhs.mass && lhs.I == rhs.I;
+        }
 
-/// @brief Computes the mass data for a circular shape.
-///
-/// @param r Radius of the circular shape.
-/// @param density Areal density of mass.
-/// @param location Location of the center of the shape.
-///
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location);
+        /// @brief Inequality operator for mass data.
+        /// @relatedalso MassData
+        template<std::size_t N>
+        constexpr bool operator!=(MassData<N> lhs, MassData<N> rhs)
+        {
+            return !(lhs == rhs);
+        }
+    }// namespace detail
 
-/// @brief Computes the mass data for a linear shape.
-///
-/// @param r Radius of the vertices of the linear shape.
-/// @param density Areal density of mass.
-/// @param v0 Location of vertex zero.
-/// @param v1 Location of vertex one.
-///
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1);
+    namespace d2
+    {
 
-/// @brief Gets the mass data for the given collection of vertices with the given
-///    properties.
-MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
-                     Span<const Length2> vertices);
+        /// @brief Mass data alias for 2-D objects.
+        /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
+        using MassData = detail::MassData<2>;
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Computes the mass data for a circular shape.
+        ///
+        /// @param r Radius of the circular shape.
+        /// @param density Areal density of mass.
+        /// @param location Location of the center of the shape.
+        ///
+        MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location);
 
-#endif // PLAYRHO_COLLISION_MASSDATA_HPP
+        /// @brief Computes the mass data for a linear shape.
+        ///
+        /// @param r Radius of the vertices of the linear shape.
+        /// @param density Areal density of mass.
+        /// @param v0 Location of vertex zero.
+        /// @param v1 Location of vertex one.
+        ///
+        MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1);
+
+        /// @brief Gets the mass data for the given collection of vertices with the given
+        ///    properties.
+        MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
+                             Span<const Length2> vertices);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_MASSDATA_HPP

--- a/PlayRho/Collision/RayCastInput.hpp
+++ b/PlayRho/Collision/RayCastInput.hpp
@@ -28,30 +28,33 @@
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/UnitInterval.hpp>
 
-namespace playrho {
-namespace detail {
-
-/// @brief Ray-cast input data for N-dimensions.
-/// @note The ray extends from <code>p1</code> to <code>p1 + maxFraction * (p2 - p1)</code>.
-template <std::size_t N>
-struct RayCastInput
+namespace playrho
 {
-    Vector<Length, N> p1; ///< Point 1.
-    Vector<Length, N> p2; ///< Point 2.
-    
-    /// @brief Max fraction.
-    /// @details Unit interval value - a value between 0 and 1 inclusive.
-    UnitInterval<Real> maxFraction = UnitInterval<Real>{0};
-};
+    namespace detail
+    {
 
-} // namespace detail
+        /// @brief Ray-cast input data for N-dimensions.
+        /// @note The ray extends from <code>p1</code> to <code>p1 + maxFraction * (p2 - p1)</code>.
+        template<std::size_t N>
+        struct RayCastInput
+        {
+            Vector<Length, N> p1;///< Point 1.
+            Vector<Length, N> p2;///< Point 2.
 
-namespace d2 {
+            /// @brief Max fraction.
+            /// @details Unit interval value - a value between 0 and 1 inclusive.
+            UnitInterval<Real> maxFraction = UnitInterval<Real>{0};
+        };
 
-/// @brief Ray cast input data for 2-dimensions.
-using RayCastInput = playrho::detail::RayCastInput<2>;
+    }// namespace detail
 
-} // namespace d2
-} // namespace playrho
+    namespace d2
+    {
 
-#endif // PLAYRHO_COLLISION_RAYCASTINPUT_HPP
+        /// @brief Ray cast input data for 2-dimensions.
+        using RayCastInput = playrho::detail::RayCastInput<2>;
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_RAYCASTINPUT_HPP

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -19,319 +19,322 @@
 
 #include <PlayRho/Collision/RayCastOutput.hpp>
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/GrowableStack.hpp>
-#include <PlayRho/Collision/RayCastInput.hpp>
 #include <PlayRho/Collision/AABB.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/DynamicTree.hpp>
+#include <PlayRho/Collision/RayCastInput.hpp>
+#include <PlayRho/Common/GrowableStack.hpp>
+#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Dynamics/WorldBody.hpp>
 #include <PlayRho/Dynamics/WorldFixture.hpp>
 #include <PlayRho/Dynamics/WorldMisc.hpp>
 
 #include <utility>
 
-namespace playrho {
-namespace d2 {
-
-RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept
+namespace playrho
 {
-    // Collision Detection in Interactive 3D Environments by Gino van den Bergen
-    // From Section 3.1.2
-    // x = s + a * r
-    // norm(x) = radius
-    
-    const auto s = input.p1 - location;
-    const auto b = GetMagnitudeSquared(s) - Square(radius);
-    
-    // Solve quadratic equation.
-    const auto raySegment = input.p2 - input.p1; // Length2
-    const auto c =  Dot(s, raySegment); // Area
-    const auto rr = GetMagnitudeSquared(raySegment); // Area
-    const auto sigma = Real{(Square(c) - rr * b) / (SquareMeter * SquareMeter)};
-    
-    // Check for negative discriminant and short segment.
-    if ((sigma < Real{0}) || AlmostZero(Real{rr / SquareMeter}))
+    namespace d2
     {
-        return RayCastOutput{};
-    }
-    
-    // Find the point of intersection of the line with the circle.
-    const auto a = -(c + sqrt(sigma) * SquareMeter);
-    const auto fraction = Real{a / rr};
 
-    // Is the intersection point on the segment?
-    if ((fraction >= Real{0}) && (fraction <= input.maxFraction))
-    {
-        const auto normal = GetUnitVector(s + fraction * raySegment, UnitVec::GetZero());
-        return RayCastOutput{{normal, fraction}};
-    }
-    
-    return RayCastOutput{};
-}
-
-RayCastOutput RayCast(const AABB& aabb, const RayCastInput& input) noexcept
-{
-    // From Real-time Collision Detection, p179.
-
-    auto normal = UnitVec{};
-    auto tmin = -MaxFloat;
-    auto tmax = MaxFloat;
-    
-    const auto p1 = input.p1;
-    const auto pDelta = input.p2 - input.p1;
-    for (auto i = decltype(pDelta.max_size()){0}; i < pDelta.max_size(); ++i)
-    {
-        const auto p1i = p1[i];
-        const auto pdi = pDelta[i];
-        const auto range = aabb.ranges[i];
-
-        if (AlmostZero(pdi))
+        RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept
         {
-            // Parallel.
-            if ((p1i < range.GetMin()) || (p1i > range.GetMax()))
+            // Collision Detection in Interactive 3D Environments by Gino van den Bergen
+            // From Section 3.1.2
+            // x = s + a * r
+            // norm(x) = radius
+
+            const auto s = input.p1 - location;
+            const auto b = GetMagnitudeSquared(s) - Square(radius);
+
+            // Solve quadratic equation.
+            const auto raySegment = input.p2 - input.p1;    // Length2
+            const auto c = Dot(s, raySegment);              // Area
+            const auto rr = GetMagnitudeSquared(raySegment);// Area
+            const auto sigma = Real{(Square(c) - rr * b) / (SquareMeter * SquareMeter)};
+
+            // Check for negative discriminant and short segment.
+            if ((sigma < Real{0}) || AlmostZero(Real{rr / SquareMeter}))
             {
                 return RayCastOutput{};
             }
-        }
-        else
-        {
-            const auto reciprocalOfPdi = Real{1} / pdi;
-            auto t1 = Real{(range.GetMin() - p1i) * reciprocalOfPdi};
-            auto t2 = Real{(range.GetMax() - p1i) * reciprocalOfPdi};
-            auto s = -1; // Sign of the normal vector.
-            if (t1 > t2)
+
+            // Find the point of intersection of the line with the circle.
+            const auto a = -(c + sqrt(sigma) * SquareMeter);
+            const auto fraction = Real{a / rr};
+
+            // Is the intersection point on the segment?
+            if ((fraction >= Real{0}) && (fraction <= input.maxFraction))
             {
-                swap(t1, t2);
-                s = 1;
+                const auto normal = GetUnitVector(s + fraction * raySegment, UnitVec::GetZero());
+                return RayCastOutput{{normal, fraction}};
             }
-            if (tmin < t1)
-            {
-                normal = (i == 0)?
-                    ((s < 0)? UnitVec::GetLeft(): UnitVec::GetRight()):
-                    ((s < 0)? UnitVec::GetBottom(): UnitVec::GetTop());
-                tmin = t1; // Push the min up
-            }
-            tmax = std::min(tmax, t2); // Pull the max down
-            if (tmin > tmax)
-            {
-                return RayCastOutput{};
-            }
-        }
-    };
-    
-    // Does the ray start inside the box?
-    // Does the ray intersect beyond the max fraction?
-    if ((tmin < 0) || (tmin > input.maxFraction))
-    {
-        return RayCastOutput{};
-    }
-    
-    // Intersection.
-    return RayCastOutput{{normal, tmin}};
-}
 
-RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
-                      const Transformation& transform) noexcept
-{
-    const auto vertexCount = proxy.GetVertexCount();
-    assert(vertexCount > 0);
-
-    const auto radius = proxy.GetVertexRadius();
-    auto v0 = proxy.GetVertex(0);
-    if (vertexCount == 1)
-    {
-        return RayCast(radius, Transform(v0, transform), input);
-    }
-
-    // Uses algorithm described at http://stackoverflow.com/a/565282/7410358
-    //
-    // The SO author gave the algorithm the following credit:
-    //   "Intersection of two lines in three-space" by Ronald Goldman,
-    //     published in Graphics Gems, page 304.
-
-    // Solve for p + t r = q + u s
-    
-    // p is input.p1
-    // q is the offset vertex
-    // s is vertexDelta
-    // r is rayDelta
-    // t = (q - p) x s / (r x s)
-    // u = (q - p) x r / (r x s)
-
-    // Put the ray into the polygon's frame of reference.
-    const auto transformedInput = RayCastInput{
-        InverseTransform(input.p1, transform),
-        InverseTransform(input.p2, transform),
-        input.maxFraction
-    };
-    const auto ray0 = transformedInput.p1;
-    const auto ray = transformedInput.p2 - transformedInput.p1; // Ray delta (p2 - p1)
-    
-    auto minT = nextafter(Real{input.maxFraction}, Real(2));
-    auto normalFound = GetInvalid<UnitVec>();
-    
-    for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
-    {
-        const auto circleResult = RayCast(radius, v0, transformedInput);
-        if (circleResult.has_value() && (minT > circleResult->fraction))
-        {
-            minT = circleResult->fraction;
-            normalFound = circleResult->normal;
+            return RayCastOutput{};
         }
 
-        const auto v1 = proxy.GetVertex(GetModuloNext(i, vertexCount));
-        const auto edge = v1 - v0; // Vertex delta
-        const auto ray_cross_edge = Cross(ray, edge);
-        
-        if (!AlmostZero(Real{ray_cross_edge / SquareMeter}))
+        RayCastOutput RayCast(const AABB& aabb, const RayCastInput& input) noexcept
         {
-            const auto normal = proxy.GetNormal(i);
-            const auto offset = normal * radius;
-            const auto v0off = v0 + offset;
-            const auto q_sub_p = v0off - ray0;
-            
-            const auto reciprocalRayCrossEdge = Real{1} / ray_cross_edge;
+            // From Real-time Collision Detection, p179.
 
-            // t = ((q - p) x s) / (r x s)
-            const auto t = Cross(q_sub_p, edge) * reciprocalRayCrossEdge;
-            
-            // u = ((q - p) x r) / (r x s)
-            const auto u = Cross(q_sub_p, ray) * reciprocalRayCrossEdge;
+            auto normal = UnitVec{};
+            auto tmin = -MaxFloat;
+            auto tmax = MaxFloat;
 
-            if ((t >= 0) && (t <= 1) && (u >= 0) && (u <= 1))
+            const auto p1 = input.p1;
+            const auto pDelta = input.p2 - input.p1;
+            for (auto i = decltype(pDelta.max_size()){0}; i < pDelta.max_size(); ++i)
             {
-                // The two lines meet at the point p + t r = q + u s
-                if (minT > t)
+                const auto p1i = p1[i];
+                const auto pdi = pDelta[i];
+                const auto range = aabb.ranges[i];
+
+                if (AlmostZero(pdi))
                 {
-                    minT = t;
-                    normalFound = normal;
+                    // Parallel.
+                    if ((p1i < range.GetMin()) || (p1i > range.GetMax()))
+                    {
+                        return RayCastOutput{};
+                    }
+                }
+                else
+                {
+                    const auto reciprocalOfPdi = Real{1} / pdi;
+                    auto t1 = Real{(range.GetMin() - p1i) * reciprocalOfPdi};
+                    auto t2 = Real{(range.GetMax() - p1i) * reciprocalOfPdi};
+                    auto s = -1;// Sign of the normal vector.
+                    if (t1 > t2)
+                    {
+                        swap(t1, t2);
+                        s = 1;
+                    }
+                    if (tmin < t1)
+                    {
+                        normal = (i == 0) ? ((s < 0) ? UnitVec::GetLeft() : UnitVec::GetRight()) : ((s < 0) ? UnitVec::GetBottom() : UnitVec::GetTop());
+                        tmin = t1;// Push the min up
+                    }
+                    tmax = std::min(tmax, t2);// Pull the max down
+                    if (tmin > tmax)
+                    {
+                        return RayCastOutput{};
+                    }
+                }
+            };
+
+            // Does the ray start inside the box?
+            // Does the ray intersect beyond the max fraction?
+            if ((tmin < 0) || (tmin > input.maxFraction))
+            {
+                return RayCastOutput{};
+            }
+
+            // Intersection.
+            return RayCastOutput{{normal, tmin}};
+        }
+
+        RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
+                              const Transformation& transform) noexcept
+        {
+            const auto vertexCount = proxy.GetVertexCount();
+            assert(vertexCount > 0);
+
+            const auto radius = proxy.GetVertexRadius();
+            auto v0 = proxy.GetVertex(0);
+            if (vertexCount == 1)
+            {
+                return RayCast(radius, Transform(v0, transform), input);
+            }
+
+            // Uses algorithm described at http://stackoverflow.com/a/565282/7410358
+            //
+            // The SO author gave the algorithm the following credit:
+            //   "Intersection of two lines in three-space" by Ronald Goldman,
+            //     published in Graphics Gems, page 304.
+
+            // Solve for p + t r = q + u s
+
+            // p is input.p1
+            // q is the offset vertex
+            // s is vertexDelta
+            // r is rayDelta
+            // t = (q - p) x s / (r x s)
+            // u = (q - p) x r / (r x s)
+
+            // Put the ray into the polygon's frame of reference.
+            const auto transformedInput = RayCastInput{
+                InverseTransform(input.p1, transform),
+                InverseTransform(input.p2, transform),
+                input.maxFraction};
+            const auto ray0 = transformedInput.p1;
+            const auto ray = transformedInput.p2 - transformedInput.p1;// Ray delta (p2 - p1)
+
+            auto minT = nextafter(Real{input.maxFraction}, Real(2));
+            auto normalFound = GetInvalid<UnitVec>();
+
+            for (auto i = decltype(vertexCount){0}; i < vertexCount; ++i)
+            {
+                const auto circleResult = RayCast(radius, v0, transformedInput);
+                if (circleResult.has_value() && (minT > circleResult->fraction))
+                {
+                    minT = circleResult->fraction;
+                    normalFound = circleResult->normal;
+                }
+
+                const auto v1 = proxy.GetVertex(GetModuloNext(i, vertexCount));
+                const auto edge = v1 - v0;// Vertex delta
+                const auto ray_cross_edge = Cross(ray, edge);
+
+                if (!AlmostZero(Real{ray_cross_edge / SquareMeter}))
+                {
+                    const auto normal = proxy.GetNormal(i);
+                    const auto offset = normal * radius;
+                    const auto v0off = v0 + offset;
+                    const auto q_sub_p = v0off - ray0;
+
+                    const auto reciprocalRayCrossEdge = Real{1} / ray_cross_edge;
+
+                    // t = ((q - p) x s) / (r x s)
+                    const auto t = Cross(q_sub_p, edge) * reciprocalRayCrossEdge;
+
+                    // u = ((q - p) x r) / (r x s)
+                    const auto u = Cross(q_sub_p, ray) * reciprocalRayCrossEdge;
+
+                    if ((t >= 0) && (t <= 1) && (u >= 0) && (u <= 1))
+                    {
+                        // The two lines meet at the point p + t r = q + u s
+                        if (minT > t)
+                        {
+                            minT = t;
+                            normalFound = normal;
+                        }
+                    }
+                    else
+                    {
+                        // The two line segments are not parallel but do not intersect.
+                    }
+                }
+                else
+                {
+                    // The two lines are parallel, ignored.
+                }
+
+                v0 = v1;
+            }
+
+            if (minT <= input.maxFraction)
+            {
+                return RayCastOutput{{Rotate(normalFound, transform.q), minT}};
+            }
+            return RayCastOutput{};
+        }
+
+        RayCastOutput RayCast(const Shape& shape, ChildCounter childIndex,
+                              const RayCastInput& input, const Transformation& transform) noexcept
+        {
+            return RayCast(GetChild(shape, childIndex), input, transform);
+        }
+
+        bool RayCast(const DynamicTree& tree, RayCastInput input, const DynamicTreeRayCastCB& callback)
+        {
+            const auto v = GetRevPerpendicular(GetUnitVector(input.p2 - input.p1, UnitVec::GetZero()));
+            const auto abs_v = abs(v);
+            auto segmentAABB = d2::GetAABB(input);
+
+            GrowableStack<ContactCounter, 256> stack;
+            stack.push(tree.GetRootIndex());
+            while (!empty(stack))
+            {
+                const auto index = stack.top();
+                stack.pop();
+                if (index == DynamicTree::GetInvalidSize())
+                {
+                    continue;
+                }
+
+                const auto aabb = tree.GetAABB(index);
+                if (!TestOverlap(aabb, segmentAABB))
+                {
+                    continue;
+                }
+
+                // Separating axis for segment (Gino, p80).
+                // |dot(v, p1 - ctr)| > dot(|v|, extents)
+                const auto center = GetCenter(aabb);
+                const auto extents = GetExtents(aabb);
+                const auto separation = abs(Dot(v, input.p1 - center)) - Dot(abs_v, extents);
+                if (separation > 0_m)
+                {
+                    continue;
+                }
+
+                if (DynamicTree::IsBranch(tree.GetHeight(index)))
+                {
+                    const auto branchData = tree.GetBranchData(index);
+                    stack.push(branchData.child1);
+                    stack.push(branchData.child2);
+                }
+                else
+                {
+                    assert(DynamicTree::IsLeaf(tree.GetHeight(index)));
+                    const auto leafData = tree.GetLeafData(index);
+                    const auto value = callback(leafData.body, leafData.fixture, leafData.childIndex,
+                                                input);
+                    if (value == 0)
+                    {
+                        return true;// Callback has terminated the ray cast.
+                    }
+                    if (value > 0)
+                    {
+                        // Update segment bounding box.
+                        input.maxFraction = value;
+                        segmentAABB = d2::GetAABB(input);
+                    }
                 }
             }
-            else
-            {
-                // The two line segments are not parallel but do not intersect.
-            }
+            return false;
         }
-        else
-        {
-            // The two lines are parallel, ignored.
-        }
-        
-        v0 = v1;
-    }
-    
-    if (minT <= input.maxFraction)
-    {
-        return RayCastOutput{{Rotate(normalFound, transform.q), minT}};
-    }
-    return RayCastOutput{};
-}
 
-RayCastOutput RayCast(const Shape& shape, ChildCounter childIndex,
-                      const RayCastInput& input, const Transformation& transform) noexcept
-{
-    return RayCast(GetChild(shape, childIndex), input, transform);
-}
+        bool RayCast(const World& world, const RayCastInput& input, const FixtureRayCastCB& callback)
+        {
+            return RayCast(GetTree(world), input,
+                           [&world, &callback](BodyID body, FixtureID fixture, ChildCounter index,
+                                               const RayCastInput& rci) {
+                               const auto output = RayCast(GetChild(GetShape(world, fixture), index), rci,
+                                                           GetTransformation(world, body));
+                               if (output.has_value())
+                               {
+                                   const auto fraction = output->fraction;
+                                   assert(fraction >= 0 && fraction <= 1);
 
-bool RayCast(const DynamicTree& tree, RayCastInput input, const DynamicTreeRayCastCB& callback)
-{    
-    const auto v = GetRevPerpendicular(GetUnitVector(input.p2 - input.p1, UnitVec::GetZero()));
-    const auto abs_v = abs(v);
-    auto segmentAABB = d2::GetAABB(input);
-    
-    GrowableStack<ContactCounter, 256> stack;
-    stack.push(tree.GetRootIndex());
-    while (!empty(stack))
-    {
-        const auto index = stack.top();
-        stack.pop();
-        if (index == DynamicTree::GetInvalidSize())
-        {
-            continue;
+                                   // Here point can be calculated these two ways:
+                                   //   (1) point = p1 * (1 - fraction) + p2 * fraction
+                                   //   (2) point = p1 + (p2 - p1) * fraction.
+                                   //
+                                   // The first way however suffers from the fact that:
+                                   //     a * (1 - fraction) + a * fraction != a
+                                   // for all values of a and fraction between 0 and 1 when a and fraction are
+                                   // floating point types.
+                                   // This leads to the posibility that (p1 == p2) && (point != p1 || point != p2),
+                                   // which may be pretty surprising to the callback. So this way SHOULD NOT be used.
+                                   //
+                                   // The second way, does not have this problem.
+                                   //
+                                   const auto point = rci.p1 + (rci.p2 - rci.p1) * fraction;
+                                   const auto opcode = callback(body, fixture, index, point, output->normal);
+                                   switch (opcode)
+                                   {
+                                   case RayCastOpcode::Terminate:
+                                       return Real{0};
+                                   case RayCastOpcode::IgnoreFixture:
+                                       return Real{-1};
+                                   case RayCastOpcode::ClipRay:
+                                       return Real{fraction};
+                                   case RayCastOpcode::ResetRay:
+                                       return Real{rci.maxFraction};
+                                   }
+                               }
+                               return Real{rci.maxFraction};
+                           });
         }
-        
-        const auto aabb = tree.GetAABB(index);
-        if (!TestOverlap(aabb, segmentAABB))
-        {
-            continue;
-        }
-        
-        // Separating axis for segment (Gino, p80).
-        // |dot(v, p1 - ctr)| > dot(|v|, extents)
-        const auto center = GetCenter(aabb);
-        const auto extents = GetExtents(aabb);
-        const auto separation = abs(Dot(v, input.p1 - center)) - Dot(abs_v, extents);
-        if (separation > 0_m)
-        {
-            continue;
-        }
-        
-        if (DynamicTree::IsBranch(tree.GetHeight(index)))
-        {
-            const auto branchData = tree.GetBranchData(index);
-            stack.push(branchData.child1);
-            stack.push(branchData.child2);
-        }
-        else
-        {
-            assert(DynamicTree::IsLeaf(tree.GetHeight(index)));
-            const auto leafData = tree.GetLeafData(index);
-            const auto value = callback(leafData.body, leafData.fixture, leafData.childIndex,
-                                        input);
-            if (value == 0)
-            {
-                return true; // Callback has terminated the ray cast.
-            }
-            if (value > 0)
-            {
-                // Update segment bounding box.
-                input.maxFraction = value;
-                segmentAABB = d2::GetAABB(input);
-            }
-        }
-    }
-    return false;
-}
 
-bool RayCast(const World& world, const RayCastInput& input, const FixtureRayCastCB& callback)
-{
-    return RayCast(GetTree(world), input,
-                   [&world,&callback](BodyID body, FixtureID fixture, ChildCounter index,
-                                      const RayCastInput& rci) {
-        const auto output = RayCast(GetChild(GetShape(world, fixture), index), rci,
-                                    GetTransformation(world, body));
-        if (output.has_value())
-        {
-            const auto fraction = output->fraction;
-            assert(fraction >= 0 && fraction <= 1);
-            
-            // Here point can be calculated these two ways:
-            //   (1) point = p1 * (1 - fraction) + p2 * fraction
-            //   (2) point = p1 + (p2 - p1) * fraction.
-            //
-            // The first way however suffers from the fact that:
-            //     a * (1 - fraction) + a * fraction != a
-            // for all values of a and fraction between 0 and 1 when a and fraction are
-            // floating point types.
-            // This leads to the posibility that (p1 == p2) && (point != p1 || point != p2),
-            // which may be pretty surprising to the callback. So this way SHOULD NOT be used.
-            //
-            // The second way, does not have this problem.
-            //
-            const auto point = rci.p1 + (rci.p2 - rci.p1) * fraction;
-            const auto opcode = callback(body, fixture, index, point, output->normal);
-            switch (opcode)
-            {
-                case RayCastOpcode::Terminate: return Real{0};
-                case RayCastOpcode::IgnoreFixture: return Real{-1};
-                case RayCastOpcode::ClipRay: return Real{fraction};
-                case RayCastOpcode::ResetRay: return Real{rci.maxFraction};
-            }
-        }
-        return Real{rci.maxFraction};
-    });
-}
-
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/RayCastOutput.hpp
+++ b/PlayRho/Collision/RayCastOutput.hpp
@@ -25,156 +25,158 @@
 /// @file
 /// Declaration of the RayCastOutput structure and related free functions.
 
-#include <PlayRho/Common/UnitInterval.hpp>
-#include <PlayRho/Common/OptionalValue.hpp>
 #include <PlayRho/Collision/RayCastInput.hpp>
+#include <PlayRho/Common/OptionalValue.hpp>
+#include <PlayRho/Common/UnitInterval.hpp>
 
 #include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/FixtureID.hpp>
 
-namespace playrho {
-namespace detail {
-
-template <std::size_t N>
-struct AABB;
-
-} // namespace detail
-
-/// @brief Ray cast opcode enumeration.
-/// @details Instructs some ray casting methods on what to do next.
-enum class RayCastOpcode
+namespace playrho
 {
-    /// @brief End the ray-cast search for fixtures.
-    /// @details Use this to stop searching for fixtures.
-    Terminate,
-    
-    /// @brief Ignore the current fixture.
-    /// @details Use this to continue searching for fixtures along the ray.
-    IgnoreFixture,
-    
-    /// @brief Clip the ray end to the current point.
-    /// @details Use this shorten the ray to the current point and to continue searching
-    ///   for fixtures now along the newly shortened ray.
-    ClipRay,
-    
-    /// @brief Reset the ray end back to the second point.
-    /// @details Use this to restore the ray to its full length and to continue searching
-    ///    for fixtures now along the restored full length ray.
-    ResetRay
-};
+    namespace detail
+    {
 
-namespace d2 {
+        template<std::size_t N>
+        struct AABB;
 
-class Shape;
-class DistanceProxy;
-class DynamicTree;
-class World;
+    }// namespace detail
 
-/// @brief Ray-cast hit data.
-/// @details The ray hits at <code>p1 + fraction * (p2 - p1)</code>, where
-///   <code>p1</code> and <code>p2</code> come from <code>RayCastInput</code>.
-struct RayCastHit
-{
-    /// @brief Surface normal in world coordinates at the point of contact.
-    UnitVec normal;
-    
-    /// @brief Fraction.
-    /// @note This is a unit interval value - a value between 0 and 1 - or it's invalid.
-    UnitInterval<Real> fraction = UnitInterval<Real>{0};
-};
+    /// @brief Ray cast opcode enumeration.
+    /// @details Instructs some ray casting methods on what to do next.
+    enum class RayCastOpcode
+    {
+        /// @brief End the ray-cast search for fixtures.
+        /// @details Use this to stop searching for fixtures.
+        Terminate,
 
-/// @brief Ray cast output.
-/// @details This is a type alias for an optional <code>RayCastHit</code> instance.
-/// @see RayCast, Optional, RayCastHit
-using RayCastOutput = Optional<RayCastHit>;
+        /// @brief Ignore the current fixture.
+        /// @details Use this to continue searching for fixtures along the ray.
+        IgnoreFixture,
 
-/// @brief Ray cast callback function.
-/// @note Return 0 to terminate ray casting, or > 0 to update the segment bounding box.
-using DynamicTreeRayCastCB = std::function<Real(BodyID body,
-                                                FixtureID fixture,
-                                                ChildCounter child,
-                                                const RayCastInput& input)>;
+        /// @brief Clip the ray end to the current point.
+        /// @details Use this shorten the ray to the current point and to continue searching
+        ///   for fixtures now along the newly shortened ray.
+        ClipRay,
 
-/// @brief Ray cast callback function signature.
-using FixtureRayCastCB = std::function<RayCastOpcode(BodyID body,
-                                                     FixtureID fixture,
-                                                     ChildCounter child,
-                                                     Length2 point,
-                                                     UnitVec normal)>;
+        /// @brief Reset the ray end back to the second point.
+        /// @details Use this to restore the ray to its full length and to continue searching
+        ///    for fixtures now along the restored full length ray.
+        ResetRay
+    };
 
-/// @defgroup RayCastGroup Ray Casting Functions
-/// @brief Collection of functions that do ray casting.
-/// @image html raycast.png
-/// @{
+    namespace d2
+    {
 
-/// @brief Cast a ray against a circle of a given radius at the given location.
-/// @param radius Radius of the circle.
-/// @param location Location in world coordinates of the circle.
-/// @param input Ray-cast input parameters.
-RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept;
+        class Shape;
+        class DistanceProxy;
+        class DynamicTree;
+        class World;
 
-/// @brief Cast a ray against the given AABB.
-/// @param aabb Axis Aligned Bounding Box.
-/// @param input the ray-cast input parameters.
-RayCastOutput RayCast(const detail::AABB<2>& aabb, const RayCastInput& input) noexcept;
+        /// @brief Ray-cast hit data.
+        /// @details The ray hits at <code>p1 + fraction * (p2 - p1)</code>, where
+        ///   <code>p1</code> and <code>p2</code> come from <code>RayCastInput</code>.
+        struct RayCastHit
+        {
+            /// @brief Surface normal in world coordinates at the point of contact.
+            UnitVec normal;
 
-/// @brief Cast a ray against the distance proxy.
-/// @param proxy Distance-proxy object (in local coordinates).
-/// @param input Ray-cast input parameters.
-/// @param transform Transform to be applied to the distance-proxy to get world coordinates.
-/// @relatedalso DistanceProxy
-RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
-                      const Transformation& transform) noexcept;
+            /// @brief Fraction.
+            /// @note This is a unit interval value - a value between 0 and 1 - or it's invalid.
+            UnitInterval<Real> fraction = UnitInterval<Real>{0};
+        };
 
-/// @brief Cast a ray against the child of the given shape.
-/// @note This is a convenience function for calling the ray cast against a distance-proxy.
-/// @param shape Shape.
-/// @param childIndex Child index.
-/// @param input the ray-cast input parameters.
-/// @param transform Transform to be applied to the child of the shape.
-/// @relatedalso Shape
-RayCastOutput RayCast(const Shape& shape, ChildCounter childIndex,
-                      const RayCastInput& input, const Transformation& transform) noexcept;
+        /// @brief Ray cast output.
+        /// @details This is a type alias for an optional <code>RayCastHit</code> instance.
+        /// @see RayCast, Optional, RayCastHit
+        using RayCastOutput = Optional<RayCastHit>;
 
-/// @brief Cast rays against the leafs in the given tree.
-///
-/// @note This relies on the callback to perform an exact ray-cast in the case where the
-///    leaf node contains a shape.
-/// @note The callback also performs collision filtering.
-/// @note Performance is roughly k * log(n), where k is the number of collisions and n is the
-///   number of leaf nodes in the tree.
-///
-/// @param tree Dynamic tree to ray cast.
-/// @param input the ray-cast input data. The ray extends from <code>p1</code> to
-///   <code>p1 + maxFraction * (p2 - p1)</code>.
-/// @param callback A callback instance function that's called for each leaf that is hit
-///   by the ray. The callback should return 0 to terminate ray casting, or greater than 0
-///   to update the segment bounding box. Values less than zero are ignored.
-///
-/// @return <code>true</code> if terminated at the callback's request,
-///   <code>false</code> otherwise.
-///
-bool RayCast(const DynamicTree& tree, RayCastInput input,
-             const DynamicTreeRayCastCB& callback);
+        /// @brief Ray cast callback function.
+        /// @note Return 0 to terminate ray casting, or > 0 to update the segment bounding box.
+        using DynamicTreeRayCastCB = std::function<Real(BodyID body,
+                                                        FixtureID fixture,
+                                                        ChildCounter child,
+                                                        const RayCastInput& input)>;
 
-/// @brief Ray-cast the world for all fixtures in the path of the ray.
-///
-/// @note The callback controls whether you get the closest point, any point, or n-points.
-/// @note The ray-cast ignores shapes that contain the starting point.
-///
-/// @param world The world instance to raycast in.
-/// @param input Ray cast input data.
-/// @param callback A user implemented callback function.
-///
-/// @return <code>true</code> if terminated by callback, <code>false</code> otherwise.
-///
-/// @relatedalso World
-bool RayCast(const World& world, const RayCastInput& input, const FixtureRayCastCB& callback);
+        /// @brief Ray cast callback function signature.
+        using FixtureRayCastCB = std::function<RayCastOpcode(BodyID body,
+                                                             FixtureID fixture,
+                                                             ChildCounter child,
+                                                             Length2 point,
+                                                             UnitVec normal)>;
 
-/// @}
+        /// @defgroup RayCastGroup Ray Casting Functions
+        /// @brief Collection of functions that do ray casting.
+        /// @image html raycast.png
+        /// @{
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Cast a ray against a circle of a given radius at the given location.
+        /// @param radius Radius of the circle.
+        /// @param location Location in world coordinates of the circle.
+        /// @param input Ray-cast input parameters.
+        RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept;
 
-#endif // PLAYRHO_COLLISION_RAYCASTOUTPUT_HPP
+        /// @brief Cast a ray against the given AABB.
+        /// @param aabb Axis Aligned Bounding Box.
+        /// @param input the ray-cast input parameters.
+        RayCastOutput RayCast(const detail::AABB<2>& aabb, const RayCastInput& input) noexcept;
 
+        /// @brief Cast a ray against the distance proxy.
+        /// @param proxy Distance-proxy object (in local coordinates).
+        /// @param input Ray-cast input parameters.
+        /// @param transform Transform to be applied to the distance-proxy to get world coordinates.
+        /// @relatedalso DistanceProxy
+        RayCastOutput RayCast(const DistanceProxy& proxy, const RayCastInput& input,
+                              const Transformation& transform) noexcept;
+
+        /// @brief Cast a ray against the child of the given shape.
+        /// @note This is a convenience function for calling the ray cast against a distance-proxy.
+        /// @param shape Shape.
+        /// @param childIndex Child index.
+        /// @param input the ray-cast input parameters.
+        /// @param transform Transform to be applied to the child of the shape.
+        /// @relatedalso Shape
+        RayCastOutput RayCast(const Shape& shape, ChildCounter childIndex,
+                              const RayCastInput& input, const Transformation& transform) noexcept;
+
+        /// @brief Cast rays against the leafs in the given tree.
+        ///
+        /// @note This relies on the callback to perform an exact ray-cast in the case where the
+        ///    leaf node contains a shape.
+        /// @note The callback also performs collision filtering.
+        /// @note Performance is roughly k * log(n), where k is the number of collisions and n is the
+        ///   number of leaf nodes in the tree.
+        ///
+        /// @param tree Dynamic tree to ray cast.
+        /// @param input the ray-cast input data. The ray extends from <code>p1</code> to
+        ///   <code>p1 + maxFraction * (p2 - p1)</code>.
+        /// @param callback A callback instance function that's called for each leaf that is hit
+        ///   by the ray. The callback should return 0 to terminate ray casting, or greater than 0
+        ///   to update the segment bounding box. Values less than zero are ignored.
+        ///
+        /// @return <code>true</code> if terminated at the callback's request,
+        ///   <code>false</code> otherwise.
+        ///
+        bool RayCast(const DynamicTree& tree, RayCastInput input,
+                     const DynamicTreeRayCastCB& callback);
+
+        /// @brief Ray-cast the world for all fixtures in the path of the ray.
+        ///
+        /// @note The callback controls whether you get the closest point, any point, or n-points.
+        /// @note The ray-cast ignores shapes that contain the starting point.
+        ///
+        /// @param world The world instance to raycast in.
+        /// @param input Ray cast input data.
+        /// @param callback A user implemented callback function.
+        ///
+        /// @return <code>true</code> if terminated by callback, <code>false</code> otherwise.
+        ///
+        /// @relatedalso World
+        bool RayCast(const World& world, const RayCastInput& input, const FixtureRayCastCB& callback);
+
+        /// @}
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_RAYCASTOUTPUT_HPP

--- a/PlayRho/Collision/SeparationScenario.cpp
+++ b/PlayRho/Collision/SeparationScenario.cpp
@@ -19,183 +19,188 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Collision/SeparationScenario.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
+#include <PlayRho/Collision/SeparationScenario.hpp>
 
-namespace playrho {
-namespace d2 {
-namespace {
-
-LengthIndexPair
-FindMinSeparationForPoints(const SeparationScenario& scenario,
-                           const Transformation& xfA, const Transformation& xfB)
+namespace playrho
 {
-    const auto dirA = InverseRotate(+scenario.axis, xfA.q);
-    const auto dirB = InverseRotate(-scenario.axis, xfB.q);
-    const auto indexA = GetSupportIndex(scenario.proxyA, dirA);
-    const auto indexB = GetSupportIndex(scenario.proxyB, dirB);
-    const auto pointA = Transform(scenario.proxyA.GetVertex(indexA), xfA);
-    const auto pointB = Transform(scenario.proxyB.GetVertex(indexB), xfB);
-    const auto delta = pointB - pointA;
-    return LengthIndexPair{Dot(delta, scenario.axis), IndexPair{indexA, indexB}};
-}
-
-LengthIndexPair
-FindMinSeparationForFaceA(const SeparationScenario& scenario,
-                          const Transformation& xfA, const Transformation& xfB)
-{
-    const auto normal = Rotate(scenario.axis, xfA.q);
-    const auto indexA = InvalidVertex;
-    const auto pointA = Transform(scenario.localPoint, xfA);
-    const auto dir = InverseRotate(-normal, xfB.q);
-    const auto indexB = GetSupportIndex(scenario.proxyB, dir);
-    const auto pointB = Transform(scenario.proxyB.GetVertex(indexB), xfB);
-    const auto delta = pointB - pointA;
-    return LengthIndexPair{Dot(delta, normal), IndexPair{indexA, indexB}};
-}
-
-LengthIndexPair
-FindMinSeparationForFaceB(const SeparationScenario& scenario,
-                          const Transformation& xfA, const Transformation& xfB)
-{
-    const auto normal = Rotate(scenario.axis, xfB.q);
-    const auto dir = InverseRotate(-normal, xfA.q);
-    const auto indexA = GetSupportIndex(scenario.proxyA, dir);
-    const auto pointA = Transform(scenario.proxyA.GetVertex(indexA), xfA);
-    const auto indexB = InvalidVertex;
-    const auto pointB = Transform(scenario.localPoint, xfB);
-    const auto delta = pointA - pointB;
-    return LengthIndexPair{Dot(delta, normal), IndexPair{indexA, indexB}};
-}
-
-Length EvaluateForPoints(const SeparationScenario& scenario,
-                         const Transformation& xfA, const Transformation& xfB,
-                         IndexPair indexPair)
-{
-    const auto pointA = Transform(scenario.proxyA.GetVertex(std::get<0>(indexPair)), xfA);
-    const auto pointB = Transform(scenario.proxyB.GetVertex(std::get<1>(indexPair)), xfB);
-    const auto delta = pointB - pointA;
-    return Dot(delta, scenario.axis);
-}
-
-Length EvaluateForFaceA(const SeparationScenario& scenario,
-                        const Transformation& xfA, const Transformation& xfB,
-                        IndexPair indexPair)
-{
-    const auto normal = Rotate(scenario.axis, xfA.q);
-    const auto pointA = Transform(scenario.localPoint, xfA);
-    const auto pointB = Transform(scenario.proxyB.GetVertex(std::get<1>(indexPair)), xfB);
-    const auto delta = pointB - pointA;
-    return Dot(delta, normal);
-}
-
-Length EvaluateForFaceB(const SeparationScenario& scenario,
-                        const Transformation& xfA, const Transformation& xfB,
-                        IndexPair indexPair)
-{
-    const auto normal = Rotate(scenario.axis, xfB.q);
-    const auto pointB = Transform(scenario.localPoint, xfB);
-    const auto pointA = Transform(scenario.proxyA.GetVertex(std::get<0>(indexPair)), xfA);
-    const auto delta = pointA - pointB;
-    return Dot(delta, normal);
-}
-
-} // namespace anonymous
-
-SeparationScenario
-GetSeparationScenario(IndexPair3 indices,
-                      const DistanceProxy& proxyA, const Transformation& xfA,
-                      const DistanceProxy& proxyB, const Transformation& xfB)
-{
-    assert(!empty(indices));
-    assert(proxyA.GetVertexCount() > 0);
-    assert(proxyB.GetVertexCount() > 0);
-    
-    const auto numIndices = GetNumValidIndices(indices);
-    const auto type = (numIndices == 1)?
-        SeparationScenario::e_points: ((std::get<0>(indices[0]) == std::get<0>(indices[1]))?
-                                       SeparationScenario::e_faceB: SeparationScenario::e_faceA);
-    
-    switch (type)
+    namespace d2
     {
-        case SeparationScenario::e_faceB:
+        namespace
         {
+
+            LengthIndexPair
+            FindMinSeparationForPoints(const SeparationScenario& scenario,
+                                       const Transformation& xfA, const Transformation& xfB)
+            {
+                const auto dirA = InverseRotate(+scenario.axis, xfA.q);
+                const auto dirB = InverseRotate(-scenario.axis, xfB.q);
+                const auto indexA = GetSupportIndex(scenario.proxyA, dirA);
+                const auto indexB = GetSupportIndex(scenario.proxyB, dirB);
+                const auto pointA = Transform(scenario.proxyA.GetVertex(indexA), xfA);
+                const auto pointB = Transform(scenario.proxyB.GetVertex(indexB), xfB);
+                const auto delta = pointB - pointA;
+                return LengthIndexPair{Dot(delta, scenario.axis), IndexPair{indexA, indexB}};
+            }
+
+            LengthIndexPair
+            FindMinSeparationForFaceA(const SeparationScenario& scenario,
+                                      const Transformation& xfA, const Transformation& xfB)
+            {
+                const auto normal = Rotate(scenario.axis, xfA.q);
+                const auto indexA = InvalidVertex;
+                const auto pointA = Transform(scenario.localPoint, xfA);
+                const auto dir = InverseRotate(-normal, xfB.q);
+                const auto indexB = GetSupportIndex(scenario.proxyB, dir);
+                const auto pointB = Transform(scenario.proxyB.GetVertex(indexB), xfB);
+                const auto delta = pointB - pointA;
+                return LengthIndexPair{Dot(delta, normal), IndexPair{indexA, indexB}};
+            }
+
+            LengthIndexPair
+            FindMinSeparationForFaceB(const SeparationScenario& scenario,
+                                      const Transformation& xfA, const Transformation& xfB)
+            {
+                const auto normal = Rotate(scenario.axis, xfB.q);
+                const auto dir = InverseRotate(-normal, xfA.q);
+                const auto indexA = GetSupportIndex(scenario.proxyA, dir);
+                const auto pointA = Transform(scenario.proxyA.GetVertex(indexA), xfA);
+                const auto indexB = InvalidVertex;
+                const auto pointB = Transform(scenario.localPoint, xfB);
+                const auto delta = pointA - pointB;
+                return LengthIndexPair{Dot(delta, normal), IndexPair{indexA, indexB}};
+            }
+
+            Length EvaluateForPoints(const SeparationScenario& scenario,
+                                     const Transformation& xfA, const Transformation& xfB,
+                                     IndexPair indexPair)
+            {
+                const auto pointA = Transform(scenario.proxyA.GetVertex(std::get<0>(indexPair)), xfA);
+                const auto pointB = Transform(scenario.proxyB.GetVertex(std::get<1>(indexPair)), xfB);
+                const auto delta = pointB - pointA;
+                return Dot(delta, scenario.axis);
+            }
+
+            Length EvaluateForFaceA(const SeparationScenario& scenario,
+                                    const Transformation& xfA, const Transformation& xfB,
+                                    IndexPair indexPair)
+            {
+                const auto normal = Rotate(scenario.axis, xfA.q);
+                const auto pointA = Transform(scenario.localPoint, xfA);
+                const auto pointB = Transform(scenario.proxyB.GetVertex(std::get<1>(indexPair)), xfB);
+                const auto delta = pointB - pointA;
+                return Dot(delta, normal);
+            }
+
+            Length EvaluateForFaceB(const SeparationScenario& scenario,
+                                    const Transformation& xfA, const Transformation& xfB,
+                                    IndexPair indexPair)
+            {
+                const auto normal = Rotate(scenario.axis, xfB.q);
+                const auto pointB = Transform(scenario.localPoint, xfB);
+                const auto pointA = Transform(scenario.proxyA.GetVertex(std::get<0>(indexPair)), xfA);
+                const auto delta = pointA - pointB;
+                return Dot(delta, normal);
+            }
+
+        }// namespace
+
+        SeparationScenario
+        GetSeparationScenario(IndexPair3 indices,
+                              const DistanceProxy& proxyA, const Transformation& xfA,
+                              const DistanceProxy& proxyB, const Transformation& xfB)
+        {
+            assert(!empty(indices));
+            assert(proxyA.GetVertexCount() > 0);
+            assert(proxyB.GetVertexCount() > 0);
+
+            const auto numIndices = GetNumValidIndices(indices);
+            const auto type = (numIndices == 1) ? SeparationScenario::e_points : ((std::get<0>(indices[0]) == std::get<0>(indices[1])) ? SeparationScenario::e_faceB : SeparationScenario::e_faceA);
+
+            switch (type)
+            {
+            case SeparationScenario::e_faceB: {
+                const auto ip0 = indices[0];
+                const auto ip1 = indices[1];
+
+                // Two points on B and one on A.
+                const auto localPointB1 = proxyB.GetVertex(std::get<1>(ip0));
+                const auto localPointB2 = proxyB.GetVertex(std::get<1>(ip1));
+                const auto axis = GetUnitVector(GetFwdPerpendicular(localPointB2 - localPointB1),
+                                                UnitVec::GetZero());
+                const auto normal = Rotate(axis, xfB.q);
+                const auto localPoint = (localPointB1 + localPointB2) / Real{2};
+                const auto pointB = Transform(localPoint, xfB);
+                const auto localPointA = proxyA.GetVertex(std::get<0>(ip0));
+                const auto pointA = Transform(localPointA, xfA);
+                const auto deltaPoint = pointA - pointB;
+                const auto axisIt = (Dot(deltaPoint, normal) < 0_m) ? -axis : axis;
+                return SeparationScenario{proxyA, proxyB, axisIt, localPoint, type};
+            }
+            case SeparationScenario::e_faceA: {
+                const auto ip0 = indices[0];
+                const auto ip1 = indices[1];
+
+                // Two points on A and one or two points on B.
+                const auto localPointA1 = proxyA.GetVertex(std::get<0>(ip0));
+                const auto localPointA2 = proxyA.GetVertex(std::get<0>(ip1));
+                const auto axis = GetUnitVector(GetFwdPerpendicular(localPointA2 - localPointA1),
+                                                UnitVec::GetZero());
+                const auto normal = Rotate(axis, xfA.q);
+                const auto localPoint = (localPointA1 + localPointA2) / Real{2};
+                const auto pointA = Transform(localPoint, xfA);
+                const auto localPointB = proxyB.GetVertex(std::get<1>(ip0));
+                const auto pointB = Transform(localPointB, xfB);
+                const auto deltaPoint = pointB - pointA;
+                const auto axisIt = (Dot(deltaPoint, normal) < 0_m) ? -axis : axis;
+                return SeparationScenario{proxyA, proxyB, axisIt, localPoint, type};
+            }
+            case SeparationScenario::e_points:
+                break;
+            }
+
+            assert(type == SeparationScenario::e_points);
             const auto ip0 = indices[0];
-            const auto ip1 = indices[1];
-            
-            // Two points on B and one on A.
-            const auto localPointB1 = proxyB.GetVertex(std::get<1>(ip0));
-            const auto localPointB2 = proxyB.GetVertex(std::get<1>(ip1));
-            const auto axis = GetUnitVector(GetFwdPerpendicular(localPointB2 - localPointB1),
-                                            UnitVec::GetZero());
-            const auto normal = Rotate(axis, xfB.q);
-            const auto localPoint = (localPointB1 + localPointB2) / Real{2};
-            const auto pointB = Transform(localPoint, xfB);
             const auto localPointA = proxyA.GetVertex(std::get<0>(ip0));
-            const auto pointA = Transform(localPointA, xfA);
-            const auto deltaPoint = pointA - pointB;
-            const auto axisIt = (Dot(deltaPoint, normal) < 0_m)? -axis: axis;
-            return SeparationScenario{proxyA, proxyB, axisIt, localPoint, type};
-        }
-        case SeparationScenario::e_faceA:
-        {
-            const auto ip0 = indices[0];
-            const auto ip1 = indices[1];
-            
-            // Two points on A and one or two points on B.
-            const auto localPointA1 = proxyA.GetVertex(std::get<0>(ip0));
-            const auto localPointA2 = proxyA.GetVertex(std::get<0>(ip1));
-            const auto axis = GetUnitVector(GetFwdPerpendicular(localPointA2 - localPointA1),
-                                            UnitVec::GetZero());
-            const auto normal = Rotate(axis, xfA.q);
-            const auto localPoint = (localPointA1 + localPointA2) / Real{2};
-            const auto pointA = Transform(localPoint, xfA);
             const auto localPointB = proxyB.GetVertex(std::get<1>(ip0));
+            const auto pointA = Transform(localPointA, xfA);
             const auto pointB = Transform(localPointB, xfB);
-            const auto deltaPoint = pointB - pointA;
-            const auto axisIt = (Dot(deltaPoint, normal) < 0_m)? -axis: axis;
-            return SeparationScenario{proxyA, proxyB, axisIt, localPoint, type};
+            const auto axis = GetUnitVector(pointB - pointA, UnitVec::GetZero());
+            return SeparationScenario{proxyA, proxyB, axis, GetInvalid<Length2>(), type};
         }
-        case SeparationScenario::e_points:
-            break;
-    }
 
-    assert(type == SeparationScenario::e_points);
-    const auto ip0 = indices[0];
-    const auto localPointA = proxyA.GetVertex(std::get<0>(ip0));
-    const auto localPointB = proxyB.GetVertex(std::get<1>(ip0));
-    const auto pointA = Transform(localPointA, xfA);
-    const auto pointB = Transform(localPointB, xfB);
-    const auto axis = GetUnitVector(pointB - pointA, UnitVec::GetZero());
-    return SeparationScenario{proxyA, proxyB, axis, GetInvalid<Length2>(), type};
-}
+        LengthIndexPair FindMinSeparation(const SeparationScenario& scenario,
+                                          const Transformation& xfA, const Transformation& xfB)
+        {
+            switch (scenario.type)
+            {
+            case SeparationScenario::e_faceA:
+                return FindMinSeparationForFaceA(scenario, xfA, xfB);
+            case SeparationScenario::e_faceB:
+                return FindMinSeparationForFaceB(scenario, xfA, xfB);
+            case SeparationScenario::e_points:
+                break;
+            }
+            assert(scenario.type == SeparationScenario::e_points);
+            return FindMinSeparationForPoints(scenario, xfA, xfB);
+        }
 
-LengthIndexPair FindMinSeparation(const SeparationScenario& scenario,
-                                  const Transformation& xfA, const Transformation& xfB)
-{
-    switch (scenario.type)
-    {
-        case SeparationScenario::e_faceA: return FindMinSeparationForFaceA(scenario, xfA, xfB);
-        case SeparationScenario::e_faceB: return FindMinSeparationForFaceB(scenario, xfA, xfB);
-        case SeparationScenario::e_points: break;
-    }
-    assert(scenario.type == SeparationScenario::e_points);
-    return FindMinSeparationForPoints(scenario, xfA, xfB);
-}
+        Length Evaluate(const SeparationScenario& scenario,
+                        const Transformation& xfA, const Transformation& xfB,
+                        IndexPair indexPair)
+        {
+            switch (scenario.type)
+            {
+            case SeparationScenario::e_faceA:
+                return EvaluateForFaceA(scenario, xfA, xfB, indexPair);
+            case SeparationScenario::e_faceB:
+                return EvaluateForFaceB(scenario, xfA, xfB, indexPair);
+            case SeparationScenario::e_points:
+                break;
+            }
+            assert(scenario.type == SeparationScenario::e_points);
+            return EvaluateForPoints(scenario, xfA, xfB, indexPair);
+        }
 
-Length Evaluate(const SeparationScenario& scenario,
-                const Transformation& xfA, const Transformation& xfB,
-                IndexPair indexPair)
-{
-    switch (scenario.type)
-    {
-        case SeparationScenario::e_faceA: return EvaluateForFaceA(scenario, xfA, xfB, indexPair);
-        case SeparationScenario::e_faceB: return EvaluateForFaceB(scenario, xfA, xfB, indexPair);
-        case SeparationScenario::e_points: break;
-    }
-    assert(scenario.type == SeparationScenario::e_points);
-    return EvaluateForPoints(scenario, xfA, xfB, indexPair);
-}
-
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/SeparationScenario.hpp
+++ b/PlayRho/Collision/SeparationScenario.hpp
@@ -22,76 +22,78 @@
 #ifndef PLAYRHO_COLLISION_SEPARATIONFINDER_HPP
 #define PLAYRHO_COLLISION_SEPARATIONFINDER_HPP
 
-#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Collision/IndexPair.hpp>
+#include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-namespace d2 {
-
-class DistanceProxy;
-struct Transformation;
-    
-/// Separation scenario.
-struct SeparationScenario
+namespace playrho
 {
-    /// Separation finder type.
-    enum Type
+    namespace d2
     {
-        e_points,
-        e_faceA,
-        e_faceB,
-    };
-    
-    const DistanceProxy& proxyA; ///< Distance proxy A.
-    const DistanceProxy& proxyB; ///< Distance proxy B.
-    const UnitVec axis; ///< Axis. @details Directional vector of the axis of separation.
 
-    /// @brief Local point.
-    /// @note Only used if type is <code>e_faceA</code> or <code>e_faceB</code>.
-    const Length2 localPoint;
-    
-    const Type type; ///< The type of this scenario.
-};
+        class DistanceProxy;
+        struct Transformation;
 
-// Free functions...
+        /// Separation scenario.
+        struct SeparationScenario
+        {
+            /// Separation finder type.
+            enum Type
+            {
+                e_points,
+                e_faceA,
+                e_faceB,
+            };
 
-/// @brief Gets a separation finder for the given inputs.
-///
-/// @warning Behavior is undefined if given less than one index pair or more than three.
-///
-/// @param indices Collection of 1 to 3 index pairs. A points-type finder will be
-///    returned if given 1 index pair. A face-type finder will be returned otherwise.
-/// @param proxyA Proxy A.
-/// @param xfA Transformation A.
-/// @param proxyB Proxy B.
-/// @param xfB Transformation B.
-///
-SeparationScenario
-GetSeparationScenario(IndexPair3 indices,
-                      const DistanceProxy& proxyA, const Transformation& xfA,
-                      const DistanceProxy& proxyB, const Transformation& xfB);
+            const DistanceProxy& proxyA;///< Distance proxy A.
+            const DistanceProxy& proxyB;///< Distance proxy B.
+            const UnitVec axis;         ///< Axis. @details Directional vector of the axis of separation.
 
-/// @brief Finds the minimum separation.
-/// @return indexes of proxy A's and proxy B's vertices that have the minimum
-///    distance between them and what that distance is.
-LengthIndexPair FindMinSeparation(const SeparationScenario& scenario,
-                                  const Transformation& xfA, const Transformation& xfB);
+            /// @brief Local point.
+            /// @note Only used if type is <code>e_faceA</code> or <code>e_faceB</code>.
+            const Length2 localPoint;
 
-/// Evaluates the separation of the identified proxy vertices at the given time factor.
-///
-/// @param scenario Separation scenario to evaluate.
-/// @param indexPair Indexes of the proxy A and proxy B vertexes.
-/// @param xfA Transformation A.
-/// @param xfB Transformation B.
-///
-/// @return Separation distance which will be negative when the given transforms put the
-///    vertices on the opposite sides of the separating axis.
-///
-Length Evaluate(const SeparationScenario& scenario,
-                const Transformation& xfA, const Transformation& xfB,
-                IndexPair indexPair);
+            const Type type;///< The type of this scenario.
+        };
 
-} // namespace d2
-} // namespace playrho
+        // Free functions...
 
-#endif // PLAYRHO_COLLISION_SEPARATIONFINDER_HPP
+        /// @brief Gets a separation finder for the given inputs.
+        ///
+        /// @warning Behavior is undefined if given less than one index pair or more than three.
+        ///
+        /// @param indices Collection of 1 to 3 index pairs. A points-type finder will be
+        ///    returned if given 1 index pair. A face-type finder will be returned otherwise.
+        /// @param proxyA Proxy A.
+        /// @param xfA Transformation A.
+        /// @param proxyB Proxy B.
+        /// @param xfB Transformation B.
+        ///
+        SeparationScenario
+        GetSeparationScenario(IndexPair3 indices,
+                              const DistanceProxy& proxyA, const Transformation& xfA,
+                              const DistanceProxy& proxyB, const Transformation& xfB);
+
+        /// @brief Finds the minimum separation.
+        /// @return indexes of proxy A's and proxy B's vertices that have the minimum
+        ///    distance between them and what that distance is.
+        LengthIndexPair FindMinSeparation(const SeparationScenario& scenario,
+                                          const Transformation& xfA, const Transformation& xfB);
+
+        /// Evaluates the separation of the identified proxy vertices at the given time factor.
+        ///
+        /// @param scenario Separation scenario to evaluate.
+        /// @param indexPair Indexes of the proxy A and proxy B vertexes.
+        /// @param xfA Transformation A.
+        /// @param xfB Transformation B.
+        ///
+        /// @return Separation distance which will be negative when the given transforms put the
+        ///    vertices on the opposite sides of the separating axis.
+        ///
+        Length Evaluate(const SeparationScenario& scenario,
+                        const Transformation& xfA, const Transformation& xfB,
+                        IndexPair indexPair);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SEPARATIONFINDER_HPP

--- a/PlayRho/Collision/ShapeSeparation.cpp
+++ b/PlayRho/Collision/ShapeSeparation.cpp
@@ -19,178 +19,181 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Collision/ShapeSeparation.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
+#include <PlayRho/Collision/ShapeSeparation.hpp>
 #include <algorithm>
 
-namespace playrho {
-namespace d2 {
-
-namespace {
-
-/// @brief Gets the minimum separation information for the given vertices from the given
-///  origin in the given direction.
-/// @param direction Directional normal for face on first convex shape starting from origin.
-/// @param origin Vertex from first convex shape from which the face normal originates.
-/// @param vertices Vertices from second convex shape.
-/// @return Minimum separation and index or indices of the vertex or edge respectively
-///   for which that's found.
-LengthIndices GetMinSeparationInfo(Length2 origin, UnitVec direction,
-                                   Range<DistanceProxy::ConstVertexIterator> vertices)
+namespace playrho
 {
-    // Search for vertices most anti-parallel to directional normal from origin.
-    // See: https://en.wikipedia.org/wiki/Antiparallel_(mathematics)#Antiparallel_vectors
-    auto minSeparation = std::numeric_limits<Length>::infinity();
-    auto first = InvalidVertex;
-    auto second = InvalidVertex;
-    auto i = VertexCounter{0};
-    for (const auto& vertex: vertices)
+    namespace d2
     {
-        const auto s = Dot(direction, vertex - origin);
-        if (minSeparation > s)
-        {
-            // most anti-parallel so far is a vertex
-            minSeparation = s;
-            first = i;
-            second = InvalidVertex;
-        }
-        else if (minSeparation == s)
-        {
-            // most anti-parallel so far is an edge
-            second = i;
-        }
-        ++i;
-    }
-    return LengthIndices{minSeparation, {{first, second}}};
-}
 
-} // anonymous namespace
+        namespace
+        {
 
-SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
-                                   const DistanceProxy& proxy2, Transformation xf2)
-{
-    // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
-    auto separation = -std::numeric_limits<Length>::infinity();
-    auto firstIndex = InvalidVertex;
-    auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
+            /// @brief Gets the minimum separation information for the given vertices from the given
+            ///  origin in the given direction.
+            /// @param direction Directional normal for face on first convex shape starting from origin.
+            /// @param origin Vertex from first convex shape from which the face normal originates.
+            /// @param vertices Vertices from second convex shape.
+            /// @return Minimum separation and index or indices of the vertex or edge respectively
+            ///   for which that's found.
+            LengthIndices GetMinSeparationInfo(Length2 origin, UnitVec direction,
+                                               Range<DistanceProxy::ConstVertexIterator> vertices)
+            {
+                // Search for vertices most anti-parallel to directional normal from origin.
+                // See: https://en.wikipedia.org/wiki/Antiparallel_(mathematics)#Antiparallel_vectors
+                auto minSeparation = std::numeric_limits<Length>::infinity();
+                auto first = InvalidVertex;
+                auto second = InvalidVertex;
+                auto i = VertexCounter{0};
+                for (const auto& vertex : vertices)
+                {
+                    const auto s = Dot(direction, vertex - origin);
+                    if (minSeparation > s)
+                    {
+                        // most anti-parallel so far is a vertex
+                        minSeparation = s;
+                        first = i;
+                        second = InvalidVertex;
+                    }
+                    else if (minSeparation == s)
+                    {
+                        // most anti-parallel so far is an edge
+                        second = i;
+                    }
+                    ++i;
+                }
+                return LengthIndices{minSeparation, {{first, second}}};
+            }
+
+        }// anonymous namespace
+
+        SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
+                                           const DistanceProxy& proxy2, Transformation xf2)
+        {
+            // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
+            auto separation = -std::numeric_limits<Length>::infinity();
+            auto firstIndex = InvalidVertex;
+            auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
 #if 1
-    const auto xf = MulT(xf1, xf2);
-    const Length2 p2vertices[4] = {
-        Transform(proxy2.GetVertex(0), xf),
-        Transform(proxy2.GetVertex(1), xf),
-        Transform(proxy2.GetVertex(2), xf),
-        Transform(proxy2.GetVertex(3), xf),
-    };
-    const auto vertices = Range<DistanceProxy::ConstVertexIterator>(p2vertices, p2vertices + 4);
+            const auto xf = MulT(xf1, xf2);
+            const Length2 p2vertices[4] = {
+                Transform(proxy2.GetVertex(0), xf),
+                Transform(proxy2.GetVertex(1), xf),
+                Transform(proxy2.GetVertex(2), xf),
+                Transform(proxy2.GetVertex(3), xf),
+            };
+            const auto vertices = Range<DistanceProxy::ConstVertexIterator>(p2vertices, p2vertices + 4);
 #else
-    const auto xf = MulT(xf2, xf1);
-    const auto vertices = proxy2.GetVertices();
+            const auto xf = MulT(xf2, xf1);
+            const auto vertices = proxy2.GetVertices();
 #endif
-    for (auto i = VertexCounter{0}; i < VertexCounter{4}; ++i)
-    {
-        // Get proxy1 normal and vertex relative to proxy2.
+            for (auto i = VertexCounter{0}; i < VertexCounter{4}; ++i)
+            {
+                // Get proxy1 normal and vertex relative to proxy2.
 #if 1
-        const auto origin = proxy1.GetVertex(i);
-        const auto normal = proxy1.GetNormal(i);
-        const auto ap = GetMinSeparationInfo(origin, normal, vertices);
+                const auto origin = proxy1.GetVertex(i);
+                const auto normal = proxy1.GetNormal(i);
+                const auto ap = GetMinSeparationInfo(origin, normal, vertices);
 #else
-        const auto origin = Transform(proxy1.GetVertex(i), xf);
-        const auto normal = Rotate(proxy1.GetNormal(i), xf.q);
-        const auto ap = GetMinIndexSeparation(origin, normal, vertices);
+                const auto origin = Transform(proxy1.GetVertex(i), xf);
+                const auto normal = Rotate(proxy1.GetNormal(i), xf.q);
+                const auto ap = GetMinIndexSeparation(origin, normal, vertices);
 #endif
-        if (separation < ap.distance)
-        {
-            separation = ap.distance;
-            secondIndices = ap.indices;
-            firstIndex = i;
+                if (separation < ap.distance)
+                {
+                    separation = ap.distance;
+                    secondIndices = ap.indices;
+                    firstIndex = i;
+                }
+            }
+            return SeparationInfo{separation, firstIndex, secondIndices};
         }
-    }
-    return SeparationInfo{separation, firstIndex, secondIndices};
-}
 
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2)
-{
-    // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
-    auto separation = -std::numeric_limits<Length>::infinity();
-    auto firstIndex = InvalidVertex;
-    auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
-    const auto count1 = proxy1.GetVertexCount();
-    const auto xf = MulT(xf2, xf1);
-    const auto proxy2vertices = proxy2.GetVertices();
-    for (auto i = VertexCounter{0}; i < count1; ++i)
-    {
-        // Get proxy1 normal and vertex relative to proxy2.
-        const auto origin = Transform(proxy1.GetVertex(i), xf);
-        const auto normal = Rotate(proxy1.GetNormal(i), xf.q);
-        const auto ap = GetMinSeparationInfo(origin, normal, proxy2vertices);
-        if (separation < ap.distance)
+        SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
+                                        const DistanceProxy& proxy2, Transformation xf2)
         {
-            separation = ap.distance;
-            secondIndices = ap.indices;
-            firstIndex = i;
+            // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
+            auto separation = -std::numeric_limits<Length>::infinity();
+            auto firstIndex = InvalidVertex;
+            auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
+            const auto count1 = proxy1.GetVertexCount();
+            const auto xf = MulT(xf2, xf1);
+            const auto proxy2vertices = proxy2.GetVertices();
+            for (auto i = VertexCounter{0}; i < count1; ++i)
+            {
+                // Get proxy1 normal and vertex relative to proxy2.
+                const auto origin = Transform(proxy1.GetVertex(i), xf);
+                const auto normal = Rotate(proxy1.GetNormal(i), xf.q);
+                const auto ap = GetMinSeparationInfo(origin, normal, proxy2vertices);
+                if (separation < ap.distance)
+                {
+                    separation = ap.distance;
+                    secondIndices = ap.indices;
+                    firstIndex = i;
+                }
+            }
+            return SeparationInfo{separation, firstIndex, secondIndices};
         }
-    }
-    return SeparationInfo{separation, firstIndex, secondIndices};
-}
 
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2,
-                                Length stop)
-{
-    // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
-    auto separation = -std::numeric_limits<Length>::infinity();
-    auto firstIndex = InvalidVertex;
-    auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
-    const auto xf = MulT(xf2, xf1);
-    const auto count1 = proxy1.GetVertexCount();
-    for (auto i = VertexCounter{0}; i < count1; ++i)
-    {
-        // Get proxy1 normal and vertex relative to proxy2.
-        const auto origin = Transform(proxy1.GetVertex(i), xf);
-        const auto normal = Rotate(proxy1.GetNormal(i), xf.q);
-        const auto ap = GetMinSeparationInfo(origin, normal, proxy2.GetVertices());
-        if (stop < ap.distance)
+        SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
+                                        const DistanceProxy& proxy2, Transformation xf2,
+                                        Length stop)
         {
-            return SeparationInfo{ap.distance, i, ap.indices};
+            // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
+            auto separation = -std::numeric_limits<Length>::infinity();
+            auto firstIndex = InvalidVertex;
+            auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
+            const auto xf = MulT(xf2, xf1);
+            const auto count1 = proxy1.GetVertexCount();
+            for (auto i = VertexCounter{0}; i < count1; ++i)
+            {
+                // Get proxy1 normal and vertex relative to proxy2.
+                const auto origin = Transform(proxy1.GetVertex(i), xf);
+                const auto normal = Rotate(proxy1.GetNormal(i), xf.q);
+                const auto ap = GetMinSeparationInfo(origin, normal, proxy2.GetVertices());
+                if (stop < ap.distance)
+                {
+                    return SeparationInfo{ap.distance, i, ap.indices};
+                }
+                if (separation < ap.distance)
+                {
+                    separation = ap.distance;
+                    secondIndices = ap.indices;
+                    firstIndex = i;
+                }
+            }
+            return SeparationInfo{separation, firstIndex, secondIndices};
         }
-        if (separation < ap.distance)
-        {
-            separation = ap.distance;
-            secondIndices = ap.indices;
-            firstIndex = i;
-        }
-    }
-    return SeparationInfo{separation, firstIndex, secondIndices};
-}
 
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, const DistanceProxy& proxy2,
-                                Length stop)
-{
-    // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
-    auto separation = -std::numeric_limits<Length>::infinity();
-    auto firstIndex = InvalidVertex;
-    auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
-    const auto count1 = proxy1.GetVertexCount();
-    for (auto i = decltype(count1){0}; i < count1; ++i)
-    {
-        // Get proxy1 normal and vertex relative to proxy2.
-        const auto origin = proxy1.GetVertex(i);
-        const auto normal = proxy1.GetNormal(i);
-        const auto ap = GetMinSeparationInfo(origin, normal, proxy2.GetVertices());
-        if (stop < ap.distance)
+        SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, const DistanceProxy& proxy2,
+                                        Length stop)
         {
-            return SeparationInfo{ap.distance, i, ap.indices};
+            // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
+            auto separation = -std::numeric_limits<Length>::infinity();
+            auto firstIndex = InvalidVertex;
+            auto secondIndices = VertexCounter2{{InvalidVertex, InvalidVertex}};
+            const auto count1 = proxy1.GetVertexCount();
+            for (auto i = decltype(count1){0}; i < count1; ++i)
+            {
+                // Get proxy1 normal and vertex relative to proxy2.
+                const auto origin = proxy1.GetVertex(i);
+                const auto normal = proxy1.GetNormal(i);
+                const auto ap = GetMinSeparationInfo(origin, normal, proxy2.GetVertices());
+                if (stop < ap.distance)
+                {
+                    return SeparationInfo{ap.distance, i, ap.indices};
+                }
+                if (separation < ap.distance)
+                {
+                    separation = ap.distance;
+                    secondIndices = ap.indices;
+                    firstIndex = i;
+                }
+            }
+            return SeparationInfo{separation, firstIndex, secondIndices};
         }
-        if (separation < ap.distance)
-        {
-            separation = ap.distance;
-            secondIndices = ap.indices;
-            firstIndex = i;
-        }
-    }
-    return SeparationInfo{separation, firstIndex, secondIndices};
-}
-    
-} // namespace d2
-} // namespace playrho
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/ShapeSeparation.hpp
+++ b/PlayRho/Collision/ShapeSeparation.hpp
@@ -22,51 +22,53 @@
 #ifndef PLAYRHO_COLLISION_SHAPESEPARATION_HPP
 #define PLAYRHO_COLLISION_SHAPESEPARATION_HPP
 
-#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Collision/IndexPair.hpp>
+#include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-class DistanceProxy;
+        class DistanceProxy;
 
-/// @brief Gets the max separation information.
-/// @note Prefer using this function - over the <code>GetMaxSeparation</code>
-///   function that takes a stopping length - when it's already known that the two
-///   convex shapes' AABBs overlap.
-/// @return Index of the vertex and normal from <code>proxy1</code>,
-///   index of the vertex from <code>proxy2</code> (that had the maximum separation
-///   distance from each other in the direction of that normal), and the maximal distance.
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2);
+        /// @brief Gets the max separation information.
+        /// @note Prefer using this function - over the <code>GetMaxSeparation</code>
+        ///   function that takes a stopping length - when it's already known that the two
+        ///   convex shapes' AABBs overlap.
+        /// @return Index of the vertex and normal from <code>proxy1</code>,
+        ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
+        ///   distance from each other in the direction of that normal), and the maximal distance.
+        SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
+                                        const DistanceProxy& proxy2, Transformation xf2);
 
-/// @brief Gets the max separation information.
-/// @return Index of the vertex and normal from <code>proxy1</code>,
-///   index of the vertex from <code>proxy2</code> (that had the maximum separation
-///   distance from each other in the direction of that normal), and the maximal distance.
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2,
-                                Length stop);
+        /// @brief Gets the max separation information.
+        /// @return Index of the vertex and normal from <code>proxy1</code>,
+        ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
+        ///   distance from each other in the direction of that normal), and the maximal distance.
+        SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
+                                        const DistanceProxy& proxy2, Transformation xf2,
+                                        Length stop);
 
-/// @brief Gets the max separation information for the first four vertices of the two
-///   given shapes.
-/// @details This is a version of the get-max-separation functions that is optimized for
-///   two quadrilateral (4-sided) polygons.
-/// @return Index of the vertex and normal from <code>proxy1</code>,
-///   index of the vertex from <code>proxy2</code> (that had the maximum separation
-///   distance from each other in the direction of that normal), and the maximal distance.
-SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
-                                   const DistanceProxy& proxy2, Transformation xf2);
+        /// @brief Gets the max separation information for the first four vertices of the two
+        ///   given shapes.
+        /// @details This is a version of the get-max-separation functions that is optimized for
+        ///   two quadrilateral (4-sided) polygons.
+        /// @return Index of the vertex and normal from <code>proxy1</code>,
+        ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
+        ///   distance from each other in the direction of that normal), and the maximal distance.
+        SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
+                                           const DistanceProxy& proxy2, Transformation xf2);
 
-/// @brief Gets the max separation information.
-/// @return Index of the vertex and normal from <code>proxy1</code>,
-///   index of the vertex from <code>proxy2</code> (that had the maximum separation
-///   distance from each other in the direction of that normal), and the maximal distance.
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1,
-                                const DistanceProxy& proxy2,
-                                Length stop = MaxFloat * Meter);
+        /// @brief Gets the max separation information.
+        /// @return Index of the vertex and normal from <code>proxy1</code>,
+        ///   index of the vertex from <code>proxy2</code> (that had the maximum separation
+        ///   distance from each other in the direction of that normal), and the maximal distance.
+        SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1,
+                                        const DistanceProxy& proxy2,
+                                        Length stop = MaxFloat * Meter);
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_COLLISION_SHAPESEPARATION_HPP
+#endif// PLAYRHO_COLLISION_SHAPESEPARATION_HPP

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -22,197 +22,199 @@
 #ifndef PLAYRHO_COLLISION_SHAPES_CHAINSHAPECONF_HPP
 #define PLAYRHO_COLLISION_SHAPES_CHAINSHAPECONF_HPP
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
+#include <PlayRho/Collision/AABB.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
-#include <PlayRho/Collision/AABB.hpp>
+#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
+#include <PlayRho/Common/Math.hpp>
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Chain shape configuration.
-///
-/// @details A chain shape is a free form sequence of line segments.
-/// The chain has two-sided collision, so you can use inside and outside collision.
-/// Therefore, you may use any winding order.
-/// Since there may be many vertices, they are allocated on the memory heap.
-///
-/// @image html Chain1.png
-/// @image html SelfIntersect.png
-///
-/// @warning The chain will not collide properly if there are self-intersections.
-///
-/// @ingroup PartsGroup
-///
-class ChainShapeConf: public ShapeBuilder<ChainShapeConf>
+namespace playrho
 {
-public:
-    /// @brief Gets the default vertex radius.
-    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+    namespace d2
     {
-        return NonNegative<Length>{DefaultLinearSlop * Real{2}};
-    }
 
-    /// @brief Default constructor.
-    ChainShapeConf();
-    
-    /// @brief Sets the configuration up for representing a chain of vertices as given.
-    ChainShapeConf& Set(std::vector<Length2> arg);
-    
-    /// @brief Adds the given vertex.
-    ChainShapeConf& Add(Length2 vertex);
-    
-    /// @brief Transforms all the vertices by the given transformation matrix.
-    /// @note This updates the normals too.
-    /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-    ChainShapeConf& Transform(const Mat22& m) noexcept;
+        /// @brief Chain shape configuration.
+        ///
+        /// @details A chain shape is a free form sequence of line segments.
+        /// The chain has two-sided collision, so you can use inside and outside collision.
+        /// Therefore, you may use any winding order.
+        /// Since there may be many vertices, they are allocated on the memory heap.
+        ///
+        /// @image html Chain1.png
+        /// @image html SelfIntersect.png
+        ///
+        /// @warning The chain will not collide properly if there are self-intersections.
+        ///
+        /// @ingroup PartsGroup
+        ///
+        class ChainShapeConf : public ShapeBuilder<ChainShapeConf>
+        {
+         public:
+            /// @brief Gets the default vertex radius.
+            static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+            {
+                return NonNegative<Length>{DefaultLinearSlop * Real{2}};
+            }
 
-    /// @brief Gets the "child" shape count.
-    ChildCounter GetChildCount() const noexcept
-    {
-        // edge count = vertex count - 1
-        const auto count = GetVertexCount();
-        return (count > 1)? count - 1: count;
-    }
+            /// @brief Default constructor.
+            ChainShapeConf();
 
-    /// @brief Gets the "child" shape at the given index.
-    DistanceProxy GetChild(ChildCounter index) const;
-    
-    /// @brief Gets the mass data.
-    MassData GetMassData() const noexcept;
-    
-    /// @brief Uses the given vertex radius.
-    ChainShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
+            /// @brief Sets the configuration up for representing a chain of vertices as given.
+            ChainShapeConf& Set(std::vector<Length2> arg);
 
-    /// @brief Gets the vertex count.
-    ChildCounter GetVertexCount() const noexcept
-    {
-        return static_cast<ChildCounter>(size(m_vertices));
-    }
-    
-    /// @brief Gets a vertex by index.
-    Length2 GetVertex(ChildCounter index) const
-    {
-        assert((0 <= index) && (index < GetVertexCount()));
-        return m_vertices[index];
-    }
-    
-    /// @brief Gets the normal at the given index.
-    UnitVec GetNormal(ChildCounter index) const
-    {
-        assert((0 <= index) && (index < GetVertexCount()));
-        return m_normals[index];
-    }
-    
-    /// @brief Equality operator.
-    friend bool operator== (const ChainShapeConf& lhs, const ChainShapeConf& rhs) noexcept
-    {
-        // Don't need to check normals since normals based on vertices.
-        return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
-            && lhs.restitution == rhs.restitution && lhs.density == rhs.density
-            && lhs.m_vertices == rhs.m_vertices;
-    }
-    
-    /// @brief Inequality operator.
-    friend bool operator!= (const ChainShapeConf& lhs, const ChainShapeConf& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
-    
-    /// @brief Vertex radius.
-    ///
-    /// @details This is the radius from the vertex that the shape's "skin" should
-    ///   extend outward by. While any edges &mdash; line segments between multiple
-    ///   vertices &mdash; are straight, corners between them (the vertices) are
-    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
-    ///   to edge lengths therefore will be more prone to rolling or having other
-    ///   shapes more prone to roll off of them.
-    ///
-    /// @note This should be a non-negative value.
-    ///
-    NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
+            /// @brief Adds the given vertex.
+            ChainShapeConf& Add(Length2 vertex);
 
-private:
-    std::vector<Length2> m_vertices; ///< Vertices.
-    std::vector<UnitVec> m_normals; ///< Normals.
-};
+            /// @brief Transforms all the vertices by the given transformation matrix.
+            /// @note This updates the normals too.
+            /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+            ChainShapeConf& Transform(const Mat22& m) noexcept;
 
-inline ChainShapeConf& ChainShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
-{
-    vertexRadius = value;
-    return *this;
-}
+            /// @brief Gets the "child" shape count.
+            ChildCounter GetChildCount() const noexcept
+            {
+                // edge count = vertex count - 1
+                const auto count = GetVertexCount();
+                return (count > 1) ? count - 1 : count;
+            }
 
-// Free functions...
+            /// @brief Gets the "child" shape at the given index.
+            DistanceProxy GetChild(ChildCounter index) const;
 
-/// @brief Gets the child count for a given chain shape configuration.
-inline ChildCounter GetChildCount(const ChainShapeConf& arg) noexcept
-{
-    return arg.GetChildCount();
-}
+            /// @brief Gets the mass data.
+            MassData GetMassData() const noexcept;
 
-/// @brief Gets the "child" shape for a given chain shape configuration.
-inline DistanceProxy GetChild(const ChainShapeConf& arg, ChildCounter index)
-{
-    return arg.GetChild(index);
-}
+            /// @brief Uses the given vertex radius.
+            ChainShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
 
-/// @brief Gets the mass data for a given chain shape configuration.
-inline MassData GetMassData(const ChainShapeConf& arg) noexcept
-{
-    return arg.GetMassData();
-}
+            /// @brief Gets the vertex count.
+            ChildCounter GetVertexCount() const noexcept
+            {
+                return static_cast<ChildCounter>(size(m_vertices));
+            }
 
-/// @brief Determines whether the given shape is looped.
-inline bool IsLooped(const ChainShapeConf& shape) noexcept
-{
-    const auto count = shape.GetVertexCount();
-    return (count > 1)? (shape.GetVertex(count - 1) == shape.GetVertex(0)): false;
-}
+            /// @brief Gets a vertex by index.
+            Length2 GetVertex(ChildCounter index) const
+            {
+                assert((0 <= index) && (index < GetVertexCount()));
+                return m_vertices[index];
+            }
 
-/// @brief Gets the next index after the given index for the given shape.
-inline ChildCounter GetNextIndex(const ChainShapeConf& shape, ChildCounter index) noexcept
-{
-    return GetModuloNext(index, shape.GetVertexCount());
-}
+            /// @brief Gets the normal at the given index.
+            UnitVec GetNormal(ChildCounter index) const
+            {
+                assert((0 <= index) && (index < GetVertexCount()));
+                return m_normals[index];
+            }
 
-/// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg)
-{
-    return arg.vertexRadius;
-}
+            /// @brief Equality operator.
+            friend bool operator==(const ChainShapeConf& lhs, const ChainShapeConf& rhs) noexcept
+            {
+                // Don't need to check normals since normals based on vertices.
+                return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
+                       && lhs.restitution == rhs.restitution && lhs.density == rhs.density
+                       && lhs.m_vertices == rhs.m_vertices;
+            }
 
-/// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCounter)
-{
-    return GetVertexRadius(arg);
-}
+            /// @brief Inequality operator.
+            friend bool operator!=(const ChainShapeConf& lhs, const ChainShapeConf& rhs) noexcept
+            {
+                return !(lhs == rhs);
+            }
 
-/// @brief Transforms the given chain shape configuration's vertices by the given
-///   transformation matrix.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-inline void Transform(ChainShapeConf& arg, const Mat22& m) noexcept
-{
-    arg.Transform(m);
-}
+            /// @brief Vertex radius.
+            ///
+            /// @details This is the radius from the vertex that the shape's "skin" should
+            ///   extend outward by. While any edges &mdash; line segments between multiple
+            ///   vertices &mdash; are straight, corners between them (the vertices) are
+            ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+            ///   to edge lengths therefore will be more prone to rolling or having other
+            ///   shapes more prone to roll off of them.
+            ///
+            /// @note This should be a non-negative value.
+            ///
+            NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
 
-/// @brief Gets an enclosing chain shape configuration for an axis aligned rectangle of the
-///    given dimensions (width and height).
-ChainShapeConf GetChainShapeConf(Length2 dimensions);
+         private:
+            std::vector<Length2> m_vertices;///< Vertices.
+            std::vector<UnitVec> m_normals; ///< Normals.
+        };
 
-/// @brief Gets an enclosing chain shape configuration for an axis aligned square of the
-///    given dimension.
-inline ChainShapeConf GetChainShapeConf(Length dimension)
-{
-    return GetChainShapeConf(Length2{dimension, dimension});
-}
+        inline ChainShapeConf& ChainShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
+        {
+            vertexRadius = value;
+            return *this;
+        }
 
-/// @brief Gets an enclosing chain shape configuration for the given axis aligned box.
-ChainShapeConf GetChainShapeConf(const AABB& arg);
+        // Free functions...
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Gets the child count for a given chain shape configuration.
+        inline ChildCounter GetChildCount(const ChainShapeConf& arg) noexcept
+        {
+            return arg.GetChildCount();
+        }
 
-#endif // PLAYRHO_COLLISION_SHAPES_CHAINSHAPECONF_HPP
+        /// @brief Gets the "child" shape for a given chain shape configuration.
+        inline DistanceProxy GetChild(const ChainShapeConf& arg, ChildCounter index)
+        {
+            return arg.GetChild(index);
+        }
+
+        /// @brief Gets the mass data for a given chain shape configuration.
+        inline MassData GetMassData(const ChainShapeConf& arg) noexcept
+        {
+            return arg.GetMassData();
+        }
+
+        /// @brief Determines whether the given shape is looped.
+        inline bool IsLooped(const ChainShapeConf& shape) noexcept
+        {
+            const auto count = shape.GetVertexCount();
+            return (count > 1) ? (shape.GetVertex(count - 1) == shape.GetVertex(0)) : false;
+        }
+
+        /// @brief Gets the next index after the given index for the given shape.
+        inline ChildCounter GetNextIndex(const ChainShapeConf& shape, ChildCounter index) noexcept
+        {
+            return GetModuloNext(index, shape.GetVertexCount());
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg)
+        {
+            return arg.vertexRadius;
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCounter)
+        {
+            return GetVertexRadius(arg);
+        }
+
+        /// @brief Transforms the given chain shape configuration's vertices by the given
+        ///   transformation matrix.
+        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+        inline void Transform(ChainShapeConf& arg, const Mat22& m) noexcept
+        {
+            arg.Transform(m);
+        }
+
+        /// @brief Gets an enclosing chain shape configuration for an axis aligned rectangle of the
+        ///    given dimensions (width and height).
+        ChainShapeConf GetChainShapeConf(Length2 dimensions);
+
+        /// @brief Gets an enclosing chain shape configuration for an axis aligned square of the
+        ///    given dimension.
+        inline ChainShapeConf GetChainShapeConf(Length dimension)
+        {
+            return GetChainShapeConf(Length2{dimension, dimension});
+        }
+
+        /// @brief Gets an enclosing chain shape configuration for the given axis aligned box.
+        ChainShapeConf GetChainShapeConf(const AABB& arg);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SHAPES_CHAINSHAPECONF_HPP

--- a/PlayRho/Collision/Shapes/DiskShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.cpp
@@ -19,6 +19,7 @@
 
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-} // namespace playrho
+}// namespace playrho

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -20,151 +20,154 @@
 #ifndef PLAYRHO_COLLISION_SHAPES_DISKSHAPECONF_HPP
 #define PLAYRHO_COLLISION_SHAPES_DISKSHAPECONF_HPP
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
+#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
+#include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Disk shape configuration.
-///
-/// @details A disk shape "is the region in a plane bounded by a circle". This is a
-///   two-dimensional solid round shape. This used to be called the circle shape but
-///   that's now used for hollow round shapes.
-///
-/// @see https://en.wikipedia.org/wiki/Disk_(mathematics)
-///
-/// @ingroup PartsGroup
-///
-struct DiskShapeConf: ShapeBuilder<DiskShapeConf>
+namespace playrho
 {
-    /// @brief Gets the default radius.
-    static constexpr NonNegative<Length> GetDefaultRadius() noexcept
+    namespace d2
     {
-        return NonNegative<Length>{DefaultLinearSlop * 2};
-    }
 
-    constexpr DiskShapeConf() = default;
+        /// @brief Disk shape configuration.
+        ///
+        /// @details A disk shape "is the region in a plane bounded by a circle". This is a
+        ///   two-dimensional solid round shape. This used to be called the circle shape but
+        ///   that's now used for hollow round shapes.
+        ///
+        /// @see https://en.wikipedia.org/wiki/Disk_(mathematics)
+        ///
+        /// @ingroup PartsGroup
+        ///
+        struct DiskShapeConf : ShapeBuilder<DiskShapeConf>
+        {
+            /// @brief Gets the default radius.
+            static constexpr NonNegative<Length> GetDefaultRadius() noexcept
+            {
+                return NonNegative<Length>{DefaultLinearSlop * 2};
+            }
 
-    /// @brief Initializing constructor.
-    constexpr DiskShapeConf(NonNegative<Length> r): vertexRadius{r}
-    {
-        // Intentionally empty.
-    }
+            constexpr DiskShapeConf() = default;
 
-    /// @brief Uses the given value as the location.
-    constexpr DiskShapeConf& UseLocation(Length2 value) noexcept
-    {
-        location = value;
-        return *this;
-    }
-    
-    /// @brief Uses the given value as the radius.
-    constexpr DiskShapeConf& UseRadius(NonNegative<Length> r) noexcept
-    {
-        vertexRadius = r;
-        return *this;
-    }
-    
-    /// @brief Transforms the location by the given transformation matrix.
-    /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-    constexpr DiskShapeConf& Transform(const Mat22& m) noexcept
-    {
-        location = m * location;
-        return *this;
-    }
-    
-    /// @brief Gets the radius property.
-    NonNegative<Length> GetRadius() const noexcept
-    {
-        return vertexRadius;
-    }
-    
-    /// @brief Gets the location.
-    Length2 GetLocation() const noexcept
-    {
-        return location;
-    }
-    
-    /// @brief Vertex radius.
-    ///
-    /// @details This is the radius from the vertex that the shape's "skin" should
-    ///   extend outward by. While any edges &mdash; line segments between multiple
-    ///   vertices &mdash; are straight, corners between them (the vertices) are
-    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
-    ///   to edge lengths therefore will be more prone to rolling or having other
-    ///   shapes more prone to roll off of them.
-    ///
-    /// @note This should be a non-negative value.
-    ///
-    NonNegative<Length> vertexRadius = GetDefaultRadius();
+            /// @brief Initializing constructor.
+            constexpr DiskShapeConf(NonNegative<Length> r)
+                : vertexRadius{r}
+            {
+                // Intentionally empty.
+            }
 
-    /// @brief Location for the disk shape to be centered at.
-    Length2 location = Length2{};
-};
+            /// @brief Uses the given value as the location.
+            constexpr DiskShapeConf& UseLocation(Length2 value) noexcept
+            {
+                location = value;
+                return *this;
+            }
 
-// Free functions...
+            /// @brief Uses the given value as the radius.
+            constexpr DiskShapeConf& UseRadius(NonNegative<Length> r) noexcept
+            {
+                vertexRadius = r;
+                return *this;
+            }
 
-/// @brief Equality operator.
-inline bool operator== (const DiskShapeConf& lhs, const DiskShapeConf& rhs) noexcept
-{
-    return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
-        && lhs.restitution == rhs.restitution && lhs.density == rhs.density
-        && lhs.location == rhs.location;
-}
+            /// @brief Transforms the location by the given transformation matrix.
+            /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+            constexpr DiskShapeConf& Transform(const Mat22& m) noexcept
+            {
+                location = m * location;
+                return *this;
+            }
 
-/// @brief Inequality operator.
-inline bool operator!= (const DiskShapeConf& lhs, const DiskShapeConf& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+            /// @brief Gets the radius property.
+            NonNegative<Length> GetRadius() const noexcept
+            {
+                return vertexRadius;
+            }
 
-/// @brief Gets the "child" count of the given disk shape configuration.
-constexpr ChildCounter GetChildCount(const DiskShapeConf&) noexcept
-{
-    return 1;
-}
+            /// @brief Gets the location.
+            Length2 GetLocation() const noexcept
+            {
+                return location;
+            }
 
-/// @brief Gets the "child" of the given disk shape configuration.
-inline DistanceProxy GetChild(const DiskShapeConf& arg, ChildCounter index)
-{
-    if (index != 0)
-    {
-        throw InvalidArgument("only index of 0 is supported");
-    }
-    return DistanceProxy{arg.vertexRadius, 1, &arg.location, nullptr};
-}
+            /// @brief Vertex radius.
+            ///
+            /// @details This is the radius from the vertex that the shape's "skin" should
+            ///   extend outward by. While any edges &mdash; line segments between multiple
+            ///   vertices &mdash; are straight, corners between them (the vertices) are
+            ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+            ///   to edge lengths therefore will be more prone to rolling or having other
+            ///   shapes more prone to roll off of them.
+            ///
+            /// @note This should be a non-negative value.
+            ///
+            NonNegative<Length> vertexRadius = GetDefaultRadius();
 
-/// @brief Gets the vertex radius of the given shape configuration.
-constexpr NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg) noexcept
-{
-    return arg.vertexRadius;
-}
+            /// @brief Location for the disk shape to be centered at.
+            Length2 location = Length2{};
+        };
 
-/// @brief Gets the vertex radius of the given shape configuration.
-constexpr NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg,
-                                                             ChildCounter) noexcept
-{
-    return GetVertexRadius(arg);
-}
+        // Free functions...
 
-/// @brief Gets the mass data of the given disk shape configuration.
-inline MassData GetMassData(const DiskShapeConf& arg) noexcept
-{
-    return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.location);
-}
+        /// @brief Equality operator.
+        inline bool operator==(const DiskShapeConf& lhs, const DiskShapeConf& rhs) noexcept
+        {
+            return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
+                   && lhs.restitution == rhs.restitution && lhs.density == rhs.density
+                   && lhs.location == rhs.location;
+        }
 
-/// @brief Transforms the given shape configuration's vertices by the given
-///   transformation matrix.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-inline void Transform(DiskShapeConf& arg, const Mat22& m) noexcept
-{
-    arg.Transform(m);
-}
+        /// @brief Inequality operator.
+        inline bool operator!=(const DiskShapeConf& lhs, const DiskShapeConf& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Gets the "child" count of the given disk shape configuration.
+        constexpr ChildCounter GetChildCount(const DiskShapeConf&) noexcept
+        {
+            return 1;
+        }
 
-#endif // PLAYRHO_COLLISION_SHAPES_DISKSHAPECONF_HPP
+        /// @brief Gets the "child" of the given disk shape configuration.
+        inline DistanceProxy GetChild(const DiskShapeConf& arg, ChildCounter index)
+        {
+            if (index != 0)
+            {
+                throw InvalidArgument("only index of 0 is supported");
+            }
+            return DistanceProxy{arg.vertexRadius, 1, &arg.location, nullptr};
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        constexpr NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg) noexcept
+        {
+            return arg.vertexRadius;
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        constexpr NonNegative<Length> GetVertexRadius(const DiskShapeConf& arg,
+                                                      ChildCounter) noexcept
+        {
+            return GetVertexRadius(arg);
+        }
+
+        /// @brief Gets the mass data of the given disk shape configuration.
+        inline MassData GetMassData(const DiskShapeConf& arg) noexcept
+        {
+            return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.location);
+        }
+
+        /// @brief Transforms the given shape configuration's vertices by the given
+        ///   transformation matrix.
+        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+        inline void Transform(DiskShapeConf& arg, const Mat22& m) noexcept
+        {
+            arg.Transform(m);
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SHAPES_DISKSHAPECONF_HPP

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
@@ -19,33 +19,35 @@
 
 #include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
 
-namespace playrho {
-namespace d2 {
-
-EdgeShapeConf::EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf) noexcept:
-    ShapeBuilder{conf}, vertexRadius{conf.vertexRadius}, m_vertices{vA, vB}
+namespace playrho
 {
-    const auto normal = GetUnitVector(GetFwdPerpendicular(vB - vA));
-    m_normals[0] = normal;
-    m_normals[1] = -normal;
-}
+    namespace d2
+    {
 
-EdgeShapeConf& EdgeShapeConf::Set(Length2 vA, Length2 vB) noexcept
-{
-    m_vertices[0] = vA;
-    m_vertices[1] = vB;
-    const auto normal = GetUnitVector(GetFwdPerpendicular(vB - vA));
-    m_normals[0] = normal;
-    m_normals[1] = -normal;
-    return *this;
-}
+        EdgeShapeConf::EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf) noexcept
+            : ShapeBuilder{conf}, vertexRadius{conf.vertexRadius}, m_vertices{vA, vB}
+        {
+            const auto normal = GetUnitVector(GetFwdPerpendicular(vB - vA));
+            m_normals[0] = normal;
+            m_normals[1] = -normal;
+        }
 
-EdgeShapeConf& EdgeShapeConf::Transform(const Mat22& m) noexcept
-{
-    const auto newA = m * GetVertexA();
-    const auto newB = m * GetVertexB();
-    return Set(newA, newB);
-}
+        EdgeShapeConf& EdgeShapeConf::Set(Length2 vA, Length2 vB) noexcept
+        {
+            m_vertices[0] = vA;
+            m_vertices[1] = vB;
+            const auto normal = GetUnitVector(GetFwdPerpendicular(vB - vA));
+            m_normals[0] = normal;
+            m_normals[1] = -normal;
+            return *this;
+        }
 
-} // namespace d2
-} // namespace playrho
+        EdgeShapeConf& EdgeShapeConf::Transform(const Mat22& m) noexcept
+        {
+            const auto newA = m * GetVertexA();
+            const auto newB = m * GetVertexB();
+            return Set(newA, newB);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -20,156 +20,158 @@
 #ifndef PLAYRHO_COLLISION_SHAPES_EDGESHAPECONF_HPP
 #define PLAYRHO_COLLISION_SHAPES_EDGESHAPECONF_HPP
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
+#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
+#include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Edge shape configuration.
-///
-/// @details A line segment (edge) shape. These can be connected in chains or loops
-///   to other edge shapes. The connectivity information is used to ensure correct
-///   contact normals.
-///
-/// @note This data structure is 56-bytes.
-///
-/// @ingroup PartsGroup
-///
-class EdgeShapeConf: public ShapeBuilder<EdgeShapeConf>
+namespace playrho
 {
-public:
-    /// @brief Gets the default vertex radius.
-    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+    namespace d2
     {
-        return NonNegative<Length>{DefaultLinearSlop * Real{2}};
-    }
-    
-    /// @brief Gets the default configuration.
-    static inline EdgeShapeConf GetDefaultConf() noexcept
-    {
-        return EdgeShapeConf{};
-    }
 
-    EdgeShapeConf() = default;
-    
-    /// @brief Initializing constructor.
-    EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf = GetDefaultConf()) noexcept;
-    
-    /// @brief Sets both vertices in one call.
-    EdgeShapeConf& Set(Length2 vA, Length2 vB) noexcept;
-    
-    /// @brief Uses the given vertex radius.
-    EdgeShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
-    
-    /// @brief Transforms both vertices by the given transformation matrix.
-    /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-    EdgeShapeConf& Transform(const Mat22& m) noexcept;
+        /// @brief Edge shape configuration.
+        ///
+        /// @details A line segment (edge) shape. These can be connected in chains or loops
+        ///   to other edge shapes. The connectivity information is used to ensure correct
+        ///   contact normals.
+        ///
+        /// @note This data structure is 56-bytes.
+        ///
+        /// @ingroup PartsGroup
+        ///
+        class EdgeShapeConf : public ShapeBuilder<EdgeShapeConf>
+        {
+         public:
+            /// @brief Gets the default vertex radius.
+            static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+            {
+                return NonNegative<Length>{DefaultLinearSlop * Real{2}};
+            }
 
-    /// @brief Gets vertex A.
-    Length2 GetVertexA() const noexcept
-    {
-        return m_vertices[0];
-    }
-    
-    /// @brief Gets vertex B.
-    Length2 GetVertexB() const noexcept
-    {
-        return m_vertices[1];
-    }
-    
-    /// @brief Gets the "child" shape.
-    DistanceProxy GetChild() const noexcept
-    {
-        return DistanceProxy{vertexRadius, 2, m_vertices, m_normals};
-    }
-    
-    /// @brief Vertex radius.
-    ///
-    /// @details This is the radius from the vertex that the shape's "skin" should
-    ///   extend outward by. While any edges &mdash; line segments between multiple
-    ///   vertices &mdash; are straight, corners between them (the vertices) are
-    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
-    ///   to edge lengths therefore will be more prone to rolling or having other
-    ///   shapes more prone to roll off of them.
-    ///
-    /// @note This should be a non-negative value.
-    ///
-    NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
+            /// @brief Gets the default configuration.
+            static inline EdgeShapeConf GetDefaultConf() noexcept
+            {
+                return EdgeShapeConf{};
+            }
 
-private:
-    Length2 m_vertices[2] = {Length2{}, Length2{}}; ///< Vertices
-    UnitVec m_normals[2] = {UnitVec{}, UnitVec{}}; ///< Normals.
-};
+            EdgeShapeConf() = default;
 
-inline EdgeShapeConf& EdgeShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
-{
-    vertexRadius = value;
-    return *this;
-}
+            /// @brief Initializing constructor.
+            EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf = GetDefaultConf()) noexcept;
 
-// Free functions...
+            /// @brief Sets both vertices in one call.
+            EdgeShapeConf& Set(Length2 vA, Length2 vB) noexcept;
 
-/// @brief Equality operator.
-inline bool operator== (const EdgeShapeConf& lhs, const EdgeShapeConf& rhs) noexcept
-{
-    return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
-        && lhs.restitution == rhs.restitution && lhs.density == rhs.density
-        && lhs.GetVertexA() == rhs.GetVertexA() && lhs.GetVertexB() == rhs.GetVertexB();
-}
+            /// @brief Uses the given vertex radius.
+            EdgeShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
 
-/// @brief Inequality operator.
-inline bool operator!= (const EdgeShapeConf& lhs, const EdgeShapeConf& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+            /// @brief Transforms both vertices by the given transformation matrix.
+            /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+            EdgeShapeConf& Transform(const Mat22& m) noexcept;
 
-/// @brief Gets the "child" count for the given shape configuration.
-/// @return 1.
-constexpr ChildCounter GetChildCount(const EdgeShapeConf&) noexcept
-{
-    return 1;
-}
+            /// @brief Gets vertex A.
+            Length2 GetVertexA() const noexcept
+            {
+                return m_vertices[0];
+            }
 
-/// @brief Gets the "child" shape for the given shape configuration.
-inline DistanceProxy GetChild(const EdgeShapeConf& arg, ChildCounter index)
-{
-    if (index != 0)
-    {
-        throw InvalidArgument("only index of 0 is supported");
-    }
-    return arg.GetChild();
-}
+            /// @brief Gets vertex B.
+            Length2 GetVertexB() const noexcept
+            {
+                return m_vertices[1];
+            }
 
-/// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const EdgeShapeConf& arg) noexcept
-{
-    return arg.vertexRadius;
-}
+            /// @brief Gets the "child" shape.
+            DistanceProxy GetChild() const noexcept
+            {
+                return DistanceProxy{vertexRadius, 2, m_vertices, m_normals};
+            }
 
-/// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const EdgeShapeConf& arg, ChildCounter) noexcept
-{
-    return GetVertexRadius(arg);
-}
+            /// @brief Vertex radius.
+            ///
+            /// @details This is the radius from the vertex that the shape's "skin" should
+            ///   extend outward by. While any edges &mdash; line segments between multiple
+            ///   vertices &mdash; are straight, corners between them (the vertices) are
+            ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+            ///   to edge lengths therefore will be more prone to rolling or having other
+            ///   shapes more prone to roll off of them.
+            ///
+            /// @note This should be a non-negative value.
+            ///
+            NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
 
-/// @brief Gets the mass data for the given shape configuration.
-inline MassData GetMassData(const EdgeShapeConf& arg) noexcept
-{
-    return playrho::d2::GetMassData(arg.vertexRadius, arg.density,
-                                    arg.GetVertexA(), arg.GetVertexB());
-}
+         private:
+            Length2 m_vertices[2] = {Length2{}, Length2{}};///< Vertices
+            UnitVec m_normals[2] = {UnitVec{}, UnitVec{}}; ///< Normals.
+        };
 
-/// @brief Transforms the given shape configuration's vertices by the given transformation matrix.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-inline void Transform(EdgeShapeConf& arg, const Mat22& m) noexcept
-{
-    arg.Transform(m);
-}
+        inline EdgeShapeConf& EdgeShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
+        {
+            vertexRadius = value;
+            return *this;
+        }
 
-} // namespace d2
-} // namespace playrho
+        // Free functions...
 
-#endif // PLAYRHO_COLLISION_SHAPES_EDGESHAPECONF_HPP
+        /// @brief Equality operator.
+        inline bool operator==(const EdgeShapeConf& lhs, const EdgeShapeConf& rhs) noexcept
+        {
+            return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
+                   && lhs.restitution == rhs.restitution && lhs.density == rhs.density
+                   && lhs.GetVertexA() == rhs.GetVertexA() && lhs.GetVertexB() == rhs.GetVertexB();
+        }
+
+        /// @brief Inequality operator.
+        inline bool operator!=(const EdgeShapeConf& lhs, const EdgeShapeConf& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
+
+        /// @brief Gets the "child" count for the given shape configuration.
+        /// @return 1.
+        constexpr ChildCounter GetChildCount(const EdgeShapeConf&) noexcept
+        {
+            return 1;
+        }
+
+        /// @brief Gets the "child" shape for the given shape configuration.
+        inline DistanceProxy GetChild(const EdgeShapeConf& arg, ChildCounter index)
+        {
+            if (index != 0)
+            {
+                throw InvalidArgument("only index of 0 is supported");
+            }
+            return arg.GetChild();
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        inline NonNegative<Length> GetVertexRadius(const EdgeShapeConf& arg) noexcept
+        {
+            return arg.vertexRadius;
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        inline NonNegative<Length> GetVertexRadius(const EdgeShapeConf& arg, ChildCounter) noexcept
+        {
+            return GetVertexRadius(arg);
+        }
+
+        /// @brief Gets the mass data for the given shape configuration.
+        inline MassData GetMassData(const EdgeShapeConf& arg) noexcept
+        {
+            return playrho::d2::GetMassData(arg.vertexRadius, arg.density,
+                                            arg.GetVertexA(), arg.GetVertexB());
+        }
+
+        /// @brief Transforms the given shape configuration's vertices by the given transformation matrix.
+        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+        inline void Transform(EdgeShapeConf& arg, const Mat22& m) noexcept
+        {
+            arg.Transform(m);
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SHAPES_EDGESHAPECONF_HPP

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -23,86 +23,88 @@
 #include <algorithm>
 #include <iterator>
 
-namespace playrho {
-namespace d2 {
-
-/// Computes the mass properties of this shape using its dimensions and density.
-/// The inertia tensor is computed about the local origin.
-/// @return Mass data for this shape.
-MassData GetMassData(const MultiShapeConf& arg) noexcept
+namespace playrho
 {
-    auto mass = 0_kg;
-    const auto origin = Length2{};
-    auto weightedCenter = origin * Kilogram;
-    auto I = RotInertia{0};
-    const auto density = arg.density;
-
-    std::for_each(begin(arg.children), end(arg.children),
-                  [&](const ConvexHull& ch) {
-        const auto dp = ch.GetDistanceProxy();
-        const auto md = playrho::d2::GetMassData(ch.GetVertexRadius(), density,
-            Span<const Length2>(begin(dp.GetVertices()), dp.GetVertexCount()));
-        mass += Mass{md.mass};
-        weightedCenter += md.center * Mass{md.mass};
-        I += RotInertia{md.I};
-    });
-
-    const auto center = (mass > 0_kg)? weightedCenter / mass: origin;
-    return MassData{center, mass, I};
-}
-
-ConvexHull ConvexHull::Get(const VertexSet& pointSet, NonNegative<Length> vertexRadius)
-{
-    auto vertices = GetConvexHullAsVector(pointSet);
-    assert(!empty(vertices) && size(vertices) < std::numeric_limits<VertexCounter>::max());
-    
-    const auto count = static_cast<VertexCounter>(size(vertices));
-    
-    auto normals = std::vector<UnitVec>();
-    if (count > 1)
+    namespace d2
     {
-        // Compute normals.
-        for (auto i = decltype(count){0}; i < count; ++i)
+
+        /// Computes the mass properties of this shape using its dimensions and density.
+        /// The inertia tensor is computed about the local origin.
+        /// @return Mass data for this shape.
+        MassData GetMassData(const MultiShapeConf& arg) noexcept
         {
-            const auto nextIndex = GetModuloNext(i, count);
-            const auto edge = vertices[nextIndex] - vertices[i];
-            normals.push_back(GetUnitVector(GetFwdPerpendicular(edge)));
+            auto mass = 0_kg;
+            const auto origin = Length2{};
+            auto weightedCenter = origin * Kilogram;
+            auto I = RotInertia{0};
+            const auto density = arg.density;
+
+            std::for_each(begin(arg.children), end(arg.children),
+                          [&](const ConvexHull& ch) {
+                              const auto dp = ch.GetDistanceProxy();
+                              const auto md = playrho::d2::GetMassData(ch.GetVertexRadius(), density,
+                                                                       Span<const Length2>(begin(dp.GetVertices()), dp.GetVertexCount()));
+                              mass += Mass{md.mass};
+                              weightedCenter += md.center * Mass{md.mass};
+                              I += RotInertia{md.I};
+                          });
+
+            const auto center = (mass > 0_kg) ? weightedCenter / mass : origin;
+            return MassData{center, mass, I};
         }
-    }
-    else if (count == 1)
-    {
-        normals.push_back(UnitVec{});
-    }
-    
-    return ConvexHull{vertices, normals, vertexRadius};
-}
 
-ConvexHull& ConvexHull::Transform(const Mat22& m) noexcept
-{
-    auto newPoints = VertexSet{};
-    // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
-    for (const auto& v: vertices)
-    {
-        newPoints.add(m * v);
-    }
-    *this = Get(newPoints, vertexRadius);
-    return *this;
-}
+        ConvexHull ConvexHull::Get(const VertexSet& pointSet, NonNegative<Length> vertexRadius)
+        {
+            auto vertices = GetConvexHullAsVector(pointSet);
+            assert(!empty(vertices) && size(vertices) < std::numeric_limits<VertexCounter>::max());
 
-MultiShapeConf& MultiShapeConf::AddConvexHull(const VertexSet& pointSet,
-                                              NonNegative<Length> vertexRadius) noexcept
-{
-    children.emplace_back(ConvexHull::Get(pointSet, vertexRadius));
-    return *this;
-}
+            const auto count = static_cast<VertexCounter>(size(vertices));
 
-MultiShapeConf& MultiShapeConf::Transform(const Mat22& m) noexcept
-{
-    std::for_each(begin(children), end(children), [=](ConvexHull& child){
-        child.Transform(m);
-    });
-    return *this;
-}
+            auto normals = std::vector<UnitVec>();
+            if (count > 1)
+            {
+                // Compute normals.
+                for (auto i = decltype(count){0}; i < count; ++i)
+                {
+                    const auto nextIndex = GetModuloNext(i, count);
+                    const auto edge = vertices[nextIndex] - vertices[i];
+                    normals.push_back(GetUnitVector(GetFwdPerpendicular(edge)));
+                }
+            }
+            else if (count == 1)
+            {
+                normals.push_back(UnitVec{});
+            }
 
-} // namespace d2
-} // namespace playrho
+            return ConvexHull{vertices, normals, vertexRadius};
+        }
+
+        ConvexHull& ConvexHull::Transform(const Mat22& m) noexcept
+        {
+            auto newPoints = VertexSet{};
+            // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
+            for (const auto& v : vertices)
+            {
+                newPoints.add(m * v);
+            }
+            *this = Get(newPoints, vertexRadius);
+            return *this;
+        }
+
+        MultiShapeConf& MultiShapeConf::AddConvexHull(const VertexSet& pointSet,
+                                                      NonNegative<Length> vertexRadius) noexcept
+        {
+            children.emplace_back(ConvexHull::Get(pointSet, vertexRadius));
+            return *this;
+        }
+
+        MultiShapeConf& MultiShapeConf::Transform(const Mat22& m) noexcept
+        {
+            std::for_each(begin(children), end(children), [=](ConvexHull& child) {
+                child.Transform(m);
+            });
+            return *this;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Shapes/MultiShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.hpp
@@ -21,181 +21,182 @@
 #ifndef PLAYRHO_COLLISION_SHAPES_MULTISHAPECONF_HPP
 #define PLAYRHO_COLLISION_SHAPES_MULTISHAPECONF_HPP
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
+#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
+#include <PlayRho/Common/Math.hpp>
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-class VertexSet;
-
-/// @brief Convex hull.
-class ConvexHull
+namespace playrho
 {
-public:
-    
-    /// @brief Gets the convex hull for the given set of vertices.
-    static ConvexHull Get(const VertexSet& pointSet, NonNegative<Length> vertexRadius =
-                          NonNegative<Length>{DefaultLinearSlop * Real{2}});
-    
-    /// @brief Gets the distance proxy for this convex hull.
-    DistanceProxy GetDistanceProxy() const
+    namespace d2
     {
-        return DistanceProxy{
-            vertexRadius, static_cast<VertexCounter>(size(vertices)),
-            data(vertices), data(normals)
+
+        class VertexSet;
+
+        /// @brief Convex hull.
+        class ConvexHull
+        {
+         public:
+            /// @brief Gets the convex hull for the given set of vertices.
+            static ConvexHull Get(const VertexSet& pointSet, NonNegative<Length> vertexRadius =
+                                                                 NonNegative<Length>{DefaultLinearSlop * Real{2}});
+
+            /// @brief Gets the distance proxy for this convex hull.
+            DistanceProxy GetDistanceProxy() const
+            {
+                return DistanceProxy{
+                    vertexRadius, static_cast<VertexCounter>(size(vertices)),
+                    data(vertices), data(normals)};
+            }
+
+            /// @brief Gets the vertex radius of this convex hull.
+            /// @return Non-negative distance.
+            NonNegative<Length> GetVertexRadius() const noexcept
+            {
+                return vertexRadius;
+            }
+
+            /// @brief Transforms all the vertices by the given transformation matrix.
+            /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+            ConvexHull& Transform(const Mat22& m) noexcept;
+
+            /// @brief Equality operator.
+            friend bool operator==(const ConvexHull& lhs, const ConvexHull& rhs) noexcept
+            {
+                // No need to check normals - they're based on vertices.
+                return lhs.vertexRadius == rhs.vertexRadius && lhs.vertices == rhs.vertices;
+            }
+
+            /// @brief Inequality operator.
+            friend bool operator!=(const ConvexHull& lhs, const ConvexHull& rhs) noexcept
+            {
+                return !(lhs == rhs);
+            }
+
+         private:
+            /// @brief Initializing constructor.
+            ConvexHull(std::vector<Length2> verts, std::vector<UnitVec> norms,
+                       NonNegative<Length> vr)
+                : vertices{verts}, normals{norms}, vertexRadius{vr}
+            {
+            }
+
+            /// Array of vertices.
+            /// @details Consecutive vertices constitute "edges" of the polygon.
+            std::vector<Length2> vertices;
+
+            /// Normals of edges.
+            /// @details
+            /// These are 90-degree clockwise-rotated unit-vectors of the vectors defined by
+            /// consecutive pairs of elements of vertices.
+            std::vector<UnitVec> normals;
+
+            /// @brief Vertex radius.
+            ///
+            /// @details This is the radius from the vertex that the shape's "skin" should
+            ///   extend outward by. While any edges &mdash; line segments between multiple
+            ///   vertices &mdash; are straight, corners between them (the vertices) are
+            ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+            ///   to edge lengths therefore will be more prone to rolling or having other
+            ///   shapes more prone to roll off of them.
+            ///
+            /// @note This should be a non-negative value.
+            ///
+            NonNegative<Length> vertexRadius;
         };
-    }
-    
-    /// @brief Gets the vertex radius of this convex hull.
-    /// @return Non-negative distance.
-    NonNegative<Length> GetVertexRadius() const noexcept
-    {
-        return vertexRadius;
-    }
-    
-    /// @brief Transforms all the vertices by the given transformation matrix.
-    /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-    ConvexHull& Transform(const Mat22& m) noexcept;
 
-    /// @brief Equality operator.
-    friend bool operator== (const ConvexHull& lhs, const ConvexHull& rhs) noexcept
-    {
-        // No need to check normals - they're based on vertices.
-        return lhs.vertexRadius == rhs.vertexRadius && lhs.vertices == rhs.vertices;
-    }
-    
-    /// @brief Inequality operator.
-    friend bool operator!= (const ConvexHull& lhs, const ConvexHull& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
-    
-private:
-    /// @brief Initializing constructor.
-    ConvexHull(std::vector<Length2> verts, std::vector<UnitVec> norms,
-               NonNegative<Length> vr):
-        vertices{verts}, normals{norms}, vertexRadius{vr}
-    {}
-    
-    /// Array of vertices.
-    /// @details Consecutive vertices constitute "edges" of the polygon.
-    std::vector<Length2> vertices;
-    
-    /// Normals of edges.
-    /// @details
-    /// These are 90-degree clockwise-rotated unit-vectors of the vectors defined by
-    /// consecutive pairs of elements of vertices.
-    std::vector<UnitVec> normals;
+        /// @brief The "multi-shape" shape configuration.
+        /// @details Composes zero or more convex shapes into what can be a concave shape.
+        /// @ingroup PartsGroup
+        struct MultiShapeConf : public ShapeBuilder<MultiShapeConf>
+        {
+            /// @brief Gets the default vertex radius for the <code>MultiShapeConf</code>.
+            static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+            {
+                return NonNegative<Length>{DefaultLinearSlop * 2};
+            }
 
-    /// @brief Vertex radius.
-    ///
-    /// @details This is the radius from the vertex that the shape's "skin" should
-    ///   extend outward by. While any edges &mdash; line segments between multiple
-    ///   vertices &mdash; are straight, corners between them (the vertices) are
-    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
-    ///   to edge lengths therefore will be more prone to rolling or having other
-    ///   shapes more prone to roll off of them.
-    ///
-    /// @note This should be a non-negative value.
-    ///
-    NonNegative<Length> vertexRadius;
-};
+            /// @brief Gets the default configuration for a <code>MultiShapeConf</code>.
+            static inline MultiShapeConf GetDefaultConf() noexcept
+            {
+                return MultiShapeConf{};
+            }
 
-/// @brief The "multi-shape" shape configuration.
-/// @details Composes zero or more convex shapes into what can be a concave shape.
-/// @ingroup PartsGroup
-struct MultiShapeConf: public ShapeBuilder<MultiShapeConf>
-{
-    /// @brief Gets the default vertex radius for the <code>MultiShapeConf</code>.
-    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
-    {
-        return NonNegative<Length>{DefaultLinearSlop * 2};
-    }
-    
-    /// @brief Gets the default configuration for a <code>MultiShapeConf</code>.
-    static inline MultiShapeConf GetDefaultConf() noexcept
-    {
-        return MultiShapeConf{};
-    }
-    
-    inline MultiShapeConf():
-        ShapeBuilder{ShapeConf{}}
-    {
-        // Intentionally empty.
-    }
-    
-    /// Creates a convex hull from the given set of local points.
-    /// The size of the set must be in the range [1, <code>MaxShapeVertices</code>].
-    /// @warning the points may be re-ordered, even if they form a convex polygon
-    /// @warning collinear points are handled but not removed. Collinear points
-    ///   may lead to poor stacking behavior.
-    MultiShapeConf& AddConvexHull(const VertexSet& pointSet, NonNegative<Length> vertexRadius =
-                                  GetDefaultVertexRadius()) noexcept;
-    
-    /// @brief Transforms the vertices of all the children by the given transformation matrix.
-    /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-    MultiShapeConf& Transform(const Mat22& m) noexcept;
+            inline MultiShapeConf()
+                : ShapeBuilder{ShapeConf{}}
+            {
+                // Intentionally empty.
+            }
 
-    std::vector<ConvexHull> children; ///< Children.
-};
+            /// Creates a convex hull from the given set of local points.
+            /// The size of the set must be in the range [1, <code>MaxShapeVertices</code>].
+            /// @warning the points may be re-ordered, even if they form a convex polygon
+            /// @warning collinear points are handled but not removed. Collinear points
+            ///   may lead to poor stacking behavior.
+            MultiShapeConf& AddConvexHull(const VertexSet& pointSet, NonNegative<Length> vertexRadius =
+                                                                         GetDefaultVertexRadius()) noexcept;
 
-// Free functions...
+            /// @brief Transforms the vertices of all the children by the given transformation matrix.
+            /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+            MultiShapeConf& Transform(const Mat22& m) noexcept;
 
-/// @brief Equality operator.
-inline bool operator== (const MultiShapeConf& lhs, const MultiShapeConf& rhs) noexcept
-{
-    return lhs.friction == rhs.friction && lhs.restitution == rhs.restitution
-        && lhs.density == rhs.density && lhs.children == rhs.children;
-}
+            std::vector<ConvexHull> children;///< Children.
+        };
 
-/// @brief Inequality operator.
-inline bool operator!= (const MultiShapeConf& lhs, const MultiShapeConf& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+        // Free functions...
 
-/// @brief Gets the "child" count for the given shape configuration.
-inline ChildCounter GetChildCount(const MultiShapeConf& arg) noexcept
-{
-    return static_cast<ChildCounter>(size(arg.children));
-}
+        /// @brief Equality operator.
+        inline bool operator==(const MultiShapeConf& lhs, const MultiShapeConf& rhs) noexcept
+        {
+            return lhs.friction == rhs.friction && lhs.restitution == rhs.restitution
+                   && lhs.density == rhs.density && lhs.children == rhs.children;
+        }
 
-/// @brief Gets the "child" shape for the given shape configuration.
-inline DistanceProxy GetChild(const MultiShapeConf& arg, ChildCounter index)
-{
-    if (index >= GetChildCount(arg))
-    {
-        throw InvalidArgument("index out of range");
-    }
-    return arg.children[index].GetDistanceProxy();
-}
+        /// @brief Inequality operator.
+        inline bool operator!=(const MultiShapeConf& lhs, const MultiShapeConf& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
 
-/// @brief Gets the mass data for the given shape configuration.
-MassData GetMassData(const MultiShapeConf& arg) noexcept;
+        /// @brief Gets the "child" count for the given shape configuration.
+        inline ChildCounter GetChildCount(const MultiShapeConf& arg) noexcept
+        {
+            return static_cast<ChildCounter>(size(arg.children));
+        }
 
-/// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const MultiShapeConf& arg, ChildCounter index)
-{
-    if (index >= GetChildCount(arg))
-    {
-        throw InvalidArgument("index out of range");
-    }
-    return arg.children[index].GetVertexRadius();
-}
+        /// @brief Gets the "child" shape for the given shape configuration.
+        inline DistanceProxy GetChild(const MultiShapeConf& arg, ChildCounter index)
+        {
+            if (index >= GetChildCount(arg))
+            {
+                throw InvalidArgument("index out of range");
+            }
+            return arg.children[index].GetDistanceProxy();
+        }
 
-/// @brief Transforms the given multi shape configuration by the given
-///   transformation matrix.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-inline void Transform(MultiShapeConf& arg, const Mat22& m) noexcept
-{
-    arg.Transform(m);
-}
+        /// @brief Gets the mass data for the given shape configuration.
+        MassData GetMassData(const MultiShapeConf& arg) noexcept;
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Gets the vertex radius of the given shape configuration.
+        inline NonNegative<Length> GetVertexRadius(const MultiShapeConf& arg, ChildCounter index)
+        {
+            if (index >= GetChildCount(arg))
+            {
+                throw InvalidArgument("index out of range");
+            }
+            return arg.children[index].GetVertexRadius();
+        }
 
-#endif // PLAYRHO_COLLISION_SHAPES_MULTISHAPECONF_HPP
+        /// @brief Transforms the given multi shape configuration by the given
+        ///   transformation matrix.
+        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+        inline void Transform(MultiShapeConf& arg, const Mat22& m) noexcept
+        {
+            arg.Transform(m);
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SHAPES_MULTISHAPECONF_HPP

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -20,174 +20,176 @@
 #include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 
-namespace playrho {
-namespace d2 {
-
-PolygonShapeConf::PolygonShapeConf() = default;
-
-PolygonShapeConf::PolygonShapeConf(Length hx, Length hy,
-                                   const PolygonShapeConf& conf) noexcept:
-    ShapeBuilder{conf}
+namespace playrho
 {
-    SetAsBox(hx, hy);
-}
-
-PolygonShapeConf::PolygonShapeConf(Span<const Length2> points,
-                                   const PolygonShapeConf& conf) noexcept:
-    ShapeBuilder{conf}
-{
-    Set(points);
-}
-
-PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy) noexcept
-{
-    m_centroid = Length2{};
-
-    // vertices must be counter-clockwise
-
-    const auto btm_rgt = Length2{+hx, -hy};
-    const auto top_rgt = Length2{ hx,  hy};
-    const auto top_lft = Length2{-hx, +hy};
-    const auto btm_lft = Length2{-hx, -hy};
-    
-    m_vertices.clear();
-    m_vertices.emplace_back(btm_rgt);
-    m_vertices.emplace_back(top_rgt);
-    m_vertices.emplace_back(top_lft);
-    m_vertices.emplace_back(btm_lft);
-
-    m_normals.clear();
-    m_normals.emplace_back(UnitVec::GetRight());
-    m_normals.emplace_back(UnitVec::GetTop());
-    m_normals.emplace_back(UnitVec::GetLeft());
-    m_normals.emplace_back(UnitVec::GetBottom());
-    
-    return *this;
-}
-
-/// @brief Uses the given vertices.
-PolygonShapeConf& PolygonShapeConf::UseVertices(const std::vector<Length2>& verts) noexcept
-{
-    return Set(Span<const Length2>(data(verts), size(verts)));
-}
-    
-PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy,
-                                                 Length2 center, Angle angle) noexcept
-{
-    SetAsBox(hx, hy);
-    Transform(Transformation{center, UnitVec::Get(angle)});
-    return *this;
-}
-
-PolygonShapeConf& PolygonShapeConf::Transform(Transformation xfm) noexcept
-{
-    for (auto i = decltype(GetVertexCount()){0}; i < GetVertexCount(); ++i)
+    namespace d2
     {
-        m_vertices[i] = playrho::d2::Transform(m_vertices[i], xfm);
-        m_normals[i] = Rotate(m_normals[i], xfm.q);
-    }
-    m_centroid = playrho::d2::Transform(m_centroid, xfm);
-    return *this;
-}
 
-PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m) noexcept
-{
-    auto newPoints = VertexSet{};
-    // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
-    for (const auto& v: m_vertices)
-    {
-        newPoints.add(m * v);
-    }
-    return Set(newPoints);
-}
+        PolygonShapeConf::PolygonShapeConf() = default;
 
-PolygonShapeConf& PolygonShapeConf::Set(Span<const Length2> points) noexcept
-{
-    // Perform welding and copy vertices into local buffer.
-    auto point_set = VertexSet(Square(DefaultLinearSlop));
-    for (auto&& p: points)
-    {
-        point_set.add(p);
-    }
-    return Set(point_set);
-}
-
-PolygonShapeConf& PolygonShapeConf::Set(const VertexSet& points) noexcept
-{
-    m_vertices = GetConvexHullAsVector(points);
-    assert(size(m_vertices) < std::numeric_limits<VertexCounter>::max());
-    
-    const auto count = static_cast<VertexCounter>(size(m_vertices));
-
-    m_normals.clear();
-    if (count > 1)
-    {
-        // Compute normals.
-        for (auto i = decltype(count){0}; i < count; ++i)
+        PolygonShapeConf::PolygonShapeConf(Length hx, Length hy,
+                                           const PolygonShapeConf& conf) noexcept
+            : ShapeBuilder{conf}
         {
-            const auto edge = GetEdge(*this, i);
-            m_normals.emplace_back(GetUnitVector(GetFwdPerpendicular(edge)));
+            SetAsBox(hx, hy);
         }
-    }
-    else if (count == 1)
-    {
-        m_normals.emplace_back(UnitVec{});
-    }
 
-    // Compute the polygon centroid.
-    switch (count)
-    {
-        case 0:
-            m_centroid = GetInvalid<Length2>();
-            break;
-        case 1:
-            m_centroid = m_vertices[0];
-            break;
-        case 2:
-            m_centroid = (m_vertices[0] + m_vertices[1]) / Real{2};
-            break;
-        default:
-            m_centroid = ComputeCentroid(GetVertices());
-            break;
-    }
-    
-    return *this;
-}
-
-Length2 GetEdge(const PolygonShapeConf& shape, VertexCounter index)
-{
-    assert(shape.GetVertexCount() > 1);
-
-    const auto i0 = index;
-    const auto i1 = GetModuloNext(index, shape.GetVertexCount());
-    return shape.GetVertex(i1) - shape.GetVertex(i0);
-}
-
-bool Validate(Span<const Length2> verts)
-{
-    const auto count = size(verts);
-    for (auto i = decltype(count){0}; i < count; ++i)
-    {
-        const auto i1 = i;
-        const auto i2 = GetModuloNext(i1, count);
-        const auto p = verts[i1];
-        const auto e = verts[i2] - p;
-        for (auto j = decltype(count){0}; j < count; ++j)
+        PolygonShapeConf::PolygonShapeConf(Span<const Length2> points,
+                                           const PolygonShapeConf& conf) noexcept
+            : ShapeBuilder{conf}
         {
-            if ((j == i1) || (j == i2))
-            {
-                continue;
-            }
-            const auto v = verts[j] - p;
-            const auto c = Cross(e, v);
-            if (c < 0_m2)
-            {
-                return false;
-            }
+            Set(points);
         }
-    }
-    return true;
-}
 
-} // namespace d2
-} // namespace playrho
+        PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy) noexcept
+        {
+            m_centroid = Length2{};
+
+            // vertices must be counter-clockwise
+
+            const auto btm_rgt = Length2{+hx, -hy};
+            const auto top_rgt = Length2{hx, hy};
+            const auto top_lft = Length2{-hx, +hy};
+            const auto btm_lft = Length2{-hx, -hy};
+
+            m_vertices.clear();
+            m_vertices.emplace_back(btm_rgt);
+            m_vertices.emplace_back(top_rgt);
+            m_vertices.emplace_back(top_lft);
+            m_vertices.emplace_back(btm_lft);
+
+            m_normals.clear();
+            m_normals.emplace_back(UnitVec::GetRight());
+            m_normals.emplace_back(UnitVec::GetTop());
+            m_normals.emplace_back(UnitVec::GetLeft());
+            m_normals.emplace_back(UnitVec::GetBottom());
+
+            return *this;
+        }
+
+        /// @brief Uses the given vertices.
+        PolygonShapeConf& PolygonShapeConf::UseVertices(const std::vector<Length2>& verts) noexcept
+        {
+            return Set(Span<const Length2>(data(verts), size(verts)));
+        }
+
+        PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy,
+                                                     Length2 center, Angle angle) noexcept
+        {
+            SetAsBox(hx, hy);
+            Transform(Transformation{center, UnitVec::Get(angle)});
+            return *this;
+        }
+
+        PolygonShapeConf& PolygonShapeConf::Transform(Transformation xfm) noexcept
+        {
+            for (auto i = decltype(GetVertexCount()){0}; i < GetVertexCount(); ++i)
+            {
+                m_vertices[i] = playrho::d2::Transform(m_vertices[i], xfm);
+                m_normals[i] = Rotate(m_normals[i], xfm.q);
+            }
+            m_centroid = playrho::d2::Transform(m_centroid, xfm);
+            return *this;
+        }
+
+        PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m) noexcept
+        {
+            auto newPoints = VertexSet{};
+            // clang++ recommends the following loop variable 'v' be of reference type (instead of value).
+            for (const auto& v : m_vertices)
+            {
+                newPoints.add(m * v);
+            }
+            return Set(newPoints);
+        }
+
+        PolygonShapeConf& PolygonShapeConf::Set(Span<const Length2> points) noexcept
+        {
+            // Perform welding and copy vertices into local buffer.
+            auto point_set = VertexSet(Square(DefaultLinearSlop));
+            for (auto&& p : points)
+            {
+                point_set.add(p);
+            }
+            return Set(point_set);
+        }
+
+        PolygonShapeConf& PolygonShapeConf::Set(const VertexSet& points) noexcept
+        {
+            m_vertices = GetConvexHullAsVector(points);
+            assert(size(m_vertices) < std::numeric_limits<VertexCounter>::max());
+
+            const auto count = static_cast<VertexCounter>(size(m_vertices));
+
+            m_normals.clear();
+            if (count > 1)
+            {
+                // Compute normals.
+                for (auto i = decltype(count){0}; i < count; ++i)
+                {
+                    const auto edge = GetEdge(*this, i);
+                    m_normals.emplace_back(GetUnitVector(GetFwdPerpendicular(edge)));
+                }
+            }
+            else if (count == 1)
+            {
+                m_normals.emplace_back(UnitVec{});
+            }
+
+            // Compute the polygon centroid.
+            switch (count)
+            {
+            case 0:
+                m_centroid = GetInvalid<Length2>();
+                break;
+            case 1:
+                m_centroid = m_vertices[0];
+                break;
+            case 2:
+                m_centroid = (m_vertices[0] + m_vertices[1]) / Real{2};
+                break;
+            default:
+                m_centroid = ComputeCentroid(GetVertices());
+                break;
+            }
+
+            return *this;
+        }
+
+        Length2 GetEdge(const PolygonShapeConf& shape, VertexCounter index)
+        {
+            assert(shape.GetVertexCount() > 1);
+
+            const auto i0 = index;
+            const auto i1 = GetModuloNext(index, shape.GetVertexCount());
+            return shape.GetVertex(i1) - shape.GetVertex(i0);
+        }
+
+        bool Validate(Span<const Length2> verts)
+        {
+            const auto count = size(verts);
+            for (auto i = decltype(count){0}; i < count; ++i)
+            {
+                const auto i1 = i;
+                const auto i2 = GetModuloNext(i1, count);
+                const auto p = verts[i1];
+                const auto e = verts[i2] - p;
+                for (auto j = decltype(count){0}; j < count; ++j)
+                {
+                    if ((j == i1) || (j == i2))
+                    {
+                        continue;
+                    }
+                    const auto v = verts[j] - p;
+                    const auto c = Cross(e, v);
+                    if (c < 0_m2)
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -20,242 +20,247 @@
 #ifndef PLAYRHO_COLLISION_SHAPES_POLYGONSHAPECONF_HPP
 #define PLAYRHO_COLLISION_SHAPES_POLYGONSHAPECONF_HPP
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
+#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
+#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/VertexSet.hpp>
 #include <type_traits>
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Polygon shape configuration.
-/// @details A convex polygon. The interior of the polygon is to the left of each edge.
-///   Polygons maximum number of vertices is defined by <code>MaxShapeVertices</code>.
-///   In most cases you should not need many vertices for a convex polygon.
-/// @image html convex_concave.gif
-/// @note This data structure is 64-bytes large (with 4-byte Real).
-/// @ingroup PartsGroup
-class PolygonShapeConf: public ShapeBuilder<PolygonShapeConf>
+namespace playrho
 {
-public:
-    /// @brief Gets the default vertex radius for the <code>PolygonShapeConf</code>.
-    static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+    namespace d2
     {
-        return NonNegative<Length>{DefaultLinearSlop * 2};
-    }
-    
-    /// @brief Gets the default configuration for a <code>PolygonShapeConf</code>.
-    static inline PolygonShapeConf GetDefaultConf() noexcept
-    {
-        return PolygonShapeConf{};
-    }
-    
-    PolygonShapeConf();
-    
-    /// @brief Initializing constructor for a 4-sided box polygon.
-    /// @param hx Half of the width.
-    /// @param hy Half of the height.
-    /// @see SetAsBox.
-    PolygonShapeConf(Length hx, Length hy,
-                     const PolygonShapeConf& conf = GetDefaultConf()) noexcept;
-    
-    /// @brief Creates a convex hull from the given array of local points.
-    /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
-    /// @warning the points may be re-ordered, even if they form a convex polygon
-    /// @warning collinear points are handled but not removed. Collinear points
-    /// may lead to poor stacking behavior.
-    explicit PolygonShapeConf(Span<const Length2> points,
-                              const PolygonShapeConf& conf = GetDefaultConf()) noexcept;
-    
-    /// @brief Uses the given vertex radius.
-    PolygonShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
 
-    /// @brief Uses the given vertices.
-    PolygonShapeConf& UseVertices(const std::vector<Length2>& verts) noexcept;
-    
-    /// @brief Sets the vertices to represent an axis-aligned box centered on the local origin.
-    /// @param hx the half-width.
-    /// @param hy the half-height.
-    PolygonShapeConf& SetAsBox(Length hx, Length hy) noexcept;
-    
-    /// @brief Sets the vertices for the described box.
-    PolygonShapeConf& SetAsBox(Length hx, Length hy, Length2 center, Angle angle) noexcept;
-    
-    /// @brief Sets the vertices to a convex hull of the given ones.
-    /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
-    /// @warning Points may be re-ordered, even if they form a convex polygon
-    /// @warning Collinear points are handled but not removed. Collinear points
-    ///   may lead to poor stacking behavior.
-    PolygonShapeConf& Set(Span<const Length2> verts) noexcept;
-    
-    /// @brief Sets the vertices to a convex hull of the given ones.
-    /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
-    /// @warning Points may be re-ordered, even if they form a convex polygon
-    /// @warning Collinear points are handled but not removed. Collinear points
-    ///   may lead to poor stacking behavior.
-    PolygonShapeConf& Set(const VertexSet& points) noexcept;
-    
-    /// @brief Transforms the vertices by the given transformation.
-    PolygonShapeConf& Transform(Transformation xfm) noexcept;
-    
-    /// @brief Transforms the vertices by the given transformation matrix.
-    /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-    PolygonShapeConf& Transform(const Mat22& m) noexcept;
+        /// @brief Polygon shape configuration.
+        /// @details A convex polygon. The interior of the polygon is to the left of each edge.
+        ///   Polygons maximum number of vertices is defined by <code>MaxShapeVertices</code>.
+        ///   In most cases you should not need many vertices for a convex polygon.
+        /// @image html convex_concave.gif
+        /// @note This data structure is 64-bytes large (with 4-byte Real).
+        /// @ingroup PartsGroup
+        class PolygonShapeConf : public ShapeBuilder<PolygonShapeConf>
+        {
+         public:
+            /// @brief Gets the default vertex radius for the <code>PolygonShapeConf</code>.
+            static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
+            {
+                return NonNegative<Length>{DefaultLinearSlop * 2};
+            }
 
-    /// @brief Equality operator.
-    friend bool operator== (const PolygonShapeConf& lhs, const PolygonShapeConf& rhs) noexcept
-    {
-        // Don't need to check normals nor centroid since they based on vertices.
-        return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
-            && lhs.restitution == rhs.restitution && lhs.density == rhs.density
-            && lhs.m_vertices == rhs.m_vertices;
-    }
-    
-    /// @brief Inequality operator.
-    friend bool operator!= (const PolygonShapeConf& lhs, const PolygonShapeConf& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
-    
-    /// Gets the vertex count.
-    /// @return value between 0 and <code>MaxShapeVertices</code> inclusive.
-    /// @see MaxShapeVertices
-    VertexCounter GetVertexCount() const noexcept
-    {
-        return static_cast<VertexCounter>(size(m_vertices));
-    }
-    
-    /// Gets a vertex by index.
-    /// @details Vertices go counter-clockwise.
-    Length2 GetVertex(VertexCounter index) const
-    {
-        assert(0 <= index && index < GetVertexCount());
-        return m_vertices[index];
-    }
-    
-    /// Gets a normal by index.
-    /// @details
-    /// These are 90-degree clockwise-rotated (outward-facing) unit-vectors of the edges defined
-    /// by consecutive pairs of vertices starting with vertex 0.
-    /// @param index Index of the normal to get.
-    /// @return Normal for the given index.
-    UnitVec GetNormal(VertexCounter index) const
-    {
-        assert(0 <= index && index < GetVertexCount());
-        return m_normals[index];
-    }
-    
-    /// Gets the span of vertices.
-    /// @details Vertices go counter-clockwise.
-    Span<const Length2> GetVertices() const noexcept
-    {
-        return Span<const Length2>(data(m_vertices), size(m_vertices));
-    }
-    
-    /// @brief Gets the span of normals.
-    Span<const UnitVec> GetNormals() const noexcept
-    {
-        return Span<const UnitVec>(data(m_normals), size(m_vertices));
-    }
-    
-    /// @brief Gets the centroid.
-    Length2 GetCentroid() const noexcept { return m_centroid; }
-    
-    /// @brief Vertex radius.
-    ///
-    /// @details This is the radius from the vertex that the shape's "skin" should
-    ///   extend outward by. While any edges &mdash; line segments between multiple
-    ///   vertices &mdash; are straight, corners between them (the vertices) are
-    ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
-    ///   to edge lengths therefore will be more prone to rolling or having other
-    ///   shapes more prone to roll off of them.
-    ///
-    /// @note This should be a non-negative value.
-    ///
-    NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
-    
-private:
-    /// @brief Array of vertices.
-    /// @details Consecutive vertices constitute "edges" of the polygon.
-    std::vector<Length2> m_vertices;
-    
-    /// @brief Normals of edges.
-    /// @details These are 90-degree clockwise-rotated unit-vectors of the vectors defined
-    ///   by consecutive pairs of elements of vertices.
-    std::vector<UnitVec> m_normals;
-    
-    /// Centroid of this shape.
-    Length2 m_centroid = GetInvalid<Length2>();
-};
+            /// @brief Gets the default configuration for a <code>PolygonShapeConf</code>.
+            static inline PolygonShapeConf GetDefaultConf() noexcept
+            {
+                return PolygonShapeConf{};
+            }
 
-inline PolygonShapeConf& PolygonShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
-{
-    vertexRadius = value;
-    return *this;
-}
+            PolygonShapeConf();
 
-// Free functions...
+            /// @brief Initializing constructor for a 4-sided box polygon.
+            /// @param hx Half of the width.
+            /// @param hy Half of the height.
+            /// @see SetAsBox.
+            PolygonShapeConf(Length hx, Length hy,
+                             const PolygonShapeConf& conf = GetDefaultConf()) noexcept;
 
-/// @brief Gets the "child" count for the given shape configuration.
-/// @return 1.
-constexpr ChildCounter GetChildCount(const PolygonShapeConf&) noexcept
-{
-    return 1;
-}
+            /// @brief Creates a convex hull from the given array of local points.
+            /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
+            /// @warning the points may be re-ordered, even if they form a convex polygon
+            /// @warning collinear points are handled but not removed. Collinear points
+            /// may lead to poor stacking behavior.
+            explicit PolygonShapeConf(Span<const Length2> points,
+                                      const PolygonShapeConf& conf = GetDefaultConf()) noexcept;
 
-/// @brief Gets the "child" shape for the given shape configuration.
-inline DistanceProxy GetChild(const PolygonShapeConf& arg, ChildCounter index)
-{
-    if (index != 0)
-    {
-        throw InvalidArgument("only index of 0 is supported");
-    }
-    return DistanceProxy{arg.vertexRadius, arg.GetVertexCount(),
-        data(arg.GetVertices()), data(arg.GetNormals())};
-}
+            /// @brief Uses the given vertex radius.
+            PolygonShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
 
-/// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const PolygonShapeConf& arg) noexcept
-{
-    return arg.vertexRadius;
-}
+            /// @brief Uses the given vertices.
+            PolygonShapeConf& UseVertices(const std::vector<Length2>& verts) noexcept;
 
-/// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const PolygonShapeConf& arg, ChildCounter) noexcept
-{
-    return GetVertexRadius(arg);
-}
+            /// @brief Sets the vertices to represent an axis-aligned box centered on the local origin.
+            /// @param hx the half-width.
+            /// @param hy the half-height.
+            PolygonShapeConf& SetAsBox(Length hx, Length hy) noexcept;
 
-/// @brief Gets the mass data for the given shape configuration.
-inline MassData GetMassData(const PolygonShapeConf& arg) noexcept
-{
-    return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.GetVertices());
-}
+            /// @brief Sets the vertices for the described box.
+            PolygonShapeConf& SetAsBox(Length hx, Length hy, Length2 center, Angle angle) noexcept;
 
-/// Gets the identified edge of the given polygon shape.
-/// @note This must not be called for shapes with less than 2 vertices.
-/// @warning Behavior is undefined if called for a shape with less than 2 vertices.
-/// @relatedalso PolygonShapeConf
-Length2 GetEdge(const PolygonShapeConf& shape, VertexCounter index);
+            /// @brief Sets the vertices to a convex hull of the given ones.
+            /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
+            /// @warning Points may be re-ordered, even if they form a convex polygon
+            /// @warning Collinear points are handled but not removed. Collinear points
+            ///   may lead to poor stacking behavior.
+            PolygonShapeConf& Set(Span<const Length2> verts) noexcept;
 
-/// @brief Transforms the given polygon configuration's vertices by the given
-///   transformation matrix.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-inline void Transform(PolygonShapeConf& arg, const Mat22& m) noexcept
-{
-    arg.Transform(m);
-}
+            /// @brief Sets the vertices to a convex hull of the given ones.
+            /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
+            /// @warning Points may be re-ordered, even if they form a convex polygon
+            /// @warning Collinear points are handled but not removed. Collinear points
+            ///   may lead to poor stacking behavior.
+            PolygonShapeConf& Set(const VertexSet& points) noexcept;
 
-/// @brief Validates the convexity of the given collection of vertices.
-/// @note This is a time consuming operation.
-/// @returns <code>true</code> if the given collection of vertices is indeed convex,
-///   <code>false</code> otherwise.
-bool Validate(const Span<const Length2> verts);
+            /// @brief Transforms the vertices by the given transformation.
+            PolygonShapeConf& Transform(Transformation xfm) noexcept;
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Transforms the vertices by the given transformation matrix.
+            /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+            PolygonShapeConf& Transform(const Mat22& m) noexcept;
 
-#endif // PLAYRHO_COLLISION_SHAPES_POLYGONSHAPECONF_HPP
+            /// @brief Equality operator.
+            friend bool operator==(const PolygonShapeConf& lhs, const PolygonShapeConf& rhs) noexcept
+            {
+                // Don't need to check normals nor centroid since they based on vertices.
+                return lhs.vertexRadius == rhs.vertexRadius && lhs.friction == rhs.friction
+                       && lhs.restitution == rhs.restitution && lhs.density == rhs.density
+                       && lhs.m_vertices == rhs.m_vertices;
+            }
+
+            /// @brief Inequality operator.
+            friend bool operator!=(const PolygonShapeConf& lhs, const PolygonShapeConf& rhs) noexcept
+            {
+                return !(lhs == rhs);
+            }
+
+            /// Gets the vertex count.
+            /// @return value between 0 and <code>MaxShapeVertices</code> inclusive.
+            /// @see MaxShapeVertices
+            VertexCounter GetVertexCount() const noexcept
+            {
+                return static_cast<VertexCounter>(size(m_vertices));
+            }
+
+            /// Gets a vertex by index.
+            /// @details Vertices go counter-clockwise.
+            Length2 GetVertex(VertexCounter index) const
+            {
+                assert(0 <= index && index < GetVertexCount());
+                return m_vertices[index];
+            }
+
+            /// Gets a normal by index.
+            /// @details
+            /// These are 90-degree clockwise-rotated (outward-facing) unit-vectors of the edges defined
+            /// by consecutive pairs of vertices starting with vertex 0.
+            /// @param index Index of the normal to get.
+            /// @return Normal for the given index.
+            UnitVec GetNormal(VertexCounter index) const
+            {
+                assert(0 <= index && index < GetVertexCount());
+                return m_normals[index];
+            }
+
+            /// Gets the span of vertices.
+            /// @details Vertices go counter-clockwise.
+            Span<const Length2> GetVertices() const noexcept
+            {
+                return Span<const Length2>(data(m_vertices), size(m_vertices));
+            }
+
+            /// @brief Gets the span of normals.
+            Span<const UnitVec> GetNormals() const noexcept
+            {
+                return Span<const UnitVec>(data(m_normals), size(m_vertices));
+            }
+
+            /// @brief Gets the centroid.
+            Length2 GetCentroid() const noexcept
+            {
+                return m_centroid;
+            }
+
+            /// @brief Vertex radius.
+            ///
+            /// @details This is the radius from the vertex that the shape's "skin" should
+            ///   extend outward by. While any edges &mdash; line segments between multiple
+            ///   vertices &mdash; are straight, corners between them (the vertices) are
+            ///   rounded and treated as rounded. Shapes with larger vertex radiuses compared
+            ///   to edge lengths therefore will be more prone to rolling or having other
+            ///   shapes more prone to roll off of them.
+            ///
+            /// @note This should be a non-negative value.
+            ///
+            NonNegative<Length> vertexRadius = GetDefaultVertexRadius();
+
+         private:
+            /// @brief Array of vertices.
+            /// @details Consecutive vertices constitute "edges" of the polygon.
+            std::vector<Length2> m_vertices;
+
+            /// @brief Normals of edges.
+            /// @details These are 90-degree clockwise-rotated unit-vectors of the vectors defined
+            ///   by consecutive pairs of elements of vertices.
+            std::vector<UnitVec> m_normals;
+
+            /// Centroid of this shape.
+            Length2 m_centroid = GetInvalid<Length2>();
+        };
+
+        inline PolygonShapeConf& PolygonShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
+        {
+            vertexRadius = value;
+            return *this;
+        }
+
+        // Free functions...
+
+        /// @brief Gets the "child" count for the given shape configuration.
+        /// @return 1.
+        constexpr ChildCounter GetChildCount(const PolygonShapeConf&) noexcept
+        {
+            return 1;
+        }
+
+        /// @brief Gets the "child" shape for the given shape configuration.
+        inline DistanceProxy GetChild(const PolygonShapeConf& arg, ChildCounter index)
+        {
+            if (index != 0)
+            {
+                throw InvalidArgument("only index of 0 is supported");
+            }
+            return DistanceProxy{arg.vertexRadius, arg.GetVertexCount(),
+                                 data(arg.GetVertices()), data(arg.GetNormals())};
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        inline NonNegative<Length> GetVertexRadius(const PolygonShapeConf& arg) noexcept
+        {
+            return arg.vertexRadius;
+        }
+
+        /// @brief Gets the vertex radius of the given shape configuration.
+        inline NonNegative<Length> GetVertexRadius(const PolygonShapeConf& arg, ChildCounter) noexcept
+        {
+            return GetVertexRadius(arg);
+        }
+
+        /// @brief Gets the mass data for the given shape configuration.
+        inline MassData GetMassData(const PolygonShapeConf& arg) noexcept
+        {
+            return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.GetVertices());
+        }
+
+        /// Gets the identified edge of the given polygon shape.
+        /// @note This must not be called for shapes with less than 2 vertices.
+        /// @warning Behavior is undefined if called for a shape with less than 2 vertices.
+        /// @relatedalso PolygonShapeConf
+        Length2 GetEdge(const PolygonShapeConf& shape, VertexCounter index);
+
+        /// @brief Transforms the given polygon configuration's vertices by the given
+        ///   transformation matrix.
+        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+        inline void Transform(PolygonShapeConf& arg, const Mat22& m) noexcept
+        {
+            arg.Transform(m);
+        }
+
+        /// @brief Validates the convexity of the given collection of vertices.
+        /// @note This is a time consuming operation.
+        /// @returns <code>true</code> if the given collection of vertices is indeed convex,
+        ///   <code>false</code> otherwise.
+        bool Validate(const Span<const Length2> verts);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SHAPES_POLYGONSHAPECONF_HPP

--- a/PlayRho/Collision/Shapes/Shape.cpp
+++ b/PlayRho/Collision/Shapes/Shape.cpp
@@ -21,21 +21,23 @@
 
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 
-namespace playrho {
-namespace d2 {
-
-bool TestPoint(const Shape& shape, Length2 point) noexcept
+namespace playrho
 {
-    const auto childCount = GetChildCount(shape);
-    for (auto i = decltype(childCount){0}; i < childCount; ++i)
+    namespace d2
     {
-        if (playrho::d2::TestPoint(GetChild(shape, i), point))
-        {
-            return true;
-        }
-    }
-    return false;
-}
 
-} // namespace d2
-} // namespace playrho
+        bool TestPoint(const Shape& shape, Length2 point) noexcept
+        {
+            const auto childCount = GetChildCount(shape);
+            for (auto i = decltype(childCount){0}; i < childCount; ++i)
+            {
+                if (playrho::d2::TestPoint(GetChild(shape, i), point))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -27,429 +27,435 @@
 
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
-#include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/InvalidArgument.hpp>
+#include <PlayRho/Common/NonNegative.hpp>
 
-#include <memory>
 #include <functional>
-#include <utility>
+#include <memory>
 #include <stdexcept>
+#include <utility>
 
-namespace playrho {
-namespace d2 {
-
-class Shape;
-
-// Forward declare functions.
-// Note that these may be friend functions but that declaring these within the class that
-// they're to be friends of, doesn't also insure that they're found within the namespace
-// in terms of lookup.
-
-/// @brief Gets the number of child primitives of the shape.
-/// @return Non-negative count.
-ChildCounter GetChildCount(const Shape& shape) noexcept;
-
-/// @brief Gets the "child" for the given index.
-/// @param shape Shape to get "child" shape of.
-/// @param index Index to a child element of the shape. Value must be less
-///   than the number of child primitives of the shape.
-/// @note The shape must remain in scope while the proxy is in use.
-/// @throws InvalidArgument if the given index is out of range.
-/// @see GetChildCount
-DistanceProxy GetChild(const Shape& shape, ChildCounter index);
-
-/// @brief Gets the mass properties of this shape using its dimensions and density.
-/// @return Mass data for this shape.
-MassData GetMassData(const Shape& shape) noexcept;
-
-/// @brief Gets the coefficient of friction.
-/// @return Value of 0 or higher.
-Real GetFriction(const Shape& shape) noexcept;
-
-/// @brief Gets the coefficient of restitution value of the given shape.
-Real GetRestitution(const Shape& shape) noexcept;
-
-/// @brief Gets the density of the given shape.
-/// @return Non-negative density (in mass per area).
-NonNegative<AreaDensity> GetDensity(const Shape& shape) noexcept;
-
-/// @brief Gets the vertex radius of the indexed child of the given shape.
-///
-/// @details This gets the radius from the vertex that the shape's "skin" should
-///   extend outward by. While any edges - line segments between multiple vertices -
-///   are straight, corners between them (the vertices) are rounded and treated
-///   as rounded. Shapes with larger vertex radiuses compared to edge lengths
-///   therefore will be more prone to rolling or having other shapes more prone
-///   to roll off of them. Here's an image of a shape configured via a
-///   <code>PolygonShapeConf</code> with it's skin drawn:
-///
-/// @param shape Shape to get child's vertex radius for.
-/// @param idx Child index to get vertex radius for.
-///
-/// @image html SkinnedPolygon.png
-///
-/// @note This must be a non-negative value.
-///
-/// @see UseVertexRadius
-///
-/// @throws InvalidArgument if the child index is not less than the child count.
-///
-NonNegative<Length> GetVertexRadius(const Shape& shape, ChildCounter idx);
-
-/// @brief Transforms all of the given shape's vertices by the given transformation matrix.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-/// @note This may throw <code>std::bad_alloc</code> or any exception that's thrown
-///   by the constructor for the model's underlying data type.
-/// @throws std::bad_alloc if there's a failure allocating storage.
-void Transform(Shape& shape, const Mat22& m);
-
-/// @brief Gets a pointer to the underlying data.
-/// @note Provided for introspective purposes like visitation.
-const void* GetData(const Shape& shape) noexcept;
-
-/// @brief Gets the type info of the use of the given shape.
-/// @note This is not the same as calling <code>GetTypeID<Shape>()</code>.
-/// @return Type info of the underlying value's type.
-TypeID GetType(const Shape& shape) noexcept;
-
-/// @brief Equality operator for shape to shape comparisons.
-bool operator== (const Shape& lhs, const Shape& rhs) noexcept;
-
-/// @brief Inequality operator for shape to shape comparisons.
-bool operator!= (const Shape& lhs, const Shape& rhs) noexcept;
-
-// Now define the shape class...
-    
-/// @defgroup PartsGroup Shape Classes
-/// @brief Classes for configuring shapes with material properties.
-/// @details These are classes that specify physical characteristics of: shape,
-///   friction, density and restitution. They've historically been called shape classes
-///   but are now &mdash; with the other properties like friction and density having been
-///   moved into them &mdash; maybe better thought of as "parts".
-
-/// @brief Shape.
-///
-/// @details A shape is used for collision detection. You can create a shape from any
-///   supporting type. Shapes are conceptually made up of zero or more convex child shapes
-///   where each child shape is made up of zero or more vertices and an associated radius
-///   called its "vertex radius".
-///
-/// @note This class implements polymorphism without inheritance. This is based on a technique
-///   that's described by Sean Parent in his January 2017 Norwegian Developers Conference
-///   London talk "Better Code: Runtime Polymorphism". With this implementation, different
-///   shapes types can be had by constructing instances of this class with the different types
-///   that provide the required support. Different shapes of a given type meanwhile are had by
-///   providing different values for the type.
-///
-/// @note This data structure is 32-bytes large (on at least one 64-bit platform).
-///
-/// @ingroup PartsGroup
-///
-/// @see Fixture
-/// @see https://youtu.be/QGcVXgEVMJg
-///
-class Shape
+namespace playrho
 {
-public:
-    /// @brief Default constructor.
-    Shape() noexcept = default;
-
-    /// @brief Initializing constructor.
-    /// @param arg Configuration value to construct a shape instance for.
-    /// @note Only usable with types of values that have all of the support functions required
-    ///   by this class. The compiler emits errors if the given type doesn't.
-    /// @see GetChildCount
-    /// @see GetChild
-    /// @see GetMassData
-    /// @see GetVertexRadius
-    /// @see GetDensity
-    /// @see GetFriction
-    /// @see GetRestitution
-    /// @throws std::bad_alloc if there's a failure allocating storage.
-    template <typename T>
-    explicit Shape(T arg): m_self{std::make_shared<Model<T>>(std::move(arg))}
+    namespace d2
     {
-        // Intentionally empty.
-    }
 
-    /// @brief Copy constructor.
-    Shape(const Shape& other) = default;
-    
-    /// @brief Move constructor.
-    Shape(Shape&& other) = default;
-    
-    /// @brief Copy assignment operator.
-    Shape& operator= (const Shape& other) = default;
-    
-    /// @brief Move assignment operator.
-    Shape& operator= (Shape&& other) = default;
+        class Shape;
 
-    /// @brief Move assignment operator.
-    template <typename T, typename Tp = std::decay_t<T>,
-        typename = std::enable_if_t<
-            !std::is_same<Tp, Shape>::value && std::is_copy_constructible<Tp>::value
-        >
-    >
-    Shape& operator= (T&& other)
-    {
-        Shape(std::forward<T>(other)).swap(*this);
-        return *this;
-    }
+        // Forward declare functions.
+        // Note that these may be friend functions but that declaring these within the class that
+        // they're to be friends of, doesn't also insure that they're found within the namespace
+        // in terms of lookup.
 
-    /// @brief Swap support.
-    void swap(Shape& other) noexcept
-    {
-        std::swap(m_self, other.m_self);
-    }
+        /// @brief Gets the number of child primitives of the shape.
+        /// @return Non-negative count.
+        ChildCounter GetChildCount(const Shape& shape) noexcept;
 
-    friend ChildCounter GetChildCount(const Shape& shape) noexcept
-    {
-        return shape.m_self? shape.m_self->GetChildCount_(): static_cast<ChildCounter>(0);
-    }
+        /// @brief Gets the "child" for the given index.
+        /// @param shape Shape to get "child" shape of.
+        /// @param index Index to a child element of the shape. Value must be less
+        ///   than the number of child primitives of the shape.
+        /// @note The shape must remain in scope while the proxy is in use.
+        /// @throws InvalidArgument if the given index is out of range.
+        /// @see GetChildCount
+        DistanceProxy GetChild(const Shape& shape, ChildCounter index);
 
-    friend DistanceProxy GetChild(const Shape& shape, ChildCounter index)
-    {
-        if (!shape.m_self) {
-            throw InvalidArgument("index out of range");
-        }
-        return shape.m_self->GetChild_(index);
-    }
+        /// @brief Gets the mass properties of this shape using its dimensions and density.
+        /// @return Mass data for this shape.
+        MassData GetMassData(const Shape& shape) noexcept;
 
-    friend MassData GetMassData(const Shape& shape) noexcept
-    {
-        return shape.m_self? shape.m_self->GetMassData_(): MassData{};
-    }
+        /// @brief Gets the coefficient of friction.
+        /// @return Value of 0 or higher.
+        Real GetFriction(const Shape& shape) noexcept;
 
-    friend NonNegative<Length> GetVertexRadius(const Shape& shape, ChildCounter idx)
-    {
-        if (!shape.m_self) {
-            throw InvalidArgument("index out of range");
-        }
-        return shape.m_self->GetVertexRadius_(idx);
-    }
+        /// @brief Gets the coefficient of restitution value of the given shape.
+        Real GetRestitution(const Shape& shape) noexcept;
 
-    friend Real GetFriction(const Shape& shape) noexcept
-    {
-        return shape.m_self? shape.m_self->GetFriction_(): Real(0);
-    }
+        /// @brief Gets the density of the given shape.
+        /// @return Non-negative density (in mass per area).
+        NonNegative<AreaDensity> GetDensity(const Shape& shape) noexcept;
 
-    friend Real GetRestitution(const Shape& shape) noexcept
-    {
-        return shape.m_self? shape.m_self->GetRestitution_(): Real(0);
-    }
+        /// @brief Gets the vertex radius of the indexed child of the given shape.
+        ///
+        /// @details This gets the radius from the vertex that the shape's "skin" should
+        ///   extend outward by. While any edges - line segments between multiple vertices -
+        ///   are straight, corners between them (the vertices) are rounded and treated
+        ///   as rounded. Shapes with larger vertex radiuses compared to edge lengths
+        ///   therefore will be more prone to rolling or having other shapes more prone
+        ///   to roll off of them. Here's an image of a shape configured via a
+        ///   <code>PolygonShapeConf</code> with it's skin drawn:
+        ///
+        /// @param shape Shape to get child's vertex radius for.
+        /// @param idx Child index to get vertex radius for.
+        ///
+        /// @image html SkinnedPolygon.png
+        ///
+        /// @note This must be a non-negative value.
+        ///
+        /// @see UseVertexRadius
+        ///
+        /// @throws InvalidArgument if the child index is not less than the child count.
+        ///
+        NonNegative<Length> GetVertexRadius(const Shape& shape, ChildCounter idx);
 
-    friend NonNegative<AreaDensity> GetDensity(const Shape& shape) noexcept
-    {
-        return shape.m_self? shape.m_self->GetDensity_(): NonNegative<AreaDensity>{0_kgpm2};
-    }
-
-    friend void Transform(Shape& shape, const Mat22& m)
-    {
-        if (shape.m_self) {
-            auto copy = shape.m_self->Clone();
-            copy->Transform_(m);
-            shape.m_self = std::unique_ptr<const Shape::Concept>{std::move(copy)};
-        }
-    }
-
-    friend const void* GetData(const Shape& shape) noexcept
-    {
-        return shape.m_self? shape.m_self->GetData_(): nullptr;
-    }
-
-    friend TypeID GetType(const Shape& shape) noexcept
-    {
-        return shape.m_self? shape.m_self->GetType_(): GetTypeID<void>();
-    }
-
-    template <typename T>
-    friend auto TypeCast(const Shape* value) noexcept
-    {
-        if (!value || (GetType(*value) != GetTypeID<std::remove_pointer_t<T>>())) {
-            return static_cast<T>(nullptr);
-        }
-        return static_cast<T>(value->m_self->GetData_());
-    }
-
-    friend bool operator== (const Shape& lhs, const Shape& rhs) noexcept
-    {
-        return (lhs.m_self == rhs.m_self) ||
-            ((lhs.m_self && rhs.m_self) && (*lhs.m_self == *rhs.m_self));
-    }
-
-    friend bool operator!= (const Shape& lhs, const Shape& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
-
-private:
-    /// @brief Internal configuration concept.
-    /// @note Provides the interface for runtime value polymorphism.
-    struct Concept
-    {
-        virtual ~Concept() = default;
-
-        /// @brief Clones this concept and returns a pointer to a mutable copy.
+        /// @brief Transforms all of the given shape's vertices by the given transformation matrix.
+        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
         /// @note This may throw <code>std::bad_alloc</code> or any exception that's thrown
         ///   by the constructor for the model's underlying data type.
         /// @throws std::bad_alloc if there's a failure allocating storage.
-        virtual std::unique_ptr<Concept> Clone() const = 0;
-        
-        /// @brief Gets the "child" count.
-        virtual ChildCounter GetChildCount_() const noexcept = 0;
-        
-        /// @brief Gets the "child" specified by the given index.
-        virtual DistanceProxy GetChild_(ChildCounter index) const = 0;
-        
-        /// @brief Gets the mass data.
-        virtual MassData GetMassData_() const noexcept = 0;
-        
-        /// @brief Gets the vertex radius.
-        /// @param idx Child index to get vertex radius for.
-        virtual NonNegative<Length> GetVertexRadius_(ChildCounter idx) const = 0;
+        void Transform(Shape& shape, const Mat22& m);
 
-        /// @brief Gets the density.
-        virtual NonNegative<AreaDensity> GetDensity_() const noexcept = 0;
-        
-        /// @brief Gets the friction.
-        virtual Real GetFriction_() const noexcept = 0;
-        
-        /// @brief Gets the restitution.
-        virtual Real GetRestitution_() const noexcept = 0;
-        
-        /// @brief Transforms all of the shape's vertices by the given transformation matrix.
-        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-        virtual void Transform_(const Mat22& m) = 0;
-        
-        /// @brief Equality checking method.
-        virtual bool IsEqual_(const Concept& other) const noexcept = 0;
-        
-        /// @brief Gets the use type information.
+        /// @brief Gets a pointer to the underlying data.
+        /// @note Provided for introspective purposes like visitation.
+        const void* GetData(const Shape& shape) noexcept;
+
+        /// @brief Gets the type info of the use of the given shape.
+        /// @note This is not the same as calling <code>GetTypeID<Shape>()</code>.
         /// @return Type info of the underlying value's type.
-        virtual TypeID GetType_() const noexcept = 0;
-        
-        /// @brief Gets the data for the underlying configuration.
-        virtual const void* GetData_() const noexcept = 0;
-        
-        /// @brief Equality operator.
-        friend bool operator== (const Concept& lhs, const Concept &rhs) noexcept
+        TypeID GetType(const Shape& shape) noexcept;
+
+        /// @brief Equality operator for shape to shape comparisons.
+        bool operator==(const Shape& lhs, const Shape& rhs) noexcept;
+
+        /// @brief Inequality operator for shape to shape comparisons.
+        bool operator!=(const Shape& lhs, const Shape& rhs) noexcept;
+
+        // Now define the shape class...
+
+        /// @defgroup PartsGroup Shape Classes
+        /// @brief Classes for configuring shapes with material properties.
+        /// @details These are classes that specify physical characteristics of: shape,
+        ///   friction, density and restitution. They've historically been called shape classes
+        ///   but are now &mdash; with the other properties like friction and density having been
+        ///   moved into them &mdash; maybe better thought of as "parts".
+
+        /// @brief Shape.
+        ///
+        /// @details A shape is used for collision detection. You can create a shape from any
+        ///   supporting type. Shapes are conceptually made up of zero or more convex child shapes
+        ///   where each child shape is made up of zero or more vertices and an associated radius
+        ///   called its "vertex radius".
+        ///
+        /// @note This class implements polymorphism without inheritance. This is based on a technique
+        ///   that's described by Sean Parent in his January 2017 Norwegian Developers Conference
+        ///   London talk "Better Code: Runtime Polymorphism". With this implementation, different
+        ///   shapes types can be had by constructing instances of this class with the different types
+        ///   that provide the required support. Different shapes of a given type meanwhile are had by
+        ///   providing different values for the type.
+        ///
+        /// @note This data structure is 32-bytes large (on at least one 64-bit platform).
+        ///
+        /// @ingroup PartsGroup
+        ///
+        /// @see Fixture
+        /// @see https://youtu.be/QGcVXgEVMJg
+        ///
+        class Shape
         {
-            return &lhs == &rhs || lhs.IsEqual_(rhs);
-        }
-        
-        /// @brief Inequality operator.
-        friend bool operator!= (const Concept& lhs, const Concept &rhs) noexcept
+         public:
+            /// @brief Default constructor.
+            Shape() noexcept = default;
+
+            /// @brief Initializing constructor.
+            /// @param arg Configuration value to construct a shape instance for.
+            /// @note Only usable with types of values that have all of the support functions required
+            ///   by this class. The compiler emits errors if the given type doesn't.
+            /// @see GetChildCount
+            /// @see GetChild
+            /// @see GetMassData
+            /// @see GetVertexRadius
+            /// @see GetDensity
+            /// @see GetFriction
+            /// @see GetRestitution
+            /// @throws std::bad_alloc if there's a failure allocating storage.
+            template<typename T>
+            explicit Shape(T arg)
+                : m_self{std::make_shared<Model<T>>(std::move(arg))}
+            {
+                // Intentionally empty.
+            }
+
+            /// @brief Copy constructor.
+            Shape(const Shape& other) = default;
+
+            /// @brief Move constructor.
+            Shape(Shape&& other) = default;
+
+            /// @brief Copy assignment operator.
+            Shape& operator=(const Shape& other) = default;
+
+            /// @brief Move assignment operator.
+            Shape& operator=(Shape&& other) = default;
+
+            /// @brief Move assignment operator.
+            template<typename T, typename Tp = std::decay_t<T>,
+                     typename = std::enable_if_t<
+                         !std::is_same<Tp, Shape>::value && std::is_copy_constructible<Tp>::value>>
+            Shape& operator=(T&& other)
+            {
+                Shape(std::forward<T>(other)).swap(*this);
+                return *this;
+            }
+
+            /// @brief Swap support.
+            void swap(Shape& other) noexcept
+            {
+                std::swap(m_self, other.m_self);
+            }
+
+            friend ChildCounter GetChildCount(const Shape& shape) noexcept
+            {
+                return shape.m_self ? shape.m_self->GetChildCount_() : static_cast<ChildCounter>(0);
+            }
+
+            friend DistanceProxy GetChild(const Shape& shape, ChildCounter index)
+            {
+                if (!shape.m_self)
+                {
+                    throw InvalidArgument("index out of range");
+                }
+                return shape.m_self->GetChild_(index);
+            }
+
+            friend MassData GetMassData(const Shape& shape) noexcept
+            {
+                return shape.m_self ? shape.m_self->GetMassData_() : MassData{};
+            }
+
+            friend NonNegative<Length> GetVertexRadius(const Shape& shape, ChildCounter idx)
+            {
+                if (!shape.m_self)
+                {
+                    throw InvalidArgument("index out of range");
+                }
+                return shape.m_self->GetVertexRadius_(idx);
+            }
+
+            friend Real GetFriction(const Shape& shape) noexcept
+            {
+                return shape.m_self ? shape.m_self->GetFriction_() : Real(0);
+            }
+
+            friend Real GetRestitution(const Shape& shape) noexcept
+            {
+                return shape.m_self ? shape.m_self->GetRestitution_() : Real(0);
+            }
+
+            friend NonNegative<AreaDensity> GetDensity(const Shape& shape) noexcept
+            {
+                return shape.m_self ? shape.m_self->GetDensity_() : NonNegative<AreaDensity>{0_kgpm2};
+            }
+
+            friend void Transform(Shape& shape, const Mat22& m)
+            {
+                if (shape.m_self)
+                {
+                    auto copy = shape.m_self->Clone();
+                    copy->Transform_(m);
+                    shape.m_self = std::unique_ptr<const Shape::Concept>{std::move(copy)};
+                }
+            }
+
+            friend const void* GetData(const Shape& shape) noexcept
+            {
+                return shape.m_self ? shape.m_self->GetData_() : nullptr;
+            }
+
+            friend TypeID GetType(const Shape& shape) noexcept
+            {
+                return shape.m_self ? shape.m_self->GetType_() : GetTypeID<void>();
+            }
+
+            template<typename T>
+            friend auto TypeCast(const Shape* value) noexcept
+            {
+                if (!value || (GetType(*value) != GetTypeID<std::remove_pointer_t<T>>()))
+                {
+                    return static_cast<T>(nullptr);
+                }
+                return static_cast<T>(value->m_self->GetData_());
+            }
+
+            friend bool operator==(const Shape& lhs, const Shape& rhs) noexcept
+            {
+                return (lhs.m_self == rhs.m_self) || ((lhs.m_self && rhs.m_self) && (*lhs.m_self == *rhs.m_self));
+            }
+
+            friend bool operator!=(const Shape& lhs, const Shape& rhs) noexcept
+            {
+                return !(lhs == rhs);
+            }
+
+         private:
+            /// @brief Internal configuration concept.
+            /// @note Provides the interface for runtime value polymorphism.
+            struct Concept
+            {
+                virtual ~Concept() = default;
+
+                /// @brief Clones this concept and returns a pointer to a mutable copy.
+                /// @note This may throw <code>std::bad_alloc</code> or any exception that's thrown
+                ///   by the constructor for the model's underlying data type.
+                /// @throws std::bad_alloc if there's a failure allocating storage.
+                virtual std::unique_ptr<Concept> Clone() const = 0;
+
+                /// @brief Gets the "child" count.
+                virtual ChildCounter GetChildCount_() const noexcept = 0;
+
+                /// @brief Gets the "child" specified by the given index.
+                virtual DistanceProxy GetChild_(ChildCounter index) const = 0;
+
+                /// @brief Gets the mass data.
+                virtual MassData GetMassData_() const noexcept = 0;
+
+                /// @brief Gets the vertex radius.
+                /// @param idx Child index to get vertex radius for.
+                virtual NonNegative<Length> GetVertexRadius_(ChildCounter idx) const = 0;
+
+                /// @brief Gets the density.
+                virtual NonNegative<AreaDensity> GetDensity_() const noexcept = 0;
+
+                /// @brief Gets the friction.
+                virtual Real GetFriction_() const noexcept = 0;
+
+                /// @brief Gets the restitution.
+                virtual Real GetRestitution_() const noexcept = 0;
+
+                /// @brief Transforms all of the shape's vertices by the given transformation matrix.
+                /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+                virtual void Transform_(const Mat22& m) = 0;
+
+                /// @brief Equality checking method.
+                virtual bool IsEqual_(const Concept& other) const noexcept = 0;
+
+                /// @brief Gets the use type information.
+                /// @return Type info of the underlying value's type.
+                virtual TypeID GetType_() const noexcept = 0;
+
+                /// @brief Gets the data for the underlying configuration.
+                virtual const void* GetData_() const noexcept = 0;
+
+                /// @brief Equality operator.
+                friend bool operator==(const Concept& lhs, const Concept& rhs) noexcept
+                {
+                    return &lhs == &rhs || lhs.IsEqual_(rhs);
+                }
+
+                /// @brief Inequality operator.
+                friend bool operator!=(const Concept& lhs, const Concept& rhs) noexcept
+                {
+                    return !(lhs == rhs);
+                }
+            };
+
+            /// @brief Internal model configuration concept.
+            /// @note Provides an implementation for runtime polymorphism for shape configuration.
+            template<typename T>
+            struct Model final : Concept
+            {
+                /// @brief Type alias for the type of the data held.
+                using data_type = T;
+
+                /// @brief Initializing constructor.
+                Model(T arg)
+                    : data{std::move(arg)}
+                {
+                }
+
+                std::unique_ptr<Concept> Clone() const override
+                {
+                    return std::make_unique<Model>(data);
+                }
+
+                ChildCounter GetChildCount_() const noexcept override
+                {
+                    return GetChildCount(data);
+                }
+
+                DistanceProxy GetChild_(ChildCounter index) const override
+                {
+                    return GetChild(data, index);
+                }
+
+                MassData GetMassData_() const noexcept override
+                {
+                    return GetMassData(data);
+                }
+
+                NonNegative<Length> GetVertexRadius_(ChildCounter idx) const override
+                {
+                    return GetVertexRadius(data, idx);
+                }
+
+                NonNegative<AreaDensity> GetDensity_() const noexcept override
+                {
+                    return GetDensity(data);
+                }
+
+                Real GetFriction_() const noexcept override
+                {
+                    return GetFriction(data);
+                }
+
+                Real GetRestitution_() const noexcept override
+                {
+                    return GetRestitution(data);
+                }
+
+                void Transform_(const Mat22& m) override
+                {
+                    Transform(data, m);
+                }
+
+                bool IsEqual_(const Concept& other) const noexcept override
+                {
+                    // Would be preferable to do this without using any kind of RTTI system.
+                    // But how would that be done?
+                    return (GetType_() == other.GetType_()) && (data == *static_cast<const T*>(other.GetData_()));
+                }
+
+                TypeID GetType_() const noexcept override
+                {
+                    return GetTypeID<data_type>();
+                }
+
+                const void* GetData_() const noexcept override
+                {
+                    // Note address of "data" not necessarily same as address of "this" since
+                    // base class is virtual.
+                    return &data;
+                }
+
+                data_type data;///< Data.
+            };
+
+            std::shared_ptr<const Concept> m_self;///< Self shared pointer.
+        };
+
+        // Related free functions...
+
+        /// @brief Test a point for containment in the given shape.
+        /// @param shape Shape to use for test.
+        /// @param point Point in local coordinates.
+        /// @return <code>true</code> if the given point is contained by the given shape,
+        ///   <code>false</code> otherwise.
+        /// @relatedalso Shape
+        /// @ingroup TestPointGroup
+        bool TestPoint(const Shape& shape, Length2 point) noexcept;
+
+        /// @brief Casts the specified instance into the template specified type.
+        /// @throws std::bad_cast If the template specified type is not the type of data underlying
+        ///   the given instance.
+        template<typename T>
+        inline auto TypeCast(const Shape& shape)
         {
-            return !(lhs == rhs);
-        }
-    };
-
-    /// @brief Internal model configuration concept.
-    /// @note Provides an implementation for runtime polymorphism for shape configuration.
-    template <typename T>
-    struct Model final: Concept
-    {
-        /// @brief Type alias for the type of the data held.
-        using data_type = T;
-
-        /// @brief Initializing constructor.
-        Model(T arg): data{std::move(arg)} {}
-        
-        std::unique_ptr<Concept> Clone() const override
-        {
-            return std::make_unique<Model>(data);
+            auto tmp = TypeCast<std::add_pointer_t<std::add_const_t<T>>>(&shape);
+            if (tmp == nullptr)
+                throw std::bad_cast();
+            return *tmp;
         }
 
-        ChildCounter GetChildCount_() const noexcept override
-        {
-            return GetChildCount(data);
-        }
+    }// namespace d2
+}// namespace playrho
 
-        DistanceProxy GetChild_(ChildCounter index) const override
-        {
-            return GetChild(data, index);
-        }
-
-        MassData GetMassData_() const noexcept override
-        {
-            return GetMassData(data);
-        }
-        
-        NonNegative<Length> GetVertexRadius_(ChildCounter idx) const override
-        {
-            return GetVertexRadius(data, idx);
-        }
-        
-        NonNegative<AreaDensity> GetDensity_() const noexcept override
-        {
-            return GetDensity(data);
-        }
-        
-        Real GetFriction_() const noexcept override
-        {
-            return GetFriction(data);
-        }
-        
-        Real GetRestitution_() const noexcept override
-        {
-            return GetRestitution(data);
-        }
-        
-        void Transform_(const Mat22& m) override
-        {
-            Transform(data, m);
-        }
-
-        bool IsEqual_(const Concept& other) const noexcept override
-        {
-            // Would be preferable to do this without using any kind of RTTI system.
-            // But how would that be done?
-            return (GetType_() == other.GetType_()) &&
-                (data == *static_cast<const T*>(other.GetData_()));
-        }
-
-        TypeID GetType_() const noexcept override
-        {
-            return GetTypeID<data_type>();
-        }
-
-        const void* GetData_() const noexcept override
-        {
-            // Note address of "data" not necessarily same as address of "this" since
-            // base class is virtual.
-            return &data;
-        }
-
-        data_type data; ///< Data.
-    };
-
-    std::shared_ptr<const Concept> m_self; ///< Self shared pointer.
-};
-
-// Related free functions...
-
-/// @brief Test a point for containment in the given shape.
-/// @param shape Shape to use for test.
-/// @param point Point in local coordinates.
-/// @return <code>true</code> if the given point is contained by the given shape,
-///   <code>false</code> otherwise.
-/// @relatedalso Shape
-/// @ingroup TestPointGroup
-bool TestPoint(const Shape& shape, Length2 point) noexcept;
-
-/// @brief Casts the specified instance into the template specified type.
-/// @throws std::bad_cast If the template specified type is not the type of data underlying
-///   the given instance.
-template <typename T>
-inline auto TypeCast(const Shape& shape)
-{
-    auto tmp = TypeCast<std::add_pointer_t<std::add_const_t<T>>>(&shape);
-    if (tmp == nullptr)
-        throw std::bad_cast();
-    return *tmp;
-}
-
-} // namespace d2
-} // namespace playrho
-
-#endif // PLAYRHO_COLLISION_SHAPES_SHAPE_HPP
+#endif// PLAYRHO_COLLISION_SHAPES_SHAPE_HPP

--- a/PlayRho/Collision/Shapes/ShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ShapeConf.hpp
@@ -22,125 +22,127 @@
 #ifndef PLAYRHO_COLLISION_SHAPES_SHAPECONF_HPP
 #define PLAYRHO_COLLISION_SHAPES_SHAPECONF_HPP
 
-#include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/Finite.hpp>
 #include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/Units.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Base configuration for initializing shapes.
-/// @note This is a nested base value class for initializing shapes.
-struct BaseShapeConf
+namespace playrho
 {
-    /// @brief Friction coefficient.
-    ///
-    /// @note This must be a value between 0 and +infinity. It is safer however to
-    ///   keep the value below the square root of the max value of a Real.
-    /// @note This is usually in the range [0,1].
-    /// @note The square-root of the product of this value multiplied by a touching
-    ///   fixture's friction becomes the friction coefficient for the contact.
-    ///
-    NonNegative<Real> friction = NonNegative<Real>{Real{2} / Real{10}};
-    
-    /// @brief Restitution (elasticity) of the associated shape.
-    ///
-    /// @note This should be a valid finite value.
-    /// @note This is usually in the range [0,1].
-    ///
-    Finite<Real> restitution = Finite<Real>{0};
-    
-    /// @brief Area density of the associated shape.
-    ///
-    /// @note This must be a non-negative value.
-    /// @note Use 0 to indicate that the shape's associated mass should be 0.
-    ///
-    NonNegative<AreaDensity> density = NonNegative<AreaDensity>{0_kgpm2};
-};
-
-/// @brief Builder configuration structure.
-/// @details This is a builder structure of chainable methods for building a shape
-///   configuration.
-/// @note This is a templated nested value class for initializing shapes that
-///   uses the Curiously Recurring Template Pattern (CRTP) to provide method chaining
-///   via static polymorphism.
-/// @see https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
-template <typename ConcreteConf>
-struct ShapeBuilder: BaseShapeConf
-{
-    // Note: don't use 'using ShapeConf::ShapeConf' here as it doesn't work in this context!
-    
-    /// @brief Default constructor.
-    constexpr ShapeBuilder() = default;
-
-    /// @brief Initializing constructor.
-    constexpr explicit ShapeBuilder(const BaseShapeConf& value) noexcept:
-        BaseShapeConf{value}
+    namespace d2
     {
-        // Intentionally empty.
-    }
-    
-    /// @brief Uses the given friction.
-    constexpr ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
-    
-    /// @brief Uses the given restitution.
-    constexpr ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
-    
-    /// @brief Uses the given density.
-    constexpr ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
-};
 
-template <typename ConcreteConf>
-constexpr ConcreteConf&
-ShapeBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
-{
-    friction = value;
-    return static_cast<ConcreteConf&>(*this);
-}
+        /// @brief Base configuration for initializing shapes.
+        /// @note This is a nested base value class for initializing shapes.
+        struct BaseShapeConf
+        {
+            /// @brief Friction coefficient.
+            ///
+            /// @note This must be a value between 0 and +infinity. It is safer however to
+            ///   keep the value below the square root of the max value of a Real.
+            /// @note This is usually in the range [0,1].
+            /// @note The square-root of the product of this value multiplied by a touching
+            ///   fixture's friction becomes the friction coefficient for the contact.
+            ///
+            NonNegative<Real> friction = NonNegative<Real>{Real{2} / Real{10}};
 
-template <typename ConcreteConf>
-constexpr ConcreteConf&
-ShapeBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
-{
-    restitution = value;
-    return static_cast<ConcreteConf&>(*this);
-}
+            /// @brief Restitution (elasticity) of the associated shape.
+            ///
+            /// @note This should be a valid finite value.
+            /// @note This is usually in the range [0,1].
+            ///
+            Finite<Real> restitution = Finite<Real>{0};
 
-template <typename ConcreteConf>
-constexpr ConcreteConf&
-ShapeBuilder<ConcreteConf>::UseDensity(NonNegative<AreaDensity> value) noexcept
-{
-    density = value;
-    return static_cast<ConcreteConf&>(*this);
-}
+            /// @brief Area density of the associated shape.
+            ///
+            /// @note This must be a non-negative value.
+            /// @note Use 0 to indicate that the shape's associated mass should be 0.
+            ///
+            NonNegative<AreaDensity> density = NonNegative<AreaDensity>{0_kgpm2};
+        };
 
-/// @brief Shape configuration structure.
-struct ShapeConf: public ShapeBuilder<ShapeConf>
-{
-    using ShapeBuilder::ShapeBuilder;
-};
+        /// @brief Builder configuration structure.
+        /// @details This is a builder structure of chainable methods for building a shape
+        ///   configuration.
+        /// @note This is a templated nested value class for initializing shapes that
+        ///   uses the Curiously Recurring Template Pattern (CRTP) to provide method chaining
+        ///   via static polymorphism.
+        /// @see https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
+        template<typename ConcreteConf>
+        struct ShapeBuilder : BaseShapeConf
+        {
+            // Note: don't use 'using ShapeConf::ShapeConf' here as it doesn't work in this context!
 
-// Free functions...
+            /// @brief Default constructor.
+            constexpr ShapeBuilder() = default;
 
-/// @brief Gets the density of the given shape configuration.
-constexpr NonNegative<AreaDensity> GetDensity(const BaseShapeConf& arg) noexcept
-{
-    return arg.density;
-}
+            /// @brief Initializing constructor.
+            constexpr explicit ShapeBuilder(const BaseShapeConf& value) noexcept
+                : BaseShapeConf{value}
+            {
+                // Intentionally empty.
+            }
 
-/// @brief Gets the restitution of the given shape configuration.
-constexpr Finite<Real> GetRestitution(const BaseShapeConf& arg) noexcept
-{
-    return arg.restitution;
-}
+            /// @brief Uses the given friction.
+            constexpr ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;
 
-/// @brief Gets the friction of the given shape configuration.
-constexpr NonNegative<Real> GetFriction(const BaseShapeConf& arg) noexcept
-{
-    return arg.friction;
-}
+            /// @brief Uses the given restitution.
+            constexpr ConcreteConf& UseRestitution(Finite<Real> value) noexcept;
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Uses the given density.
+            constexpr ConcreteConf& UseDensity(NonNegative<AreaDensity> value) noexcept;
+        };
 
-#endif // PLAYRHO_COLLISION_SHAPES_SHAPECONF_HPP
+        template<typename ConcreteConf>
+        constexpr ConcreteConf&
+        ShapeBuilder<ConcreteConf>::UseFriction(NonNegative<Real> value) noexcept
+        {
+            friction = value;
+            return static_cast<ConcreteConf&>(*this);
+        }
+
+        template<typename ConcreteConf>
+        constexpr ConcreteConf&
+        ShapeBuilder<ConcreteConf>::UseRestitution(Finite<Real> value) noexcept
+        {
+            restitution = value;
+            return static_cast<ConcreteConf&>(*this);
+        }
+
+        template<typename ConcreteConf>
+        constexpr ConcreteConf&
+        ShapeBuilder<ConcreteConf>::UseDensity(NonNegative<AreaDensity> value) noexcept
+        {
+            density = value;
+            return static_cast<ConcreteConf&>(*this);
+        }
+
+        /// @brief Shape configuration structure.
+        struct ShapeConf : public ShapeBuilder<ShapeConf>
+        {
+            using ShapeBuilder::ShapeBuilder;
+        };
+
+        // Free functions...
+
+        /// @brief Gets the density of the given shape configuration.
+        constexpr NonNegative<AreaDensity> GetDensity(const BaseShapeConf& arg) noexcept
+        {
+            return arg.density;
+        }
+
+        /// @brief Gets the restitution of the given shape configuration.
+        constexpr Finite<Real> GetRestitution(const BaseShapeConf& arg) noexcept
+        {
+            return arg.restitution;
+        }
+
+        /// @brief Gets the friction of the given shape configuration.
+        constexpr NonNegative<Real> GetFriction(const BaseShapeConf& arg) noexcept
+        {
+            return arg.friction;
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SHAPES_SHAPECONF_HPP

--- a/PlayRho/Collision/Simplex.cpp
+++ b/PlayRho/Collision/Simplex.cpp
@@ -19,228 +19,235 @@
 
 #include <PlayRho/Collision/Simplex.hpp>
 
-namespace playrho {
-namespace d2 {
-
-IndexPair3 GetIndexPairs(const SimplexEdges& collection) noexcept
+namespace playrho
 {
-    auto list = IndexPair3{{InvalidIndexPair, InvalidIndexPair, InvalidIndexPair}};
-    switch (size(collection))
+    namespace d2
     {
-        case 3: list[2] = collection[2].GetIndexPair(); // fall through
-        case 2: list[1] = collection[1].GetIndexPair(); // fall through
-        case 1: list[0] = collection[0].GetIndexPair(); // fall through
-    }
-    return list;
-}
 
-Length2 CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept
-{
-    switch (size(simplexEdges))
-    {
-        case 1:
+        IndexPair3 GetIndexPairs(const SimplexEdges& collection) noexcept
         {
-            return -GetPointDelta(simplexEdges[0]);
+            auto list = IndexPair3{{InvalidIndexPair, InvalidIndexPair, InvalidIndexPair}};
+            switch (size(collection))
+            {
+            case 3:
+                list[2] = collection[2].GetIndexPair();// fall through
+            case 2:
+                list[1] = collection[1].GetIndexPair();// fall through
+            case 1:
+                list[0] = collection[0].GetIndexPair();// fall through
+            }
+            return list;
         }
-        case 2:
+
+        Length2 CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept
         {
-            const auto e12 = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
-            const auto e0 = GetPointDelta(simplexEdges[0]);
-            const auto sgn = Cross(e12, -e0);
-            // If sgn > 0, then origin is left of e12, else origin is right of e12.
-            return (sgn > 0_m2)? GetRevPerpendicular(e12): GetFwdPerpendicular(e12);
+            switch (size(simplexEdges))
+            {
+            case 1: {
+                return -GetPointDelta(simplexEdges[0]);
+            }
+            case 2: {
+                const auto e12 = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
+                const auto e0 = GetPointDelta(simplexEdges[0]);
+                const auto sgn = Cross(e12, -e0);
+                // If sgn > 0, then origin is left of e12, else origin is right of e12.
+                return (sgn > 0_m2) ? GetRevPerpendicular(e12) : GetFwdPerpendicular(e12);
+            }
+            default:
+                break;
+            }
+            assert(size(simplexEdges) < 4);
+            return Length2{0_m, 0_m};
         }
-        default:
-            break;
-    }
-    assert(size(simplexEdges) < 4);
-    return Length2{0_m, 0_m};
-}
 
-Simplex Simplex::Get(const SimplexEdge& s0) noexcept
-{
-    return Simplex{{s0}, {1}};
-}
-
-Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1) noexcept
-{
-    assert(s0.GetIndexPair() != s1.GetIndexPair() || s0 == s1);
-
-    // Solves the given line segment simplex using barycentric coordinates.
-    //
-    // p = a1 * w1 + a2 * w2
-    // a1 + a2 = 1
-    //
-    // The vector from the origin to the closest point on the line is
-    // perpendicular to the line.
-    // e12 = w2 - w1
-    // dot(p, e) = 0
-    // a1 * dot(w1, e) + a2 * dot(w2, e) = 0
-    //
-    // 2-by-2 linear system
-    // [1      1     ][a1] = [1]
-    // [w1.e12 w2.e12][a2] = [0]
-    //
-    // Define
-    // d12_1 =  dot(w2, e12)
-    // d12_2 = -dot(w1, e12)
-    // d12_sum = d12_1 + d12_2
-    //
-    // Solution
-    // a1 = d12_1 / d12_sum
-    // a2 = d12_2 / d12_sum
-
-    const auto w1 = GetPointDelta(s0);
-    const auto w2 = GetPointDelta(s1);
-    const auto e12 = w2 - w1;
-    
-    // w1 region
-    const auto d12_2 = -Dot(w1, e12);
-    if (d12_2 <= 0_m2)
-    {
-        // a2 <= 0, so we clamp it to 0
-        return Simplex{{s0}, {1}};
-    }
-    
-    // w2 region
-    const auto d12_1 = Dot(w2, e12);
-    if (d12_1 <= 0_m2)
-    {
-        // a1 <= 0, so we clamp it to 0
-        return Simplex{{s1}, {1}};
-    }
-    
-    // Must be in e12 region.
-    const auto inv_sum = Real{1} / (d12_1 + d12_2);
-    return Simplex{{s0, s1}, {d12_1 * inv_sum, d12_2 * inv_sum}};
-}
-
-Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1, const SimplexEdge& s2) noexcept
-{
-    // Solves the given 3-edge simplex.
-    //
-    // Possible regions:
-    // - points[2]
-    // - edge points[0]-points[2]
-    // - edge points[1]-points[2]
-    // - inside the triangle
-
-    const auto w1 = GetPointDelta(s0);
-    const auto w2 = GetPointDelta(s1);
-    const auto w3 = GetPointDelta(s2);
-    
-    // Edge12
-    // [1      1     ][a1] = [1]
-    // [w1.e12 w2.e12][a2] = [0]
-    // a3 = 0
-    const auto e12 = w2 - w1;
-    const auto d12_1 = Dot(w2, e12);
-    const auto d12_2 = -Dot(w1, e12);
-    
-    // Edge13
-    // [1      1     ][a1] = [1]
-    // [w1.e13 w3.e13][a3] = [0]
-    // a2 = 0
-    const auto e13 = w3 - w1;
-    const auto d13_1 = Dot(w3, e13);
-    const auto d13_2 = -Dot(w1, e13);
-    
-    // Edge23
-    // [1      1     ][a2] = [1]
-    // [w2.e23 w3.e23][a3] = [0]
-    // a1 = 0
-    const auto e23 = w3 - w2;
-    const auto d23_1 = Dot(w3, e23);
-    const auto d23_2 = -Dot(w2, e23);
-    
-    // w1 region
-    if ((d12_2 <= 0_m2) && (d13_2 <= 0_m2))
-    {
-        return Simplex{{s0}, {1}};
-    }
-    
-    // w2 region
-    if ((d12_1 <= 0_m2) && (d23_2 <= 0_m2))
-    {
-        return Simplex{{s1}, {1}};
-    }
-    
-    // w3 region
-    if ((d13_1 <= 0_m2) && (d23_1 <= 0_m2))
-    {
-        return Simplex{{s2}, {1}};
-    }
-
-    // Triangle123
-    const auto n123 = Cross(e12, e13);
-
-    // e12
-    const auto cp_w1_w2 = Cross(w1, w2);
-    const auto d123_3 = n123 * cp_w1_w2;
-    if ((d12_1 > 0_m2) && (d12_2 > 0_m2) && (d123_3 <= 0 * SquareMeter * SquareMeter))
-    {
-        const auto inv_sum = Real{1} / (d12_1 + d12_2);
-        return Simplex{{s0, s1}, {d12_1 * inv_sum, d12_2 * inv_sum}};
-    }
-    
-    // e13
-    const auto cp_w3_w1 = Cross(w3, w1);
-    const auto d123_2 = n123 * cp_w3_w1;
-    if ((d13_1 > 0_m2) && (d13_2 > 0_m2) && (d123_2 <= 0 * SquareMeter * SquareMeter))
-    {
-        const auto inv_sum = Real{1} / (d13_1 + d13_2);
-        return Simplex{{s0, s2}, {d13_1 * inv_sum, d13_2 * inv_sum}};
-    }
-    
-    // e23
-    const auto cp_w2_w3 = Cross(w2, w3);
-    const auto d123_1 = n123 * cp_w2_w3;
-    if ((d23_1 > 0_m2) && (d23_2 > 0_m2) && (d123_1 <= 0 * SquareMeter * SquareMeter))
-    {
-        const auto inv_sum = Real{1} / (d23_1 + d23_2);
-        return Simplex{{s2, s1}, {d23_2 * inv_sum, d23_1 * inv_sum}};
-    }
-    
-    // Must be in triangle123
-    const auto inv_sum = Real{1} / (d123_1 + d123_2 + d123_3);
-    return Simplex{{s0, s1, s2}, {d123_1 * inv_sum, d123_2 * inv_sum, d123_3 * inv_sum}};
-}
-
-Simplex Simplex::Get(const SimplexEdges& edges) noexcept
-{
-    const auto count = edges.size();
-    assert(count < 4);
-    switch (count)
-    {
-        case 1: return Get(edges[0]);
-        case 2: return Get(edges[0], edges[1]);
-        case 3: return Get(edges[0], edges[1], edges[2]);
-        default: break; // should be zero in this case
-    }
-    return Simplex{};
-}
-
-Real Simplex::CalcMetric(const SimplexEdges& simplexEdges)
-{
-    assert(simplexEdges.size() < 4);
-    switch (simplexEdges.size())
-    {
-        case 1: return Real{0};
-        case 2:
+        Simplex Simplex::Get(const SimplexEdge& s0) noexcept
         {
-            const auto delta = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
-            return StripUnit(GetMagnitude(delta)); // Length
+            return Simplex{{s0}, {1}};
         }
-        case 3:
-        {
-            const auto delta10 = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
-            const auto delta20 = GetPointDelta(simplexEdges[2]) - GetPointDelta(simplexEdges[0]);
-            return StripUnit(Cross(delta10, delta20)); // Area
-        }
-        default: break; // should be zero in this case
-    }
-    return Real{0};
-}
 
-} // namespace d2
-} // namespace playrho
+        Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1) noexcept
+        {
+            assert(s0.GetIndexPair() != s1.GetIndexPair() || s0 == s1);
+
+            // Solves the given line segment simplex using barycentric coordinates.
+            //
+            // p = a1 * w1 + a2 * w2
+            // a1 + a2 = 1
+            //
+            // The vector from the origin to the closest point on the line is
+            // perpendicular to the line.
+            // e12 = w2 - w1
+            // dot(p, e) = 0
+            // a1 * dot(w1, e) + a2 * dot(w2, e) = 0
+            //
+            // 2-by-2 linear system
+            // [1      1     ][a1] = [1]
+            // [w1.e12 w2.e12][a2] = [0]
+            //
+            // Define
+            // d12_1 =  dot(w2, e12)
+            // d12_2 = -dot(w1, e12)
+            // d12_sum = d12_1 + d12_2
+            //
+            // Solution
+            // a1 = d12_1 / d12_sum
+            // a2 = d12_2 / d12_sum
+
+            const auto w1 = GetPointDelta(s0);
+            const auto w2 = GetPointDelta(s1);
+            const auto e12 = w2 - w1;
+
+            // w1 region
+            const auto d12_2 = -Dot(w1, e12);
+            if (d12_2 <= 0_m2)
+            {
+                // a2 <= 0, so we clamp it to 0
+                return Simplex{{s0}, {1}};
+            }
+
+            // w2 region
+            const auto d12_1 = Dot(w2, e12);
+            if (d12_1 <= 0_m2)
+            {
+                // a1 <= 0, so we clamp it to 0
+                return Simplex{{s1}, {1}};
+            }
+
+            // Must be in e12 region.
+            const auto inv_sum = Real{1} / (d12_1 + d12_2);
+            return Simplex{{s0, s1}, {d12_1 * inv_sum, d12_2 * inv_sum}};
+        }
+
+        Simplex Simplex::Get(const SimplexEdge& s0, const SimplexEdge& s1, const SimplexEdge& s2) noexcept
+        {
+            // Solves the given 3-edge simplex.
+            //
+            // Possible regions:
+            // - points[2]
+            // - edge points[0]-points[2]
+            // - edge points[1]-points[2]
+            // - inside the triangle
+
+            const auto w1 = GetPointDelta(s0);
+            const auto w2 = GetPointDelta(s1);
+            const auto w3 = GetPointDelta(s2);
+
+            // Edge12
+            // [1      1     ][a1] = [1]
+            // [w1.e12 w2.e12][a2] = [0]
+            // a3 = 0
+            const auto e12 = w2 - w1;
+            const auto d12_1 = Dot(w2, e12);
+            const auto d12_2 = -Dot(w1, e12);
+
+            // Edge13
+            // [1      1     ][a1] = [1]
+            // [w1.e13 w3.e13][a3] = [0]
+            // a2 = 0
+            const auto e13 = w3 - w1;
+            const auto d13_1 = Dot(w3, e13);
+            const auto d13_2 = -Dot(w1, e13);
+
+            // Edge23
+            // [1      1     ][a2] = [1]
+            // [w2.e23 w3.e23][a3] = [0]
+            // a1 = 0
+            const auto e23 = w3 - w2;
+            const auto d23_1 = Dot(w3, e23);
+            const auto d23_2 = -Dot(w2, e23);
+
+            // w1 region
+            if ((d12_2 <= 0_m2) && (d13_2 <= 0_m2))
+            {
+                return Simplex{{s0}, {1}};
+            }
+
+            // w2 region
+            if ((d12_1 <= 0_m2) && (d23_2 <= 0_m2))
+            {
+                return Simplex{{s1}, {1}};
+            }
+
+            // w3 region
+            if ((d13_1 <= 0_m2) && (d23_1 <= 0_m2))
+            {
+                return Simplex{{s2}, {1}};
+            }
+
+            // Triangle123
+            const auto n123 = Cross(e12, e13);
+
+            // e12
+            const auto cp_w1_w2 = Cross(w1, w2);
+            const auto d123_3 = n123 * cp_w1_w2;
+            if ((d12_1 > 0_m2) && (d12_2 > 0_m2) && (d123_3 <= 0 * SquareMeter * SquareMeter))
+            {
+                const auto inv_sum = Real{1} / (d12_1 + d12_2);
+                return Simplex{{s0, s1}, {d12_1 * inv_sum, d12_2 * inv_sum}};
+            }
+
+            // e13
+            const auto cp_w3_w1 = Cross(w3, w1);
+            const auto d123_2 = n123 * cp_w3_w1;
+            if ((d13_1 > 0_m2) && (d13_2 > 0_m2) && (d123_2 <= 0 * SquareMeter * SquareMeter))
+            {
+                const auto inv_sum = Real{1} / (d13_1 + d13_2);
+                return Simplex{{s0, s2}, {d13_1 * inv_sum, d13_2 * inv_sum}};
+            }
+
+            // e23
+            const auto cp_w2_w3 = Cross(w2, w3);
+            const auto d123_1 = n123 * cp_w2_w3;
+            if ((d23_1 > 0_m2) && (d23_2 > 0_m2) && (d123_1 <= 0 * SquareMeter * SquareMeter))
+            {
+                const auto inv_sum = Real{1} / (d23_1 + d23_2);
+                return Simplex{{s2, s1}, {d23_2 * inv_sum, d23_1 * inv_sum}};
+            }
+
+            // Must be in triangle123
+            const auto inv_sum = Real{1} / (d123_1 + d123_2 + d123_3);
+            return Simplex{{s0, s1, s2}, {d123_1 * inv_sum, d123_2 * inv_sum, d123_3 * inv_sum}};
+        }
+
+        Simplex Simplex::Get(const SimplexEdges& edges) noexcept
+        {
+            const auto count = edges.size();
+            assert(count < 4);
+            switch (count)
+            {
+            case 1:
+                return Get(edges[0]);
+            case 2:
+                return Get(edges[0], edges[1]);
+            case 3:
+                return Get(edges[0], edges[1], edges[2]);
+            default:
+                break;// should be zero in this case
+            }
+            return Simplex{};
+        }
+
+        Real Simplex::CalcMetric(const SimplexEdges& simplexEdges)
+        {
+            assert(simplexEdges.size() < 4);
+            switch (simplexEdges.size())
+            {
+            case 1:
+                return Real{0};
+            case 2: {
+                const auto delta = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
+                return StripUnit(GetMagnitude(delta));// Length
+            }
+            case 3: {
+                const auto delta10 = GetPointDelta(simplexEdges[1]) - GetPointDelta(simplexEdges[0]);
+                const auto delta20 = GetPointDelta(simplexEdges[2]) - GetPointDelta(simplexEdges[0]);
+                return StripUnit(Cross(delta10, delta20));// Area
+            }
+            default:
+                break;// should be zero in this case
+            }
+            return Real{0};
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/Simplex.hpp
+++ b/PlayRho/Collision/Simplex.hpp
@@ -20,202 +20,206 @@
 #ifndef PLAYRHO_COLLISION_SIMPLEX_HPP
 #define PLAYRHO_COLLISION_SIMPLEX_HPP
 
+#include <PlayRho/Collision/SimplexEdge.hpp>
 #include <PlayRho/Common/ArrayList.hpp>
 #include <PlayRho/Common/Vector.hpp>
-#include <PlayRho/Collision/SimplexEdge.hpp>
 #include <array>
 
-namespace playrho {
-namespace d2 {
-
-    /// @brief Simplex edge collection.
-    /// @note This data is 20 * 3 + 4 = 64-bytes large (on at least one 64-bit platform).
-    using SimplexEdges = ArrayList<SimplexEdge, MaxSimplexEdges,
-        std::remove_const<decltype(MaxSimplexEdges)>::type>;
-    
-    /// @brief Gets index pairs for the given edges collection.
-    IndexPair3 GetIndexPairs(const SimplexEdges& collection) noexcept;
-    
-    /// @brief Calculates the "search direction" for the given simplex edge list.
-    /// @param simplexEdges A one or two edge list.
-    /// @warning Behavior is undefined if the given edge list has zero edges.
-    /// @return "search direction" vector.
-    Length2 CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept;
-
-    /// @brief An encapsulation of a point, line segment, or triangle.
-    ///
-    /// @details An encapsulation of a point, line segment, or triangle.
-    ///   These are defined respectively as: a 0-simplex, a 1-simplex, and a 2-simplex.
-    ///   Used in doing G.J.K. collision detection.
-    ///
-    /// @note This data structure is 104-bytes large.
-    ///
-    /// @invariant Vertex's for the same index must have the same point locations.
-    /// @invariant There may not be more than one entry for the same index pair.
-    ///
-    /// @see https://en.wikipedia.org/wiki/Simplex
-    /// @see https://en.wikipedia.org/wiki/Gilbert%2DJohnson%2DKeerthi_distance_algorithm
-    ///
-    class Simplex
+namespace playrho
+{
+    namespace d2
     {
-    public:
 
-        /// Size type.
-        ///
-        /// @note This data type is explicitly set to 1-byte large.
-        using size_type = SimplexEdges::size_type;
+        /// @brief Simplex edge collection.
+        /// @note This data is 20 * 3 + 4 = 64-bytes large (on at least one 64-bit platform).
+        using SimplexEdges = ArrayList<SimplexEdge, MaxSimplexEdges,
+                                       std::remove_const<decltype(MaxSimplexEdges)>::type>;
 
-        /// Coefficients.
+        /// @brief Gets index pairs for the given edges collection.
+        IndexPair3 GetIndexPairs(const SimplexEdges& collection) noexcept;
+
+        /// @brief Calculates the "search direction" for the given simplex edge list.
+        /// @param simplexEdges A one or two edge list.
+        /// @warning Behavior is undefined if the given edge list has zero edges.
+        /// @return "search direction" vector.
+        Length2 CalcSearchDirection(const SimplexEdges& simplexEdges) noexcept;
+
+        /// @brief An encapsulation of a point, line segment, or triangle.
         ///
-        /// @details Collection of coefficient values.
+        /// @details An encapsulation of a point, line segment, or triangle.
+        ///   These are defined respectively as: a 0-simplex, a 1-simplex, and a 2-simplex.
+        ///   Used in doing G.J.K. collision detection.
         ///
-        /// @note This data structure is 4 * 3 + 4 = 16-bytes large.
+        /// @note This data structure is 104-bytes large.
         ///
-        using Coefficients = ArrayList<Real, MaxSimplexEdges,
-            std::remove_const<decltype(MaxSimplexEdges)>::type>;
-        
-        /// @brief Simplex cache.
-        /// @details Used to warm start Distance. Caches particular information from a simplex:
-        ///   a related metric and up-to 3 index pairs.
-        /// @note This data structure is 12-bytes large.
-        struct Cache
+        /// @invariant Vertex's for the same index must have the same point locations.
+        /// @invariant There may not be more than one entry for the same index pair.
+        ///
+        /// @see https://en.wikipedia.org/wiki/Simplex
+        /// @see https://en.wikipedia.org/wiki/Gilbert%2DJohnson%2DKeerthi_distance_algorithm
+        ///
+        class Simplex
         {
-            /// @brief Metric.
-            /// @details Metric based on a length or area value of edges.
-            Real metric = GetInvalid<Real>();
+         public:
+            /// Size type.
+            ///
+            /// @note This data type is explicitly set to 1-byte large.
+            using size_type = SimplexEdges::size_type;
 
-            /// @brief Indices.
-            /// @details Collection of index-pairs.
-            IndexPair3 indices = InvalidIndexPair3;
+            /// Coefficients.
+            ///
+            /// @details Collection of coefficient values.
+            ///
+            /// @note This data structure is 4 * 3 + 4 = 16-bytes large.
+            ///
+            using Coefficients = ArrayList<Real, MaxSimplexEdges,
+                                           std::remove_const<decltype(MaxSimplexEdges)>::type>;
+
+            /// @brief Simplex cache.
+            /// @details Used to warm start Distance. Caches particular information from a simplex:
+            ///   a related metric and up-to 3 index pairs.
+            /// @note This data structure is 12-bytes large.
+            struct Cache
+            {
+                /// @brief Metric.
+                /// @details Metric based on a length or area value of edges.
+                Real metric = GetInvalid<Real>();
+
+                /// @brief Indices.
+                /// @details Collection of index-pairs.
+                IndexPair3 indices = InvalidIndexPair3;
+            };
+
+            /// @brief Gets the cache value for the given edges.
+            static Cache GetCache(const SimplexEdges& edges) noexcept;
+
+            /// Gets the given simplex's "metric".
+            static Real CalcMetric(const SimplexEdges& simplexEdges);
+
+            /// @brief Gets the Simplex for the given simplex edge.
+            static Simplex Get(const SimplexEdge& s0) noexcept;
+
+            /// Gets the simplex for the given 2 edges.
+            ///
+            /// @note The given simplex vertices must have different index pairs or be of the same values.
+            /// @warning Behavior is undefined if the given simplex edges index pairs are the same
+            ///    and the whole edges values are not also the same.
+            ///
+            /// @param s0 Simplex edge 0.
+            /// @param s1 Simplex edge 1.
+            ///
+            /// @result One or two edge simplex.
+            ///
+            static Simplex Get(const SimplexEdge& s0, const SimplexEdge& s1) noexcept;
+
+            /// Gets the simplex for the given 3 edges.
+            ///
+            /// @result One, two, or three edge simplex.
+            ///
+            static Simplex Get(const SimplexEdge& s0, const SimplexEdge& s1, const SimplexEdge& s2) noexcept;
+
+            /// Gets the simplex for the given collection of vertices.
+            /// @param edges Collection of zero, one, two, or three simplex edges.
+            /// @warning Behavior is undefined if the given collection has more than 3 edges.
+            /// @return Zero, one, two, or three edge simplex.
+            static Simplex Get(const SimplexEdges& edges) noexcept;
+
+            Simplex() = default;
+
+            /// @brief Gets the edges.
+            constexpr SimplexEdges GetEdges() const noexcept;
+
+            /// @brief Gets the give indexed simplex edge.
+            const SimplexEdge& GetSimplexEdge(size_type index) const noexcept;
+
+            /// @brief Gets the coefficient for the given index.
+            constexpr Real GetCoefficient(size_type index) const noexcept;
+
+            /// @brief Gets the size in number of simplex edges that this instance is made up of.
+            constexpr size_type size() const noexcept;
+
+         private:
+            /// @brief Initializing constructor.
+            Simplex(const SimplexEdges& simplexEdges, const Coefficients& normalizedWeights) noexcept;
+
+            /// Collection of valid simplex edges.
+            ///
+            /// @note This member variable is 88-bytes.
+            ///
+            SimplexEdges m_simplexEdges;
+
+            /// Normalized weights.
+            ///
+            /// @details Collection of coefficients (ranging from greater than 0 to less than 1).
+            /// A.k.a.: barycentric coordinates.
+            ///
+            /// @note This member variable is 16-bytes.
+            ///
+            Coefficients m_normalizedWeights;
         };
-        
-        /// @brief Gets the cache value for the given edges.
-        static Cache GetCache(const SimplexEdges& edges) noexcept;
-        
-        /// Gets the given simplex's "metric".
-        static Real CalcMetric(const SimplexEdges& simplexEdges);
 
-        /// @brief Gets the Simplex for the given simplex edge.
-        static Simplex Get(const SimplexEdge& s0) noexcept;
-
-        /// Gets the simplex for the given 2 edges.
-        ///
-        /// @note The given simplex vertices must have different index pairs or be of the same values.
-        /// @warning Behavior is undefined if the given simplex edges index pairs are the same
-        ///    and the whole edges values are not also the same.
-        ///
-        /// @param s0 Simplex edge 0.
-        /// @param s1 Simplex edge 1.
-        ///
-        /// @result One or two edge simplex.
-        ///
-        static Simplex Get(const SimplexEdge& s0, const SimplexEdge& s1) noexcept;
-        
-        /// Gets the simplex for the given 3 edges.
-        ///
-        /// @result One, two, or three edge simplex.
-        ///
-        static Simplex Get(const SimplexEdge& s0, const SimplexEdge& s1, const SimplexEdge& s2) noexcept;
-        
-        /// Gets the simplex for the given collection of vertices.
-        /// @param edges Collection of zero, one, two, or three simplex edges.
-        /// @warning Behavior is undefined if the given collection has more than 3 edges.
-        /// @return Zero, one, two, or three edge simplex.
-        static Simplex Get(const SimplexEdges& edges) noexcept;
-
-        Simplex() = default;
-
-        /// @brief Gets the edges.
-        constexpr SimplexEdges GetEdges() const noexcept;
-
-        /// @brief Gets the give indexed simplex edge.
-        const SimplexEdge& GetSimplexEdge(size_type index) const noexcept;
-
-        /// @brief Gets the coefficient for the given index.
-        constexpr Real GetCoefficient(size_type index) const noexcept;
-
-        /// @brief Gets the size in number of simplex edges that this instance is made up of.
-        constexpr size_type size() const noexcept;
-
-    private:
-        
-        /// @brief Initializing constructor.
-        Simplex(const SimplexEdges& simplexEdges, const Coefficients& normalizedWeights) noexcept;
-
-        /// Collection of valid simplex edges.
-        ///
-        /// @note This member variable is 88-bytes.
-        ///
-        SimplexEdges m_simplexEdges;
-
-        /// Normalized weights.
-        ///
-        /// @details Collection of coefficients (ranging from greater than 0 to less than 1).
-        /// A.k.a.: barycentric coordinates.
-        ///
-        /// @note This member variable is 16-bytes.
-        ///
-        Coefficients m_normalizedWeights;
-    };
-
-    inline Simplex::Cache Simplex::GetCache(const SimplexEdges& edges) noexcept
-    {
-        return Simplex::Cache{Simplex::CalcMetric(edges), GetIndexPairs(edges)};
-    }
-
-    inline Simplex::Simplex(const SimplexEdges& simplexEdges,
-                            const Coefficients& normalizedWeights) noexcept:
-        m_simplexEdges{simplexEdges}, m_normalizedWeights{normalizedWeights}
-    {
-        assert(simplexEdges.size() == normalizedWeights.size());
-#ifndef NDEBUG
-        const auto sum = std::accumulate(begin(normalizedWeights), end(normalizedWeights),
-                                         Real{0});
-        assert(AlmostEqual(Real{1}, sum));
-#endif
-    }
-
-    constexpr SimplexEdges Simplex::GetEdges() const noexcept
-    {
-        return m_simplexEdges;
-    }
-    
-    const inline SimplexEdge& Simplex::GetSimplexEdge(size_type index) const noexcept
-    {
-        return m_simplexEdges[index];
-    }
-    
-    constexpr Real Simplex::GetCoefficient(size_type index) const noexcept
-    {
-        return m_normalizedWeights[index];
-    }
-    
-    /// @brief Gets the size in number of valid edges of this Simplex.
-    /// @return Value between 0 and <code>MaxEdges</code> (inclusive).
-    constexpr Simplex::size_type Simplex::size() const noexcept
-    {
-        return m_simplexEdges.size();
-    }
-
-    /// @brief Gets the scaled delta for the given indexed element of the given simplex.
-    inline Length2 GetScaledDelta(const Simplex& simplex, Simplex::size_type index)
-    {
-        return GetPointDelta(simplex.GetSimplexEdge(index)) * simplex.GetCoefficient(index);
-    }
-
-    /// Gets the "closest point".
-    constexpr Length2 GetClosestPoint(const Simplex& simplex)
-    {
-        switch (simplex.size())
+        inline Simplex::Cache Simplex::GetCache(const SimplexEdges& edges) noexcept
         {
-            case 1: return GetScaledDelta(simplex, 0);
-            case 2: return GetScaledDelta(simplex, 0) + GetScaledDelta(simplex, 1);
-            case 3: return Length2{0_m, 0_m};
-            default: return Length2{0_m, 0_m};
+            return Simplex::Cache{Simplex::CalcMetric(edges), GetIndexPairs(edges)};
         }
-    }
 
-} // namespace d2
-} // namespace playrho
+        inline Simplex::Simplex(const SimplexEdges& simplexEdges,
+                                const Coefficients& normalizedWeights) noexcept
+            : m_simplexEdges{simplexEdges}, m_normalizedWeights{normalizedWeights}
+        {
+            assert(simplexEdges.size() == normalizedWeights.size());
+#ifndef NDEBUG
+            const auto sum = std::accumulate(begin(normalizedWeights), end(normalizedWeights),
+                                             Real{0});
+            assert(AlmostEqual(Real{1}, sum));
+#endif
+        }
 
-#endif // PLAYRHO_COLLISION_SIMPLEX_HPP
+        constexpr SimplexEdges Simplex::GetEdges() const noexcept
+        {
+            return m_simplexEdges;
+        }
+
+        const inline SimplexEdge& Simplex::GetSimplexEdge(size_type index) const noexcept
+        {
+            return m_simplexEdges[index];
+        }
+
+        constexpr Real Simplex::GetCoefficient(size_type index) const noexcept
+        {
+            return m_normalizedWeights[index];
+        }
+
+        /// @brief Gets the size in number of valid edges of this Simplex.
+        /// @return Value between 0 and <code>MaxEdges</code> (inclusive).
+        constexpr Simplex::size_type Simplex::size() const noexcept
+        {
+            return m_simplexEdges.size();
+        }
+
+        /// @brief Gets the scaled delta for the given indexed element of the given simplex.
+        inline Length2 GetScaledDelta(const Simplex& simplex, Simplex::size_type index)
+        {
+            return GetPointDelta(simplex.GetSimplexEdge(index)) * simplex.GetCoefficient(index);
+        }
+
+        /// Gets the "closest point".
+        constexpr Length2 GetClosestPoint(const Simplex& simplex)
+        {
+            switch (simplex.size())
+            {
+            case 1:
+                return GetScaledDelta(simplex, 0);
+            case 2:
+                return GetScaledDelta(simplex, 0) + GetScaledDelta(simplex, 1);
+            case 3:
+                return Length2{0_m, 0_m};
+            default:
+                return Length2{0_m, 0_m};
+            }
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SIMPLEX_HPP

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -20,86 +20,103 @@
 #ifndef PLAYRHO_COLLISION_SIMPLEXEDGE_HPP
 #define PLAYRHO_COLLISION_SIMPLEXEDGE_HPP
 
-#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Collision/IndexPair.hpp>
+#include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Simplex edge.
-///
-/// @details This is the locations (in world coordinates) and indices of a pair of vertices
-/// from two shapes (shape A and shape B).
-///
-/// @note This data structure is 20-bytes large (on at least one 64-bit platform).
-///
-class SimplexEdge
+namespace playrho
 {
-public:
-    /// @brief Default constructor.
-    SimplexEdge() = default;
-    
-    /// @brief Copy constructor.
-    constexpr SimplexEdge(const SimplexEdge& copy) = default;
-    
-    /// @brief Initializing constructor.
-    /// @param pA Point A in world coordinates.
-    /// @param iA Index of point A within the shape that it comes from.
-    /// @param pB Point B in world coordinates.
-    /// @param iB Index of point B within the shape that it comes from.
-    constexpr SimplexEdge(Length2 pA, VertexCounter iA,
-                                         Length2 pB, VertexCounter iB) noexcept;
-    
-    /// @brief Gets point A (in world coordinates).
-    constexpr auto GetPointA() const noexcept { return m_wA; }
-    
-    /// @brief Gets point B (in world coordinates).
-    constexpr auto GetPointB() const noexcept { return m_wB; }
+    namespace d2
+    {
 
-    /// @brief Gets index A.
-    constexpr auto GetIndexA() const noexcept { return std::get<0>(m_indexPair); }
-    
-    /// @brief Gets index B.
-    constexpr auto GetIndexB() const noexcept { return std::get<1>(m_indexPair); }
+        /// @brief Simplex edge.
+        ///
+        /// @details This is the locations (in world coordinates) and indices of a pair of vertices
+        /// from two shapes (shape A and shape B).
+        ///
+        /// @note This data structure is 20-bytes large (on at least one 64-bit platform).
+        ///
+        class SimplexEdge
+        {
+         public:
+            /// @brief Default constructor.
+            SimplexEdge() = default;
 
-    /// @brief Gets the index pair.
-    constexpr auto GetIndexPair() const noexcept { return m_indexPair; }
+            /// @brief Copy constructor.
+            constexpr SimplexEdge(const SimplexEdge& copy) = default;
 
-private:
-    Length2 m_wA; ///< Point A in world coordinates. This is the support point in proxy A. 8-bytes.
-    Length2 m_wB; ///< Point B in world coordinates. This is the support point in proxy B. 8-bytes.
-    IndexPair m_indexPair; ///< Index pair. @details Indices of points A and B. 2-bytes.
-};
+            /// @brief Initializing constructor.
+            /// @param pA Point A in world coordinates.
+            /// @param iA Index of point A within the shape that it comes from.
+            /// @param pB Point B in world coordinates.
+            /// @param iB Index of point B within the shape that it comes from.
+            constexpr SimplexEdge(Length2 pA, VertexCounter iA,
+                                  Length2 pB, VertexCounter iB) noexcept;
 
-constexpr SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
-                                                  Length2 pB, VertexCounter iB) noexcept:
-    m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
-{
-    // Intentionally empty.
-}
+            /// @brief Gets point A (in world coordinates).
+            constexpr auto GetPointA() const noexcept
+            {
+                return m_wA;
+            }
 
-/// @brief Gets "w".
-/// @return 2-dimensional vector value of the simplex edge's point B minus its point A.
-constexpr Length2 GetPointDelta(const SimplexEdge& sv) noexcept
-{
-    return sv.GetPointB() - sv.GetPointA();
-}
+            /// @brief Gets point B (in world coordinates).
+            constexpr auto GetPointB() const noexcept
+            {
+                return m_wB;
+            }
 
-/// @brief Equality operator for <code>SimplexEdge</code>.
-constexpr bool operator== (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
-{
-    return (lhs.GetPointA() == rhs.GetPointA())
-        && (lhs.GetPointB() == rhs.GetPointB())
-        && (lhs.GetIndexPair() == rhs.GetIndexPair());
-}
+            /// @brief Gets index A.
+            constexpr auto GetIndexA() const noexcept
+            {
+                return std::get<0>(m_indexPair);
+            }
 
-/// @brief Inequality operator for <code>SimplexEdge</code>.
-constexpr bool operator!= (const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+            /// @brief Gets index B.
+            constexpr auto GetIndexB() const noexcept
+            {
+                return std::get<1>(m_indexPair);
+            }
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Gets the index pair.
+            constexpr auto GetIndexPair() const noexcept
+            {
+                return m_indexPair;
+            }
 
-#endif // PLAYRHO_COLLISION_SIMPLEXEDGE_HPP
+         private:
+            Length2 m_wA;         ///< Point A in world coordinates. This is the support point in proxy A. 8-bytes.
+            Length2 m_wB;         ///< Point B in world coordinates. This is the support point in proxy B. 8-bytes.
+            IndexPair m_indexPair;///< Index pair. @details Indices of points A and B. 2-bytes.
+        };
+
+        constexpr SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
+                                           Length2 pB, VertexCounter iB) noexcept
+            : m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Gets "w".
+        /// @return 2-dimensional vector value of the simplex edge's point B minus its point A.
+        constexpr Length2 GetPointDelta(const SimplexEdge& sv) noexcept
+        {
+            return sv.GetPointB() - sv.GetPointA();
+        }
+
+        /// @brief Equality operator for <code>SimplexEdge</code>.
+        constexpr bool operator==(const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+        {
+            return (lhs.GetPointA() == rhs.GetPointA())
+                   && (lhs.GetPointB() == rhs.GetPointB())
+                   && (lhs.GetIndexPair() == rhs.GetIndexPair());
+        }
+
+        /// @brief Inequality operator for <code>SimplexEdge</code>.
+        constexpr bool operator!=(const SimplexEdge& lhs, const SimplexEdge& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_SIMPLEXEDGE_HPP

--- a/PlayRho/Collision/TimeOfImpact.cpp
+++ b/PlayRho/Collision/TimeOfImpact.cpp
@@ -19,295 +19,310 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Collision/TimeOfImpact.hpp>
 #include <PlayRho/Collision/Distance.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/SeparationScenario.hpp>
+#include <PlayRho/Collision/TimeOfImpact.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <algorithm>
 
-namespace playrho {
-
-const char *GetName(TOIOutput::State state) noexcept
+namespace playrho
 {
-    switch (state)
+
+    const char* GetName(TOIOutput::State state) noexcept
     {
-        case TOIOutput::e_unknown: break;
-        case TOIOutput::e_touching: return "touching";
-        case TOIOutput::e_separated: return "separated";
-        case TOIOutput::e_overlapped: return "overlapped";
-        case TOIOutput::e_nextAfter: return "next-after";
-        case TOIOutput::e_maxRootIters: return "max-root-iters";
-        case TOIOutput::e_maxToiIters: return "max-toi-iters";
-        case TOIOutput::e_belowMinTarget: return "below-min-target";
-        case TOIOutput::e_maxDistIters: return "max-dist-iters";
-        case TOIOutput::e_targetDepthExceedsTotalRadius: return "target-depth-exceeds-total-radius";
-        case TOIOutput::e_minTargetSquaredOverflow: return "min-target-squared-overflow";
-        case TOIOutput::e_maxTargetSquaredOverflow: return "max-target-squared-overflow";
-        case TOIOutput::e_notFinite: return "not-finite";
-    }
-    assert(state == TOIOutput::e_unknown);
-    return "unknown";
-}
-
-ToiConf GetToiConf(const StepConf& conf) noexcept
-{
-    return ToiConf{}
-        .UseTimeMax(1)
-        .UseTargetDepth(conf.targetDepth)
-        .UseTolerance(conf.tolerance)
-        .UseMaxRootIters(conf.maxToiRootIters)
-        .UseMaxToiIters(conf.maxToiIters)
-        .UseMaxDistIters(conf.maxDistanceIters);
-}
-
-namespace d2 {
-
-TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
-                       const DistanceProxy& proxyB, const Sweep& sweepB,
-                       ToiConf conf)
-{
-    assert(IsValid(sweepA));
-    assert(IsValid(sweepB));
-    assert(sweepA.GetAlpha0() == sweepB.GetAlpha0());
-    assert(conf.tMax >= 0 && conf.tMax <=1);
-
-    // CCD via the local separating axis method. This seeks progression
-    // by computing the largest time at which separation is maintained.
-    
-    auto stats = TOIOutput::Statistics{};
-    
-    const auto totalRadius = proxyA.GetVertexRadius() + proxyB.GetVertexRadius();
-    if (conf.targetDepth > totalRadius)
-    {
-        return TOIOutput{0, stats, TOIOutput::e_targetDepthExceedsTotalRadius};
-    }
-    
-    const auto target = totalRadius - conf.targetDepth;
-    const auto maxTarget = std::max(target + conf.tolerance, 0_m);
-    const auto minTarget = std::max(target - conf.tolerance, 0_m);
-    
-    const auto minTargetSquared = Square(minTarget);
-    if (!isfinite(minTargetSquared) && isfinite(minTarget))
-    {
-        return TOIOutput{0, stats, TOIOutput::e_minTargetSquaredOverflow};
-    }
-
-    const auto maxTargetSquared = Square(maxTarget);
-    if (!isfinite(maxTargetSquared) && isfinite(maxTarget))
-    {
-        return TOIOutput{0, stats, TOIOutput::e_maxTargetSquaredOverflow};
-    }
-
-    auto timeLo = Real{0}; // Will be set to value of timeHi
-    auto timeLoXfA = GetTransformation(sweepA, timeLo);
-    auto timeLoXfB = GetTransformation(sweepB, timeLo);
-
-    // Prepare input for distance query.
-    auto distanceConf = GetDistanceConf(conf);
-
-    // The outer loop progressively attempts to compute new separating axes.
-    // This loop terminates when an axis is repeated (no progress is made).
-    while (stats.toi_iters < conf.maxToiIters)
-    {
-        // Get information on the distance between shapes. We can also use the results
-        // to get a separating axis.
-        const auto dinfo = Distance(proxyA, timeLoXfA, proxyB, timeLoXfB, distanceConf);
-        ++stats.toi_iters;
-        stats.sum_dist_iters += dinfo.iterations;
-        stats.max_dist_iters = std::max(stats.max_dist_iters, dinfo.iterations);
-
-        if (dinfo.state == DistanceOutput::HitMaxIters)
+        switch (state)
         {
-            return TOIOutput{timeLo, stats, TOIOutput::e_maxDistIters};
+        case TOIOutput::e_unknown:
+            break;
+        case TOIOutput::e_touching:
+            return "touching";
+        case TOIOutput::e_separated:
+            return "separated";
+        case TOIOutput::e_overlapped:
+            return "overlapped";
+        case TOIOutput::e_nextAfter:
+            return "next-after";
+        case TOIOutput::e_maxRootIters:
+            return "max-root-iters";
+        case TOIOutput::e_maxToiIters:
+            return "max-toi-iters";
+        case TOIOutput::e_belowMinTarget:
+            return "below-min-target";
+        case TOIOutput::e_maxDistIters:
+            return "max-dist-iters";
+        case TOIOutput::e_targetDepthExceedsTotalRadius:
+            return "target-depth-exceeds-total-radius";
+        case TOIOutput::e_minTargetSquaredOverflow:
+            return "min-target-squared-overflow";
+        case TOIOutput::e_maxTargetSquaredOverflow:
+            return "max-target-squared-overflow";
+        case TOIOutput::e_notFinite:
+            return "not-finite";
         }
-        assert(dinfo.state != DistanceOutput::Unknown);
-        distanceConf.cache = Simplex::GetCache(dinfo.simplex.GetEdges());
-        
-        // Get the real distance squared between shapes at the time of timeLo.
-        const auto distSquared = GetMagnitudeSquared(GetDelta(GetWitnessPoints(dinfo.simplex)));
+        assert(state == TOIOutput::e_unknown);
+        return "unknown";
+    }
+
+    ToiConf GetToiConf(const StepConf& conf) noexcept
+    {
+        return ToiConf{}
+            .UseTimeMax(1)
+            .UseTargetDepth(conf.targetDepth)
+            .UseTolerance(conf.tolerance)
+            .UseMaxRootIters(conf.maxToiRootIters)
+            .UseMaxToiIters(conf.maxToiIters)
+            .UseMaxDistIters(conf.maxDistanceIters);
+    }
+
+    namespace d2
+    {
+
+        TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
+                               const DistanceProxy& proxyB, const Sweep& sweepB,
+                               ToiConf conf)
+        {
+            assert(IsValid(sweepA));
+            assert(IsValid(sweepB));
+            assert(sweepA.GetAlpha0() == sweepB.GetAlpha0());
+            assert(conf.tMax >= 0 && conf.tMax <= 1);
+
+            // CCD via the local separating axis method. This seeks progression
+            // by computing the largest time at which separation is maintained.
+
+            auto stats = TOIOutput::Statistics{};
+
+            const auto totalRadius = proxyA.GetVertexRadius() + proxyB.GetVertexRadius();
+            if (conf.targetDepth > totalRadius)
+            {
+                return TOIOutput{0, stats, TOIOutput::e_targetDepthExceedsTotalRadius};
+            }
+
+            const auto target = totalRadius - conf.targetDepth;
+            const auto maxTarget = std::max(target + conf.tolerance, 0_m);
+            const auto minTarget = std::max(target - conf.tolerance, 0_m);
+
+            const auto minTargetSquared = Square(minTarget);
+            if (!isfinite(minTargetSquared) && isfinite(minTarget))
+            {
+                return TOIOutput{0, stats, TOIOutput::e_minTargetSquaredOverflow};
+            }
+
+            const auto maxTargetSquared = Square(maxTarget);
+            if (!isfinite(maxTargetSquared) && isfinite(maxTarget))
+            {
+                return TOIOutput{0, stats, TOIOutput::e_maxTargetSquaredOverflow};
+            }
+
+            auto timeLo = Real{0};// Will be set to value of timeHi
+            auto timeLoXfA = GetTransformation(sweepA, timeLo);
+            auto timeLoXfB = GetTransformation(sweepB, timeLo);
+
+            // Prepare input for distance query.
+            auto distanceConf = GetDistanceConf(conf);
+
+            // The outer loop progressively attempts to compute new separating axes.
+            // This loop terminates when an axis is repeated (no progress is made).
+            while (stats.toi_iters < conf.maxToiIters)
+            {
+                // Get information on the distance between shapes. We can also use the results
+                // to get a separating axis.
+                const auto dinfo = Distance(proxyA, timeLoXfA, proxyB, timeLoXfB, distanceConf);
+                ++stats.toi_iters;
+                stats.sum_dist_iters += dinfo.iterations;
+                stats.max_dist_iters = std::max(stats.max_dist_iters, dinfo.iterations);
+
+                if (dinfo.state == DistanceOutput::HitMaxIters)
+                {
+                    return TOIOutput{timeLo, stats, TOIOutput::e_maxDistIters};
+                }
+                assert(dinfo.state != DistanceOutput::Unknown);
+                distanceConf.cache = Simplex::GetCache(dinfo.simplex.GetEdges());
+
+                // Get the real distance squared between shapes at the time of timeLo.
+                const auto distSquared = GetMagnitudeSquared(GetDelta(GetWitnessPoints(dinfo.simplex)));
 #if 0
         if (!isfinite(distSquared))
         {
             return TOIOutput{timeLo, stats, TOIOutput::e_notFinite};
         }
 #endif
-        // If shapes closer at time timeLo than min-target squared, bail as overlapped.
-        if (distSquared < minTargetSquared)
-        {
-            /// XXX maybe should return TOIOutput{timeLo, stats, TOIOutput::e_belowMinTarget}?
-            return TOIOutput{timeLo, stats, TOIOutput::e_overlapped};
-        }
-
-        if (distSquared <= maxTargetSquared) // Victory!
-        {
-            // The two convex polygons are within the target range of each other at time timeLo!
-            return TOIOutput{timeLo, stats, TOIOutput::e_touching};
-        }
-
-        // From here on, the real distance squared at time timeLo is > than maxTargetSquared
-
-        // Initialize the separating axis.
-        const auto fcn = GetSeparationScenario(distanceConf.cache.indices,
-                                               proxyA, timeLoXfA, proxyB, timeLoXfB);
-
-        // Compute the TOI on the separating axis. We do this by successively
-        // resolving the deepest point. This loop is bounded by the number of vertices.
-        auto timeHi = conf.tMax; // timeHi goes to values between timeLo and timeHi.
-        auto timeHiXfA = GetTransformation(sweepA, timeHi);
-        auto timeHiXfB = GetTransformation(sweepB, timeHi);
-
-        auto pbIter = decltype(MaxShapeVertices){0};
-        for (; pbIter < MaxShapeVertices; ++pbIter)
-        {
-            // Find the deepest point at timeHi. Store the witness point indices.
-            const auto timeHiMinSep = FindMinSeparation(fcn, timeHiXfA, timeHiXfB);
-
-            // Is the final configuration separated?
-            if (timeHiMinSep.distance > maxTarget)
-            {
-                // Victory! No collision occurs within time span.
-                assert(timeHi == conf.tMax);
-                // Formerly this used tMax as in...
-                // return TOIOutput{TOIOutput::e_separated, tMax};
-                // timeHi seems more appropriate however given s2 was derived from it.
-                // Meanwhile timeHi always seems equal to input.tMax at this point.
-                stats.sum_finder_iters += pbIter;
-                return TOIOutput{timeHi, stats, TOIOutput::e_separated};
-            }
-
-            // From here on, timeHiMinSep.distance <= maxTarget
-
-            // Has the separation reached tolerance?
-            if (timeHiMinSep.distance >= minTarget)
-            {
-                if (timeHi == timeLo)
+                // If shapes closer at time timeLo than min-target squared, bail as overlapped.
+                if (distSquared < minTargetSquared)
                 {
-                    //
-                    // Can't advance timeLo since timeHi already the same.
-                    //
-                    // This state happens when the real distance is greater than maxTarget but the
-                    // timeHiMinSep distance is less than maxTarget. If function not stopped,
-                    // it runs till stats.toi_iters == conf.maxToiIters and returns a failed state.
-                    // Given that the function can't advance anymore, there's no need to run
-                    // anymore. Additionally, given that timeLo is the same as timeHi and the real
-                    // distance is separated, this function can return the separated state.
-                    //
-                    stats.sum_finder_iters += pbIter;
-                    return TOIOutput{timeHi, stats, TOIOutput::e_separated};
+                    /// XXX maybe should return TOIOutput{timeLo, stats, TOIOutput::e_belowMinTarget}?
+                    return TOIOutput{timeLo, stats, TOIOutput::e_overlapped};
                 }
 
-                // Advance the sweeps
-                timeLo = timeHi;
-                timeLoXfA = timeHiXfA;
-                timeLoXfB = timeHiXfB;
-                break;
-            }
-
-            // From here on timeHiMinSep.distance is < minTarget; i.e. at timeHi, shapes too close.
-
-            // Compute the initial separation of the witness points.
-            const auto timeLoEvalDistance = Evaluate(fcn, timeLoXfA, timeLoXfB,
-                                                     timeHiMinSep.indices);
-
-            // Check for initial overlap. Might happen if root finder runs out of iterations.
-            //assert(s1 >= minTarget);
-            // Check for touching
-            if (timeLoEvalDistance <= maxTarget)
-            {
-                if (timeLoEvalDistance < minTarget)
+                if (distSquared <= maxTargetSquared)// Victory!
                 {
-                    stats.sum_finder_iters += pbIter;
-                    return TOIOutput{timeLo, stats, TOIOutput::e_belowMinTarget};
+                    // The two convex polygons are within the target range of each other at time timeLo!
+                    return TOIOutput{timeLo, stats, TOIOutput::e_touching};
                 }
-                // Victory! timeLo should hold the TOI (could be 0.0).
-                stats.sum_finder_iters += pbIter;
-                return TOIOutput{timeLo, stats, TOIOutput::e_touching};
-            }
 
-            // Now: timeLoEvalDistance > maxTarget
+                // From here on, the real distance squared at time timeLo is > than maxTargetSquared
 
-            // Compute 1D root of: f(t) - target = 0
-            auto a1 = timeLo;
-            auto a2 = timeHi;
-            auto s1 = timeLoEvalDistance;
-            auto s2 = timeHiMinSep.distance;
-            auto roots = decltype(conf.maxRootIters){0}; // counts # times f(t) checked
-            auto t = timeLo;
-            for (;;)
-            {
-                assert(!AlmostZero(s2 - s1));
-                assert(a1 <= a2);
+                // Initialize the separating axis.
+                const auto fcn = GetSeparationScenario(distanceConf.cache.indices,
+                                                       proxyA, timeLoXfA, proxyB, timeLoXfB);
 
-                auto state = TOIOutput::e_unknown;
-                if (roots == conf.maxRootIters)
+                // Compute the TOI on the separating axis. We do this by successively
+                // resolving the deepest point. This loop is bounded by the number of vertices.
+                auto timeHi = conf.tMax;// timeHi goes to values between timeLo and timeHi.
+                auto timeHiXfA = GetTransformation(sweepA, timeHi);
+                auto timeHiXfB = GetTransformation(sweepB, timeHi);
+
+                auto pbIter = decltype(MaxShapeVertices){0};
+                for (; pbIter < MaxShapeVertices; ++pbIter)
                 {
-                    state = TOIOutput::e_maxRootIters;
-                }
-                else if (nextafter(a1, a2) >= a2)
-                {
-                    state = TOIOutput::e_nextAfter;
-                }
-                if (state != TOIOutput::e_unknown)
-                {
-                    // Reached max root iterations or...
-                    // Reached the limit of the Real type's precision!
-                    // In this state, there's no way to make progress anymore.
-                    // (a1 + a2) / 2 results in a1! So bail from function.
-                    stats.sum_finder_iters += pbIter;
+                    // Find the deepest point at timeHi. Store the witness point indices.
+                    const auto timeHiMinSep = FindMinSeparation(fcn, timeHiXfA, timeHiXfB);
+
+                    // Is the final configuration separated?
+                    if (timeHiMinSep.distance > maxTarget)
+                    {
+                        // Victory! No collision occurs within time span.
+                        assert(timeHi == conf.tMax);
+                        // Formerly this used tMax as in...
+                        // return TOIOutput{TOIOutput::e_separated, tMax};
+                        // timeHi seems more appropriate however given s2 was derived from it.
+                        // Meanwhile timeHi always seems equal to input.tMax at this point.
+                        stats.sum_finder_iters += pbIter;
+                        return TOIOutput{timeHi, stats, TOIOutput::e_separated};
+                    }
+
+                    // From here on, timeHiMinSep.distance <= maxTarget
+
+                    // Has the separation reached tolerance?
+                    if (timeHiMinSep.distance >= minTarget)
+                    {
+                        if (timeHi == timeLo)
+                        {
+                            //
+                            // Can't advance timeLo since timeHi already the same.
+                            //
+                            // This state happens when the real distance is greater than maxTarget but the
+                            // timeHiMinSep distance is less than maxTarget. If function not stopped,
+                            // it runs till stats.toi_iters == conf.maxToiIters and returns a failed state.
+                            // Given that the function can't advance anymore, there's no need to run
+                            // anymore. Additionally, given that timeLo is the same as timeHi and the real
+                            // distance is separated, this function can return the separated state.
+                            //
+                            stats.sum_finder_iters += pbIter;
+                            return TOIOutput{timeHi, stats, TOIOutput::e_separated};
+                        }
+
+                        // Advance the sweeps
+                        timeLo = timeHi;
+                        timeLoXfA = timeHiXfA;
+                        timeLoXfB = timeHiXfB;
+                        break;
+                    }
+
+                    // From here on timeHiMinSep.distance is < minTarget; i.e. at timeHi, shapes too close.
+
+                    // Compute the initial separation of the witness points.
+                    const auto timeLoEvalDistance = Evaluate(fcn, timeLoXfA, timeLoXfB,
+                                                             timeHiMinSep.indices);
+
+                    // Check for initial overlap. Might happen if root finder runs out of iterations.
+                    //assert(s1 >= minTarget);
+                    // Check for touching
+                    if (timeLoEvalDistance <= maxTarget)
+                    {
+                        if (timeLoEvalDistance < minTarget)
+                        {
+                            stats.sum_finder_iters += pbIter;
+                            return TOIOutput{timeLo, stats, TOIOutput::e_belowMinTarget};
+                        }
+                        // Victory! timeLo should hold the TOI (could be 0.0).
+                        stats.sum_finder_iters += pbIter;
+                        return TOIOutput{timeLo, stats, TOIOutput::e_touching};
+                    }
+
+                    // Now: timeLoEvalDistance > maxTarget
+
+                    // Compute 1D root of: f(t) - target = 0
+                    auto a1 = timeLo;
+                    auto a2 = timeHi;
+                    auto s1 = timeLoEvalDistance;
+                    auto s2 = timeHiMinSep.distance;
+                    auto roots = decltype(conf.maxRootIters){0};// counts # times f(t) checked
+                    auto t = timeLo;
+                    for (;;)
+                    {
+                        assert(!AlmostZero(s2 - s1));
+                        assert(a1 <= a2);
+
+                        auto state = TOIOutput::e_unknown;
+                        if (roots == conf.maxRootIters)
+                        {
+                            state = TOIOutput::e_maxRootIters;
+                        }
+                        else if (nextafter(a1, a2) >= a2)
+                        {
+                            state = TOIOutput::e_nextAfter;
+                        }
+                        if (state != TOIOutput::e_unknown)
+                        {
+                            // Reached max root iterations or...
+                            // Reached the limit of the Real type's precision!
+                            // In this state, there's no way to make progress anymore.
+                            // (a1 + a2) / 2 results in a1! So bail from function.
+                            stats.sum_finder_iters += pbIter;
+                            stats.sum_root_iters += roots;
+                            stats.max_root_iters = std::max(stats.max_root_iters, roots);
+                            return TOIOutput{t, stats, state};
+                        }
+
+                        // Uses secant to improve convergence & bisection to guarantee progress.
+                        t = IsOdd(roots) ? Secant(target, a1, s1, a2, s2) : Bisect(a1, a2);
+
+                        // Using secant method, t may equal a2 now.
+                        //assert(t != a1);
+                        ++roots;
+
+                        // If t == a1 or t == a2 then, there's a precision/rounding problem.
+                        // Allow that for now and keep going...
+
+                        const auto txfA = GetTransformation(sweepA, t);
+                        const auto txfB = GetTransformation(sweepB, t);
+                        const auto s = Evaluate(fcn, txfA, txfB, timeHiMinSep.indices);
+
+                        if (abs(s - target) <= conf.tolerance)// Root finding succeeded!
+                        {
+                            assert(t != timeHi);
+                            timeHi = t;// timeHi holds a tentative value for timeLo
+                            timeHiXfA = txfA;
+                            timeHiXfB = txfB;
+                            break;// leave before roots can be == conf.maxRootIters
+                        }
+
+                        // Ensure we continue to bracket the root.
+                        if (s > target)
+                        {
+                            a1 = t;
+                            s1 = s;
+                        }
+                        else// s <= target
+                        {
+                            a2 = t;
+                            s2 = s;
+                        }
+                    }
+
+                    // Found a new timeHi: timeHi, timeHiXfA, and timeHiXfB have been updated.
                     stats.sum_root_iters += roots;
                     stats.max_root_iters = std::max(stats.max_root_iters, roots);
-                    return TOIOutput{t, stats, state};
                 }
-
-                // Uses secant to improve convergence & bisection to guarantee progress.
-                t = IsOdd(roots)? Secant(target, a1, s1, a2, s2): Bisect(a1, a2);
-                
-                // Using secant method, t may equal a2 now.
-                //assert(t != a1);
-                ++roots;
-
-                // If t == a1 or t == a2 then, there's a precision/rounding problem.
-                // Allow that for now and keep going...
-
-                const auto txfA = GetTransformation(sweepA, t);
-                const auto txfB = GetTransformation(sweepB, t);
-                const auto s = Evaluate(fcn, txfA, txfB, timeHiMinSep.indices);
-
-                if (abs(s - target) <= conf.tolerance) // Root finding succeeded!
-                {
-                    assert(t != timeHi);
-                    timeHi = t; // timeHi holds a tentative value for timeLo
-                    timeHiXfA = txfA;
-                    timeHiXfB = txfB;
-                    break; // leave before roots can be == conf.maxRootIters
-                }
-
-                // Ensure we continue to bracket the root.
-                if (s > target)
-                {
-                    a1 = t;
-                    s1 = s;
-                }
-                else // s <= target
-                {
-                    a2 = t;
-                    s2 = s;
-                }
+                stats.sum_finder_iters += pbIter;
             }
 
-            // Found a new timeHi: timeHi, timeHiXfA, and timeHiXfB have been updated.
-            stats.sum_root_iters += roots;
-            stats.max_root_iters = std::max(stats.max_root_iters, roots);
+            // stats.toi_iters == conf.maxToiIters
+            // Root finder got stuck.
+            // This can happen if the two shapes never actually collide within their sweeps.
+            return TOIOutput{timeLo, stats, TOIOutput::e_maxToiIters};
         }
-        stats.sum_finder_iters += pbIter;
-    }
 
-    // stats.toi_iters == conf.maxToiIters
-    // Root finder got stuck.
-    // This can happen if the two shapes never actually collide within their sweeps.
-    return TOIOutput{timeLo, stats, TOIOutput::e_maxToiIters};
-}
-
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Collision/TimeOfImpact.hpp
+++ b/PlayRho/Collision/TimeOfImpact.hpp
@@ -23,281 +23,286 @@
 #define PLAYRHO_COLLISION_TIMEOFIMPACT_HPP
 
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Wider.hpp>
 #include <PlayRho/Common/NonNegative.hpp>
+#include <PlayRho/Common/Wider.hpp>
 
-namespace playrho {
-
-struct StepConf;
-    
-/// @brief Time of impact configuration.
-///
-/// @details These parameters effect time of impact calculations by limiting the definitions
-///    of time and impact. If total radius is expressed as TR, and target depth as TD, then:
-///    the max target distance is (TR - TD) + tolerance; and the min target distance is
-///    (TR - TD) - tolerance.
-///
-/// @note Max target distance must be less than or equal to the total radius as the target
-///   range has to be chosen such that the contact manifold will have a greater than zero
-///   contact point count.
-/// @note A max target of <code>totalRadius - DefaultLinearSlop * x</code> where
-///   <code>x is <= 1</code> is increasingly slower as x goes below 1.
-/// @note Min target distance needs to be significantly less than the max target distance and
-///   significantly more than 0.
-///
-/// @see SolvePositionConstraints
-/// @see SolveTOIPositionConstraints
-///
-struct ToiConf
+namespace playrho
 {
-    /// @brief Root iteration type.
-    using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
-    
-    /// @brief TOI iteration type.
-    using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
 
-    /// @brief Distance iteration type.
-    using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+    struct StepConf;
 
-    /// @brief Uses the given time max value.
-    constexpr ToiConf& UseTimeMax(Real value) noexcept;
-
-    /// @brief Uses the given target depth value.
-    constexpr ToiConf& UseTargetDepth(Length value) noexcept;
-    
-    /// @brief Uses the given tolerance value.
-    constexpr ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
-    
-    /// @brief Uses the given max root iterations value.
-    constexpr ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
-    
-    /// @brief Uses the given max TOI iterations value.
-    constexpr ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
-    
-    /// @brief Uses the given max distance iterations value.
-    constexpr ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
-
-    /// @brief T-Max.
-    Real tMax = 1;
-    
-    /// @brief Targeted depth of impact.
-    /// @note Value must be less than twice the minimum vertex radius of any shape.
-    Length targetDepth = DefaultLinearSlop * Real{3};
-
-    /// @brief Tolerance.
-    /// @details Provides a +/- range from the target depth that defines a minimum and
-    ///   maximum target depth within which inclusively, time of impact calculating code
-    ///   is expected to return a "touching" status.
-    /// @note Use the default value unless you really know what you're doing.
-    /// @note Use 0 to require a TOI at exactly the target depth. This is ill-advised.
-    NonNegative<Length> tolerance = NonNegative<Length>{DefaultLinearSlop / Real{4}};
-    
-    /// @brief Maximum number of root finder iterations.
-    /// @details This is the maximum number of iterations for calculating the 1-dimensional
-    ///   root of <code>f(t) - (totalRadius - targetDepth) < tolerance</code>
-    /// where <code>f(t)</code> is the distance between the shapes at time <code>t</code>,
-    /// and <code>totalRadius</code> is the sum of the vertex radiuses of 2 distance proxies.
-    /// @note This value never needs to be more than the number of iterations needed to
-    ///    achieve full machine precision.
-    root_iter_type maxRootIters = DefaultMaxToiRootIters;
-    
-    toi_iter_type maxToiIters = DefaultMaxToiIters; ///< Max time of impact iterations.
-    
-    dist_iter_type maxDistIters = DefaultMaxDistanceIters; ///< Max distance iterations.
-};
-
-constexpr ToiConf& ToiConf::UseTimeMax(Real value) noexcept
-{
-    tMax = value;
-    return *this;
-}
-
-constexpr ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
-{
-    targetDepth = value;
-    return *this;
-}
-
-constexpr ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
-{
-    tolerance = value;
-    return *this;
-}
-
-constexpr ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
-{
-    maxRootIters = value;
-    return *this;
-}
-
-constexpr ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
-{
-    maxToiIters = value;
-    return *this;
-}
-
-constexpr ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
-{
-    maxDistIters = value;
-    return *this;
-}
-
-/// @brief Gets the default time of impact configuration.
-/// @relatedalso ToiConf
-constexpr auto GetDefaultToiConf()
-{
-    return ToiConf{};
-}
-
-/// @brief Gets the time of impact configuration for the given step configuration.
-ToiConf GetToiConf(const StepConf& conf) noexcept;
-
-/// @brief Output data for time of impact.
-struct TOIOutput
-{
-    /// @brief Time of impact statistics.
-    struct Statistics
+    /// @brief Time of impact configuration.
+    ///
+    /// @details These parameters effect time of impact calculations by limiting the definitions
+    ///    of time and impact. If total radius is expressed as TR, and target depth as TD, then:
+    ///    the max target distance is (TR - TD) + tolerance; and the min target distance is
+    ///    (TR - TD) - tolerance.
+    ///
+    /// @note Max target distance must be less than or equal to the total radius as the target
+    ///   range has to be chosen such that the contact manifold will have a greater than zero
+    ///   contact point count.
+    /// @note A max target of <code>totalRadius - DefaultLinearSlop * x</code> where
+    ///   <code>x is <= 1</code> is increasingly slower as x goes below 1.
+    /// @note Min target distance needs to be significantly less than the max target distance and
+    ///   significantly more than 0.
+    ///
+    /// @see SolvePositionConstraints
+    /// @see SolveTOIPositionConstraints
+    ///
+    struct ToiConf
     {
-        /// @brief TOI iterations type.
-        using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
-        
-        /// @brief Distance iterations type.
-        using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
-        
-        /// @brief Root iterations type.
+        /// @brief Root iteration type.
         using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
-        
-        /// @brief TOI iterations sum type.
-        using toi_sum_type = Wider<toi_iter_type>::type;
-        
-        /// @brief Distance iterations sum type.
-        using dist_sum_type = Wider<dist_iter_type>::type;
-        
-        /// @brief Root iterations sum type.
-        using root_sum_type = Wider<root_iter_type>::type;
 
-        // 6-bytes
-        toi_sum_type sum_finder_iters = 0; ///< Sum total TOI iterations.
-        dist_sum_type sum_dist_iters = 0; ///< Sum total distance iterations.
-        root_sum_type sum_root_iters = 0; ///< Sum total of root finder iterations.
+        /// @brief TOI iteration type.
+        using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
 
-        // 3-bytes
-        toi_iter_type toi_iters = 0; ///< Time of impact iterations.
-        dist_iter_type max_dist_iters = 0; ///< Max. distance iterations count.
-        root_iter_type max_root_iters = 0; ///< Max. root finder iterations for all TOI iterations.
+        /// @brief Distance iteration type.
+        using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+
+        /// @brief Uses the given time max value.
+        constexpr ToiConf& UseTimeMax(Real value) noexcept;
+
+        /// @brief Uses the given target depth value.
+        constexpr ToiConf& UseTargetDepth(Length value) noexcept;
+
+        /// @brief Uses the given tolerance value.
+        constexpr ToiConf& UseTolerance(NonNegative<Length> value) noexcept;
+
+        /// @brief Uses the given max root iterations value.
+        constexpr ToiConf& UseMaxRootIters(root_iter_type value) noexcept;
+
+        /// @brief Uses the given max TOI iterations value.
+        constexpr ToiConf& UseMaxToiIters(toi_iter_type value) noexcept;
+
+        /// @brief Uses the given max distance iterations value.
+        constexpr ToiConf& UseMaxDistIters(dist_iter_type value) noexcept;
+
+        /// @brief T-Max.
+        Real tMax = 1;
+
+        /// @brief Targeted depth of impact.
+        /// @note Value must be less than twice the minimum vertex radius of any shape.
+        Length targetDepth = DefaultLinearSlop * Real{3};
+
+        /// @brief Tolerance.
+        /// @details Provides a +/- range from the target depth that defines a minimum and
+        ///   maximum target depth within which inclusively, time of impact calculating code
+        ///   is expected to return a "touching" status.
+        /// @note Use the default value unless you really know what you're doing.
+        /// @note Use 0 to require a TOI at exactly the target depth. This is ill-advised.
+        NonNegative<Length> tolerance = NonNegative<Length>{DefaultLinearSlop / Real{4}};
+
+        /// @brief Maximum number of root finder iterations.
+        /// @details This is the maximum number of iterations for calculating the 1-dimensional
+        ///   root of <code>f(t) - (totalRadius - targetDepth) < tolerance</code>
+        /// where <code>f(t)</code> is the distance between the shapes at time <code>t</code>,
+        /// and <code>totalRadius</code> is the sum of the vertex radiuses of 2 distance proxies.
+        /// @note This value never needs to be more than the number of iterations needed to
+        ///    achieve full machine precision.
+        root_iter_type maxRootIters = DefaultMaxToiRootIters;
+
+        toi_iter_type maxToiIters = DefaultMaxToiIters;///< Max time of impact iterations.
+
+        dist_iter_type maxDistIters = DefaultMaxDistanceIters;///< Max distance iterations.
     };
-    
-    /// @brief State.
-    enum State: std::uint8_t
+
+    constexpr ToiConf& ToiConf::UseTimeMax(Real value) noexcept
     {
-        /// @brief Unknown.
-        /// @details Unknown state.
-        /// @note This is the default initialized state.
-        e_unknown,
-        
-        /// @brief Touching.
-        /// @details Indicates that the returned time of impact for two convex polygons
-        ///   is for a time at which the two polygons are within the minimum and maximum
-        ///   target range inclusively.
-        /// @note This is a desirable result.
-        /// @note Time of impact is the time when the two convex polygons "touch".
-        e_touching,
-        
-        /// @brief Separated.
-        /// @details Indicates that the two convex polygons never actually collide
-        ///   during their defined sweeps.
-        /// @note This is a desirable result.
-        /// @note Time of impact in this case is <code>tMax</code> (which is typically 1).
-        e_separated,
-        
-        /// @brief Overlapped.
-        /// @details Indicates that the two convex polygons are closer to each other
-        ///   at the returned time than the target depth range allows for.
-        /// @note Can happen if total radius of the two convex polygons is too small.
-        /// @note Can happen if the tolerance is too low.
-        /// @note Time of impact is the time when the two convex polygons have already
-        ///   collided too much.
-        e_overlapped,
+        tMax = value;
+        return *this;
+    }
 
-        /// @brief Max root iterations.
-        /// @details Got to max number of root iterations allowed.
-        /// @note Can happen if the configured max number of root iterations is too low.
-        /// @note Can happen if the tolerance is too small.
-        e_maxRootIters,
-        
-        /// @brief Next after.
-        /// @note Can happen if the length moved is too much bigger than the tolerance.
-        e_nextAfter,
-        
-        /// @brief Max TOI iterations.
-        e_maxToiIters,
-        
-        /// @brief Below minimum target.
-        e_belowMinTarget,
-        
-        /// @brief Max distance iterations.
-        /// @details Indicates that the maximum number of distance iterations was done.
-        /// @note Can happen if the configured max number of distance iterations was too low.
-        e_maxDistIters,
-        
-        e_targetDepthExceedsTotalRadius,
-        e_minTargetSquaredOverflow,
-        e_maxTargetSquaredOverflow,
-        
-        e_notFinite,
+    constexpr ToiConf& ToiConf::UseTargetDepth(Length value) noexcept
+    {
+        targetDepth = value;
+        return *this;
+    }
+
+    constexpr ToiConf& ToiConf::UseTolerance(NonNegative<Length> value) noexcept
+    {
+        tolerance = value;
+        return *this;
+    }
+
+    constexpr ToiConf& ToiConf::UseMaxRootIters(root_iter_type value) noexcept
+    {
+        maxRootIters = value;
+        return *this;
+    }
+
+    constexpr ToiConf& ToiConf::UseMaxToiIters(toi_iter_type value) noexcept
+    {
+        maxToiIters = value;
+        return *this;
+    }
+
+    constexpr ToiConf& ToiConf::UseMaxDistIters(dist_iter_type value) noexcept
+    {
+        maxDistIters = value;
+        return *this;
+    }
+
+    /// @brief Gets the default time of impact configuration.
+    /// @relatedalso ToiConf
+    constexpr auto GetDefaultToiConf()
+    {
+        return ToiConf{};
+    }
+
+    /// @brief Gets the time of impact configuration for the given step configuration.
+    ToiConf GetToiConf(const StepConf& conf) noexcept;
+
+    /// @brief Output data for time of impact.
+    struct TOIOutput
+    {
+        /// @brief Time of impact statistics.
+        struct Statistics
+        {
+            /// @brief TOI iterations type.
+            using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
+
+            /// @brief Distance iterations type.
+            using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+
+            /// @brief Root iterations type.
+            using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
+
+            /// @brief TOI iterations sum type.
+            using toi_sum_type = Wider<toi_iter_type>::type;
+
+            /// @brief Distance iterations sum type.
+            using dist_sum_type = Wider<dist_iter_type>::type;
+
+            /// @brief Root iterations sum type.
+            using root_sum_type = Wider<root_iter_type>::type;
+
+            // 6-bytes
+            toi_sum_type sum_finder_iters = 0;///< Sum total TOI iterations.
+            dist_sum_type sum_dist_iters = 0; ///< Sum total distance iterations.
+            root_sum_type sum_root_iters = 0; ///< Sum total of root finder iterations.
+
+            // 3-bytes
+            toi_iter_type toi_iters = 0;      ///< Time of impact iterations.
+            dist_iter_type max_dist_iters = 0;///< Max. distance iterations count.
+            root_iter_type max_root_iters = 0;///< Max. root finder iterations for all TOI iterations.
+        };
+
+        /// @brief State.
+        enum State : std::uint8_t
+        {
+            /// @brief Unknown.
+            /// @details Unknown state.
+            /// @note This is the default initialized state.
+            e_unknown,
+
+            /// @brief Touching.
+            /// @details Indicates that the returned time of impact for two convex polygons
+            ///   is for a time at which the two polygons are within the minimum and maximum
+            ///   target range inclusively.
+            /// @note This is a desirable result.
+            /// @note Time of impact is the time when the two convex polygons "touch".
+            e_touching,
+
+            /// @brief Separated.
+            /// @details Indicates that the two convex polygons never actually collide
+            ///   during their defined sweeps.
+            /// @note This is a desirable result.
+            /// @note Time of impact in this case is <code>tMax</code> (which is typically 1).
+            e_separated,
+
+            /// @brief Overlapped.
+            /// @details Indicates that the two convex polygons are closer to each other
+            ///   at the returned time than the target depth range allows for.
+            /// @note Can happen if total radius of the two convex polygons is too small.
+            /// @note Can happen if the tolerance is too low.
+            /// @note Time of impact is the time when the two convex polygons have already
+            ///   collided too much.
+            e_overlapped,
+
+            /// @brief Max root iterations.
+            /// @details Got to max number of root iterations allowed.
+            /// @note Can happen if the configured max number of root iterations is too low.
+            /// @note Can happen if the tolerance is too small.
+            e_maxRootIters,
+
+            /// @brief Next after.
+            /// @note Can happen if the length moved is too much bigger than the tolerance.
+            e_nextAfter,
+
+            /// @brief Max TOI iterations.
+            e_maxToiIters,
+
+            /// @brief Below minimum target.
+            e_belowMinTarget,
+
+            /// @brief Max distance iterations.
+            /// @details Indicates that the maximum number of distance iterations was done.
+            /// @note Can happen if the configured max number of distance iterations was too low.
+            e_maxDistIters,
+
+            e_targetDepthExceedsTotalRadius,
+            e_minTargetSquaredOverflow,
+            e_maxTargetSquaredOverflow,
+
+            e_notFinite,
+        };
+
+        /// @brief Default constructor.
+        TOIOutput() = default;
+
+        /// @brief Initializing constructor.
+        TOIOutput(Real t, Statistics s, State z) noexcept
+            : time{t}, stats{s}, state{z}
+        {
+        }
+
+        Real time = 0;          ///< Time factor in range of [0,1] into the future.
+        Statistics stats;       ///< Statistics.
+        State state = e_unknown;///< State at time factor.
     };
-    
-    /// @brief Default constructor.
-    TOIOutput() = default;
-    
-    /// @brief Initializing constructor.
-    TOIOutput(Real t, Statistics s, State z) noexcept: time{t}, stats{s}, state{z} {}
 
-    Real time = 0; ///< Time factor in range of [0,1] into the future.
-    Statistics stats; ///< Statistics.
-    State state = e_unknown; ///< State at time factor.
-};
+    /// @brief Gets a human readable name for the given output state.
+    const char* GetName(TOIOutput::State state) noexcept;
 
-/// @brief Gets a human readable name for the given output state.
-const char *GetName(TOIOutput::State state) noexcept;
+    namespace d2
+    {
 
-namespace d2 {
+        class DistanceProxy;
 
-class DistanceProxy;
+        /// @brief Gets the time of impact for two disjoint convex sets using the
+        ///    Separating Axis Theorem.
+        ///
+        /// @details
+        /// Computes the upper bound on time before two shapes penetrate too much.
+        /// Time is represented as a fraction between [0,<code>tMax</code>].
+        /// This uses a swept separating axis and may miss some intermediate,
+        /// non-tunneling collision.
+        /// If you change the time interval, you should call this function again.
+        ///
+        /// @see https://en.wikipedia.org/wiki/Hyperplane_separation_theorem
+        /// @pre The given sweeps are both at the same alpha-0.
+        /// @warning Behavior is undefined if sweeps are not at the same alpha-0.
+        /// @warning Behavior is undefined if the configuration's <code>tMax</code> is not
+        ///    between 0 and 1 inclusive.
+        /// @note Uses Distance to compute the contact point and normal at the time of impact.
+        /// @note This only works for two disjoint convex sets.
+        ///
+        /// @param proxyA Proxy A. The proxy's vertex count must be 1 or more.
+        /// @param sweepA Sweep A. Sweep of motion for shape represented by proxy A.
+        /// @param proxyB Proxy B. The proxy's vertex count must be 1 or more.
+        /// @param sweepB Sweep B. Sweep of motion for shape represented by proxy B.
+        /// @param conf Configuration details for on calculation. Like the targeted depth of penetration.
+        ///
+        /// @return Time of impact output data.
+        ///
+        /// @relatedalso ::playrho::TOIOutput
+        ///
+        TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
+                               const DistanceProxy& proxyB, const Sweep& sweepB,
+                               ToiConf conf = GetDefaultToiConf());
 
-/// @brief Gets the time of impact for two disjoint convex sets using the
-///    Separating Axis Theorem.
-///
-/// @details
-/// Computes the upper bound on time before two shapes penetrate too much.
-/// Time is represented as a fraction between [0,<code>tMax</code>].
-/// This uses a swept separating axis and may miss some intermediate,
-/// non-tunneling collision.
-/// If you change the time interval, you should call this function again.
-///
-/// @see https://en.wikipedia.org/wiki/Hyperplane_separation_theorem
-/// @pre The given sweeps are both at the same alpha-0.
-/// @warning Behavior is undefined if sweeps are not at the same alpha-0.
-/// @warning Behavior is undefined if the configuration's <code>tMax</code> is not
-///    between 0 and 1 inclusive.
-/// @note Uses Distance to compute the contact point and normal at the time of impact.
-/// @note This only works for two disjoint convex sets.
-///
-/// @param proxyA Proxy A. The proxy's vertex count must be 1 or more.
-/// @param sweepA Sweep A. Sweep of motion for shape represented by proxy A.
-/// @param proxyB Proxy B. The proxy's vertex count must be 1 or more.
-/// @param sweepB Sweep B. Sweep of motion for shape represented by proxy B.
-/// @param conf Configuration details for on calculation. Like the targeted depth of penetration.
-///
-/// @return Time of impact output data.
-///
-/// @relatedalso ::playrho::TOIOutput
-///
-TOIOutput GetToiViaSat(const DistanceProxy& proxyA, const Sweep& sweepA,
-                       const DistanceProxy& proxyB, const Sweep& sweepB,
-                       ToiConf conf = GetDefaultToiConf());
+    }// namespace d2
+}// namespace playrho
 
-} // namespace d2
-} // namespace playrho
-
-#endif // PLAYRHO_COLLISION_TIMEOFIMPACT_HPP
+#endif// PLAYRHO_COLLISION_TIMEOFIMPACT_HPP

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -22,188 +22,192 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-namespace d2 {
-
-class Manifold;
-class Contact;
-class World;
-
-/// @brief Essentially a Manifold expressed in world coordinate terms.
-///
-/// @details Used to recognize the current state of a contact manifold in world coordinates.
-///
-/// @note This data structure is 48-bytes large (on at least one 64-bit platform).
-///
-/// @see GetWorldManifold
-///
-class WorldManifold
+namespace playrho
 {
-private:
-    UnitVec m_normal = GetInvalid<UnitVec>(); ///< world vector pointing from A to B
-    
-    /// @brief Points.
-    /// @details Manifold's contact points in world coordinates (mid-point of intersection)
-    /// @note 16-bytes.
-    Length2 m_points[MaxManifoldPoints] = {GetInvalid<Length2>(), GetInvalid<Length2>()};
+    namespace d2
+    {
 
-    /// @brief Impulses.
-    /// @note 16-bytes.
-    Momentum2 m_impulses[MaxManifoldPoints] = {Momentum2{}, Momentum2{}};
-    
-    /// @brief Separations.
-    /// @details A negative value indicates overlap.
-    Length m_separations[MaxManifoldPoints] = {GetInvalid<Length>(), GetInvalid<Length>()};
-    
-public:
-    
-    /// @brief Size type.
-    using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
+        class Manifold;
+        class Contact;
+        class World;
 
-    /// @brief Point data for world manifold.
-    /// @note This data structure is 20-bytes large at least on one 64-bit architecture.
-    struct PointData
-    {
-        Length2 location; ///< Location of point or the invalid value.
-        Momentum2 impulse; ///< "Normal" and "tangent" impulses at the point.
-        Length separation; ///< Separation at point or the invalid value.
-    };
-    
-    /// Default constructor.
-    /// @details
-    /// A default constructed world manifold will gave a point count of zero, an invalid
-    /// normal, invalid points, and invalid separations.
-    WorldManifold() = default;
-    
-    /// @brief Initializing constructor.
-    constexpr explicit WorldManifold(UnitVec normal) noexcept:
-        m_normal{normal}
-    {
-        assert(IsValid(normal));
-        // Intentionally empty.
-    }
-    
-    /// @brief Initializing constructor.
-    constexpr explicit WorldManifold(UnitVec normal, PointData ps0) noexcept:
-        m_normal{normal},
-        m_points{ps0.location, GetInvalid<Length2>()},
-        m_impulses{ps0.impulse, Momentum2{}},
-        m_separations{ps0.separation, GetInvalid<Length>()}
-    {
-        assert(IsValid(normal));
-        // Intentionally empty.
-    }
-    
-    /// @brief Initializing constructor.
-    constexpr explicit WorldManifold(UnitVec normal, PointData ps0, PointData ps1) noexcept:
-        m_normal{normal},
-        m_points{ps0.location, ps1.location},
-        m_impulses{ps0.impulse, ps1.impulse},
-        m_separations{ps0.separation, ps1.separation}
-    {
-        assert(IsValid(normal));
-        // Intentionally empty.
-    }
-    
-    /// @brief Gets the point count.
-    ///
-    /// @details This is the maximum index value that can be used to access valid point or
-    ///   separation information.
-    ///
-    /// @return Value between 0 and 2.
-    ///
-    size_type GetPointCount() const noexcept
-    {
-        return (IsValid(m_separations[0])? 1: 0) + (IsValid(m_separations[1])? 1: 0);
-    }
-    
-    /// Gets the normal of the contact.
-    /// @details This is a directional unit-vector.
-    /// @return Normal of the contact or an invalid value.
-    UnitVec GetNormal() const noexcept { return m_normal; }
-    
-    /// Gets the indexed point's location in world coordinates.
-    ///
-    /// @warning Behavior is undefined if the index value is not less than
-    ///   <code>MaxManifoldPoints</code>
-    ///
-    /// @param index Index to return point for. This must be between 0 and
-    ///   <code>GetPointCount()</code> to get a valid point from this method.
-    ///
-    /// @return Point or an invalid value if the given index was invalid.
-    ///
-    Length2 GetPoint(size_type index) const noexcept
-    {
-        assert(index < MaxManifoldPoints);
-        return m_points[index];
-    }
-    
-    /// Gets the amount of separation at the given indexed point.
-    ///
-    /// @warning Behavior is undefined if the index value is not less than
-    ///   <code>MaxManifoldPoints</code>
-    /// @param index Index to return separation for. This must be between 0 and
-    ///   <code>GetPointCount()</code>.
-    ///
-    /// @return Separation amount (a negative value), or an invalid value if the given index
-    ///   was invalid.
-    ///
-    Length GetSeparation(size_type index) const noexcept
-    {
-        assert(index < MaxManifoldPoints);
-        return m_separations[index];
-    }
-    
-    /// @brief Gets the given index contact impulses.
-    /// @return "Normal impulse" and "tangent impulse" pair.
-    Momentum2 GetImpulses(size_type index) const noexcept
-    {
-        assert(index < MaxManifoldPoints);
-        return m_impulses[index];
-    }
-};
+        /// @brief Essentially a Manifold expressed in world coordinate terms.
+        ///
+        /// @details Used to recognize the current state of a contact manifold in world coordinates.
+        ///
+        /// @note This data structure is 48-bytes large (on at least one 64-bit platform).
+        ///
+        /// @see GetWorldManifold
+        ///
+        class WorldManifold
+        {
+         private:
+            UnitVec m_normal = GetInvalid<UnitVec>();///< world vector pointing from A to B
 
-/// @brief Gets the world manifold for the given data.
-///
-/// @pre The given manifold input has between 0 and 2 points.
-///
-/// @param manifold Manifold to use.
-///   Uses the manifold's type, local point, local normal, point-count,
-///   and the indexed-points' local point data.
-/// @param xfA Transformation A.
-/// @param radiusA Radius of shape A.
-/// @param xfB Transformation B.
-/// @param radiusB Radius of shape B.
-///
-/// @return World manifold value for the given inputs which will have the same number of points as
-///   the given manifold has. The returned world manifold points will be the mid-points of the
-///   manifold intersection.
-///
-/// @relatedalso Manifold
-///
-WorldManifold GetWorldManifold(const Manifold& manifold,
-                               Transformation xfA, Length radiusA,
-                               Transformation xfB, Length radiusB);
+            /// @brief Points.
+            /// @details Manifold's contact points in world coordinates (mid-point of intersection)
+            /// @note 16-bytes.
+            Length2 m_points[MaxManifoldPoints] = {GetInvalid<Length2>(), GetInvalid<Length2>()};
 
-/// Gets the world manifold for the given data.
-///
-/// @note This is a convenience function that in turn calls the
-///    <code>GetWorldManifold(const Manifold&, const Transformation&, const Real,
-///                           const Transformation& xfB, const Real)</code>
-///    function.
-///
-/// @param contact Contact to return a world manifold for.
-///
-/// @return World manifold value for the given inputs which will have the same number of points as
-///   the given manifold has. The returned world manifold points will be the mid-points of the
-///   contact's intersection.
-///
-/// @relatedalso Contact
-///
-WorldManifold GetWorldManifold(const World& world,
-                               const Contact& contact, const Manifold& manifold);
+            /// @brief Impulses.
+            /// @note 16-bytes.
+            Momentum2 m_impulses[MaxManifoldPoints] = {Momentum2{}, Momentum2{}};
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Separations.
+            /// @details A negative value indicates overlap.
+            Length m_separations[MaxManifoldPoints] = {GetInvalid<Length>(), GetInvalid<Length>()};
 
-#endif // PLAYRHO_COLLISION_WORLDMANIFOLD_HPP
+         public:
+            /// @brief Size type.
+            using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
+
+            /// @brief Point data for world manifold.
+            /// @note This data structure is 20-bytes large at least on one 64-bit architecture.
+            struct PointData
+            {
+                Length2 location; ///< Location of point or the invalid value.
+                Momentum2 impulse;///< "Normal" and "tangent" impulses at the point.
+                Length separation;///< Separation at point or the invalid value.
+            };
+
+            /// Default constructor.
+            /// @details
+            /// A default constructed world manifold will gave a point count of zero, an invalid
+            /// normal, invalid points, and invalid separations.
+            WorldManifold() = default;
+
+            /// @brief Initializing constructor.
+            constexpr explicit WorldManifold(UnitVec normal) noexcept
+                : m_normal{normal}
+            {
+                assert(IsValid(normal));
+                // Intentionally empty.
+            }
+
+            /// @brief Initializing constructor.
+            constexpr explicit WorldManifold(UnitVec normal, PointData ps0) noexcept
+                : m_normal{normal},
+                  m_points{ps0.location, GetInvalid<Length2>()},
+                  m_impulses{ps0.impulse, Momentum2{}},
+                  m_separations{ps0.separation, GetInvalid<Length>()}
+            {
+                assert(IsValid(normal));
+                // Intentionally empty.
+            }
+
+            /// @brief Initializing constructor.
+            constexpr explicit WorldManifold(UnitVec normal, PointData ps0, PointData ps1) noexcept
+                : m_normal{normal},
+                  m_points{ps0.location, ps1.location},
+                  m_impulses{ps0.impulse, ps1.impulse},
+                  m_separations{ps0.separation, ps1.separation}
+            {
+                assert(IsValid(normal));
+                // Intentionally empty.
+            }
+
+            /// @brief Gets the point count.
+            ///
+            /// @details This is the maximum index value that can be used to access valid point or
+            ///   separation information.
+            ///
+            /// @return Value between 0 and 2.
+            ///
+            size_type GetPointCount() const noexcept
+            {
+                return (IsValid(m_separations[0]) ? 1 : 0) + (IsValid(m_separations[1]) ? 1 : 0);
+            }
+
+            /// Gets the normal of the contact.
+            /// @details This is a directional unit-vector.
+            /// @return Normal of the contact or an invalid value.
+            UnitVec GetNormal() const noexcept
+            {
+                return m_normal;
+            }
+
+            /// Gets the indexed point's location in world coordinates.
+            ///
+            /// @warning Behavior is undefined if the index value is not less than
+            ///   <code>MaxManifoldPoints</code>
+            ///
+            /// @param index Index to return point for. This must be between 0 and
+            ///   <code>GetPointCount()</code> to get a valid point from this method.
+            ///
+            /// @return Point or an invalid value if the given index was invalid.
+            ///
+            Length2 GetPoint(size_type index) const noexcept
+            {
+                assert(index < MaxManifoldPoints);
+                return m_points[index];
+            }
+
+            /// Gets the amount of separation at the given indexed point.
+            ///
+            /// @warning Behavior is undefined if the index value is not less than
+            ///   <code>MaxManifoldPoints</code>
+            /// @param index Index to return separation for. This must be between 0 and
+            ///   <code>GetPointCount()</code>.
+            ///
+            /// @return Separation amount (a negative value), or an invalid value if the given index
+            ///   was invalid.
+            ///
+            Length GetSeparation(size_type index) const noexcept
+            {
+                assert(index < MaxManifoldPoints);
+                return m_separations[index];
+            }
+
+            /// @brief Gets the given index contact impulses.
+            /// @return "Normal impulse" and "tangent impulse" pair.
+            Momentum2 GetImpulses(size_type index) const noexcept
+            {
+                assert(index < MaxManifoldPoints);
+                return m_impulses[index];
+            }
+        };
+
+        /// @brief Gets the world manifold for the given data.
+        ///
+        /// @pre The given manifold input has between 0 and 2 points.
+        ///
+        /// @param manifold Manifold to use.
+        ///   Uses the manifold's type, local point, local normal, point-count,
+        ///   and the indexed-points' local point data.
+        /// @param xfA Transformation A.
+        /// @param radiusA Radius of shape A.
+        /// @param xfB Transformation B.
+        /// @param radiusB Radius of shape B.
+        ///
+        /// @return World manifold value for the given inputs which will have the same number of points as
+        ///   the given manifold has. The returned world manifold points will be the mid-points of the
+        ///   manifold intersection.
+        ///
+        /// @relatedalso Manifold
+        ///
+        WorldManifold GetWorldManifold(const Manifold& manifold,
+                                       Transformation xfA, Length radiusA,
+                                       Transformation xfB, Length radiusB);
+
+        /// Gets the world manifold for the given data.
+        ///
+        /// @note This is a convenience function that in turn calls the
+        ///    <code>GetWorldManifold(const Manifold&, const Transformation&, const Real,
+        ///                           const Transformation& xfB, const Real)</code>
+        ///    function.
+        ///
+        /// @param contact Contact to return a world manifold for.
+        ///
+        /// @return World manifold value for the given inputs which will have the same number of points as
+        ///   the given manifold has. The returned world manifold points will be the mid-points of the
+        ///   contact's intersection.
+        ///
+        /// @relatedalso Contact
+        ///
+        WorldManifold GetWorldManifold(const World& world,
+                                       const Contact& contact, const Manifold& manifold);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COLLISION_WORLDMANIFOLD_HPP

--- a/PlayRho/Common/Acceleration.hpp
+++ b/PlayRho/Common/Acceleration.hpp
@@ -25,128 +25,129 @@
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Vector2.hpp>
 
-namespace playrho {
-namespace d2 {
-
-    /// @brief 2-D acceleration related data structure.
-    /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
-    struct Acceleration
-    {
-        LinearAcceleration2 linear; ///< Linear acceleration.
-        AngularAcceleration angular; ///< Angular acceleration.
-    };
-    
-    /// @brief Equality operator.
-    /// @relatedalso Acceleration
-    constexpr bool operator==(const Acceleration& lhs, const Acceleration& rhs)
-    {
-        return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
-    }
-    
-    /// @brief Inequality operator.
-    /// @relatedalso Acceleration
-    constexpr bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
-    {
-        return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
-    }
-    
-    /// @brief Multiplication assignment operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration& operator*= (Acceleration& lhs, const Real rhs)
-    {
-        lhs.linear *= rhs;
-        lhs.angular *= rhs;
-        return lhs;
-    }
-    
-    /// @brief Division assignment operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration& operator/= (Acceleration& lhs, const Real rhs)
-    {
-        lhs.linear /= rhs;
-        lhs.angular /= rhs;
-        return lhs;
-    }
-    
-    /// @brief Addition assignment operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration& operator+= (Acceleration& lhs, const Acceleration& rhs)
-    {
-        lhs.linear += rhs.linear;
-        lhs.angular += rhs.angular;
-        return lhs;
-    }
-    
-    /// @brief Addition operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration operator+ (const Acceleration& lhs, const Acceleration& rhs)
-    {
-        return Acceleration{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
-    }
-    
-    /// @brief Subtraction assignment operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration& operator-= (Acceleration& lhs, const Acceleration& rhs)
-    {
-        lhs.linear -= rhs.linear;
-        lhs.angular -= rhs.angular;
-        return lhs;
-    }
-    
-    /// @brief Subtraction operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration operator- (const Acceleration& lhs, const Acceleration& rhs)
-    {
-        return Acceleration{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
-    }
-    
-    /// @brief Negation operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration operator- (const Acceleration& value)
-    {
-        return Acceleration{-value.linear, -value.angular};
-    }
-    
-    /// @brief Positive operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration operator+ (const Acceleration& value)
-    {
-        return value;
-    }
-    
-    /// @brief Multiplication operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration operator* (const Acceleration& lhs, const Real rhs)
-    {
-        return Acceleration{lhs.linear * rhs, lhs.angular * rhs};
-    }
-    
-    /// @brief Multiplication operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration operator* (const Real lhs, const Acceleration& rhs)
-    {
-        return Acceleration{rhs.linear * lhs, rhs.angular * lhs};
-    }
-    
-    /// @brief Division operator.
-    /// @relatedalso Acceleration
-    constexpr Acceleration operator/ (const Acceleration& lhs, const Real rhs)
-    {
-        const auto inverseRhs = Real{1} / rhs;
-        return Acceleration{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
-    }
-    
-} // namespace d2
-
-/// @brief Determines if the given value is valid.
-/// @relatedalso playrho::d2::Acceleration
-template <>
-constexpr bool IsValid(const d2::Acceleration& value) noexcept
+namespace playrho
 {
-    return IsValid(value.linear) && IsValid(value.angular);
-}
+    namespace d2
+    {
 
-} // namespace playrho
+        /// @brief 2-D acceleration related data structure.
+        /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
+        struct Acceleration
+        {
+            LinearAcceleration2 linear; ///< Linear acceleration.
+            AngularAcceleration angular;///< Angular acceleration.
+        };
 
-#endif // PLAYRHO_COMMON_ACCELERATION_HPP
+        /// @brief Equality operator.
+        /// @relatedalso Acceleration
+        constexpr bool operator==(const Acceleration& lhs, const Acceleration& rhs)
+        {
+            return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
+        }
 
+        /// @brief Inequality operator.
+        /// @relatedalso Acceleration
+        constexpr bool operator!=(const Acceleration& lhs, const Acceleration& rhs)
+        {
+            return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
+        }
+
+        /// @brief Multiplication assignment operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration& operator*=(Acceleration& lhs, const Real rhs)
+        {
+            lhs.linear *= rhs;
+            lhs.angular *= rhs;
+            return lhs;
+        }
+
+        /// @brief Division assignment operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration& operator/=(Acceleration& lhs, const Real rhs)
+        {
+            lhs.linear /= rhs;
+            lhs.angular /= rhs;
+            return lhs;
+        }
+
+        /// @brief Addition assignment operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration& operator+=(Acceleration& lhs, const Acceleration& rhs)
+        {
+            lhs.linear += rhs.linear;
+            lhs.angular += rhs.angular;
+            return lhs;
+        }
+
+        /// @brief Addition operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration operator+(const Acceleration& lhs, const Acceleration& rhs)
+        {
+            return Acceleration{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
+        }
+
+        /// @brief Subtraction assignment operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration& operator-=(Acceleration& lhs, const Acceleration& rhs)
+        {
+            lhs.linear -= rhs.linear;
+            lhs.angular -= rhs.angular;
+            return lhs;
+        }
+
+        /// @brief Subtraction operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration operator-(const Acceleration& lhs, const Acceleration& rhs)
+        {
+            return Acceleration{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
+        }
+
+        /// @brief Negation operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration operator-(const Acceleration& value)
+        {
+            return Acceleration{-value.linear, -value.angular};
+        }
+
+        /// @brief Positive operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration operator+(const Acceleration& value)
+        {
+            return value;
+        }
+
+        /// @brief Multiplication operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration operator*(const Acceleration& lhs, const Real rhs)
+        {
+            return Acceleration{lhs.linear * rhs, lhs.angular * rhs};
+        }
+
+        /// @brief Multiplication operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration operator*(const Real lhs, const Acceleration& rhs)
+        {
+            return Acceleration{rhs.linear * lhs, rhs.angular * lhs};
+        }
+
+        /// @brief Division operator.
+        /// @relatedalso Acceleration
+        constexpr Acceleration operator/(const Acceleration& lhs, const Real rhs)
+        {
+            const auto inverseRhs = Real{1} / rhs;
+            return Acceleration{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
+        }
+
+    }// namespace d2
+
+    /// @brief Determines if the given value is valid.
+    /// @relatedalso playrho::d2::Acceleration
+    template<>
+    constexpr bool IsValid(const d2::Acceleration& value) noexcept
+    {
+        return IsValid(value.linear) && IsValid(value.angular);
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_ACCELERATION_HPP

--- a/PlayRho/Common/AllocatedArray.hpp
+++ b/PlayRho/Common/AllocatedArray.hpp
@@ -25,164 +25,195 @@
 
 #include <functional>
 
-namespace playrho {
-
-/// Allocated Array.
-template <typename T, typename Deleter = std::function<void (void *)> >
-class AllocatedArray
+namespace playrho
 {
-public:
-    
-    /// @brief Size type.
-    using size_type = std::size_t;
 
-    /// @brief Value type.
-    using value_type = T;
-    
-    /// @brief Constant value type.
-    using const_value_type = const value_type;
-    
-    /// @brief Reference type.
-    using reference = value_type&;
-    
-    /// @brief Constant reference type.
-    using const_reference = const value_type&;
-    
-    /// @brief Pointer type.
-    using pointer = value_type*;
-    
-    /// @brief Constant pointer type.
-    using const_pointer = const value_type*;
-    
-    /// @brief Difference type.
-    using difference_type = std::ptrdiff_t;
-    
-    /// @brief Deleter type.
-    using deleter_type = Deleter;
-
-    /// @brief Iterator alias.
-    using iterator = pointer;
-
-    /// @brief Constant iterator alias.
-    using const_iterator = const_pointer;
-
-    /// @brief Initializing constructor.
-    constexpr AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter):
-        m_max_size{max_size}, m_data{data}, m_deleter{deleter}
+    /// Allocated Array.
+    template<typename T, typename Deleter = std::function<void(void*)>>
+    class AllocatedArray
     {
-        assert(data);
-    }
-    
-    /// @brief Destructor.
-    ~AllocatedArray() noexcept
-    {
-        m_deleter(m_data);
-        m_data = nullptr;
-    }
+     public:
+        /// @brief Size type.
+        using size_type = std::size_t;
 
-    AllocatedArray() = delete;
-    AllocatedArray(const AllocatedArray& copy) = delete;
+        /// @brief Value type.
+        using value_type = T;
 
-    /// @brief Move constructor.
-    AllocatedArray(AllocatedArray&& other) noexcept:
-        m_max_size{other.m_max_size}, m_size{other.m_size}, m_data{other.m_data}, m_deleter{other.m_deleter}
-    {
-        other.m_size = 0;
-        other.m_data = nullptr;
-    }
+        /// @brief Constant value type.
+        using const_value_type = const value_type;
 
-    /// @brief Gets the current size of this array.
-    size_type size() const noexcept { return m_size; }
+        /// @brief Reference type.
+        using reference = value_type&;
 
-    /// @brief Gets the maximum size this array can possibly get to.
-    size_type max_size() const noexcept { return m_max_size; }
-    
-    /// @brief Determines whether this array is empty.
-    bool empty() const noexcept { return size() == 0; }
+        /// @brief Constant reference type.
+        using const_reference = const value_type&;
 
-    /// @brief Gets a direct pointer to this array's memory.
-    pointer data() const noexcept { return m_data; }
+        /// @brief Pointer type.
+        using pointer = value_type*;
 
-    /// @brief Indexed operator.
-    reference operator[](size_type i)
-    {
-        assert(i < m_size);
-        return m_data[i];
-    }
+        /// @brief Constant pointer type.
+        using const_pointer = const value_type*;
 
-    /// @brief Indexed operator.
-    const_reference operator[](size_type i) const
-    {
-        assert(i < m_size);
-        return m_data[i];
-    }
+        /// @brief Difference type.
+        using difference_type = std::ptrdiff_t;
 
-    /// @brief Gets the "begin" iterator value for this array.
-    iterator begin() { return iterator{m_data}; }
+        /// @brief Deleter type.
+        using deleter_type = Deleter;
 
-    /// @brief Gets the "end" iterator value for this array.
-    iterator end() { return iterator{m_data + size()}; }
-    
-    /// @brief Gets the "begin" iterator value for this array.
-    const_iterator begin() const { return const_iterator{m_data}; }
-    
-    /// @brief Gets the "end" iterator value for this array.
-    const_iterator end() const { return const_iterator{m_data + size()}; }
-    
-    /// @brief Gets the "begin" iterator value for this array.
-    const_iterator cbegin() const { return const_iterator{m_data}; }
-    
-    /// @brief Gets the "end" iterator value for this array.
-    const_iterator cend() const { return const_iterator{m_data + size()}; }
+        /// @brief Iterator alias.
+        using iterator = pointer;
 
-    /// @brief Gets a reference to the "back" element of this array.
-    /// @warning Behavior is undefined if the size of this array is less than 1.
-    reference back() noexcept
-    {
-        assert(m_size > 0);
-        return m_data[m_size - 1];        
-    }
+        /// @brief Constant iterator alias.
+        using const_iterator = const_pointer;
 
-    /// @brief Gets a reference to the "back" element of this array.
-    /// @warning Behavior is undefined if the size of this array is less than 1.
-    const_reference back() const noexcept
-    {
-        assert(m_size > 0);
-        return m_data[m_size - 1];
-    }
+        /// @brief Initializing constructor.
+        constexpr AllocatedArray(size_type max_size, pointer data, deleter_type deleter = noop_deleter)
+            : m_max_size{max_size}, m_data{data}, m_deleter{deleter}
+        {
+            assert(data);
+        }
 
-    /// @brief Clears this array.
-    void clear() noexcept
-    {
-        m_size = 0;
-    }
+        /// @brief Destructor.
+        ~AllocatedArray() noexcept
+        {
+            m_deleter(m_data);
+            m_data = nullptr;
+        }
 
-    /// @brief Push "back" the given value.
-    void push_back(const_reference value)
-    {
-        assert(m_size < m_max_size);
-        m_data[m_size] = value;
-        ++m_size;
-    }
-    
-    /// @brief Pop "back".
-    void pop_back() noexcept
-    {
-        assert(m_size > 0);
-        --m_size;
-    }
+        AllocatedArray() = delete;
+        AllocatedArray(const AllocatedArray& copy) = delete;
 
-private:
-    
-    /// @brief No-op deleter method.
-    static void noop_deleter(void* /*unused*/) {}
+        /// @brief Move constructor.
+        AllocatedArray(AllocatedArray&& other) noexcept
+            : m_max_size{other.m_max_size}, m_size{other.m_size}, m_data{other.m_data}, m_deleter{other.m_deleter}
+        {
+            other.m_size = 0;
+            other.m_data = nullptr;
+        }
 
-    size_type m_max_size = 0; ///< Max size. 8-bytes.
-    size_type m_size = 0; ///< Current size. 8-bytes.
-    pointer m_data = nullptr; ///< Pointer to allocated data space. 8-bytes.
-    deleter_type m_deleter; ///< Deleter. 8-bytes (with default Deleter).
-};
+        /// @brief Gets the current size of this array.
+        size_type size() const noexcept
+        {
+            return m_size;
+        }
 
-}; // namespace playrho
+        /// @brief Gets the maximum size this array can possibly get to.
+        size_type max_size() const noexcept
+        {
+            return m_max_size;
+        }
 
-#endif // PLAYRHO_COMMON_ALLOCATEDARRAY_HPP
+        /// @brief Determines whether this array is empty.
+        bool empty() const noexcept
+        {
+            return size() == 0;
+        }
+
+        /// @brief Gets a direct pointer to this array's memory.
+        pointer data() const noexcept
+        {
+            return m_data;
+        }
+
+        /// @brief Indexed operator.
+        reference operator[](size_type i)
+        {
+            assert(i < m_size);
+            return m_data[i];
+        }
+
+        /// @brief Indexed operator.
+        const_reference operator[](size_type i) const
+        {
+            assert(i < m_size);
+            return m_data[i];
+        }
+
+        /// @brief Gets the "begin" iterator value for this array.
+        iterator begin()
+        {
+            return iterator{m_data};
+        }
+
+        /// @brief Gets the "end" iterator value for this array.
+        iterator end()
+        {
+            return iterator{m_data + size()};
+        }
+
+        /// @brief Gets the "begin" iterator value for this array.
+        const_iterator begin() const
+        {
+            return const_iterator{m_data};
+        }
+
+        /// @brief Gets the "end" iterator value for this array.
+        const_iterator end() const
+        {
+            return const_iterator{m_data + size()};
+        }
+
+        /// @brief Gets the "begin" iterator value for this array.
+        const_iterator cbegin() const
+        {
+            return const_iterator{m_data};
+        }
+
+        /// @brief Gets the "end" iterator value for this array.
+        const_iterator cend() const
+        {
+            return const_iterator{m_data + size()};
+        }
+
+        /// @brief Gets a reference to the "back" element of this array.
+        /// @warning Behavior is undefined if the size of this array is less than 1.
+        reference back() noexcept
+        {
+            assert(m_size > 0);
+            return m_data[m_size - 1];
+        }
+
+        /// @brief Gets a reference to the "back" element of this array.
+        /// @warning Behavior is undefined if the size of this array is less than 1.
+        const_reference back() const noexcept
+        {
+            assert(m_size > 0);
+            return m_data[m_size - 1];
+        }
+
+        /// @brief Clears this array.
+        void clear() noexcept
+        {
+            m_size = 0;
+        }
+
+        /// @brief Push "back" the given value.
+        void push_back(const_reference value)
+        {
+            assert(m_size < m_max_size);
+            m_data[m_size] = value;
+            ++m_size;
+        }
+
+        /// @brief Pop "back".
+        void pop_back() noexcept
+        {
+            assert(m_size > 0);
+            --m_size;
+        }
+
+     private:
+        /// @brief No-op deleter method.
+        static void noop_deleter(void* /*unused*/)
+        {
+        }
+
+        size_type m_max_size = 0;///< Max size. 8-bytes.
+        size_type m_size = 0;    ///< Current size. 8-bytes.
+        pointer m_data = nullptr;///< Pointer to allocated data space. 8-bytes.
+        deleter_type m_deleter;  ///< Deleter. 8-bytes (with default Deleter).
+    };
+
+};// namespace playrho
+
+#endif// PLAYRHO_COMMON_ALLOCATEDARRAY_HPP

--- a/PlayRho/Common/ArrayAllocator.hpp
+++ b/PlayRho/Common/ArrayAllocator.hpp
@@ -21,147 +21,148 @@
 #ifndef PLAYRHO_COMMON_ARRAYALLOCATOR_HPP
 #define PLAYRHO_COMMON_ARRAYALLOCATOR_HPP
 
+#include <type_traits>
 #include <utility>
 #include <vector>
-#include <type_traits>
 
-namespace playrho {
-
-/// @brief Array allocator.
-template <typename T>
-class ArrayAllocator
+namespace playrho
 {
-public:
-    /// @brief Element type.
-    using value_type = T;
 
-    /// @brief Size type.
-    using size_type = typename std::vector<value_type>::size_type;
-
-    /// @brief Reference type alias.
-    using reference = typename std::vector<value_type>::reference;
-
-    /// @brief Constant reference type alias.
-    using const_reference = typename std::vector<value_type>::const_reference;
-
-    /// @brief Gets the index of the given pointer.
-    /// @return -1 if the given pointer is not within the range of the allocator's allocation,
-    ///    otherwise return index of pointer within allocator.
-    size_type GetIndex(value_type* ptr) const
+    /// @brief Array allocator.
+    template<typename T>
+    class ArrayAllocator
     {
-        const auto i = ptr - m_data.data();
-        return static_cast<size_type>(((i >= 0) && (static_cast<size_type>(i) < m_data.size()))? i: -1);
-    }
+     public:
+        /// @brief Element type.
+        using value_type = T;
 
-    /// @brief Allocates an entry in the array with the given constructor parameters.
-    template< class... Args >
-    size_type Allocate(Args&&... args)
-    {
-        if (!m_free.empty())
+        /// @brief Size type.
+        using size_type = typename std::vector<value_type>::size_type;
+
+        /// @brief Reference type alias.
+        using reference = typename std::vector<value_type>::reference;
+
+        /// @brief Constant reference type alias.
+        using const_reference = typename std::vector<value_type>::const_reference;
+
+        /// @brief Gets the index of the given pointer.
+        /// @return -1 if the given pointer is not within the range of the allocator's allocation,
+        ///    otherwise return index of pointer within allocator.
+        size_type GetIndex(value_type* ptr) const
         {
-            const auto index = m_free.back();
-            m_data[index] = value_type{std::forward<Args>(args)...};
-            m_free.pop_back();
+            const auto i = ptr - m_data.data();
+            return static_cast<size_type>(((i >= 0) && (static_cast<size_type>(i) < m_data.size())) ? i : -1);
+        }
+
+        /// @brief Allocates an entry in the array with the given constructor parameters.
+        template<class... Args>
+        size_type Allocate(Args&&... args)
+        {
+            if (!m_free.empty())
+            {
+                const auto index = m_free.back();
+                m_data[index] = value_type{std::forward<Args>(args)...};
+                m_free.pop_back();
+                return index;
+            }
+            const auto index = m_data.size();
+            m_data.emplace_back(std::forward<Args>(args)...);
             return index;
         }
-        const auto index = m_data.size();
-        m_data.emplace_back(std::forward<Args>(args)...);
-        return index;
-    }
 
-    /// @brief Allocates an entry in the array with the given instance.
-    size_type Allocate(const value_type& copy)
-    {
-        if (!m_free.empty())
+        /// @brief Allocates an entry in the array with the given instance.
+        size_type Allocate(const value_type& copy)
         {
-            const auto index = m_free.back();
-            m_data[index] = copy;
-            m_free.pop_back();
+            if (!m_free.empty())
+            {
+                const auto index = m_free.back();
+                m_data[index] = copy;
+                m_free.pop_back();
+                return index;
+            }
+            const auto index = m_data.size();
+            m_data.push_back(copy);
             return index;
         }
-        const auto index = m_data.size();
-        m_data.push_back(copy);
-        return index;
-    }
 
-    /// @brief Frees the specified index entry.
-    void Free(size_type index)
-    {
-        if (index != static_cast<size_type>(-1))
+        /// @brief Frees the specified index entry.
+        void Free(size_type index)
         {
-            m_data[index] = value_type{};
-            m_free.push_back(index);
+            if (index != static_cast<size_type>(-1))
+            {
+                m_data[index] = value_type{};
+                m_free.push_back(index);
+            }
         }
-    }
 
-    /// @brief Array index operator.
-    reference operator[](size_type pos)
+        /// @brief Array index operator.
+        reference operator[](size_type pos)
+        {
+            return m_data[pos];
+        }
+
+        /// @brief Constant array index operator.
+        const_reference operator[](size_type pos) const
+        {
+            return m_data[pos];
+        }
+
+        /// @brief Bounds checking indexed array accessor.
+        reference at(size_type pos)
+        {
+            return m_data.at(pos);
+        }
+
+        /// @brief Bounds checking indexed array accessor.
+        const_reference at(size_type pos) const
+        {
+            return m_data.at(pos);
+        }
+
+        /// @brief Gets the size of this instance in number of elements.
+        size_type size() const noexcept
+        {
+            return m_data.size();
+        }
+
+        /// @brief Gets the maximum theoretical size this instance can have in number of elements.
+        size_type max_size() const noexcept
+        {
+            return m_data.max_size();
+        }
+
+        /// @brief Gets the number of elements currently free.
+        size_type free() const noexcept
+        {
+            return m_free.size();
+        }
+
+        /// @brief Reserves the given number of elements from dynamic memory.
+        void reserve(size_type value)
+        {
+            m_data.reserve(value);
+        }
+
+        /// @brief Clears this instance's free pool and allocated pool.
+        void clear() noexcept
+        {
+            m_data.clear();
+            m_free.clear();
+        }
+
+     private:
+        std::vector<value_type> m_data;                                 ///< Array data (both used & free).
+        std::vector<typename std::vector<value_type>::size_type> m_free;///< Indices of free elements.
+    };
+
+    /// @brief Gets the number of elements that are used in the specified structure.
+    /// @return Size of the specified structure minus the size of its free pool.
+    template<typename T>
+    typename ArrayAllocator<T>::size_type used(const ArrayAllocator<T>& array) noexcept
     {
-        return m_data[pos];
+        return array.size() - array.free();
     }
 
-    /// @brief Constant array index operator.
-    const_reference operator[](size_type pos) const
-    {
-        return m_data[pos];
-    }
+}// namespace playrho
 
-    /// @brief Bounds checking indexed array accessor.
-    reference at(size_type pos)
-    {
-        return m_data.at(pos);
-    }
-
-    /// @brief Bounds checking indexed array accessor.
-    const_reference at(size_type pos) const
-    {
-        return m_data.at(pos);
-    }
-
-    /// @brief Gets the size of this instance in number of elements.
-    size_type size() const noexcept
-    {
-        return m_data.size();
-    }
-
-    /// @brief Gets the maximum theoretical size this instance can have in number of elements.
-    size_type max_size() const noexcept
-    {
-        return m_data.max_size();
-    }
-
-    /// @brief Gets the number of elements currently free.
-    size_type free() const noexcept
-    {
-        return m_free.size();
-    }
-
-    /// @brief Reserves the given number of elements from dynamic memory.
-    void reserve(size_type value)
-    {
-        m_data.reserve(value);
-    }
-
-    /// @brief Clears this instance's free pool and allocated pool.
-    void clear() noexcept
-    {
-        m_data.clear();
-        m_free.clear();
-    }
-
-private:
-    std::vector<value_type> m_data; ///< Array data (both used & free).
-    std::vector<typename std::vector<value_type>::size_type> m_free; ///< Indices of free elements.
-};
-
-/// @brief Gets the number of elements that are used in the specified structure.
-/// @return Size of the specified structure minus the size of its free pool.
-template <typename T>
-typename ArrayAllocator<T>::size_type used(const ArrayAllocator<T>& array) noexcept
-{
-    return array.size() - array.free();
-}
-
-} // namespace playrho
-
-#endif // PLAYRHO_COMMON_ARRAYALLOCATOR_HPP
+#endif// PLAYRHO_COMMON_ARRAYALLOCATOR_HPP

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -30,25 +30,25 @@
 namespace playrho
 {
     /// Array list.
-    template <typename VALUE_TYPE, std::size_t MAXSIZE, typename SIZE_TYPE = std::size_t>
+    template<typename VALUE_TYPE, std::size_t MAXSIZE, typename SIZE_TYPE = std::size_t>
     class ArrayList
     {
-    public:
+     public:
         /// @brief Size type.
         using size_type = SIZE_TYPE;
 
         /// @brief Value type.
         using value_type = VALUE_TYPE;
-        
+
         /// @brief Reference type.
         using reference = value_type&;
-        
+
         /// @brief Constant reference type.
         using const_reference = const value_type&;
-        
+
         /// @brief Pointer type.
         using pointer = value_type*;
-        
+
         /// @brief Constant pointer type.
         using const_pointer = const value_type*;
 
@@ -59,27 +59,27 @@ namespace playrho
             // causes issues with gcc.
         }
 
-        template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t< COPY_MAXSIZE <= MAXSIZE >>
-        constexpr explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy):
-            m_size{size(copy)},
-            m_elements{data(copy)}
+        template<std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t<COPY_MAXSIZE <= MAXSIZE>>
+        constexpr explicit ArrayList(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, SIZE_TYPE>& copy)
+            : m_size{size(copy)},
+              m_elements{data(copy)}
         {
             // Intentionally empty
         }
 
         /// @brief Assignment operator.
-        template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t< COPY_MAXSIZE <= MAXSIZE >>
-        ArrayList& operator= (const ArrayList<VALUE_TYPE, COPY_MAXSIZE, COPY_SIZE_TYPE>& copy)
+        template<std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE, typename = std::enable_if_t<COPY_MAXSIZE <= MAXSIZE>>
+        ArrayList& operator=(const ArrayList<VALUE_TYPE, COPY_MAXSIZE, COPY_SIZE_TYPE>& copy)
         {
             m_size = static_cast<SIZE_TYPE>(size(copy));
             m_elements = data(copy);
             return *this;
         }
 
-        template <std::size_t SIZE, typename = std::enable_if_t< SIZE <= MAXSIZE >>
+        template<std::size_t SIZE, typename = std::enable_if_t<SIZE <= MAXSIZE>>
         explicit ArrayList(value_type (&value)[SIZE]) noexcept
         {
-            for (auto&& elem: value)
+            for (auto&& elem : value)
             {
                 push_back(elem);
             }
@@ -87,12 +87,12 @@ namespace playrho
 
         ArrayList(std::initializer_list<value_type> list)
         {
-            for (auto&& elem: list)
+            for (auto&& elem : list)
             {
                 push_back(elem);
             }
         }
-        
+
         constexpr ArrayList& Append(const value_type& value)
         {
             push_back(value);
@@ -105,7 +105,7 @@ namespace playrho
             m_elements[m_size] = value;
             ++m_size;
         }
-        
+
         void size(size_type value) noexcept
         {
             assert(value <= MAXSIZE);
@@ -116,8 +116,11 @@ namespace playrho
         {
             m_size = 0;
         }
-        
-        bool empty() const noexcept { return m_size == 0; }
+
+        bool empty() const noexcept
+        {
+            return m_size == 0;
+        }
 
         bool add(value_type value) noexcept
         {
@@ -129,13 +132,13 @@ namespace playrho
             }
             return false;
         }
-        
+
         reference operator[](size_type index) noexcept
         {
             assert(index < MAXSIZE);
             return m_elements[index];
         }
-        
+
         constexpr const_reference operator[](size_type index) const noexcept
         {
             assert(index < MAXSIZE);
@@ -146,36 +149,57 @@ namespace playrho
         /// @details This is the number of elements that have been added to this collection.
         /// @return Value between 0 and the maximum size for this collection.
         /// @see max_size().
-        constexpr size_type size() const noexcept { return m_size; }
-        
+        constexpr size_type size() const noexcept
+        {
+            return m_size;
+        }
+
         /// Gets the maximum size that this collection can be.
         /// @details This is the maximum number of elements that can be contained in this collection.
-        constexpr size_type max_size() const noexcept { return MAXSIZE; }
+        constexpr size_type max_size() const noexcept
+        {
+            return MAXSIZE;
+        }
 
-        auto data() const noexcept { return m_elements.data(); }
+        auto data() const noexcept
+        {
+            return m_elements.data();
+        }
 
-        pointer begin() noexcept { return m_elements.data(); }
-        pointer end() noexcept { return m_elements.data() + m_size; }
-        
-        const_pointer begin() const noexcept { return m_elements.data(); }
-        const_pointer end() const noexcept { return m_elements.data() + m_size; }
-        
-    private:
+        pointer begin() noexcept
+        {
+            return m_elements.data();
+        }
+        pointer end() noexcept
+        {
+            return m_elements.data() + m_size;
+        }
+
+        const_pointer begin() const noexcept
+        {
+            return m_elements.data();
+        }
+        const_pointer end() const noexcept
+        {
+            return m_elements.data() + m_size;
+        }
+
+     private:
         size_type m_size = size_type{0};
-        std::array<value_type,MAXSIZE> m_elements;
+        std::array<value_type, MAXSIZE> m_elements;
     };
-    
+
     /// @brief <code>ArrayList</code> append operator.
-    template <typename T, std::size_t S>
-    ArrayList<T, S>& operator+= (ArrayList<T, S>& lhs, const typename ArrayList<T, S>::data_type& rhs)
+    template<typename T, std::size_t S>
+    ArrayList<T, S>& operator+=(ArrayList<T, S>& lhs, const typename ArrayList<T, S>::data_type& rhs)
     {
         lhs.push_back(rhs);
         return lhs;
     }
 
     /// @brief <code>ArrayList</code> add operator.
-    template <typename T, std::size_t S>
-    ArrayList<T, S> operator+ (ArrayList<T, S> lhs, const typename ArrayList<T, S>::data_type& rhs)
+    template<typename T, std::size_t S>
+    ArrayList<T, S> operator+(ArrayList<T, S> lhs, const typename ArrayList<T, S>::data_type& rhs)
     {
         lhs.push_back(rhs);
         return lhs;
@@ -183,15 +207,16 @@ namespace playrho
 
 } /* namespace playrho */
 
-namespace std {
+namespace std
+{
 
     /// Tuple size specialization for <code>ArrayList</code> classes.
-    template< class T, std::size_t N, typename SIZE_TYPE >
-    class tuple_size< playrho::ArrayList<T, N, SIZE_TYPE> >: public integral_constant<std::size_t, N>
+    template<class T, std::size_t N, typename SIZE_TYPE>
+    class tuple_size<playrho::ArrayList<T, N, SIZE_TYPE>> : public integral_constant<std::size_t, N>
     {
         // Intentionally empty.
     };
 
-} // namespace std
+}// namespace std
 
-#endif // PLAYRHO_COMMON_ARRAYLIST_HPP
+#endif// PLAYRHO_COMMON_ARRAYLIST_HPP

--- a/PlayRho/Common/BlockAllocator.cpp
+++ b/PlayRho/Common/BlockAllocator.cpp
@@ -19,16 +19,17 @@
 
 #include <PlayRho/Common/BlockAllocator.hpp>
 #include <PlayRho/Common/DynamicMemory.hpp>
-#include <limits>
-#include <cstring>
 #include <cstddef>
+#include <cstring>
+#include <limits>
 
-namespace playrho {
+namespace playrho
+{
 
-static_assert(size(AllocatorBlockSizes) == 14,
-              "Invalid number of elements of AllocatorBlockSizes");
-static_assert(BlockAllocator::GetMaxBlockSize() == 640,
-              "Invalid maximum block size of AllocatorBlockSizes");
+    static_assert(size(AllocatorBlockSizes) == 14,
+                  "Invalid number of elements of AllocatorBlockSizes");
+    static_assert(BlockAllocator::GetMaxBlockSize() == 640,
+                  "Invalid maximum block size of AllocatorBlockSizes");
 
 #if 0
 struct LookupTable
@@ -53,178 +54,178 @@ struct LookupTable
 static constexpr LookupTable BlockSizeLookup;
 #endif
 
-/// @brief Block size lookup array.
-static constexpr std::uint8_t s_blockSizeLookup[BlockAllocator::GetMaxBlockSize() + 1] =
-{
-    0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 1-16
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 17-32
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 33-64
-    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // 65-96
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, // 97-128
-    5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, // 129-160
-    6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, // 161-192
-    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, // 193-224
-    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, // 225-256
-    9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, // 257-288
-    9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, // 288-320
-    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // 321-352
-    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // 353-384
-    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // 385-416
-    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // 427-448
-    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // 449-480
-    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // 481-512
-    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // 513-544
-    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // 545-576
-    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // 577-608
-    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // 608-640
-};
-
-/// @brief Gets the block size index for the given data block size.
-static inline std::uint8_t GetBlockSizeIndex(std::size_t n)
-{
-    assert(n < size(s_blockSizeLookup));
-    return s_blockSizeLookup[n];
-}
-
-/// @brief Chunk.
-struct BlockAllocator::Chunk
-{
-    using size_type = std::size_t; ///< Size type.
-
-    size_type blockSize; ///< Block size.
-    Block* blocks; ///< Pointer to blocks.
-};
-
-/// @brief Block.
-struct BlockAllocator::Block
-{
-    Block* next; ///< Next block.
-};
-
-BlockAllocator::BlockAllocator():
-    m_chunks(AllocArray<Chunk>(m_chunkSpace))
-{
-    static_assert(size(AllocatorBlockSizes) < std::numeric_limits<std::uint8_t>::max(),
-                  "AllocatorBlockSizes too big");
-    std::memset(m_chunks, 0, m_chunkSpace * sizeof(Chunk));
-    std::memset(m_freeLists, 0, sizeof(m_freeLists));
-}
-
-BlockAllocator::~BlockAllocator() noexcept
-{
-    for (auto i = decltype(m_chunkCount){0}; i < m_chunkCount; ++i)
-    {
-        playrho::Free(m_chunks[i].blocks);
-    }
-    playrho::Free(m_chunks);
-}
-
-void* BlockAllocator::Allocate(size_type n)
-{
-    if (n == 0)
-    {
-        return nullptr;
-    }
-
-    if (n > GetMaxBlockSize())
-    {
-        return Alloc(n);
-    }
-
-    const auto index = GetBlockSizeIndex(n);
-    assert((0 <= index) && (index < size(m_freeLists)));
-    {
-        const auto block = m_freeLists[index];
-        if (block)
+    /// @brief Block size lookup array.
+    static constexpr std::uint8_t s_blockSizeLookup[BlockAllocator::GetMaxBlockSize() + 1] =
         {
-            m_freeLists[index] = block->next;
-            return block;
-        }
+            0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,                                                                                // 1-16
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,                                                                                // 17-32
+            2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,                                // 33-64
+            3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,                                // 65-96
+            4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,                                // 97-128
+            5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,                                // 129-160
+            6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,                                // 161-192
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,                                // 193-224
+            8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,                                // 225-256
+            9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,                                // 257-288
+            9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9,                                // 288-320
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,// 321-352
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,// 353-384
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,// 385-416
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,// 427-448
+            12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,// 449-480
+            12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,// 481-512
+            13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,// 513-544
+            13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,// 545-576
+            13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,// 577-608
+            13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,// 608-640
+    };
+
+    /// @brief Gets the block size index for the given data block size.
+    static inline std::uint8_t GetBlockSizeIndex(std::size_t n)
+    {
+        assert(n < size(s_blockSizeLookup));
+        return s_blockSizeLookup[n];
     }
 
-    if (m_chunkCount == m_chunkSpace)
+    /// @brief Chunk.
+    struct BlockAllocator::Chunk
     {
-        m_chunkSpace += GetChunkArrayIncrement();
-        m_chunks = ReallocArray<Chunk>(m_chunks, m_chunkSpace);
-        std::memset(m_chunks + m_chunkCount, 0, GetChunkArrayIncrement() * sizeof(Chunk));
+        using size_type = std::size_t;///< Size type.
+
+        size_type blockSize;///< Block size.
+        Block* blocks;      ///< Pointer to blocks.
+    };
+
+    /// @brief Block.
+    struct BlockAllocator::Block
+    {
+        Block* next;///< Next block.
+    };
+
+    BlockAllocator::BlockAllocator()
+        : m_chunks(AllocArray<Chunk>(m_chunkSpace))
+    {
+        static_assert(size(AllocatorBlockSizes) < std::numeric_limits<std::uint8_t>::max(),
+                      "AllocatorBlockSizes too big");
+        std::memset(m_chunks, 0, m_chunkSpace * sizeof(Chunk));
+        std::memset(m_freeLists, 0, sizeof(m_freeLists));
     }
 
-    const auto chunk = m_chunks + m_chunkCount;
-    chunk->blocks = static_cast<Block*>(Alloc(ChunkSize));
-#if defined(_DEBUG)
-    std::memset(chunk->blocks, 0xcd, ChunkSize);
-#endif
-    const auto blockSize = AllocatorBlockSizes[index];
-    assert(blockSize > 0);
-    chunk->blockSize = blockSize;
-    const auto blockCount = ChunkSize / blockSize;
-    assert((blockCount * blockSize) <= ChunkSize);
-    const auto chunkBlocks = reinterpret_cast<std::int8_t*>(chunk->blocks);
-    for (auto i = decltype(blockCount){0}; i < blockCount - 1; ++i)
+    BlockAllocator::~BlockAllocator() noexcept
     {
-        const auto block = reinterpret_cast<Block*>(chunkBlocks + blockSize * i);
-        const auto next  = reinterpret_cast<Block*>(chunkBlocks + blockSize * (i + 1));
-        block->next = next;
-    }
-    const auto last = reinterpret_cast<Block*>(chunkBlocks + blockSize * (blockCount - 1));
-    last->next = nullptr;
-    m_freeLists[index] = chunk->blocks->next;
-    ++m_chunkCount;
-
-    return chunk->blocks;
-}
-
-void BlockAllocator::Free(void* p, size_type n)
-{
-    if (n > GetMaxBlockSize())
-    {
-        playrho::Free(p);
-    }
-    else if (n > 0)
-    {
-        const auto index = GetBlockSizeIndex(n);
-        assert((0 <= index) && (index < size(m_freeLists)));
-#ifdef _DEBUG
-        // Verify the memory address and size is valid.
-        assert((0 <= index) && (index < size(AllocatorBlockSizes)));
-        const auto blockSize = AllocatorBlockSizes[index];
-        bool found = false;
         for (auto i = decltype(m_chunkCount){0}; i < m_chunkCount; ++i)
         {
-            const auto chunk = m_chunks + i;
-            const auto chunkBlocks = (std::int8_t*)chunk->blocks;
-            if (chunk->blockSize != blockSize)
+            playrho::Free(m_chunks[i].blocks);
+        }
+        playrho::Free(m_chunks);
+    }
+
+    void* BlockAllocator::Allocate(size_type n)
+    {
+        if (n == 0)
+        {
+            return nullptr;
+        }
+
+        if (n > GetMaxBlockSize())
+        {
+            return Alloc(n);
+        }
+
+        const auto index = GetBlockSizeIndex(n);
+        assert((0 <= index) && (index < size(m_freeLists)));
+        {
+            const auto block = m_freeLists[index];
+            if (block)
             {
-                assert(((std::int8_t*)p + blockSize <= chunkBlocks) || (chunkBlocks + ChunkSize <= (std::int8_t*)p));
-            }
-            else
-            {
-                if ((chunkBlocks <= (std::int8_t*)p) && ((std::int8_t*)p + blockSize <= chunkBlocks + ChunkSize))
-                {
-                    found = true;
-                }
+                m_freeLists[index] = block->next;
+                return block;
             }
         }
-        assert(found);
-        std::memset(p, 0xfd, blockSize);
+
+        if (m_chunkCount == m_chunkSpace)
+        {
+            m_chunkSpace += GetChunkArrayIncrement();
+            m_chunks = ReallocArray<Chunk>(m_chunks, m_chunkSpace);
+            std::memset(m_chunks + m_chunkCount, 0, GetChunkArrayIncrement() * sizeof(Chunk));
+        }
+
+        const auto chunk = m_chunks + m_chunkCount;
+        chunk->blocks = static_cast<Block*>(Alloc(ChunkSize));
+#if defined(_DEBUG)
+        std::memset(chunk->blocks, 0xcd, ChunkSize);
 #endif
-        const auto block = static_cast<Block*>(p);
-        block->next = m_freeLists[index];
-        m_freeLists[index] = block;
-    }
-}
+        const auto blockSize = AllocatorBlockSizes[index];
+        assert(blockSize > 0);
+        chunk->blockSize = blockSize;
+        const auto blockCount = ChunkSize / blockSize;
+        assert((blockCount * blockSize) <= ChunkSize);
+        const auto chunkBlocks = reinterpret_cast<std::int8_t*>(chunk->blocks);
+        for (auto i = decltype(blockCount){0}; i < blockCount - 1; ++i)
+        {
+            const auto block = reinterpret_cast<Block*>(chunkBlocks + blockSize * i);
+            const auto next = reinterpret_cast<Block*>(chunkBlocks + blockSize * (i + 1));
+            block->next = next;
+        }
+        const auto last = reinterpret_cast<Block*>(chunkBlocks + blockSize * (blockCount - 1));
+        last->next = nullptr;
+        m_freeLists[index] = chunk->blocks->next;
+        ++m_chunkCount;
 
-void BlockAllocator::Clear()
-{
-    for (auto i = decltype(m_chunkCount){0}; i < m_chunkCount; ++i)
+        return chunk->blocks;
+    }
+
+    void BlockAllocator::Free(void* p, size_type n)
     {
-        playrho::Free(m_chunks[i].blocks);
+        if (n > GetMaxBlockSize())
+        {
+            playrho::Free(p);
+        }
+        else if (n > 0)
+        {
+            const auto index = GetBlockSizeIndex(n);
+            assert((0 <= index) && (index < size(m_freeLists)));
+#ifdef _DEBUG
+            // Verify the memory address and size is valid.
+            assert((0 <= index) && (index < size(AllocatorBlockSizes)));
+            const auto blockSize = AllocatorBlockSizes[index];
+            bool found = false;
+            for (auto i = decltype(m_chunkCount){0}; i < m_chunkCount; ++i)
+            {
+                const auto chunk = m_chunks + i;
+                const auto chunkBlocks = (std::int8_t*)chunk->blocks;
+                if (chunk->blockSize != blockSize)
+                {
+                    assert(((std::int8_t*)p + blockSize <= chunkBlocks) || (chunkBlocks + ChunkSize <= (std::int8_t*)p));
+                }
+                else
+                {
+                    if ((chunkBlocks <= (std::int8_t*)p) && ((std::int8_t*)p + blockSize <= chunkBlocks + ChunkSize))
+                    {
+                        found = true;
+                    }
+                }
+            }
+            assert(found);
+            std::memset(p, 0xfd, blockSize);
+#endif
+            const auto block = static_cast<Block*>(p);
+            block->next = m_freeLists[index];
+            m_freeLists[index] = block;
+        }
     }
 
-    m_chunkCount = 0;
-    std::memset(m_chunks, 0, m_chunkSpace * sizeof(Chunk));
-    std::memset(m_freeLists, 0, sizeof(m_freeLists));
-}
+    void BlockAllocator::Clear()
+    {
+        for (auto i = decltype(m_chunkCount){0}; i < m_chunkCount; ++i)
+        {
+            playrho::Free(m_chunks[i].blocks);
+        }
 
-} // namespace playrho
+        m_chunkCount = 0;
+        std::memset(m_chunks, 0, m_chunkSpace * sizeof(Chunk));
+        std::memset(m_freeLists, 0, sizeof(m_freeLists));
+    }
+
+}// namespace playrho

--- a/PlayRho/Common/BlockAllocator.hpp
+++ b/PlayRho/Common/BlockAllocator.hpp
@@ -22,14 +22,28 @@
 
 #include <PlayRho/Common/Settings.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
     /// @brief Allocator block sizes array data.
     constexpr std::size_t AllocatorBlockSizes[] =
-    {
-        16, 32, 64, 96, 128, 160, 192, 224, 256, 320, 384, 448, 512, 640,
+        {
+            16,
+            32,
+            64,
+            96,
+            128,
+            160,
+            192,
+            224,
+            256,
+            320,
+            384,
+            448,
+            512,
+            640,
     };
-    
+
     /// Block allocator.
     ///
     /// This is a small object allocator used for allocating small
@@ -39,37 +53,36 @@ namespace playrho {
     ///
     class BlockAllocator
     {
-    public:
-        
+     public:
         /// @brief Size type.
         using size_type = std::size_t;
 
         /// @brief Chunk size.
         static constexpr auto ChunkSize = size_type{16 * 1024};
-        
+
         /// @brief Max block size (before using external allocator).
         static constexpr size_type GetMaxBlockSize() noexcept
         {
             return AllocatorBlockSizes[size(AllocatorBlockSizes) - 1];
         }
-        
+
         /// @brief Chunk array increment.
         static constexpr size_type GetChunkArrayIncrement() noexcept
         {
             return size_type{128};
         }
-        
+
         BlockAllocator();
-        
+
         BlockAllocator(const BlockAllocator& other) = delete;
 
         BlockAllocator(BlockAllocator&& other) = delete;
 
         ~BlockAllocator() noexcept;
-        
-        BlockAllocator& operator= (const BlockAllocator& other) = delete;
 
-        BlockAllocator& operator= (BlockAllocator&& other) = delete;
+        BlockAllocator& operator=(const BlockAllocator& other) = delete;
+
+        BlockAllocator& operator=(BlockAllocator&& other) = delete;
 
         /// Allocates memory.
         /// @details Allocates uninitialized storage.
@@ -85,82 +98,82 @@ namespace playrho {
 
         /// @brief Allocates an array.
         /// @throws std::bad_alloc If unable to allocate non-zero elements of non-zero size.
-        template <typename T>
+        template<typename T>
         T* AllocateArray(size_type n)
         {
             return static_cast<T*>(Allocate(n * sizeof(T)));
         }
-        
+
         /// @brief Frees memory.
         /// @details This will use free if the size is larger than <code>GetMaxBlockSize()</code>.
         void Free(void* p, size_type n);
-        
+
         /// Clears this allocator.
         /// @note This resets the chunk-count back to zero.
         void Clear();
-        
+
         /// @brief Gets the chunk count.
         auto GetChunkCount() const noexcept
         {
             return m_chunkCount;
         }
 
-    private:
+     private:
         struct Chunk;
         struct Block;
-        
-        size_type m_chunkCount = 0; ///< Chunk count.
-        size_type m_chunkSpace = GetChunkArrayIncrement(); ///< Chunk space.
-        Chunk* m_chunks; ///< Chunks array.
-        Block* m_freeLists[size(AllocatorBlockSizes)]; ///< Free lists.
+
+        size_type m_chunkCount = 0;                       ///< Chunk count.
+        size_type m_chunkSpace = GetChunkArrayIncrement();///< Chunk space.
+        Chunk* m_chunks;                                  ///< Chunks array.
+        Block* m_freeLists[size(AllocatorBlockSizes)];    ///< Free lists.
     };
-    
+
     /// @brief Deletes the given pointer by calling the pointed-to object's destructor and
     ///    returning it to the given allocator.
-    template <typename T>
+    template<typename T>
     inline void Delete(const T* p, BlockAllocator& allocator)
     {
         p->~T();
         allocator.Free(const_cast<T*>(p), sizeof(T));
     }
-    
+
     /// Block deallocator.
     struct BlockDeallocator
     {
         /// @brief Size type.
         using size_type = BlockAllocator::size_type;
-        
+
         BlockDeallocator() = default;
 
         /// @brief Initializing constructor.
-        constexpr BlockDeallocator(BlockAllocator* a, size_type n) noexcept:
-            allocator{a}, nelem{n}
+        constexpr BlockDeallocator(BlockAllocator* a, size_type n) noexcept
+            : allocator{a}, nelem{n}
         {
             // Intentionally empty.
         }
-        
+
         /// @brief Default operator.
-        void operator()(void *p) noexcept
+        void operator()(void* p) noexcept
         {
             allocator->Free(p, nelem);
         }
-        
-        BlockAllocator* allocator; ///< Allocator pointer.
-        size_type nelem; ///< Number of elements.
+
+        BlockAllocator* allocator;///< Allocator pointer.
+        size_type nelem;          ///< Number of elements.
     };
-    
+
     /// @brief <code>BlockAllocator</code> equality operator.
     inline bool operator==(const BlockAllocator& a, const BlockAllocator& b)
     {
         return &a == &b;
     }
-    
+
     /// @brief <code>BlockAllocator</code> inequality operator.
     inline bool operator!=(const BlockAllocator& a, const BlockAllocator& b)
     {
         return &a != &b;
     }
-    
-} // namespace playrho
 
-#endif // PLAYRHO_COMMON_BLOCKALLOCATOR_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_BLOCKALLOCATOR_HPP

--- a/PlayRho/Common/CheckedValue.hpp
+++ b/PlayRho/Common/CheckedValue.hpp
@@ -23,529 +23,527 @@
 
 #include <PlayRho/Common/Templates.hpp>
 
-#include <type_traits>
 #include <iostream>
-#include <utility> // for std::declval
+#include <type_traits>
+#include <utility>// for std::declval
 
-namespace playrho {
-
-/// @brief No-op value checker.
-/// @details Provides functors ensuring values are the value given.
-/// @tparam T Value type to check (or pass-through in this case).
-/// @note This is meant to be used as a checker with types like <code>CheckedValue</code>.
-/// @see CheckedValue.
-template <typename T>
-struct NoOpChecker
+namespace playrho
 {
-    /// @brief Valid value supplying functor.
-    /// @return Default initialized value of the type.
-    constexpr auto operator()() noexcept -> decltype(T())
+
+    /// @brief No-op value checker.
+    /// @details Provides functors ensuring values are the value given.
+    /// @tparam T Value type to check (or pass-through in this case).
+    /// @note This is meant to be used as a checker with types like <code>CheckedValue</code>.
+    /// @see CheckedValue.
+    template<typename T>
+    struct NoOpChecker
     {
-        return T();
+        /// @brief Valid value supplying functor.
+        /// @return Default initialized value of the type.
+        constexpr auto operator()() noexcept -> decltype(T())
+        {
+            return T();
+        }
+
+        /// @brief Value checking functor.
+        /// @param v Value to check or to just pass through in this case.
+        /// @throws exception_type if given value is not valid.
+        /// @return Value given if greater-than or equal-to zero and less-than or equal-to one.
+        constexpr auto operator()(T v) noexcept -> decltype(T(v))
+        {
+            return v;
+        }
+    };
+
+    /// @brief Checked value.
+    /// @tparam ValueType Type of the underlying value that will get checked.
+    /// @tparam CheckerType Checker type to check or possibly transform values with.
+    template<typename ValueType, typename CheckerType = NoOpChecker<ValueType>>
+    class CheckedValue
+    {
+     public:
+        static_assert(HasUnaryFunctor<CheckerType, ValueType, ValueType>::value,
+                      "Checker type doesn't provide acceptable unary functor!");
+
+        /// @brief Value type.
+        using value_type = ValueType;
+
+        /// @brief Remove pointer type.
+        using remove_pointer_type = typename std::remove_pointer<ValueType>::type;
+
+        /// @brief Checker type.
+        using checker_type = CheckerType;
+
+        /// Default constructor available for checker types with acceptable nullary functors.
+        template<bool B = HasNullaryFunctor<CheckerType, ValueType>::value, typename std::enable_if_t<B, int> = 0>
+        constexpr CheckedValue() noexcept(noexcept(CheckerType{}()))
+            : m_value{CheckerType{}()}
+        {
+        }
+
+        /// @brief Initializing constructor.
+        /// @todo Consider marking this function "explicit".
+        constexpr CheckedValue(value_type value) noexcept(noexcept(checker_type{}(value)))
+            : m_value{CheckerType{}(value)}
+        {
+        }
+
+        /// @brief Gets the underlying value.
+        constexpr value_type get() const noexcept
+        {
+            return m_value;
+        }
+
+        /// @brief Gets the underlying value.
+        /// @todo Consider marking this function "explicit".
+        constexpr operator value_type() const noexcept
+        {
+            return m_value;
+        }
+
+        /// @brief Member of pointer operator available for pointer <code>ValueType</code>.
+        template<typename U = ValueType>
+        constexpr std::enable_if_t<std::is_pointer<U>::value, U> operator->() const
+        {
+            return m_value;
+        }
+
+        /// @brief Indirection operator available for pointer <code>ValueType</code>.
+        template<typename U = ValueType>
+        constexpr std::enable_if_t<std::is_pointer<U>::value, remove_pointer_type>&
+        operator*() const
+        {
+            return *m_value;
+        }
+
+     private:
+        value_type m_value;///< Underlying value.
+    };
+
+    // Common operations.
+
+    /// @brief Constrained value stream output operator for value types which support it.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType>
+    auto operator<<(::std::ostream& os, const CheckedValue<ValueType, CheckerType>& value) -> decltype(os << ValueType(value))
+    {
+        return os << ValueType(value);
     }
 
-    /// @brief Value checking functor.
-    /// @param v Value to check or to just pass through in this case.
-    /// @throws exception_type if given value is not valid.
-    /// @return Value given if greater-than or equal-to zero and less-than or equal-to one.
-    constexpr auto operator()(T v) noexcept -> decltype(T(v))
+    /// @brief Constrained value equality operator for value types which support it.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator==(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                              const CheckedValue<RhsValueType, RhsCheckerType>& rhs) noexcept(noexcept(std::declval<LhsValueType>() == std::declval<RhsValueType>()))
+        -> decltype(LhsValueType(lhs) == RhsValueType(rhs))
     {
-        return v;
-    }
-};
-
-/// @brief Checked value.
-/// @tparam ValueType Type of the underlying value that will get checked.
-/// @tparam CheckerType Checker type to check or possibly transform values with.
-template <typename ValueType, typename CheckerType = NoOpChecker<ValueType>>
-class CheckedValue
-{
-public:
-    static_assert(HasUnaryFunctor<CheckerType, ValueType, ValueType>::value,
-                  "Checker type doesn't provide acceptable unary functor!");
-
-    /// @brief Value type.
-    using value_type = ValueType;
-
-    /// @brief Remove pointer type.
-    using remove_pointer_type = typename std::remove_pointer<ValueType>::type;
-
-    /// @brief Checker type.
-    using checker_type = CheckerType;
-
-    /// Default constructor available for checker types with acceptable nullary functors.
-    template <bool B = HasNullaryFunctor<CheckerType,ValueType>::value, typename std::enable_if_t<B, int> = 0>
-    constexpr CheckedValue() noexcept(noexcept(CheckerType{}())): m_value{CheckerType{}()}
-    {
+        return LhsValueType(lhs) == RhsValueType(rhs);
     }
 
-    /// @brief Initializing constructor.
-    /// @todo Consider marking this function "explicit".
-    constexpr CheckedValue(value_type value) noexcept(noexcept(checker_type{}(value))):
-        m_value{CheckerType{}(value)}
+    /// @brief Constrained value inequality operator for value types which support it.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator!=(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                              const CheckedValue<RhsValueType, RhsCheckerType>& rhs) noexcept(noexcept(std::declval<LhsValueType>() != std::declval<RhsValueType>()))
+        -> decltype(LhsValueType(lhs) != RhsValueType(rhs))
     {
+        return LhsValueType(lhs) != RhsValueType(rhs);
     }
 
-    /// @brief Gets the underlying value.
-    constexpr value_type get() const noexcept
+    /// @brief Constrained value less-than or equal-to operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator<=(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                              const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) <= RhsValueType(rhs))
     {
-        return m_value;
+        return LhsValueType(lhs) <= RhsValueType(rhs);
     }
 
-    /// @brief Gets the underlying value.
-    /// @todo Consider marking this function "explicit".
-    constexpr operator value_type () const noexcept
+    /// @brief Constrained value greater-than or equal-to operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator>=(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                              const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) >= RhsValueType(rhs))
     {
-        return m_value;
+        return LhsValueType(lhs) >= RhsValueType(rhs);
     }
 
-    /// @brief Member of pointer operator available for pointer <code>ValueType</code>.
-    template <typename U = ValueType>
-    constexpr std::enable_if_t<std::is_pointer<U>::value, U> operator-> () const
+    /// @brief Constrained value less-than operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator<(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                             const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) < RhsValueType(rhs))
     {
-        return m_value;
+        return LhsValueType(lhs) < RhsValueType(rhs);
     }
 
-    /// @brief Indirection operator available for pointer <code>ValueType</code>.
-    template <typename U = ValueType>
-    constexpr std::enable_if_t<std::is_pointer<U>::value, remove_pointer_type>&
-    operator* () const
+    /// @brief Constrained value greater-than operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator>(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                             const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) > RhsValueType(rhs))
     {
-        return *m_value;
+        return LhsValueType(lhs) > RhsValueType(rhs);
     }
 
-private:
-    value_type m_value; ///< Underlying value.
-};
+    /// @brief Constrained value multiplication operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator*(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                             const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) * RhsValueType(rhs))
+    {
+        return LhsValueType(lhs) * RhsValueType(rhs);
+    }
 
-// Common operations.
+    /// @brief Constrained value division operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator/(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                             const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) / RhsValueType(rhs))
+    {
+        return LhsValueType(lhs) / RhsValueType(rhs);
+    }
 
-/// @brief Constrained value stream output operator for value types which support it.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType>
-auto operator<<(::std::ostream& os, const CheckedValue<ValueType, CheckerType>& value) ->
-    decltype(os << ValueType(value))
-{
-    return os << ValueType(value);
-}
+    /// @brief Constrained value addition operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator+(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                             const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) + RhsValueType(rhs))
+    {
+        return LhsValueType(lhs) + RhsValueType(rhs);
+    }
 
-/// @brief Constrained value equality operator for value types which support it.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator== (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                           const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
-    noexcept(noexcept(std::declval<LhsValueType>() == std::declval<RhsValueType>()))
--> decltype(LhsValueType(lhs) == RhsValueType(rhs))
-{
-    return LhsValueType(lhs) == RhsValueType(rhs);
-}
+    /// @brief Constrained value subtraction operator.
+    /// @tparam LhsValueType Type of the value used by the left hand side checked value.
+    /// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
+    /// @tparam RhsValueType Type of the value used by the right hand side checked value.
+    /// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
+    /// @relatedalso CheckedValue
+    template<typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
+    constexpr auto operator-(const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
+                             const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
+        -> decltype(LhsValueType(lhs) - RhsValueType(rhs))
+    {
+        return LhsValueType(lhs) - RhsValueType(rhs);
+    }
 
-/// @brief Constrained value inequality operator for value types which support it.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator!= (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                           const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
-    noexcept(noexcept(std::declval<LhsValueType>() != std::declval<RhsValueType>()))
--> decltype(LhsValueType(lhs) != RhsValueType(rhs))
-{
-    return LhsValueType(lhs) != RhsValueType(rhs);
-}
+    /// @brief Constrained value equality operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator==(const CheckedValue<ValueType, CheckerType>& lhs,
+                              const Other& rhs)
+        -> decltype(ValueType(lhs) == rhs)
+    {
+        return ValueType(lhs) == rhs;
+    }
 
-/// @brief Constrained value less-than or equal-to operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator<= (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                           const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) <= RhsValueType(rhs))
-{
-    return LhsValueType(lhs) <= RhsValueType(rhs);
-}
+    /// @brief Constrained value equality operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator==(const Other& lhs,
+                              const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs == ValueType(rhs))
+    {
+        return lhs == ValueType(rhs);
+    }
 
-/// @brief Constrained value greater-than or equal-to operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator>= (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                           const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) >= RhsValueType(rhs))
-{
-    return LhsValueType(lhs) >= RhsValueType(rhs);
-}
+    /// @brief Constrained value inequality operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator!=(const CheckedValue<ValueType, CheckerType>& lhs,
+                              const Other& rhs)
+        -> decltype(ValueType(lhs) != rhs)
+    {
+        return ValueType(lhs) != rhs;
+    }
 
-/// @brief Constrained value less-than operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator< (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                          const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) < RhsValueType(rhs))
-{
-    return LhsValueType(lhs) < RhsValueType(rhs);
-}
+    /// @brief Constrained value inequality operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator!=(const Other& lhs,
+                              const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs != ValueType(rhs))
+    {
+        return lhs != ValueType(rhs);
+    }
 
-/// @brief Constrained value greater-than operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator> (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                          const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) > RhsValueType(rhs))
-{
-    return LhsValueType(lhs) > RhsValueType(rhs);
-}
+    /// @brief Constrained value less-than or equal-to operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator<=(const CheckedValue<ValueType, CheckerType>& lhs,
+                              const Other& rhs)
+        -> decltype(ValueType(lhs) <= rhs)
+    {
+        return ValueType(lhs) <= rhs;
+    }
 
-/// @brief Constrained value multiplication operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator* (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                          const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) * RhsValueType(rhs))
-{
-    return LhsValueType(lhs) * RhsValueType(rhs);
-}
+    /// @brief Constrained value less-than or equal-to operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator<=(const Other& lhs,
+                              const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs <= ValueType(rhs))
+    {
+        return lhs <= ValueType(rhs);
+    }
 
-/// @brief Constrained value division operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator/ (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                          const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) / RhsValueType(rhs))
-{
-    return LhsValueType(lhs) / RhsValueType(rhs);
-}
+    /// @brief Constrained value greater-than or equal-to operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator>=(const CheckedValue<ValueType, CheckerType>& lhs,
+                              const Other& rhs)
+        -> decltype(ValueType(lhs) >= rhs)
+    {
+        return ValueType(lhs) >= rhs;
+    }
 
-/// @brief Constrained value addition operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator+ (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                          const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) + RhsValueType(rhs))
-{
-    return LhsValueType(lhs) + RhsValueType(rhs);
-}
+    /// @brief Constrained value greater-than or equal-to operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator>=(const Other& lhs,
+                              const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs >= ValueType(rhs))
+    {
+        return lhs >= ValueType(rhs);
+    }
 
-/// @brief Constrained value subtraction operator.
-/// @tparam LhsValueType Type of the value used by the left hand side checked value.
-/// @tparam LhsCheckerType Type of the checker used by the left hand side checked value.
-/// @tparam RhsValueType Type of the value used by the right hand side checked value.
-/// @tparam RhsCheckerType Type of the checker used by the right hand side checked value.
-/// @relatedalso CheckedValue
-template <typename LhsValueType, typename LhsCheckerType, typename RhsValueType, typename RhsCheckerType>
-constexpr auto operator- (const CheckedValue<LhsValueType, LhsCheckerType>& lhs,
-                          const CheckedValue<RhsValueType, RhsCheckerType>& rhs)
--> decltype(LhsValueType(lhs) - RhsValueType(rhs))
-{
-    return LhsValueType(lhs) - RhsValueType(rhs);
-}
+    /// @brief Constrained value less-than operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator<(const CheckedValue<ValueType, CheckerType>& lhs,
+                             const Other& rhs)
+        -> decltype(ValueType(lhs) < rhs)
+    {
+        return ValueType(lhs) < rhs;
+    }
 
-/// @brief Constrained value equality operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator== (const CheckedValue<ValueType, CheckerType>& lhs,
-                           const Other& rhs)
--> decltype(ValueType(lhs) == rhs)
-{
-    return ValueType(lhs) == rhs;
-}
+    /// @brief Constrained value less-than operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator<(const Other& lhs,
+                             const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs < ValueType(rhs))
+    {
+        return lhs < ValueType(rhs);
+    }
 
-/// @brief Constrained value equality operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator== (const Other& lhs,
-                           const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs == ValueType(rhs))
-{
-    return lhs == ValueType(rhs);
-}
+    /// @brief Constrained value greater-than operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator>(const CheckedValue<ValueType, CheckerType>& lhs,
+                             const Other& rhs)
+        -> decltype(ValueType(lhs) > rhs)
+    {
+        return ValueType(lhs) > rhs;
+    }
 
-/// @brief Constrained value inequality operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator!= (const CheckedValue<ValueType, CheckerType>& lhs,
-                           const Other& rhs)
--> decltype(ValueType(lhs) != rhs)
-{
-    return ValueType(lhs) != rhs;
-}
+    /// @brief Constrained value greater-than ooperator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator>(const Other& lhs,
+                             const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs > ValueType(rhs))
+    {
+        return lhs > ValueType(rhs);
+    }
 
-/// @brief Constrained value inequality operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator!= (const Other& lhs,
-                           const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs != ValueType(rhs))
-{
-    return lhs != ValueType(rhs);
-}
+    /// @brief Constrained value multiplication operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator*(const CheckedValue<ValueType, CheckerType>& lhs, const Other& rhs)
+        -> std::enable_if_t<!IsMultipliable<CheckedValue<ValueType, CheckerType>, Other>::value, decltype(ValueType() * Other())>
+    {
+        return ValueType(lhs) * rhs;
+    }
 
-/// @brief Constrained value less-than or equal-to operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator<= (const CheckedValue<ValueType, CheckerType>& lhs,
-                           const Other& rhs)
--> decltype(ValueType(lhs) <= rhs)
-{
-    return ValueType(lhs) <= rhs;
-}
+    /// @brief Constrained value multiplication operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator*(const Other& lhs, const CheckedValue<ValueType, CheckerType>& rhs)
+        -> std::enable_if_t<!IsMultipliable<Other, CheckedValue<ValueType, CheckerType>>::value, decltype(Other() * ValueType())>
+    {
+        return lhs * ValueType(rhs);
+    }
 
-/// @brief Constrained value less-than or equal-to operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator<= (const Other& lhs,
-                           const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs <= ValueType(rhs))
-{
-    return lhs <= ValueType(rhs);
-}
+    /// @brief Constrained value division operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator/(const CheckedValue<ValueType, CheckerType>& lhs,
+                             const Other& rhs)
+        -> decltype(ValueType(lhs) / rhs)
+    {
+        return ValueType(lhs) / rhs;
+    }
 
-/// @brief Constrained value greater-than or equal-to operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator>= (const CheckedValue<ValueType, CheckerType>& lhs,
-                           const Other& rhs)
--> decltype(ValueType(lhs) >= rhs)
-{
-    return ValueType(lhs) >= rhs;
-}
+    /// @brief Constrained value division operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator/(const Other& lhs,
+                             const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs / ValueType(rhs))
+    {
+        return lhs / ValueType(rhs);
+    }
 
-/// @brief Constrained value greater-than or equal-to operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator>= (const Other& lhs,
-                           const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs >= ValueType(rhs))
-{
-    return lhs >= ValueType(rhs);
-}
+    /// @brief Constrained value addition operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator+(const CheckedValue<ValueType, CheckerType>& lhs,
+                             const Other& rhs)
+        -> decltype(ValueType(lhs) + rhs)
+    {
+        return ValueType(lhs) + rhs;
+    }
 
+    /// @brief Constrained value addition operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator+(const Other& lhs,
+                             const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs + ValueType(rhs))
+    {
+        return lhs + ValueType(rhs);
+    }
 
-/// @brief Constrained value less-than operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator< (const CheckedValue<ValueType, CheckerType>& lhs,
-                          const Other& rhs)
--> decltype(ValueType(lhs) < rhs)
-{
-    return ValueType(lhs) < rhs;
-}
+    /// @brief Constrained value subtraction operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator-(const CheckedValue<ValueType, CheckerType>& lhs,
+                             const Other& rhs)
+        -> decltype(ValueType(lhs) - rhs)
+    {
+        return ValueType(lhs) - rhs;
+    }
 
-/// @brief Constrained value less-than operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator< (const Other& lhs,
-                          const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs < ValueType(rhs))
-{
-    return lhs < ValueType(rhs);
-}
+    /// @brief Constrained value subtraction operator.
+    /// @tparam ValueType Type of the value used by the checked value.
+    /// @tparam CheckerType Type of the checker used by the checked value.
+    /// @tparam Other Type of the other value that this operation will operator with.
+    /// @relatedalso CheckedValue
+    template<typename ValueType, typename CheckerType, typename Other>
+    constexpr auto operator-(const Other& lhs,
+                             const CheckedValue<ValueType, CheckerType>& rhs)
+        -> decltype(lhs - ValueType(rhs))
+    {
+        return lhs - ValueType(rhs);
+    }
 
-/// @brief Constrained value greater-than operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator> (const CheckedValue<ValueType, CheckerType>& lhs,
-                          const Other& rhs)
--> decltype(ValueType(lhs) > rhs)
-{
-    return ValueType(lhs) > rhs;
-}
+    /// @defgroup CheckedValues Checked Value Types
+    /// @brief Types for checked values.
+    /// @details Type aliases for checked values via on-construction checks that
+    ///   may throw an exception if an attempt is made to construct the checked value
+    ///   type with a value not allowed by the specific alias.
+    /// @see CheckedValue
 
-/// @brief Constrained value greater-than ooperator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator> (const Other& lhs,
-                          const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs > ValueType(rhs))
-{
-    return lhs > ValueType(rhs);
-}
+    /// @ingroup CheckedValues
+    /// @brief Default checked value type.
+    /// @details A checked value type using the default checker type.
+    /// @note This is basically a no-op for base line testing and demonstration purposes.
+    template<typename T>
+    using DefaultCheckedValue = CheckedValue<T>;
 
-/// @brief Constrained value multiplication operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator* (const CheckedValue<ValueType, CheckerType>& lhs, const Other& rhs)
--> std::enable_if_t<!IsMultipliable<CheckedValue<ValueType, CheckerType>, Other>::value, decltype(ValueType()*Other())>
-{
-    return ValueType(lhs) * rhs;
-}
+}// namespace playrho
 
-/// @brief Constrained value multiplication operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator* (const Other& lhs, const CheckedValue<ValueType, CheckerType>& rhs)
--> std::enable_if_t<!IsMultipliable<Other, CheckedValue<ValueType, CheckerType>>::value, decltype(Other()*ValueType())>
-{
-    return lhs * ValueType(rhs);
-}
-
-/// @brief Constrained value division operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator/ (const CheckedValue<ValueType, CheckerType>& lhs,
-                          const Other& rhs)
--> decltype(ValueType(lhs) / rhs)
-{
-    return ValueType(lhs) / rhs;
-}
-
-/// @brief Constrained value division operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator/ (const Other& lhs,
-                          const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs / ValueType(rhs))
-{
-    return lhs / ValueType(rhs);
-}
-
-/// @brief Constrained value addition operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator+ (const CheckedValue<ValueType, CheckerType>& lhs,
-                          const Other& rhs)
--> decltype(ValueType(lhs) + rhs)
-{
-    return ValueType(lhs) + rhs;
-}
-
-/// @brief Constrained value addition operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator+ (const Other& lhs,
-                          const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs + ValueType(rhs))
-{
-    return lhs + ValueType(rhs);
-}
-
-/// @brief Constrained value subtraction operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator- (const CheckedValue<ValueType, CheckerType>& lhs,
-                          const Other& rhs)
--> decltype(ValueType(lhs) - rhs)
-{
-    return ValueType(lhs) - rhs;
-}
-
-/// @brief Constrained value subtraction operator.
-/// @tparam ValueType Type of the value used by the checked value.
-/// @tparam CheckerType Type of the checker used by the checked value.
-/// @tparam Other Type of the other value that this operation will operator with.
-/// @relatedalso CheckedValue
-template <typename ValueType, typename CheckerType, typename Other>
-constexpr auto operator- (const Other& lhs,
-                          const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs - ValueType(rhs))
-{
-    return lhs - ValueType(rhs);
-}
-
-/// @defgroup CheckedValues Checked Value Types
-/// @brief Types for checked values.
-/// @details Type aliases for checked values via on-construction checks that
-///   may throw an exception if an attempt is made to construct the checked value
-///   type with a value not allowed by the specific alias.
-/// @see CheckedValue
-
-/// @ingroup CheckedValues
-/// @brief Default checked value type.
-/// @details A checked value type using the default checker type.
-/// @note This is basically a no-op for base line testing and demonstration purposes.
-template <typename T>
-using DefaultCheckedValue = CheckedValue<T>;
-
-} // namespace playrho
-
-#endif // PLAYRHO_COMMON_CHECKEDVALUE_HPP
+#endif// PLAYRHO_COMMON_CHECKEDVALUE_HPP

--- a/PlayRho/Common/CodeDumper.cpp
+++ b/PlayRho/Common/CodeDumper.cpp
@@ -22,51 +22,53 @@
 #include <PlayRho/Dynamics/WorldBody.hpp>
 #include <PlayRho/Dynamics/WorldJoint.hpp>
 
-#include <PlayRho/Dynamics/Contacts/Contact.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
+#include <PlayRho/Dynamics/Contacts/Contact.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 
-#include <PlayRho/Dynamics/Joints/Joint.hpp>
-#include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/DistanceJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/FrictionJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/MotorJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/GearJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/Joint.hpp>
+#include <PlayRho/Dynamics/Joints/MotorJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/RopeJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/WheelJointConf.hpp>
 
-#include <PlayRho/Collision/Shapes/Shape.hpp>
+#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
-#include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
-#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/MultiShapeConf.hpp>
+#include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 
 #include <cstdarg>
 
-namespace playrho {
-namespace d2 {
-
-namespace {
-
-    // You can modify this to use your logging facility.
-    void log(const char* string, ...)
-    {
-        va_list args;
-        va_start(args, string);
-        std::vprintf(string, args);
-        va_end(args);
-    }
-    
-}
-
-void Dump(const World& world)
+namespace playrho
 {
+    namespace d2
+    {
+
+        namespace
+        {
+
+            // You can modify this to use your logging facility.
+            void log(const char* string, ...)
+            {
+                va_list args;
+                va_start(args, string);
+                std::vprintf(string, args);
+                va_end(args);
+            }
+
+        }// namespace
+
+        void Dump(const World& world)
+        {
 #if 0
     const auto& bodies = world.GetBodies();
     log("Body** bodies = (Body**)Alloc(%d * sizeof(Body*));\n", size(bodies));
@@ -94,10 +96,10 @@ void Dump(const World& world)
     log("joints = nullptr;\n");
     log("bodies = nullptr;\n");
 #endif
-}
+        }
 
-void Dump(const Body& body, std::size_t bodyIndex)
-{
+        void Dump(const Body& body, std::size_t bodyIndex)
+        {
 #if 0
     log("{\n");
     log("  BodyConf bd;\n");
@@ -130,303 +132,314 @@ void Dump(const Body& body, std::size_t bodyIndex)
     }
     log("}\n");
 #endif
-}
+        }
 
-void Dump(const Joint& joint, std::size_t index, const World& world)
-{
-    const auto type = GetType(joint);
-    if (type == GetTypeID<PulleyJointConf>()) {
-        Dump(TypeCast<PulleyJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<DistanceJointConf>()) {
-        Dump(TypeCast<DistanceJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<FrictionJointConf>()) {
-        Dump(TypeCast<FrictionJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<MotorJointConf>()) {
-        Dump(TypeCast<MotorJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<WeldJointConf>()) {
-        Dump(TypeCast<WeldJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<TargetJointConf>()) {
-        Dump(TypeCast<TargetJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<RevoluteJointConf>()) {
-        Dump(TypeCast<RevoluteJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<PrismaticJointConf>()) {
-        Dump(TypeCast<PrismaticJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<GearJointConf>()) {
-        Dump(TypeCast<GearJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<RopeJointConf>()) {
-        Dump(TypeCast<RopeJointConf>(joint), index, world);
-    }
-    else if (type == GetTypeID<WheelJointConf>()) {
-        Dump(TypeCast<WheelJointConf>(joint), index, world);
-    }
-}
+        void Dump(const Joint& joint, std::size_t index, const World& world)
+        {
+            const auto type = GetType(joint);
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                Dump(TypeCast<PulleyJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<DistanceJointConf>())
+            {
+                Dump(TypeCast<DistanceJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<FrictionJointConf>())
+            {
+                Dump(TypeCast<FrictionJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<MotorJointConf>())
+            {
+                Dump(TypeCast<MotorJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<WeldJointConf>())
+            {
+                Dump(TypeCast<WeldJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<TargetJointConf>())
+            {
+                Dump(TypeCast<TargetJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<RevoluteJointConf>())
+            {
+                Dump(TypeCast<RevoluteJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<PrismaticJointConf>())
+            {
+                Dump(TypeCast<PrismaticJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<GearJointConf>())
+            {
+                Dump(TypeCast<GearJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<RopeJointConf>())
+            {
+                Dump(TypeCast<RopeJointConf>(joint), index, world);
+            }
+            else if (type == GetTypeID<WheelJointConf>())
+            {
+                Dump(TypeCast<WheelJointConf>(joint), index, world);
+            }
+        }
 
-void Dump(const Fixture& fixture, std::size_t bodyIndex)
-{
-    log("    FixtureConf fd;\n");
-    log("    fd.friction = %.15lef;\n", static_cast<double>(fixture.GetFriction()));
-    log("    fd.restitution = %.15lef;\n", static_cast<double>(fixture.GetRestitution()));
-    log("    fd.density = %.15lef;\n",
-        static_cast<double>(Real{fixture.GetDensity() * SquareMeter / Kilogram}));
-    log("    fd.isSensor = bool(%d);\n", fixture.IsSensor());
-    log("    fd.filter.categoryBits = Filter::bits_type(%u);\n",
-        fixture.GetFilterData().categoryBits);
-    log("    fd.filter.maskBits = Filter::bits_type(%u);\n",
-        fixture.GetFilterData().maskBits);
-    log("    fd.filter.groupIndex = Filter::index_type(%d);\n",
-        fixture.GetFilterData().groupIndex);
+        void Dump(const Fixture& fixture, std::size_t bodyIndex)
+        {
+            log("    FixtureConf fd;\n");
+            log("    fd.friction = %.15lef;\n", static_cast<double>(fixture.GetFriction()));
+            log("    fd.restitution = %.15lef;\n", static_cast<double>(fixture.GetRestitution()));
+            log("    fd.density = %.15lef;\n",
+                static_cast<double>(Real{fixture.GetDensity() * SquareMeter / Kilogram}));
+            log("    fd.isSensor = bool(%d);\n", fixture.IsSensor());
+            log("    fd.filter.categoryBits = Filter::bits_type(%u);\n",
+                fixture.GetFilterData().categoryBits);
+            log("    fd.filter.maskBits = Filter::bits_type(%u);\n",
+                fixture.GetFilterData().maskBits);
+            log("    fd.filter.groupIndex = Filter::index_type(%d);\n",
+                fixture.GetFilterData().groupIndex);
 #if 0
     const auto shape = fixture.GetShape();
     std::ostringstream os;
     os << shape << "\n";
     log(os.str().c_str());
 #endif
-    log("\n");
-    log("    fd.shape = &shape;\n");
-    log("\n");
-    log("    bodies[%d]->CreateFixture(fd);\n", bodyIndex);
-}
+            log("\n");
+            log("    fd.shape = &shape;\n");
+            log("\n");
+            log("    bodies[%d]->CreateFixture(fd);\n", bodyIndex);
+        }
 
-void Dump(const DistanceJointConf& joint, std::size_t index, const World& world)
-{
-    log("  DistanceJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.length = %.15lef;\n",
-        static_cast<double>(Real{GetLength(joint) / Meter}));
-    log("  jd.frequency = %.15lef;\n",
-        static_cast<double>(Real{GetFrequency(joint) / Hertz}));
-    log("  jd.dampingRatio = %.15lef;\n", GetDampingRatio(joint));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const DistanceJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  DistanceJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.length = %.15lef;\n",
+                static_cast<double>(Real{GetLength(joint) / Meter}));
+            log("  jd.frequency = %.15lef;\n",
+                static_cast<double>(Real{GetFrequency(joint) / Hertz}));
+            log("  jd.dampingRatio = %.15lef;\n", GetDampingRatio(joint));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const FrictionJointConf& joint, std::size_t index, const World& world)
-{
-    log("  FrictionJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.maxForce = %.15lef;\n",
-        static_cast<double>(Real{GetMaxForce(joint) / Newton}));
-    log("  jd.maxTorque = %.15lef;\n",
-        static_cast<double>(Real{GetMaxTorque(joint) / NewtonMeter}));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const FrictionJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  FrictionJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.maxForce = %.15lef;\n",
+                static_cast<double>(Real{GetMaxForce(joint) / Newton}));
+            log("  jd.maxTorque = %.15lef;\n",
+                static_cast<double>(Real{GetMaxTorque(joint) / NewtonMeter}));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const GearJointConf& joint, std::size_t index, const World& world)
-{
-    log("  GearJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-  //  log("  jd.joint1 = joints[%d];\n", GetWorldIndex(world, joint.GetJoint1()));
-  //  log("  jd.joint2 = joints[%d];\n", GetWorldIndex(world, joint.GetJoint2()));
-    log("  jd.ratio = %.15lef;\n", GetRatio(joint));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const GearJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  GearJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            //  log("  jd.joint1 = joints[%d];\n", GetWorldIndex(world, joint.GetJoint1()));
+            //  log("  jd.joint2 = joints[%d];\n", GetWorldIndex(world, joint.GetJoint2()));
+            log("  jd.ratio = %.15lef;\n", GetRatio(joint));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const MotorJointConf& joint, std::size_t index, const World& world)
-{
-    log("  MotorJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.linearOffset = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLinearOffset(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLinearOffset(joint)) / Meter}));
-    log("  jd.angularOffset = %.15lef;\n",
-        static_cast<double>(Real{GetAngularOffset(joint) / Radian}));
-    log("  jd.maxForce = %.15lef;\n",
-        static_cast<double>(Real{GetMaxForce(joint) / Newton}));
-    log("  jd.maxTorque = %.15lef;\n",
-        static_cast<double>(Real{GetMaxTorque(joint) / NewtonMeter}));
-    log("  jd.correctionFactor = %.15lef;\n", joint.correctionFactor);
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const MotorJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  MotorJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.linearOffset = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLinearOffset(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLinearOffset(joint)) / Meter}));
+            log("  jd.angularOffset = %.15lef;\n",
+                static_cast<double>(Real{GetAngularOffset(joint) / Radian}));
+            log("  jd.maxForce = %.15lef;\n",
+                static_cast<double>(Real{GetMaxForce(joint) / Newton}));
+            log("  jd.maxTorque = %.15lef;\n",
+                static_cast<double>(Real{GetMaxTorque(joint) / NewtonMeter}));
+            log("  jd.correctionFactor = %.15lef;\n", joint.correctionFactor);
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const TargetJointConf& joint, std::size_t index, const World& world)
-{
-    log("  TargetJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.frequency = %.15lef;\n",
-        static_cast<double>(Real{GetFrequency(joint) / Hertz}));
-    log("  jd.dampingRatio = %.15lef;\n", static_cast<double>(Real{GetDampingRatio(joint)}));
-    log("  jd.maxForce = %.15lef;\n",
-        static_cast<double>(Real{GetMaxForce(joint) / Newton}));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const TargetJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  TargetJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.frequency = %.15lef;\n",
+                static_cast<double>(Real{GetFrequency(joint) / Hertz}));
+            log("  jd.dampingRatio = %.15lef;\n", static_cast<double>(Real{GetDampingRatio(joint)}));
+            log("  jd.maxForce = %.15lef;\n",
+                static_cast<double>(Real{GetMaxForce(joint) / Newton}));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const PrismaticJointConf& joint, std::size_t index, const World& world)
-{
-    log("  PrismaticJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.localXAxisA = Vec2(%.15lef, %.15lef);\n",
-        GetX(GetLocalXAxisA(joint)), GetY(GetLocalXAxisA(joint)));
-    log("  jd.referenceAngle = %.15lef;\n",
-        static_cast<double>(Real{GetReferenceAngle(joint) / Radian}));
-    log("  jd.enableLimit = bool(%d);\n", IsLimitEnabled(joint));
-    log("  jd.lowerTranslation = %.15lef;\n",
-        static_cast<double>(Real{GetLinearLowerLimit(joint) / Meter}));
-    log("  jd.upperTranslation = %.15lef;\n",
-        static_cast<double>(Real{GetLinearUpperLimit(joint) / Meter}));
-    log("  jd.enableMotor = bool(%d);\n", IsMotorEnabled(joint));
-    log("  jd.motorSpeed = %.15lef;\n",
-        static_cast<double>(Real{GetMotorSpeed(joint) / RadianPerSecond}));
-    log("  jd.maxMotorForce = %.15lef;\n",
-        static_cast<double>(Real{joint.maxMotorForce / Newton}));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const PrismaticJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  PrismaticJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.localXAxisA = Vec2(%.15lef, %.15lef);\n",
+                GetX(GetLocalXAxisA(joint)), GetY(GetLocalXAxisA(joint)));
+            log("  jd.referenceAngle = %.15lef;\n",
+                static_cast<double>(Real{GetReferenceAngle(joint) / Radian}));
+            log("  jd.enableLimit = bool(%d);\n", IsLimitEnabled(joint));
+            log("  jd.lowerTranslation = %.15lef;\n",
+                static_cast<double>(Real{GetLinearLowerLimit(joint) / Meter}));
+            log("  jd.upperTranslation = %.15lef;\n",
+                static_cast<double>(Real{GetLinearUpperLimit(joint) / Meter}));
+            log("  jd.enableMotor = bool(%d);\n", IsMotorEnabled(joint));
+            log("  jd.motorSpeed = %.15lef;\n",
+                static_cast<double>(Real{GetMotorSpeed(joint) / RadianPerSecond}));
+            log("  jd.maxMotorForce = %.15lef;\n",
+                static_cast<double>(Real{joint.maxMotorForce / Newton}));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const PulleyJointConf& joint, std::size_t index, const World& world)
-{
-    log("  PulleyJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.groundAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetGroundAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetGroundAnchorA(joint)) / Meter}));
-    log("  jd.groundAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetGroundAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetGroundAnchorB(joint)) / Meter}));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.lengthA = %.15lef;\n",
-        static_cast<double>(Real{joint.lengthA / Meter}));
-    log("  jd.lengthB = %.15lef;\n",
-        static_cast<double>(Real{joint.lengthB / Meter}));
-    log("  jd.ratio = %.15lef;\n", GetRatio(joint));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const PulleyJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  PulleyJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.groundAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetGroundAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetGroundAnchorA(joint)) / Meter}));
+            log("  jd.groundAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetGroundAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetGroundAnchorB(joint)) / Meter}));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.lengthA = %.15lef;\n",
+                static_cast<double>(Real{joint.lengthA / Meter}));
+            log("  jd.lengthB = %.15lef;\n",
+                static_cast<double>(Real{joint.lengthB / Meter}));
+            log("  jd.ratio = %.15lef;\n", GetRatio(joint));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const RevoluteJointConf& joint, std::size_t index, const World& world)
-{
-    log("  RevoluteJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.referenceAngle = %.15lef;\n",
-        static_cast<double>(Real{GetReferenceAngle(joint) / Radian}));
-    log("  jd.enableLimit = bool(%d);\n", IsLimitEnabled(joint));
-    log("  jd.lowerAngle = %.15lef;\n",
-        static_cast<double>(Real{GetAngularLowerLimit(joint) / Radian}));
-    log("  jd.upperAngle = %.15lef;\n",
-        static_cast<double>(Real{GetAngularUpperLimit(joint) / Radian}));
-    log("  jd.enableMotor = bool(%d);\n", IsMotorEnabled(joint));
-    log("  jd.motorSpeed = %.15lef;\n",
-        static_cast<double>(Real{GetMotorSpeed(joint) / RadianPerSecond}));
-    log("  jd.maxMotorTorque = %.15lef;\n",
-        static_cast<double>(Real{GetMaxMotorTorque(joint) / NewtonMeter}));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const RevoluteJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  RevoluteJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.referenceAngle = %.15lef;\n",
+                static_cast<double>(Real{GetReferenceAngle(joint) / Radian}));
+            log("  jd.enableLimit = bool(%d);\n", IsLimitEnabled(joint));
+            log("  jd.lowerAngle = %.15lef;\n",
+                static_cast<double>(Real{GetAngularLowerLimit(joint) / Radian}));
+            log("  jd.upperAngle = %.15lef;\n",
+                static_cast<double>(Real{GetAngularUpperLimit(joint) / Radian}));
+            log("  jd.enableMotor = bool(%d);\n", IsMotorEnabled(joint));
+            log("  jd.motorSpeed = %.15lef;\n",
+                static_cast<double>(Real{GetMotorSpeed(joint) / RadianPerSecond}));
+            log("  jd.maxMotorTorque = %.15lef;\n",
+                static_cast<double>(Real{GetMaxMotorTorque(joint) / NewtonMeter}));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const RopeJointConf& joint, std::size_t index, const World& world)
-{
-    log("  RopeJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.maxLength = %.15lef;\n",
-        static_cast<double>(Real{joint.maxLength / Meter}));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const RopeJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  RopeJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.maxLength = %.15lef;\n",
+                static_cast<double>(Real{joint.maxLength / Meter}));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const WeldJointConf& joint, std::size_t index, const World& world)
-{
-    log("  WeldJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.referenceAngle = %.15lef;\n",
-        static_cast<double>(Real{GetReferenceAngle(joint) / Radian}));
-    log("  jd.frequency = %.15lef;\n",
-        static_cast<double>(Real{GetFrequency(joint) / Hertz}));
-    log("  jd.dampingRatio = %.15lef;\n", GetDampingRatio(joint));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const WeldJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  WeldJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.referenceAngle = %.15lef;\n",
+                static_cast<double>(Real{GetReferenceAngle(joint) / Radian}));
+            log("  jd.frequency = %.15lef;\n",
+                static_cast<double>(Real{GetFrequency(joint) / Hertz}));
+            log("  jd.dampingRatio = %.15lef;\n", GetDampingRatio(joint));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-void Dump(const WheelJointConf& joint, std::size_t index, const World& world)
-{
-    log("  WheelJointConf jd;\n");
-    log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
-    log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
-    log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
-    log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
-    log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
-        static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
-    log("  jd.localAxisA = Vec2(%.15lef, %.15lef);\n",
-        static_cast<double>(GetX(GetLocalXAxisA(joint))),
-        static_cast<double>(GetY(GetLocalXAxisA(joint))));
-    log("  jd.enableMotor = bool(%d);\n", IsMotorEnabled(joint));
-    log("  jd.motorSpeed = %.15lef;\n",
-        static_cast<double>(Real{GetMotorSpeed(joint) / RadianPerSecond}));
-    log("  jd.maxMotorTorque = %.15lef;\n",
-        static_cast<double>(Real{GetMaxMotorTorque(joint) / NewtonMeter}));
-    log("  jd.frequency = %.15lef;\n",
-        static_cast<double>(Real{GetFrequency(joint) / Hertz}));
-    log("  jd.dampingRatio = %.15lef;\n", GetDampingRatio(joint));
-    log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
-}
+        void Dump(const WheelJointConf& joint, std::size_t index, const World& world)
+        {
+            log("  WheelJointConf jd;\n");
+            log("  jd.bodyA = bodies[%d];\n", GetWorldIndex(world, GetBodyA(joint)));
+            log("  jd.bodyB = bodies[%d];\n", GetWorldIndex(world, GetBodyB(joint)));
+            log("  jd.collideConnected = bool(%d);\n", GetCollideConnected(joint));
+            log("  jd.localAnchorA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorA(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorA(joint)) / Meter}));
+            log("  jd.localAnchorB = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(Real{get<0>(GetLocalAnchorB(joint)) / Meter}),
+                static_cast<double>(Real{get<1>(GetLocalAnchorB(joint)) / Meter}));
+            log("  jd.localAxisA = Vec2(%.15lef, %.15lef);\n",
+                static_cast<double>(GetX(GetLocalXAxisA(joint))),
+                static_cast<double>(GetY(GetLocalXAxisA(joint))));
+            log("  jd.enableMotor = bool(%d);\n", IsMotorEnabled(joint));
+            log("  jd.motorSpeed = %.15lef;\n",
+                static_cast<double>(Real{GetMotorSpeed(joint) / RadianPerSecond}));
+            log("  jd.maxMotorTorque = %.15lef;\n",
+                static_cast<double>(Real{GetMaxMotorTorque(joint) / NewtonMeter}));
+            log("  jd.frequency = %.15lef;\n",
+                static_cast<double>(Real{GetFrequency(joint) / Hertz}));
+            log("  jd.dampingRatio = %.15lef;\n", GetDampingRatio(joint));
+            log("  joints[%d] = m_world->CreateJoint(jd);\n", index);
+        }
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Common/CodeDumper.hpp
+++ b/PlayRho/Common/CodeDumper.hpp
@@ -22,72 +22,74 @@
 
 #include <PlayRho/Common/Settings.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-    class World;
-    class Body;
-    class Joint;
-    class Fixture;
-    struct DistanceJointConf;
-    struct FrictionJointConf;
-    struct GearJointConf;
-    struct MotorJointConf;
-    struct TargetJointConf;
-    struct PrismaticJointConf;
-    struct PulleyJointConf;
-    struct RevoluteJointConf;
-    struct RopeJointConf;
-    struct WeldJointConf;
-    struct WheelJointConf;
+        class World;
+        class Body;
+        class Joint;
+        class Fixture;
+        struct DistanceJointConf;
+        struct FrictionJointConf;
+        struct GearJointConf;
+        struct MotorJointConf;
+        struct TargetJointConf;
+        struct PrismaticJointConf;
+        struct PulleyJointConf;
+        struct RevoluteJointConf;
+        struct RopeJointConf;
+        struct WeldJointConf;
+        struct WheelJointConf;
 
-    /// Dump the world into the log file.
-    /// @warning this should be called outside of a time step.
-    void Dump(const World& world);
-    
-    /// Dump body to a log file.
-    void Dump(const Body& body, std::size_t bodyIndex);
-    
-    /// Dump joint to the log file.
-    void Dump(const Joint& joint, std::size_t index, const World& world);
+        /// Dump the world into the log file.
+        /// @warning this should be called outside of a time step.
+        void Dump(const World& world);
 
-    /// Dump fixture to log file.
-    void Dump(const Fixture& fixture, std::size_t bodyIndex);
+        /// Dump body to a log file.
+        void Dump(const Body& body, std::size_t bodyIndex);
 
-    /// Dump joint to log file.
-    void Dump(const DistanceJointConf& joint, std::size_t index, const World& world);
+        /// Dump joint to the log file.
+        void Dump(const Joint& joint, std::size_t index, const World& world);
 
-    /// Dump joint to the log file.
-    void Dump(const FrictionJointConf& joint, std::size_t index, const World& world);
+        /// Dump fixture to log file.
+        void Dump(const Fixture& fixture, std::size_t bodyIndex);
 
-    /// @brief Dumps the joint to the log file.
-    void Dump(const GearJointConf& joint, std::size_t index, const World& world);
-    
-    /// @brief Dumps the joint to the log file.
-    void Dump(const MotorJointConf& joint, std::size_t index, const World& world);
+        /// Dump joint to log file.
+        void Dump(const DistanceJointConf& joint, std::size_t index, const World& world);
 
-    /// @brief Dumps the joint to the log file.
-    void Dump(const TargetJointConf& joint, std::size_t index, const World& world);
+        /// Dump joint to the log file.
+        void Dump(const FrictionJointConf& joint, std::size_t index, const World& world);
 
-    /// @brief Dumps the joint to the log file.
-    void Dump(const PrismaticJointConf& joint, std::size_t index, const World& world);
+        /// @brief Dumps the joint to the log file.
+        void Dump(const GearJointConf& joint, std::size_t index, const World& world);
 
-    /// Dump joint to log file.
-    void Dump(const PulleyJointConf& joint, std::size_t index, const World& world);
+        /// @brief Dumps the joint to the log file.
+        void Dump(const MotorJointConf& joint, std::size_t index, const World& world);
 
-    /// @brief Dumps the joint to the log file.
-    void Dump(const RevoluteJointConf& joint, std::size_t index, const World& world);
+        /// @brief Dumps the joint to the log file.
+        void Dump(const TargetJointConf& joint, std::size_t index, const World& world);
 
-    /// @brief Dumps the joint to the log file.
-    void Dump(const RopeJointConf& joint, std::size_t index, const World& world);
+        /// @brief Dumps the joint to the log file.
+        void Dump(const PrismaticJointConf& joint, std::size_t index, const World& world);
 
-    /// @brief Dumps the joint to the log file.
-    void Dump(const WeldJointConf& joint, std::size_t index, const World& world);
+        /// Dump joint to log file.
+        void Dump(const PulleyJointConf& joint, std::size_t index, const World& world);
 
-    /// @brief Dumps the joint to the log file.
-    void Dump(const WheelJointConf& joint, std::size_t index, const World& world);
-    
-} // namespace d2
-} // namespace playrho
+        /// @brief Dumps the joint to the log file.
+        void Dump(const RevoluteJointConf& joint, std::size_t index, const World& world);
 
-#endif // PLAYRHO_COMMON_CODEDUMPER_HPP
+        /// @brief Dumps the joint to the log file.
+        void Dump(const RopeJointConf& joint, std::size_t index, const World& world);
+
+        /// @brief Dumps the joint to the log file.
+        void Dump(const WeldJointConf& joint, std::size_t index, const World& world);
+
+        /// @brief Dumps the joint to the log file.
+        void Dump(const WheelJointConf& joint, std::size_t index, const World& world);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_CODEDUMPER_HPP

--- a/PlayRho/Common/DynamicMemory.cpp
+++ b/PlayRho/Common/DynamicMemory.cpp
@@ -23,37 +23,42 @@
 
 #include <cstdlib>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     // Memory allocators. Modify these to use your own allocator.
     void* Alloc(std::size_t size)
     {
-        if (size) {
+        if (size)
+        {
             const auto memory = std::malloc(size);
-            if (!memory) {
+            if (!memory)
+            {
                 throw std::bad_alloc{};
             }
             return memory;
         }
         return nullptr;
     }
-    
+
     void* Realloc(void* ptr, std::size_t size)
     {
-        if (size) {
+        if (size)
+        {
             const auto memory = std::realloc(ptr, size);
-             if (!memory) {
-                 throw std::bad_alloc{};
-             }
-             return memory;
+            if (!memory)
+            {
+                throw std::bad_alloc{};
+            }
+            return memory;
         }
         Free(ptr);
         return nullptr;
     }
-    
+
     void Free(void* mem)
     {
         std::free(mem);
     }
 
-} // namespace playrho
+}// namespace playrho

--- a/PlayRho/Common/DynamicMemory.hpp
+++ b/PlayRho/Common/DynamicMemory.hpp
@@ -32,7 +32,7 @@
 namespace playrho
 {
     // Memory Allocation
-    
+
     /// @brief Allocates memory.
     /// @note One can change this function to use ones own memory allocator. Be sure to conform
     ///   to this function's interface: throw a <code>std::bad_alloc</code> exception if
@@ -44,18 +44,18 @@ namespace playrho
     ///   deallocated with <code>Free(void*)</code> or one of the <code>Realloc</code> functions.
     /// @see Free, Realloc, ReallocArray.
     void* Alloc(std::size_t size);
-    
+
     /// @brief Allocates memory for an array.
     /// @throws std::bad_alloc If unable to allocate non-zero sized memory.
     /// @return Non-null pointer if size is not zero else <code>nullptr</code>. Pointer must be
     ///   deallocated with <code>Free(void*)</code> or one of the <code>Realloc</code> functions.
     /// @see Free, Alloc, ReallocArray.
-    template <typename T>
+    template<typename T>
     T* AllocArray(std::size_t size)
     {
         return static_cast<T*>(Alloc(size * sizeof(T)));
     }
-    
+
     /// @brief Reallocates memory.
     /// @note One can change this function to use ones own memory allocator. Be sure to conform
     ///   to this function's interface: throw a <code>std::bad_alloc</code> exception if
@@ -68,7 +68,7 @@ namespace playrho
     /// @return Non-null pointer if size is not zero else <code>nullptr</code>.
     /// @see Alloc, Free.
     void* Realloc(void* ptr, std::size_t size);
-    
+
     /// @brief Reallocates memory for an array.
     /// @param ptr Pointer to the old memory.
     /// @param count Count of elements to reallocate for. This value must be less than the value
@@ -79,22 +79,23 @@ namespace playrho
     /// @return Non-null pointer if count is not zero else <code>nullptr</code>. Pointer must be
     ///   deallocated with <code>Free(void*)</code> or one of the <code>Realloc</code> functions.
     /// @see Realloc, Free.
-    template <typename T>
+    template<typename T>
     T* ReallocArray(T* ptr, std::size_t count)
     {
         // Ensure no overflow
         constexpr auto maxCount = std::numeric_limits<std::size_t>::max() / sizeof(T);
-        if (count >= maxCount) {
+        if (count >= maxCount)
+        {
             throw std::bad_array_new_length{};
         }
-        return static_cast<T*>(Realloc(static_cast<void *>(ptr), count * sizeof(T)));
+        return static_cast<T*>(Realloc(static_cast<void*>(ptr), count * sizeof(T)));
     }
-    
+
     /// @brief Frees memory.
     /// @note If you change <code>Alloc</code>, consider also changing this function.
     /// @see Alloc, AllocArray, Realloc, ReallocArray.
     void Free(void* mem);
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_DYNAMICMEMORY_HPP
+#endif// PLAYRHO_COMMON_DYNAMICMEMORY_HPP

--- a/PlayRho/Common/Finite.hpp
+++ b/PlayRho/Common/Finite.hpp
@@ -25,41 +25,44 @@
 
 #include <cmath>
 
-namespace playrho {
+namespace playrho
+{
 
-using std::isfinite;
+    using std::isfinite;
 
-/// @brief Finite constrained value checker.
-template <typename T>
-struct FiniteChecker {
-
-    /// @brief Exception type possibly thrown by this checker.
-    using exception_type = std::invalid_argument;
-
-    /// @brief Valid value supplying functor.
-    constexpr auto operator()() noexcept(noexcept(static_cast<T>(0))) -> decltype(static_cast<T>(0))
+    /// @brief Finite constrained value checker.
+    template<typename T>
+    struct FiniteChecker
     {
-        return static_cast<T>(0);
-    }
 
-    /// @brief Value checking functor.
-    /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(isfinite(v), T{v})
-    {
-        if (!isfinite(v)) {
-            throw exception_type("value not finite");
+        /// @brief Exception type possibly thrown by this checker.
+        using exception_type = std::invalid_argument;
+
+        /// @brief Valid value supplying functor.
+        constexpr auto operator()() noexcept(noexcept(static_cast<T>(0))) -> decltype(static_cast<T>(0))
+        {
+            return static_cast<T>(0);
         }
-        return v;
-    }
-};
 
-/// @ingroup CheckedValues
-/// @brief Finite constrained value type.
-template <typename T>
-using Finite = CheckedValue<T, FiniteChecker<T>>;
+        /// @brief Value checking functor.
+        /// @throws exception_type if given value is not valid.
+        constexpr auto operator()(const T& v) -> decltype(isfinite(v), T{v})
+        {
+            if (!isfinite(v))
+            {
+                throw exception_type("value not finite");
+            }
+            return v;
+        }
+    };
 
-static_assert(std::is_default_constructible<Finite<int>>::value);
+    /// @ingroup CheckedValues
+    /// @brief Finite constrained value type.
+    template<typename T>
+    using Finite = CheckedValue<T, FiniteChecker<T>>;
 
-} // namespace playrho
+    static_assert(std::is_default_constructible<Finite<int>>::value);
 
-#endif // PLAYRHO_COMMON_FINITE_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_FINITE_HPP

--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -21,895 +21,890 @@
 #ifndef PLAYRHO_COMMON_FIXED_HPP
 #define PLAYRHO_COMMON_FIXED_HPP
 
-#include <PlayRho/Common/Wider.hpp>
 #include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Common/TypeInfo.hpp>
+#include <PlayRho/Common/Wider.hpp>
 
-#include <cstdint>
-#include <limits>
 #include <cassert>
-#include <type_traits>
+#include <cstdint>
 #include <iostream>
+#include <limits>
+#include <type_traits>
 
-namespace playrho {
-
-/// @brief Template class for fixed-point numbers.
-///
-/// @details This is a fixed point type template for a given base type using a given number
-///   of fraction bits that satisfies the <code>LiteralType</code> named requirement.
-///
-/// @see https://en.wikipedia.org/wiki/Fixed-point_arithmetic
-/// @see https://en.cppreference.com/w/cpp/named_req/LiteralType
-///
-template <typename BASE_TYPE, unsigned int FRACTION_BITS>
-class Fixed
+namespace playrho
 {
-public:
 
-    /// @brief Value type.
-    using value_type = BASE_TYPE;
-
-    /// @brief Total number of bits.
-    static constexpr auto TotalBits = static_cast<unsigned int>(sizeof(BASE_TYPE) * 8u);
-
-    /// @brief Fraction bits.
-    static constexpr auto FractionBits = FRACTION_BITS;
-
-    /// @brief Whole value bits.
-    static constexpr auto WholeBits = TotalBits - FractionBits;
-
-    /// @brief Scale factor.
-    static constexpr auto ScaleFactor = static_cast<value_type>(1u << FractionBits);
-
-    /// @brief Compare result enumeration.
-    enum class CmpResult
+    /// @brief Template class for fixed-point numbers.
+    ///
+    /// @details This is a fixed point type template for a given base type using a given number
+    ///   of fraction bits that satisfies the <code>LiteralType</code> named requirement.
+    ///
+    /// @see https://en.wikipedia.org/wiki/Fixed-point_arithmetic
+    /// @see https://en.cppreference.com/w/cpp/named_req/LiteralType
+    ///
+    template<typename BASE_TYPE, unsigned int FRACTION_BITS>
+    class Fixed
     {
-        Incomparable,
-        Equal,
-        LessThan,
-        GreaterThan
-    };
+     public:
+        /// @brief Value type.
+        using value_type = BASE_TYPE;
 
-    /// @brief Gets the min value this type is capable of expressing.
-    static constexpr Fixed GetMin() noexcept
-    {
-        return Fixed{1, scalar_type{1}};
-    }
+        /// @brief Total number of bits.
+        static constexpr auto TotalBits = static_cast<unsigned int>(sizeof(BASE_TYPE) * 8u);
 
-    /// @brief Gets an infinite value for this type.
-    static constexpr Fixed GetInfinity() noexcept
-    {
-        return Fixed{numeric_limits::max(), scalar_type{1}};
-    }
+        /// @brief Fraction bits.
+        static constexpr auto FractionBits = FRACTION_BITS;
 
-    /// @brief Gets the max value this type is capable of expressing.
-    static constexpr Fixed GetMax() noexcept
-    {
-        // max reserved for +inf
-        return Fixed{numeric_limits::max() - 1, scalar_type{1}};
-    }
+        /// @brief Whole value bits.
+        static constexpr auto WholeBits = TotalBits - FractionBits;
 
-    /// @brief Gets a NaN value for this type.
-    static constexpr Fixed GetNaN() noexcept
-    {
-        return Fixed{numeric_limits::lowest(), scalar_type{1}};
-    }
+        /// @brief Scale factor.
+        static constexpr auto ScaleFactor = static_cast<value_type>(1u << FractionBits);
 
-    /// @brief Gets the negative infinity value for this type.
-    static constexpr Fixed GetNegativeInfinity() noexcept
-    {
-        // lowest reserved for NaN
-        return Fixed{numeric_limits::lowest() + 1, scalar_type{1}};
-    }
-
-    /// @brief Gets the lowest value this type is capable of expressing.
-    static constexpr Fixed GetLowest() noexcept
-    {
-        // lowest reserved for NaN
-        // lowest + 1 reserved for -inf
-        return Fixed{numeric_limits::lowest() + 2, scalar_type{1}};
-    }
-
-    /// @brief Gets the value from a floating point value.
-    template <typename T>
-    static constexpr value_type GetFromFloat(T val) noexcept
-    {
-        static_assert(std::is_floating_point<T>::value, "floating point value required");
-        // Note: std::isnan(val) *NOT* constant expression, so can't use here!
-        return !(val <= 0 || val >= 0)? GetNaN().m_value:
-            (val > static_cast<long double>(GetMax()))? GetInfinity().m_value:
-            (val < static_cast<long double>(GetLowest()))? GetNegativeInfinity().m_value:
-            static_cast<value_type>(val * ScaleFactor);
-    }
-
-    /// @brief Gets the value from a signed integral value.
-    template <typename T>
-    static constexpr value_type GetFromSignedInt(T val) noexcept
-    {
-        static_assert(std::is_integral<T>::value, "integral value required");
-        static_assert(std::is_signed<T>::value, "must be signed");
-        return (val > (GetMax().m_value / ScaleFactor))? GetInfinity().m_value:
-            (val < (GetLowest().m_value / ScaleFactor))? GetNegativeInfinity().m_value:
-            static_cast<value_type>(val * ScaleFactor);
-    }
-
-    /// @brief Gets the value from an unsigned integral value.
-    template <typename T>
-    static constexpr value_type GetFromUnsignedInt(T val) noexcept
-    {
-        static_assert(std::is_integral<T>::value, "integral value required");
-        static_assert(!std::is_signed<T>::value, "must be unsigned");
-        const auto max = static_cast<unsigned_wider_type>(GetMax().m_value / ScaleFactor);
-        return (val > max)? GetInfinity().m_value: static_cast<value_type>(val) * ScaleFactor;
-    }
-
-    Fixed() = default;
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(long double val) noexcept:
-        m_value{GetFromFloat(val)}
-    {
-        // Intentionally empty
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(double val) noexcept:
-        m_value{GetFromFloat(val)}
-    {
-        // Intentionally empty
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(float val) noexcept:
-        m_value{GetFromFloat(val)}
-    {
-        // Intentionally empty
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(unsigned long long val) noexcept:
-        m_value{GetFromUnsignedInt(val)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(unsigned long val) noexcept:
-        m_value{GetFromUnsignedInt(val)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(unsigned int val) noexcept:
-        m_value{GetFromUnsignedInt(val)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(long long val) noexcept:
-        m_value{GetFromSignedInt(val)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(long val) noexcept:
-        m_value{GetFromSignedInt(val)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(int val) noexcept:
-        m_value{GetFromSignedInt(val)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(short val) noexcept:
-        m_value{GetFromSignedInt(val)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(value_type val, unsigned int fraction) noexcept:
-        m_value{static_cast<value_type>(static_cast<std::uint32_t>(val * ScaleFactor) | fraction)}
-    {
-        // Intentionally empty.
-    }
-
-    /// @brief Initializing constructor.
-    template <typename BT, unsigned int FB>
-    constexpr Fixed(const Fixed<BT, FB> val) noexcept:
-        Fixed(static_cast<long double>(val))
-    {
-        // Intentionally empty
-    }
-
-    // Methods
-
-    /// @brief Converts the value to the expressed type.
-    template <typename T>
-    constexpr T ConvertTo() const noexcept
-    {
-        return isnan()? std::numeric_limits<T>::signaling_NaN():
-            !isfinite()? std::numeric_limits<T>::infinity() * getsign():
-                m_value / static_cast<T>(ScaleFactor);
-    }
-
-    /// @brief Compares this value to the given one.
-    constexpr CmpResult Compare(const Fixed other) const noexcept
-    {
-        if (isnan() || other.isnan())
+        /// @brief Compare result enumeration.
+        enum class CmpResult
         {
-            return CmpResult::Incomparable;
+            Incomparable,
+            Equal,
+            LessThan,
+            GreaterThan
+        };
+
+        /// @brief Gets the min value this type is capable of expressing.
+        static constexpr Fixed GetMin() noexcept
+        {
+            return Fixed{1, scalar_type{1}};
         }
-        if (m_value < other.m_value)
+
+        /// @brief Gets an infinite value for this type.
+        static constexpr Fixed GetInfinity() noexcept
         {
-            return CmpResult::LessThan;
+            return Fixed{numeric_limits::max(), scalar_type{1}};
         }
-        if (m_value > other.m_value)
+
+        /// @brief Gets the max value this type is capable of expressing.
+        static constexpr Fixed GetMax() noexcept
         {
-            return CmpResult::GreaterThan;
+            // max reserved for +inf
+            return Fixed{numeric_limits::max() - 1, scalar_type{1}};
         }
-        return CmpResult::Equal;
-    }
 
-    // Unary operations
-
-    /// @brief Long double operator.
-    explicit constexpr operator long double() const noexcept
-    {
-        return ConvertTo<long double>();
-    }
-
-    /// @brief Double operator.
-    explicit constexpr operator double() const noexcept
-    {
-        return ConvertTo<double>();
-    }
-
-    /// @brief Float operator.
-    explicit constexpr operator float() const noexcept
-    {
-        return ConvertTo<float>();
-    }
-
-    /// @brief Long long operator.
-    explicit constexpr operator long long() const noexcept
-    {
-        return m_value / ScaleFactor;
-    }
-
-    /// @brief Long operator.
-    explicit constexpr operator long() const noexcept
-    {
-        return m_value / ScaleFactor;
-    }
-
-    /// @brief Unsigned long long operator.
-    explicit constexpr operator unsigned long long() const noexcept
-    {
-        // Behavior is undefined if m_value is negative
-        return static_cast<unsigned long long>(m_value / ScaleFactor);
-    }
-
-    /// @brief Unsigned long operator.
-    explicit constexpr operator unsigned long() const noexcept
-    {
-        // Behavior is undefined if m_value is negative
-        return static_cast<unsigned long>(m_value / ScaleFactor);
-    }
-
-    /// @brief Unsigned int operator.
-    explicit constexpr operator unsigned int() const noexcept
-    {
-        // Behavior is undefined if m_value is negative
-        return static_cast<unsigned int>(m_value / ScaleFactor);
-    }
-
-    /// @brief int operator.
-    explicit constexpr operator int() const noexcept
-    {
-        return static_cast<int>(m_value / ScaleFactor);
-    }
-
-    /// @brief short operator.
-    explicit constexpr operator short() const noexcept
-    {
-        return static_cast<short>(m_value / ScaleFactor);
-    }
-
-    /// @brief Negation operator.
-    constexpr Fixed operator- () const noexcept
-    {
-        return (isnan())? *this: Fixed{-m_value, scalar_type{1}};
-    }
-
-    /// @brief Positive operator.
-    constexpr Fixed operator+ () const noexcept
-    {
-        return *this;
-    }
-
-    /// @brief Boolean operator.
-    explicit constexpr operator bool() const noexcept
-    {
-        return m_value != 0;
-    }
-
-    /// @brief Logical not operator.
-    constexpr bool operator! () const noexcept
-    {
-        return m_value == 0;
-    }
-
-    /// @brief Addition assignment operator.
-    constexpr Fixed& operator+= (Fixed val) noexcept
-    {
-        if (isnan() || val.isnan()
-            || ((m_value == GetInfinity().m_value) && (val.m_value == GetNegativeInfinity().m_value))
-            || ((m_value == GetNegativeInfinity().m_value) && (val.m_value == GetInfinity().m_value))
-            )
+        /// @brief Gets a NaN value for this type.
+        static constexpr Fixed GetNaN() noexcept
         {
-            *this = GetNaN();
+            return Fixed{numeric_limits::lowest(), scalar_type{1}};
         }
-        else if (val.m_value == GetInfinity().m_value)
+
+        /// @brief Gets the negative infinity value for this type.
+        static constexpr Fixed GetNegativeInfinity() noexcept
         {
-            m_value = GetInfinity().m_value;
+            // lowest reserved for NaN
+            return Fixed{numeric_limits::lowest() + 1, scalar_type{1}};
         }
-        else if (val.m_value == GetNegativeInfinity().m_value)
+
+        /// @brief Gets the lowest value this type is capable of expressing.
+        static constexpr Fixed GetLowest() noexcept
         {
-            m_value = GetNegativeInfinity().m_value;
+            // lowest reserved for NaN
+            // lowest + 1 reserved for -inf
+            return Fixed{numeric_limits::lowest() + 2, scalar_type{1}};
         }
-        else if (isfinite() && val.isfinite())
+
+        /// @brief Gets the value from a floating point value.
+        template<typename T>
+        static constexpr value_type GetFromFloat(T val) noexcept
         {
-            const auto result = wider_type{m_value} + val.m_value;
-            if (result > GetMax().m_value)
+            static_assert(std::is_floating_point<T>::value, "floating point value required");
+            // Note: std::isnan(val) *NOT* constant expression, so can't use here!
+            return !(val <= 0 || val >= 0) ? GetNaN().m_value : (val > static_cast<long double>(GetMax()))  ? GetInfinity().m_value
+                                                            : (val < static_cast<long double>(GetLowest())) ? GetNegativeInfinity().m_value
+                                                                                                            : static_cast<value_type>(val * ScaleFactor);
+        }
+
+        /// @brief Gets the value from a signed integral value.
+        template<typename T>
+        static constexpr value_type GetFromSignedInt(T val) noexcept
+        {
+            static_assert(std::is_integral<T>::value, "integral value required");
+            static_assert(std::is_signed<T>::value, "must be signed");
+            return (val > (GetMax().m_value / ScaleFactor)) ? GetInfinity().m_value : (val < (GetLowest().m_value / ScaleFactor)) ? GetNegativeInfinity().m_value
+                                                                                                                                  : static_cast<value_type>(val * ScaleFactor);
+        }
+
+        /// @brief Gets the value from an unsigned integral value.
+        template<typename T>
+        static constexpr value_type GetFromUnsignedInt(T val) noexcept
+        {
+            static_assert(std::is_integral<T>::value, "integral value required");
+            static_assert(!std::is_signed<T>::value, "must be unsigned");
+            const auto max = static_cast<unsigned_wider_type>(GetMax().m_value / ScaleFactor);
+            return (val > max) ? GetInfinity().m_value : static_cast<value_type>(val) * ScaleFactor;
+        }
+
+        Fixed() = default;
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(long double val) noexcept
+            : m_value{GetFromFloat(val)}
+        {
+            // Intentionally empty
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(double val) noexcept
+            : m_value{GetFromFloat(val)}
+        {
+            // Intentionally empty
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(float val) noexcept
+            : m_value{GetFromFloat(val)}
+        {
+            // Intentionally empty
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(unsigned long long val) noexcept
+            : m_value{GetFromUnsignedInt(val)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(unsigned long val) noexcept
+            : m_value{GetFromUnsignedInt(val)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(unsigned int val) noexcept
+            : m_value{GetFromUnsignedInt(val)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(long long val) noexcept
+            : m_value{GetFromSignedInt(val)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(long val) noexcept
+            : m_value{GetFromSignedInt(val)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(int val) noexcept
+            : m_value{GetFromSignedInt(val)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(short val) noexcept
+            : m_value{GetFromSignedInt(val)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(value_type val, unsigned int fraction) noexcept
+            : m_value{static_cast<value_type>(static_cast<std::uint32_t>(val * ScaleFactor) | fraction)}
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        template<typename BT, unsigned int FB>
+        constexpr Fixed(const Fixed<BT, FB> val) noexcept
+            : Fixed(static_cast<long double>(val))
+        {
+            // Intentionally empty
+        }
+
+        // Methods
+
+        /// @brief Converts the value to the expressed type.
+        template<typename T>
+        constexpr T ConvertTo() const noexcept
+        {
+            return isnan() ? std::numeric_limits<T>::signaling_NaN() : !isfinite() ? std::numeric_limits<T>::infinity() * getsign()
+                                                                                   : m_value / static_cast<T>(ScaleFactor);
+        }
+
+        /// @brief Compares this value to the given one.
+        constexpr CmpResult Compare(const Fixed other) const noexcept
+        {
+            if (isnan() || other.isnan())
             {
-                // overflow from max
-                m_value = GetInfinity().m_value;
+                return CmpResult::Incomparable;
             }
-            else if (result < GetLowest().m_value)
+            if (m_value < other.m_value)
             {
-                // overflow from lowest
-                m_value = GetNegativeInfinity().m_value;
+                return CmpResult::LessThan;
             }
-            else
+            if (m_value > other.m_value)
             {
-                m_value = static_cast<value_type>(result);
+                return CmpResult::GreaterThan;
             }
+            return CmpResult::Equal;
         }
-        return *this;
-    }
 
-    /// @brief Subtraction assignment operator.
-    constexpr Fixed& operator-= (Fixed val) noexcept
-    {
-        if (isnan() || val.isnan()
-            || ((m_value == GetInfinity().m_value) && (val.m_value == GetInfinity().m_value))
-            || ((m_value == GetNegativeInfinity().m_value) && (val.m_value == GetNegativeInfinity().m_value))
-        )
-        {
-            *this = GetNaN();
-        }
-        else if (val.m_value == GetInfinity().m_value)
-        {
-            m_value = GetNegativeInfinity().m_value;
-        }
-        else if (val.m_value == GetNegativeInfinity().m_value)
-        {
-            m_value = GetInfinity().m_value;
-        }
-        else if (isfinite() && val.isfinite())
-        {
-            const auto result = wider_type{m_value} - val.m_value;
-            if (result > GetMax().m_value)
-            {
-                // overflow from max
-                m_value = GetInfinity().m_value;
-            }
-            else if (result < GetLowest().m_value)
-            {
-                // overflow from lowest
-                m_value = GetNegativeInfinity().m_value;
-            }
-            else
-            {
-                m_value = static_cast<value_type>(result);
-            }
-        }
-        return *this;
-    }
+        // Unary operations
 
-    /// @brief Multiplication assignment operator.
-    constexpr Fixed& operator*= (Fixed val) noexcept
-    {
-        if (isnan() || val.isnan())
+        /// @brief Long double operator.
+        explicit constexpr operator long double() const noexcept
         {
-            *this = GetNaN();
+            return ConvertTo<long double>();
         }
-        else if (!isfinite() || !val.isfinite())
+
+        /// @brief Double operator.
+        explicit constexpr operator double() const noexcept
         {
-            if (m_value == 0 || val.m_value == 0)
+            return ConvertTo<double>();
+        }
+
+        /// @brief Float operator.
+        explicit constexpr operator float() const noexcept
+        {
+            return ConvertTo<float>();
+        }
+
+        /// @brief Long long operator.
+        explicit constexpr operator long long() const noexcept
+        {
+            return m_value / ScaleFactor;
+        }
+
+        /// @brief Long operator.
+        explicit constexpr operator long() const noexcept
+        {
+            return m_value / ScaleFactor;
+        }
+
+        /// @brief Unsigned long long operator.
+        explicit constexpr operator unsigned long long() const noexcept
+        {
+            // Behavior is undefined if m_value is negative
+            return static_cast<unsigned long long>(m_value / ScaleFactor);
+        }
+
+        /// @brief Unsigned long operator.
+        explicit constexpr operator unsigned long() const noexcept
+        {
+            // Behavior is undefined if m_value is negative
+            return static_cast<unsigned long>(m_value / ScaleFactor);
+        }
+
+        /// @brief Unsigned int operator.
+        explicit constexpr operator unsigned int() const noexcept
+        {
+            // Behavior is undefined if m_value is negative
+            return static_cast<unsigned int>(m_value / ScaleFactor);
+        }
+
+        /// @brief int operator.
+        explicit constexpr operator int() const noexcept
+        {
+            return static_cast<int>(m_value / ScaleFactor);
+        }
+
+        /// @brief short operator.
+        explicit constexpr operator short() const noexcept
+        {
+            return static_cast<short>(m_value / ScaleFactor);
+        }
+
+        /// @brief Negation operator.
+        constexpr Fixed operator-() const noexcept
+        {
+            return (isnan()) ? *this : Fixed{-m_value, scalar_type{1}};
+        }
+
+        /// @brief Positive operator.
+        constexpr Fixed operator+() const noexcept
+        {
+            return *this;
+        }
+
+        /// @brief Boolean operator.
+        explicit constexpr operator bool() const noexcept
+        {
+            return m_value != 0;
+        }
+
+        /// @brief Logical not operator.
+        constexpr bool operator!() const noexcept
+        {
+            return m_value == 0;
+        }
+
+        /// @brief Addition assignment operator.
+        constexpr Fixed& operator+=(Fixed val) noexcept
+        {
+            if (isnan() || val.isnan()
+                || ((m_value == GetInfinity().m_value) && (val.m_value == GetNegativeInfinity().m_value))
+                || ((m_value == GetNegativeInfinity().m_value) && (val.m_value == GetInfinity().m_value)))
             {
                 *this = GetNaN();
             }
-            else
+            else if (val.m_value == GetInfinity().m_value)
             {
-                *this = ((m_value > 0) != (val.m_value > 0))? -GetInfinity(): GetInfinity();
-            }
-        }
-        else
-        {
-            const auto product = wider_type{m_value} * wider_type{val.m_value};
-            const auto result = product / ScaleFactor;
-
-            if (product != 0 && result == 0)
-            {
-                // underflow
-                m_value = static_cast<value_type>(result);
-            }
-            else if (result > GetMax().m_value)
-            {
-                // overflow from max
                 m_value = GetInfinity().m_value;
             }
-            else if (result < GetLowest().m_value)
+            else if (val.m_value == GetNegativeInfinity().m_value)
             {
-                // overflow from lowest
                 m_value = GetNegativeInfinity().m_value;
+            }
+            else if (isfinite() && val.isfinite())
+            {
+                const auto result = wider_type{m_value} + val.m_value;
+                if (result > GetMax().m_value)
+                {
+                    // overflow from max
+                    m_value = GetInfinity().m_value;
+                }
+                else if (result < GetLowest().m_value)
+                {
+                    // overflow from lowest
+                    m_value = GetNegativeInfinity().m_value;
+                }
+                else
+                {
+                    m_value = static_cast<value_type>(result);
+                }
+            }
+            return *this;
+        }
+
+        /// @brief Subtraction assignment operator.
+        constexpr Fixed& operator-=(Fixed val) noexcept
+        {
+            if (isnan() || val.isnan()
+                || ((m_value == GetInfinity().m_value) && (val.m_value == GetInfinity().m_value))
+                || ((m_value == GetNegativeInfinity().m_value) && (val.m_value == GetNegativeInfinity().m_value)))
+            {
+                *this = GetNaN();
+            }
+            else if (val.m_value == GetInfinity().m_value)
+            {
+                m_value = GetNegativeInfinity().m_value;
+            }
+            else if (val.m_value == GetNegativeInfinity().m_value)
+            {
+                m_value = GetInfinity().m_value;
+            }
+            else if (isfinite() && val.isfinite())
+            {
+                const auto result = wider_type{m_value} - val.m_value;
+                if (result > GetMax().m_value)
+                {
+                    // overflow from max
+                    m_value = GetInfinity().m_value;
+                }
+                else if (result < GetLowest().m_value)
+                {
+                    // overflow from lowest
+                    m_value = GetNegativeInfinity().m_value;
+                }
+                else
+                {
+                    m_value = static_cast<value_type>(result);
+                }
+            }
+            return *this;
+        }
+
+        /// @brief Multiplication assignment operator.
+        constexpr Fixed& operator*=(Fixed val) noexcept
+        {
+            if (isnan() || val.isnan())
+            {
+                *this = GetNaN();
+            }
+            else if (!isfinite() || !val.isfinite())
+            {
+                if (m_value == 0 || val.m_value == 0)
+                {
+                    *this = GetNaN();
+                }
+                else
+                {
+                    *this = ((m_value > 0) != (val.m_value > 0)) ? -GetInfinity() : GetInfinity();
+                }
             }
             else
             {
-                m_value = static_cast<value_type>(result);
+                const auto product = wider_type{m_value} * wider_type{val.m_value};
+                const auto result = product / ScaleFactor;
+
+                if (product != 0 && result == 0)
+                {
+                    // underflow
+                    m_value = static_cast<value_type>(result);
+                }
+                else if (result > GetMax().m_value)
+                {
+                    // overflow from max
+                    m_value = GetInfinity().m_value;
+                }
+                else if (result < GetLowest().m_value)
+                {
+                    // overflow from lowest
+                    m_value = GetNegativeInfinity().m_value;
+                }
+                else
+                {
+                    m_value = static_cast<value_type>(result);
+                }
             }
+            return *this;
         }
-        return *this;
+
+        /// @brief Division assignment operator.
+        constexpr Fixed& operator/=(Fixed val) noexcept
+        {
+            if (isnan() || val.isnan())
+            {
+                *this = GetNaN();
+            }
+            else if (!isfinite() && !val.isfinite())
+            {
+                *this = GetNaN();
+            }
+            else if (!isfinite())
+            {
+                *this = ((m_value > 0) != (val.m_value > 0)) ? -GetInfinity() : GetInfinity();
+            }
+            else if (!val.isfinite())
+            {
+                *this = 0;
+            }
+            else
+            {
+                const auto product = wider_type{m_value} * ScaleFactor;
+                const auto result = product / val.m_value;
+
+                if (product != 0 && result == 0)
+                {
+                    // underflow
+                    m_value = static_cast<value_type>(result);
+                }
+                else if (result > GetMax().m_value)
+                {
+                    // overflow from max
+                    m_value = GetInfinity().m_value;
+                }
+                else if (result < GetLowest().m_value)
+                {
+                    // overflow from lowest
+                    m_value = GetNegativeInfinity().m_value;
+                }
+                else
+                {
+                    m_value = static_cast<value_type>(result);
+                }
+            }
+            return *this;
+        }
+
+        /// @brief Modulo operator.
+        constexpr Fixed& operator%=(Fixed val) noexcept
+        {
+            assert(!isnan());
+            assert(!val.isnan());
+
+            m_value %= val.m_value;
+            return *this;
+        }
+
+        /// @brief Is finite.
+        constexpr bool isfinite() const noexcept
+        {
+            return (m_value > GetNegativeInfinity().m_value)
+                   && (m_value < GetInfinity().m_value);
+        }
+
+        /// @brief Is NaN.
+        constexpr bool isnan() const noexcept
+        {
+            return m_value == GetNaN().m_value;
+        }
+
+        /// @brief Gets this value's sign.
+        constexpr int getsign() const noexcept
+        {
+            return (m_value >= 0) ? +1 : -1;
+        }
+
+     private:
+        /// @brief Widened type alias.
+        using wider_type = typename Wider<value_type>::type;
+
+        /// @brief Unsigned widened type alias.
+        using unsigned_wider_type = typename std::make_unsigned<wider_type>::type;
+
+        /// @brief Scalar type.
+        struct scalar_type
+        {
+            value_type value = 1;///< Value.
+        };
+
+        /// @brief Numeric limits type alias.
+        using numeric_limits = std::numeric_limits<value_type>;
+
+        /// @brief Initializing constructor.
+        constexpr Fixed(value_type val, scalar_type scalar) noexcept
+            : m_value{val * scalar.value}
+        {
+            // Intentionally empty.
+        }
+
+        value_type m_value;///< Value in internal form.
+    };
+
+    /// @brief Equality operator.
+    template<typename BT, unsigned int FB>
+    constexpr bool operator==(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::Equal;
     }
 
-    /// @brief Division assignment operator.
-    constexpr Fixed& operator/= (Fixed val) noexcept
+    /// @brief Inequality operator.
+    template<typename BT, unsigned int FB>
+    constexpr bool operator!=(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
-        if (isnan() || val.isnan())
-        {
-            *this = GetNaN();
-        }
-        else if (!isfinite() && !val.isfinite())
-        {
-            *this = GetNaN();
-        }
-        else if (!isfinite())
-        {
-            *this = ((m_value > 0) != (val.m_value > 0))? -GetInfinity(): GetInfinity();
-        }
-        else if (!val.isfinite())
-        {
-            *this = 0;
-        }
-        else
-        {
-            const auto product = wider_type{m_value} * ScaleFactor;
-            const auto result = product / val.m_value;
+        return lhs.Compare(rhs) != Fixed<BT, FB>::CmpResult::Equal;
+    }
 
-            if (product != 0 && result == 0)
-            {
-                // underflow
-                m_value = static_cast<value_type>(result);
-            }
-            else if (result > GetMax().m_value)
-            {
-                // overflow from max
-                m_value = GetInfinity().m_value;
-            }
-            else if (result < GetLowest().m_value)
-            {
-                // overflow from lowest
-                m_value = GetNegativeInfinity().m_value;
-            }
-            else
-            {
-                m_value = static_cast<value_type>(result);
-            }
-        }
-        return *this;
+    /// @brief Less-than operator.
+    template<typename BT, unsigned int FB>
+    constexpr bool operator<(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::LessThan;
+    }
+
+    /// @brief Greater-than operator.
+    template<typename BT, unsigned int FB>
+    constexpr bool operator>(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::GreaterThan;
+    }
+
+    /// @brief Less-than or equal-to operator.
+    template<typename BT, unsigned int FB>
+    constexpr bool operator<=(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return result == Fixed<BT, FB>::CmpResult::LessThan || result == Fixed<BT, FB>::CmpResult::Equal;
+    }
+
+    /// @brief Greater-than or equal-to operator.
+    template<typename BT, unsigned int FB>
+    constexpr bool operator>=(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return result == Fixed<BT, FB>::CmpResult::GreaterThan || result == Fixed<BT, FB>::CmpResult::Equal;
+    }
+
+    /// @brief Addition operator.
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> operator+(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        lhs += rhs;
+        return lhs;
+    }
+
+    /// @brief Subtraction operator.
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> operator-(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        lhs -= rhs;
+        return lhs;
+    }
+
+    /// @brief Multiplication operator.
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> operator*(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        lhs *= rhs;
+        return lhs;
+    }
+
+    /// @brief Division operator.
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> operator/(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
+    {
+        lhs /= rhs;
+        return lhs;
     }
 
     /// @brief Modulo operator.
-    constexpr Fixed& operator%= (Fixed val) noexcept
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> operator%(Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
     {
-        assert(!isnan());
-        assert(!val.isnan());
-
-        m_value %= val.m_value;
-        return *this;
+        lhs %= rhs;
+        return lhs;
     }
 
-    /// @brief Is finite.
-    constexpr bool isfinite() const noexcept
+    /// @brief Gets whether a given value is almost zero.
+    /// @details An almost zero value is "subnormal". Dividing by these values can lead to
+    /// odd results like a divide by zero trap occurring.
+    /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
+    template<typename BT, unsigned int FB>
+    constexpr bool AlmostZero(Fixed<BT, FB> value)
     {
-        return (m_value > GetNegativeInfinity().m_value)
-        && (m_value < GetInfinity().m_value);
+        return value == 0;
     }
 
-    /// @brief Is NaN.
-    constexpr bool isnan() const noexcept
+    /// @brief Determines whether the given two values are "almost equal".
+    template<typename BT, unsigned int FB>
+    constexpr bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
     {
-        return m_value == GetNaN().m_value;
+        return abs(x - y) <= Fixed<BT, FB>{0, static_cast<std::uint32_t>(ulp)};
     }
-
-    /// @brief Gets this value's sign.
-    constexpr int getsign() const noexcept
-    {
-        return (m_value >= 0)? +1: -1;
-    }
-
-private:
-
-    /// @brief Widened type alias.
-    using wider_type = typename Wider<value_type>::type;
-
-    /// @brief Unsigned widened type alias.
-    using unsigned_wider_type = typename std::make_unsigned<wider_type>::type;
-
-    /// @brief Scalar type.
-    struct scalar_type
-    {
-        value_type value = 1; ///< Value.
-    };
-
-    /// @brief Numeric limits type alias.
-    using numeric_limits = std::numeric_limits<value_type>;
-
-    /// @brief Initializing constructor.
-    constexpr Fixed(value_type val, scalar_type scalar) noexcept:
-        m_value{val * scalar.value}
-    {
-        // Intentionally empty.
-    }
-
-    value_type m_value; ///< Value in internal form.
-};
-
-/// @brief Equality operator.
-template <typename BT, unsigned int FB>
-constexpr bool operator== (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::Equal;
-}
-
-/// @brief Inequality operator.
-template <typename BT, unsigned int FB>
-constexpr bool operator!= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    return lhs.Compare(rhs) != Fixed<BT, FB>::CmpResult::Equal;
-}
-
-/// @brief Less-than operator.
-template <typename BT, unsigned int FB>
-constexpr bool operator< (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::LessThan;
-}
-
-/// @brief Greater-than operator.
-template <typename BT, unsigned int FB>
-constexpr bool operator> (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    return lhs.Compare(rhs) == Fixed<BT, FB>::CmpResult::GreaterThan;
-}
-
-/// @brief Less-than or equal-to operator.
-template <typename BT, unsigned int FB>
-constexpr bool operator<= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return result == Fixed<BT, FB>::CmpResult::LessThan ||
-           result == Fixed<BT, FB>::CmpResult::Equal;
-}
-
-/// @brief Greater-than or equal-to operator.
-template <typename BT, unsigned int FB>
-constexpr bool operator>= (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return result == Fixed<BT, FB>::CmpResult::GreaterThan || result == Fixed<BT, FB>::CmpResult::Equal;
-}
-
-/// @brief Addition operator.
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> operator+ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    lhs += rhs;
-    return lhs;
-}
-
-/// @brief Subtraction operator.
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> operator- (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    lhs -= rhs;
-    return lhs;
-}
-
-/// @brief Multiplication operator.
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> operator* (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    lhs *= rhs;
-    return lhs;
-}
-
-/// @brief Division operator.
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> operator/ (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    lhs /= rhs;
-    return lhs;
-}
-
-/// @brief Modulo operator.
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> operator% (Fixed<BT, FB> lhs, Fixed<BT, FB> rhs) noexcept
-{
-    lhs %= rhs;
-    return lhs;
-}
-
-/// @brief Gets whether a given value is almost zero.
-/// @details An almost zero value is "subnormal". Dividing by these values can lead to
-/// odd results like a divide by zero trap occurring.
-/// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
-template <typename BT, unsigned int FB>
-constexpr bool AlmostZero(Fixed<BT, FB> value)
-{
-    return value == 0;
-}
-
-/// @brief Determines whether the given two values are "almost equal".
-template <typename BT, unsigned int FB>
-constexpr bool AlmostEqual(Fixed<BT, FB> x, Fixed<BT, FB> y, int ulp = 2)
-{
-    return abs(x - y) <= Fixed<BT, FB>{0, static_cast<std::uint32_t>(ulp)};
-}
 
 #ifdef CONFLICT_WITH_GETINVALID
-/// @brief Gets an invalid value.
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> GetInvalid() noexcept
-{
-    return Fixed<BT, FB>::GetNaN();
-}
-#endif // CONFLICT_WITH_GETINVALID
+    /// @brief Gets an invalid value.
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> GetInvalid() noexcept
+    {
+        return Fixed<BT, FB>::GetNaN();
+    }
+#endif// CONFLICT_WITH_GETINVALID
 
-/// @brief Output stream operator.
-template <typename BT, unsigned int FB>
-inline ::std::ostream& operator<<(::std::ostream& os, const Fixed<BT, FB>& value)
-{
-    return os << static_cast<double>(value);
-}
+    /// @brief Output stream operator.
+    template<typename BT, unsigned int FB>
+    inline ::std::ostream& operator<<(::std::ostream& os, const Fixed<BT, FB>& value)
+    {
+        return os << static_cast<double>(value);
+    }
 
-/// @brief 32-bit fixed precision type.
-/// @details This is a 32-bit fixed precision type with a Q number-format of
-///   <code>Q23.9</code>.
-///
-/// @warning The available numeric fidelity of any 32-bit fixed point type is very limited.
-///   Using a 32-bit fixed point type for Real should only be considered for simulations
-///   where it's been found to work and where the dynamics won't be changing between runs.
-///
-/// @note Maximum value (with 9 fraction bits) is approximately 4194303.99609375.
-/// @note Minimum value (with 9 fraction bits) is approximately 0.001953125.
-///
-/// @see Fixed, Real
-/// @see https://en.wikipedia.org/wiki/Q_(number_format)
-///
-using Fixed32 = Fixed<std::int32_t,9>;
+    /// @brief 32-bit fixed precision type.
+    /// @details This is a 32-bit fixed precision type with a Q number-format of
+    ///   <code>Q23.9</code>.
+    ///
+    /// @warning The available numeric fidelity of any 32-bit fixed point type is very limited.
+    ///   Using a 32-bit fixed point type for Real should only be considered for simulations
+    ///   where it's been found to work and where the dynamics won't be changing between runs.
+    ///
+    /// @note Maximum value (with 9 fraction bits) is approximately 4194303.99609375.
+    /// @note Minimum value (with 9 fraction bits) is approximately 0.001953125.
+    ///
+    /// @see Fixed, Real
+    /// @see https://en.wikipedia.org/wiki/Q_(number_format)
+    ///
+    using Fixed32 = Fixed<std::int32_t, 9>;
 
-// Fixed32 free functions.
+    // Fixed32 free functions.
 
-/// @brief Gets an invalid value.
-template <>
-constexpr Fixed32 GetInvalid() noexcept
-{
-    return Fixed32::GetNaN();
-}
+    /// @brief Gets an invalid value.
+    template<>
+    constexpr Fixed32 GetInvalid() noexcept
+    {
+        return Fixed32::GetNaN();
+    }
 
-/// @brief Addition operator.
-constexpr Fixed32 operator+ (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    lhs += rhs;
-    return lhs;
-}
+    /// @brief Addition operator.
+    constexpr Fixed32 operator+(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        lhs += rhs;
+        return lhs;
+    }
 
-/// @brief Subtraction operator.
-constexpr Fixed32 operator- (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    lhs -= rhs;
-    return lhs;
-}
+    /// @brief Subtraction operator.
+    constexpr Fixed32 operator-(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        lhs -= rhs;
+        return lhs;
+    }
 
-/// @brief Multiplication operator.
-constexpr Fixed32 operator* (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    lhs *= rhs;
-    return lhs;
-}
+    /// @brief Multiplication operator.
+    constexpr Fixed32 operator*(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        lhs *= rhs;
+        return lhs;
+    }
 
-/// @brief Division operator.
-constexpr Fixed32 operator/ (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    lhs /= rhs;
-    return lhs;
-}
+    /// @brief Division operator.
+    constexpr Fixed32 operator/(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        lhs /= rhs;
+        return lhs;
+    }
 
-/// @brief Modulo operator.
-constexpr Fixed32 operator% (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    lhs %= rhs;
-    return lhs;
-}
+    /// @brief Modulo operator.
+    constexpr Fixed32 operator%(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        lhs %= rhs;
+        return lhs;
+    }
 
-/// @brief Equality operator.
-constexpr bool operator== (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    return lhs.Compare(rhs) == Fixed32::CmpResult::Equal;
-}
+    /// @brief Equality operator.
+    constexpr bool operator==(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        return lhs.Compare(rhs) == Fixed32::CmpResult::Equal;
+    }
 
-/// @brief Inequality operator.
-constexpr bool operator!= (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    return lhs.Compare(rhs) != Fixed32::CmpResult::Equal;
-}
+    /// @brief Inequality operator.
+    constexpr bool operator!=(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        return lhs.Compare(rhs) != Fixed32::CmpResult::Equal;
+    }
 
-/// @brief Less-than or equal-to operator.
-constexpr bool operator <= (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return (result == Fixed32::CmpResult::LessThan) || (result == Fixed32::CmpResult::Equal);
-}
+    /// @brief Less-than or equal-to operator.
+    constexpr bool operator<=(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return (result == Fixed32::CmpResult::LessThan) || (result == Fixed32::CmpResult::Equal);
+    }
 
-/// @brief Greater-than or equal-to operator.
-constexpr bool operator >= (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return (result == Fixed32::CmpResult::GreaterThan) || (result == Fixed32::CmpResult::Equal);
-}
+    /// @brief Greater-than or equal-to operator.
+    constexpr bool operator>=(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return (result == Fixed32::CmpResult::GreaterThan) || (result == Fixed32::CmpResult::Equal);
+    }
 
-/// @brief Less-than operator.
-constexpr bool operator < (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return result == Fixed32::CmpResult::LessThan;
-}
+    /// @brief Less-than operator.
+    constexpr bool operator<(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return result == Fixed32::CmpResult::LessThan;
+    }
 
-/// @brief Greater-than operator.
-constexpr bool operator > (Fixed32 lhs, Fixed32 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return result == Fixed32::CmpResult::GreaterThan;
-}
+    /// @brief Greater-than operator.
+    constexpr bool operator>(Fixed32 lhs, Fixed32 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return result == Fixed32::CmpResult::GreaterThan;
+    }
 
-/// @brief Type info specialization for <code>Fixed32</code>.
-template <>
-struct TypeInfo<Fixed32>
-{
-    /// @brief The specialized name for the <code>Fixed32</code> type.
-    static constexpr const char* name = "Fixed32";
-};
+    /// @brief Type info specialization for <code>Fixed32</code>.
+    template<>
+    struct TypeInfo<Fixed32>
+    {
+        /// @brief The specialized name for the <code>Fixed32</code> type.
+        static constexpr const char* name = "Fixed32";
+    };
 
 #ifdef PLAYRHO_INT128
-// Fixed64 free functions.
+    // Fixed64 free functions.
 
-/// @brief 64-bit fixed precision type.
-/// @details This is a 64-bit fixed precision type with a Q number-format of
-///   <code>Q40.24</code>.
-///
-/// @note Minimum value (with 24 fraction bits) is approximately
-///   <code>5.9604644775390625e-08</code>.
-/// @note Maximum value (with 24 fraction bits) is approximately
-///   <code>549755813888</code>.
-///
-/// @see Fixed, Real
-/// @see https://en.wikipedia.org/wiki/Q_(number_format)
-///
-using Fixed64 = Fixed<std::int64_t,24>;
+    /// @brief 64-bit fixed precision type.
+    /// @details This is a 64-bit fixed precision type with a Q number-format of
+    ///   <code>Q40.24</code>.
+    ///
+    /// @note Minimum value (with 24 fraction bits) is approximately
+    ///   <code>5.9604644775390625e-08</code>.
+    /// @note Maximum value (with 24 fraction bits) is approximately
+    ///   <code>549755813888</code>.
+    ///
+    /// @see Fixed, Real
+    /// @see https://en.wikipedia.org/wiki/Q_(number_format)
+    ///
+    using Fixed64 = Fixed<std::int64_t, 24>;
 
-/// @brief Gets an invalid value.
-template <>
-constexpr Fixed64 GetInvalid() noexcept
-{
-    return Fixed64::GetNaN();
-}
+    /// @brief Gets an invalid value.
+    template<>
+    constexpr Fixed64 GetInvalid() noexcept
+    {
+        return Fixed64::GetNaN();
+    }
 
-/// @brief Addition operator.
-constexpr Fixed64 operator+ (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    lhs += rhs;
-    return lhs;
-}
+    /// @brief Addition operator.
+    constexpr Fixed64 operator+(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        lhs += rhs;
+        return lhs;
+    }
 
-/// @brief Subtraction operator.
-constexpr Fixed64 operator- (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    lhs -= rhs;
-    return lhs;
-}
+    /// @brief Subtraction operator.
+    constexpr Fixed64 operator-(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        lhs -= rhs;
+        return lhs;
+    }
 
-/// @brief Multiplication operator.
-constexpr Fixed64 operator* (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    lhs *= rhs;
-    return lhs;
-}
+    /// @brief Multiplication operator.
+    constexpr Fixed64 operator*(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        lhs *= rhs;
+        return lhs;
+    }
 
-/// @brief Division operator.
-constexpr Fixed64 operator/ (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    lhs /= rhs;
-    return lhs;
-}
+    /// @brief Division operator.
+    constexpr Fixed64 operator/(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        lhs /= rhs;
+        return lhs;
+    }
 
-constexpr Fixed64 operator% (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    lhs %= rhs;
-    return lhs;
-}
+    constexpr Fixed64 operator%(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        lhs %= rhs;
+        return lhs;
+    }
 
-/// @brief Equality operator.
-constexpr bool operator== (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    return lhs.Compare(rhs) == Fixed64::CmpResult::Equal;
-}
+    /// @brief Equality operator.
+    constexpr bool operator==(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        return lhs.Compare(rhs) == Fixed64::CmpResult::Equal;
+    }
 
-/// @brief Inequality operator.
-constexpr bool operator!= (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    return lhs.Compare(rhs) != Fixed64::CmpResult::Equal;
-}
+    /// @brief Inequality operator.
+    constexpr bool operator!=(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        return lhs.Compare(rhs) != Fixed64::CmpResult::Equal;
+    }
 
-constexpr bool operator <= (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return (result == Fixed64::CmpResult::LessThan) || (result == Fixed64::CmpResult::Equal);
-}
+    constexpr bool operator<=(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return (result == Fixed64::CmpResult::LessThan) || (result == Fixed64::CmpResult::Equal);
+    }
 
-constexpr bool operator >= (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return (result == Fixed64::CmpResult::GreaterThan) || (result == Fixed64::CmpResult::Equal);
-}
+    constexpr bool operator>=(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return (result == Fixed64::CmpResult::GreaterThan) || (result == Fixed64::CmpResult::Equal);
+    }
 
-constexpr bool operator < (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return result == Fixed64::CmpResult::LessThan;
-}
+    constexpr bool operator<(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return result == Fixed64::CmpResult::LessThan;
+    }
 
-constexpr bool operator > (Fixed64 lhs, Fixed64 rhs) noexcept
-{
-    const auto result = lhs.Compare(rhs);
-    return result == Fixed64::CmpResult::GreaterThan;
-}
+    constexpr bool operator>(Fixed64 lhs, Fixed64 rhs) noexcept
+    {
+        const auto result = lhs.Compare(rhs);
+        return result == Fixed64::CmpResult::GreaterThan;
+    }
 
-/// @brief Specialization of the Wider trait for the <code>Fixed32</code> type.
-template<> struct Wider<Fixed32> {
-    using type = Fixed64; ///< Wider type.
-};
+    /// @brief Specialization of the Wider trait for the <code>Fixed32</code> type.
+    template<>
+    struct Wider<Fixed32>
+    {
+        using type = Fixed64;///< Wider type.
+    };
 
-/// @brief Type info specialization for <code>Fixed64</code>.
-template <>
-struct TypeInfo<Fixed64>
-{
-    /// @brief The specialized name for the <code>Fixed64</code> type.
-    static constexpr const char* name = "Fixed64";
-};
+    /// @brief Type info specialization for <code>Fixed64</code>.
+    template<>
+    struct TypeInfo<Fixed64>
+    {
+        /// @brief The specialized name for the <code>Fixed64</code> type.
+        static constexpr const char* name = "Fixed64";
+    };
 
 #endif /* PLAYRHO_INT128 */
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_FIXED_HPP
+#endif// PLAYRHO_COMMON_FIXED_HPP

--- a/PlayRho/Common/FixedLimits.hpp
+++ b/PlayRho/Common/FixedLimits.hpp
@@ -23,86 +23,114 @@
 
 #include <PlayRho/Common/Fixed.hpp>
 
-namespace std {
+namespace std
+{
 
     /// @brief Template specialization of numeric limits for Fixed types.
     /// @see https://en.cppreference.com/w/cpp/types/numeric_limits
-    template <typename BT, unsigned int FB>
-    class numeric_limits<playrho::Fixed<BT,FB>>
+    template<typename BT, unsigned int FB>
+    class numeric_limits<playrho::Fixed<BT, FB>>
     {
-    public:
-        static constexpr bool is_specialized = true; ///< Type is specialized.
-        
+     public:
+        static constexpr bool is_specialized = true;///< Type is specialized.
+
         /// @brief Gets the min value available for the type.
-        static constexpr playrho::Fixed<BT,FB> min() noexcept { return playrho::Fixed<BT,FB>::GetMin(); }
-        
+        static constexpr playrho::Fixed<BT, FB> min() noexcept
+        {
+            return playrho::Fixed<BT, FB>::GetMin();
+        }
+
         /// @brief Gets the max value available for the type.
-        static constexpr playrho::Fixed<BT,FB> max() noexcept    { return playrho::Fixed<BT,FB>::GetMax(); }
-        
+        static constexpr playrho::Fixed<BT, FB> max() noexcept
+        {
+            return playrho::Fixed<BT, FB>::GetMax();
+        }
+
         /// @brief Gets the lowest value available for the type.
-        static constexpr playrho::Fixed<BT,FB> lowest() noexcept { return playrho::Fixed<BT,FB>::GetLowest(); }
-        
+        static constexpr playrho::Fixed<BT, FB> lowest() noexcept
+        {
+            return playrho::Fixed<BT, FB>::GetLowest();
+        }
+
         /// @brief Number of radix digits that can be represented.
-        static constexpr int digits = playrho::Fixed<BT,FB>::WholeBits - 1;
-        
+        static constexpr int digits = playrho::Fixed<BT, FB>::WholeBits - 1;
+
         /// @brief Number of decimal digits that can be represented.
-        static constexpr int digits10 = playrho::Fixed<BT,FB>::WholeBits - 1;
-        
+        static constexpr int digits10 = playrho::Fixed<BT, FB>::WholeBits - 1;
+
         /// @brief Number of decimal digits necessary to differentiate all values.
-        static constexpr int max_digits10 = 5; // TODO(lou): check this
-        
-        static constexpr bool is_signed = true; ///< Identifies signed types.
-        static constexpr bool is_integer = false; ///< Identifies integer types.
-        static constexpr bool is_exact = true; ///< Identifies exact type.
-        static constexpr int radix = 0; ///< Radix used by the type.
-        
+        static constexpr int max_digits10 = 5;// TODO(lou): check this
+
+        static constexpr bool is_signed = true;  ///< Identifies signed types.
+        static constexpr bool is_integer = false;///< Identifies integer types.
+        static constexpr bool is_exact = true;   ///< Identifies exact type.
+        static constexpr int radix = 0;          ///< Radix used by the type.
+
         /// @brief Gets the epsilon value for the type.
-        static constexpr playrho::Fixed32 epsilon() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
-        
+        static constexpr playrho::Fixed32 epsilon() noexcept
+        {
+            return playrho::Fixed<BT, FB>{0};
+        }// TODO(lou)
+
         /// @brief Gets the round error value for the type.
-        static constexpr playrho::Fixed32 round_error() noexcept { return playrho::Fixed<BT,FB>{0}; } // TODO(lou)
-        
+        static constexpr playrho::Fixed32 round_error() noexcept
+        {
+            return playrho::Fixed<BT, FB>{0};
+        }// TODO(lou)
+
         /// @brief One more than smallest negative power of the radix that's a valid
         ///    normalized floating-point value.
         static constexpr int min_exponent = 0;
-        
+
         /// @brief Smallest negative power of ten that's a valid normalized floating-point value.
         static constexpr int min_exponent10 = 0;
-        
+
         /// @brief One more than largest integer power of radix that's a valid finite
         ///   floating-point value.
         static constexpr int max_exponent = 0;
-        
+
         /// @brief Largest integer power of 10 that's a valid finite floating-point value.
         static constexpr int max_exponent10 = 0;
-        
-        static constexpr bool has_infinity = true; ///< Whether can represent infinity.
-        static constexpr bool has_quiet_NaN = true; ///< Whether can represent quiet-NaN.
-        static constexpr bool has_signaling_NaN = false; ///< Whether can represent signaling-NaN.
-        static constexpr float_denorm_style has_denorm = denorm_absent; ///< <code>Denorm</code> style used.
-        static constexpr bool has_denorm_loss = false; ///< Has <code>denorm</code> loss amount.
-        
-        /// @brief Gets the infinite value for the type.
-        static constexpr playrho::Fixed<BT,FB> infinity() noexcept { return playrho::Fixed<BT,FB>::GetInfinity(); }
-        
-        /// @brief Gets the quiet NaN value for the type.
-        static constexpr playrho::Fixed<BT,FB> quiet_NaN() noexcept { return playrho::Fixed<BT,FB>::GetNaN(); }
-        
-        /// @brief Gets the signaling NaN value for the type.
-        static constexpr playrho::Fixed<BT,FB> signaling_NaN() noexcept { return playrho::Fixed<BT,FB>{0}; }
-        
-        /// @brief Gets the <code>denorm</code> value for the type.
-        static constexpr playrho::Fixed<BT,FB> denorm_min() noexcept { return playrho::Fixed<BT,FB>{0}; }
-        
-        static constexpr bool is_iec559 = false; ///< @brief Not an IEEE 754 floating-point type.
-        static constexpr bool is_bounded = true; ///< Type bounded: has limited precision.
-        static constexpr bool is_modulo = false; ///< Doesn't modulo arithmetic overflows.
-        
-        static constexpr bool traps = false; ///< Doesn't do traps.
-        static constexpr bool tinyness_before = false; ///< Doesn't detect <code>tinyness</code> before rounding.
-        static constexpr float_round_style round_style = round_toward_zero; ///< Rounds down.
-    };
-    
-} // namespace std
 
-#endif // PLAYRHO_COMMON_FIXEDLIMITS_HPP
+        static constexpr bool has_infinity = true;                     ///< Whether can represent infinity.
+        static constexpr bool has_quiet_NaN = true;                    ///< Whether can represent quiet-NaN.
+        static constexpr bool has_signaling_NaN = false;               ///< Whether can represent signaling-NaN.
+        static constexpr float_denorm_style has_denorm = denorm_absent;///< <code>Denorm</code> style used.
+        static constexpr bool has_denorm_loss = false;                 ///< Has <code>denorm</code> loss amount.
+
+        /// @brief Gets the infinite value for the type.
+        static constexpr playrho::Fixed<BT, FB> infinity() noexcept
+        {
+            return playrho::Fixed<BT, FB>::GetInfinity();
+        }
+
+        /// @brief Gets the quiet NaN value for the type.
+        static constexpr playrho::Fixed<BT, FB> quiet_NaN() noexcept
+        {
+            return playrho::Fixed<BT, FB>::GetNaN();
+        }
+
+        /// @brief Gets the signaling NaN value for the type.
+        static constexpr playrho::Fixed<BT, FB> signaling_NaN() noexcept
+        {
+            return playrho::Fixed<BT, FB>{0};
+        }
+
+        /// @brief Gets the <code>denorm</code> value for the type.
+        static constexpr playrho::Fixed<BT, FB> denorm_min() noexcept
+        {
+            return playrho::Fixed<BT, FB>{0};
+        }
+
+        static constexpr bool is_iec559 = false;///< @brief Not an IEEE 754 floating-point type.
+        static constexpr bool is_bounded = true;///< Type bounded: has limited precision.
+        static constexpr bool is_modulo = false;///< Doesn't modulo arithmetic overflows.
+
+        static constexpr bool traps = false;                               ///< Doesn't do traps.
+        static constexpr bool tinyness_before = false;                     ///< Doesn't detect <code>tinyness</code> before rounding.
+        static constexpr float_round_style round_style = round_toward_zero;///< Rounds down.
+    };
+
+}// namespace std
+
+#endif// PLAYRHO_COMMON_FIXEDLIMITS_HPP

--- a/PlayRho/Common/FixedMath.hpp
+++ b/PlayRho/Common/FixedMath.hpp
@@ -24,561 +24,564 @@
 #include <PlayRho/Common/Fixed.hpp>
 #include <cmath>
 
-namespace playrho {
-
-/// @defgroup FixedMath Math Functions For Fixed Types
-/// @brief Common Mathematical Functions For Fixed Types.
-/// @note These functions directly compute their respective results. They don't convert
-///   their inputs to a floating point type to use the standard math functions and then
-///   convert those results back to the fixed point type. This has pros and cons. Some
-///   pros are that: this won't suffer from the "non-determinism" inherent with different
-///   hardware platforms potentially having different floating point or math library
-///   implementations; this implementation won't suffer any overhead of converting between
-///   the underlying type and a floating point type. On the con side however: this
-///   implementation is unlikely to be anywhere near as tested as standard C++ math library
-///   functions likely are; this implementation is unlikely to have anywhere near as much
-///   performance tuning as standard library functions have had.
-/// @see Fixed
-/// @see https://en.cppreference.com/w/cpp/numeric/math
-/// @{
-
-/// @brief Computes the absolute value.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/fabs
-template <typename BT, unsigned int FB, int N = 5>
-constexpr Fixed<BT, FB> abs(Fixed<BT, FB> arg)
+namespace playrho
 {
-    return arg >= 0? arg: -arg;
-}
 
-/// @brief Computes the value of the given number raised to the given power.
-/// @note This implementation is for raising a given value to an integer power.
-///   This may have significantly different performance than raising a value to a
-///   non-integer power.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/pow
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> pow(Fixed<BT, FB> value, int n)
-{
-    if (!n)
+    /// @defgroup FixedMath Math Functions For Fixed Types
+    /// @brief Common Mathematical Functions For Fixed Types.
+    /// @note These functions directly compute their respective results. They don't convert
+    ///   their inputs to a floating point type to use the standard math functions and then
+    ///   convert those results back to the fixed point type. This has pros and cons. Some
+    ///   pros are that: this won't suffer from the "non-determinism" inherent with different
+    ///   hardware platforms potentially having different floating point or math library
+    ///   implementations; this implementation won't suffer any overhead of converting between
+    ///   the underlying type and a floating point type. On the con side however: this
+    ///   implementation is unlikely to be anywhere near as tested as standard C++ math library
+    ///   functions likely are; this implementation is unlikely to have anywhere near as much
+    ///   performance tuning as standard library functions have had.
+    /// @see Fixed
+    /// @see https://en.cppreference.com/w/cpp/numeric/math
+    /// @{
+
+    /// @brief Computes the absolute value.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/fabs
+    template<typename BT, unsigned int FB, int N = 5>
+    constexpr Fixed<BT, FB> abs(Fixed<BT, FB> arg)
     {
-        return Fixed<BT, FB>{1};
+        return arg >= 0 ? arg : -arg;
     }
-    if (value == 0)
+
+    /// @brief Computes the value of the given number raised to the given power.
+    /// @note This implementation is for raising a given value to an integer power.
+    ///   This may have significantly different performance than raising a value to a
+    ///   non-integer power.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/pow
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> pow(Fixed<BT, FB> value, int n)
     {
-        if (n > 0)
+        if (!n)
         {
+            return Fixed<BT, FB>{1};
+        }
+        if (value == 0)
+        {
+            if (n > 0)
+            {
+                return Fixed<BT, FB>{0};
+            }
+            return Fixed<BT, FB>::GetInfinity();
+        }
+        if (value == 1)
+        {
+            return Fixed<BT, FB>{1};
+        }
+        if (value == Fixed<BT, FB>::GetNegativeInfinity())
+        {
+            if (n > 0)
+            {
+                if (n % 2 == 0)
+                {
+                    return Fixed<BT, FB>::GetInfinity();
+                }
+                return Fixed<BT, FB>::GetNegativeInfinity();
+            }
             return Fixed<BT, FB>{0};
         }
-        return Fixed<BT, FB>::GetInfinity();
-    }
-    if (value == 1)
-    {
-        return Fixed<BT, FB>{1};
-    }
-    if (value == Fixed<BT, FB>::GetNegativeInfinity())
-    {
-        if (n > 0)
+        if (value == Fixed<BT, FB>::GetInfinity())
         {
-            if (n % 2 == 0)
+            return (n < 0) ? Fixed<BT, FB>{0} : Fixed<BT, FB>::GetInfinity();
+        }
+
+        const auto doReciprocal = (n < 0);
+        if (doReciprocal)
+        {
+            n = -n;
+        }
+
+        auto res = value;
+        for (; n > 1; --n)
+        {
+            res *= value;
+        }
+
+        return (doReciprocal) ? 1 / res : res;
+    }
+
+    namespace detail
+    {
+
+        /// @brief Fixed point pi value.
+        template<typename BT, unsigned int FB>
+        constexpr auto FixedPi = Fixed<BT, FB>{3.14159265358979323846264338327950288};
+
+        /// @brief Computes the factorial.
+        constexpr auto factorial(std::int64_t n)
+        {
+            // n! = n·(n – 1)·(n – 2) · · · 3·2·1
+            auto res = n;
+            for (--n; n > 1; --n)
+            {
+                res *= n;
+            }
+            return res;
+        }
+
+        /// @brief Computes Euler's number raised to the given power argument.
+        /// @note Uses Maclaurin series approximation.
+        /// @see https://en.cppreference.com/w/cpp/numeric/math/exp
+        /// @see https://en.wikipedia.org/wiki/Taylor_series
+        /// @see https://en.wikipedia.org/wiki/Exponentiation
+        /// @see https://en.wikipedia.org/wiki/Exponential_function
+        template<typename BT, unsigned int FB, int N = 6>
+        constexpr Fixed<BT, FB> exp(Fixed<BT, FB> arg)
+        {
+            const auto doReciprocal = (arg < 0);
+            if (doReciprocal)
+            {
+                arg = -arg;
+            }
+
+            // Maclaurin series approximation...
+            // e^x = sum(x^n/n!) for n =0 to infinity.
+            // e^x = 1 + x + x^2/2! + x^3/3! + ...
+            // Note: e^(x+y) = e^x * e^y.
+            // Note: convergence is slower for arg > 2 and overflow happens by i == 9
+            auto pt = arg;
+            auto res = pt + 1;
+            auto ft = 1;
+            auto last = pt / ft;
+            for (auto i = 2; i < N; ++i)
+            {
+                // have to avoid unnecessarily overflowing...
+                last /= i;
+                last *= arg;
+                res += last;
+            }
+            return doReciprocal ? 1 / res : res;
+        }
+
+        /// @brief Computes the natural logarithm.
+        /// @note A better method may be explained in https://math.stackexchange.com/a/61236/408405
+        /// @see https://en.cppreference.com/w/cpp/numeric/math/log
+        /// @see https://en.wikipedia.org/wiki/Natural_logarithm
+        template<typename BT, unsigned int FB, int N = 6>
+        Fixed<BT, FB> log(Fixed<BT, FB> arg)
+        {
+            if (arg.isnan() || (arg < 0))
+            {
+                return Fixed<BT, FB>::GetNaN();
+            }
+            if (arg == 0)
+            {
+                return Fixed<BT, FB>::GetNegativeInfinity();
+            }
+            if (arg == 1)
+            {
+                return Fixed<BT, FB>{0};
+            }
+            if (arg == Fixed<BT, FB>::GetInfinity())
             {
                 return Fixed<BT, FB>::GetInfinity();
             }
-            return Fixed<BT, FB>::GetNegativeInfinity();
+            if (arg <= 2)
+            {
+                // ln(x) = sum((-1)^(n + 1) * (x - 1)^n / n) from n = 1 to infinity
+                // ln(x) = (x - 1) - (x - 1)^2/2 + (x - 1)^3/3 - (x - 1)^4/4 ....
+                arg -= 1;
+                auto res = arg;
+                auto sign = -1;
+                auto pt = arg;
+                for (auto i = 2; i < N; ++i)
+                {
+                    pt *= arg;
+                    res += sign * pt / i;
+                    sign = -sign;
+                }
+                return res;
+            }
+
+            // The following algorithm isn't as accurate as desired.
+            // Is there a better one?
+            // ln(x) = ((x - 1) / x) + ((x - 1) / x)^2/2 + ((x - 1) / x)^3/3 + ...
+            arg = (arg - 1) / arg;
+            auto pt = arg;
+            auto res = pt;
+            for (auto i = 2; i < N; ++i)
+            {
+                pt *= arg;
+                res += pt / i;
+            }
+            return res;
         }
-        return Fixed<BT, FB>{0};
-    }
-    if (value == Fixed<BT, FB>::GetInfinity())
-    {
-        return (n < 0)? Fixed<BT, FB>{0}: Fixed<BT, FB>::GetInfinity();
-    }
-    
-    const auto doReciprocal = (n < 0);
-    if (doReciprocal)
-    {
-        n = -n;
-    }
-    
-    auto res = value;
-    for (; n > 1; --n)
-    {
-        res *= value;
-    }
-    
-    return (doReciprocal)? 1 / res: res;
-}
 
-namespace detail {
-
-/// @brief Fixed point pi value.
-template <typename BT, unsigned int FB>
-constexpr auto FixedPi = Fixed<BT, FB>{3.14159265358979323846264338327950288};
-
-/// @brief Computes the factorial.
-constexpr auto factorial(std::int64_t n)
-{
-    // n! = n·(n – 1)·(n – 2) · · · 3·2·1
-    auto res = n;
-    for (--n; n > 1; --n)
-    {
-        res *= n;
-    }
-    return res;
-}
-
-/// @brief Computes Euler's number raised to the given power argument.
-/// @note Uses Maclaurin series approximation.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/exp
-/// @see https://en.wikipedia.org/wiki/Taylor_series
-/// @see https://en.wikipedia.org/wiki/Exponentiation
-/// @see https://en.wikipedia.org/wiki/Exponential_function
-template <typename BT, unsigned int FB, int N = 6>
-constexpr Fixed<BT, FB> exp(Fixed<BT, FB> arg)
-{
-    const auto doReciprocal = (arg < 0);
-    if (doReciprocal)
-    {
-        arg = -arg;
-    }
-
-    // Maclaurin series approximation...
-    // e^x = sum(x^n/n!) for n =0 to infinity.
-    // e^x = 1 + x + x^2/2! + x^3/3! + ...
-    // Note: e^(x+y) = e^x * e^y.
-    // Note: convergence is slower for arg > 2 and overflow happens by i == 9
-    auto pt = arg;
-    auto res = pt + 1;
-    auto ft = 1;
-    auto last = pt / ft;
-    for (auto i = 2; i < N; ++i)
-    {
-        // have to avoid unnecessarily overflowing...
-        last /= i;
-        last *= arg;
-        res += last;
-    }
-    return doReciprocal? 1 / res: res;
-}
-
-/// @brief Computes the natural logarithm.
-/// @note A better method may be explained in https://math.stackexchange.com/a/61236/408405
-/// @see https://en.cppreference.com/w/cpp/numeric/math/log
-/// @see https://en.wikipedia.org/wiki/Natural_logarithm
-template <typename BT, unsigned int FB, int N = 6>
-Fixed<BT, FB> log(Fixed<BT, FB> arg)
-{
-    if (arg.isnan() || (arg < 0))
-    {
-        return Fixed<BT, FB>::GetNaN();
-    }
-    if (arg == 0)
-    {
-        return Fixed<BT, FB>::GetNegativeInfinity();
-    }
-    if (arg == 1)
-    {
-        return Fixed<BT, FB>{0};
-    }
-    if (arg == Fixed<BT, FB>::GetInfinity())
-    {
-        return Fixed<BT, FB>::GetInfinity();
-    }
-    if (arg <= 2)
-    {
-        // ln(x) = sum((-1)^(n + 1) * (x - 1)^n / n) from n = 1 to infinity
-        // ln(x) = (x - 1) - (x - 1)^2/2 + (x - 1)^3/3 - (x - 1)^4/4 ....
-        arg -= 1;
-        auto res = arg;
-        auto sign = -1;
-        auto pt = arg;
-        for (auto i = 2; i < N; ++i)
+        /// @brief Computes the sine of the given argument via Maclaurin series approximation.
+        /// @see https://en.wikipedia.org/wiki/Taylor_series
+        template<typename BT, unsigned int FB, int N = 5>
+        constexpr Fixed<BT, FB> sin(Fixed<BT, FB> arg)
         {
-            pt *= arg;
-            res += sign * pt / i;
-            sign = -sign;
+            // Maclaurin series approximation...
+            // sin x = sum((-1^n)*(x^(2n+1))/(2n+1)!)
+            // sin(2) = 0.90929742682
+            // x - x^3/6 + x^5/120 - x^7/5040 + x^9/
+            // 2 - 8/6 = 0.666
+            // 2 - 8/6 + 32/120 = 0.9333
+            // 2 - 8/6 + 32/120 - 128/5040 = 0.90793650793
+            // 2 - 8/6 + 32/120 - 128/5040 + 512/362880 = 0.90934744268
+            auto res = arg;
+            auto sgn = -1;
+            constexpr auto last = 2 * N + 1;
+            auto pt = arg;
+            auto ft = 1;
+            for (auto i = 3; i <= last; i += 2)
+            {
+                ft *= (i - 1) * i;
+                pt *= arg * arg;
+                const auto term = pt / ft;
+                res += sgn * term;
+                sgn = -sgn;
+            }
+            return res;
         }
-        return res;
-    }
-    
-    // The following algorithm isn't as accurate as desired.
-    // Is there a better one?
-    // ln(x) = ((x - 1) / x) + ((x - 1) / x)^2/2 + ((x - 1) / x)^3/3 + ...
-    arg = (arg - 1) / arg;
-    auto pt = arg;
-    auto res = pt;
-    for (auto i = 2; i < N; ++i)
-    {
-        pt *= arg;
-        res += pt / i;
-    }
-    return res;
-}
 
-/// @brief Computes the sine of the given argument via Maclaurin series approximation.
-/// @see https://en.wikipedia.org/wiki/Taylor_series
-template <typename BT, unsigned int FB, int N = 5>
-constexpr Fixed<BT, FB> sin(Fixed<BT, FB> arg)
-{
-    // Maclaurin series approximation...
-    // sin x = sum((-1^n)*(x^(2n+1))/(2n+1)!)
-    // sin(2) = 0.90929742682
-    // x - x^3/6 + x^5/120 - x^7/5040 + x^9/
-    // 2 - 8/6 = 0.666
-    // 2 - 8/6 + 32/120 = 0.9333
-    // 2 - 8/6 + 32/120 - 128/5040 = 0.90793650793
-    // 2 - 8/6 + 32/120 - 128/5040 + 512/362880 = 0.90934744268
-    auto res = arg;
-    auto sgn = -1;
-    constexpr auto last = 2 * N + 1;
-    auto pt = arg;
-    auto ft = 1;
-    for (auto i = 3; i <= last; i += 2)
-    {
-        ft *= (i - 1) * i;
-        pt *= arg * arg;
-        const auto term = pt / ft;
-        res += sgn * term;
-        sgn = -sgn;
-    }
-    return res;
-}
-
-/// @brief Computes the cosine of the given argument via Maclaurin series approximation.
-/// @see https://en.wikipedia.org/wiki/Taylor_series
-template <typename BT, unsigned int FB, int N = 5>
-constexpr Fixed<BT, FB> cos(Fixed<BT, FB> arg)
-{
-    // Maclaurin series approximation...
-    // cos x = sum((-1^n)*(x^(2n))/(2n)!)
-    // cos(2) = -0.41614683654
-    // 1 - 2^2/2 = -1
-    // 1 - 2^2/2 + 2^4/24 = -0.3333
-    // 1 - 2^2/2 + 2^4/24 - 2^6/720 = -0.422
-    auto res = Fixed<BT, FB>{1};
-    auto sgn = -1;
-    constexpr auto last = 2 * N;
-    auto ft = 1;
-    auto pt = Fixed<BT, FB>{1};
-    for (auto i = 2; i <= last; i += 2)
-    {
-        ft *= (i - 1) * i;
-        pt *= arg * arg;
-        const auto term = pt / ft;
-        res += sgn * term;
-        sgn = -sgn;
-    }
-    return res;
-}
-
-/// @brief Computes the arctangent of the given argument via Maclaurin series approximation.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/atan
-/// @see https://en.wikipedia.org/wiki/Taylor_series
-template <typename BT, unsigned int FB, int N = 5>
-constexpr Fixed<BT, FB> atan(Fixed<BT, FB> arg)
-{
-    // Note: if (x > 0) then arctan(x) ==  Pi/2 - arctan(1/x)
-    //       if (x < 0) then arctan(x) == -Pi/2 - arctan(1/x).
-    const auto doReciprocal = (abs(arg) > 1);
-    if (doReciprocal)
-    {
-        arg = 1 / arg;
-    }
-
-    // Maclaurin series approximation...
-    // For |arg| <= 1, arg != +/- i
-    // If |arg| > 1 the result is too wrong which is why the reciprocal is done then.
-    auto res = arg;
-    auto sgn = -1;
-    const auto last = 2 * N + 1;
-    auto pt = arg;
-    for (auto i = 3; i <= last; i += 2)
-    {
-        pt *= arg * arg;
-        const auto term = pt / i;
-        res += sgn * term;
-        sgn = -sgn;
-    }
-    
-    if (doReciprocal)
-    {
-        return (arg > 0)? FixedPi<BT, FB> / 2 - res: -FixedPi<BT, FB> / 2 - res;
-    }
-    return res;
-}
-
-/// @brief Computes the square root of a non-negative value.
-/// @see https://en.wikipedia.org/wiki/Methods_of_computing_square_roots
-template <typename BT, unsigned int FB>
-constexpr auto ComputeSqrt(Fixed<BT, FB> arg)
-{
-    auto temp = Fixed<BT, FB>{1};
-    auto tempSquared = Square(temp);
-    const auto greaterThanOne = arg > 1;
-    auto lower = greaterThanOne? Fixed<BT, FB>{1}: arg;
-    auto upper = greaterThanOne? arg: Fixed<BT, FB>{1};
-    while (arg != tempSquared)
-    {
-        const auto mid = (lower + upper) / 2;
-        if (temp == mid)
+        /// @brief Computes the cosine of the given argument via Maclaurin series approximation.
+        /// @see https://en.wikipedia.org/wiki/Taylor_series
+        template<typename BT, unsigned int FB, int N = 5>
+        constexpr Fixed<BT, FB> cos(Fixed<BT, FB> arg)
         {
-            break;
+            // Maclaurin series approximation...
+            // cos x = sum((-1^n)*(x^(2n))/(2n)!)
+            // cos(2) = -0.41614683654
+            // 1 - 2^2/2 = -1
+            // 1 - 2^2/2 + 2^4/24 = -0.3333
+            // 1 - 2^2/2 + 2^4/24 - 2^6/720 = -0.422
+            auto res = Fixed<BT, FB>{1};
+            auto sgn = -1;
+            constexpr auto last = 2 * N;
+            auto ft = 1;
+            auto pt = Fixed<BT, FB>{1};
+            for (auto i = 2; i <= last; i += 2)
+            {
+                ft *= (i - 1) * i;
+                pt *= arg * arg;
+                const auto term = pt / ft;
+                res += sgn * term;
+                sgn = -sgn;
+            }
+            return res;
         }
-        temp = mid;
-        tempSquared = Square(temp);
-        if (tempSquared > arg)
+
+        /// @brief Computes the arctangent of the given argument via Maclaurin series approximation.
+        /// @see https://en.cppreference.com/w/cpp/numeric/math/atan
+        /// @see https://en.wikipedia.org/wiki/Taylor_series
+        template<typename BT, unsigned int FB, int N = 5>
+        constexpr Fixed<BT, FB> atan(Fixed<BT, FB> arg)
         {
-            upper = temp;
+            // Note: if (x > 0) then arctan(x) ==  Pi/2 - arctan(1/x)
+            //       if (x < 0) then arctan(x) == -Pi/2 - arctan(1/x).
+            const auto doReciprocal = (abs(arg) > 1);
+            if (doReciprocal)
+            {
+                arg = 1 / arg;
+            }
+
+            // Maclaurin series approximation...
+            // For |arg| <= 1, arg != +/- i
+            // If |arg| > 1 the result is too wrong which is why the reciprocal is done then.
+            auto res = arg;
+            auto sgn = -1;
+            const auto last = 2 * N + 1;
+            auto pt = arg;
+            for (auto i = 3; i <= last; i += 2)
+            {
+                pt *= arg * arg;
+                const auto term = pt / i;
+                res += sgn * term;
+                sgn = -sgn;
+            }
+
+            if (doReciprocal)
+            {
+                return (arg > 0) ? FixedPi<BT, FB> / 2 - res : -FixedPi<BT, FB> / 2 - res;
+            }
+            return res;
         }
-        else if (tempSquared < arg)
+
+        /// @brief Computes the square root of a non-negative value.
+        /// @see https://en.wikipedia.org/wiki/Methods_of_computing_square_roots
+        template<typename BT, unsigned int FB>
+        constexpr auto ComputeSqrt(Fixed<BT, FB> arg)
         {
-            lower = temp;
+            auto temp = Fixed<BT, FB>{1};
+            auto tempSquared = Square(temp);
+            const auto greaterThanOne = arg > 1;
+            auto lower = greaterThanOne ? Fixed<BT, FB>{1} : arg;
+            auto upper = greaterThanOne ? arg : Fixed<BT, FB>{1};
+            while (arg != tempSquared)
+            {
+                const auto mid = (lower + upper) / 2;
+                if (temp == mid)
+                {
+                    break;
+                }
+                temp = mid;
+                tempSquared = Square(temp);
+                if (tempSquared > arg)
+                {
+                    upper = temp;
+                }
+                else if (tempSquared < arg)
+                {
+                    lower = temp;
+                }
+            }
+            return temp;
         }
-    }
-    return temp;
-}
 
-} // namespace detail
+    }// namespace detail
 
-/// @brief Truncates the given value.
-/// @see https://en.cppreference.com/w/c/numeric/math/trunc
-template <typename BT, unsigned int FB>
-constexpr Fixed<BT, FB> trunc(Fixed<BT, FB> arg)
-{
-    return static_cast<Fixed<BT, FB>>(static_cast<long long>(arg));
-}
-
-/// @brief Next after function for Fixed types.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/nextafter
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> nextafter(Fixed<BT, FB> from, Fixed<BT, FB> to) noexcept
-{
-    if (from < to)
+    /// @brief Truncates the given value.
+    /// @see https://en.cppreference.com/w/c/numeric/math/trunc
+    template<typename BT, unsigned int FB>
+    constexpr Fixed<BT, FB> trunc(Fixed<BT, FB> arg)
     {
-        return static_cast<Fixed<BT, FB>>(from + Fixed<BT,FB>::GetMin());
+        return static_cast<Fixed<BT, FB>>(static_cast<long long>(arg));
     }
-    if (from > to)
+
+    /// @brief Next after function for Fixed types.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/nextafter
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> nextafter(Fixed<BT, FB> from, Fixed<BT, FB> to) noexcept
     {
-        return static_cast<Fixed<BT, FB>>(from - Fixed<BT,FB>::GetMin());
-    }
-    return static_cast<Fixed<BT, FB>>(to);
-}
-
-/// @brief Computes the remainder of the division of the given dividend by the given divisor.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/fmod
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> fmod(Fixed<BT, FB> dividend, Fixed<BT, FB> divisor) noexcept
-{
-    const auto quotient = dividend / divisor;
-    const auto integer = trunc(quotient);
-    const auto remainder = quotient - integer;
-    return remainder * divisor;
-}
-
-/// @brief Square root's the given value.
-/// @note This implementation isn't meant to be fast, only correct enough.
-/// @note The IEEE standard (presumably IEC 60559), requires <code>std::sqrt</code> to be exact
-///   to within half of a ULP for floating-point types (float, double). That sets a precedence
-///   that puts a high expectation on this implementation for fixed-point types.
-/// @note "Domain error" occurs if <code>arg</code> is less than zero.
-/// @return Mathematical square root value of the given value or the <code>NaN</code> value.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/sqrt
-template <typename BT, unsigned int FB>
-inline auto sqrt(Fixed<BT, FB> arg)
-{
-    if ((arg == Fixed<BT, FB>{1}) || (arg == Fixed<BT, FB>{0}))
-    {
-        return arg;
-    }
-    if (arg > Fixed<BT, FB>{0})
-    {
-        return detail::ComputeSqrt(arg);
-    }
-    // else arg < 0 or NaN...
-    return Fixed<BT, FB>::GetNaN();
-}
-
-/// @brief Gets whether the given value is normal - i.e. not 0 nor infinite.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/isnormal
-template <typename BT, unsigned int FB>
-inline bool isnormal(Fixed<BT, FB> arg)
-{
-    return arg != Fixed<BT, FB>{0} && arg.isfinite();
-}
-
-namespace detail {
-
-/// @brief Normalizes the given angular argument.
-template <typename BT, unsigned int FB>
-inline auto AngularNormalize(Fixed<BT, FB> angleInRadians)
-{
-    constexpr auto oneRotationInRadians = 2 * FixedPi<BT, FB>;
-
-    angleInRadians = fmod(angleInRadians, oneRotationInRadians);
-    if (angleInRadians > FixedPi<BT, FB>)
-    {
-        // 190_deg becomes 190_deg - 360_deg = -170_deg
-        angleInRadians -= oneRotationInRadians;
-    }
-    else if (angleInRadians < -FixedPi<BT, FB>)
-    {
-        // -200_deg becomes -200_deg + 360_deg = 100_deg
-        angleInRadians += oneRotationInRadians;
-    }
-    return angleInRadians;
-}
-
-} // namespace detail
-
-/// @brief Computes the sine of the argument for Fixed types.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/sin
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> sin(Fixed<BT, FB> arg)
-{
-    arg = detail::AngularNormalize(arg);
-    return detail::sin<BT, FB, 5>(arg);
-}
-
-/// @brief Computes the cosine of the argument for Fixed types.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/cos
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> cos(Fixed<BT, FB> arg)
-{
-    arg = detail::AngularNormalize(arg);
-    return detail::cos<BT, FB, 5>(arg);
-}
-
-/// @brief Computes the arc tangent.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/atan
-/// @return Value between <code>-Pi / 2</code> and <code>Pi / 2</code>.
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> atan(Fixed<BT, FB> arg)
-{
-    if (arg.isnan() || (arg == 0))
-    {
-        return arg;
-    }
-    if (arg == Fixed<BT, FB>::GetInfinity())
-    {
-        return detail::FixedPi<BT, FB> / 2;
-    }
-    if (arg == Fixed<BT, FB>::GetNegativeInfinity())
-    {
-        return -detail::FixedPi<BT, FB> / 2;
-    }
-    return detail::atan<BT, FB, 5>(arg);
-}
-
-/// @brief Computes the multi-valued inverse tangent.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/atan2
-/// @return Value between <code>-Pi</code> and <code>+Pi</code> inclusive.
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> atan2(Fixed<BT, FB> y, Fixed<BT, FB> x)
-{
-    // See https://en.wikipedia.org/wiki/Atan2
-    // See https://en.wikipedia.org/wiki/Taylor_series
-    if (x > 0)
-    {
-        return atan(y / x);
-    }
-    if (x < 0)
-    {
-        return atan(y / x) + ((y >= 0)? +1: -1) * detail::FixedPi<BT, FB>;
-    }
-    if (y > 0)
-    {
-        return +detail::FixedPi<BT, FB> / 2;
-    }
-    if (y < 0)
-    {
-        return -detail::FixedPi<BT, FB> / 2;
-    }
-    return Fixed<BT, FB>::GetNaN();
-}
-
-/// @brief Computes the natural logarithm of the given argument.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/log
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> log(Fixed<BT, FB> arg)
-{
-    return (arg < 8)? detail::log<BT, FB, 36>(arg): detail::log<BT, FB, 96>(arg);
-}
-
-/// @brief Computes the Euler number raised to the power of the given argument.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/exp
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> exp(Fixed<BT, FB> arg)
-{
-    return (arg <= 2)? detail::exp<BT, FB, 6>(arg): detail::exp<BT, FB, 24>(arg);
-}
-
-/// @brief Computes the value of the base number raised to the power of the exponent.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/pow
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> pow(Fixed<BT, FB> base, Fixed<BT, FB> exponent)
-{
-    if (exponent.isfinite())
-    {
-        const auto intExp = static_cast<int>(exponent);
-        if (intExp == exponent)
+        if (from < to)
         {
-            // fall back to integer version...
-            return pow(base, intExp);
+            return static_cast<Fixed<BT, FB>>(from + Fixed<BT, FB>::GetMin());
         }
+        if (from > to)
+        {
+            return static_cast<Fixed<BT, FB>>(from - Fixed<BT, FB>::GetMin());
+        }
+        return static_cast<Fixed<BT, FB>>(to);
     }
-    
-    if (base < 0)
+
+    /// @brief Computes the remainder of the division of the given dividend by the given divisor.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/fmod
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> fmod(Fixed<BT, FB> dividend, Fixed<BT, FB> divisor) noexcept
     {
+        const auto quotient = dividend / divisor;
+        const auto integer = trunc(quotient);
+        const auto remainder = quotient - integer;
+        return remainder * divisor;
+    }
+
+    /// @brief Square root's the given value.
+    /// @note This implementation isn't meant to be fast, only correct enough.
+    /// @note The IEEE standard (presumably IEC 60559), requires <code>std::sqrt</code> to be exact
+    ///   to within half of a ULP for floating-point types (float, double). That sets a precedence
+    ///   that puts a high expectation on this implementation for fixed-point types.
+    /// @note "Domain error" occurs if <code>arg</code> is less than zero.
+    /// @return Mathematical square root value of the given value or the <code>NaN</code> value.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/sqrt
+    template<typename BT, unsigned int FB>
+    inline auto sqrt(Fixed<BT, FB> arg)
+    {
+        if ((arg == Fixed<BT, FB>{1}) || (arg == Fixed<BT, FB>{0}))
+        {
+            return arg;
+        }
+        if (arg > Fixed<BT, FB>{0})
+        {
+            return detail::ComputeSqrt(arg);
+        }
+        // else arg < 0 or NaN...
         return Fixed<BT, FB>::GetNaN();
     }
 
-    const auto lnResult = log(base);
-    const auto expResult = exp(lnResult * exponent);
-    return expResult;
-}
+    /// @brief Gets whether the given value is normal - i.e. not 0 nor infinite.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/isnormal
+    template<typename BT, unsigned int FB>
+    inline bool isnormal(Fixed<BT, FB> arg)
+    {
+        return arg != Fixed<BT, FB>{0} && arg.isfinite();
+    }
 
-/// @brief Computes the square root of the sum of the squares.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/hypot
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> hypot(Fixed<BT, FB> x, Fixed<BT, FB> y)
-{
-    return sqrt(x * x + y * y);
-}
+    namespace detail
+    {
 
-/// @brief Rounds the given value.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/round
-template <typename BT, unsigned int FB>
-inline Fixed<BT, FB> round(Fixed<BT, FB> value) noexcept
-{
-    const auto tmp = value + (Fixed<BT, FB>{1} / Fixed<BT, FB>{2});
-    const auto truncated = static_cast<typename Fixed<BT, FB>::value_type>(tmp);
-    return Fixed<BT, FB>{truncated, 0};
-}
+        /// @brief Normalizes the given angular argument.
+        template<typename BT, unsigned int FB>
+        inline auto AngularNormalize(Fixed<BT, FB> angleInRadians)
+        {
+            constexpr auto oneRotationInRadians = 2 * FixedPi<BT, FB>;
 
-/// @brief Determines whether the given value is negative.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/signbit
-template <typename BT, unsigned int FB>
-inline bool signbit(Fixed<BT, FB> value) noexcept
-{
-    return value.getsign() < 0;
-}
+            angleInRadians = fmod(angleInRadians, oneRotationInRadians);
+            if (angleInRadians > FixedPi<BT, FB>)
+            {
+                // 190_deg becomes 190_deg - 360_deg = -170_deg
+                angleInRadians -= oneRotationInRadians;
+            }
+            else if (angleInRadians < -FixedPi<BT, FB>)
+            {
+                // -200_deg becomes -200_deg + 360_deg = 100_deg
+                angleInRadians += oneRotationInRadians;
+            }
+            return angleInRadians;
+        }
 
-/// @brief Gets whether the given value is not-a-number.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/isnan
-template <typename BT, unsigned int FB>
-constexpr bool isnan(Fixed<BT, FB> value) noexcept
-{
-    return value.Compare(0) == Fixed<BT, FB>::CmpResult::Incomparable;
-}
+    }// namespace detail
 
-/// @brief Gets whether the given value is finite.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/isfinite
-template <typename BT, unsigned int FB>
-inline bool isfinite(Fixed<BT, FB> value) noexcept
-{
-    return (value > Fixed<BT, FB>::GetNegativeInfinity())
-    && (value < Fixed<BT, FB>::GetInfinity());
-}
+    /// @brief Computes the sine of the argument for Fixed types.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/sin
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> sin(Fixed<BT, FB> arg)
+    {
+        arg = detail::AngularNormalize(arg);
+        return detail::sin<BT, FB, 5>(arg);
+    }
 
-/// @}
+    /// @brief Computes the cosine of the argument for Fixed types.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/cos
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> cos(Fixed<BT, FB> arg)
+    {
+        arg = detail::AngularNormalize(arg);
+        return detail::cos<BT, FB, 5>(arg);
+    }
 
-} // namespace playrho
+    /// @brief Computes the arc tangent.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/atan
+    /// @return Value between <code>-Pi / 2</code> and <code>Pi / 2</code>.
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> atan(Fixed<BT, FB> arg)
+    {
+        if (arg.isnan() || (arg == 0))
+        {
+            return arg;
+        }
+        if (arg == Fixed<BT, FB>::GetInfinity())
+        {
+            return detail::FixedPi<BT, FB> / 2;
+        }
+        if (arg == Fixed<BT, FB>::GetNegativeInfinity())
+        {
+            return -detail::FixedPi<BT, FB> / 2;
+        }
+        return detail::atan<BT, FB, 5>(arg);
+    }
 
-#endif // PLAYRHO_COMMON_FIXEDMATH_HPP
+    /// @brief Computes the multi-valued inverse tangent.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/atan2
+    /// @return Value between <code>-Pi</code> and <code>+Pi</code> inclusive.
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> atan2(Fixed<BT, FB> y, Fixed<BT, FB> x)
+    {
+        // See https://en.wikipedia.org/wiki/Atan2
+        // See https://en.wikipedia.org/wiki/Taylor_series
+        if (x > 0)
+        {
+            return atan(y / x);
+        }
+        if (x < 0)
+        {
+            return atan(y / x) + ((y >= 0) ? +1 : -1) * detail::FixedPi<BT, FB>;
+        }
+        if (y > 0)
+        {
+            return +detail::FixedPi<BT, FB> / 2;
+        }
+        if (y < 0)
+        {
+            return -detail::FixedPi<BT, FB> / 2;
+        }
+        return Fixed<BT, FB>::GetNaN();
+    }
+
+    /// @brief Computes the natural logarithm of the given argument.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/log
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> log(Fixed<BT, FB> arg)
+    {
+        return (arg < 8) ? detail::log<BT, FB, 36>(arg) : detail::log<BT, FB, 96>(arg);
+    }
+
+    /// @brief Computes the Euler number raised to the power of the given argument.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/exp
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> exp(Fixed<BT, FB> arg)
+    {
+        return (arg <= 2) ? detail::exp<BT, FB, 6>(arg) : detail::exp<BT, FB, 24>(arg);
+    }
+
+    /// @brief Computes the value of the base number raised to the power of the exponent.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/pow
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> pow(Fixed<BT, FB> base, Fixed<BT, FB> exponent)
+    {
+        if (exponent.isfinite())
+        {
+            const auto intExp = static_cast<int>(exponent);
+            if (intExp == exponent)
+            {
+                // fall back to integer version...
+                return pow(base, intExp);
+            }
+        }
+
+        if (base < 0)
+        {
+            return Fixed<BT, FB>::GetNaN();
+        }
+
+        const auto lnResult = log(base);
+        const auto expResult = exp(lnResult * exponent);
+        return expResult;
+    }
+
+    /// @brief Computes the square root of the sum of the squares.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/hypot
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> hypot(Fixed<BT, FB> x, Fixed<BT, FB> y)
+    {
+        return sqrt(x * x + y * y);
+    }
+
+    /// @brief Rounds the given value.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/round
+    template<typename BT, unsigned int FB>
+    inline Fixed<BT, FB> round(Fixed<BT, FB> value) noexcept
+    {
+        const auto tmp = value + (Fixed<BT, FB>{1} / Fixed<BT, FB>{2});
+        const auto truncated = static_cast<typename Fixed<BT, FB>::value_type>(tmp);
+        return Fixed<BT, FB>{truncated, 0};
+    }
+
+    /// @brief Determines whether the given value is negative.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/signbit
+    template<typename BT, unsigned int FB>
+    inline bool signbit(Fixed<BT, FB> value) noexcept
+    {
+        return value.getsign() < 0;
+    }
+
+    /// @brief Gets whether the given value is not-a-number.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/isnan
+    template<typename BT, unsigned int FB>
+    constexpr bool isnan(Fixed<BT, FB> value) noexcept
+    {
+        return value.Compare(0) == Fixed<BT, FB>::CmpResult::Incomparable;
+    }
+
+    /// @brief Gets whether the given value is finite.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/isfinite
+    template<typename BT, unsigned int FB>
+    inline bool isfinite(Fixed<BT, FB> value) noexcept
+    {
+        return (value > Fixed<BT, FB>::GetNegativeInfinity())
+               && (value < Fixed<BT, FB>::GetInfinity());
+    }
+
+    /// @}
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_FIXEDMATH_HPP

--- a/PlayRho/Common/FlagGuard.hpp
+++ b/PlayRho/Common/FlagGuard.hpp
@@ -23,13 +23,14 @@
 
 #include <type_traits>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     /// @brief Flag guard type.
-    template <typename T>
+    template<typename T>
     class FlagGuard
     {
-    public:
+     public:
         static_assert(std::is_unsigned<T>::value, "Unsigned type required");
 
         /// @brief Initializing constructor.
@@ -37,11 +38,12 @@ namespace playrho {
         ///   given value and then unsets those bits on destruction of this instance.
         /// @param flag Flag variable to set until the destruction of this instance.
         /// @param value Bit value to or with the flag variable on construction.
-        FlagGuard(T& flag, T value) : m_flag{flag}, m_value{value}
+        FlagGuard(T& flag, T value)
+            : m_flag{flag}, m_value{value}
         {
             m_flag |= m_value;
         }
-        
+
         /// @brief Copy constructor is deleted.
         FlagGuard(const FlagGuard<T>& value) = delete;
 
@@ -49,10 +51,10 @@ namespace playrho {
         FlagGuard(FlagGuard<T>&& value) noexcept = default;
 
         /// @brief Copy assignment operator is deleted.
-        FlagGuard<T>& operator= (const FlagGuard<T>& value) = delete;
+        FlagGuard<T>& operator=(const FlagGuard<T>& value) = delete;
 
         /// @brief Move assignment operator.
-        FlagGuard<T>& operator= (FlagGuard<T>&& value) noexcept = default;
+        FlagGuard<T>& operator=(FlagGuard<T>&& value) noexcept = default;
 
         /// @brief Destructor.
         /// @details Unsets the bits that were set on construction.
@@ -60,14 +62,14 @@ namespace playrho {
         {
             m_flag &= ~m_value;
         }
-        
+
         FlagGuard() = delete;
-        
-    private:
-        T& m_flag; ///< Flag.
-        T m_value; ///< Value.
+
+     private:
+        T& m_flag;///< Flag.
+        T m_value;///< Value.
     };
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_FLAGGUARD_HPP
+#endif// PLAYRHO_COMMON_FLAGGUARD_HPP

--- a/PlayRho/Common/GrowableStack.hpp
+++ b/PlayRho/Common/GrowableStack.hpp
@@ -25,113 +25,113 @@
 #include <PlayRho/Common/DynamicMemory.hpp>
 #include <cstring>
 
-namespace playrho {
-
-/// This is a growable LIFO stack with an initial capacity of N.
-/// If the stack size exceeds the initial capacity, the heap is used
-/// to increase the size of the stack.
-template <typename T, std::size_t N>
-class GrowableStack
+namespace playrho
 {
-public:
-    
-    /// @brief Element type.
-    using ElementType = T;
 
-    /// @brief Count type.
-    using CountType = std::size_t;
-
-    /// @brief Gets the initial capacity.
-    static constexpr CountType GetInitialCapacity() noexcept
+    /// This is a growable LIFO stack with an initial capacity of N.
+    /// If the stack size exceeds the initial capacity, the heap is used
+    /// to increase the size of the stack.
+    template<typename T, std::size_t N>
+    class GrowableStack
     {
-        return CountType(N);
-    }
-    
-    /// @brief Gets the buffer growth rate.
-    static constexpr CountType GetBufferGrowthRate() noexcept
-    {
-        return CountType{2};
-    }
+     public:
+        /// @brief Element type.
+        using ElementType = T;
 
-    GrowableStack() = default;
-    
-    GrowableStack(const GrowableStack& other) = delete;
+        /// @brief Count type.
+        using CountType = std::size_t;
 
-    GrowableStack(GrowableStack&& other) = delete;
-
-    ~GrowableStack() noexcept
-    {
-        if (m_stack != m_array)
+        /// @brief Gets the initial capacity.
+        static constexpr CountType GetInitialCapacity() noexcept
         {
-            Free(m_stack);
-            m_stack = nullptr;
+            return CountType(N);
         }
-    }
 
-    GrowableStack& operator= (const GrowableStack& copy) = delete;
-
-    GrowableStack& operator= (GrowableStack&& copy) = delete;
-    
-    /// @brief Pushes the given elements onto this stack.
-    void push(const ElementType& element)
-    {
-        if (m_count == m_capacity)
+        /// @brief Gets the buffer growth rate.
+        static constexpr CountType GetBufferGrowthRate() noexcept
         {
-            const auto old = m_stack;
-            m_capacity *= GetBufferGrowthRate();
-            m_stack = AllocArray<T>(m_capacity);
-            std::memcpy(m_stack, old, m_count * sizeof(T));
-            if (old != m_array)
+            return CountType{2};
+        }
+
+        GrowableStack() = default;
+
+        GrowableStack(const GrowableStack& other) = delete;
+
+        GrowableStack(GrowableStack&& other) = delete;
+
+        ~GrowableStack() noexcept
+        {
+            if (m_stack != m_array)
             {
-                Free(old);
+                Free(m_stack);
+                m_stack = nullptr;
             }
         }
 
-        *(m_stack + m_count) = element;
-        ++m_count;
-    }
+        GrowableStack& operator=(const GrowableStack& copy) = delete;
 
-    /// @brief Accesses the "top" element.
-    /// @warning Behavior is undefined if this stack doesn't already have at least
-    ///   one value pushed onto it.
-    ElementType top() const
-    {
-        assert(m_count > 0);
-        return m_stack[m_count - 1];
-    }
+        GrowableStack& operator=(GrowableStack&& copy) = delete;
 
-    /// @brief Pops the "top" element.
-    void pop() noexcept
-    {
-        assert(m_count > 0);
-        --m_count;
-    }
+        /// @brief Pushes the given elements onto this stack.
+        void push(const ElementType& element)
+        {
+            if (m_count == m_capacity)
+            {
+                const auto old = m_stack;
+                m_capacity *= GetBufferGrowthRate();
+                m_stack = AllocArray<T>(m_capacity);
+                std::memcpy(m_stack, old, m_count * sizeof(T));
+                if (old != m_array)
+                {
+                    Free(old);
+                }
+            }
 
-    /// @brief Gets the current size in numbers of elements.
-    constexpr CountType size() const noexcept
-    {
-        return m_count;
-    }
-    
-    /// @brief Gets the capacity in number of elements.
-    constexpr CountType capacity() const noexcept
-    {
-        return m_capacity;
-    }
+            *(m_stack + m_count) = element;
+            ++m_count;
+        }
 
-    /// @brief Whether this stack is empty.
-    constexpr bool empty() const noexcept
-    {
-        return m_count == 0;
-    }
+        /// @brief Accesses the "top" element.
+        /// @warning Behavior is undefined if this stack doesn't already have at least
+        ///   one value pushed onto it.
+        ElementType top() const
+        {
+            assert(m_count > 0);
+            return m_stack[m_count - 1];
+        }
 
-private:
-    ElementType m_array[N]; ///< Array data.
-    ElementType* m_stack = m_array; ///< Pointer to array of data.
-    CountType m_count = 0; ///< Count of elements.
-    CountType m_capacity = N; ///< Capacity for storing elements.
-};
+        /// @brief Pops the "top" element.
+        void pop() noexcept
+        {
+            assert(m_count > 0);
+            --m_count;
+        }
 
-} // namespace playrho
+        /// @brief Gets the current size in numbers of elements.
+        constexpr CountType size() const noexcept
+        {
+            return m_count;
+        }
 
-#endif // PLAYRHO_COMMON_GROWABLESTACK_HPP
+        /// @brief Gets the capacity in number of elements.
+        constexpr CountType capacity() const noexcept
+        {
+            return m_capacity;
+        }
+
+        /// @brief Whether this stack is empty.
+        constexpr bool empty() const noexcept
+        {
+            return m_count == 0;
+        }
+
+     private:
+        ElementType m_array[N];        ///< Array data.
+        ElementType* m_stack = m_array;///< Pointer to array of data.
+        CountType m_count = 0;         ///< Count of elements.
+        CountType m_capacity = N;      ///< Capacity for storing elements.
+    };
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_GROWABLESTACK_HPP

--- a/PlayRho/Common/Interval.hpp
+++ b/PlayRho/Common/Interval.hpp
@@ -23,347 +23,343 @@
 
 #include <PlayRho/Common/NonNegative.hpp>
 #include <algorithm>
-#include <limits>
 #include <iostream>
+#include <limits>
 
-namespace playrho {
-
-/// @brief Interval template type.
-/// @details This type encapsulates an interval as a min-max value range relationship.
-/// @invariant The min and max values can only be the result of
-///   <code>std::minmax(a, b)</code> or the special values of the "highest" and
-///   "lowest" values supported by the type for this class respectively indicating
-///   the "unset" value.
-/// @see https://en.wikipedia.org/wiki/Interval_(mathematics)
-template <typename T>
-class Interval
+namespace playrho
 {
-public:
-    
-    /// @brief Value type.
-    /// @details Alias for the type of the value that this class was template
-    ///   instantiated for.
-    using value_type = T;
-    
-    /// @brief Limits alias for the <code>value_type</code>.
-    using limits = std::numeric_limits<value_type>;
-    
-    /// @brief Gets the "lowest" value supported by the <code>value_type</code>.
-    /// @return Negative infinity if supported by the value type, limits::lowest()
-    ///   otherwise.
-    static constexpr value_type GetLowest() noexcept
-    {
-        return (limits::has_infinity)? -limits::infinity(): limits::lowest();
-    }
-    
-    /// @brief Gets the "highest" value supported by the <code>value_type</code>.
-    /// @return Positive infinity if supported by the value type, limits::max()
-    ///   otherwise.
-    static constexpr value_type GetHighest() noexcept
-    {
-        return (limits::has_infinity)? limits::infinity(): limits::max();
-    }
 
-    /// @brief Default constructor.
-    /// @details Constructs an "unset" interval.
-    /// @post <code>GetMin()</code> returns the value of <code>GetHighest()</code>.
-    /// @post <code>GetMax()</code> returns the value of <code>GetLowest()</code>.
-    constexpr Interval() = default;
-    
-    /// @brief Copy constructor.
-    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    constexpr Interval(const Interval& other) = default;
+    /// @brief Interval template type.
+    /// @details This type encapsulates an interval as a min-max value range relationship.
+    /// @invariant The min and max values can only be the result of
+    ///   <code>std::minmax(a, b)</code> or the special values of the "highest" and
+    ///   "lowest" values supported by the type for this class respectively indicating
+    ///   the "unset" value.
+    /// @see https://en.wikipedia.org/wiki/Interval_(mathematics)
+    template<typename T>
+    class Interval
+    {
+     public:
+        /// @brief Value type.
+        /// @details Alias for the type of the value that this class was template
+        ///   instantiated for.
+        using value_type = T;
 
-    /// @brief Move constructor.
-    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    constexpr Interval(Interval&& other) = default;
-    
-    /// @brief Initializing constructor.
-    /// @post <code>GetMin()</code> returns the value of <code>v</code>.
-    /// @post <code>GetMax()</code> returns the value of <code>v</code>.
-    constexpr explicit Interval(const value_type& v) noexcept:
-        Interval(pair_type{v, v})
-    {
-        // Intentionally empty.
-    }
-    
-    /// @brief Initializing constructor.
-    constexpr Interval(const value_type& a, const value_type& b) noexcept:
-        Interval(std::minmax(a, b))
-    {
-        // Intentionally empty.
-    }
-    
-    /// @brief Initializing constructor.
-    constexpr Interval(const std::initializer_list<T> ilist) noexcept:
-        Interval(std::minmax(ilist))
-    {
-        // Intentionally empty.
-    }
-    
-    ~Interval() noexcept = default;
-    
-    /// @brief Copy assignment operator.
-    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    Interval& operator= (const Interval& other) = default;
+        /// @brief Limits alias for the <code>value_type</code>.
+        using limits = std::numeric_limits<value_type>;
 
-    /// @brief Move assignment operator.
-    /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
-    /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
-    Interval& operator= (Interval&& other) = default;
-    
-    /// @brief Moves the interval by the given amount.
-    /// @warning Behavior is undefined if incrementing the min or max value by
-    ///   the given amount overflows the finite range of the <code>value_type</code>,
-    constexpr Interval& Move(const value_type& v) noexcept
-    {
-        m_min += v;
-        m_max += v;
-        return *this;
-    }
+        /// @brief Gets the "lowest" value supported by the <code>value_type</code>.
+        /// @return Negative infinity if supported by the value type, limits::lowest()
+        ///   otherwise.
+        static constexpr value_type GetLowest() noexcept
+        {
+            return (limits::has_infinity) ? -limits::infinity() : limits::lowest();
+        }
 
-    /// @brief Gets the minimum value of this range.
-    constexpr value_type GetMin() const noexcept
-    {
-        return m_min;
-    }
+        /// @brief Gets the "highest" value supported by the <code>value_type</code>.
+        /// @return Positive infinity if supported by the value type, limits::max()
+        ///   otherwise.
+        static constexpr value_type GetHighest() noexcept
+        {
+            return (limits::has_infinity) ? limits::infinity() : limits::max();
+        }
 
-    /// @brief Gets the maximum value of this range.
-    constexpr value_type GetMax() const noexcept
-    {
-        return m_max;
-    }
-    
-    /// @brief Includes the given value into this interval.
-    /// @note If this value is the "unset" value then the result of this operation
-    ///   will be the given value.
-    /// @param v Value to "include" into this value.
-    /// @post This value's "min" is the minimum of the given value and this value's "min".
-    constexpr Interval& Include(const value_type& v) noexcept
-    {
-        m_min = std::min(v, GetMin());
-        m_max = std::max(v, GetMax());
-        return *this;
-    }
-    
-    /// @brief Includes the given interval into this interval.
-    /// @note If this value is the "unset" value then the result of this operation
-    ///   will be the given value.
-    /// @param v Value to "include" into this value.
-    /// @post This value's "min" is the minimum of the given value's "min" and
-    ///   this value's "min".
-    constexpr Interval& Include(const Interval& v) noexcept
-    {
-        m_min = std::min(v.GetMin(), GetMin());
-        m_max = std::max(v.GetMax(), GetMax());
-        return *this;
-    }
-    
-    /// @brief Intersects this interval with the given interval.
-    constexpr Interval& Intersect(const Interval& v) noexcept
-    {
-        const auto min = std::max(v.GetMin(), GetMin());
-        const auto max = std::min(v.GetMax(), GetMax());
-        *this = (min <= max)? Interval{pair_type{min, max}}: Interval{};
-        return *this;
-    }
-    
-    /// @brief Expands this interval.
-    /// @details Expands this interval by decreasing the min value if the
-    ///   given value is negative, or by increasing the max value if the
-    ///   given value is positive.
-    /// @param v Amount to expand this interval by.
-    /// @warning Behavior is undefined if expanding the range by
-    ///   the given amount overflows the range of the <code>value_type</code>,
-    constexpr Interval& Expand(const value_type& v) noexcept
-    {
-        if (v < value_type{})
+        /// @brief Default constructor.
+        /// @details Constructs an "unset" interval.
+        /// @post <code>GetMin()</code> returns the value of <code>GetHighest()</code>.
+        /// @post <code>GetMax()</code> returns the value of <code>GetLowest()</code>.
+        constexpr Interval() = default;
+
+        /// @brief Copy constructor.
+        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+        constexpr Interval(const Interval& other) = default;
+
+        /// @brief Move constructor.
+        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+        constexpr Interval(Interval&& other) = default;
+
+        /// @brief Initializing constructor.
+        /// @post <code>GetMin()</code> returns the value of <code>v</code>.
+        /// @post <code>GetMax()</code> returns the value of <code>v</code>.
+        constexpr explicit Interval(const value_type& v) noexcept
+            : Interval(pair_type{v, v})
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Interval(const value_type& a, const value_type& b) noexcept
+            : Interval(std::minmax(a, b))
+        {
+            // Intentionally empty.
+        }
+
+        /// @brief Initializing constructor.
+        constexpr Interval(const std::initializer_list<T> ilist) noexcept
+            : Interval(std::minmax(ilist))
+        {
+            // Intentionally empty.
+        }
+
+        ~Interval() noexcept = default;
+
+        /// @brief Copy assignment operator.
+        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+        Interval& operator=(const Interval& other) = default;
+
+        /// @brief Move assignment operator.
+        /// @post <code>GetMin()</code> returns the value of <code>other.GetMin()</code>.
+        /// @post <code>GetMax()</code> returns the value of <code>other.GetMax()</code>.
+        Interval& operator=(Interval&& other) = default;
+
+        /// @brief Moves the interval by the given amount.
+        /// @warning Behavior is undefined if incrementing the min or max value by
+        ///   the given amount overflows the finite range of the <code>value_type</code>,
+        constexpr Interval& Move(const value_type& v) noexcept
         {
             m_min += v;
-        }
-        else
-        {
             m_max += v;
+            return *this;
         }
-        return *this;
-    }
-    
-    /// @brief Expands equally both ends of this interval.
-    /// @details Expands equally this interval by decreasing the min value and
-    ///   by increasing the max value by the given amount.
-    /// @note This operation has no effect if this interval is "unset".
-    /// @param v Amount to expand both ends of this interval by.
-    /// @warning Behavior is undefined if expanding the range by
-    ///   the given amount overflows the range of the <code>value_type</code>,
-    constexpr Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
+
+        /// @brief Gets the minimum value of this range.
+        constexpr value_type GetMin() const noexcept
+        {
+            return m_min;
+        }
+
+        /// @brief Gets the maximum value of this range.
+        constexpr value_type GetMax() const noexcept
+        {
+            return m_max;
+        }
+
+        /// @brief Includes the given value into this interval.
+        /// @note If this value is the "unset" value then the result of this operation
+        ///   will be the given value.
+        /// @param v Value to "include" into this value.
+        /// @post This value's "min" is the minimum of the given value and this value's "min".
+        constexpr Interval& Include(const value_type& v) noexcept
+        {
+            m_min = std::min(v, GetMin());
+            m_max = std::max(v, GetMax());
+            return *this;
+        }
+
+        /// @brief Includes the given interval into this interval.
+        /// @note If this value is the "unset" value then the result of this operation
+        ///   will be the given value.
+        /// @param v Value to "include" into this value.
+        /// @post This value's "min" is the minimum of the given value's "min" and
+        ///   this value's "min".
+        constexpr Interval& Include(const Interval& v) noexcept
+        {
+            m_min = std::min(v.GetMin(), GetMin());
+            m_max = std::max(v.GetMax(), GetMax());
+            return *this;
+        }
+
+        /// @brief Intersects this interval with the given interval.
+        constexpr Interval& Intersect(const Interval& v) noexcept
+        {
+            const auto min = std::max(v.GetMin(), GetMin());
+            const auto max = std::min(v.GetMax(), GetMax());
+            *this = (min <= max) ? Interval{pair_type{min, max}} : Interval{};
+            return *this;
+        }
+
+        /// @brief Expands this interval.
+        /// @details Expands this interval by decreasing the min value if the
+        ///   given value is negative, or by increasing the max value if the
+        ///   given value is positive.
+        /// @param v Amount to expand this interval by.
+        /// @warning Behavior is undefined if expanding the range by
+        ///   the given amount overflows the range of the <code>value_type</code>,
+        constexpr Interval& Expand(const value_type& v) noexcept
+        {
+            if (v < value_type{})
+            {
+                m_min += v;
+            }
+            else
+            {
+                m_max += v;
+            }
+            return *this;
+        }
+
+        /// @brief Expands equally both ends of this interval.
+        /// @details Expands equally this interval by decreasing the min value and
+        ///   by increasing the max value by the given amount.
+        /// @note This operation has no effect if this interval is "unset".
+        /// @param v Amount to expand both ends of this interval by.
+        /// @warning Behavior is undefined if expanding the range by
+        ///   the given amount overflows the range of the <code>value_type</code>,
+        constexpr Interval& ExpandEqually(const NonNegative<value_type>& v) noexcept
+        {
+            const auto amount = value_type{v};
+            m_min -= amount;
+            m_max += amount;
+            return *this;
+        }
+
+     private:
+        /// @brief Internal pair type.
+        /// @note Uses <code>std::pair</code> since it's the most natural type given that
+        ///   <code>std::minmax</code> returns it.
+        using pair_type = std::pair<value_type, value_type>;
+
+        /// @brief Internal pair type accepting constructor.
+        constexpr explicit Interval(pair_type pair) noexcept
+            : m_min{std::get<0>(pair)}, m_max{std::get<1>(pair)}
+        {
+            // Intentionally empty.
+        }
+
+        value_type m_min = GetHighest();///< Min value.
+        value_type m_max = GetLowest(); ///< Max value.
+    };
+
+    /// @brief Gets the size of the given interval.
+    /// @details Gets the difference between the max and min values.
+    /// @warning Behavior is undefined if the difference between the given range's
+    ///   max and min values overflows the range of the <code>Interval::value_type</code>.
+    /// @return Non-negative value unless the given interval is "unset" or invalid.
+    template<typename T>
+    constexpr T GetSize(const Interval<T>& v) noexcept
     {
-        const auto amount = value_type{v};
-        m_min -= amount;
-        m_max += amount;
-        return *this;
+        return v.GetMax() - v.GetMin();
     }
-    
-private:
-    /// @brief Internal pair type.
-    /// @note Uses <code>std::pair</code> since it's the most natural type given that
-    ///   <code>std::minmax</code> returns it.
-    using pair_type = std::pair<value_type, value_type>;
-    
-    /// @brief Internal pair type accepting constructor.
-    constexpr explicit Interval(pair_type pair) noexcept:
-        m_min{std::get<0>(pair)}, m_max{std::get<1>(pair)}
+
+    /// @brief Gets the center of the given interval.
+    /// @warning Behavior is undefined if the difference between the given range's
+    ///   max and min values overflows the range of the <code>Interval::value_type</code>.
+    /// @relatedalso Interval
+    template<typename T>
+    constexpr T GetCenter(const Interval<T>& v) noexcept
     {
-        // Intentionally empty.
+        // Rounding may cause issues...
+        return (v.GetMin() + v.GetMax()) / 2;
     }
 
-    value_type m_min = GetHighest(); ///< Min value.
-    value_type m_max = GetLowest(); ///< Max value.
-};
+    /// @brief Checks whether two value ranges have any intersection/overlap at all.
+    /// @relatedalso Interval
+    template<typename T>
+    constexpr bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
+    {
+        const auto maxOfMins = std::max(a.GetMin(), b.GetMin());
+        const auto minOfMaxs = std::min(a.GetMax(), b.GetMax());
+        return minOfMaxs >= maxOfMins;
+    }
 
-/// @brief Gets the size of the given interval.
-/// @details Gets the difference between the max and min values.
-/// @warning Behavior is undefined if the difference between the given range's
-///   max and min values overflows the range of the <code>Interval::value_type</code>.
-/// @return Non-negative value unless the given interval is "unset" or invalid.
-template <typename T>
-constexpr T GetSize(const Interval<T>& v) noexcept
-{
-    return v.GetMax() - v.GetMin();
-}
+    /// @brief Gets the intersecting interval of two given ranges.
+    /// @relatedalso Interval
+    template<typename T>
+    constexpr Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
+    {
+        return a.Intersect(b);
+    }
 
-/// @brief Gets the center of the given interval.
-/// @warning Behavior is undefined if the difference between the given range's
-///   max and min values overflows the range of the <code>Interval::value_type</code>.
-/// @relatedalso Interval
-template <typename T>
-constexpr T GetCenter(const Interval<T>& v) noexcept
-{
-    // Rounding may cause issues...
-    return (v.GetMin() + v.GetMax()) / 2;
-}
+    /// @brief Determines whether the first range is entirely before the second range.
+    template<typename T>
+    constexpr bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
+    {
+        return a.GetMax() < b.GetMin();
+    }
 
-/// @brief Checks whether two value ranges have any intersection/overlap at all.
-/// @relatedalso Interval
-template <typename T>
-constexpr bool IsIntersecting(const Interval<T>& a, const Interval<T>& b) noexcept
-{
-    const auto maxOfMins = std::max(a.GetMin(), b.GetMin());
-    const auto minOfMaxs = std::min(a.GetMax(), b.GetMax());
-    return minOfMaxs >= maxOfMins;
-}
+    /// @brief Determines whether the first range is entirely after the second range.
+    template<typename T>
+    constexpr bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
+    {
+        return a.GetMin() > b.GetMax();
+    }
 
-/// @brief Gets the intersecting interval of two given ranges.
-/// @relatedalso Interval
-template <typename T>
-constexpr Interval<T> GetIntersection(Interval<T> a, const Interval<T>& b) noexcept
-{
-    return a.Intersect(b);
-}
+    /// @brief Determines whether the first range entirely encloses the second.
+    template<typename T>
+    constexpr bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
+    {
+        return a.GetMin() <= b.GetMin() && a.GetMax() >= b.GetMax();
+    }
 
-/// @brief Determines whether the first range is entirely before the second range.
-template <typename T>
-constexpr bool IsEntirelyBefore(const Interval<T>& a, const Interval<T>& b)
-{
-    return a.GetMax() < b.GetMin();
-}
+    /// @brief Equality operator.
+    /// @note Satisfies the <code>EqualityComparable</code> named requirement for Interval objects.
+    /// @relatedalso Interval
+    /// @see https://en.cppreference.com/w/cpp/named_req/EqualityComparable
+    template<typename T>
+    constexpr bool operator==(const Interval<T>& a, const Interval<T>& b) noexcept
+    {
+        return (a.GetMin() == b.GetMin()) && (a.GetMax() == b.GetMax());
+    }
 
-/// @brief Determines whether the first range is entirely after the second range.
-template <typename T>
-constexpr bool IsEntirelyAfter(const Interval<T>& a, const Interval<T>& b)
-{
-    return a.GetMin() > b.GetMax();
-}
+    /// @brief Inequality operator.
+    /// @note Satisfies the <code>EqualityComparable</code> named requirement for Interval objects.
+    /// @relatedalso Interval
+    /// @see https://en.cppreference.com/w/cpp/named_req/EqualityComparable
+    template<typename T>
+    constexpr bool operator!=(const Interval<T>& a, const Interval<T>& b) noexcept
+    {
+        return !(a == b);
+    }
 
-/// @brief Determines whether the first range entirely encloses the second.
-template <typename T>
-constexpr bool IsEntirelyEnclosing(const Interval<T>& a, const Interval<T>& b)
-{
-    return a.GetMin() <= b.GetMin() && a.GetMax() >= b.GetMax();
-}
+    /// @brief Less-than operator.
+    /// @note Provides a "strict weak ordering" relation.
+    /// @note This is a lexicographical comparison.
+    /// @note Obeys the <code>LessThanComparable</code> named requirement:
+    ///   <code>for all a, !(a < a); if (a < b) then !(b < a); if (a < b) and (b < c)
+    ///   then (a < c); with equiv = !(a < b) && !(b < a), if equiv(a, b) and equiv(b, c),
+    ///   then equiv(a, c).</code>
+    /// @relatedalso Interval
+    /// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+    /// @see https://en.cppreference.com/w/cpp/named_req/LessThanComparable
+    template<typename T>
+    constexpr bool operator<(const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    {
+        return (lhs.GetMin() < rhs.GetMin()) || (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() < rhs.GetMax());
+    }
 
-/// @brief Equality operator.
-/// @note Satisfies the <code>EqualityComparable</code> named requirement for Interval objects.
-/// @relatedalso Interval
-/// @see https://en.cppreference.com/w/cpp/named_req/EqualityComparable
-template <typename T>
-constexpr bool operator== (const Interval<T>& a, const Interval<T>& b) noexcept
-{
-    return (a.GetMin() == b.GetMin()) && (a.GetMax() == b.GetMax());
-}
+    /// @brief Less-than or equal-to operator.
+    /// @note Provides a "strict weak ordering" relation.
+    /// @note This is a lexicographical comparison.
+    /// @relatedalso Interval
+    /// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+    template<typename T>
+    constexpr bool operator<=(const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    {
+        return (lhs.GetMin() < rhs.GetMin()) || (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() <= rhs.GetMax());
+    }
 
-/// @brief Inequality operator.
-/// @note Satisfies the <code>EqualityComparable</code> named requirement for Interval objects.
-/// @relatedalso Interval
-/// @see https://en.cppreference.com/w/cpp/named_req/EqualityComparable
-template <typename T>
-constexpr bool operator!= (const Interval<T>& a, const Interval<T>& b) noexcept
-{
-    return !(a == b);
-}
+    /// @brief Greater-than operator.
+    /// @note Provides a "strict weak ordering" relation.
+    /// @note This is a lexicographical comparison.
+    /// @relatedalso Interval
+    /// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+    template<typename T>
+    constexpr bool operator>(const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    {
+        return (lhs.GetMin() > rhs.GetMin()) || (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() > rhs.GetMax());
+    }
 
-/// @brief Less-than operator.
-/// @note Provides a "strict weak ordering" relation.
-/// @note This is a lexicographical comparison.
-/// @note Obeys the <code>LessThanComparable</code> named requirement:
-///   <code>for all a, !(a < a); if (a < b) then !(b < a); if (a < b) and (b < c)
-///   then (a < c); with equiv = !(a < b) && !(b < a), if equiv(a, b) and equiv(b, c),
-///   then equiv(a, c).</code>
-/// @relatedalso Interval
-/// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-/// @see https://en.cppreference.com/w/cpp/named_req/LessThanComparable
-template <typename T>
-constexpr bool operator< (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-{
-    return (lhs.GetMin() < rhs.GetMin()) ||
-        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() < rhs.GetMax());
-}
+    /// @brief Greater-than or equal-to operator.
+    /// @note Provides a "strict weak ordering" relation.
+    /// @note This is a lexicographical comparison.
+    /// @relatedalso Interval
+    /// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
+    template<typename T>
+    constexpr bool operator>=(const Interval<T>& lhs, const Interval<T>& rhs) noexcept
+    {
+        return (lhs.GetMin() > rhs.GetMin()) || (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() >= rhs.GetMax());
+    }
 
-/// @brief Less-than or equal-to operator.
-/// @note Provides a "strict weak ordering" relation.
-/// @note This is a lexicographical comparison.
-/// @relatedalso Interval
-/// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-template <typename T>
-constexpr bool operator<= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-{
-    return (lhs.GetMin() < rhs.GetMin()) ||
-        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() <= rhs.GetMax());
-}
+    /// @brief Output stream operator.
+    template<typename T>
+    ::std::ostream& operator<<(::std::ostream& os, const Interval<T>& value)
+    {
+        return os << '{' << value.GetMin() << "..." << value.GetMax() << '}';
+    }
 
-/// @brief Greater-than operator.
-/// @note Provides a "strict weak ordering" relation.
-/// @note This is a lexicographical comparison.
-/// @relatedalso Interval
-/// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-template <typename T>
-constexpr bool operator> (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-{
-    return (lhs.GetMin() > rhs.GetMin()) ||
-        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() > rhs.GetMax());
-}
+}// namespace playrho
 
-/// @brief Greater-than or equal-to operator.
-/// @note Provides a "strict weak ordering" relation.
-/// @note This is a lexicographical comparison.
-/// @relatedalso Interval
-/// @see https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings
-template <typename T>
-constexpr bool operator>= (const Interval<T>& lhs, const Interval<T>& rhs) noexcept
-{
-    return (lhs.GetMin() > rhs.GetMin()) ||
-        (lhs.GetMin() == rhs.GetMin() && lhs.GetMax() >= rhs.GetMax());
-}
-
-/// @brief Output stream operator.
-template <typename T>
-::std::ostream& operator<< (::std::ostream& os, const Interval<T>& value)
-{
-    return os << '{' << value.GetMin() << "..." << value.GetMax() << '}';
-}
-
-} // namespace playrho
-
-#endif // PLAYRHO_COMMON_INTERVAL_HPP
+#endif// PLAYRHO_COMMON_INTERVAL_HPP

--- a/PlayRho/Common/Intervals.hpp
+++ b/PlayRho/Common/Intervals.hpp
@@ -18,19 +18,19 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-
 #ifndef PLAYRHO_COMMON_INTERVALS_HPP
 #define PLAYRHO_COMMON_INTERVALS_HPP
 
 #include <PlayRho/Common/Interval.hpp>
 #include <PlayRho/Common/Units.hpp>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     /// @brief Length Interval alias.
     /// @relatedalso Interval
     using LengthInterval = Interval<Length>;
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_INTERVALS_HPP
+#endif// PLAYRHO_COMMON_INTERVALS_HPP

--- a/PlayRho/Common/InvalidArgument.hpp
+++ b/PlayRho/Common/InvalidArgument.hpp
@@ -24,17 +24,18 @@
 #include <PlayRho/Defines.hpp>
 #include <stdexcept>
 
-namespace playrho {
-
-/// @brief Invalid argument logic error.
-/// @details Indicates that an argument to a function or method was invalid.
-/// @ingroup ExceptionsGroup
-class InvalidArgument: public std::invalid_argument
+namespace playrho
 {
-public:
-    using std::invalid_argument::invalid_argument;
-};
 
-} // namespace playrho
+    /// @brief Invalid argument logic error.
+    /// @details Indicates that an argument to a function or method was invalid.
+    /// @ingroup ExceptionsGroup
+    class InvalidArgument : public std::invalid_argument
+    {
+     public:
+        using std::invalid_argument::invalid_argument;
+    };
 
-#endif // PLAYRHO_COMMON_INVALIDARGUMENT_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_INVALIDARGUMENT_HPP

--- a/PlayRho/Common/LengthError.hpp
+++ b/PlayRho/Common/LengthError.hpp
@@ -23,19 +23,19 @@
 
 #include <stdexcept>
 
-namespace playrho {
-
-/// @brief Length based logic error.
-/// @details The exception used to indicate that an operation would produce a
-///   result that exceeded an object's maximum size.
-/// @ingroup ExceptionsGroup
-class LengthError: public std::length_error
+namespace playrho
 {
-public:
-    using std::length_error::length_error;
-};
 
-} // namespace playrho
+    /// @brief Length based logic error.
+    /// @details The exception used to indicate that an operation would produce a
+    ///   result that exceeded an object's maximum size.
+    /// @ingroup ExceptionsGroup
+    class LengthError : public std::length_error
+    {
+     public:
+        using std::length_error::length_error;
+    };
 
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_LENGTHERROR_HPP
+#endif// PLAYRHO_COMMON_LENGTHERROR_HPP

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -21,159 +21,161 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-Angle GetDelta(Angle a1, Angle a2) noexcept
+namespace playrho
 {
-    a1 = GetNormalized(a1);
-    a2 = GetNormalized(a2);
-    const auto a12 = a2 - a1;
-    if (a12 > Pi * Radian)
-    {
-        // 190_deg becomes 190_deg - 360_deg = -170_deg
-        return a12 - 2 * Pi * Radian;
-    }
-    if (a12 < -Pi * Radian)
-    {
-        // -200_deg becomes -200_deg + 360_deg = 100_deg
-        return a12 + 2 * Pi * Radian;
-    }
-    return a12;
-}
 
-Length2 ComputeCentroid(const Span<const Length2>& vertices)
-{
-    assert(size(vertices) >= 3);
-    
-    auto c = Length2{} * 0_m2;
-    auto area = 0_m2;
-    
-    // <code>pRef</code> is the reference point for forming triangles.
-    // It's location doesn't change the result (except for rounding error).
-    const auto pRef = Average(vertices);
-
-    for (auto i = decltype(size(vertices)){0}; i < size(vertices); ++i)
+    Angle GetDelta(Angle a1, Angle a2) noexcept
     {
-        // Triangle vertices.
-        const auto p1 = pRef;
-        const auto p2 = vertices[i];
-        const auto p3 = vertices[GetModuloNext(i, size(vertices))];
-        
-        const auto e1 = p2 - p1;
-        const auto e2 = p3 - p1;
-        
+        a1 = GetNormalized(a1);
+        a2 = GetNormalized(a2);
+        const auto a12 = a2 - a1;
+        if (a12 > Pi * Radian)
+        {
+            // 190_deg becomes 190_deg - 360_deg = -170_deg
+            return a12 - 2 * Pi * Radian;
+        }
+        if (a12 < -Pi * Radian)
+        {
+            // -200_deg becomes -200_deg + 360_deg = 100_deg
+            return a12 + 2 * Pi * Radian;
+        }
+        return a12;
+    }
+
+    Length2 ComputeCentroid(const Span<const Length2>& vertices)
+    {
+        assert(size(vertices) >= 3);
+
+        auto c = Length2{} * 0_m2;
+        auto area = 0_m2;
+
+        // <code>pRef</code> is the reference point for forming triangles.
+        // It's location doesn't change the result (except for rounding error).
+        const auto pRef = Average(vertices);
+
+        for (auto i = decltype(size(vertices)){0}; i < size(vertices); ++i)
+        {
+            // Triangle vertices.
+            const auto p1 = pRef;
+            const auto p2 = vertices[i];
+            const auto p3 = vertices[GetModuloNext(i, size(vertices))];
+
+            const auto e1 = p2 - p1;
+            const auto e2 = p3 - p1;
+
+            constexpr auto RealInverseOfTwo = Real{1} / Real{2};
+            const auto triangleArea = Area{Cross(e1, e2) * RealInverseOfTwo};
+            area += triangleArea;
+
+            // Area weighted centroid
+            constexpr auto RealInverseOfThree = Real{1} / Real{3};
+            const auto aveP = (p1 + p2 + p3) * RealInverseOfThree;
+            c += triangleArea * aveP;
+        }
+
+        // Centroid
+        assert((area > 0_m2) && !AlmostZero(area / SquareMeter));
+        return c / area;
+    }
+
+    std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle start, Real turns)
+    {
+        std::vector<Length2> vertices;
+        if (slices > 0)
+        {
+            const auto integralTurns = static_cast<long int>(turns);
+            const auto wholeNum = (turns == static_cast<Real>(integralTurns));
+            const auto deltaAngle = (Pi * 2_rad * turns) / static_cast<Real>(slices);
+            auto i = decltype(slices){0};
+            while (i < slices)
+            {
+                const auto angleInRadians = Real{(start + (static_cast<Real>(i) * deltaAngle)) / Radian};
+                const auto x = radius * cos(angleInRadians);
+                const auto y = radius * sin(angleInRadians);
+                vertices.emplace_back(x, y);
+                ++i;
+            }
+            if (wholeNum)
+            {
+                // Ensure whole circles come back to original point EXACTLY.
+                vertices.push_back(vertices[0]);
+            }
+            else
+            {
+                const auto angleInRadians = Real{(start + (static_cast<Real>(i) * deltaAngle)) / Radian};
+                const auto x = radius * cos(angleInRadians);
+                const auto y = radius * sin(angleInRadians);
+                vertices.emplace_back(x, y);
+            }
+        }
+        return vertices;
+    }
+
+    NonNegative<Area> GetAreaOfCircle(Length radius)
+    {
+        return Area{radius * radius * Pi};
+    }
+
+    NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices)
+    {
+        // Uses the "Shoelace formula".
+        // See: https://en.wikipedia.org/wiki/Shoelace_formula
+        auto sum = 0_m2;
+        const auto count = size(vertices);
+        for (auto i = decltype(count){0}; i < count; ++i)
+        {
+            const auto last_v = vertices[GetModuloPrev(i, count)];
+            const auto this_v = vertices[i];
+            const auto next_v = vertices[GetModuloNext(i, count)];
+            sum += GetX(this_v) * (GetY(next_v) - GetY(last_v));
+        }
+
+        // Note that using the absolute value isn't necessary for vertices in counter-clockwise
+        // ordering; only needed for clockwise ordering.
         constexpr auto RealInverseOfTwo = Real{1} / Real{2};
-        const auto triangleArea = Area{Cross(e1, e2) * RealInverseOfTwo};
-        area += triangleArea;
-        
-        // Area weighted centroid
-        constexpr auto RealInverseOfThree = Real{1} / Real{3};
-        const auto aveP = (p1 + p2 + p3) * RealInverseOfThree;
-        c += triangleArea * aveP;
+        return abs(sum) * RealInverseOfTwo;
     }
-    
-    // Centroid
-    assert((area > 0_m2) && !AlmostZero(area / SquareMeter));
-    return c / area;
-}
 
-std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle start, Real turns)
-{
-    std::vector<Length2> vertices;
-    if (slices > 0)
+    SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices)
     {
-        const auto integralTurns = static_cast<long int>(turns);
-        const auto wholeNum = (turns == static_cast<Real>(integralTurns));
-        const auto deltaAngle = (Pi * 2_rad * turns) / static_cast<Real>(slices);
-        auto i = decltype(slices){0};
-        while (i < slices)
+        assert(size(vertices) > 2);
+
+        // Use formulas Ix and Iy for second moment of area of any simple polygon and apply
+        // the perpendicular axis theorem on these to get the desired answer.
+        //
+        // See:
+        // https://en.wikipedia.org/wiki/Second_moment_of_area#Any_polygon
+        // https://en.wikipedia.org/wiki/Second_moment_of_area#Perpendicular_axis_theorem
+        auto sum_x = SquareMeter * SquareMeter * 0;
+        auto sum_y = SquareMeter * SquareMeter * 0;
+        const auto count = size(vertices);
+        for (auto i = decltype(count){0}; i < count; ++i)
         {
-            const auto angleInRadians = Real{(start + (static_cast<Real>(i) * deltaAngle)) / Radian};
-            const auto x = radius * cos(angleInRadians);
-            const auto y = radius * sin(angleInRadians);
-            vertices.emplace_back(x, y);
-            ++i;
+            const auto this_v = vertices[i];
+            const auto next_v = vertices[GetModuloNext(i, count)];
+            const auto fact_b = Cross(this_v, next_v);
+            sum_x += [&]() {
+                const auto fact_a = Square(GetY(this_v)) + GetY(this_v) * GetY(next_v) + Square(GetY(next_v));
+                return fact_a * fact_b;
+            }();
+            sum_y += [&]() {
+                const auto fact_a = Square(GetX(this_v)) + GetX(this_v) * GetX(next_v) + Square(GetX(next_v));
+                return fact_a * fact_b;
+            }();
         }
-        if (wholeNum)
-        {
-            // Ensure whole circles come back to original point EXACTLY.
-            vertices.push_back(vertices[0]);
-        }
-        else
-        {
-            const auto angleInRadians = Real{(start + (static_cast<Real>(i) * deltaAngle)) / Radian};
-            const auto x = radius * cos(angleInRadians);
-            const auto y = radius * sin(angleInRadians);
-            vertices.emplace_back(x, y);
-        }
+        const auto secondMomentOfAreaX = SecondMomentOfArea{sum_x};
+        const auto secondMomentOfAreaY = SecondMomentOfArea{sum_y};
+        constexpr auto RealInverseOfTwelve = Real{1} / Real{12};
+        return (secondMomentOfAreaX + secondMomentOfAreaY) * RealInverseOfTwelve;
     }
-    return vertices;
-}
 
-NonNegative<Area> GetAreaOfCircle(Length radius)
-{
-    return Area{radius * radius * Pi};
-}
-
-NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices)
-{
-    // Uses the "Shoelace formula".
-    // See: https://en.wikipedia.org/wiki/Shoelace_formula
-    auto sum = 0_m2;
-    const auto count = size(vertices);
-    for (auto i = decltype(count){0}; i < count; ++i)
+    namespace d2
     {
-        const auto last_v = vertices[GetModuloPrev(i, count)];
-        const auto this_v = vertices[i];
-        const auto next_v = vertices[GetModuloNext(i, count)];
-        sum += GetX(this_v) * (GetY(next_v) - GetY(last_v));
-    }
-    
-    // Note that using the absolute value isn't necessary for vertices in counter-clockwise
-    // ordering; only needed for clockwise ordering.
-    constexpr auto RealInverseOfTwo = Real{1} / Real{2};
-    return abs(sum) * RealInverseOfTwo;
-}
 
-SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices)
-{
-    assert(size(vertices) > 2);
-    
-    // Use formulas Ix and Iy for second moment of area of any simple polygon and apply
-    // the perpendicular axis theorem on these to get the desired answer.
-    //
-    // See:
-    // https://en.wikipedia.org/wiki/Second_moment_of_area#Any_polygon
-    // https://en.wikipedia.org/wiki/Second_moment_of_area#Perpendicular_axis_theorem
-    auto sum_x = SquareMeter * SquareMeter * 0;
-    auto sum_y = SquareMeter * SquareMeter * 0;
-    const auto count = size(vertices);
-    for (auto i = decltype(count){0}; i < count; ++i)
-    {
-        const auto this_v = vertices[i];
-        const auto next_v = vertices[GetModuloNext(i, count)];
-        const auto fact_b = Cross(this_v, next_v);
-        sum_x += [&]() {
-            const auto fact_a = Square(GetY(this_v)) + GetY(this_v) * GetY(next_v) + Square(GetY(next_v));
-            return fact_a * fact_b;
-        }();
-        sum_y += [&]() {
-            const auto fact_a = Square(GetX(this_v)) + GetX(this_v) * GetX(next_v) + Square(GetX(next_v));
-            return fact_a * fact_b;
-        }();
-    }
-    const auto secondMomentOfAreaX = SecondMomentOfArea{sum_x};
-    const auto secondMomentOfAreaY = SecondMomentOfArea{sum_y};
-    constexpr auto RealInverseOfTwelve = Real{1} / Real{12};
-    return (secondMomentOfAreaX + secondMomentOfAreaY) * RealInverseOfTwelve;
-}
-
-namespace d2 {
-
-LinearVelocity2 GetContactRelVelocity(const Velocity velA, const Length2 relA,
-                                      const Velocity velB, const Length2 relB) noexcept
-{
-#if 0 // Using std::fma appears to be slower!
+        LinearVelocity2 GetContactRelVelocity(const Velocity velA, const Length2 relA,
+                                              const Velocity velB, const Length2 relB) noexcept
+        {
+#if 0// Using std::fma appears to be slower!
     const auto revPerpRelB = GetRevPerpendicular(relB);
     const auto xRevPerpRelB = StripUnit(revPerpRelB.x);
     const auto yRevPerpRelB = StripUnit(revPerpRelB.y);
@@ -197,12 +199,12 @@ LinearVelocity2 GetContactRelVelocity(const Velocity velA, const Length2 relA,
     
     return Vec2{deltaFmaX, deltaFmaY} * MeterPerSecond;
 #else
-    const auto velBrot = GetRevPerpendicular(relB) * (velB.angular / Radian);
-    const auto velArot = GetRevPerpendicular(relA) * (velA.angular / Radian);
-    return (velB.linear + velBrot) - (velA.linear + velArot);
+            const auto velBrot = GetRevPerpendicular(relB) * (velB.angular / Radian);
+            const auto velArot = GetRevPerpendicular(relA) * (velA.angular / Radian);
+            return (velB.linear + velBrot) - (velA.linear + velArot);
 #endif
-}
+        }
 
-} // namespace d2
+    }// namespace d2
 
-} // namespace playrho
+}// namespace playrho

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -22,918 +22,911 @@
 #ifndef PLAYRHO_COMMON_MATH_HPP
 #define PLAYRHO_COMMON_MATH_HPP
 
-#include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/Acceleration.hpp>
+#include <PlayRho/Common/FixedMath.hpp>
+#include <PlayRho/Common/Matrix.hpp>
 #include <PlayRho/Common/NonNegative.hpp>
+#include <PlayRho/Common/Position.hpp>
+#include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Span.hpp>
+#include <PlayRho/Common/Sweep.hpp>
+#include <PlayRho/Common/Transformation.hpp>
 #include <PlayRho/Common/UnitVec.hpp>
 #include <PlayRho/Common/Vector2.hpp>
 #include <PlayRho/Common/Vector3.hpp>
-#include <PlayRho/Common/Position.hpp>
 #include <PlayRho/Common/Velocity.hpp>
-#include <PlayRho/Common/Acceleration.hpp>
-#include <PlayRho/Common/Transformation.hpp>
-#include <PlayRho/Common/Sweep.hpp>
-#include <PlayRho/Common/Matrix.hpp>
-#include <PlayRho/Common/FixedMath.hpp>
 
 #include <cmath>
-#include <vector>
 #include <numeric>
+#include <vector>
 
-namespace playrho {
-
-// Import common standard mathematical functions into the playrho namespace...
-using std::signbit;
-using std::nextafter;
-using std::trunc;
-using std::fmod;
-using std::isfinite;
-using std::round;
-using std::isnormal;
-using std::isnan;
-using std::hypot;
-using std::cos;
-using std::sin;
-using std::atan2;
-using std::sqrt;
-using std::pow;
-using std::abs;
-
-// Other templates.
-
-/// @brief Gets the "X" element of the given value - i.e. the first element.
-template <typename T>
-constexpr auto& GetX(T& value)
+namespace playrho
 {
-    return get<0>(value);
-}
 
-/// @brief Gets the "Y" element of the given value - i.e. the second element.
-template <typename T>
-constexpr auto& GetY(T& value)
-{
-    return get<1>(value);
-}
+    // Import common standard mathematical functions into the playrho namespace...
+    using std::abs;
+    using std::atan2;
+    using std::cos;
+    using std::fmod;
+    using std::hypot;
+    using std::isfinite;
+    using std::isnan;
+    using std::isnormal;
+    using std::nextafter;
+    using std::pow;
+    using std::round;
+    using std::signbit;
+    using std::sin;
+    using std::sqrt;
+    using std::trunc;
 
-/// @brief Gets the "Z" element of the given value - i.e. the third element.
-template <typename T>
-constexpr auto& GetZ(T& value)
-{
-    return get<2>(value);
-}
+    // Other templates.
 
-/// @brief Gets the "X" element of the given value - i.e. the first element.
-template <typename T>
-constexpr auto GetX(const T& value)
-{
-    return get<0>(value);
-}
-
-/// @brief Gets the "Y" element of the given value - i.e. the second element.
-template <typename T>
-constexpr auto GetY(const T& value)
-{
-    return get<1>(value);
-}
-
-/// @brief Gets the "Z" element of the given value - i.e. the third element.
-template <typename T>
-constexpr auto GetZ(const T& value)
-{
-    return get<2>(value);
-}
-
-/// @brief Makes the given value into an unsigned value.
-/// @note If the given value is negative, this will result in an unsigned value which is the
-///   two's complement modulo-wrapped value.
-template <typename T>
-constexpr std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
-MakeUnsigned(const T& arg) noexcept
-{
-    return static_cast<std::make_unsigned_t<T>>(arg);
-}
-
-/// @brief Strips the unit from the given value.
-template <typename T>
-constexpr auto StripUnit(const T& v)
--> decltype(StripUnit(v.get()))
-{
-    return StripUnit(v.get());
-}
-
-/// @defgroup Math Additional Math Functions
-/// @brief Additional functions for common mathematical operations.
-/// @details These are non-member non-friend functions for mathematical operations
-///   especially those with mixed input and output types.
-/// @{
-
-/// @brief Secant method.
-/// @see https://en.wikipedia.org/wiki/Secant_method
-template <typename T, typename U>
-constexpr U Secant(T target, U a1, T s1, U a2, T s2) noexcept
-{
-    static_assert(IsArithmetic<T>::value && IsArithmetic<U>::value, "Arithmetic types required.");
-    return a1 + (target - s1) * (a2 - a1) / (s2 - s1);
-}
-
-/// @brief Bisection method.
-/// @see https://en.wikipedia.org/wiki/Bisection_method
-template <typename T>
-constexpr T Bisect(T a1, T a2) noexcept
-{
-    return (a1 + a2) / 2;
-}
-
-/// @brief Is-odd.
-/// @details Determines whether the given integral value is odd (as opposed to being even).
-template <typename T>
-constexpr bool IsOdd(T val) noexcept
-{
-    static_assert(std::is_integral<T>::value, "Integral type required.");
-    return val % 2;
-}
-
-/// @brief Squares the given value.
-template<class TYPE>
-constexpr auto Square(TYPE t) noexcept { return t * t; }
-
-/// @brief Computes the arc-tangent of the given y and x values.
-/// @return Normalized angle - an angle between -Pi and Pi inclusively.
-/// @see https://en.cppreference.com/w/cpp/numeric/math/atan2
-template<typename T>
-inline auto Atan2(T y, T x)
-{
-    return Angle{static_cast<Real>(atan2(StripUnit(y), StripUnit(x))) * Radian};
-}
-
-/// @brief Computes the average of the given values.
-template <typename T, typename = std::enable_if_t<
-    IsIterable<T>::value && IsAddable<decltype(*begin(std::declval<T>()))>::value
-    > >
-inline auto Average(const T& span)
-{
-    using value_type = decltype(*begin(std::declval<T>()));
-
-    // Relies on C++11 zero initialization to zero initialize value_type.
-    // See: http://en.cppreference.com/w/cpp/language/zero_initialization
-    constexpr auto zero = value_type{};
-    assert(zero * Real{2} == zero);
-    
-    // For C++17, switch from using std::accumulate to using std::reduce.
-    const auto sum = std::accumulate(begin(span), end(span), zero);
-    const auto count = std::max(size(span), std::size_t{1});
-    return sum / static_cast<Real>(count);
-}
-
-/// @brief Computes the rounded value of the given value.
-template <typename T>
-inline std::enable_if_t<IsArithmetic<T>::value, T> RoundOff(T value, unsigned precision = 100000)
-{
-    const auto factor = static_cast<T>(precision);
-    return round(value * factor) / factor;
-}
-
-/// @brief Computes the rounded value of the given value.
-inline Vec2 RoundOff(Vec2 value, std::uint32_t precision = 100000)
-{
-    return Vec2{RoundOff(value[0], precision), RoundOff(value[1], precision)};
-}
-
-/// @brief Absolute value function for vectors.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr Vector<T, N> abs(const Vector<T, N>& v) noexcept
-{
-    auto result = Vector<T, N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
+    /// @brief Gets the "X" element of the given value - i.e. the first element.
+    template<typename T>
+    constexpr auto& GetX(T& value)
     {
-        result[i] = abs(v[i]);
+        return get<0>(value);
     }
-    return result;
-}
 
-/// @brief Gets the absolute value of the given value.
-inline d2::UnitVec abs(const d2::UnitVec& v) noexcept
-{
-    return v.Absolute();
-}
-
-/// @brief Gets whether a given value is almost zero.
-/// @details An almost zero value is "subnormal". Dividing by these values can lead to
-/// odd results like a divide by zero trap occurring.
-/// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
-template <typename T>
-constexpr
-std::enable_if_t<std::is_arithmetic<T>::value, bool> AlmostZero(T value)
-{
-    return abs(value) < std::numeric_limits<T>::min();
-}
-
-/// @brief Determines whether the given two values are "almost equal".
-template <typename T>
-constexpr
-std::enable_if_t<std::is_floating_point<T>::value, bool> AlmostEqual(T x, T y, int ulp = 2)
-{
-    // From http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon :
-    //   "the machine epsilon has to be scaled to the magnitude of the values used
-    //    and multiplied by the desired precision in ULPs (units in the last place)
-    //    unless the result is subnormal".
-    // Where "subnormal" means almost zero.
-    //
-    return (abs(x - y) < (std::numeric_limits<T>::epsilon() * abs(x + y) * static_cast<T>(ulp)))
-        || AlmostZero(x - y);
-}
-
-/// @brief Modulo operation using <code>std::fmod</code>.
-/// @note Modulo via <code>std::fmod</code> appears slower than via <code>std::trunc</code>.
-/// @see ModuloViaTrunc
-template <typename T>
-inline auto ModuloViaFmod(T dividend, T divisor) noexcept
-{
-    // Note: modulo via std::fmod appears slower than via std::trunc.
-    return static_cast<T>(fmod(dividend, divisor));
-}
-
-/// @brief Modulo operation using <code>std::trunc</code>.
-/// @note Modulo via <code>std::fmod</code> appears slower than via <code>std::trunc</code>.
-/// @see ModuloViaFmod
-template <typename T>
-inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
-{
-    const auto quotient = dividend / divisor;
-    const auto integer = static_cast<T>(trunc(quotient));
-    const auto remainder = quotient - integer;
-    return remainder * divisor;
-}
-
-/// @brief Gets the "normalized" value of the given angle.
-/// @return Angle between -Pi and Pi radians inclusively where 0 represents the positive X-axis.
-/// @see Atan2
-inline Angle GetNormalized(Angle value) noexcept
-{
-    constexpr auto oneRotationInRadians = Real{2 * Pi};
-    auto angleInRadians = Real{value / Radian};
-#if defined(NORMALIZE_ANGLE_VIA_FMOD)
-    // Note: std::fmod appears slower than std::trunc.
-    //   See Benchmark ModuloViaFmod for data.
-    angleInRadians = ModuloViaFmod(angleInRadians, oneRotationInRadians);
-#else
-    // Note: std::trunc appears more than twice as fast as std::fmod.
-    //   See Benchmark ModuloViaTrunc for data.
-    angleInRadians = ModuloViaTrunc(angleInRadians, oneRotationInRadians);
-#endif
-    if (angleInRadians > Pi)
+    /// @brief Gets the "Y" element of the given value - i.e. the second element.
+    template<typename T>
+    constexpr auto& GetY(T& value)
     {
-        // 190_deg becomes 190_deg - 360_deg = -170_deg
-        angleInRadians -= Pi * 2;
+        return get<1>(value);
     }
-    else if (angleInRadians < -Pi)
+
+    /// @brief Gets the "Z" element of the given value - i.e. the third element.
+    template<typename T>
+    constexpr auto& GetZ(T& value)
     {
-        // -200_deg becomes -200_deg + 360_deg = 100_deg
-        angleInRadians += Pi * 2;
+        return get<2>(value);
     }
-    return angleInRadians * Radian;
-}
 
-/// @brief Gets the angle.
-/// @return Angular value in the range of -Pi to +Pi radians.
-template <class T>
-inline Angle GetAngle(const Vector2<T> value)
-{
-    return Atan2(GetY(value), GetX(value));
-}
-
-/// @brief Gets the square of the magnitude of the given iterable value.
-/// @note For performance, use this instead of <code>GetMagnitude(T value)</code> (if possible).
-/// @return Non-negative value from 0 to infinity, or NaN.
-template <typename T>
-constexpr
-auto GetMagnitudeSquared(T value) noexcept
-{
-    using VT = typename T::value_type;
-    using OT = decltype(VT{} * VT{});
-    auto result = OT{};
-    for (auto&& e: value)
+    /// @brief Gets the "X" element of the given value - i.e. the first element.
+    template<typename T>
+    constexpr auto GetX(const T& value)
     {
-        result += Square(e);
+        return get<0>(value);
     }
-    return result;
-}
 
-/// @brief Gets the magnitude of the given value.
-/// @note Works for any type for which <code>GetMagnitudeSquared</code> also works.
-template <typename T>
-inline auto GetMagnitude(T value)
-{
-    return sqrt(GetMagnitudeSquared(value));
-}
-
-/// @brief Performs the dot product on two vectors (A and B).
-///
-/// @details The dot product of two vectors is defined as:
-///   the magnitude of vector A, multiplied by, the magnitude of vector B,
-///   multiplied by, the cosine of the angle between the two vectors (A and B).
-///   Thus the dot product of two vectors is a value ranging between plus and minus the
-///   magnitudes of each vector times each other.
-///   The middle value of 0 indicates that two vectors are perpendicular to each other
-///   (at an angle of +/- 90 degrees from each other).
-///
-/// @note This operation is commutative. I.e. Dot(a, b) == Dot(b, a).
-/// @note If A and B are the same vectors, <code>GetMagnitudeSquared(Vec2)</code> returns
-///   the same value using effectively one less input parameter.
-/// @note This is similar to the <code>std::inner_product</code> standard library algorithm
-///   except benchmark tests suggest this implementation is faster at least for
-///   <code>Vec2</code> like instances.
-///
-/// @see https://en.wikipedia.org/wiki/Dot_product
-///
-/// @param a Vector A.
-/// @param b Vector B.
-///
-/// @return Dot product of the vectors (0 means the two vectors are perpendicular).
-///
-template <typename T1, typename T2>
-constexpr auto Dot(const T1 a, const T2 b) noexcept
-{
-    static_assert(std::tuple_size<T1>::value == std::tuple_size<T2>::value,
-                  "Dot only for same tuple-like sized types");
-    using VT1 = typename T1::value_type;
-    using VT2 = typename T2::value_type;
-    using OT = decltype(VT1{} * VT2{});
-    auto result = OT{};
-    const auto numElements = size(a);
-    for (auto i = decltype(numElements){0}; i < numElements; ++i)
+    /// @brief Gets the "Y" element of the given value - i.e. the second element.
+    template<typename T>
+    constexpr auto GetY(const T& value)
     {
-        result += a[i] * b[i];
+        return get<1>(value);
     }
-    return result;
-}
 
-/// @brief Performs the 2-element analog of the cross product of two vectors.
-///
-/// @details Defined as the result of: <code>(a.x * b.y) - (a.y * b.x)</code>.
-///
-/// @note This operation is dimension squashing. I.e. A cross of a 2-D length by a 2-D unit
-///   vector results in a 1-D length value.
-/// @note The unit of the result is the 1-D product of the inputs.
-/// @note This operation is anti-commutative. I.e. Cross(a, b) == -Cross(b, a).
-/// @note The result will be 0 if any of the following are true:
-///   vector A or vector B has a length of zero;
-///   vectors A and B point in the same direction; or
-///   vectors A and B point in exactly opposite direction of each other.
-/// @note The result will be positive if:
-///   neither vector A nor B has a length of zero; and
-///   vector B is at an angle from vector A of greater than 0 and less than 180 degrees
-///   (counter-clockwise from A being a positive angle).
-/// @note Result will be negative if:
-///   neither vector A nor B has a length of zero; and
-///   vector B is at an angle from vector A of less than 0 and greater than -180 degrees
-///   (clockwise from A being a negative angle).
-/// @note The absolute value of the result is the area of the parallelogram formed by
-///   the vectors A and B.
-///
-/// @see https://en.wikipedia.org/wiki/Cross_product
-///
-/// @return Cross product of the two values.
-///
-template <class T1, class T2, std::enable_if_t<
-    std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
-constexpr auto Cross(T1 a, T2 b) noexcept
-{
-    assert(isfinite(StripUnit(get<0>(a))));
-    assert(isfinite(StripUnit(get<1>(a))));
-    assert(isfinite(StripUnit(get<0>(b))));
-    assert(isfinite(StripUnit(get<1>(b))));
-
-    // Both vectors of same direction...
-    // If a = Vec2{1, 2} and b = Vec2{1, 2} then: a x b = 1 * 2 - 2 * 1 = 0.
-    // If a = Vec2{1, 2} and b = Vec2{2, 4} then: a x b = 1 * 4 - 2 * 2 = 0.
-    //
-    // Vectors at +/- 90 degrees of each other...
-    // If a = Vec2{1, 2} and b = Vec2{-2, 1} then: a x b = 1 * 1 - 2 * (-2) = 1 + 4 = 5.
-    // If a = Vec2{1, 2} and b = Vec2{2, -1} then: a x b = 1 * (-1) - 2 * 2 = -1 - 4 = -5.
-    //
-    // Vectors between 0 and 180 degrees of each other excluding 90 degrees...
-    // If a = Vec2{1, 2} and b = Vec2{-1, 2} then: a x b = 1 * 2 - 2 * (-1) = 2 + 2 = 4.
-    const auto minuend = get<0>(a) * get<1>(b);
-    const auto subtrahend = get<1>(a) * get<0>(b);
-    assert(isfinite(StripUnit(minuend)));
-    assert(isfinite(StripUnit(subtrahend)));
-    return minuend - subtrahend;
-}
-
-/// @brief Cross-products the given two values.
-/// @note This operation is anti-commutative. I.e. Cross(a, b) == -Cross(b, a).
-/// @see https://en.wikipedia.org/wiki/Cross_product
-/// @param a Value A of a 3-element type.
-/// @param b Value B of a 3-element type.
-/// @return Cross product of the two values.
-template <class T1, class T2, std::enable_if_t<
-    std::tuple_size<T1>::value == 3 && std::tuple_size<T2>::value == 3, int> = 0>
-constexpr auto Cross(T1 a, T2 b) noexcept
-{
-    assert(isfinite(get<0>(a)));
-    assert(isfinite(get<1>(a)));
-    assert(isfinite(get<2>(a)));
-    assert(isfinite(get<0>(b)));
-    assert(isfinite(get<1>(b)));
-    assert(isfinite(get<2>(b)));
-
-    using OT = decltype(get<0>(a) * get<0>(b));
-    return Vector<OT, 3>{
-        GetY(a) * GetZ(b) - GetZ(a) * GetY(b),
-        GetZ(a) * GetX(b) - GetX(a) * GetZ(b),
-        GetX(a) * GetY(b) - GetY(a) * GetX(b)
-    };
-}
-
-/// @brief Solves A * x = b, where b is a column vector.
-/// @note This is more efficient than computing the inverse in one-shot cases.
-template <typename T, typename U>
-constexpr auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
-{
-    const auto cp = Cross(get<0>(mat), get<1>(mat));
-    const auto inverseCp = Real{1} / cp;
-    using OutType = decltype((U{} * T{}) / cp);
-    return (!AlmostZero(StripUnit(cp)))?
-        Vector2<OutType>{
-            (get<1>(mat)[1] * b[0] - get<1>(mat)[0] * b[1]) * inverseCp,
-            (get<0>(mat)[0] * b[1] - get<0>(mat)[1] * b[0]) * inverseCp
-        }: Vector2<OutType>{};
-}
-
-/// @brief Inverts the given value.
-template <class IN_TYPE>
-constexpr auto Invert(const Matrix22<IN_TYPE> value) noexcept
-{
-    const auto cp = Cross(get<0>(value), get<1>(value));
-    using OutType = decltype(get<0>(value)[0] / cp);
-    const auto inverseCp = Real{1} / cp;
-    return (!AlmostZero(StripUnit(cp)))?
-        Matrix22<OutType>{
-            Vector2<OutType>{ get<1>(get<1>(value)) * inverseCp, -get<1>(get<0>(value)) * inverseCp},
-            Vector2<OutType>{-get<0>(get<1>(value)) * inverseCp,  get<0>(get<0>(value)) * inverseCp}
-        }:
-        Matrix22<OutType>{};
-}
-
-/// @brief Solves A * x = b, where b is a column vector.
-/// @note This is more efficient than computing the inverse in one-shot cases.
-constexpr Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
-{
-    const auto dp = Dot(GetX(mat), Cross(GetY(mat), GetZ(mat)));
-    const auto det = (dp != 0)? Real{1} / dp: dp;
-    const auto x = det * Dot(b, Cross(GetY(mat), GetZ(mat)));
-    const auto y = det * Dot(GetX(mat), Cross(b, GetZ(mat)));
-    const auto z = det * Dot(GetX(mat), Cross(GetY(mat), b));
-    return Vec3{x, y, z};
-}
-    
-/// @brief Solves A * x = b, where b is a column vector.
-/// @note This is more efficient than computing the inverse in one-shot cases.
-/// @note Solves only the upper 2-by-2 matrix equation.
-template <typename T>
-constexpr T Solve22(const Mat33& mat, const T b) noexcept
-{
-    const auto cp = GetX(GetX(mat)) * GetY(GetY(mat)) - GetX(GetY(mat)) * GetY(GetX(mat));
-    const auto det = (cp != 0)? Real{1} / cp: cp;
-    const auto x = det * (GetY(GetY(mat)) * GetX(b) - GetX(GetY(mat)) * GetY(b));
-    const auto y = det * (GetX(GetX(mat)) * GetY(b) - GetY(GetX(mat)) * GetX(b));
-    return T{x, y};
-}
-
-/// @brief Gets the inverse of the given matrix as a 2-by-2.
-/// @return Zero matrix if singular.
-constexpr Mat33 GetInverse22(const Mat33& value) noexcept
-{
-    const auto a = GetX(GetX(value)), b = GetX(GetY(value)), c = GetY(GetX(value)), d = GetY(GetY(value));
-    auto det = (a * d) - (b * c);
-    if (det != Real{0})
+    /// @brief Gets the "Z" element of the given value - i.e. the third element.
+    template<typename T>
+    constexpr auto GetZ(const T& value)
     {
-        det = Real{1} / det;
+        return get<2>(value);
     }
-    return Mat33{Vec3{det * d, -det * c, Real{0}}, Vec3{-det * b, det * a, 0}, Vec3{0, 0, 0}};
-}
-    
-/// @brief Gets the symmetric inverse of this matrix as a 3-by-3.
-/// @return Zero matrix if singular.
-constexpr Mat33 GetSymInverse33(const Mat33& value) noexcept
-{
-    auto det = Dot(GetX(value), Cross(GetY(value), GetZ(value)));
-    if (det != Real{0})
+
+    /// @brief Makes the given value into an unsigned value.
+    /// @note If the given value is negative, this will result in an unsigned value which is the
+    ///   two's complement modulo-wrapped value.
+    template<typename T>
+    constexpr std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
+    MakeUnsigned(const T& arg) noexcept
     {
-        det = Real{1} / det;
+        return static_cast<std::make_unsigned_t<T>>(arg);
     }
-    
-    const auto a11 = GetX(GetX(value)), a12 = GetX(GetY(value)), a13 = GetX(GetZ(value));
-    const auto a22 = GetY(GetY(value)), a23 = GetY(GetZ(value));
-    const auto a33 = GetZ(GetZ(value));
-    
-    const auto ex_y = det * (a13 * a23 - a12 * a33);
-    const auto ey_z = det * (a13 * a12 - a11 * a23);
-    const auto ex_z = det * (a12 * a23 - a13 * a22);
-    
-    return Mat33{
-        Vec3{det * (a22 * a33 - a23 * a23), ex_y, ex_z},
-        Vec3{ex_y, det * (a11 * a33 - a13 * a13), ey_z},
-        Vec3{ex_z, ey_z, det * (a11 * a22 - a12 * a12)}
-    };
-}
 
-/// @brief Gets a vector counter-clockwise (reverse-clockwise) perpendicular to the given vector.
-/// @details This takes a vector of form (x, y) and returns the vector (-y, x).
-/// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
-/// @return A counter-clockwise 90-degree rotation of the given vector.
-/// @see GetFwdPerpendicular.
-template <class T>
-constexpr auto GetRevPerpendicular(const T vector) noexcept
-{
-    // See http://mathworld.wolfram.com/PerpendicularVector.html
-    return T{-GetY(vector), GetX(vector)};
-}
-    
-/// @brief Gets a vector clockwise (forward-clockwise) perpendicular to the given vector.
-/// @details This takes a vector of form (x, y) and returns the vector (y, -x).
-/// @param vector Vector to return a clockwise perpendicular equivalent for.
-/// @return A clockwise 90-degree rotation of the given vector.
-/// @see GetRevPerpendicular.
-template <class T>
-constexpr auto GetFwdPerpendicular(const T vector) noexcept
-{
-    // See http://mathworld.wolfram.com/PerpendicularVector.html
-    return T{GetY(vector), -GetX(vector)};
-}
-
-/// @brief Multiplies an M-element vector by an M-by-N matrix.
-/// @param v Vector that's interpreted as a matrix with 1 row and M-columns.
-/// @param m An M-row by N-column *transformation matrix* to multiply the vector by.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-template <std::size_t M, typename T1, std::size_t N, typename T2>
-constexpr auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
-{
-    return m * v;
-}
-
-/// @brief Multiplies a vector by a matrix.
-constexpr Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
-{
-    return Vec2{
-        get<0>(get<0>(A)) * v[0] + get<0>(get<1>(A)) * v[1],
-        get<1>(get<0>(A)) * v[0] + get<1>(get<1>(A)) * v[1]
-    };
-}
-
-/// Multiply a matrix transpose times a vector. If a rotation matrix is provided,
-/// then this transforms the vector from one frame to another (inverse transform).
-constexpr Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
-{
-    return Vec2{Dot(v, GetX(A)), Dot(v, GetY(A))};
-}
-
-/// @brief Computes A^T * B.
-constexpr Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
-{
-    const auto c1 = Vec2{Dot(GetX(A), GetX(B)), Dot(GetY(A), GetX(B))};
-    const auto c2 = Vec2{Dot(GetX(A), GetY(B)), Dot(GetY(A), GetY(B))};
-    return Mat22{c1, c2};
-}
-
-/// @brief Gets the absolute value of the given value.
-inline Mat22 abs(const Mat22& A)
-{
-    return Mat22{abs(GetX(A)), abs(GetY(A))};
-}
-
-/// @brief Gets the next largest power of 2
-/// @details
-/// Given a binary integer value x, the next largest power of 2 can be computed by a S.W.A.R.
-/// algorithm that recursively "folds" the upper bits into the lower bits. This process yields
-/// a bit vector with the same most significant 1 as x, but all one's below it. Adding 1 to
-/// that value yields the next largest power of 2. For a 64-bit value:"
-inline std::uint64_t NextPowerOfTwo(std::uint64_t x)
-{
-    x |= (x >>  1u);
-    x |= (x >>  2u);
-    x |= (x >>  4u);
-    x |= (x >>  8u);
-    x |= (x >> 16u);
-    x |= (x >> 32u);
-    return x + 1;
-}
-
-/// @brief Converts the given vector into a unit vector and returns its original length.
-inline Real Normalize(Vec2& vector)
-{
-    const auto length = GetMagnitude(vector);
-    if (!AlmostZero(length))
+    /// @brief Strips the unit from the given value.
+    template<typename T>
+    constexpr auto StripUnit(const T& v)
+        -> decltype(StripUnit(v.get()))
     {
-        const auto invLength = Real{1} / length;
-        vector[0] *= invLength;
-        vector[1] *= invLength;
-        return length;
+        return StripUnit(v.get());
     }
-    return 0;
-}
 
-/// @brief Computes the centroid of a counter-clockwise array of 3 or more vertices.
-/// @note Behavior is undefined if there are less than 3 vertices or the vertices don't
-///   go counter-clockwise.
-Length2 ComputeCentroid(const Span<const Length2>& vertices);
+    /// @defgroup Math Additional Math Functions
+    /// @brief Additional functions for common mathematical operations.
+    /// @details These are non-member non-friend functions for mathematical operations
+    ///   especially those with mixed input and output types.
+    /// @{
 
-/// @brief Gets the modulo next value.
-template <typename T>
-constexpr T GetModuloNext(T value, T count) noexcept
-{
-    assert(value < count);
-    return (value + 1) % count;
-}
-
-/// @brief Gets the modulo previous value.
-template <typename T>
-constexpr T GetModuloPrev(T value, T count) noexcept
-{
-    assert(value < count);
-    return (value? value: count) - 1;
-}
-
-/// @brief Gets the shortest angular distance to go from angle 1 to angle 2.
-/// @details This gets the angle to rotate angle 1 by in order to get to angle 2 with the
-///   least amount of rotation.
-/// @return Angle between -Pi and Pi radians inclusively.
-/// @see GetNormalized
-Angle GetDelta(Angle a1, Angle a2) noexcept;
-
-/// Gets the reverse (counter) clockwise rotational angle to go from angle 1 to angle 2.
-/// @return Angular rotation in the counter clockwise direction to go from angle 1 to angle 2.
-constexpr Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
-{
-    return (a1 > a2)? 360_deg - (a1 - a2): a2 - a1;
-}
-    
-/// @brief Gets the vertices for a circle described by the given parameters.
-std::vector<Length2> GetCircleVertices(Length radius, unsigned slices,
-                                        Angle start = 0_deg, Real turns = Real{1});
-
-/// @brief Gets the area of a circle.
-NonNegative<Area> GetAreaOfCircle(Length radius);
-
-/// @brief Gets the area of a polygon.
-/// @note This function is valid for any non-self-intersecting (simple) polygon,
-///   which can be convex or concave.
-/// @note Winding order doesn't matter.
-NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices);
-
-/// @brief Gets the polar moment of the area enclosed by the given vertices.
-///
-/// @warning Behavior is undefined if given collection has less than 3 vertices.
-///
-/// @param vertices Collection of three or more vertices.
-///
-SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices);
-
-/// @}
-
-namespace d2 {
-
-/// @brief Gets a <code>Vec2</code> representation of the given value.
-constexpr Vec2 GetVec2(const UnitVec value)
-{
-    return Vec2{get<0>(value), get<1>(value)};
-}
-
-/// @brief Gets the angle of the given unit vector.
-inline Angle GetAngle(const UnitVec value)
-{
-    return Atan2(GetY(value), GetX(value));
-}
-
-/// @brief Multiplication operator.
-template <class T, typename U>
-constexpr Vector2<T> operator* (CheckedValue<T, U> s, UnitVec u) noexcept
-{
-    return Vector2<T>{u.GetX() * s, u.GetY() * s};
-}
-
-/// @brief Multiplication operator.
-template <class T>
-constexpr Vector2<T> operator* (const T s, const UnitVec u) noexcept
-{
-    return Vector2<T>{u.GetX() * s, u.GetY() * s};
-}
-
-/// @brief Multiplication operator.
-template <class T, typename U>
-constexpr Vector2<T> operator* (UnitVec u, CheckedValue<T, U> s) noexcept
-{
-    return Vector2<T>{u.GetX() * s, u.GetY() * s};
-}
-
-/// @brief Multiplication operator.
-template <class T>
-constexpr Vector2<T> operator* (const UnitVec u, const T s) noexcept
-{
-    return Vector2<T>{u.GetX() * s, u.GetY() * s};
-}
-
-/// @brief Division operator.
-constexpr Vec2 operator/ (const UnitVec u, const UnitVec::value_type s) noexcept
-{
-    const auto inverseS = Real{1} / s;
-    return Vec2{GetX(u) * inverseS, GetY(u) * inverseS};
-}
-
-/// @brief Rotates a vector by a given angle.
-/// @details This rotates a vector by the angle expressed by the angle parameter.
-/// @param vector Vector to forward rotate.
-/// @param angle Expresses the angle to forward rotate the given vector by.
-/// @see InverseRotate.
-template <class T>
-constexpr auto Rotate(const Vector2<T> vector, const UnitVec& angle) noexcept
-{
-    const auto newX = (GetX(angle) * GetX(vector)) - (GetY(angle) * GetY(vector));
-    const auto newY = (GetY(angle) * GetX(vector)) + (GetX(angle) * GetY(vector));
-    return Vector2<T>{newX, newY};
-}
-
-/// @brief Inverse rotates a vector.
-/// @details This is the inverse of rotating a vector - it undoes what rotate does. I.e.
-///   this effectively subtracts from the angle of the given vector the angle that's
-///   expressed by the angle parameter.
-/// @param vector Vector to reverse rotate.
-/// @param angle Expresses the angle to reverse rotate the given vector by.
-/// @see Rotate.
-template <class T>
-constexpr auto InverseRotate(const Vector2<T> vector, const UnitVec& angle) noexcept
-{
-    const auto newX = (GetX(angle) * GetX(vector)) + (GetY(angle) * GetY(vector));
-    const auto newY = (GetX(angle) * GetY(vector)) - (GetY(angle) * GetX(vector));
-    return Vector2<T>{newX, newY};
-}
-
-/// Gets the unit vector for the given value.
-/// @param value Value to get the unit vector for.
-/// @param fallback Fallback unit vector value to use in case a unit vector can't effectively be
-///   calculated from the given value.
-/// @return value divided by its length if length not almost zero otherwise invalid value.
-/// @see AlmostEqual.
-template <class T>
-inline UnitVec GetUnitVector(Vector2<T> value, UnitVec fallback = UnitVec::GetDefaultFallback())
-{
-    return std::get<0>(UnitVec::Get(StripUnit(GetX(value)), StripUnit(GetY(value)), fallback));
-}
-
-/// @brief Gets the "normalized" position.
-/// @details Enforces a wrap-around of one rotation on the angular position.
-/// @note Use to prevent unbounded angles in positions.
-inline Position GetNormalized(const Position& val) noexcept
-{
-    return Position{val.linear, playrho::GetNormalized(val.angular)};
-}
-
-/// @brief Gets a sweep with the given sweep's angles normalized.
-/// @param sweep Sweep to return with its angles normalized.
-/// @return Sweep with its position 0 angle to be between -2 pi and 2 pi and its
-///   position 1 angle reduced by the amount the position 0 angle was reduced by.
-/// @relatedalso Sweep
-inline Sweep GetNormalized(Sweep sweep) noexcept
-{
-    const auto pos0a = playrho::GetNormalized(sweep.pos0.angular);
-    const auto d = sweep.pos0.angular - pos0a;
-    sweep.pos0.angular = pos0a;
-    sweep.pos1.angular -= d;
-    return sweep;
-}
-
-/// @brief Transforms the given 2-D vector with the given transformation.
-/// @details
-/// Rotate and translate the given 2-D linear position according to the rotation and translation
-/// defined by the given transformation.
-/// @note Passing the output of this function to <code>InverseTransform</code> (with the same
-/// transformation again) will result in the original vector being returned.
-/// @note For a 2-D linear position of the origin (0, 0), the result is simply the translation.
-/// @see <code>InverseTransform</code>.
-/// @param v 2-D position to transform (to rotate and then translate).
-/// @param xfm Transformation (a translation and rotation) to apply to the given vector.
-/// @return Rotated and translated vector.
-constexpr Length2 Transform(const Length2 v, const Transformation xfm) noexcept
-{
-    return Rotate(v, xfm.q) + xfm.p;
-}
-
-/// @brief Inverse transforms the given 2-D vector with the given transformation.
-/// @details
-/// Inverse translate and rotate the given 2-D vector according to the translation and rotation
-/// defined by the given transformation.
-/// @note Passing the output of this function to <code>Transform</code> (with the same
-/// transformation again) will result in the original vector being returned.
-/// @see <code>Transform</code>.
-/// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
-/// @param xfm Transformation (a translation and rotation) to inversely apply to the given vector.
-/// @return Inverse transformed vector.
-constexpr Length2 InverseTransform(const Length2 v, const Transformation xfm) noexcept
-{
-    return InverseRotate(v - xfm.p, xfm.q);
-}
-
-/// @brief Multiplies a given transformation by another given transformation.
-/// @note <code>v2 = A.q.Rot(B.q.Rot(v1) + B.p) + A.p
-///                = (A.q * B.q).Rot(v1) + A.q.Rot(B.p) + A.p</code>
-constexpr Transformation Mul(const Transformation& A, const Transformation& B) noexcept
-{
-    return Transformation{A.p + Rotate(B.p, A.q), A.q.Rotate(B.q)};
-}
-
-/// @brief Inverse multiplies a given transformation by another given transformation.
-/// @note <code>v2 = A.q' * (B.q * v1 + B.p - A.p)
-///                = A.q' * B.q * v1 + A.q' * (B.p - A.p)</code>
-constexpr Transformation MulT(const Transformation& A, const Transformation& B) noexcept
-{
-    const auto dp = B.p - A.p;
-    return Transformation{InverseRotate(dp, A.q), B.q.Rotate(A.q.FlipY())};
-}
-
-/// @brief Gets the transformation for the given values.
-constexpr Transformation GetTransformation(const Length2 ctr, const UnitVec rot,
-                                                            const Length2 localCtr) noexcept
-{
-    assert(IsValid(rot));
-    return Transformation{ctr - (Rotate(localCtr, rot)), rot};
-}
-
-/// @brief Gets the transformation for the given values.
-inline Transformation GetTransformation(const Position pos, const Length2 local_ctr) noexcept
-{
-    assert(IsValid(pos));
-    assert(IsValid(local_ctr));
-    return GetTransformation(pos.linear, UnitVec::Get(pos.angular), local_ctr);
-}
-
-/// @brief Gets the interpolated transform at a specific time.
-/// @param sweep Sweep data to get the transform from.
-/// @param beta Time factor in [0,1], where 0 indicates alpha 0.
-/// @return Transformation of the given sweep at the specified time.
-inline Transformation GetTransformation(const Sweep& sweep, const Real beta) noexcept
-{
-    assert(beta >= 0);
-    assert(beta <= 1);
-    return GetTransformation(GetPosition(sweep.pos0, sweep.pos1, beta), sweep.GetLocalCenter());
-}
-
-/// @brief Gets the transform at "time" zero.
-/// @note This is like calling <code>GetTransformation(sweep, 0)</code>, except more efficiently.
-/// @see GetTransformation(const Sweep& sweep, Real beta).
-/// @param sweep Sweep data to get the transform from.
-/// @return Transformation of the given sweep at time zero.
-inline Transformation GetTransform0(const Sweep& sweep) noexcept
-{
-    return GetTransformation(sweep.pos0, sweep.GetLocalCenter());
-}
-
-/// @brief Gets the transform at "time" one.
-/// @note This is like calling <code>GetTransformation(sweep, 1.0)</code>, except more efficiently.
-/// @see GetTransformation(const Sweep& sweep, Real beta).
-/// @param sweep Sweep data to get the transform from.
-/// @return Transformation of the given sweep at time one.
-inline Transformation GetTransform1(const Sweep& sweep) noexcept
-{
-    return GetTransformation(sweep.pos1, sweep.GetLocalCenter());
-}
-
-/// @brief Gets the contact relative velocity.
-/// @note If <code>relA</code> and <code>relB</code> are the zero vectors, the resulting
-///    value is simply <code>velB.linear - velA.linear</code>.
-LinearVelocity2 GetContactRelVelocity(const Velocity velA, const Length2 relA,
-                                      const Velocity velB, const Length2 relB) noexcept;
-
-/// @brief Gets whether the given velocity is "under active" based on the given tolerances.
-inline bool IsUnderActive(Velocity velocity,
-                          LinearVelocity linSleepTol, AngularVelocity angSleepTol) noexcept
-{
-    const auto linVelSquared = GetMagnitudeSquared(velocity.linear);
-    const auto angVelSquared = Square(velocity.angular);
-    return (angVelSquared <= Square(angSleepTol)) && (linVelSquared <= Square(linSleepTol));
-}
-
-/// @brief Gets the reflection matrix for the given unit vector that defines the normal of
-///   the line through the origin that points should be reflected against.
-/// @see https://en.wikipedia.org/wiki/Transformation_matrix
-constexpr auto GetReflectionMatrix(UnitVec axis)
-{
-    constexpr auto TupleSize = std::tuple_size<decltype(axis)>::value;
-    constexpr auto NumRows = TupleSize;
-    constexpr auto NumCols = TupleSize;
-    auto result = Matrix<Real, NumRows, NumCols>{};
-    for (auto row = decltype(NumRows){0}; row < NumRows; ++row)
+    /// @brief Secant method.
+    /// @see https://en.wikipedia.org/wiki/Secant_method
+    template<typename T, typename U>
+    constexpr U Secant(T target, U a1, T s1, U a2, T s2) noexcept
     {
-        for (auto col = decltype(NumCols){0}; col < NumCols; ++col)
+        static_assert(IsArithmetic<T>::value && IsArithmetic<U>::value, "Arithmetic types required.");
+        return a1 + (target - s1) * (a2 - a1) / (s2 - s1);
+    }
+
+    /// @brief Bisection method.
+    /// @see https://en.wikipedia.org/wiki/Bisection_method
+    template<typename T>
+    constexpr T Bisect(T a1, T a2) noexcept
+    {
+        return (a1 + a2) / 2;
+    }
+
+    /// @brief Is-odd.
+    /// @details Determines whether the given integral value is odd (as opposed to being even).
+    template<typename T>
+    constexpr bool IsOdd(T val) noexcept
+    {
+        static_assert(std::is_integral<T>::value, "Integral type required.");
+        return val % 2;
+    }
+
+    /// @brief Squares the given value.
+    template<class TYPE>
+    constexpr auto Square(TYPE t) noexcept
+    {
+        return t * t;
+    }
+
+    /// @brief Computes the arc-tangent of the given y and x values.
+    /// @return Normalized angle - an angle between -Pi and Pi inclusively.
+    /// @see https://en.cppreference.com/w/cpp/numeric/math/atan2
+    template<typename T>
+    inline auto Atan2(T y, T x)
+    {
+        return Angle{static_cast<Real>(atan2(StripUnit(y), StripUnit(x))) * Radian};
+    }
+
+    /// @brief Computes the average of the given values.
+    template<typename T, typename = std::enable_if_t<
+                             IsIterable<T>::value && IsAddable<decltype(*begin(std::declval<T>()))>::value>>
+    inline auto Average(const T& span)
+    {
+        using value_type = decltype(*begin(std::declval<T>()));
+
+        // Relies on C++11 zero initialization to zero initialize value_type.
+        // See: http://en.cppreference.com/w/cpp/language/zero_initialization
+        constexpr auto zero = value_type{};
+        assert(zero * Real{2} == zero);
+
+        // For C++17, switch from using std::accumulate to using std::reduce.
+        const auto sum = std::accumulate(begin(span), end(span), zero);
+        const auto count = std::max(size(span), std::size_t{1});
+        return sum / static_cast<Real>(count);
+    }
+
+    /// @brief Computes the rounded value of the given value.
+    template<typename T>
+    inline std::enable_if_t<IsArithmetic<T>::value, T> RoundOff(T value, unsigned precision = 100000)
+    {
+        const auto factor = static_cast<T>(precision);
+        return round(value * factor) / factor;
+    }
+
+    /// @brief Computes the rounded value of the given value.
+    inline Vec2 RoundOff(Vec2 value, std::uint32_t precision = 100000)
+    {
+        return Vec2{RoundOff(value[0], precision), RoundOff(value[1], precision)};
+    }
+
+    /// @brief Absolute value function for vectors.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr Vector<T, N> abs(const Vector<T, N>& v) noexcept
+    {
+        auto result = Vector<T, N>{};
+        for (auto i = decltype(N){0}; i < N; ++i)
         {
-            result[row][col] = ((row == col)? Real{1}: Real{0}) - axis[row] * axis[col] * 2;
+            result[i] = abs(v[i]);
         }
+        return result;
     }
-    return result;
-}
 
-} // namespace d2
-} // namespace playrho
+    /// @brief Gets the absolute value of the given value.
+    inline d2::UnitVec abs(const d2::UnitVec& v) noexcept
+    {
+        return v.Absolute();
+    }
 
-#endif // PLAYRHO_COMMON_MATH_HPP
+    /// @brief Gets whether a given value is almost zero.
+    /// @details An almost zero value is "subnormal". Dividing by these values can lead to
+    /// odd results like a divide by zero trap occurring.
+    /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
+    template<typename T>
+    constexpr std::enable_if_t<std::is_arithmetic<T>::value, bool> AlmostZero(T value)
+    {
+        return abs(value) < std::numeric_limits<T>::min();
+    }
+
+    /// @brief Determines whether the given two values are "almost equal".
+    template<typename T>
+    constexpr std::enable_if_t<std::is_floating_point<T>::value, bool> AlmostEqual(T x, T y, int ulp = 2)
+    {
+        // From http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon :
+        //   "the machine epsilon has to be scaled to the magnitude of the values used
+        //    and multiplied by the desired precision in ULPs (units in the last place)
+        //    unless the result is subnormal".
+        // Where "subnormal" means almost zero.
+        //
+        return (abs(x - y) < (std::numeric_limits<T>::epsilon() * abs(x + y) * static_cast<T>(ulp)))
+               || AlmostZero(x - y);
+    }
+
+    /// @brief Modulo operation using <code>std::fmod</code>.
+    /// @note Modulo via <code>std::fmod</code> appears slower than via <code>std::trunc</code>.
+    /// @see ModuloViaTrunc
+    template<typename T>
+    inline auto ModuloViaFmod(T dividend, T divisor) noexcept
+    {
+        // Note: modulo via std::fmod appears slower than via std::trunc.
+        return static_cast<T>(fmod(dividend, divisor));
+    }
+
+    /// @brief Modulo operation using <code>std::trunc</code>.
+    /// @note Modulo via <code>std::fmod</code> appears slower than via <code>std::trunc</code>.
+    /// @see ModuloViaFmod
+    template<typename T>
+    inline auto ModuloViaTrunc(T dividend, T divisor) noexcept
+    {
+        const auto quotient = dividend / divisor;
+        const auto integer = static_cast<T>(trunc(quotient));
+        const auto remainder = quotient - integer;
+        return remainder * divisor;
+    }
+
+    /// @brief Gets the "normalized" value of the given angle.
+    /// @return Angle between -Pi and Pi radians inclusively where 0 represents the positive X-axis.
+    /// @see Atan2
+    inline Angle GetNormalized(Angle value) noexcept
+    {
+        constexpr auto oneRotationInRadians = Real{2 * Pi};
+        auto angleInRadians = Real{value / Radian};
+#if defined(NORMALIZE_ANGLE_VIA_FMOD)
+        // Note: std::fmod appears slower than std::trunc.
+        //   See Benchmark ModuloViaFmod for data.
+        angleInRadians = ModuloViaFmod(angleInRadians, oneRotationInRadians);
+#else
+        // Note: std::trunc appears more than twice as fast as std::fmod.
+        //   See Benchmark ModuloViaTrunc for data.
+        angleInRadians = ModuloViaTrunc(angleInRadians, oneRotationInRadians);
+#endif
+        if (angleInRadians > Pi)
+        {
+            // 190_deg becomes 190_deg - 360_deg = -170_deg
+            angleInRadians -= Pi * 2;
+        }
+        else if (angleInRadians < -Pi)
+        {
+            // -200_deg becomes -200_deg + 360_deg = 100_deg
+            angleInRadians += Pi * 2;
+        }
+        return angleInRadians * Radian;
+    }
+
+    /// @brief Gets the angle.
+    /// @return Angular value in the range of -Pi to +Pi radians.
+    template<class T>
+    inline Angle GetAngle(const Vector2<T> value)
+    {
+        return Atan2(GetY(value), GetX(value));
+    }
+
+    /// @brief Gets the square of the magnitude of the given iterable value.
+    /// @note For performance, use this instead of <code>GetMagnitude(T value)</code> (if possible).
+    /// @return Non-negative value from 0 to infinity, or NaN.
+    template<typename T>
+    constexpr auto GetMagnitudeSquared(T value) noexcept
+    {
+        using VT = typename T::value_type;
+        using OT = decltype(VT{} * VT{});
+        auto result = OT{};
+        for (auto&& e : value)
+        {
+            result += Square(e);
+        }
+        return result;
+    }
+
+    /// @brief Gets the magnitude of the given value.
+    /// @note Works for any type for which <code>GetMagnitudeSquared</code> also works.
+    template<typename T>
+    inline auto GetMagnitude(T value)
+    {
+        return sqrt(GetMagnitudeSquared(value));
+    }
+
+    /// @brief Performs the dot product on two vectors (A and B).
+    ///
+    /// @details The dot product of two vectors is defined as:
+    ///   the magnitude of vector A, multiplied by, the magnitude of vector B,
+    ///   multiplied by, the cosine of the angle between the two vectors (A and B).
+    ///   Thus the dot product of two vectors is a value ranging between plus and minus the
+    ///   magnitudes of each vector times each other.
+    ///   The middle value of 0 indicates that two vectors are perpendicular to each other
+    ///   (at an angle of +/- 90 degrees from each other).
+    ///
+    /// @note This operation is commutative. I.e. Dot(a, b) == Dot(b, a).
+    /// @note If A and B are the same vectors, <code>GetMagnitudeSquared(Vec2)</code> returns
+    ///   the same value using effectively one less input parameter.
+    /// @note This is similar to the <code>std::inner_product</code> standard library algorithm
+    ///   except benchmark tests suggest this implementation is faster at least for
+    ///   <code>Vec2</code> like instances.
+    ///
+    /// @see https://en.wikipedia.org/wiki/Dot_product
+    ///
+    /// @param a Vector A.
+    /// @param b Vector B.
+    ///
+    /// @return Dot product of the vectors (0 means the two vectors are perpendicular).
+    ///
+    template<typename T1, typename T2>
+    constexpr auto Dot(const T1 a, const T2 b) noexcept
+    {
+        static_assert(std::tuple_size<T1>::value == std::tuple_size<T2>::value,
+                      "Dot only for same tuple-like sized types");
+        using VT1 = typename T1::value_type;
+        using VT2 = typename T2::value_type;
+        using OT = decltype(VT1{} * VT2{});
+        auto result = OT{};
+        const auto numElements = size(a);
+        for (auto i = decltype(numElements){0}; i < numElements; ++i)
+        {
+            result += a[i] * b[i];
+        }
+        return result;
+    }
+
+    /// @brief Performs the 2-element analog of the cross product of two vectors.
+    ///
+    /// @details Defined as the result of: <code>(a.x * b.y) - (a.y * b.x)</code>.
+    ///
+    /// @note This operation is dimension squashing. I.e. A cross of a 2-D length by a 2-D unit
+    ///   vector results in a 1-D length value.
+    /// @note The unit of the result is the 1-D product of the inputs.
+    /// @note This operation is anti-commutative. I.e. Cross(a, b) == -Cross(b, a).
+    /// @note The result will be 0 if any of the following are true:
+    ///   vector A or vector B has a length of zero;
+    ///   vectors A and B point in the same direction; or
+    ///   vectors A and B point in exactly opposite direction of each other.
+    /// @note The result will be positive if:
+    ///   neither vector A nor B has a length of zero; and
+    ///   vector B is at an angle from vector A of greater than 0 and less than 180 degrees
+    ///   (counter-clockwise from A being a positive angle).
+    /// @note Result will be negative if:
+    ///   neither vector A nor B has a length of zero; and
+    ///   vector B is at an angle from vector A of less than 0 and greater than -180 degrees
+    ///   (clockwise from A being a negative angle).
+    /// @note The absolute value of the result is the area of the parallelogram formed by
+    ///   the vectors A and B.
+    ///
+    /// @see https://en.wikipedia.org/wiki/Cross_product
+    ///
+    /// @return Cross product of the two values.
+    ///
+    template<class T1, class T2, std::enable_if_t<std::tuple_size<T1>::value == 2 && std::tuple_size<T2>::value == 2, int> = 0>
+    constexpr auto Cross(T1 a, T2 b) noexcept
+    {
+        assert(isfinite(StripUnit(get<0>(a))));
+        assert(isfinite(StripUnit(get<1>(a))));
+        assert(isfinite(StripUnit(get<0>(b))));
+        assert(isfinite(StripUnit(get<1>(b))));
+
+        // Both vectors of same direction...
+        // If a = Vec2{1, 2} and b = Vec2{1, 2} then: a x b = 1 * 2 - 2 * 1 = 0.
+        // If a = Vec2{1, 2} and b = Vec2{2, 4} then: a x b = 1 * 4 - 2 * 2 = 0.
+        //
+        // Vectors at +/- 90 degrees of each other...
+        // If a = Vec2{1, 2} and b = Vec2{-2, 1} then: a x b = 1 * 1 - 2 * (-2) = 1 + 4 = 5.
+        // If a = Vec2{1, 2} and b = Vec2{2, -1} then: a x b = 1 * (-1) - 2 * 2 = -1 - 4 = -5.
+        //
+        // Vectors between 0 and 180 degrees of each other excluding 90 degrees...
+        // If a = Vec2{1, 2} and b = Vec2{-1, 2} then: a x b = 1 * 2 - 2 * (-1) = 2 + 2 = 4.
+        const auto minuend = get<0>(a) * get<1>(b);
+        const auto subtrahend = get<1>(a) * get<0>(b);
+        assert(isfinite(StripUnit(minuend)));
+        assert(isfinite(StripUnit(subtrahend)));
+        return minuend - subtrahend;
+    }
+
+    /// @brief Cross-products the given two values.
+    /// @note This operation is anti-commutative. I.e. Cross(a, b) == -Cross(b, a).
+    /// @see https://en.wikipedia.org/wiki/Cross_product
+    /// @param a Value A of a 3-element type.
+    /// @param b Value B of a 3-element type.
+    /// @return Cross product of the two values.
+    template<class T1, class T2, std::enable_if_t<std::tuple_size<T1>::value == 3 && std::tuple_size<T2>::value == 3, int> = 0>
+    constexpr auto Cross(T1 a, T2 b) noexcept
+    {
+        assert(isfinite(get<0>(a)));
+        assert(isfinite(get<1>(a)));
+        assert(isfinite(get<2>(a)));
+        assert(isfinite(get<0>(b)));
+        assert(isfinite(get<1>(b)));
+        assert(isfinite(get<2>(b)));
+
+        using OT = decltype(get<0>(a) * get<0>(b));
+        return Vector<OT, 3>{
+            GetY(a) * GetZ(b) - GetZ(a) * GetY(b),
+            GetZ(a) * GetX(b) - GetX(a) * GetZ(b),
+            GetX(a) * GetY(b) - GetY(a) * GetX(b)};
+    }
+
+    /// @brief Solves A * x = b, where b is a column vector.
+    /// @note This is more efficient than computing the inverse in one-shot cases.
+    template<typename T, typename U>
+    constexpr auto Solve(const Matrix22<U> mat, const Vector2<T> b) noexcept
+    {
+        const auto cp = Cross(get<0>(mat), get<1>(mat));
+        const auto inverseCp = Real{1} / cp;
+        using OutType = decltype((U{} * T{}) / cp);
+        return (!AlmostZero(StripUnit(cp))) ? Vector2<OutType>{
+                   (get<1>(mat)[1] * b[0] - get<1>(mat)[0] * b[1]) * inverseCp,
+                   (get<0>(mat)[0] * b[1] - get<0>(mat)[1] * b[0]) * inverseCp}
+                                            : Vector2<OutType>{};
+    }
+
+    /// @brief Inverts the given value.
+    template<class IN_TYPE>
+    constexpr auto Invert(const Matrix22<IN_TYPE> value) noexcept
+    {
+        const auto cp = Cross(get<0>(value), get<1>(value));
+        using OutType = decltype(get<0>(value)[0] / cp);
+        const auto inverseCp = Real{1} / cp;
+        return (!AlmostZero(StripUnit(cp))) ? Matrix22<OutType>{
+                   Vector2<OutType>{get<1>(get<1>(value)) * inverseCp, -get<1>(get<0>(value)) * inverseCp},
+                   Vector2<OutType>{-get<0>(get<1>(value)) * inverseCp, get<0>(get<0>(value)) * inverseCp}}
+                                            : Matrix22<OutType>{};
+    }
+
+    /// @brief Solves A * x = b, where b is a column vector.
+    /// @note This is more efficient than computing the inverse in one-shot cases.
+    constexpr Vec3 Solve33(const Mat33& mat, const Vec3 b) noexcept
+    {
+        const auto dp = Dot(GetX(mat), Cross(GetY(mat), GetZ(mat)));
+        const auto det = (dp != 0) ? Real{1} / dp : dp;
+        const auto x = det * Dot(b, Cross(GetY(mat), GetZ(mat)));
+        const auto y = det * Dot(GetX(mat), Cross(b, GetZ(mat)));
+        const auto z = det * Dot(GetX(mat), Cross(GetY(mat), b));
+        return Vec3{x, y, z};
+    }
+
+    /// @brief Solves A * x = b, where b is a column vector.
+    /// @note This is more efficient than computing the inverse in one-shot cases.
+    /// @note Solves only the upper 2-by-2 matrix equation.
+    template<typename T>
+    constexpr T Solve22(const Mat33& mat, const T b) noexcept
+    {
+        const auto cp = GetX(GetX(mat)) * GetY(GetY(mat)) - GetX(GetY(mat)) * GetY(GetX(mat));
+        const auto det = (cp != 0) ? Real{1} / cp : cp;
+        const auto x = det * (GetY(GetY(mat)) * GetX(b) - GetX(GetY(mat)) * GetY(b));
+        const auto y = det * (GetX(GetX(mat)) * GetY(b) - GetY(GetX(mat)) * GetX(b));
+        return T{x, y};
+    }
+
+    /// @brief Gets the inverse of the given matrix as a 2-by-2.
+    /// @return Zero matrix if singular.
+    constexpr Mat33 GetInverse22(const Mat33& value) noexcept
+    {
+        const auto a = GetX(GetX(value)), b = GetX(GetY(value)), c = GetY(GetX(value)), d = GetY(GetY(value));
+        auto det = (a * d) - (b * c);
+        if (det != Real{0})
+        {
+            det = Real{1} / det;
+        }
+        return Mat33{Vec3{det * d, -det * c, Real{0}}, Vec3{-det * b, det * a, 0}, Vec3{0, 0, 0}};
+    }
+
+    /// @brief Gets the symmetric inverse of this matrix as a 3-by-3.
+    /// @return Zero matrix if singular.
+    constexpr Mat33 GetSymInverse33(const Mat33& value) noexcept
+    {
+        auto det = Dot(GetX(value), Cross(GetY(value), GetZ(value)));
+        if (det != Real{0})
+        {
+            det = Real{1} / det;
+        }
+
+        const auto a11 = GetX(GetX(value)), a12 = GetX(GetY(value)), a13 = GetX(GetZ(value));
+        const auto a22 = GetY(GetY(value)), a23 = GetY(GetZ(value));
+        const auto a33 = GetZ(GetZ(value));
+
+        const auto ex_y = det * (a13 * a23 - a12 * a33);
+        const auto ey_z = det * (a13 * a12 - a11 * a23);
+        const auto ex_z = det * (a12 * a23 - a13 * a22);
+
+        return Mat33{
+            Vec3{det * (a22 * a33 - a23 * a23), ex_y, ex_z},
+            Vec3{ex_y, det * (a11 * a33 - a13 * a13), ey_z},
+            Vec3{ex_z, ey_z, det * (a11 * a22 - a12 * a12)}};
+    }
+
+    /// @brief Gets a vector counter-clockwise (reverse-clockwise) perpendicular to the given vector.
+    /// @details This takes a vector of form (x, y) and returns the vector (-y, x).
+    /// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
+    /// @return A counter-clockwise 90-degree rotation of the given vector.
+    /// @see GetFwdPerpendicular.
+    template<class T>
+    constexpr auto GetRevPerpendicular(const T vector) noexcept
+    {
+        // See http://mathworld.wolfram.com/PerpendicularVector.html
+        return T{-GetY(vector), GetX(vector)};
+    }
+
+    /// @brief Gets a vector clockwise (forward-clockwise) perpendicular to the given vector.
+    /// @details This takes a vector of form (x, y) and returns the vector (y, -x).
+    /// @param vector Vector to return a clockwise perpendicular equivalent for.
+    /// @return A clockwise 90-degree rotation of the given vector.
+    /// @see GetRevPerpendicular.
+    template<class T>
+    constexpr auto GetFwdPerpendicular(const T vector) noexcept
+    {
+        // See http://mathworld.wolfram.com/PerpendicularVector.html
+        return T{GetY(vector), -GetX(vector)};
+    }
+
+    /// @brief Multiplies an M-element vector by an M-by-N matrix.
+    /// @param v Vector that's interpreted as a matrix with 1 row and M-columns.
+    /// @param m An M-row by N-column *transformation matrix* to multiply the vector by.
+    /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+    template<std::size_t M, typename T1, std::size_t N, typename T2>
+    constexpr auto Transform(const Vector<T1, M> v, const Matrix<T2, M, N>& m) noexcept
+    {
+        return m * v;
+    }
+
+    /// @brief Multiplies a vector by a matrix.
+    constexpr Vec2 Transform(const Vec2 v, const Mat33& A) noexcept
+    {
+        return Vec2{
+            get<0>(get<0>(A)) * v[0] + get<0>(get<1>(A)) * v[1],
+            get<1>(get<0>(A)) * v[0] + get<1>(get<1>(A)) * v[1]};
+    }
+
+    /// Multiply a matrix transpose times a vector. If a rotation matrix is provided,
+    /// then this transforms the vector from one frame to another (inverse transform).
+    constexpr Vec2 InverseTransform(const Vec2 v, const Mat22& A) noexcept
+    {
+        return Vec2{Dot(v, GetX(A)), Dot(v, GetY(A))};
+    }
+
+    /// @brief Computes A^T * B.
+    constexpr Mat22 MulT(const Mat22& A, const Mat22& B) noexcept
+    {
+        const auto c1 = Vec2{Dot(GetX(A), GetX(B)), Dot(GetY(A), GetX(B))};
+        const auto c2 = Vec2{Dot(GetX(A), GetY(B)), Dot(GetY(A), GetY(B))};
+        return Mat22{c1, c2};
+    }
+
+    /// @brief Gets the absolute value of the given value.
+    inline Mat22 abs(const Mat22& A)
+    {
+        return Mat22{abs(GetX(A)), abs(GetY(A))};
+    }
+
+    /// @brief Gets the next largest power of 2
+    /// @details
+    /// Given a binary integer value x, the next largest power of 2 can be computed by a S.W.A.R.
+    /// algorithm that recursively "folds" the upper bits into the lower bits. This process yields
+    /// a bit vector with the same most significant 1 as x, but all one's below it. Adding 1 to
+    /// that value yields the next largest power of 2. For a 64-bit value:"
+    inline std::uint64_t NextPowerOfTwo(std::uint64_t x)
+    {
+        x |= (x >> 1u);
+        x |= (x >> 2u);
+        x |= (x >> 4u);
+        x |= (x >> 8u);
+        x |= (x >> 16u);
+        x |= (x >> 32u);
+        return x + 1;
+    }
+
+    /// @brief Converts the given vector into a unit vector and returns its original length.
+    inline Real Normalize(Vec2& vector)
+    {
+        const auto length = GetMagnitude(vector);
+        if (!AlmostZero(length))
+        {
+            const auto invLength = Real{1} / length;
+            vector[0] *= invLength;
+            vector[1] *= invLength;
+            return length;
+        }
+        return 0;
+    }
+
+    /// @brief Computes the centroid of a counter-clockwise array of 3 or more vertices.
+    /// @note Behavior is undefined if there are less than 3 vertices or the vertices don't
+    ///   go counter-clockwise.
+    Length2 ComputeCentroid(const Span<const Length2>& vertices);
+
+    /// @brief Gets the modulo next value.
+    template<typename T>
+    constexpr T GetModuloNext(T value, T count) noexcept
+    {
+        assert(value < count);
+        return (value + 1) % count;
+    }
+
+    /// @brief Gets the modulo previous value.
+    template<typename T>
+    constexpr T GetModuloPrev(T value, T count) noexcept
+    {
+        assert(value < count);
+        return (value ? value : count) - 1;
+    }
+
+    /// @brief Gets the shortest angular distance to go from angle 1 to angle 2.
+    /// @details This gets the angle to rotate angle 1 by in order to get to angle 2 with the
+    ///   least amount of rotation.
+    /// @return Angle between -Pi and Pi radians inclusively.
+    /// @see GetNormalized
+    Angle GetDelta(Angle a1, Angle a2) noexcept;
+
+    /// Gets the reverse (counter) clockwise rotational angle to go from angle 1 to angle 2.
+    /// @return Angular rotation in the counter clockwise direction to go from angle 1 to angle 2.
+    constexpr Angle GetRevRotationalAngle(Angle a1, Angle a2) noexcept
+    {
+        return (a1 > a2) ? 360_deg - (a1 - a2) : a2 - a1;
+    }
+
+    /// @brief Gets the vertices for a circle described by the given parameters.
+    std::vector<Length2> GetCircleVertices(Length radius, unsigned slices,
+                                           Angle start = 0_deg, Real turns = Real{1});
+
+    /// @brief Gets the area of a circle.
+    NonNegative<Area> GetAreaOfCircle(Length radius);
+
+    /// @brief Gets the area of a polygon.
+    /// @note This function is valid for any non-self-intersecting (simple) polygon,
+    ///   which can be convex or concave.
+    /// @note Winding order doesn't matter.
+    NonNegative<Area> GetAreaOfPolygon(Span<const Length2> vertices);
+
+    /// @brief Gets the polar moment of the area enclosed by the given vertices.
+    ///
+    /// @warning Behavior is undefined if given collection has less than 3 vertices.
+    ///
+    /// @param vertices Collection of three or more vertices.
+    ///
+    SecondMomentOfArea GetPolarMoment(Span<const Length2> vertices);
+
+    /// @}
+
+    namespace d2
+    {
+
+        /// @brief Gets a <code>Vec2</code> representation of the given value.
+        constexpr Vec2 GetVec2(const UnitVec value)
+        {
+            return Vec2{get<0>(value), get<1>(value)};
+        }
+
+        /// @brief Gets the angle of the given unit vector.
+        inline Angle GetAngle(const UnitVec value)
+        {
+            return Atan2(GetY(value), GetX(value));
+        }
+
+        /// @brief Multiplication operator.
+        template<class T, typename U>
+        constexpr Vector2<T> operator*(CheckedValue<T, U> s, UnitVec u) noexcept
+        {
+            return Vector2<T>{u.GetX() * s, u.GetY() * s};
+        }
+
+        /// @brief Multiplication operator.
+        template<class T>
+        constexpr Vector2<T> operator*(const T s, const UnitVec u) noexcept
+        {
+            return Vector2<T>{u.GetX() * s, u.GetY() * s};
+        }
+
+        /// @brief Multiplication operator.
+        template<class T, typename U>
+        constexpr Vector2<T> operator*(UnitVec u, CheckedValue<T, U> s) noexcept
+        {
+            return Vector2<T>{u.GetX() * s, u.GetY() * s};
+        }
+
+        /// @brief Multiplication operator.
+        template<class T>
+        constexpr Vector2<T> operator*(const UnitVec u, const T s) noexcept
+        {
+            return Vector2<T>{u.GetX() * s, u.GetY() * s};
+        }
+
+        /// @brief Division operator.
+        constexpr Vec2 operator/(const UnitVec u, const UnitVec::value_type s) noexcept
+        {
+            const auto inverseS = Real{1} / s;
+            return Vec2{GetX(u) * inverseS, GetY(u) * inverseS};
+        }
+
+        /// @brief Rotates a vector by a given angle.
+        /// @details This rotates a vector by the angle expressed by the angle parameter.
+        /// @param vector Vector to forward rotate.
+        /// @param angle Expresses the angle to forward rotate the given vector by.
+        /// @see InverseRotate.
+        template<class T>
+        constexpr auto Rotate(const Vector2<T> vector, const UnitVec& angle) noexcept
+        {
+            const auto newX = (GetX(angle) * GetX(vector)) - (GetY(angle) * GetY(vector));
+            const auto newY = (GetY(angle) * GetX(vector)) + (GetX(angle) * GetY(vector));
+            return Vector2<T>{newX, newY};
+        }
+
+        /// @brief Inverse rotates a vector.
+        /// @details This is the inverse of rotating a vector - it undoes what rotate does. I.e.
+        ///   this effectively subtracts from the angle of the given vector the angle that's
+        ///   expressed by the angle parameter.
+        /// @param vector Vector to reverse rotate.
+        /// @param angle Expresses the angle to reverse rotate the given vector by.
+        /// @see Rotate.
+        template<class T>
+        constexpr auto InverseRotate(const Vector2<T> vector, const UnitVec& angle) noexcept
+        {
+            const auto newX = (GetX(angle) * GetX(vector)) + (GetY(angle) * GetY(vector));
+            const auto newY = (GetX(angle) * GetY(vector)) - (GetY(angle) * GetX(vector));
+            return Vector2<T>{newX, newY};
+        }
+
+        /// Gets the unit vector for the given value.
+        /// @param value Value to get the unit vector for.
+        /// @param fallback Fallback unit vector value to use in case a unit vector can't effectively be
+        ///   calculated from the given value.
+        /// @return value divided by its length if length not almost zero otherwise invalid value.
+        /// @see AlmostEqual.
+        template<class T>
+        inline UnitVec GetUnitVector(Vector2<T> value, UnitVec fallback = UnitVec::GetDefaultFallback())
+        {
+            return std::get<0>(UnitVec::Get(StripUnit(GetX(value)), StripUnit(GetY(value)), fallback));
+        }
+
+        /// @brief Gets the "normalized" position.
+        /// @details Enforces a wrap-around of one rotation on the angular position.
+        /// @note Use to prevent unbounded angles in positions.
+        inline Position GetNormalized(const Position& val) noexcept
+        {
+            return Position{val.linear, playrho::GetNormalized(val.angular)};
+        }
+
+        /// @brief Gets a sweep with the given sweep's angles normalized.
+        /// @param sweep Sweep to return with its angles normalized.
+        /// @return Sweep with its position 0 angle to be between -2 pi and 2 pi and its
+        ///   position 1 angle reduced by the amount the position 0 angle was reduced by.
+        /// @relatedalso Sweep
+        inline Sweep GetNormalized(Sweep sweep) noexcept
+        {
+            const auto pos0a = playrho::GetNormalized(sweep.pos0.angular);
+            const auto d = sweep.pos0.angular - pos0a;
+            sweep.pos0.angular = pos0a;
+            sweep.pos1.angular -= d;
+            return sweep;
+        }
+
+        /// @brief Transforms the given 2-D vector with the given transformation.
+        /// @details
+        /// Rotate and translate the given 2-D linear position according to the rotation and translation
+        /// defined by the given transformation.
+        /// @note Passing the output of this function to <code>InverseTransform</code> (with the same
+        /// transformation again) will result in the original vector being returned.
+        /// @note For a 2-D linear position of the origin (0, 0), the result is simply the translation.
+        /// @see <code>InverseTransform</code>.
+        /// @param v 2-D position to transform (to rotate and then translate).
+        /// @param xfm Transformation (a translation and rotation) to apply to the given vector.
+        /// @return Rotated and translated vector.
+        constexpr Length2 Transform(const Length2 v, const Transformation xfm) noexcept
+        {
+            return Rotate(v, xfm.q) + xfm.p;
+        }
+
+        /// @brief Inverse transforms the given 2-D vector with the given transformation.
+        /// @details
+        /// Inverse translate and rotate the given 2-D vector according to the translation and rotation
+        /// defined by the given transformation.
+        /// @note Passing the output of this function to <code>Transform</code> (with the same
+        /// transformation again) will result in the original vector being returned.
+        /// @see <code>Transform</code>.
+        /// @param v 2-D vector to inverse transform (inverse translate and inverse rotate).
+        /// @param xfm Transformation (a translation and rotation) to inversely apply to the given vector.
+        /// @return Inverse transformed vector.
+        constexpr Length2 InverseTransform(const Length2 v, const Transformation xfm) noexcept
+        {
+            return InverseRotate(v - xfm.p, xfm.q);
+        }
+
+        /// @brief Multiplies a given transformation by another given transformation.
+        /// @note <code>v2 = A.q.Rot(B.q.Rot(v1) + B.p) + A.p
+        ///                = (A.q * B.q).Rot(v1) + A.q.Rot(B.p) + A.p</code>
+        constexpr Transformation Mul(const Transformation& A, const Transformation& B) noexcept
+        {
+            return Transformation{A.p + Rotate(B.p, A.q), A.q.Rotate(B.q)};
+        }
+
+        /// @brief Inverse multiplies a given transformation by another given transformation.
+        /// @note <code>v2 = A.q' * (B.q * v1 + B.p - A.p)
+        ///                = A.q' * B.q * v1 + A.q' * (B.p - A.p)</code>
+        constexpr Transformation MulT(const Transformation& A, const Transformation& B) noexcept
+        {
+            const auto dp = B.p - A.p;
+            return Transformation{InverseRotate(dp, A.q), B.q.Rotate(A.q.FlipY())};
+        }
+
+        /// @brief Gets the transformation for the given values.
+        constexpr Transformation GetTransformation(const Length2 ctr, const UnitVec rot,
+                                                   const Length2 localCtr) noexcept
+        {
+            assert(IsValid(rot));
+            return Transformation{ctr - (Rotate(localCtr, rot)), rot};
+        }
+
+        /// @brief Gets the transformation for the given values.
+        inline Transformation GetTransformation(const Position pos, const Length2 local_ctr) noexcept
+        {
+            assert(IsValid(pos));
+            assert(IsValid(local_ctr));
+            return GetTransformation(pos.linear, UnitVec::Get(pos.angular), local_ctr);
+        }
+
+        /// @brief Gets the interpolated transform at a specific time.
+        /// @param sweep Sweep data to get the transform from.
+        /// @param beta Time factor in [0,1], where 0 indicates alpha 0.
+        /// @return Transformation of the given sweep at the specified time.
+        inline Transformation GetTransformation(const Sweep& sweep, const Real beta) noexcept
+        {
+            assert(beta >= 0);
+            assert(beta <= 1);
+            return GetTransformation(GetPosition(sweep.pos0, sweep.pos1, beta), sweep.GetLocalCenter());
+        }
+
+        /// @brief Gets the transform at "time" zero.
+        /// @note This is like calling <code>GetTransformation(sweep, 0)</code>, except more efficiently.
+        /// @see GetTransformation(const Sweep& sweep, Real beta).
+        /// @param sweep Sweep data to get the transform from.
+        /// @return Transformation of the given sweep at time zero.
+        inline Transformation GetTransform0(const Sweep& sweep) noexcept
+        {
+            return GetTransformation(sweep.pos0, sweep.GetLocalCenter());
+        }
+
+        /// @brief Gets the transform at "time" one.
+        /// @note This is like calling <code>GetTransformation(sweep, 1.0)</code>, except more efficiently.
+        /// @see GetTransformation(const Sweep& sweep, Real beta).
+        /// @param sweep Sweep data to get the transform from.
+        /// @return Transformation of the given sweep at time one.
+        inline Transformation GetTransform1(const Sweep& sweep) noexcept
+        {
+            return GetTransformation(sweep.pos1, sweep.GetLocalCenter());
+        }
+
+        /// @brief Gets the contact relative velocity.
+        /// @note If <code>relA</code> and <code>relB</code> are the zero vectors, the resulting
+        ///    value is simply <code>velB.linear - velA.linear</code>.
+        LinearVelocity2 GetContactRelVelocity(const Velocity velA, const Length2 relA,
+                                              const Velocity velB, const Length2 relB) noexcept;
+
+        /// @brief Gets whether the given velocity is "under active" based on the given tolerances.
+        inline bool IsUnderActive(Velocity velocity,
+                                  LinearVelocity linSleepTol, AngularVelocity angSleepTol) noexcept
+        {
+            const auto linVelSquared = GetMagnitudeSquared(velocity.linear);
+            const auto angVelSquared = Square(velocity.angular);
+            return (angVelSquared <= Square(angSleepTol)) && (linVelSquared <= Square(linSleepTol));
+        }
+
+        /// @brief Gets the reflection matrix for the given unit vector that defines the normal of
+        ///   the line through the origin that points should be reflected against.
+        /// @see https://en.wikipedia.org/wiki/Transformation_matrix
+        constexpr auto GetReflectionMatrix(UnitVec axis)
+        {
+            constexpr auto TupleSize = std::tuple_size<decltype(axis)>::value;
+            constexpr auto NumRows = TupleSize;
+            constexpr auto NumCols = TupleSize;
+            auto result = Matrix<Real, NumRows, NumCols>{};
+            for (auto row = decltype(NumRows){0}; row < NumRows; ++row)
+            {
+                for (auto col = decltype(NumCols){0}; col < NumCols; ++col)
+                {
+                    result[row][col] = ((row == col) ? Real{1} : Real{0}) - axis[row] * axis[col] * 2;
+                }
+            }
+            return result;
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_MATH_HPP

--- a/PlayRho/Common/Matrix.hpp
+++ b/PlayRho/Common/Matrix.hpp
@@ -22,191 +22,195 @@
 #ifndef PLAYRHO_COMMON_MATRIX_HPP
 #define PLAYRHO_COMMON_MATRIX_HPP
 
+#include <PlayRho/Common/Real.hpp>
+#include <PlayRho/Common/Templates.hpp>
+#include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/Vector.hpp>
 #include <PlayRho/Common/Vector2.hpp>
-#include <PlayRho/Common/Templates.hpp>
-#include <PlayRho/Common/Real.hpp>
-#include <PlayRho/Common/Units.hpp>
 
-namespace playrho {
-
-/// @brief Generic M by N matrix.
-/// @note M is the number of rows of the matrix.
-/// @note N is the number of columns of the matrix.
-/// @see https://en.wikipedia.org/wiki/Matrix_(mathematics)
-/// @see Vector, MatrixTraitsGroup, IsVector
-template <typename T, std::size_t M, std::size_t N>
-using Matrix = Vector<Vector<T, N>, M>;
-
-/// @defgroup MatrixTraitsGroup Matrix Traits
-/// @brief Collection of trait classes for matrices.
-/// @see Matrix
-/// @{
-
-/// @brief Trait class for checking if type is a matrix type.
-/// @details Trait class for determining whether the given type is a matrix, that is,
-///   a vector of vectors.
-/// @note This implements the default case where any arbitrary type *is not* a matrix.
-/// @note For example the following is false:
-/// @code{.cpp}
-/// IsMatrix<int>::value || IsMatrix<float>::value
-/// @endcode
-/// @see Matrix, IsSquareMatrix, IsVector
-template <typename>
-struct IsMatrix: std::false_type {};
-
-/// @brief Trait class specialization for checking if type is a matrix type.
-/// @details Trait class for determining whether the given type is a matrix, that is,
-///   a vector of vectors.
-/// @note This implements the specialized case where the given type *is indeed* a matrix.
-/// @note For example the following is true:
-/// @code{.cpp}
-/// IsMatrix<Matrix<int, 2, 3>>::value && IsMatrix<Mat22>::value && IsMatrix<Mat33>::value
-/// @endcode
-/// @see Matrix, IsSquareMatrix, IsVector
-template <typename T, std::size_t M, std::size_t N>
-struct IsMatrix<Vector<Vector<T, N>, M>>: std::true_type {};
-
-/// @brief Trait class for checking if type is a square matrix type.
-/// @details Trait class for determining whether the given type is a matrix having an equal
-///   number of rows and columns.
-/// @note This implements the default case where any arbitrary type *is not* a square matrix.
-/// @note For example the following is false:
-/// @code{.cpp}
-/// IsSquareMatrix<int>::value || IsSquareMatrix<float>::value
-/// @endcode
-/// @relatedalso Vector
-/// @see IsMatrix, Matrix, Vector
-template <typename>
-struct IsSquareMatrix: std::false_type {};
-
-/// @brief Trait class specialization for checking if type is a square matrix type.
-/// @details This determines whether the given type is a matrix having an equal number
-///   of rows and columns.
-/// @note This implements the specialized case where the given type *is indeed* a square matrix.
-/// @note For example the following is true:
-/// @code{.cpp}
-/// IsSquareMatrix<Mat22>::value && IsSquareMatrix<Mat33>::value
-/// @endcode
-/// @see IsMatrix, Matrix, Vector
-template <typename T, std::size_t M>
-struct IsSquareMatrix<Vector<Vector<T, M>, M>>: std::true_type {};
-
-/// @}
-
-/// @brief Gets the identity matrix of the template type and size.
-/// @see https://en.wikipedia.org/wiki/Identity_matrix
-/// @see Matrix, IsMatrix, IsSquareMatrix
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<!IsVector<T>::value, Matrix<T, N, N>> GetIdentityMatrix()
+namespace playrho
 {
-    auto result = Matrix<Real, N, N>{};
-    for (auto i = std::size_t{0}; i < N; ++i)
+
+    /// @brief Generic M by N matrix.
+    /// @note M is the number of rows of the matrix.
+    /// @note N is the number of columns of the matrix.
+    /// @see https://en.wikipedia.org/wiki/Matrix_(mathematics)
+    /// @see Vector, MatrixTraitsGroup, IsVector
+    template<typename T, std::size_t M, std::size_t N>
+    using Matrix = Vector<Vector<T, N>, M>;
+
+    /// @defgroup MatrixTraitsGroup Matrix Traits
+    /// @brief Collection of trait classes for matrices.
+    /// @see Matrix
+    /// @{
+
+    /// @brief Trait class for checking if type is a matrix type.
+    /// @details Trait class for determining whether the given type is a matrix, that is,
+    ///   a vector of vectors.
+    /// @note This implements the default case where any arbitrary type *is not* a matrix.
+    /// @note For example the following is false:
+    /// @code{.cpp}
+    /// IsMatrix<int>::value || IsMatrix<float>::value
+    /// @endcode
+    /// @see Matrix, IsSquareMatrix, IsVector
+    template<typename>
+    struct IsMatrix : std::false_type
     {
-        result[i][i] = T{1};
-    }
-    return result;
-}
+    };
 
-/// @brief Gets the identity matrix of the template type and size as given by the argument.
-/// @see https://en.wikipedia.org/wiki/Identity_matrix
-/// @see Matrix, IsMatrix, IsSquareMatrix
-template <typename T>
-constexpr std::enable_if_t<IsSquareMatrix<T>::value, T> GetIdentity()
-{
-    return GetIdentityMatrix<typename T::value_type::value_type, std::tuple_size<T>::value>();
-}
-
-/// @brief Gets the specified row of the given matrix as a row matrix.
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, N>, 1>> GetRowMatrix(Vector<T, N> arg)
-{
-    return Vector<Vector<T, N>, 1>{arg};
-}
-
-/// @brief Gets the specified column of the given matrix as a column matrix.
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, 1>, N>> GetColumnMatrix(Vector<T, N> arg)
-{
-    auto result = Vector<Vector<T, 1>, N>{};
-    for (auto i = std::size_t{0}; i < N; ++i)
+    /// @brief Trait class specialization for checking if type is a matrix type.
+    /// @details Trait class for determining whether the given type is a matrix, that is,
+    ///   a vector of vectors.
+    /// @note This implements the specialized case where the given type *is indeed* a matrix.
+    /// @note For example the following is true:
+    /// @code{.cpp}
+    /// IsMatrix<Matrix<int, 2, 3>>::value && IsMatrix<Mat22>::value && IsMatrix<Mat33>::value
+    /// @endcode
+    /// @see Matrix, IsSquareMatrix, IsVector
+    template<typename T, std::size_t M, std::size_t N>
+    struct IsMatrix<Vector<Vector<T, N>, M>> : std::true_type
     {
-        result[i][0] = arg[i];
-    }
-    return result;
-}
+    };
 
-/// @brief Matrix addition operator for two same-type, same-sized matrices.
-/// @see https://en.wikipedia.org/wiki/Matrix_addition
-template <typename T, std::size_t M, std::size_t N>
-constexpr
-auto operator+ (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
-{
-    auto result = Matrix<T, M, N>{};
-    for (auto m = decltype(M){0}; m < M; ++m)
+    /// @brief Trait class for checking if type is a square matrix type.
+    /// @details Trait class for determining whether the given type is a matrix having an equal
+    ///   number of rows and columns.
+    /// @note This implements the default case where any arbitrary type *is not* a square matrix.
+    /// @note For example the following is false:
+    /// @code{.cpp}
+    /// IsSquareMatrix<int>::value || IsSquareMatrix<float>::value
+    /// @endcode
+    /// @relatedalso Vector
+    /// @see IsMatrix, Matrix, Vector
+    template<typename>
+    struct IsSquareMatrix : std::false_type
     {
-        for (auto n = decltype(N){0}; n < N; ++n)
+    };
+
+    /// @brief Trait class specialization for checking if type is a square matrix type.
+    /// @details This determines whether the given type is a matrix having an equal number
+    ///   of rows and columns.
+    /// @note This implements the specialized case where the given type *is indeed* a square matrix.
+    /// @note For example the following is true:
+    /// @code{.cpp}
+    /// IsSquareMatrix<Mat22>::value && IsSquareMatrix<Mat33>::value
+    /// @endcode
+    /// @see IsMatrix, Matrix, Vector
+    template<typename T, std::size_t M>
+    struct IsSquareMatrix<Vector<Vector<T, M>, M>> : std::true_type
+    {
+    };
+
+    /// @}
+
+    /// @brief Gets the identity matrix of the template type and size.
+    /// @see https://en.wikipedia.org/wiki/Identity_matrix
+    /// @see Matrix, IsMatrix, IsSquareMatrix
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<!IsVector<T>::value, Matrix<T, N, N>> GetIdentityMatrix()
+    {
+        auto result = Matrix<Real, N, N>{};
+        for (auto i = std::size_t{0}; i < N; ++i)
         {
-            result[m][n] = lhs[m][n] + rhs[m][n];
+            result[i][i] = T{1};
         }
+        return result;
     }
-    return result;
-}
 
-/// @brief Matrix subtraction operator for two same-type, same-sized matrices.
-/// @see https://en.wikipedia.org/wiki/Matrix_addition
-template <typename T, std::size_t M, std::size_t N>
-constexpr
-auto operator- (const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
-{
-    auto result = Matrix<T, M, N>{};
-    for (auto m = decltype(M){0}; m < M; ++m)
+    /// @brief Gets the identity matrix of the template type and size as given by the argument.
+    /// @see https://en.wikipedia.org/wiki/Identity_matrix
+    /// @see Matrix, IsMatrix, IsSquareMatrix
+    template<typename T>
+    constexpr std::enable_if_t<IsSquareMatrix<T>::value, T> GetIdentity()
     {
-        for (auto n = decltype(N){0}; n < N; ++n)
-        {
-            result[m][n] = lhs[m][n] - rhs[m][n];
-        }
+        return GetIdentityMatrix<typename T::value_type::value_type, std::tuple_size<T>::value>();
     }
-    return result;
-}
 
-/// @brief 2 by 2 matrix.
-template <typename T>
-using Matrix22 = Matrix<T, 2, 2>;
+    /// @brief Gets the specified row of the given matrix as a row matrix.
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, N>, 1>> GetRowMatrix(Vector<T, N> arg)
+    {
+        return Vector<Vector<T, N>, 1>{arg};
+    }
 
-/// @brief 3 by 3 matrix.
-template <typename T>
-using Matrix33 = Matrix<T, 3, 3>;
+    /// @brief Gets the specified column of the given matrix as a column matrix.
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<!IsVector<T>::value, Vector<Vector<T, 1>, N>> GetColumnMatrix(Vector<T, N> arg)
+    {
+        auto result = Vector<Vector<T, 1>, N>{};
+        for (auto i = std::size_t{0}; i < N; ++i)
+        {
+            result[i][0] = arg[i];
+        }
+        return result;
+    }
 
-/// @brief 2 by 2 matrix of Real elements.
-using Mat22 = Matrix22<Real>;
+    /// @brief Matrix addition operator for two same-type, same-sized matrices.
+    /// @see https://en.wikipedia.org/wiki/Matrix_addition
+    template<typename T, std::size_t M, std::size_t N>
+    constexpr auto operator+(const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
+    {
+        auto result = Matrix<T, M, N>{};
+        for (auto m = decltype(M){0}; m < M; ++m)
+        {
+            for (auto n = decltype(N){0}; n < N; ++n)
+            {
+                result[m][n] = lhs[m][n] + rhs[m][n];
+            }
+        }
+        return result;
+    }
 
-/// @brief 2 by 2 matrix of Mass elements.
-using Mass22 = Matrix22<Mass>;
+    /// @brief Matrix subtraction operator for two same-type, same-sized matrices.
+    /// @see https://en.wikipedia.org/wiki/Matrix_addition
+    template<typename T, std::size_t M, std::size_t N>
+    constexpr auto operator-(const Matrix<T, M, N>& lhs, const Matrix<T, M, N>& rhs) noexcept
+    {
+        auto result = Matrix<T, M, N>{};
+        for (auto m = decltype(M){0}; m < M; ++m)
+        {
+            for (auto n = decltype(N){0}; n < N; ++n)
+            {
+                result[m][n] = lhs[m][n] - rhs[m][n];
+            }
+        }
+        return result;
+    }
 
-/// @brief 2 by 2 matrix of <code>InvMass</code> elements.
-using InvMass22 = Matrix22<InvMass>;
+    /// @brief 2 by 2 matrix.
+    template<typename T>
+    using Matrix22 = Matrix<T, 2, 2>;
 
-/// @brief 3 by 3 matrix of Real elements.
-using Mat33 = Matrix33<Real>;
+    /// @brief 3 by 3 matrix.
+    template<typename T>
+    using Matrix33 = Matrix<T, 3, 3>;
 
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const Mat22& value) noexcept
-{
-    return IsValid(get<0>(value)) && IsValid(get<1>(value));
-}
+    /// @brief 2 by 2 matrix of Real elements.
+    using Mat22 = Matrix22<Real>;
 
-/// @brief Gets an invalid value for a <code>Mat22</code>.
-template <>
-constexpr Mat22 GetInvalid() noexcept
-{
-    return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
-}
+    /// @brief 2 by 2 matrix of Mass elements.
+    using Mass22 = Matrix22<Mass>;
 
-} // namespace playrho
+    /// @brief 2 by 2 matrix of <code>InvMass</code> elements.
+    using InvMass22 = Matrix22<InvMass>;
 
-#endif // PLAYRHO_COMMON_MATRIX_HPP
+    /// @brief 3 by 3 matrix of Real elements.
+    using Mat33 = Matrix33<Real>;
+
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const Mat22& value) noexcept
+    {
+        return IsValid(get<0>(value)) && IsValid(get<1>(value));
+    }
+
+    /// @brief Gets an invalid value for a <code>Mat22</code>.
+    template<>
+    constexpr Mat22 GetInvalid() noexcept
+    {
+        return Mat22{GetInvalid<Vec2>(), GetInvalid<Vec2>()};
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_MATRIX_HPP

--- a/PlayRho/Common/Negative.hpp
+++ b/PlayRho/Common/Negative.hpp
@@ -23,32 +23,35 @@
 
 #include <PlayRho/Common/CheckedValue.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Negative constrained value checker.
-template <typename T>
-struct NegativeChecker {
-    /// @brief Exception type possibly thrown by this checker.
-    using exception_type = std::invalid_argument;
-
-    /// @brief Value checking functor.
-    /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(!(v < static_cast<T>(0)), T{v})
+    /// @brief Negative constrained value checker.
+    template<typename T>
+    struct NegativeChecker
     {
-        if (!(v < static_cast<T>(0))) {
-            throw exception_type("value not less than zero");
+        /// @brief Exception type possibly thrown by this checker.
+        using exception_type = std::invalid_argument;
+
+        /// @brief Value checking functor.
+        /// @throws exception_type if given value is not valid.
+        constexpr auto operator()(const T& v) -> decltype(!(v < static_cast<T>(0)), T{v})
+        {
+            if (!(v < static_cast<T>(0)))
+            {
+                throw exception_type("value not less than zero");
+            }
+            return v;
         }
-        return v;
-    }
-};
+    };
 
-/// @ingroup CheckedValues
-/// @brief Negative constrained value type.
-template <typename T>
-using Negative = CheckedValue<T, NegativeChecker<T>>;
+    /// @ingroup CheckedValues
+    /// @brief Negative constrained value type.
+    template<typename T>
+    using Negative = CheckedValue<T, NegativeChecker<T>>;
 
-static_assert(!std::is_default_constructible<Negative<int>>::value);
+    static_assert(!std::is_default_constructible<Negative<int>>::value);
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_NEGATIVE_HPP
+#endif// PLAYRHO_COMMON_NEGATIVE_HPP

--- a/PlayRho/Common/NonNegative.hpp
+++ b/PlayRho/Common/NonNegative.hpp
@@ -23,38 +23,41 @@
 
 #include <PlayRho/Common/CheckedValue.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Non-negative constrained value checker.
-template <typename T>
-struct NonNegativeChecker {
-    /// @brief Exception type possibly thrown by this checker.
-    using exception_type = std::invalid_argument;
-
-    /// @brief Valid value supplying functor.
-    constexpr auto operator()() noexcept -> decltype(static_cast<T>(0))
+    /// @brief Non-negative constrained value checker.
+    template<typename T>
+    struct NonNegativeChecker
     {
-        return static_cast<T>(0);
-    }
+        /// @brief Exception type possibly thrown by this checker.
+        using exception_type = std::invalid_argument;
 
-    /// @brief Value checking functor.
-    /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(!(v >= static_cast<T>(0)), T{v})
-    {
-        if (!(v >= static_cast<T>(0))) {
-            throw exception_type("value not greater than nor equal to zero");
+        /// @brief Valid value supplying functor.
+        constexpr auto operator()() noexcept -> decltype(static_cast<T>(0))
+        {
+            return static_cast<T>(0);
         }
-        return v;
-    }
-};
 
-/// @ingroup CheckedValues
-/// @brief Non-negative constrained value type.
-template <typename T>
-using NonNegative = CheckedValue<T, NonNegativeChecker<T>>;
+        /// @brief Value checking functor.
+        /// @throws exception_type if given value is not valid.
+        constexpr auto operator()(const T& v) -> decltype(!(v >= static_cast<T>(0)), T{v})
+        {
+            if (!(v >= static_cast<T>(0)))
+            {
+                throw exception_type("value not greater than nor equal to zero");
+            }
+            return v;
+        }
+    };
 
-static_assert(std::is_default_constructible<NonNegative<int>>::value);
+    /// @ingroup CheckedValues
+    /// @brief Non-negative constrained value type.
+    template<typename T>
+    using NonNegative = CheckedValue<T, NonNegativeChecker<T>>;
 
-} // namespace playrho
+    static_assert(std::is_default_constructible<NonNegative<int>>::value);
 
-#endif // PLAYRHO_COMMON_NONNEGATIVE_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_NONNEGATIVE_HPP

--- a/PlayRho/Common/NonPositive.hpp
+++ b/PlayRho/Common/NonPositive.hpp
@@ -23,38 +23,41 @@
 
 #include <PlayRho/Common/CheckedValue.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Non-positive constrained value checker.
-template <typename T>
-struct NonPositiveChecker {
-    /// @brief Exception type possibly thrown by this checker.
-    using exception_type = std::invalid_argument;
-
-    /// @brief Valid value supplying functor.
-    constexpr auto operator()() noexcept -> decltype(static_cast<T>(0))
+    /// @brief Non-positive constrained value checker.
+    template<typename T>
+    struct NonPositiveChecker
     {
-        return static_cast<T>(0);
-    }
+        /// @brief Exception type possibly thrown by this checker.
+        using exception_type = std::invalid_argument;
 
-    /// @brief Value checking functor.
-    /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(!(v <= static_cast<T>(0)), T{v})
-    {
-        if (!(v <= static_cast<T>(0))) {
-            throw exception_type("value not lesser than nor equal to zero");
+        /// @brief Valid value supplying functor.
+        constexpr auto operator()() noexcept -> decltype(static_cast<T>(0))
+        {
+            return static_cast<T>(0);
         }
-        return v;
-    }
-};
 
-/// @ingroup CheckedValues
-/// @brief Non-positive constrained value type.
-template <typename T>
-using NonPositive = CheckedValue<T, NonPositiveChecker<T>>;
+        /// @brief Value checking functor.
+        /// @throws exception_type if given value is not valid.
+        constexpr auto operator()(const T& v) -> decltype(!(v <= static_cast<T>(0)), T{v})
+        {
+            if (!(v <= static_cast<T>(0)))
+            {
+                throw exception_type("value not lesser than nor equal to zero");
+            }
+            return v;
+        }
+    };
 
-static_assert(std::is_default_constructible<NonPositive<int>>::value);
+    /// @ingroup CheckedValues
+    /// @brief Non-positive constrained value type.
+    template<typename T>
+    using NonPositive = CheckedValue<T, NonPositiveChecker<T>>;
 
-} // namespace playrho
+    static_assert(std::is_default_constructible<NonPositive<int>>::value);
 
-#endif // PLAYRHO_COMMON_NONPOSITIVE_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_NONPOSITIVE_HPP

--- a/PlayRho/Common/NonZero.hpp
+++ b/PlayRho/Common/NonZero.hpp
@@ -23,39 +23,42 @@
 
 #include <PlayRho/Common/CheckedValue.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Non-zero constrained value checker.
-template <typename T>
-struct NonZeroChecker {
-    /// @brief Exception type possibly thrown by this checker.
-    using exception_type = std::invalid_argument;
-
-    /// @brief Value checking functor.
-    /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(!(v != static_cast<T>(0)), T{v})
+    /// @brief Non-zero constrained value checker.
+    template<typename T>
+    struct NonZeroChecker
     {
-        if (!(v != static_cast<T>(0))) {
-            throw exception_type("value not non-zero");
+        /// @brief Exception type possibly thrown by this checker.
+        using exception_type = std::invalid_argument;
+
+        /// @brief Value checking functor.
+        /// @throws exception_type if given value is not valid.
+        constexpr auto operator()(const T& v) -> decltype(!(v != static_cast<T>(0)), T{v})
+        {
+            if (!(v != static_cast<T>(0)))
+            {
+                throw exception_type("value not non-zero");
+            }
+            return v;
         }
-        return v;
-    }
-};
+    };
 
-/// @ingroup CheckedValues
-/// @brief Non-zero constrained value type.
-template <typename T>
-using NonZero = std::enable_if_t<!std::is_pointer<T>::value, CheckedValue<T, NonZeroChecker<T>>>;
+    /// @ingroup CheckedValues
+    /// @brief Non-zero constrained value type.
+    template<typename T>
+    using NonZero = std::enable_if_t<!std::is_pointer<T>::value, CheckedValue<T, NonZeroChecker<T>>>;
 
-static_assert(!std::is_default_constructible<NonZero<int>>::value);
+    static_assert(!std::is_default_constructible<NonZero<int>>::value);
 
-/// @ingroup CheckedValues
-/// @brief Non-null constrained value type.
-template <typename T>
-using NonNull = std::enable_if_t<std::is_pointer<T>::value, CheckedValue<T, NonZeroChecker<T>>>;
+    /// @ingroup CheckedValues
+    /// @brief Non-null constrained value type.
+    template<typename T>
+    using NonNull = std::enable_if_t<std::is_pointer<T>::value, CheckedValue<T, NonZeroChecker<T>>>;
 
-static_assert(!std::is_default_constructible<NonNull<int*>>::value);
+    static_assert(!std::is_default_constructible<NonNull<int*>>::value);
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_NONZERO_HPP
+#endif// PLAYRHO_COMMON_NONZERO_HPP

--- a/PlayRho/Common/OptionalValue.hpp
+++ b/PlayRho/Common/OptionalValue.hpp
@@ -25,8 +25,9 @@
 #include <cassert>
 #include <utility>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     /// @brief Optional value template class.
     /// @details An implementation of the optional value type idea.
     /// @note This is meant to be compatible with <code>std::optional</code> from C++ 17.
@@ -34,19 +35,18 @@ namespace playrho {
     template<typename T>
     class OptionalValue
     {
-    public:
-        
+     public:
         /// @brief Value type.
         using value_type = T;
-        
+
         constexpr OptionalValue() = default;
-        
+
         /// @brief Copy constructor.
         constexpr OptionalValue(const OptionalValue& other) = default;
 
         /// @brief Move constructor.
-        constexpr OptionalValue(OptionalValue&& other) noexcept:
-            m_value{std::move(other.m_value)}, m_set{other.m_set}
+        constexpr OptionalValue(OptionalValue&& other) noexcept
+            : m_value{std::move(other.m_value)}, m_set{other.m_set}
         {
             // Intentionally empty.
             // Note that the exception specification of this constructor
@@ -59,28 +59,28 @@ namespace playrho {
         ~OptionalValue() = default;
 
         /// @brief Indirection operator.
-        constexpr const T& operator* () const;
+        constexpr const T& operator*() const;
 
         /// @brief Indirection operator.
-        constexpr T& operator* ();
-        
+        constexpr T& operator*();
+
         /// @brief Member of pointer operator.
-        constexpr const T* operator-> () const;
-        
+        constexpr const T* operator->() const;
+
         /// @brief Member of pointer operator.
-        constexpr T* operator-> ();
+        constexpr T* operator->();
 
         /// @brief Boolean operator.
         constexpr explicit operator bool() const noexcept;
 
         /// @brief Whether this optional value has a value.
         constexpr bool has_value() const noexcept;
-        
+
         /// @brief Assignment operator.
-        OptionalValue& operator= (const OptionalValue& other) = default;
+        OptionalValue& operator=(const OptionalValue& other) = default;
 
         /// @brief Move assignment operator.
-        OptionalValue& operator= (OptionalValue&& other) noexcept
+        OptionalValue& operator=(OptionalValue&& other) noexcept
         {
             // Note that the exception specification of this method
             //   doesn't match the defaulted one (when built with boost units).
@@ -90,44 +90,47 @@ namespace playrho {
         }
 
         /// @brief Assignment operator.
-        OptionalValue& operator= (T v);
+        OptionalValue& operator=(T v);
 
         /// @brief Accesses the value.
         constexpr T& value();
 
         /// @brief Accesses the value.
         constexpr const T& value() const;
-        
+
         /// @brief Gets the value or provides the alternate given value instead.
         constexpr T value_or(const T& alt) const;
-        
+
         /// @brief Resets the optional value back to its default constructed state.
         void reset() noexcept
         {
             m_value = value_type{};
             m_set = false;
         }
-        
-    private:
-        value_type m_value = value_type{}; ///< Underlying value.
-        bool m_set = false; ///< Whether <code>m_value</code> is set.
+
+     private:
+        value_type m_value = value_type{};///< Underlying value.
+        bool m_set = false;               ///< Whether <code>m_value</code> is set.
     };
-    
+
     template<typename T>
-    constexpr OptionalValue<T>::OptionalValue(T v): m_value{v}, m_set{true} {}
-    
+    constexpr OptionalValue<T>::OptionalValue(T v)
+        : m_value{v}, m_set{true}
+    {
+    }
+
     template<typename T>
     constexpr bool OptionalValue<T>::has_value() const noexcept
     {
         return m_set;
     }
-    
+
     template<typename T>
     constexpr OptionalValue<T>::operator bool() const noexcept
     {
         return m_set;
     }
-    
+
     template<typename T>
     OptionalValue<T>& OptionalValue<T>::operator=(T v)
     {
@@ -135,14 +138,14 @@ namespace playrho {
         m_set = true;
         return *this;
     }
-    
+
     template<typename T>
     constexpr const T* OptionalValue<T>::operator->() const
     {
         assert(m_set);
         return &m_value;
     }
-    
+
     template<typename T>
     constexpr T* OptionalValue<T>::operator->()
     {
@@ -156,7 +159,7 @@ namespace playrho {
         assert(m_set);
         return m_value;
     }
-    
+
     template<typename T>
     constexpr T& OptionalValue<T>::operator*()
     {
@@ -169,7 +172,7 @@ namespace playrho {
     {
         return m_value;
     }
-    
+
     template<typename T>
     constexpr const T& OptionalValue<T>::value() const
     {
@@ -179,16 +182,16 @@ namespace playrho {
     template<typename T>
     constexpr T OptionalValue<T>::value_or(const T& alt) const
     {
-        return m_set? m_value: alt;
+        return m_set ? m_value : alt;
     }
-    
+
     /// @brief Optional type alias.
     /// @details An alias setup to facilitate switching between implementations of the
     ///   optional type idea.
     /// @note This is meant to be used directly for optional values.
-    template <typename T>
+    template<typename T>
     using Optional = OptionalValue<T>;
-    
-} // namespace playrho
 
-#endif // PLAYRHO_COMMON_OPTIONALVALUE_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_OPTIONALVALUE_HPP

--- a/PlayRho/Common/Position.hpp
+++ b/PlayRho/Common/Position.hpp
@@ -22,138 +22,140 @@
 #ifndef PLAYRHO_COMMON_POSITION_HPP
 #define PLAYRHO_COMMON_POSITION_HPP
 
-#include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Common/Vector2.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief 2-D positional data structure.
-/// @details A 2-element length and angle pair suitable for representing a linear and
-///   angular position in 2-D.
-/// @note This structure is likely to be 12-bytes large (at least on 64-bit platforms).
-struct Position
+namespace playrho
 {
-    Length2 linear; ///< Linear position.
-    Angle angular; ///< Angular position.
-};
+    namespace d2
+    {
 
-/// @brief Equality operator.
-/// @relatedalso Position
-constexpr bool operator==(const Position& lhs, const Position& rhs)
-{
-    return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
-}
+        /// @brief 2-D positional data structure.
+        /// @details A 2-element length and angle pair suitable for representing a linear and
+        ///   angular position in 2-D.
+        /// @note This structure is likely to be 12-bytes large (at least on 64-bit platforms).
+        struct Position
+        {
+            Length2 linear;///< Linear position.
+            Angle angular; ///< Angular position.
+        };
 
-/// @brief Inequality operator.
-/// @relatedalso Position
-constexpr bool operator!=(const Position& lhs, const Position& rhs)
-{
-    return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
-}
+        /// @brief Equality operator.
+        /// @relatedalso Position
+        constexpr bool operator==(const Position& lhs, const Position& rhs)
+        {
+            return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
+        }
 
-/// @brief Negation operator.
-/// @relatedalso Position
-constexpr Position operator- (const Position& value)
-{
-    return Position{-value.linear, -value.angular};
-}
+        /// @brief Inequality operator.
+        /// @relatedalso Position
+        constexpr bool operator!=(const Position& lhs, const Position& rhs)
+        {
+            return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
+        }
 
-/// @brief Positive operator.
-/// @relatedalso Position
-constexpr Position operator+ (const Position& value)
-{
-    return value;
-}
+        /// @brief Negation operator.
+        /// @relatedalso Position
+        constexpr Position operator-(const Position& value)
+        {
+            return Position{-value.linear, -value.angular};
+        }
 
-/// @brief Addition assignment operator.
-/// @relatedalso Position
-constexpr Position& operator+= (Position& lhs, const Position& rhs)
-{
-    lhs.linear += rhs.linear;
-    lhs.angular += rhs.angular;
-    return lhs;
-}
+        /// @brief Positive operator.
+        /// @relatedalso Position
+        constexpr Position operator+(const Position& value)
+        {
+            return value;
+        }
 
-/// @brief Addition operator.
-/// @relatedalso Position
-constexpr Position operator+ (const Position& lhs, const Position& rhs)
-{
-    return Position{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
-}
+        /// @brief Addition assignment operator.
+        /// @relatedalso Position
+        constexpr Position& operator+=(Position& lhs, const Position& rhs)
+        {
+            lhs.linear += rhs.linear;
+            lhs.angular += rhs.angular;
+            return lhs;
+        }
 
-/// @brief Subtraction assignment operator.
-/// @relatedalso Position
-constexpr Position& operator-= (Position& lhs, const Position& rhs)
-{
-    lhs.linear -= rhs.linear;
-    lhs.angular -= rhs.angular;
-    return lhs;
-}
+        /// @brief Addition operator.
+        /// @relatedalso Position
+        constexpr Position operator+(const Position& lhs, const Position& rhs)
+        {
+            return Position{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
+        }
 
-/// @brief Subtraction operator.
-/// @relatedalso Position
-constexpr Position operator- (const Position& lhs, const Position& rhs)
-{
-    return Position{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
-}
+        /// @brief Subtraction assignment operator.
+        /// @relatedalso Position
+        constexpr Position& operator-=(Position& lhs, const Position& rhs)
+        {
+            lhs.linear -= rhs.linear;
+            lhs.angular -= rhs.angular;
+            return lhs;
+        }
 
-/// @brief Multiplication operator.
-constexpr Position operator* (const Position& pos, const Real scalar)
-{
-    return Position{pos.linear * scalar, pos.angular * scalar};
-}
+        /// @brief Subtraction operator.
+        /// @relatedalso Position
+        constexpr Position operator-(const Position& lhs, const Position& rhs)
+        {
+            return Position{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
+        }
 
-/// @brief Multiplication operator.
-/// @relatedalso Position
-constexpr Position operator* (const Real scalar, const Position& pos)
-{
-    return Position{pos.linear * scalar, pos.angular * scalar};
-}
+        /// @brief Multiplication operator.
+        constexpr Position operator*(const Position& pos, const Real scalar)
+        {
+            return Position{pos.linear * scalar, pos.angular * scalar};
+        }
 
-} // namespace d2
+        /// @brief Multiplication operator.
+        /// @relatedalso Position
+        constexpr Position operator*(const Real scalar, const Position& pos)
+        {
+            return Position{pos.linear * scalar, pos.angular * scalar};
+        }
 
-/// @brief Determines if the given value is valid.
-/// @relatedalso d2::Position
-template <>
-constexpr
-bool IsValid(const d2::Position& value) noexcept
-{
-    return IsValid(value.linear) && IsValid(value.angular);
-}
+    }// namespace d2
 
-namespace d2 {
+    /// @brief Determines if the given value is valid.
+    /// @relatedalso d2::Position
+    template<>
+    constexpr bool IsValid(const d2::Position& value) noexcept
+    {
+        return IsValid(value.linear) && IsValid(value.angular);
+    }
 
-/// Gets the position between two positions at a given unit interval.
-/// @param pos0 Position at unit interval value of 0.
-/// @param pos1 Position at unit interval value of 1.
-/// @param beta Unit interval (value between 0 and 1) of travel between position 0 and
-///   position 1.
-/// @return position 0 if <code>pos0 == pos1</code> or <code>beta == 0</code>,
-///   position 1 if <code>beta == 1</code>, or at the given unit interval value
-///   between position 0 and position 1.
-/// @relatedalso Position
-constexpr Position GetPosition(const Position pos0, const Position pos1,
-                                              const Real beta) noexcept
-{
-    assert(IsValid(pos0));
-    assert(IsValid(pos1));
-    assert(IsValid(beta));
+    namespace d2
+    {
 
-    // Note: have to be careful how this is done.
-    //   If pos0 == pos1 then return value should always be equal to pos0 too.
-    //   But if Real is float, pos0 * (1 - beta) + pos1 * beta can fail this requirement.
-    //   Meanwhile, pos0 + (pos1 - pos0) * beta always works.
-    
-    // pos0 * (1 - beta) + pos1 * beta
-    // pos0 - pos0 * beta + pos1 * beta
-    // pos0 + (pos1 * beta - pos0 * beta)
-    // pos0 + (pos1 - pos0) * beta
-    return pos0 + (pos1 - pos0) * beta;
-}
+        /// Gets the position between two positions at a given unit interval.
+        /// @param pos0 Position at unit interval value of 0.
+        /// @param pos1 Position at unit interval value of 1.
+        /// @param beta Unit interval (value between 0 and 1) of travel between position 0 and
+        ///   position 1.
+        /// @return position 0 if <code>pos0 == pos1</code> or <code>beta == 0</code>,
+        ///   position 1 if <code>beta == 1</code>, or at the given unit interval value
+        ///   between position 0 and position 1.
+        /// @relatedalso Position
+        constexpr Position GetPosition(const Position pos0, const Position pos1,
+                                       const Real beta) noexcept
+        {
+            assert(IsValid(pos0));
+            assert(IsValid(pos1));
+            assert(IsValid(beta));
 
-} // namespace d2
-} // namespace playrho
+            // Note: have to be careful how this is done.
+            //   If pos0 == pos1 then return value should always be equal to pos0 too.
+            //   But if Real is float, pos0 * (1 - beta) + pos1 * beta can fail this requirement.
+            //   Meanwhile, pos0 + (pos1 - pos0) * beta always works.
 
-#endif // PLAYRHO_COMMON_POSITION_HPP
+            // pos0 * (1 - beta) + pos1 * beta
+            // pos0 - pos0 * beta + pos1 * beta
+            // pos0 + (pos1 * beta - pos0 * beta)
+            // pos0 + (pos1 - pos0) * beta
+            return pos0 + (pos1 - pos0) * beta;
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_POSITION_HPP

--- a/PlayRho/Common/Positive.hpp
+++ b/PlayRho/Common/Positive.hpp
@@ -23,32 +23,35 @@
 
 #include <PlayRho/Common/CheckedValue.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Positive constrained value checker.
-template <typename T>
-struct PositiveChecker {
-    /// @brief Exception type possibly thrown by this checker.
-    using exception_type = std::invalid_argument;
-
-    /// @brief Value checking functor.
-    /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(!(v > static_cast<T>(0)), T{v})
+    /// @brief Positive constrained value checker.
+    template<typename T>
+    struct PositiveChecker
     {
-        if (!(v > static_cast<T>(0))) {
-            throw exception_type("value not greater than zero");
+        /// @brief Exception type possibly thrown by this checker.
+        using exception_type = std::invalid_argument;
+
+        /// @brief Value checking functor.
+        /// @throws exception_type if given value is not valid.
+        constexpr auto operator()(const T& v) -> decltype(!(v > static_cast<T>(0)), T{v})
+        {
+            if (!(v > static_cast<T>(0)))
+            {
+                throw exception_type("value not greater than zero");
+            }
+            return v;
         }
-        return v;
-    }
-};
+    };
 
-/// @ingroup CheckedValues
-/// @brief Positive constrained value type.
-template <typename T>
-using Positive = CheckedValue<T, PositiveChecker<T>>;
+    /// @ingroup CheckedValues
+    /// @brief Positive constrained value type.
+    template<typename T>
+    using Positive = CheckedValue<T, PositiveChecker<T>>;
 
-static_assert(!std::is_default_constructible<Positive<int>>::value);
+    static_assert(!std::is_default_constructible<Positive<int>>::value);
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_POSITIVE_HPP
+#endif// PLAYRHO_COMMON_POSITIVE_HPP

--- a/PlayRho/Common/Range.hpp
+++ b/PlayRho/Common/Range.hpp
@@ -24,13 +24,14 @@
 #include <PlayRho/Defines.hpp>
 #include <cstddef>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     /// @brief Template range value class.
-    template <typename IT>
+    template<typename IT>
     class Range
     {
-    public:
+     public:
         /// @brief Iterator type.
         using iterator_type = IT;
 
@@ -38,8 +39,8 @@ namespace playrho {
         using value_type = decltype(*std::declval<iterator_type>());
 
         /// @brief Initializing constructor.
-        constexpr Range(iterator_type iter_begin, iterator_type iter_end) noexcept:
-        	m_begin{iter_begin}, m_end{iter_end}
+        constexpr Range(iterator_type iter_begin, iterator_type iter_end) noexcept
+            : m_begin{iter_begin}, m_end{iter_end}
         {
             // Intentionally empty.
         }
@@ -62,24 +63,24 @@ namespace playrho {
             return m_begin == m_end;
         }
 
-    private:
-        iterator_type m_begin; ///< Begin iterator.
-        iterator_type m_end; ///< End iterator.
+     private:
+        iterator_type m_begin;///< Begin iterator.
+        iterator_type m_end;  ///< End iterator.
     };
 
     /// @brief Template sized range value class.
-    template <typename IT>
-    class SizedRange: public Range<IT>
+    template<typename IT>
+    class SizedRange : public Range<IT>
     {
-    public:
+     public:
         /// @brief Size type.
         using size_type = std::size_t;
 
         /// @brief Initializing constructor.
         constexpr SizedRange(typename Range<IT>::iterator_type iter_begin,
                              typename Range<IT>::iterator_type iter_end,
-                             size_type size) noexcept:
-        	Range<IT>{iter_begin, iter_end}, m_size{size}
+                             size_type size) noexcept
+            : Range<IT>{iter_begin, iter_end}, m_size{size}
         {
             // Intentionally empty.
         }
@@ -90,10 +91,10 @@ namespace playrho {
             return m_size;
         }
 
-    private:
-        size_type m_size; ///< Size in number of elements in the range.
+     private:
+        size_type m_size;///< Size in number of elements in the range.
     };
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_RANGE_HPP
+#endif// PLAYRHO_COMMON_RANGE_HPP

--- a/PlayRho/Common/Real.hpp
+++ b/PlayRho/Common/Real.hpp
@@ -29,45 +29,46 @@
 #define PLAYRHO_COMMON_REAL_HPP
 
 #include <PlayRho/Common/Fixed.hpp>
-#include <PlayRho/Common/FixedMath.hpp>
 #include <PlayRho/Common/FixedLimits.hpp>
+#include <PlayRho/Common/FixedMath.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Real-number type.
-///
-/// @details This is the number type underlying numerical calculations conceptually involving
-///   real-numbers. Ideally the implementation of this type doesn't suffer from things like:
-///   catastrophic cancellation, catastrophic division, overflows, nor underflows.
-///
-/// @note This can be implemented using any of the fundamental floating point types (
-///   <code>float</code>, <code>double</code>, or <code>long double</code>).
-/// @note This can also be implemented using a <code>LiteralType</code> that has the necessary
-///   support: all common mathematical functions, support for infinity and NaN, and a
-///   specialization of the <code>std::numeric_limits</code> class template for it.
-/// @note At present, the <code>Fixed32</code> and <code>Fixed64</code> aliases of the
-///   <code>Fixed</code> template type are provided as examples of qualifying literal types
-///   though the usability of these are limited and their use is discouraged.
-///
-/// @note Regarding division:
-///  - While dividing 1 by a real, caching the result, and then doing multiplications with the
-///    result may well be faster (than repeatedly dividing), dividing 1 by the real can also
-///    result in an underflow situation that's then compounded every time it's multiplied with
-///    other values.
-///  - Meanwhile, dividing every time by a real isolates any underflows to the particular
-///    division where underflow occurs.
-///
-/// @warning Using <code>Fixed32</code> is not advised as its numerical limitations are more
-///   likely to result in problems like overflows or underflows.
-/// @warning The note regarding division applies even more so when using a fixed-point type
-///   (for <code>Real</code>).
-///
-/// @see https://en.cppreference.com/w/cpp/language/types
-/// @see https://en.cppreference.com/w/cpp/types/is_floating_point
-/// @see https://en.cppreference.com/w/cpp/named_req/LiteralType
-///
-using Real = float;
+    /// @brief Real-number type.
+    ///
+    /// @details This is the number type underlying numerical calculations conceptually involving
+    ///   real-numbers. Ideally the implementation of this type doesn't suffer from things like:
+    ///   catastrophic cancellation, catastrophic division, overflows, nor underflows.
+    ///
+    /// @note This can be implemented using any of the fundamental floating point types (
+    ///   <code>float</code>, <code>double</code>, or <code>long double</code>).
+    /// @note This can also be implemented using a <code>LiteralType</code> that has the necessary
+    ///   support: all common mathematical functions, support for infinity and NaN, and a
+    ///   specialization of the <code>std::numeric_limits</code> class template for it.
+    /// @note At present, the <code>Fixed32</code> and <code>Fixed64</code> aliases of the
+    ///   <code>Fixed</code> template type are provided as examples of qualifying literal types
+    ///   though the usability of these are limited and their use is discouraged.
+    ///
+    /// @note Regarding division:
+    ///  - While dividing 1 by a real, caching the result, and then doing multiplications with the
+    ///    result may well be faster (than repeatedly dividing), dividing 1 by the real can also
+    ///    result in an underflow situation that's then compounded every time it's multiplied with
+    ///    other values.
+    ///  - Meanwhile, dividing every time by a real isolates any underflows to the particular
+    ///    division where underflow occurs.
+    ///
+    /// @warning Using <code>Fixed32</code> is not advised as its numerical limitations are more
+    ///   likely to result in problems like overflows or underflows.
+    /// @warning The note regarding division applies even more so when using a fixed-point type
+    ///   (for <code>Real</code>).
+    ///
+    /// @see https://en.cppreference.com/w/cpp/language/types
+    /// @see https://en.cppreference.com/w/cpp/types/is_floating_point
+    /// @see https://en.cppreference.com/w/cpp/named_req/LiteralType
+    ///
+    using Real = float;
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_REAL_HPP
+#endif// PLAYRHO_COMMON_REAL_HPP

--- a/PlayRho/Common/Real.hpp.in
+++ b/PlayRho/Common/Real.hpp.in
@@ -29,45 +29,46 @@
 #define PLAYRHO_COMMON_REAL_HPP
 
 #include <PlayRho/Common/Fixed.hpp>
-#include <PlayRho/Common/FixedMath.hpp>
 #include <PlayRho/Common/FixedLimits.hpp>
+#include <PlayRho/Common/FixedMath.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Real-number type.
-///
-/// @details This is the number type underlying numerical calculations conceptually involving
-///   real-numbers. Ideally the implementation of this type doesn't suffer from things like:
-///   catastrophic cancellation, catastrophic division, overflows, nor underflows.
-///
-/// @note This can be implemented using any of the fundamental floating point types (
-///   <code>float</code>, <code>double</code>, or <code>long double</code>).
-/// @note This can also be implemented using a <code>LiteralType</code> that has the necessary
-///   support: all common mathematical functions, support for infinity and NaN, and a
-///   specialization of the <code>std::numeric_limits</code> class template for it.
-/// @note At present, the <code>Fixed32</code> and <code>Fixed64</code> aliases of the
-///   <code>Fixed</code> template type are provided as examples of qualifying literal types
-///   though the usability of these are limited and their use is discouraged.
-///
-/// @note Regarding division:
-///  - While dividing 1 by a real, caching the result, and then doing multiplications with the
-///    result may well be faster (than repeatedly dividing), dividing 1 by the real can also
-///    result in an underflow situation that's then compounded every time it's multiplied with
-///    other values.
-///  - Meanwhile, dividing every time by a real isolates any underflows to the particular
-///    division where underflow occurs.
-///
-/// @warning Using <code>Fixed32</code> is not advised as its numerical limitations are more
-///   likely to result in problems like overflows or underflows.
-/// @warning The note regarding division applies even more so when using a fixed-point type
-///   (for <code>Real</code>).
-///
-/// @see https://en.cppreference.com/w/cpp/language/types
-/// @see https://en.cppreference.com/w/cpp/types/is_floating_point
-/// @see https://en.cppreference.com/w/cpp/named_req/LiteralType
-///
-using Real = @PLAYRHO_REAL_TYPE@;
+    /// @brief Real-number type.
+    ///
+    /// @details This is the number type underlying numerical calculations conceptually involving
+    ///   real-numbers. Ideally the implementation of this type doesn't suffer from things like:
+    ///   catastrophic cancellation, catastrophic division, overflows, nor underflows.
+    ///
+    /// @note This can be implemented using any of the fundamental floating point types (
+    ///   <code>float</code>, <code>double</code>, or <code>long double</code>).
+    /// @note This can also be implemented using a <code>LiteralType</code> that has the necessary
+    ///   support: all common mathematical functions, support for infinity and NaN, and a
+    ///   specialization of the <code>std::numeric_limits</code> class template for it.
+    /// @note At present, the <code>Fixed32</code> and <code>Fixed64</code> aliases of the
+    ///   <code>Fixed</code> template type are provided as examples of qualifying literal types
+    ///   though the usability of these are limited and their use is discouraged.
+    ///
+    /// @note Regarding division:
+    ///  - While dividing 1 by a real, caching the result, and then doing multiplications with the
+    ///    result may well be faster (than repeatedly dividing), dividing 1 by the real can also
+    ///    result in an underflow situation that's then compounded every time it's multiplied with
+    ///    other values.
+    ///  - Meanwhile, dividing every time by a real isolates any underflows to the particular
+    ///    division where underflow occurs.
+    ///
+    /// @warning Using <code>Fixed32</code> is not advised as its numerical limitations are more
+    ///   likely to result in problems like overflows or underflows.
+    /// @warning The note regarding division applies even more so when using a fixed-point type
+    ///   (for <code>Real</code>).
+    ///
+    /// @see https://en.cppreference.com/w/cpp/language/types
+    /// @see https://en.cppreference.com/w/cpp/types/is_floating_point
+    /// @see https://en.cppreference.com/w/cpp/named_req/LiteralType
+    ///
+    using Real = @PLAYRHO_REAL_TYPE @;
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_REAL_HPP
+#endif// PLAYRHO_COMMON_REAL_HPP

--- a/PlayRho/Common/RealConstants.hpp
+++ b/PlayRho/Common/RealConstants.hpp
@@ -29,79 +29,80 @@
 #ifndef PLAYRHO_COMMON_REALCONSTANTS_HPP
 #define PLAYRHO_COMMON_REALCONSTANTS_HPP
 
-#include <PlayRho/Defines.hpp>
 #include <PlayRho/Common/Real.hpp>
+#include <PlayRho/Defines.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Pi.
-///
-/// @details An "irrational number" that's defined as the ratio of a circle's
-///   circumference to its diameter.
-///
-/// @note While the include file definition of M_PI may be a POSIX compliance requirement
-///   and initially attractive to use, it's apparently not a C++ standards requirement
-///   and casually including it pollutes the name space of all code that uses this library.
-///   Whatever the case, MSVC 2017 doesn't make it part of the <code>cmath</code> include
-///   without enabling <code>_USE_MATH_DEFINES</code>. So rather than add yet more
-///   C preprocessor macros to all sources that this library may be compiled with, it's
-///   simply hard-coded in here instead using a C++ mechanism that also keeps it with the
-///   enclosing name space.
-/// @note Any narrowing is intentional.
-///
-/// @see https://en.wikipedia.org/wiki/Pi
-///
-constexpr auto Pi = Real(3.14159265358979323846264338327950288);
+    /// @brief Pi.
+    ///
+    /// @details An "irrational number" that's defined as the ratio of a circle's
+    ///   circumference to its diameter.
+    ///
+    /// @note While the include file definition of M_PI may be a POSIX compliance requirement
+    ///   and initially attractive to use, it's apparently not a C++ standards requirement
+    ///   and casually including it pollutes the name space of all code that uses this library.
+    ///   Whatever the case, MSVC 2017 doesn't make it part of the <code>cmath</code> include
+    ///   without enabling <code>_USE_MATH_DEFINES</code>. So rather than add yet more
+    ///   C preprocessor macros to all sources that this library may be compiled with, it's
+    ///   simply hard-coded in here instead using a C++ mechanism that also keeps it with the
+    ///   enclosing name space.
+    /// @note Any narrowing is intentional.
+    ///
+    /// @see https://en.wikipedia.org/wiki/Pi
+    ///
+    constexpr auto Pi = Real(3.14159265358979323846264338327950288);
 
-/// @brief Square root of two.
-///
-/// @see https://en.wikipedia.org/wiki/Square_root_of_2
-///
-constexpr auto SquareRootTwo =
-    Real(1.414213562373095048801688724209698078569671875376948073176679737990732478462);
+    /// @brief Square root of two.
+    ///
+    /// @see https://en.wikipedia.org/wiki/Square_root_of_2
+    ///
+    constexpr auto SquareRootTwo =
+        Real(1.414213562373095048801688724209698078569671875376948073176679737990732478462);
 
-/// @defgroup DecimalUnitPrefices Decimal Unit Prefices
-/// @brief Decimal unit prefices in the metric system for denoting a multiple, or
-///   a fraction of, a unit.
-/// @note <code>std::ratio</code> doesn't necessarily support larger sizes like Yotta
-///    or bigger so floating-point literal notation is used instead.
-/// @see https://en.wikipedia.org/wiki/Metric_prefix
-/// @{
+    /// @defgroup DecimalUnitPrefices Decimal Unit Prefices
+    /// @brief Decimal unit prefices in the metric system for denoting a multiple, or
+    ///   a fraction of, a unit.
+    /// @note <code>std::ratio</code> doesn't necessarily support larger sizes like Yotta
+    ///    or bigger so floating-point literal notation is used instead.
+    /// @see https://en.wikipedia.org/wiki/Metric_prefix
+    /// @{
 
-/// @brief Centi- (1 x 10^-2).
-/// @see https://en.wikipedia.org/wiki/Centi-
-constexpr auto Centi = Real(1e-2);
+    /// @brief Centi- (1 x 10^-2).
+    /// @see https://en.wikipedia.org/wiki/Centi-
+    constexpr auto Centi = Real(1e-2);
 
-/// @brief Deci- (1 x 10^-1).
-/// @see https://en.wikipedia.org/wiki/Deci-
-constexpr auto Deci = Real(1e-1);
+    /// @brief Deci- (1 x 10^-1).
+    /// @see https://en.wikipedia.org/wiki/Deci-
+    constexpr auto Deci = Real(1e-1);
 
-/// @brief Kilo- (1 x 10^3).
-/// @see https://en.wikipedia.org/wiki/Kilo-
-constexpr auto Kilo = Real(1e3);
+    /// @brief Kilo- (1 x 10^3).
+    /// @see https://en.wikipedia.org/wiki/Kilo-
+    constexpr auto Kilo = Real(1e3);
 
-/// @brief Mega- (1 x 10^6).
-/// @see https://en.wikipedia.org/wiki/Mega-
-constexpr auto Mega = Real(1e6);
+    /// @brief Mega- (1 x 10^6).
+    /// @see https://en.wikipedia.org/wiki/Mega-
+    constexpr auto Mega = Real(1e6);
 
-/// @brief Giga- (1 x 10^9).
-/// @see https://en.wikipedia.org/wiki/Giga-
-constexpr auto Giga = Real(1e9);
+    /// @brief Giga- (1 x 10^9).
+    /// @see https://en.wikipedia.org/wiki/Giga-
+    constexpr auto Giga = Real(1e9);
 
-/// @brief Tera- (1 x 10^12).
-/// @see https://en.wikipedia.org/wiki/Tera-
-constexpr auto Tera = Real(1e12);
+    /// @brief Tera- (1 x 10^12).
+    /// @see https://en.wikipedia.org/wiki/Tera-
+    constexpr auto Tera = Real(1e12);
 
-/// @brief Peta- (1 x 10^15).
-/// @see https://en.wikipedia.org/wiki/Peta-
-constexpr auto Peta = Real(1e15);
+    /// @brief Peta- (1 x 10^15).
+    /// @see https://en.wikipedia.org/wiki/Peta-
+    constexpr auto Peta = Real(1e15);
 
-/// @brief Yotta- (1 x 10^24).
-/// @see https://en.wikipedia.org/wiki/Yotta-
-constexpr auto Yotta = Real(1e24);
+    /// @brief Yotta- (1 x 10^24).
+    /// @see https://en.wikipedia.org/wiki/Yotta-
+    constexpr auto Yotta = Real(1e24);
 
-/// @}
+    /// @}
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_REALCONSTANTS_HPP
+#endif// PLAYRHO_COMMON_REALCONSTANTS_HPP

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -27,241 +27,240 @@
 #ifndef PLAYRHO_COMMON_SETTINGS_HPP
 #define PLAYRHO_COMMON_SETTINGS_HPP
 
-#include <cstddef>
+#include <algorithm>
 #include <cassert>
 #include <cfloat>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
-#include <algorithm>
 
-#include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Common/RealConstants.hpp>
+#include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/Wider.hpp>
 
-namespace playrho {
-namespace detail {
-
-/// @brief Defaults object for real types.
-template <typename T>
-struct Defaults
+namespace playrho
 {
-    /// @brief Gets the linear slop.
-    static constexpr auto GetLinearSlop() noexcept
+    namespace detail
     {
-        // Return the value used by Box2D 2.3.2 b2_linearSlop define....
-        return 0.005_m;
-    }
-    
-    /// @brief Gets the max vertex radius.
-    static constexpr auto GetMaxVertexRadius() noexcept
-    {
-        // DefaultLinearSlop * Real{2 * 1024 * 1024};
-        // linearSlop * 2550000
-        return 255_m;
-    }
-};
 
-/// @brief Specialization of defaults object for fixed point types.
-template <unsigned int FRACTION_BITS>
-struct Defaults<Fixed<std::int32_t,FRACTION_BITS>>
-{
-    /// @brief Gets the linear slop.
-    static constexpr auto GetLinearSlop() noexcept
-    {
-        // Needs to be big enough that the step tolerance doesn't go to zero.
-        // ex: FRACTION_BITS==10, then divisor==256
-        return Length{1_m / Real{(1u << (FRACTION_BITS - 2))}};
-    }
-    
-    /// @brief Gets the max vertex radius.
-    static constexpr auto GetMaxVertexRadius() noexcept
-    {
-        // linearSlop * 2550000
-        return Length{Real(1u << (28 - FRACTION_BITS)) * 1_m};
-    }
-};
+        /// @brief Defaults object for real types.
+        template<typename T>
+        struct Defaults
+        {
+            /// @brief Gets the linear slop.
+            static constexpr auto GetLinearSlop() noexcept
+            {
+                // Return the value used by Box2D 2.3.2 b2_linearSlop define....
+                return 0.005_m;
+            }
 
-} // namespace detail
+            /// @brief Gets the max vertex radius.
+            static constexpr auto GetMaxVertexRadius() noexcept
+            {
+                // DefaultLinearSlop * Real{2 * 1024 * 1024};
+                // linearSlop * 2550000
+                return 255_m;
+            }
+        };
 
-/// @brief Maximum number of supportable edges in a simplex.
-constexpr auto MaxSimplexEdges = std::uint8_t{3};
+        /// @brief Specialization of defaults object for fixed point types.
+        template<unsigned int FRACTION_BITS>
+        struct Defaults<Fixed<std::int32_t, FRACTION_BITS>>
+        {
+            /// @brief Gets the linear slop.
+            static constexpr auto GetLinearSlop() noexcept
+            {
+                // Needs to be big enough that the step tolerance doesn't go to zero.
+                // ex: FRACTION_BITS==10, then divisor==256
+                return Length{1_m / Real{(1u << (FRACTION_BITS - 2))}};
+            }
 
-/// @brief Max child count.
-constexpr auto MaxChildCount = std::numeric_limits<std::uint32_t>::max() >> 6;
+            /// @brief Gets the max vertex radius.
+            static constexpr auto GetMaxVertexRadius() noexcept
+            {
+                // linearSlop * 2550000
+                return Length{Real(1u << (28 - FRACTION_BITS)) * 1_m};
+            }
+        };
 
-/// @brief Child counter type.
-/// @details Relating to "children" of shape where each child is a convex shape possibly
-///   comprising a concave shape.
-/// @note This type must always be able to contain the <code>MaxChildCount</code> value.
-using ChildCounter = std::remove_const<decltype(MaxChildCount)>::type;
+    }// namespace detail
 
-/// Time step iterations type.
-/// @details A type for counting iterations per time-step.
-using TimestepIters = std::uint8_t;
+    /// @brief Maximum number of supportable edges in a simplex.
+    constexpr auto MaxSimplexEdges = std::uint8_t{3};
 
-/// @brief Maximum float value.
-constexpr auto MaxFloat = std::numeric_limits<Real>::max(); // FLT_MAX
+    /// @brief Max child count.
+    constexpr auto MaxChildCount = std::numeric_limits<std::uint32_t>::max() >> 6;
 
-// Collision
+    /// @brief Child counter type.
+    /// @details Relating to "children" of shape where each child is a convex shape possibly
+    ///   comprising a concave shape.
+    /// @note This type must always be able to contain the <code>MaxChildCount</code> value.
+    using ChildCounter = std::remove_const<decltype(MaxChildCount)>::type;
 
-/// Maximum manifold points.
-/// This is the maximum number of contact points between two convex shapes.
-/// Do not change this value.
-/// @note For memory efficiency, uses the smallest integral type that can hold the value. 
-constexpr auto MaxManifoldPoints = std::uint8_t{2};
+    /// Time step iterations type.
+    /// @details A type for counting iterations per time-step.
+    using TimestepIters = std::uint8_t;
 
-/// @brief Maximum number of vertices for any shape type.
-/// @note For memory efficiency, uses the smallest integral type that can hold the value minus
-///   one that's left out as a sentinel value.
-constexpr auto MaxShapeVertices = std::uint8_t{254};
+    /// @brief Maximum float value.
+    constexpr auto MaxFloat = std::numeric_limits<Real>::max();// FLT_MAX
 
-/// @brief Vertex count type.
-/// @note This type must not support more than 255 vertices as that would conflict
-///   with the <code>ContactFeature::Index</code> type.
-using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
+    // Collision
 
-/// @brief Invalid vertex index.
-constexpr auto InvalidVertex = static_cast<VertexCounter>(-1);
+    /// Maximum manifold points.
+    /// This is the maximum number of contact points between two convex shapes.
+    /// Do not change this value.
+    /// @note For memory efficiency, uses the smallest integral type that can hold the value.
+    constexpr auto MaxManifoldPoints = std::uint8_t{2};
 
-/// @brief Default linear slop.
-/// @details Length used as a collision and constraint tolerance.
-///   Usually chosen to be numerically significant, but visually insignificant.
-///   Lower or raise to decrease or increase respectively the minimum of space
-///   between bodies at rest.
-/// @note Smaller values relative to sizes of bodies increases the time it takes
-///   for bodies to come to rest.
-constexpr auto DefaultLinearSlop = detail::Defaults<Real>::GetLinearSlop();
+    /// @brief Maximum number of vertices for any shape type.
+    /// @note For memory efficiency, uses the smallest integral type that can hold the value minus
+    ///   one that's left out as a sentinel value.
+    constexpr auto MaxShapeVertices = std::uint8_t{254};
 
-/// @brief Default minimum vertex radius.
-constexpr auto DefaultMinVertexRadius = DefaultLinearSlop * Real{2};
+    /// @brief Vertex count type.
+    /// @note This type must not support more than 255 vertices as that would conflict
+    ///   with the <code>ContactFeature::Index</code> type.
+    using VertexCounter = std::remove_const<decltype(MaxShapeVertices)>::type;
 
-/// @brief Default maximum vertex radius.
-constexpr auto DefaultMaxVertexRadius = detail::Defaults<Real>::GetMaxVertexRadius();
+    /// @brief Invalid vertex index.
+    constexpr auto InvalidVertex = static_cast<VertexCounter>(-1);
 
-/// @brief Default AABB extension amount.
-constexpr auto DefaultAabbExtension = DefaultLinearSlop * Real{20};
+    /// @brief Default linear slop.
+    /// @details Length used as a collision and constraint tolerance.
+    ///   Usually chosen to be numerically significant, but visually insignificant.
+    ///   Lower or raise to decrease or increase respectively the minimum of space
+    ///   between bodies at rest.
+    /// @note Smaller values relative to sizes of bodies increases the time it takes
+    ///   for bodies to come to rest.
+    constexpr auto DefaultLinearSlop = detail::Defaults<Real>::GetLinearSlop();
 
-/// @brief Default distance multiplier.
-constexpr auto DefaultDistanceMultiplier = Real{2};
+    /// @brief Default minimum vertex radius.
+    constexpr auto DefaultMinVertexRadius = DefaultLinearSlop * Real{2};
 
-/// @brief Default angular slop.
-/// @details
-/// A small angle used as a collision and constraint tolerance. Usually it is
-/// chosen to be numerically significant, but visually insignificant.
-constexpr auto DefaultAngularSlop = (Pi * 2_rad) / Real{180};
+    /// @brief Default maximum vertex radius.
+    constexpr auto DefaultMaxVertexRadius = detail::Defaults<Real>::GetMaxVertexRadius();
 
-/// @brief Default maximum linear correction.
-/// @details The maximum linear position correction used when solving constraints.
-///   This helps to prevent overshoot.
-/// @note This value should be greater than the linear slop value.
-constexpr auto DefaultMaxLinearCorrection = 0.2_m;
+    /// @brief Default AABB extension amount.
+    constexpr auto DefaultAabbExtension = DefaultLinearSlop * Real{20};
 
-/// @brief Default maximum angular correction.
-/// @note This value should be greater than the angular slop value.
-constexpr auto DefaultMaxAngularCorrection = Real(8.0f / 180.0f) * Pi * 1_rad;
+    /// @brief Default distance multiplier.
+    constexpr auto DefaultDistanceMultiplier = Real{2};
 
-/// @brief Default maximum translation amount.
-constexpr auto DefaultMaxTranslation = 2_m;
+    /// @brief Default angular slop.
+    /// @details
+    /// A small angle used as a collision and constraint tolerance. Usually it is
+    /// chosen to be numerically significant, but visually insignificant.
+    constexpr auto DefaultAngularSlop = (Pi * 2_rad) / Real{180};
 
-/// @brief Default maximum rotation per world step.
-/// @warning This value should be less than Pi * Radian.
-/// @note This limit is meant to prevent numerical problems. Adjusting this value isn't advised.
-/// @see StepConf::maxRotation.
-constexpr auto DefaultMaxRotation = Angle{Pi * 1_rad / Real(2)};
+    /// @brief Default maximum linear correction.
+    /// @details The maximum linear position correction used when solving constraints.
+    ///   This helps to prevent overshoot.
+    /// @note This value should be greater than the linear slop value.
+    constexpr auto DefaultMaxLinearCorrection = 0.2_m;
 
-/// @brief Default maximum time of impact iterations.
-constexpr auto DefaultMaxToiIters = std::uint8_t{20};
+    /// @brief Default maximum angular correction.
+    /// @note This value should be greater than the angular slop value.
+    constexpr auto DefaultMaxAngularCorrection = Real(8.0f / 180.0f) * Pi * 1_rad;
 
-/// Default maximum time of impact root iterator count.
-constexpr auto DefaultMaxToiRootIters = std::uint8_t{30};
+    /// @brief Default maximum translation amount.
+    constexpr auto DefaultMaxTranslation = 2_m;
 
-/// Default max number of distance iterations.
-constexpr auto DefaultMaxDistanceIters = std::uint8_t{20};
+    /// @brief Default maximum rotation per world step.
+    /// @warning This value should be less than Pi * Radian.
+    /// @note This limit is meant to prevent numerical problems. Adjusting this value isn't advised.
+    /// @see StepConf::maxRotation.
+    constexpr auto DefaultMaxRotation = Angle{Pi * 1_rad / Real(2)};
 
-/// Default maximum number of sub steps.
-/// @details
-/// This is the default maximum number of sub-steps per contact in continuous physics simulation.
-/// In other words, this is the default maximum number of times in a world step that a contact will
-/// have continuous collision resolution done for it.
-/// @note Used in the TOI phase of step processing.
-constexpr auto DefaultMaxSubSteps = std::uint8_t{8};
-    
-// Dynamics
+    /// @brief Default maximum time of impact iterations.
+    constexpr auto DefaultMaxToiIters = std::uint8_t{20};
 
-/// @brief Default velocity threshold.
-constexpr auto DefaultVelocityThreshold = 1_mps;
+    /// Default maximum time of impact root iterator count.
+    constexpr auto DefaultMaxToiRootIters = std::uint8_t{30};
 
-/// @brief Default regular-phase minimum momentum.
-constexpr auto DefaultRegMinMomentum = Momentum{0_Ns / 100};
+    /// Default max number of distance iterations.
+    constexpr auto DefaultMaxDistanceIters = std::uint8_t{20};
 
-/// @brief Default TOI-phase minimum momentum.
-constexpr auto DefaultToiMinMomentum = Momentum{0_Ns / 100};
+    /// Default maximum number of sub steps.
+    /// @details
+    /// This is the default maximum number of sub-steps per contact in continuous physics simulation.
+    /// In other words, this is the default maximum number of times in a world step that a contact will
+    /// have continuous collision resolution done for it.
+    /// @note Used in the TOI phase of step processing.
+    constexpr auto DefaultMaxSubSteps = std::uint8_t{8};
 
-/// @brief Maximum number of fixtures in a world.
-/// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
-constexpr auto MaxFixtures = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
-                                                        std::uint16_t{1u});
-/// @brief Fixture count type.
-/// @note This type must always be able to contain the <code>MaxFixtures</code> value.
-using FixtureCounter = std::remove_const<decltype(MaxFixtures)>::type;
+    // Dynamics
 
-/// @brief Maximum number of bodies in a world.
-/// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
-constexpr auto MaxBodies = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
-                                                      std::uint16_t{1});
+    /// @brief Default velocity threshold.
+    constexpr auto DefaultVelocityThreshold = 1_mps;
 
-/// @brief Body count type.
-/// @note This type must always be able to contain the <code>MaxBodies</code> value.
-using BodyCounter = std::remove_const<decltype(MaxBodies)>::type;
+    /// @brief Default regular-phase minimum momentum.
+    constexpr auto DefaultRegMinMomentum = Momentum{0_Ns / 100};
 
-/// @brief Contact count type.
-/// @note This type must be able to contain the squared value of <code>BodyCounter</code>.
-using ContactCounter = Wider<BodyCounter>::type;
+    /// @brief Default TOI-phase minimum momentum.
+    constexpr auto DefaultToiMinMomentum = Momentum{0_Ns / 100};
 
-/// @brief Invalid contact index.
-constexpr auto InvalidContactIndex = static_cast<ContactCounter>(-1);
+    /// @brief Maximum number of fixtures in a world.
+    /// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
+    constexpr auto MaxFixtures = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() - std::uint16_t{1u});
+    /// @brief Fixture count type.
+    /// @note This type must always be able to contain the <code>MaxFixtures</code> value.
+    using FixtureCounter = std::remove_const<decltype(MaxFixtures)>::type;
 
-/// @brief Maximum number of contacts in a world (2147319811).
-/// @details Uses the formula for the maximum number of edges in an unidirectional graph of
-///   <code>MaxBodies</code> nodes.
-/// This occurs when every possible body is connected to every other body.
-constexpr auto MaxContacts = ContactCounter{MaxBodies} * ContactCounter{MaxBodies - 1} / ContactCounter{2};
+    /// @brief Maximum number of bodies in a world.
+    /// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
+    constexpr auto MaxBodies = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() - std::uint16_t{1});
 
-/// @brief Maximum number of joints in a world.
-/// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
-constexpr auto MaxJoints = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() -
-                                                      std::uint16_t{1});
+    /// @brief Body count type.
+    /// @note This type must always be able to contain the <code>MaxBodies</code> value.
+    using BodyCounter = std::remove_const<decltype(MaxBodies)>::type;
 
-/// @brief Joint count type.
-/// @note This type must be able to contain the <code>MaxJoints</code> value.
-using JointCounter = std::remove_const<decltype(MaxJoints)>::type;
+    /// @brief Contact count type.
+    /// @note This type must be able to contain the squared value of <code>BodyCounter</code>.
+    using ContactCounter = Wider<BodyCounter>::type;
 
-/// @brief Default step time.
-constexpr auto DefaultStepTime = Time{1_s / 60};
+    /// @brief Invalid contact index.
+    constexpr auto InvalidContactIndex = static_cast<ContactCounter>(-1);
 
-/// @brief Default step frequency.
-constexpr auto DefaultStepFrequency = 60_Hz;
+    /// @brief Maximum number of contacts in a world (2147319811).
+    /// @details Uses the formula for the maximum number of edges in an unidirectional graph of
+    ///   <code>MaxBodies</code> nodes.
+    /// This occurs when every possible body is connected to every other body.
+    constexpr auto MaxContacts = ContactCounter{MaxBodies} * ContactCounter{MaxBodies - 1} / ContactCounter{2};
 
-// Sleep
+    /// @brief Maximum number of joints in a world.
+    /// @note This is 65534 based off <code>std::uint16_t</code> and eliminating one value for invalid.
+    constexpr auto MaxJoints = static_cast<std::uint16_t>(std::numeric_limits<std::uint16_t>::max() - std::uint16_t{1});
 
-/// Default minimum still time to sleep.
-/// @details The default minimum time bodies must be still for bodies to be put to sleep.
-constexpr auto DefaultMinStillTimeToSleep = Time{1_s / 2}; // aka 0.5 secs
+    /// @brief Joint count type.
+    /// @note This type must be able to contain the <code>MaxJoints</code> value.
+    using JointCounter = std::remove_const<decltype(MaxJoints)>::type;
 
-/// Default linear sleep tolerance.
-/// @details A body cannot sleep if the magnitude of its linear velocity is above this amount.
-constexpr auto DefaultLinearSleepTolerance = 0.01_mps; // aka 0.01
+    /// @brief Default step time.
+    constexpr auto DefaultStepTime = Time{1_s / 60};
 
-/// Default angular sleep tolerance.
-/// @details A body cannot sleep if its angular velocity is above this amount.
-constexpr auto DefaultAngularSleepTolerance = Real{(Pi * 2) / 180} * RadianPerSecond;
+    /// @brief Default step frequency.
+    constexpr auto DefaultStepFrequency = 60_Hz;
 
-/// Default circles ratio.
-/// @details Ratio used for switching between rounded-corner collisions and closest-face
-///   biased normal collisions.
-constexpr auto DefaultCirclesRatio = Real{10};
+    // Sleep
 
-} // namespace playrho
+    /// Default minimum still time to sleep.
+    /// @details The default minimum time bodies must be still for bodies to be put to sleep.
+    constexpr auto DefaultMinStillTimeToSleep = Time{1_s / 2};// aka 0.5 secs
 
-#endif // PLAYRHO_COMMON_SETTINGS_HPP
+    /// Default linear sleep tolerance.
+    /// @details A body cannot sleep if the magnitude of its linear velocity is above this amount.
+    constexpr auto DefaultLinearSleepTolerance = 0.01_mps;// aka 0.01
+
+    /// Default angular sleep tolerance.
+    /// @details A body cannot sleep if its angular velocity is above this amount.
+    constexpr auto DefaultAngularSleepTolerance = Real{(Pi * 2) / 180} * RadianPerSecond;
+
+    /// Default circles ratio.
+    /// @details Ratio used for switching between rounded-corner collisions and closest-face
+    ///   biased normal collisions.
+    constexpr auto DefaultCirclesRatio = Real{10};
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_SETTINGS_HPP

--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -19,74 +19,93 @@
 #ifndef PLAYRHO_COMMON_SPAN_HPP
 #define PLAYRHO_COMMON_SPAN_HPP
 
-#include <PlayRho/Defines.hpp>
 #include <PlayRho/Common/Templates.hpp>
+#include <PlayRho/Defines.hpp>
 
-#include <cstddef>
 #include <cassert>
-#include <type_traits>
+#include <cstddef>
 #include <iterator>
+#include <type_traits>
 #include <vector>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     /// @brief A C++ encapsulation of an array and its size.
     ///
     /// @note This is conceptually like the Guideline Support Library's span template class.
     /// @see http://open-std.org/JTC1/SC22/WG21/docs/papers/2016/p0122r1.pdf
     ///
-    template <typename T>
+    template<typename T>
     class Span
     {
-    public:
-        
+     public:
         /// @brief Data type.
         using data_type = T;
 
         /// @brief Pointer type.
         using pointer = data_type*;
-        
+
         /// @brief Constant pointer type.
-        using const_pointer = const data_type *;
+        using const_pointer = const data_type*;
 
         /// @brief Size type.
         using size_type = std::size_t;
-        
+
         Span() = default;
-        
+
         /// @brief Copy constructor.
         Span(const Span& copy) = default;
-        
+
         /// @brief Initializing constructor.
-        constexpr Span(pointer array, size_type size) noexcept:
-            m_array{array}, m_size{size}
+        constexpr Span(pointer array, size_type size) noexcept
+            : m_array{array}, m_size{size}
         {
         }
-        
+
         /// @brief Initializing constructor.
-        template <std::size_t SIZE>
-        constexpr Span(data_type (&array)[SIZE]) noexcept: m_array{&array[0]}, m_size{SIZE} {}
-        
+        template<std::size_t SIZE>
+        constexpr Span(data_type (&array)[SIZE]) noexcept
+            : m_array{&array[0]}, m_size{SIZE}
+        {
+        }
+
         /// @brief Initializing constructor.
-        template <typename U, typename = std::enable_if_t< !std::is_array<U>::value > >
-        constexpr Span(U& value) noexcept:
-        m_array{detail::Data(value)}, m_size{detail::Size(value)} {}
-        
+        template<typename U, typename = std::enable_if_t<!std::is_array<U>::value>>
+        constexpr Span(U& value) noexcept
+            : m_array{detail::Data(value)}, m_size{detail::Size(value)}
+        {
+        }
+
         /// @brief Initializing constructor.
-        constexpr Span(std::initializer_list<T> list) noexcept:
-            m_array{list.begin()}, m_size{list.size()} {}
+        constexpr Span(std::initializer_list<T> list) noexcept
+            : m_array{list.begin()}, m_size{list.size()}
+        {
+        }
 
         /// @brief Gets the "begin" iterator value.
-        pointer begin() const noexcept { return m_array; }
+        pointer begin() const noexcept
+        {
+            return m_array;
+        }
 
         /// @brief Gets the "begin" iterator value.
-        const_pointer cbegin() const noexcept { return m_array; }
-        
+        const_pointer cbegin() const noexcept
+        {
+            return m_array;
+        }
+
         /// @brief Gets the "end" iterator value.
-        pointer end() const noexcept { return m_array + m_size; }
-        
+        pointer end() const noexcept
+        {
+            return m_array + m_size;
+        }
+
         /// @brief Gets the "end" iterator value.
-        const_pointer cend() const noexcept { return m_array + m_size; }
+        const_pointer cend() const noexcept
+        {
+            return m_array + m_size;
+        }
 
         /// @brief Accesses the indexed element.
         data_type& operator[](size_type index) noexcept
@@ -94,7 +113,7 @@ namespace playrho {
             assert(index < m_size);
             return m_array[index];
         }
-        
+
         /// @brief Accesses the indexed element.
         const data_type& operator[](size_type index) const noexcept
         {
@@ -103,19 +122,28 @@ namespace playrho {
         }
 
         /// @brief Gets the size of this span.
-        constexpr size_type size() const noexcept { return m_size; }
-        
+        constexpr size_type size() const noexcept
+        {
+            return m_size;
+        }
+
         /// @brief Direct access to data.
-        pointer data() const noexcept { return m_array; }
-        
+        pointer data() const noexcept
+        {
+            return m_array;
+        }
+
         /// @brief Checks whether this span is empty.
-        constexpr bool empty() const noexcept { return m_size == 0; }
+        constexpr bool empty() const noexcept
+        {
+            return m_size == 0;
+        }
 
-    private:
-        pointer m_array = nullptr; ///< Pointer to array of data.
-        size_type m_size = 0; ///< Size of array of data.
+     private:
+        pointer m_array = nullptr;///< Pointer to array of data.
+        size_type m_size = 0;     ///< Size of array of data.
     };
-    
-} // namespace playrho
 
-#endif // PLAYRHO_COMMON_SPAN_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_SPAN_HPP

--- a/PlayRho/Common/StackAllocator.cpp
+++ b/PlayRho/Common/StackAllocator.cpp
@@ -17,30 +17,31 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Common/StackAllocator.hpp>
-#include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/DynamicMemory.hpp>
+#include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/StackAllocator.hpp>
 
 #include <memory>
 
 using namespace playrho;
 
-namespace {
-
-inline std::size_t alignment_size(std::size_t size)
+namespace
 {
-    constexpr auto one = static_cast<std::size_t>(1u);
-    return (size < one)? one: (size < sizeof(std::max_align_t))?
-        static_cast<std::size_t>(NextPowerOfTwo(size - one)): alignof(std::max_align_t);
-};
 
-} // anonymous namespace
+    inline std::size_t alignment_size(std::size_t size)
+    {
+        constexpr auto one = static_cast<std::size_t>(1u);
+        return (size < one) ? one : (size < sizeof(std::max_align_t)) ? static_cast<std::size_t>(NextPowerOfTwo(size - one))
+                                                                      : alignof(std::max_align_t);
+    };
 
-StackAllocator::StackAllocator(Conf config):
-    m_data{static_cast<decltype(m_data)>(Alloc(config.preallocation_size))},
-    m_entries{static_cast<AllocationRecord*>(Alloc(config.allocation_records * sizeof(AllocationRecord)))},
-    m_size{config.preallocation_size},
-    m_max_entries{config.allocation_records}
+}// anonymous namespace
+
+StackAllocator::StackAllocator(Conf config)
+    : m_data{static_cast<decltype(m_data)>(Alloc(config.preallocation_size))},
+      m_entries{static_cast<AllocationRecord*>(Alloc(config.allocation_records * sizeof(AllocationRecord)))},
+      m_size{config.preallocation_size},
+      m_max_entries{config.allocation_records}
 {
     // Intentionally empty.
 }
@@ -60,7 +61,7 @@ void* StackAllocator::Allocate(size_type size)
     if (m_entryCount < m_max_entries)
     {
         auto entry = m_entries + m_entryCount;
-        
+
         const auto available = m_size - m_index;
         if (size > (available / sizeof(std::max_align_t)) * sizeof(std::max_align_t))
         {

--- a/PlayRho/Common/StackAllocator.hpp
+++ b/PlayRho/Common/StackAllocator.hpp
@@ -22,137 +22,136 @@
 
 #include <PlayRho/Common/Settings.hpp>
 
-namespace playrho {
-
-/// Stack allocator.
-/// @details
-/// This is a stack allocator used for fast per step allocations.
-/// You must nest allocate/free pairs. The code will assert
-/// if you try to interleave multiple allocate/free pairs.
-/// @note This class satisfies the C++11 <code>std::unique_ptr()</code> Deleter requirement.
-/// @note This data structure is 64-bytes large (on at least one 64-bit platform).
-class StackAllocator
+namespace playrho
 {
-public:
 
-    /// @brief Size type.
-    using size_type = std::size_t;
-
-    /// @brief Stack allocator configuration data.
-    struct Conf
+    /// Stack allocator.
+    /// @details
+    /// This is a stack allocator used for fast per step allocations.
+    /// You must nest allocate/free pairs. The code will assert
+    /// if you try to interleave multiple allocate/free pairs.
+    /// @note This class satisfies the C++11 <code>std::unique_ptr()</code> Deleter requirement.
+    /// @note This data structure is 64-bytes large (on at least one 64-bit platform).
+    class StackAllocator
     {
-        size_type preallocation_size = 100 * 1024; ///< Preallocation size.
-        size_type allocation_records = 32; ///< Allocation records.
+     public:
+        /// @brief Size type.
+        using size_type = std::size_t;
+
+        /// @brief Stack allocator configuration data.
+        struct Conf
+        {
+            size_type preallocation_size = 100 * 1024;///< Preallocation size.
+            size_type allocation_records = 32;        ///< Allocation records.
+        };
+
+        /// @brief Gets the default configuration.
+        static constexpr Conf GetDefaultConf()
+        {
+            return Conf{};
+        }
+
+        /// @brief Initializing constructor.
+        explicit StackAllocator(Conf config = GetDefaultConf());
+
+        ~StackAllocator() noexcept;
+
+        /// @brief Copy constructor.
+        StackAllocator(const StackAllocator& copy) = delete;
+
+        StackAllocator(StackAllocator&& other) = delete;
+
+        /// @brief Copy assignment operator.
+        StackAllocator& operator=(const StackAllocator& other) = delete;
+
+        StackAllocator& operator=(StackAllocator&& other) = delete;
+
+        /// Allocates an aligned block of memory of the given size.
+        /// @return Pointer to memory if the allocator has allocation records left,
+        /// <code>nullptr</code> otherwise.
+        /// @see GetEntryCount.
+        void* Allocate(size_type size);
+
+        /// @brief Frees the given pointer.
+        void Free(void* p) noexcept;
+
+        /// @brief Allocates and array of the given size number of elements.
+        template<typename T>
+        T* AllocateArray(size_type size)
+        {
+            return static_cast<T*>(Allocate(size * sizeof(T)));
+        }
+
+        /// Functional operator for freeing memory allocated by this object.
+        /// @details This method frees memory (like called Free) and allows this object
+        ///   to be used as deleter to <code>std::unique_ptr</code>.
+        void operator()(void* p) noexcept
+        {
+            Free(p);
+        }
+
+        /// @brief Gets the max allocation.
+        auto GetMaxAllocation() const noexcept
+        {
+            return m_maxAllocation;
+        }
+
+        /// Gets the current allocation record entry usage count.
+        /// @return Value between 0 and the maximum number of entries possible for this allocator.
+        /// @see GetMaxEntries.
+        auto GetEntryCount() const noexcept
+        {
+            return m_entryCount;
+        }
+
+        /// Gets the current index location.
+        /// @details This represents the number of bytes used (of the storage allocated at construction
+        ///    time by this object). Storage remaining is calculated by subtracting this value from
+        ///    <code>StackSize</code>.
+        /// @return Value between 0 and <code>StackSize</code>.
+        auto GetIndex() const noexcept
+        {
+            return m_index;
+        }
+
+        /// Gets the total number of bytes that this object has currently allocated.
+        auto GetAllocation() const noexcept
+        {
+            return m_allocation;
+        }
+
+        /// @brief Gets the preallocated size.
+        auto GetPreallocatedSize() const noexcept
+        {
+            return m_size;
+        }
+
+        /// @brief Gets the max entries.
+        auto GetMaxEntries() const noexcept
+        {
+            return m_max_entries;
+        }
+
+     private:
+        /// @brief Allocation record.
+        struct AllocationRecord
+        {
+            void* data;     ///< Data.
+            size_type size; ///< Size.
+            bool usedMalloc;///< Whether <code>malloc</code> was used.
+        };
+
+        char* const m_data;               ///< Data.
+        AllocationRecord* const m_entries;///< Entries.
+        size_type const m_size;           ///< Size.
+        size_type const m_max_entries;    ///< Max entries.
+
+        size_type m_index = 0;        ///< Index.
+        size_type m_allocation = 0;   ///< Allocation.
+        size_type m_maxAllocation = 0;///< Max allocation.
+        size_type m_entryCount = 0;   ///< Entry count.
     };
 
-    /// @brief Gets the default configuration.
-    static constexpr Conf GetDefaultConf()
-    {
-        return Conf{};
-    }
+}// namespace playrho
 
-    /// @brief Initializing constructor.
-    explicit StackAllocator(Conf config = GetDefaultConf());
-
-    ~StackAllocator() noexcept;
-
-    /// @brief Copy constructor.
-    StackAllocator(const StackAllocator& copy) = delete;
-
-    StackAllocator(StackAllocator&& other) = delete;
-
-    /// @brief Copy assignment operator.
-    StackAllocator& operator= (const StackAllocator& other) = delete;
-
-    StackAllocator& operator= (StackAllocator&& other) = delete;
-
-    /// Allocates an aligned block of memory of the given size.
-    /// @return Pointer to memory if the allocator has allocation records left,
-    /// <code>nullptr</code> otherwise.
-    /// @see GetEntryCount.
-    void* Allocate(size_type size);
-
-    /// @brief Frees the given pointer.
-    void Free(void* p) noexcept;
-
-    /// @brief Allocates and array of the given size number of elements.
-    template <typename T>
-    T* AllocateArray(size_type size)
-    {
-        return static_cast<T*>(Allocate(size * sizeof(T)));
-    }
-
-    /// Functional operator for freeing memory allocated by this object.
-    /// @details This method frees memory (like called Free) and allows this object
-    ///   to be used as deleter to <code>std::unique_ptr</code>.
-    void operator()(void *p) noexcept
-    {
-        Free(p);
-    }
-
-    /// @brief Gets the max allocation.
-    auto GetMaxAllocation() const noexcept
-    {
-        return m_maxAllocation;
-    }
-
-    /// Gets the current allocation record entry usage count.
-    /// @return Value between 0 and the maximum number of entries possible for this allocator.
-    /// @see GetMaxEntries.
-    auto GetEntryCount() const noexcept
-    {
-        return m_entryCount;
-    }
-
-    /// Gets the current index location.
-    /// @details This represents the number of bytes used (of the storage allocated at construction
-    ///    time by this object). Storage remaining is calculated by subtracting this value from
-    ///    <code>StackSize</code>.
-    /// @return Value between 0 and <code>StackSize</code>.
-    auto GetIndex() const noexcept
-    {
-        return m_index;
-    }
-
-    /// Gets the total number of bytes that this object has currently allocated.
-    auto GetAllocation() const noexcept
-    {
-        return m_allocation;
-    }
-    
-    /// @brief Gets the preallocated size.
-    auto GetPreallocatedSize() const noexcept
-    {
-        return m_size;
-    }
-    
-    /// @brief Gets the max entries.
-    auto GetMaxEntries() const noexcept
-    {
-        return m_max_entries;
-    }
-    
-private:
-
-    /// @brief Allocation record.
-    struct AllocationRecord
-    {
-        void* data; ///< Data.
-        size_type size; ///< Size.
-        bool usedMalloc; ///< Whether <code>malloc</code> was used.
-    };
-    
-    char* const m_data; ///< Data.
-    AllocationRecord* const m_entries; ///< Entries.
-    size_type const m_size; ///< Size.
-    size_type const m_max_entries; ///< Max entries.
-    
-    size_type m_index = 0; ///< Index.
-    size_type m_allocation = 0; ///< Allocation.
-    size_type m_maxAllocation = 0; ///< Max allocation.
-    size_type m_entryCount = 0; ///< Entry count.
-};
-    
-} // namespace playrho
-
-#endif // PLAYRHO_COMMON_STACKALLOCATOR_HPP
+#endif// PLAYRHO_COMMON_STACKALLOCATOR_HPP

--- a/PlayRho/Common/StrongType.hpp
+++ b/PlayRho/Common/StrongType.hpp
@@ -22,159 +22,168 @@
 #ifndef PLAYRHO_COMMON_STRONGTYPE_HPP
 #define PLAYRHO_COMMON_STRONGTYPE_HPP
 
-#include <utility>
 #include <functional> // for std::hash
-#include <type_traits> // for std::is_nothrow_default_constructible
+#include <type_traits>// for std::is_nothrow_default_constructible
+#include <utility>
 
-namespace playrho {
-namespace strongtype {
-
-/// @brief An indexable, hashable, named "strong type" template class.
-/// @details A template class for wrapping types into more special-purposed types. Wrapping
-///   types this way is often referred to as more "strongly typing" the underlying type.
-/// @note This comes from pulling together code found from various sites on the Internet.
-/// @see https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/
-/// @see https://foonathan.net/blog/2016/10/19/strong-typedefs.html
-template <typename T, typename Tag>
-class IndexingNamedType
+namespace playrho
 {
-public:
-    /// @brief Underlying type alias.
-    using underlying_type = T;
-
-    /// @brief Default constructor.
-    /// @note This causes default initialization of the underlying type.
-    constexpr explicit IndexingNamedType()
-    noexcept(std::is_nothrow_default_constructible<underlying_type>::value): value_{} {}
-
-    /// @brief Copy initializing constructor.
-    constexpr explicit IndexingNamedType(const underlying_type& value)
-    noexcept(std::is_nothrow_copy_constructible<underlying_type>::value): value_(value) {}
-
-    /// @brief Move initializing constructor.
-    constexpr explicit IndexingNamedType(underlying_type&& value)
-    noexcept(std::is_nothrow_move_constructible<underlying_type>::value):
-        value_(std::move(value)) {}
-
-    /// @brief Underlying type cast operator support.
-    constexpr explicit operator underlying_type&() noexcept
+    namespace strongtype
     {
-        return value_;
-    }
 
-    /// @brief Underlying type cast operator support.
-    constexpr explicit operator const underlying_type&() const noexcept
-    {
-        return value_;
-    }
+        /// @brief An indexable, hashable, named "strong type" template class.
+        /// @details A template class for wrapping types into more special-purposed types. Wrapping
+        ///   types this way is often referred to as more "strongly typing" the underlying type.
+        /// @note This comes from pulling together code found from various sites on the Internet.
+        /// @see https://www.fluentcpp.com/2016/12/08/strong-types-for-strong-interfaces/
+        /// @see https://foonathan.net/blog/2016/10/19/strong-typedefs.html
+        template<typename T, typename Tag>
+        class IndexingNamedType
+        {
+         public:
+            /// @brief Underlying type alias.
+            using underlying_type = T;
 
-    /// @brief Accesses the underlying value.
-    constexpr underlying_type& get() noexcept
-    {
-        return value_;
-    }
+            /// @brief Default constructor.
+            /// @note This causes default initialization of the underlying type.
+            constexpr explicit IndexingNamedType() noexcept(std::is_nothrow_default_constructible<underlying_type>::value)
+                : value_{}
+            {
+            }
 
-    /// @brief Accesses the underlying value.
-    constexpr underlying_type const& get() const noexcept
-    {
-        return value_;
-    }
+            /// @brief Copy initializing constructor.
+            constexpr explicit IndexingNamedType(const underlying_type& value) noexcept(std::is_nothrow_copy_constructible<underlying_type>::value)
+                : value_(value)
+            {
+            }
 
-    /// @brief Swap function.
-    friend void swap(IndexingNamedType& a, IndexingNamedType& b) noexcept
-    {
-        using std::swap;
-        swap(static_cast<underlying_type&>(a), static_cast<underlying_type&>(b));
-    }
+            /// @brief Move initializing constructor.
+            constexpr explicit IndexingNamedType(underlying_type&& value) noexcept(std::is_nothrow_move_constructible<underlying_type>::value)
+                : value_(std::move(value))
+            {
+            }
 
-    /// @brief Equality operator.
-    friend constexpr bool operator== (const IndexingNamedType& lhs, const IndexingNamedType& rhs)
-    {
-        return lhs.get() == rhs.get();
-    }
+            /// @brief Underlying type cast operator support.
+            constexpr explicit operator underlying_type&() noexcept
+            {
+                return value_;
+            }
 
-    /// @brief Inequality operator.
-    friend constexpr bool operator!= (const IndexingNamedType& lhs, const IndexingNamedType& rhs)
-    {
-        return lhs.get() != rhs.get();
-    }
+            /// @brief Underlying type cast operator support.
+            constexpr explicit operator const underlying_type&() const noexcept
+            {
+                return value_;
+            }
 
-    /// @brief Less-than operator.
-    friend constexpr bool operator< (const IndexingNamedType& lhs, const IndexingNamedType& rhs)
-    {
-        return lhs.get() < rhs.get();
-    }
+            /// @brief Accesses the underlying value.
+            constexpr underlying_type& get() noexcept
+            {
+                return value_;
+            }
 
-    /// @brief Greater-than operator.
-    friend constexpr bool operator> (const IndexingNamedType& lhs, const IndexingNamedType& rhs)
-    {
-        return lhs.get() > rhs.get();
-    }
+            /// @brief Accesses the underlying value.
+            constexpr underlying_type const& get() const noexcept
+            {
+                return value_;
+            }
 
-    /// @brief Less-than-or-equal-to operator.
-    friend constexpr bool operator<= (const IndexingNamedType& lhs, const IndexingNamedType& rhs)
-    {
-        return lhs.get() <= rhs.get();
-    }
+            /// @brief Swap function.
+            friend void swap(IndexingNamedType& a, IndexingNamedType& b) noexcept
+            {
+                using std::swap;
+                swap(static_cast<underlying_type&>(a), static_cast<underlying_type&>(b));
+            }
 
-    /// @brief Greater-than-or-equal-to operator.
-    friend constexpr bool operator>= (const IndexingNamedType& lhs, const IndexingNamedType& rhs)
-    {
-        return lhs.get() >= rhs.get();
-    }
+            /// @brief Equality operator.
+            friend constexpr bool operator==(const IndexingNamedType& lhs, const IndexingNamedType& rhs)
+            {
+                return lhs.get() == rhs.get();
+            }
 
-    /// @brief Hashes the value given.
-    friend ::std::size_t hash(const IndexingNamedType& v) noexcept
-    {
-        return ::std::hash(v.get());
-    }
+            /// @brief Inequality operator.
+            friend constexpr bool operator!=(const IndexingNamedType& lhs, const IndexingNamedType& rhs)
+            {
+                return lhs.get() != rhs.get();
+            }
 
-private:
-    underlying_type value_; ///< Underlying value.
-};
+            /// @brief Less-than operator.
+            friend constexpr bool operator<(const IndexingNamedType& lhs, const IndexingNamedType& rhs)
+            {
+                return lhs.get() < rhs.get();
+            }
 
-static_assert(std::is_default_constructible<IndexingNamedType<int, struct Test>>::value, "");
-static_assert(std::is_nothrow_copy_constructible<IndexingNamedType<int, struct Test>>::value, "");
-static_assert(std::is_nothrow_move_constructible<IndexingNamedType<int, struct Test>>::value, "");
+            /// @brief Greater-than operator.
+            friend constexpr bool operator>(const IndexingNamedType& lhs, const IndexingNamedType& rhs)
+            {
+                return lhs.get() > rhs.get();
+            }
 
-template <typename T, typename Tag>
-constexpr T UnderlyingTypeImpl(IndexingNamedType<T, Tag>);
+            /// @brief Less-than-or-equal-to operator.
+            friend constexpr bool operator<=(const IndexingNamedType& lhs, const IndexingNamedType& rhs)
+            {
+                return lhs.get() <= rhs.get();
+            }
 
-template <typename T>
-using UnderlyingType = decltype(UnderlyingTypeImpl(std::declval<T>()));
+            /// @brief Greater-than-or-equal-to operator.
+            friend constexpr bool operator>=(const IndexingNamedType& lhs, const IndexingNamedType& rhs)
+            {
+                return lhs.get() >= rhs.get();
+            }
 
-/// @brief Gets the underlying value.
-template <typename T, typename Tag>
-constexpr T& UnderlyingValue(IndexingNamedType<T, Tag>& o) noexcept
+            /// @brief Hashes the value given.
+            friend ::std::size_t hash(const IndexingNamedType& v) noexcept
+            {
+                return ::std::hash(v.get());
+            }
+
+         private:
+            underlying_type value_;///< Underlying value.
+        };
+
+        static_assert(std::is_default_constructible<IndexingNamedType<int, struct Test>>::value, "");
+        static_assert(std::is_nothrow_copy_constructible<IndexingNamedType<int, struct Test>>::value, "");
+        static_assert(std::is_nothrow_move_constructible<IndexingNamedType<int, struct Test>>::value, "");
+
+        template<typename T, typename Tag>
+        constexpr T UnderlyingTypeImpl(IndexingNamedType<T, Tag>);
+
+        template<typename T>
+        using UnderlyingType = decltype(UnderlyingTypeImpl(std::declval<T>()));
+
+        /// @brief Gets the underlying value.
+        template<typename T, typename Tag>
+        constexpr T& UnderlyingValue(IndexingNamedType<T, Tag>& o) noexcept
+        {
+            return static_cast<T&>(o);
+        }
+
+        /// @brief Gets the underlying value.
+        template<typename T, typename Tag>
+        constexpr const T& UnderlyingValue(const IndexingNamedType<T, Tag>& o) noexcept
+        {
+            return static_cast<const T&>(o);
+        }
+
+    }// namespace strongtype
+}// namespace playrho
+
+namespace std
 {
-    return static_cast<T&>(o);
-}
 
-/// @brief Gets the underlying value.
-template <typename T, typename Tag>
-constexpr const T& UnderlyingValue(const IndexingNamedType<T, Tag>& o) noexcept
-{
-    return static_cast<const T&>(o);
-}
-
-} // namespace strongtype
-} // namespace playrho
-
-namespace std {
-
-/// @brief Custom specialization of std::hash for
-///   <code>::playrho::strongtype::IndexingNamedType</code>.
-template <typename T, typename Tag>
-struct hash<::playrho::strongtype::IndexingNamedType<T, Tag>>
-{
-    /// @brief Hashing functor operator.
-    ::std::size_t operator()(const ::playrho::strongtype::IndexingNamedType<T, Tag>& v) const noexcept
+    /// @brief Custom specialization of std::hash for
+    ///   <code>::playrho::strongtype::IndexingNamedType</code>.
+    template<typename T, typename Tag>
+    struct hash<::playrho::strongtype::IndexingNamedType<T, Tag>>
     {
-        using type = ::playrho::strongtype::UnderlyingType<::playrho::strongtype::IndexingNamedType<T, Tag>>;
-        return ::std::hash<type>()(v.get());;
-    }
-};
+        /// @brief Hashing functor operator.
+        ::std::size_t operator()(const ::playrho::strongtype::IndexingNamedType<T, Tag>& v) const noexcept
+        {
+            using type = ::playrho::strongtype::UnderlyingType<::playrho::strongtype::IndexingNamedType<T, Tag>>;
+            return ::std::hash<type>()(v.get());
+            ;
+        }
+    };
 
-} // namespace std
+}// namespace std
 
-#endif // PLAYRHO_COMMON_STRONGTYPE_HPP
+#endif// PLAYRHO_COMMON_STRONGTYPE_HPP

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -26,118 +26,125 @@
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Vector2.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Description of a "sweep" of motion in 2-D space.
-///
-/// @details This describes the motion of a body/shape for TOI computation.
-///   Shapes are defined with respect to the body origin, which may
-///   not coincide with the center of mass. However, to support dynamics
-///   we must interpolate the center of mass position.
-///
-/// @note This data structure is likely 36-bytes (at least on 64-bit platforms).
-///
-class Sweep
+namespace playrho
 {
-public:
-
-    /// @brief Default constructor.
-    Sweep() = default;
-    
-    /// @brief Copy constructor.
-    constexpr Sweep(const Sweep& copy) = default;
-    
-    /// @brief Initializing constructor.
-    constexpr Sweep(const Position p0, const Position p1,
-                    const Length2 lc = Length2{0_m, 0_m},
-                    Real a0 = 0) noexcept:
-        pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
+    namespace d2
     {
-        assert(a0 >= 0);
-        assert(a0 < 1);
-    }
-    
-    /// @brief Initializing constructor.
-    constexpr explicit Sweep(const Position p,
-                             const Length2 lc = Length2{0_m, 0_m}):
-        Sweep{p, p, lc, 0}
+
+        /// @brief Description of a "sweep" of motion in 2-D space.
+        ///
+        /// @details This describes the motion of a body/shape for TOI computation.
+        ///   Shapes are defined with respect to the body origin, which may
+        ///   not coincide with the center of mass. However, to support dynamics
+        ///   we must interpolate the center of mass position.
+        ///
+        /// @note This data structure is likely 36-bytes (at least on 64-bit platforms).
+        ///
+        class Sweep
+        {
+         public:
+            /// @brief Default constructor.
+            Sweep() = default;
+
+            /// @brief Copy constructor.
+            constexpr Sweep(const Sweep& copy) = default;
+
+            /// @brief Initializing constructor.
+            constexpr Sweep(const Position p0, const Position p1,
+                            const Length2 lc = Length2{0_m, 0_m},
+                            Real a0 = 0) noexcept
+                : pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
+            {
+                assert(a0 >= 0);
+                assert(a0 < 1);
+            }
+
+            /// @brief Initializing constructor.
+            constexpr explicit Sweep(const Position p,
+                                     const Length2 lc = Length2{0_m, 0_m})
+                : Sweep{p, p, lc, 0}
+            {
+                // Intentionally empty.
+            }
+
+            /// @brief Gets the local center of mass position.
+            /// @note This value can only be set via a sweep constructed using an initializing
+            ///   constructor.
+            Length2 GetLocalCenter() const noexcept
+            {
+                return localCenter;
+            }
+
+            /// @brief Gets the alpha 0 for this sweep.
+            /// @return Value between 0 and less than 1.
+            Real GetAlpha0() const noexcept
+            {
+                return alpha0;
+            }
+
+            /// @brief Advances the sweep by a factor of the difference between the given time alpha
+            ///   and the sweep's alpha 0.
+            /// @details This advances position 0 (<code>pos0</code>) of the sweep towards position
+            ///   1 (<code>pos1</code>) by a factor of the difference between the given alpha and
+            ///   the alpha 0.
+            ///
+            /// @param alpha Valid new time factor in [0,1) to update the sweep to. Behavior is
+            ///   undefined if value is invalid.
+            ///
+            void Advance0(Real alpha) noexcept;
+
+            /// @brief Resets the alpha 0 value back to zero.
+            /// @post Getting the alpha 0 value after calling this method will return zero.
+            void ResetAlpha0() noexcept;
+
+            /// @brief Center world position and world angle at time "0".
+            Position pos0;
+
+            /// @brief Center world position and world angle at time "1".
+            Position pos1;
+
+         private:
+            /// @brief Local center of mass position.
+            /// @note 8-bytes.
+            Length2 localCenter = Length2{0_m, 0_m};
+
+            /// @brief Fraction of the current time step in the range [0,1]
+            /// @note <code>pos0.linear</code> and <code>pos0.angular</code> are the positions at
+            ///   <code>alpha0</code>.
+            /// @note 4-bytes.
+            Real alpha0 = 0;
+        };
+
+        inline void Sweep::Advance0(const Real alpha) noexcept
+        {
+            assert(IsValid(alpha));
+            assert(alpha >= 0);
+            assert(alpha < 1);
+            assert(alpha0 < 1);
+
+            const auto beta = (alpha - alpha0) / (1 - alpha0);
+            pos0 = GetPosition(pos0, pos1, beta);
+            alpha0 = alpha;
+        }
+
+        inline void Sweep::ResetAlpha0() noexcept
+        {
+            alpha0 = 0;
+        }
+
+        // Free functions...
+
+    }// namespace d2
+
+    /// @brief Determines if the given value is valid.
+    /// @relatedalso d2::Transformation
+    template<>
+    constexpr bool IsValid(const d2::Sweep& value) noexcept
     {
-        // Intentionally empty.
+        return IsValid(value.pos0) && IsValid(value.pos1)
+               && IsValid(value.GetLocalCenter()) && IsValid(value.GetAlpha0());
     }
-    
-    /// @brief Gets the local center of mass position.
-    /// @note This value can only be set via a sweep constructed using an initializing
-    ///   constructor.
-    Length2 GetLocalCenter() const noexcept { return localCenter; }
-    
-    /// @brief Gets the alpha 0 for this sweep.
-    /// @return Value between 0 and less than 1.
-    Real GetAlpha0() const noexcept { return alpha0; }
-    
-    /// @brief Advances the sweep by a factor of the difference between the given time alpha
-    ///   and the sweep's alpha 0.
-    /// @details This advances position 0 (<code>pos0</code>) of the sweep towards position
-    ///   1 (<code>pos1</code>) by a factor of the difference between the given alpha and
-    ///   the alpha 0.
-    ///
-    /// @param alpha Valid new time factor in [0,1) to update the sweep to. Behavior is
-    ///   undefined if value is invalid.
-    ///
-    void Advance0(Real alpha) noexcept;
-    
-    /// @brief Resets the alpha 0 value back to zero.
-    /// @post Getting the alpha 0 value after calling this method will return zero.
-    void ResetAlpha0() noexcept;
-    
-    /// @brief Center world position and world angle at time "0".
-    Position pos0;
 
-    /// @brief Center world position and world angle at time "1".
-    Position pos1;
-    
-private:
-    /// @brief Local center of mass position.
-    /// @note 8-bytes.
-    Length2 localCenter = Length2{0_m, 0_m};
-    
-    /// @brief Fraction of the current time step in the range [0,1]
-    /// @note <code>pos0.linear</code> and <code>pos0.angular</code> are the positions at
-    ///   <code>alpha0</code>.
-    /// @note 4-bytes.
-    Real alpha0 = 0;
-};
+}// namespace playrho
 
-inline void Sweep::Advance0(const Real alpha) noexcept
-{
-    assert(IsValid(alpha));
-    assert(alpha >= 0);
-    assert(alpha < 1);
-    assert(alpha0 < 1);
-    
-    const auto beta = (alpha - alpha0) / (1 - alpha0);
-    pos0 = GetPosition(pos0, pos1, beta);
-    alpha0 = alpha;
-}
-
-inline void Sweep::ResetAlpha0() noexcept
-{
-    alpha0 = 0;
-}
-
-// Free functions...
-
-} // namespace d2
-
-/// @brief Determines if the given value is valid.
-/// @relatedalso d2::Transformation
-template <>
-constexpr bool IsValid(const d2::Sweep& value) noexcept
-{
-    return IsValid(value.pos0) && IsValid(value.pos1)
-    && IsValid(value.GetLocalCenter()) && IsValid(value.GetAlpha0());
-}
-
-} // namespace playrho
-
-#endif // PLAYRHO_COMMON_SWEEP_HPP
+#endif// PLAYRHO_COMMON_SWEEP_HPP

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -27,410 +27,449 @@
 #include <functional>
 #include <iterator>
 #include <limits>
-#include <type_traits>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
-namespace playrho {
-
-// Bring standard customization points into the namespace...
-using std::begin;
-using std::end;
-using std::cbegin;
-using std::cend;
-using std::size;
-using std::empty;
-using std::data;
-using std::swap;
-
-namespace detail {
-
-/// @brief Voiding template class.
-template<class...> struct Voidify {
-    /// @brief Type alias.
-    using type = void;
-};
-
-/// @brief Void type templated alias.
-template<class... Ts> using VoidT = typename Voidify<Ts...>::type;
-
-/// @brief Low-level implementation of the is-iterable default value trait.
-template<class T, class = void>
-struct IsIterableImpl: std::false_type {};
-
-/// @brief Low-level implementation of the is-iterable true value trait.
-template<class T>
-struct IsIterableImpl<T, VoidT<
-    decltype(begin(std::declval<T>())),
-    decltype(end(std::declval<T>())),
-    decltype(++std::declval<decltype(begin(std::declval<T&>()))&>()),
-    decltype(*begin(std::declval<T>()))
-    >>:
-    std::true_type
-{};
-
-/// @brief Gets the maximum size of the given container.
-template <class T>
-constexpr auto max_size(const T& arg) -> decltype(arg.max_size())
+namespace playrho
 {
-    return arg.max_size();
-}
 
-/// @brief Checks whether the given container is full.
-template <class T>
-constexpr auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
-{
-    return size(arg) == max_size(arg);
-}
+    // Bring standard customization points into the namespace...
+    using std::begin;
+    using std::cbegin;
+    using std::cend;
+    using std::data;
+    using std::empty;
+    using std::end;
+    using std::size;
+    using std::swap;
 
-/// @brief Internal helper template function to avoid confusion for use within classes
-///   that define their own <code>data()</code> method.
-template <typename T>
-static auto Data(T& v)
-{
-    using ::playrho::data;
-    return data(v);
-}
-
-/// @brief Internal helper template function to avoid confusion for use within classes
-///   that define their own <code>size()</code> method.
-template <typename T>
-static auto Size(T& v)
-{
-    using ::playrho::size;
-    return size(v);
-}
-
-} // namespace detail
-    
-/// @brief "Not used" annotator.
-template<class... T> void NOT_USED(T&&...){}
-
-/// @brief Gets an invalid value for the type.
-/// @tparam T Type to get an invalid value for.
-/// @note Specialize this function for the types which have an invalid value concept.
-/// @see IsValid.
-template <typename T>
-constexpr T GetInvalid() noexcept
-{
-    static_assert(sizeof(T) == 0, "No available specialization");
-}
-
-/// @brief Determines if the given value is valid.
-/// @see GetInvalid.
-template <typename T>
-constexpr bool IsValid(const T& value) noexcept
-{
-    // Note: This is not necessarily a no-op!! But it is a "constexpr".
-    //
-    // From http://en.cppreference.com/w/cpp/numeric/math/isnan:
-    //   "Another way to test if a floating-point value is NaN is
-    //    to compare it with itself:
-    //      bool is_nan(double x) { return x != x; }
-    //
-    // So for all T, for which isnan() is implemented, this should work
-    // correctly and quite usefully!
-    //
-    return value == value;
-}
-
-// GetInvalid template specializations.
-
-/// @brief Gets an invalid value for the float type.
-template <>
-constexpr float GetInvalid() noexcept
-{
-    return std::numeric_limits<float>::signaling_NaN();
-}
-
-/// @brief Gets an invalid value for the double type.
-template <>
-constexpr double GetInvalid() noexcept
-{
-    return std::numeric_limits<double>::signaling_NaN();
-}
-
-/// @brief Gets an invalid value for the long double type.
-template <>
-constexpr long double GetInvalid() noexcept
-{
-    return std::numeric_limits<long double>::signaling_NaN();
-}
-
-/// @brief Gets an invalid value for the std::size_t type.
-template <>
-constexpr std::size_t GetInvalid() noexcept
-{
-    return static_cast<std::size_t>(-1);
-}
-
-// IsValid template specializations.
-
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const std::size_t& value) noexcept
-{
-    return value != GetInvalid<std::size_t>();
-}
-
-// Other templates.
-
-/// @brief Template for determining if the given type is an equality comparable type.
-/// @note This isn't exactly the same as the "EqualityComparable" named requirement.
-/// @see https://en.cppreference.com/w/cpp/named_req/EqualityComparable
-template<class T1, class T2, class = void>
-struct IsEqualityComparable: std::false_type {};
-
-/// @brief Template specialization for equality comparable types.
-template<class T1, class T2>
-struct IsEqualityComparable<T1, T2, detail::VoidT<decltype(T1{} == T2{})> >: std::true_type {};
-
-/// @brief Template for determining if the given type is an inequality comparable type.
-template<class T1, class T2, class = void>
-struct IsInequalityComparable: std::false_type {};
-
-/// @brief Template specialization for inequality comparable types.
-template<class T1, class T2>
-struct IsInequalityComparable<T1, T2, detail::VoidT<decltype(T1{} != T2{})> >: std::true_type {};
-
-/// @brief Template for determining if the given types are addable.
-template<class T1, class T2 = T1, class = void>
-struct IsAddable: std::false_type {};
-
-/// @brief Template specializing for addable types.
-template<class T1, class T2>
-struct IsAddable<T1, T2, detail::VoidT<decltype(T1{} + T2{})> >: std::true_type {};
-
-/// @brief Template for determining if the given types are multipliable.
-template<class T1, class T2, class = void>
-struct IsMultipliable: std::false_type {};
-
-/// @brief Template specializing for multipliable types.
-template<class T1, class T2>
-struct IsMultipliable<T1, T2, detail::VoidT<decltype(T1{} * T2{})> >: std::true_type {};
-
-/// @brief Template for determining if the given types are divisable.
-template<class T1, class T2, class = void>
-struct IsDivisable: std::false_type {};
-
-/// @brief Template specializing for divisable types.
-template<class T1, class T2>
-struct IsDivisable<T1, T2, detail::VoidT<decltype(T1{} / T2{})> >: std::true_type {};
-
-/// @brief Template for determining if the given type is an "arithmetic" type.
-/// @note In the context of this library, "arithmetic" types are all types which
-///   have +, -, *, / arithmetic operator support.
-template<class T, class = void>
-struct IsArithmetic: std::false_type {};
-
-/// @brief Template specialization for valid/acceptable "arithmetic" types.
-template<class T>
-struct IsArithmetic<T, detail::VoidT<
-    decltype(T{} + T{}), decltype(T{} - T{}), decltype(T{} * T{}), decltype(T{} / T{})
-> >: std::true_type {};
-
-/// @brief Determines whether the given type is an iterable type.
-template<class T>
-using IsIterable = typename detail::IsIterableImpl<T>;
-
-/// @brief Has-type trait template class.
-/// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
-///   to the question of: "How do I find out if a tuple contains a type?".
-/// @see https://stackoverflow.com/a/25958302/7410358
-template <typename T, typename Tuple>
-struct HasType;
-
-/// @brief Has-type trait template class specialized for <code>std::tuple</code> classes.
-/// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
-///   to the question of: "How do I find out if a tuple contains a type?".
-/// @see https://stackoverflow.com/a/25958302/7410358
-template <typename T>
-struct HasType<T, std::tuple<>> : std::false_type {};
-
-/// @brief Has-type trait true class.
-/// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
-///   to the question of: "How do I find out if a tuple contains a type?".
-/// @see https://stackoverflow.com/a/25958302/7410358
-template <typename T, typename... Ts>
-struct HasType<T, std::tuple<T, Ts...>> : std::true_type {};
-
-/// @brief Has-type trait template super class.
-/// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
-///   to the question of: "How do I find out if a tuple contains a type?".
-/// @see https://stackoverflow.com/a/25958302/7410358
-template <typename T, typename U, typename... Ts>
-struct HasType<T, std::tuple<U, Ts...>> : HasType<T, std::tuple<Ts...>> {};
-
-/// @brief Tuple contains type alias.
-/// @details Alias in case the trait itself should be <code>std::true_type</code> or
-///   <code>std::false_type</code>.
-/// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
-///   to the question of: "How do I find out if a tuple contains a type?".
-/// @see https://stackoverflow.com/a/25958302/7410358
-template <typename T, typename Tuple>
-using TupleContainsType = typename HasType<T, Tuple>::type;
-
-/// @brief Alias for pulling the <code>max_size</code> constomization point into the
-///   playrho namesapce.
-using detail::max_size;
-
-/// @brief Alias for pulling the <code>IsFull</code> constomization point into the
-///   playrho namesapce.
-using detail::IsFull;
-
-/// @brief Function object for performing lexicographical less-than
-///   comparisons of containers.
-/// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
-/// @see https://en.cppreference.com/w/cpp/utility/functional/less
-template <typename T>
-struct LexicographicalLess
-{
-    /// @brief Checks whether the first argument is lexicographically less-than the
-    ///   second argument.
-    constexpr bool operator()(const T& lhs, const T& rhs) const
+    namespace detail
     {
-        using std::less;
-        using ElementType = decltype(*begin(lhs));
-        return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs),
-                                            less<ElementType>{});
-    }
-};
 
-/// @brief Function object for performing lexicographical greater-than
-///   comparisons of containers.
-/// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
-/// @see https://en.cppreference.com/w/cpp/utility/functional/greater
-template <typename T>
-struct LexicographicalGreater
-{
-    /// @brief Checks whether the first argument is lexicographically greater-than the
-    ///   second argument.
-    constexpr bool operator()(const T& lhs, const T& rhs) const
+        /// @brief Voiding template class.
+        template<class...>
+        struct Voidify
+        {
+            /// @brief Type alias.
+            using type = void;
+        };
+
+        /// @brief Void type templated alias.
+        template<class... Ts>
+        using VoidT = typename Voidify<Ts...>::type;
+
+        /// @brief Low-level implementation of the is-iterable default value trait.
+        template<class T, class = void>
+        struct IsIterableImpl : std::false_type
+        {
+        };
+
+        /// @brief Low-level implementation of the is-iterable true value trait.
+        template<class T>
+        struct IsIterableImpl<T, VoidT<
+                                     decltype(begin(std::declval<T>())),
+                                     decltype(end(std::declval<T>())),
+                                     decltype(++std::declval<decltype(begin(std::declval<T&>()))&>()),
+                                     decltype(*begin(std::declval<T>()))>> : std::true_type
+        {
+        };
+
+        /// @brief Gets the maximum size of the given container.
+        template<class T>
+        constexpr auto max_size(const T& arg) -> decltype(arg.max_size())
+        {
+            return arg.max_size();
+        }
+
+        /// @brief Checks whether the given container is full.
+        template<class T>
+        constexpr auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
+        {
+            return size(arg) == max_size(arg);
+        }
+
+        /// @brief Internal helper template function to avoid confusion for use within classes
+        ///   that define their own <code>data()</code> method.
+        template<typename T>
+        static auto Data(T& v)
+        {
+            using ::playrho::data;
+            return data(v);
+        }
+
+        /// @brief Internal helper template function to avoid confusion for use within classes
+        ///   that define their own <code>size()</code> method.
+        template<typename T>
+        static auto Size(T& v)
+        {
+            using ::playrho::size;
+            return size(v);
+        }
+
+    }// namespace detail
+
+    /// @brief "Not used" annotator.
+    template<class... T>
+    void NOT_USED(T&&...)
     {
-        using std::greater;
-        using ElementType = decltype(*begin(lhs));
-        return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs),
-                                            greater<ElementType>{});
     }
-};
 
-/// @brief Function object for performing lexicographical less-than or equal-to
-///   comparisons of containers.
-/// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
-/// @see https://en.cppreference.com/w/cpp/utility/functional/less_equal
-template <typename T>
-struct LexicographicalLessEqual
-{
-    /// @brief Checks whether the first argument is lexicographically less-than or
-    ///   equal-to the second argument.
-    constexpr bool operator()(const T& lhs, const T& rhs) const
-    {
-        using std::mismatch;
-        using std::less;
-        using std::get;
-        using ElementType = decltype(*begin(lhs));
-        const auto lhsEnd = end(lhs);
-        const auto diff = mismatch(begin(lhs), lhsEnd, begin(rhs), end(rhs));
-        return (get<0>(diff) == lhsEnd) || less<ElementType>{}(*get<0>(diff), *get<1>(diff));
-    }
-};
-
-/// @brief Function object for performing lexicographical greater-than or equal-to
-///   comparisons of containers.
-/// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
-/// @see https://en.cppreference.com/w/cpp/utility/functional/greater_equal
-template <typename T>
-struct LexicographicalGreaterEqual
-{
-    /// @brief Checks whether the first argument is lexicographically greater-than or
-    ///   equal-to the second argument.
-    constexpr bool operator()(const T& lhs, const T& rhs) const
-    {
-        using std::mismatch;
-        using std::greater;
-        using std::get;
-        using ElementType = decltype(*begin(lhs));
-        const auto lhsEnd = end(lhs);
-        const auto diff = mismatch(begin(lhs), lhsEnd, begin(rhs), end(rhs));
-        return (get<0>(diff) == lhsEnd) || greater<ElementType>{}(*get<0>(diff), *get<1>(diff));
-    }
-};
-
-/// @brief Convenience template function for erasing first found value from container.
-/// @return <code>true</code> if value was found and erased, <code>false</code> otherwise.
-/// @see EraseAll.
-template <typename T, typename U>
-auto EraseFirst(T& container, const U& value) ->
-    decltype(container.erase(find(begin(container), end(container), value)) != end(container))
-{
-    const auto endIt = end(container);
-    const auto it = find(begin(container), endIt, value);
-    if (it != endIt) {
-        container.erase(it);
-        return true;
-    }
-    return false;
-}
-
-/// @brief Convenience template function for erasing specified value from container.
-/// @note This basically is the C++20 <code>std::erase</code> function.
-/// @return Count of elements erased.
-/// @see EraseFirst.
-template <typename T, typename U>
-auto EraseAll(T& container, const U& value) ->
-    decltype(distance(container.erase(remove(begin(container), end(container), value), end(container)), end(container)))
-{
-    const auto itEnd = end(container);
-    const auto it = remove(begin(container), itEnd, value);
-    const auto count = distance(it, itEnd);
-    container.erase(it, itEnd);
-    return count;
-}
-
-/// @brief Has-functor trait template fallback class.
-/// @note This is based off the answer by "jrok" on the <em>StackOverflow</em> website
-///   to the question of: "Check if a class has a member function of a given signature".
-/// @see https://stackoverflow.com/a/16824239/7410358
-template <typename, typename T>
-struct HasFunctor {
-    static_assert(std::integral_constant<T, false>::value,
-                  "Second template parameter needs to be of function type.");
-};
-
-/// @brief Has-functor trait template class.
-/// @note This is based off the answer by "jrok" on the <em>StackOverflow</em> website
-///   to the question of: "Check if a class has a member function of a given signature".
-/// @see https://stackoverflow.com/a/16824239/7410358
-template <typename Type, typename Return, typename... Args>
-struct HasFunctor<Type, Return(Args...)> {
-private:
-    /// @brief Declaration of check function for supporting types given to template.
+    /// @brief Gets an invalid value for the type.
+    /// @tparam T Type to get an invalid value for.
+    /// @note Specialize this function for the types which have an invalid value concept.
+    /// @see IsValid.
     template<typename T>
-    static constexpr auto check(T*)
-    -> typename std::is_same<decltype(std::declval<T>()(std::declval<Args>()...)),Return>::type;
+    constexpr T GetInvalid() noexcept
+    {
+        static_assert(sizeof(T) == 0, "No available specialization");
+    }
 
-    /// @brief Declaration of check function for non-supporting types given to template.
-    template<typename>
-    static constexpr std::false_type check(...);
+    /// @brief Determines if the given value is valid.
+    /// @see GetInvalid.
+    template<typename T>
+    constexpr bool IsValid(const T& value) noexcept
+    {
+        // Note: This is not necessarily a no-op!! But it is a "constexpr".
+        //
+        // From http://en.cppreference.com/w/cpp/numeric/math/isnan:
+        //   "Another way to test if a floating-point value is NaN is
+        //    to compare it with itself:
+        //      bool is_nan(double x) { return x != x; }
+        //
+        // So for all T, for which isnan() is implemented, this should work
+        // correctly and quite usefully!
+        //
+        return value == value;
+    }
 
-    /// @brief Type alias for given template parameters.
-    using type = decltype(check<Type>(0));
+    // GetInvalid template specializations.
 
-public:
-    /// Whether or not the given type has the specified functor.
-    static constexpr auto value = type::value;
-};
+    /// @brief Gets an invalid value for the float type.
+    template<>
+    constexpr float GetInvalid() noexcept
+    {
+        return std::numeric_limits<float>::signaling_NaN();
+    }
 
-/// @brief Has nullary functor type alias.
-/// @see HasUnaryFunctor.
-template <typename Type, typename Return>
-using HasNullaryFunctor = HasFunctor<Type,Return()>;
+    /// @brief Gets an invalid value for the double type.
+    template<>
+    constexpr double GetInvalid() noexcept
+    {
+        return std::numeric_limits<double>::signaling_NaN();
+    }
 
-/// @brief Has unary functor type alias.
-/// @see HasNullaryFunctor.
-template <typename Type, typename Return, typename Arg>
-using HasUnaryFunctor = HasFunctor<Type,Return(Arg)>;
+    /// @brief Gets an invalid value for the long double type.
+    template<>
+    constexpr long double GetInvalid() noexcept
+    {
+        return std::numeric_limits<long double>::signaling_NaN();
+    }
 
-} // namespace playrho
+    /// @brief Gets an invalid value for the std::size_t type.
+    template<>
+    constexpr std::size_t GetInvalid() noexcept
+    {
+        return static_cast<std::size_t>(-1);
+    }
 
-#endif // PLAYRHO_COMMON_TEMPLATES_HPP
+    // IsValid template specializations.
+
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const std::size_t& value) noexcept
+    {
+        return value != GetInvalid<std::size_t>();
+    }
+
+    // Other templates.
+
+    /// @brief Template for determining if the given type is an equality comparable type.
+    /// @note This isn't exactly the same as the "EqualityComparable" named requirement.
+    /// @see https://en.cppreference.com/w/cpp/named_req/EqualityComparable
+    template<class T1, class T2, class = void>
+    struct IsEqualityComparable : std::false_type
+    {
+    };
+
+    /// @brief Template specialization for equality comparable types.
+    template<class T1, class T2>
+    struct IsEqualityComparable<T1, T2, detail::VoidT<decltype(T1{} == T2{})>> : std::true_type
+    {
+    };
+
+    /// @brief Template for determining if the given type is an inequality comparable type.
+    template<class T1, class T2, class = void>
+    struct IsInequalityComparable : std::false_type
+    {
+    };
+
+    /// @brief Template specialization for inequality comparable types.
+    template<class T1, class T2>
+    struct IsInequalityComparable<T1, T2, detail::VoidT<decltype(T1{} != T2{})>> : std::true_type
+    {
+    };
+
+    /// @brief Template for determining if the given types are addable.
+    template<class T1, class T2 = T1, class = void>
+    struct IsAddable : std::false_type
+    {
+    };
+
+    /// @brief Template specializing for addable types.
+    template<class T1, class T2>
+    struct IsAddable<T1, T2, detail::VoidT<decltype(T1{} + T2{})>> : std::true_type
+    {
+    };
+
+    /// @brief Template for determining if the given types are multipliable.
+    template<class T1, class T2, class = void>
+    struct IsMultipliable : std::false_type
+    {
+    };
+
+    /// @brief Template specializing for multipliable types.
+    template<class T1, class T2>
+    struct IsMultipliable<T1, T2, detail::VoidT<decltype(T1{} * T2{})>> : std::true_type
+    {
+    };
+
+    /// @brief Template for determining if the given types are divisable.
+    template<class T1, class T2, class = void>
+    struct IsDivisable : std::false_type
+    {
+    };
+
+    /// @brief Template specializing for divisable types.
+    template<class T1, class T2>
+    struct IsDivisable<T1, T2, detail::VoidT<decltype(T1{} / T2{})>> : std::true_type
+    {
+    };
+
+    /// @brief Template for determining if the given type is an "arithmetic" type.
+    /// @note In the context of this library, "arithmetic" types are all types which
+    ///   have +, -, *, / arithmetic operator support.
+    template<class T, class = void>
+    struct IsArithmetic : std::false_type
+    {
+    };
+
+    /// @brief Template specialization for valid/acceptable "arithmetic" types.
+    template<class T>
+    struct IsArithmetic<T, detail::VoidT<
+                               decltype(T{} + T{}), decltype(T{} - T{}), decltype(T{} * T{}), decltype(T{} / T{})>> : std::true_type
+    {
+    };
+
+    /// @brief Determines whether the given type is an iterable type.
+    template<class T>
+    using IsIterable = typename detail::IsIterableImpl<T>;
+
+    /// @brief Has-type trait template class.
+    /// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
+    ///   to the question of: "How do I find out if a tuple contains a type?".
+    /// @see https://stackoverflow.com/a/25958302/7410358
+    template<typename T, typename Tuple>
+    struct HasType;
+
+    /// @brief Has-type trait template class specialized for <code>std::tuple</code> classes.
+    /// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
+    ///   to the question of: "How do I find out if a tuple contains a type?".
+    /// @see https://stackoverflow.com/a/25958302/7410358
+    template<typename T>
+    struct HasType<T, std::tuple<>> : std::false_type
+    {
+    };
+
+    /// @brief Has-type trait true class.
+    /// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
+    ///   to the question of: "How do I find out if a tuple contains a type?".
+    /// @see https://stackoverflow.com/a/25958302/7410358
+    template<typename T, typename... Ts>
+    struct HasType<T, std::tuple<T, Ts...>> : std::true_type
+    {
+    };
+
+    /// @brief Has-type trait template super class.
+    /// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
+    ///   to the question of: "How do I find out if a tuple contains a type?".
+    /// @see https://stackoverflow.com/a/25958302/7410358
+    template<typename T, typename U, typename... Ts>
+    struct HasType<T, std::tuple<U, Ts...>> : HasType<T, std::tuple<Ts...>>
+    {
+    };
+
+    /// @brief Tuple contains type alias.
+    /// @details Alias in case the trait itself should be <code>std::true_type</code> or
+    ///   <code>std::false_type</code>.
+    /// @note This is from Piotr Skotnicki's answer on the <em>StackOverflow</em> website
+    ///   to the question of: "How do I find out if a tuple contains a type?".
+    /// @see https://stackoverflow.com/a/25958302/7410358
+    template<typename T, typename Tuple>
+    using TupleContainsType = typename HasType<T, Tuple>::type;
+
+    /// @brief Alias for pulling the <code>max_size</code> constomization point into the
+    ///   playrho namesapce.
+    using detail::max_size;
+
+    /// @brief Alias for pulling the <code>IsFull</code> constomization point into the
+    ///   playrho namesapce.
+    using detail::IsFull;
+
+    /// @brief Function object for performing lexicographical less-than
+    ///   comparisons of containers.
+    /// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @see https://en.cppreference.com/w/cpp/utility/functional/less
+    template<typename T>
+    struct LexicographicalLess
+    {
+        /// @brief Checks whether the first argument is lexicographically less-than the
+        ///   second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::less;
+            using ElementType = decltype(*begin(lhs));
+            return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs),
+                                                less<ElementType>{});
+        }
+    };
+
+    /// @brief Function object for performing lexicographical greater-than
+    ///   comparisons of containers.
+    /// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @see https://en.cppreference.com/w/cpp/utility/functional/greater
+    template<typename T>
+    struct LexicographicalGreater
+    {
+        /// @brief Checks whether the first argument is lexicographically greater-than the
+        ///   second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::greater;
+            using ElementType = decltype(*begin(lhs));
+            return std::lexicographical_compare(begin(lhs), end(lhs), begin(rhs), end(rhs),
+                                                greater<ElementType>{});
+        }
+    };
+
+    /// @brief Function object for performing lexicographical less-than or equal-to
+    ///   comparisons of containers.
+    /// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @see https://en.cppreference.com/w/cpp/utility/functional/less_equal
+    template<typename T>
+    struct LexicographicalLessEqual
+    {
+        /// @brief Checks whether the first argument is lexicographically less-than or
+        ///   equal-to the second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::get;
+            using std::less;
+            using std::mismatch;
+            using ElementType = decltype(*begin(lhs));
+            const auto lhsEnd = end(lhs);
+            const auto diff = mismatch(begin(lhs), lhsEnd, begin(rhs), end(rhs));
+            return (get<0>(diff) == lhsEnd) || less<ElementType>{}(*get<0>(diff), *get<1>(diff));
+        }
+    };
+
+    /// @brief Function object for performing lexicographical greater-than or equal-to
+    ///   comparisons of containers.
+    /// @see https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare
+    /// @see https://en.cppreference.com/w/cpp/utility/functional/greater_equal
+    template<typename T>
+    struct LexicographicalGreaterEqual
+    {
+        /// @brief Checks whether the first argument is lexicographically greater-than or
+        ///   equal-to the second argument.
+        constexpr bool operator()(const T& lhs, const T& rhs) const
+        {
+            using std::get;
+            using std::greater;
+            using std::mismatch;
+            using ElementType = decltype(*begin(lhs));
+            const auto lhsEnd = end(lhs);
+            const auto diff = mismatch(begin(lhs), lhsEnd, begin(rhs), end(rhs));
+            return (get<0>(diff) == lhsEnd) || greater<ElementType>{}(*get<0>(diff), *get<1>(diff));
+        }
+    };
+
+    /// @brief Convenience template function for erasing first found value from container.
+    /// @return <code>true</code> if value was found and erased, <code>false</code> otherwise.
+    /// @see EraseAll.
+    template<typename T, typename U>
+    auto EraseFirst(T& container, const U& value) -> decltype(container.erase(find(begin(container), end(container), value)) != end(container))
+    {
+        const auto endIt = end(container);
+        const auto it = find(begin(container), endIt, value);
+        if (it != endIt)
+        {
+            container.erase(it);
+            return true;
+        }
+        return false;
+    }
+
+    /// @brief Convenience template function for erasing specified value from container.
+    /// @note This basically is the C++20 <code>std::erase</code> function.
+    /// @return Count of elements erased.
+    /// @see EraseFirst.
+    template<typename T, typename U>
+    auto EraseAll(T& container, const U& value) -> decltype(distance(container.erase(remove(begin(container), end(container), value), end(container)), end(container)))
+    {
+        const auto itEnd = end(container);
+        const auto it = remove(begin(container), itEnd, value);
+        const auto count = distance(it, itEnd);
+        container.erase(it, itEnd);
+        return count;
+    }
+
+    /// @brief Has-functor trait template fallback class.
+    /// @note This is based off the answer by "jrok" on the <em>StackOverflow</em> website
+    ///   to the question of: "Check if a class has a member function of a given signature".
+    /// @see https://stackoverflow.com/a/16824239/7410358
+    template<typename, typename T>
+    struct HasFunctor
+    {
+        static_assert(std::integral_constant<T, false>::value,
+                      "Second template parameter needs to be of function type.");
+    };
+
+    /// @brief Has-functor trait template class.
+    /// @note This is based off the answer by "jrok" on the <em>StackOverflow</em> website
+    ///   to the question of: "Check if a class has a member function of a given signature".
+    /// @see https://stackoverflow.com/a/16824239/7410358
+    template<typename Type, typename Return, typename... Args>
+    struct HasFunctor<Type, Return(Args...)>
+    {
+     private:
+        /// @brief Declaration of check function for supporting types given to template.
+        template<typename T>
+        static constexpr auto check(T*)
+            -> typename std::is_same<decltype(std::declval<T>()(std::declval<Args>()...)), Return>::type;
+
+        /// @brief Declaration of check function for non-supporting types given to template.
+        template<typename>
+        static constexpr std::false_type check(...);
+
+        /// @brief Type alias for given template parameters.
+        using type = decltype(check<Type>(0));
+
+     public:
+        /// Whether or not the given type has the specified functor.
+        static constexpr auto value = type::value;
+    };
+
+    /// @brief Has nullary functor type alias.
+    /// @see HasUnaryFunctor.
+    template<typename Type, typename Return>
+    using HasNullaryFunctor = HasFunctor<Type, Return()>;
+
+    /// @brief Has unary functor type alias.
+    /// @see HasNullaryFunctor.
+    template<typename Type, typename Return, typename Arg>
+    using HasUnaryFunctor = HasFunctor<Type, Return(Arg)>;
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_TEMPLATES_HPP

--- a/PlayRho/Common/Transformation.hpp
+++ b/PlayRho/Common/Transformation.hpp
@@ -23,58 +23,59 @@
 #define PLAYRHO_COMMON_TRANSFORMATION_HPP
 
 #include <PlayRho/Common/Settings.hpp>
-#include <PlayRho/Common/Vector2.hpp>
 #include <PlayRho/Common/UnitVec.hpp>
+#include <PlayRho/Common/Vector2.hpp>
 
 /// @file
 /// Definition of the Transformation class and free functions directly associated with it.
 
-namespace playrho {
-namespace d2 {
-
-struct BodyConf;
-
-/// @brief Describes a geometric transformation.
-/// @details A transform contains translation and rotation. It is used to represent
-///   the position and orientation of rigid frames.
-/// @note The default transformation is the identity transformation - the transformation
-///   which neither translates nor rotates a location.
-/// @note This data structure is 16-bytes large (on at least one 64-bit platform).
-struct Transformation
+namespace playrho
 {
-    Length2 p = Length2{}; ///< Translational portion of the transformation. 8-bytes.
-    UnitVec q = UnitVec::GetRight(); ///< Rotational portion of the transformation. 8-bytes.
-};
+    namespace d2
+    {
 
-/// @brief Identity transformation value.
-constexpr auto Transform_identity = Transformation{
-    Length2{0_m, 0_m}, UnitVec::GetRight()
-};
+        struct BodyConf;
 
-/// @brief Equality operator.
-/// @relatedalso Transformation
-constexpr bool operator== (Transformation lhs, Transformation rhs) noexcept
-{
-    return (lhs.p == rhs.p) && (lhs.q == rhs.q);
-}
+        /// @brief Describes a geometric transformation.
+        /// @details A transform contains translation and rotation. It is used to represent
+        ///   the position and orientation of rigid frames.
+        /// @note The default transformation is the identity transformation - the transformation
+        ///   which neither translates nor rotates a location.
+        /// @note This data structure is 16-bytes large (on at least one 64-bit platform).
+        struct Transformation
+        {
+            Length2 p = Length2{};          ///< Translational portion of the transformation. 8-bytes.
+            UnitVec q = UnitVec::GetRight();///< Rotational portion of the transformation. 8-bytes.
+        };
 
-/// @brief Inequality operator.
-/// @relatedalso Transformation
-constexpr bool operator!= (Transformation lhs, Transformation rhs) noexcept
-{
-    return (lhs.p != rhs.p) || (lhs.q != rhs.q);
-}
+        /// @brief Identity transformation value.
+        constexpr auto Transform_identity = Transformation{
+            Length2{0_m, 0_m}, UnitVec::GetRight()};
 
-} // namespace d2
+        /// @brief Equality operator.
+        /// @relatedalso Transformation
+        constexpr bool operator==(Transformation lhs, Transformation rhs) noexcept
+        {
+            return (lhs.p == rhs.p) && (lhs.q == rhs.q);
+        }
 
-/// @brief Determines if the given value is valid.
-/// @relatedalso d2::Transformation
-template <>
-constexpr bool IsValid(const d2::Transformation& value) noexcept
-{
-    return IsValid(value.p) && IsValid(value.q);
-}
+        /// @brief Inequality operator.
+        /// @relatedalso Transformation
+        constexpr bool operator!=(Transformation lhs, Transformation rhs) noexcept
+        {
+            return (lhs.p != rhs.p) || (lhs.q != rhs.q);
+        }
 
-} // namespace playrho
+    }// namespace d2
 
-#endif // PLAYRHO_COMMON_TRANSFORMATION_HPP
+    /// @brief Determines if the given value is valid.
+    /// @relatedalso d2::Transformation
+    template<>
+    constexpr bool IsValid(const d2::Transformation& value) noexcept
+    {
+        return IsValid(value.p) && IsValid(value.q);
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_TRANSFORMATION_HPP

--- a/PlayRho/Common/TypeInfo.hpp
+++ b/PlayRho/Common/TypeInfo.hpp
@@ -22,93 +22,94 @@
 #define PLAYRHO_COMMON_TYPEID_HPP
 
 #include <PlayRho/Common/StrongType.hpp>
-#include <PlayRho/Common/Templates.hpp> // for GetInvalid, IsValid
+#include <PlayRho/Common/Templates.hpp>// for GetInvalid, IsValid
 
-namespace playrho {
-
-/// @brief Type information.
-/// @note Users may specialize this for their own types.
-template <typename T>
-struct TypeInfo
+namespace playrho
 {
-    /// @brief The name of the templated type.
-    /// @note This is also a static member providing a unique ID, via its address, for
-    ///   the type T without resorting to using C++ run-time type information (RTTI).
-    static constexpr const char* name = nullptr;
-};
 
-/// @brief Type info specialization for <code>float</code>.
-template <>
-struct TypeInfo<float>
-{
-    /// @brief Provides name of the type as a null-terminated string.
-    static constexpr const char* name = "float";
-};
+    /// @brief Type information.
+    /// @note Users may specialize this for their own types.
+    template<typename T>
+    struct TypeInfo
+    {
+        /// @brief The name of the templated type.
+        /// @note This is also a static member providing a unique ID, via its address, for
+        ///   the type T without resorting to using C++ run-time type information (RTTI).
+        static constexpr const char* name = nullptr;
+    };
 
-/// @brief Type info specialization for <code>double</code>.
-template <>
-struct TypeInfo<double>
-{
-    /// @brief Provides name of the type as a null-terminated string.
-    static constexpr const char* name = "double";
-};
+    /// @brief Type info specialization for <code>float</code>.
+    template<>
+    struct TypeInfo<float>
+    {
+        /// @brief Provides name of the type as a null-terminated string.
+        static constexpr const char* name = "float";
+    };
 
-/// @brief Type info specialization for <code>long double</code>.
-template <>
-struct TypeInfo<long double>
-{
-    /// @brief Provides name of the type as a null-terminated string.
-    static constexpr const char* name = "long double";
-};
+    /// @brief Type info specialization for <code>double</code>.
+    template<>
+    struct TypeInfo<double>
+    {
+        /// @brief Provides name of the type as a null-terminated string.
+        static constexpr const char* name = "double";
+    };
 
-/// @brief Type identifier.
-using TypeID = strongtype::IndexingNamedType<const char * const *, struct TypeIdentifier>;
+    /// @brief Type info specialization for <code>long double</code>.
+    template<>
+    struct TypeInfo<long double>
+    {
+        /// @brief Provides name of the type as a null-terminated string.
+        static constexpr const char* name = "long double";
+    };
 
-/// @brief Invalid type ID value.
-constexpr auto InvalidTypeID =
-    static_cast<TypeID>(static_cast<TypeID::underlying_type>(nullptr));
+    /// @brief Type identifier.
+    using TypeID = strongtype::IndexingNamedType<const char* const*, struct TypeIdentifier>;
 
-/// @brief Gets an invalid value for the TypeID type.
-template <>
-constexpr TypeID GetInvalid() noexcept
-{
-    return InvalidTypeID;
-}
+    /// @brief Invalid type ID value.
+    constexpr auto InvalidTypeID =
+        static_cast<TypeID>(static_cast<TypeID::underlying_type>(nullptr));
 
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const TypeID& value) noexcept
-{
-    return value != GetInvalid<TypeID>();
-}
+    /// @brief Gets an invalid value for the TypeID type.
+    template<>
+    constexpr TypeID GetInvalid() noexcept
+    {
+        return InvalidTypeID;
+    }
 
-/// @brief Gets the type ID for the template parameter type.
-template <typename T>
-constexpr TypeID GetTypeID()
-{
-    return TypeID{&TypeInfo<std::decay_t<T>>::name};
-}
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const TypeID& value) noexcept
+    {
+        return value != GetInvalid<TypeID>();
+    }
 
-/// @brief Gets the type ID for the function parameter type.
-template <typename T>
-constexpr TypeID GetTypeID(T)
-{
-    return TypeID{&TypeInfo<std::decay_t<T>>::name};
-}
+    /// @brief Gets the type ID for the template parameter type.
+    template<typename T>
+    constexpr TypeID GetTypeID()
+    {
+        return TypeID{&TypeInfo<std::decay_t<T>>::name};
+    }
 
-/// @brief Gets the name associated with the given type ID.
-constexpr const char* GetName(TypeID id) noexcept
-{
-    return *id.get();
-}
+    /// @brief Gets the type ID for the function parameter type.
+    template<typename T>
+    constexpr TypeID GetTypeID(T)
+    {
+        return TypeID{&TypeInfo<std::decay_t<T>>::name};
+    }
 
-/// @brief Gets the name associated with the given template parameter type.
-template <typename T>
-constexpr const char* GetTypeName() noexcept
-{
-    return TypeInfo<T>::name;
-}
+    /// @brief Gets the name associated with the given type ID.
+    constexpr const char* GetName(TypeID id) noexcept
+    {
+        return *id.get();
+    }
 
-} // namespace playrho
+    /// @brief Gets the name associated with the given template parameter type.
+    template<typename T>
+    constexpr const char* GetTypeName() noexcept
+    {
+        return TypeInfo<T>::name;
+    }
 
-#endif // PLAYRHO_COMMON_TYPEID_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_TYPEID_HPP

--- a/PlayRho/Common/UnitInterval.hpp
+++ b/PlayRho/Common/UnitInterval.hpp
@@ -23,47 +23,51 @@
 
 #include <PlayRho/Common/CheckedValue.hpp>
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Unit-interval constrained value checker.
-/// @details Provides functors ensuring values are:
-///   greater-than or equal-to zero, and less-than or equal-to one.
-/// @note This is meant to be used as a checker with types like <code>CheckedValue</code>.
-/// @see CheckedValue.
-template <typename T>
-struct UnitIntervalChecker {
-    /// @brief Exception type possibly thrown by this checker.
-    using exception_type = std::invalid_argument;
-
-    /// @brief Valid value supplying functor.
-    /// @return Zero casted to the checked type.
-    constexpr auto operator()() noexcept -> decltype(static_cast<T>(0))
+    /// @brief Unit-interval constrained value checker.
+    /// @details Provides functors ensuring values are:
+    ///   greater-than or equal-to zero, and less-than or equal-to one.
+    /// @note This is meant to be used as a checker with types like <code>CheckedValue</code>.
+    /// @see CheckedValue.
+    template<typename T>
+    struct UnitIntervalChecker
     {
-        return static_cast<T>(0);
-    }
+        /// @brief Exception type possibly thrown by this checker.
+        using exception_type = std::invalid_argument;
 
-    /// @brief Value checking functor.
-    /// @throws exception_type if given value is not valid.
-    /// @return Value given if greater-than or equal-to zero and less-than or equal-to one.
-    constexpr auto operator()(const T& v) -> decltype((v >= static_cast<T>(0) && v <= static_cast<T>(1)), T(v))
-    {
-        if (!(v >= static_cast<T>(0))) {
-            throw exception_type("value not greater than nor equal to zero");
+        /// @brief Valid value supplying functor.
+        /// @return Zero casted to the checked type.
+        constexpr auto operator()() noexcept -> decltype(static_cast<T>(0))
+        {
+            return static_cast<T>(0);
         }
-        if (!(v <= static_cast<T>(1))) {
-            throw exception_type("value not less than nor equal to one");
+
+        /// @brief Value checking functor.
+        /// @throws exception_type if given value is not valid.
+        /// @return Value given if greater-than or equal-to zero and less-than or equal-to one.
+        constexpr auto operator()(const T& v) -> decltype((v >= static_cast<T>(0) && v <= static_cast<T>(1)), T(v))
+        {
+            if (!(v >= static_cast<T>(0)))
+            {
+                throw exception_type("value not greater than nor equal to zero");
+            }
+            if (!(v <= static_cast<T>(1)))
+            {
+                throw exception_type("value not less than nor equal to one");
+            }
+            return v;
         }
-        return v;
-    }
-};
+    };
 
-/// @ingroup CheckedValues
-/// @brief Unit interval constrained value type.
-template <typename T>
-using UnitInterval = CheckedValue<T, UnitIntervalChecker<T>>;
+    /// @ingroup CheckedValues
+    /// @brief Unit interval constrained value type.
+    template<typename T>
+    using UnitInterval = CheckedValue<T, UnitIntervalChecker<T>>;
 
-static_assert(std::is_default_constructible<UnitInterval<int>>::value);
+    static_assert(std::is_default_constructible<UnitInterval<int>>::value);
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_UNITINTERVAL_HPP
+#endif// PLAYRHO_COMMON_UNITINTERVAL_HPP

--- a/PlayRho/Common/UnitVec.cpp
+++ b/PlayRho/Common/UnitVec.cpp
@@ -18,17 +18,18 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Common/UnitVec.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/UnitVec.hpp>
 
-namespace playrho {
-namespace d2 {
-
-UnitVec UnitVec::Get(const Angle angle) noexcept
+namespace playrho
 {
-    return UnitVec{cos(angle), sin(angle)};
-}
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        UnitVec UnitVec::Get(const Angle angle) noexcept
+        {
+            return UnitVec{cos(angle), sin(angle)};
+        }
 
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Common/UnitVec.hpp
+++ b/PlayRho/Common/UnitVec.hpp
@@ -24,398 +24,476 @@
 /// @file
 /// Declarations of the UnitVec class and free functions associated with it.
 
+#include <PlayRho/Common/InvalidArgument.hpp>
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Units.hpp>
-#include <PlayRho/Common/InvalidArgument.hpp>
 
 #include <cstdlib>
 #include <iostream>
-#include <utility>
 #include <type_traits>
+#include <utility>
 
-namespace playrho {
-
-// Explicitly import needed functions into this namespace to avoid including the math
-//  header which itself expects UnitVec to already be defined.
-using std::isnormal;
-using std::sqrt;
-using std::hypot;
-using std::abs;
-
-namespace d2 {
-
-/// @brief 2-D unit vector.
-/// @details This is a 2-dimensional directional vector.
-class UnitVec
+namespace playrho
 {
-public:
-    /// @brief Value type used for the coordinate values of this vector.
-    using value_type = Real;
-    
-    /// @brief Size type.
-    using size_type = std::size_t;
-    
-    /// @brief Constant reference type.
-    using const_reference = const value_type&;
-    
-    /// @brief Constant pointer type.
-    using const_pointer = const value_type*;
-    
-    /// @brief Constant iterator type.
-    using const_iterator = const value_type*;
-    
-    /// @brief Constant reverse iterator type.
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    
-    /// @brief Gets the right-ward oriented unit vector.
-    /// @note This is the value for the 0/4 turned (0 angled) unit vector.
-    /// @note This is the reverse perpendicular unit vector of the bottom oriented vector.
-    /// @note This is the forward perpendicular unit vector of the top oriented vector.
-    static constexpr UnitVec GetRight() noexcept { return UnitVec{1, 0}; }
 
-    /// @brief Gets the top-ward oriented unit vector.
-    /// @note This is the actual value for the 1/4 turned (90 degree angled) unit vector.
-    /// @note This is the reverse perpendicular unit vector of the right oriented vector.
-    /// @note This is the forward perpendicular unit vector of the left oriented vector.
-    static constexpr UnitVec GetTop() noexcept { return UnitVec{0, 1}; }
+    // Explicitly import needed functions into this namespace to avoid including the math
+    //  header which itself expects UnitVec to already be defined.
+    using std::abs;
+    using std::hypot;
+    using std::isnormal;
+    using std::sqrt;
 
-    /// @brief Gets the left-ward oriented unit vector.
-    /// @note This is the actual value for the 2/4 turned (180 degree angled) unit vector.
-    /// @note This is the reverse perpendicular unit vector of the top oriented vector.
-    /// @note This is the forward perpendicular unit vector of the bottom oriented vector.
-    static constexpr UnitVec GetLeft() noexcept { return UnitVec{-1, 0}; }
-
-    /// @brief Gets the bottom-ward oriented unit vector.
-    /// @note This is the actual value for the 3/4 turned (270 degree angled) unit vector.
-    /// @note This is the reverse perpendicular unit vector of the left oriented vector.
-    /// @note This is the forward perpendicular unit vector of the right oriented vector.
-    static constexpr UnitVec GetBottom() noexcept { return UnitVec{0, -1}; }
-
-    /// @brief Gets the non-oriented unit vector.
-    static constexpr UnitVec GetZero() noexcept { return UnitVec{0, 0}; }
-
-    /// @brief Gets the 45 degree unit vector.
-    /// @details This is the unit vector in the positive X and Y quadrant where X == Y.
-    static constexpr UnitVec GetTopRight() noexcept
+    namespace d2
     {
-        // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
-        return UnitVec{+SquareRootTwo/Real(2), +SquareRootTwo/Real(2)};
-    }
-    
-    /// @brief Gets the -45 degree unit vector.
-    /// @details This is the unit vector in the positive X and negative Y quadrant
-    ///   where |X| == |Y|.
-    static constexpr UnitVec GetBottomRight() noexcept
-    {
-        // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
-        return UnitVec{+SquareRootTwo/Real(2), -SquareRootTwo/Real(2)};
-    }
-    
-    /// @brief Gets the default fallback.
-    static constexpr UnitVec GetDefaultFallback() noexcept { return UnitVec{}; }
 
-    /// @brief Polar coordinate.
-    /// @details This is a direction and magnitude pair defined by the unit vector class.
-    /// @note A magnitude of 0 indicates that no conclusive direction could be determined.
-    ///   The magnitude will otherwise be a normal value.
-    template <typename T>
-    using PolarCoord = std::enable_if_t<IsArithmetic<T>::value, std::pair<UnitVec, T>>;
-
-    /// @brief Gets the unit vector & magnitude from the given parameters.
-    template <typename T>
-    static PolarCoord<T> Get(const T x, const T y,
-                             const UnitVec fallback = GetDefaultFallback()) noexcept
-    {
-        // Try the faster way first...
-        const auto magnitudeSquared = x * x + y * y;
-        if (isnormal(magnitudeSquared))
+        /// @brief 2-D unit vector.
+        /// @details This is a 2-dimensional directional vector.
+        class UnitVec
         {
-            const auto magnitude = sqrt(magnitudeSquared);
-            assert(isnormal(magnitude));
-            const auto invMagnitude = Real{1} / magnitude;
-            return {UnitVec{value_type{x * invMagnitude}, value_type{y * invMagnitude}}, magnitude};
-        }
-        
-        // Failed the faster way, try the more accurate and robust way...
-        const auto magnitude = hypot(x, y);
-        if (isnormal(magnitude))
+         public:
+            /// @brief Value type used for the coordinate values of this vector.
+            using value_type = Real;
+
+            /// @brief Size type.
+            using size_type = std::size_t;
+
+            /// @brief Constant reference type.
+            using const_reference = const value_type&;
+
+            /// @brief Constant pointer type.
+            using const_pointer = const value_type*;
+
+            /// @brief Constant iterator type.
+            using const_iterator = const value_type*;
+
+            /// @brief Constant reverse iterator type.
+            using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+            /// @brief Gets the right-ward oriented unit vector.
+            /// @note This is the value for the 0/4 turned (0 angled) unit vector.
+            /// @note This is the reverse perpendicular unit vector of the bottom oriented vector.
+            /// @note This is the forward perpendicular unit vector of the top oriented vector.
+            static constexpr UnitVec GetRight() noexcept
+            {
+                return UnitVec{1, 0};
+            }
+
+            /// @brief Gets the top-ward oriented unit vector.
+            /// @note This is the actual value for the 1/4 turned (90 degree angled) unit vector.
+            /// @note This is the reverse perpendicular unit vector of the right oriented vector.
+            /// @note This is the forward perpendicular unit vector of the left oriented vector.
+            static constexpr UnitVec GetTop() noexcept
+            {
+                return UnitVec{0, 1};
+            }
+
+            /// @brief Gets the left-ward oriented unit vector.
+            /// @note This is the actual value for the 2/4 turned (180 degree angled) unit vector.
+            /// @note This is the reverse perpendicular unit vector of the top oriented vector.
+            /// @note This is the forward perpendicular unit vector of the bottom oriented vector.
+            static constexpr UnitVec GetLeft() noexcept
+            {
+                return UnitVec{-1, 0};
+            }
+
+            /// @brief Gets the bottom-ward oriented unit vector.
+            /// @note This is the actual value for the 3/4 turned (270 degree angled) unit vector.
+            /// @note This is the reverse perpendicular unit vector of the left oriented vector.
+            /// @note This is the forward perpendicular unit vector of the right oriented vector.
+            static constexpr UnitVec GetBottom() noexcept
+            {
+                return UnitVec{0, -1};
+            }
+
+            /// @brief Gets the non-oriented unit vector.
+            static constexpr UnitVec GetZero() noexcept
+            {
+                return UnitVec{0, 0};
+            }
+
+            /// @brief Gets the 45 degree unit vector.
+            /// @details This is the unit vector in the positive X and Y quadrant where X == Y.
+            static constexpr UnitVec GetTopRight() noexcept
+            {
+                // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
+                return UnitVec{+SquareRootTwo / Real(2), +SquareRootTwo / Real(2)};
+            }
+
+            /// @brief Gets the -45 degree unit vector.
+            /// @details This is the unit vector in the positive X and negative Y quadrant
+            ///   where |X| == |Y|.
+            static constexpr UnitVec GetBottomRight() noexcept
+            {
+                // Note that 1/sqrt(2) == sqrt(2)/(sqrt(2)*sqrt(2)) == sqrt(2)/2
+                return UnitVec{+SquareRootTwo / Real(2), -SquareRootTwo / Real(2)};
+            }
+
+            /// @brief Gets the default fallback.
+            static constexpr UnitVec GetDefaultFallback() noexcept
+            {
+                return UnitVec{};
+            }
+
+            /// @brief Polar coordinate.
+            /// @details This is a direction and magnitude pair defined by the unit vector class.
+            /// @note A magnitude of 0 indicates that no conclusive direction could be determined.
+            ///   The magnitude will otherwise be a normal value.
+            template<typename T>
+            using PolarCoord = std::enable_if_t<IsArithmetic<T>::value, std::pair<UnitVec, T>>;
+
+            /// @brief Gets the unit vector & magnitude from the given parameters.
+            template<typename T>
+            static PolarCoord<T> Get(const T x, const T y,
+                                     const UnitVec fallback = GetDefaultFallback()) noexcept
+            {
+                // Try the faster way first...
+                const auto magnitudeSquared = x * x + y * y;
+                if (isnormal(magnitudeSquared))
+                {
+                    const auto magnitude = sqrt(magnitudeSquared);
+                    assert(isnormal(magnitude));
+                    const auto invMagnitude = Real{1} / magnitude;
+                    return {UnitVec{value_type{x * invMagnitude}, value_type{y * invMagnitude}}, magnitude};
+                }
+
+                // Failed the faster way, try the more accurate and robust way...
+                const auto magnitude = hypot(x, y);
+                if (isnormal(magnitude))
+                {
+                    return std::make_pair(UnitVec{x / magnitude, y / magnitude}, magnitude);
+                }
+
+                // Give up and return the fallback value.
+                return std::make_pair(fallback, T{0});
+            }
+
+            /// @brief Gets the given angled unit vector.
+            ///
+            /// @note For angles that are meant to be at exact multiples of the quarter turn,
+            ///   better accuracy will be had by using one of the four oriented unit
+            ///   vector returning methods - for the right, top, left, bottom orientations.
+            ///
+            static UnitVec Get(const Angle angle) noexcept;
+
+            constexpr UnitVec() noexcept = default;
+
+            /// @brief Gets the max size.
+            constexpr size_type max_size() const noexcept
+            {
+                return size_type{2};
+            }
+
+            /// @brief Gets the size.
+            constexpr size_type size() const noexcept
+            {
+                return size_type{2};
+            }
+
+            /// @brief Whether empty.
+            /// @note Always false for N > 0.
+            constexpr bool empty() const noexcept
+            {
+                return false;
+            }
+
+            /// @brief Gets a "begin" iterator.
+            const_iterator begin() const noexcept
+            {
+                return const_iterator(m_elems);
+            }
+
+            /// @brief Gets an "end" iterator.
+            const_iterator end() const noexcept
+            {
+                return const_iterator(m_elems + 2);
+            }
+
+            /// @brief Gets a "begin" iterator.
+            const_iterator cbegin() const noexcept
+            {
+                return begin();
+            }
+
+            /// @brief Gets an "end" iterator.
+            const_iterator cend() const noexcept
+            {
+                return end();
+            }
+
+            /// @brief Gets a reverse "begin" iterator.
+            const_reverse_iterator crbegin() const noexcept
+            {
+                return const_reverse_iterator{m_elems + 2};
+            }
+
+            /// @brief Gets a reverse "end" iterator.
+            const_reverse_iterator crend() const noexcept
+            {
+                return const_reverse_iterator{m_elems};
+            }
+
+            /// @brief Gets a reverse "begin" iterator.
+            const_reverse_iterator rbegin() const noexcept
+            {
+                return crbegin();
+            }
+
+            /// @brief Gets a reverse "end" iterator.
+            const_reverse_iterator rend() const noexcept
+            {
+                return crend();
+            }
+
+            /// @brief Gets a constant reference to the requested element.
+            /// @note No bounds checking is performed.
+            /// @warning Behavior is undefined if given a position equal to or greater than size().
+            constexpr const_reference operator[](size_type pos) const noexcept
+            {
+                assert(pos < size());
+                return m_elems[pos];
+            }
+
+            /// @brief Gets a constant reference to the requested element.
+            /// @throws InvalidArgument if given a position that's >= size().
+            constexpr const_reference at(size_type pos) const
+            {
+                if (pos >= size())
+                {
+                    throw InvalidArgument("Vector::at: position >= size()");
+                }
+                return m_elems[pos];
+            }
+
+            /// @brief Direct access to data.
+            constexpr const_pointer data() const noexcept
+            {
+                return m_elems;
+            }
+
+            /// @brief Gets the "X" value.
+            constexpr auto GetX() const noexcept
+            {
+                return m_elems[0];
+            }
+
+            /// @brief Gets the "Y" value.
+            constexpr auto GetY() const noexcept
+            {
+                return m_elems[1];
+            }
+
+            /// @brief Flips the X and Y values.
+            constexpr UnitVec FlipXY() const noexcept
+            {
+                return UnitVec{-GetX(), -GetY()};
+            }
+
+            /// @brief Flips the X value.
+            constexpr UnitVec FlipX() const noexcept
+            {
+                return UnitVec{-GetX(), GetY()};
+            }
+
+            /// @brief Flips the Y value.
+            constexpr UnitVec FlipY() const noexcept
+            {
+                return UnitVec{GetX(), -GetY()};
+            }
+
+            /// @brief Rotates the unit vector by the given amount.
+            ///
+            /// @param amount Expresses the angular difference from the right-ward oriented unit
+            ///   vector to rotate this unit vector by.
+            ///
+            /// @return Result of rotating this unit vector by the given amount.
+            ///
+            constexpr UnitVec Rotate(UnitVec amount) const noexcept
+            {
+                return UnitVec{GetX() * amount.GetX() - GetY() * amount.GetY(),
+                               GetY() * amount.GetX() + GetX() * amount.GetY()};
+            }
+
+            /// @brief Gets a vector counter-clockwise (reverse-clockwise) perpendicular to this vector.
+            /// @details This returns the unit vector (-y, x).
+            /// @return A counter-clockwise 90-degree rotation of this vector.
+            /// @see GetFwdPerpendicular.
+            constexpr UnitVec GetRevPerpendicular() const noexcept
+            {
+                // See http://mathworld.wolfram.com/PerpendicularVector.html
+                return UnitVec{-GetY(), GetX()};
+            }
+
+            /// @brief Gets a vector clockwise (forward-clockwise) perpendicular to this vector.
+            /// @details This returns the unit vector (y, -x).
+            /// @return A clockwise 90-degree rotation of this vector.
+            /// @see GetRevPerpendicular.
+            constexpr UnitVec GetFwdPerpendicular() const noexcept
+            {
+                // See http://mathworld.wolfram.com/PerpendicularVector.html
+                return UnitVec{GetY(), -GetX()};
+            }
+
+            /// @brief Negation operator.
+            constexpr UnitVec operator-() const noexcept
+            {
+                return UnitVec{-GetX(), -GetY()};
+            }
+
+            /// @brief Positive operator.
+            constexpr UnitVec operator+() const noexcept
+            {
+                return UnitVec{+GetX(), +GetY()};
+            }
+
+            /// @brief Gets the absolute value.
+            constexpr UnitVec Absolute() const noexcept
+            {
+                return UnitVec{abs(GetX()), abs(GetY())};
+            }
+
+         private:
+            /// @brief Initializing constructor.
+            constexpr UnitVec(value_type x, value_type y) noexcept
+                : m_elems{x, y}
+            {
+                // Intentionally empty.
+            }
+
+            value_type m_elems[2] = {value_type{0}, value_type{0}};///< Element values.
+        };
+
+        // Free functions...
+
+        /// @brief Gets the "X-axis".
+        constexpr UnitVec GetXAxis(UnitVec rot) noexcept
         {
-            return std::make_pair(UnitVec{x / magnitude, y / magnitude}, magnitude);
+            return rot;
         }
-        
-        // Give up and return the fallback value.
-        return std::make_pair(fallback, T{0});
-    }
 
-    /// @brief Gets the given angled unit vector.
-    ///
-    /// @note For angles that are meant to be at exact multiples of the quarter turn,
-    ///   better accuracy will be had by using one of the four oriented unit
-    ///   vector returning methods - for the right, top, left, bottom orientations.
-    ///
-    static UnitVec Get(const Angle angle) noexcept;
-
-    constexpr UnitVec() noexcept = default;
-    
-    /// @brief Gets the max size.
-    constexpr size_type max_size() const noexcept { return size_type{2}; }
-    
-    /// @brief Gets the size.
-    constexpr size_type size() const noexcept { return size_type{2}; }
-    
-    /// @brief Whether empty.
-    /// @note Always false for N > 0.
-    constexpr bool empty() const noexcept { return false; }
-    
-    /// @brief Gets a "begin" iterator.
-    const_iterator begin() const noexcept { return const_iterator(m_elems); }
-    
-    /// @brief Gets an "end" iterator.
-    const_iterator end() const noexcept { return const_iterator(m_elems + 2); }
-    
-    /// @brief Gets a "begin" iterator.
-    const_iterator cbegin() const noexcept { return begin(); }
-    
-    /// @brief Gets an "end" iterator.
-    const_iterator cend() const noexcept { return end(); }
-    
-    /// @brief Gets a reverse "begin" iterator.
-    const_reverse_iterator crbegin() const noexcept
-    {
-        return const_reverse_iterator{m_elems + 2};
-    }
-    
-    /// @brief Gets a reverse "end" iterator.
-    const_reverse_iterator crend() const noexcept
-    {
-        return const_reverse_iterator{m_elems};
-    }
-    
-    /// @brief Gets a reverse "begin" iterator.
-    const_reverse_iterator rbegin() const noexcept
-    {
-        return crbegin();
-    }
-    
-    /// @brief Gets a reverse "end" iterator.
-    const_reverse_iterator rend() const noexcept
-    {
-        return crend();
-    }
-    
-    /// @brief Gets a constant reference to the requested element.
-    /// @note No bounds checking is performed.
-    /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr const_reference operator[](size_type pos) const noexcept
-    {
-        assert(pos < size());
-        return m_elems[pos];
-    }
-    
-    /// @brief Gets a constant reference to the requested element.
-    /// @throws InvalidArgument if given a position that's >= size().
-    constexpr const_reference at(size_type pos) const
-    {
-        if (pos >= size())
+        /// @brief Gets the "Y-axis".
+        /// @note This is the reverse perpendicular vector of the given unit vector.
+        constexpr UnitVec GetYAxis(UnitVec rot) noexcept
         {
-            throw InvalidArgument("Vector::at: position >= size()");
+            return rot.GetRevPerpendicular();
         }
-        return m_elems[pos];
-    }
-    
-    /// @brief Direct access to data.
-    constexpr const_pointer data() const noexcept
+
+        /// @brief Equality operator.
+        constexpr bool operator==(const UnitVec a, const UnitVec b) noexcept
+        {
+            return (a.GetX() == b.GetX()) && (a.GetY() == b.GetY());
+        }
+
+        /// @brief Inequality operator.
+        constexpr bool operator!=(const UnitVec a, const UnitVec b) noexcept
+        {
+            return (a.GetX() != b.GetX()) || (a.GetY() != b.GetY());
+        }
+
+        /// @brief Gets a vector counter-clockwise (reverse-clockwise) perpendicular to the
+        ///   given vector.
+        /// @details This takes a vector of form (x, y) and returns the vector (-y, x).
+        /// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
+        /// @return A counter-clockwise 90-degree rotation of the given vector.
+        /// @see GetFwdPerpendicular.
+        constexpr UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
+        {
+            return vector.GetRevPerpendicular();
+        }
+
+        /// @brief Gets a vector clockwise (forward-clockwise) perpendicular to the given vector.
+        /// @details This takes a vector of form (x, y) and returns the vector (y, -x).
+        /// @param vector Vector to return a clockwise perpendicular equivalent for.
+        /// @return A clockwise 90-degree rotation of the given vector.
+        /// @see GetRevPerpendicular.
+        constexpr UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
+        {
+            return vector.GetFwdPerpendicular();
+        }
+
+        /// @brief Rotates a unit vector by the angle expressed by the second unit vector.
+        /// @return Unit vector for the angle that's the sum of the two angles expressed by
+        ///   the input unit vectors.
+        constexpr UnitVec Rotate(const UnitVec vector, const UnitVec& angle) noexcept
+        {
+            return vector.Rotate(angle);
+        }
+
+        /// @brief Inverse rotates a vector.
+        constexpr UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noexcept
+        {
+            return vector.Rotate(angle.FlipY());
+        }
+
+        /// @brief Gets the specified element of the given collection.
+        template<std::size_t I>
+        constexpr UnitVec::value_type get(UnitVec v) noexcept
+        {
+            static_assert(I < 2, "Index out of bounds in playrho::get<> (playrho::UnitVec)");
+            switch (I)
+            {
+            case 0:
+                return v.GetX();
+            case 1:
+                return v.GetY();
+            }
+        }
+
+        /// @brief Gets element 0 of the given collection.
+        template<>
+        constexpr UnitVec::value_type get<0>(UnitVec v) noexcept
+        {
+            return v.GetX();
+        }
+
+        /// @brief Gets element 1 of the given collection.
+        template<>
+        constexpr UnitVec::value_type get<1>(UnitVec v) noexcept
+        {
+            return v.GetY();
+        }
+
+        /// @brief Output stream operator.
+        inline ::std::ostream& operator<<(::std::ostream& os, const UnitVec& value)
+        {
+            return os << "UnitVec(" << get<0>(value) << "," << get<1>(value) << ")";
+        }
+
+    }// namespace d2
+
+    /// @brief Gets an invalid value for the <code>UnitVec</code> type.
+    template<>
+    constexpr d2::UnitVec GetInvalid() noexcept
     {
-        return m_elems;
+        return d2::UnitVec{};
     }
-    
-    /// @brief Gets the "X" value.
-    constexpr auto GetX() const noexcept { return m_elems[0]; }
 
-    /// @brief Gets the "Y" value.
-    constexpr auto GetY() const noexcept { return m_elems[1]; }
-    
-    /// @brief Flips the X and Y values.
-    constexpr UnitVec FlipXY() const noexcept { return UnitVec{-GetX(), -GetY()}; }
-
-    /// @brief Flips the X value.
-    constexpr UnitVec FlipX() const noexcept { return UnitVec{-GetX(), GetY()}; }
-
-    /// @brief Flips the Y value.
-    constexpr UnitVec FlipY() const noexcept { return UnitVec{GetX(), -GetY()}; }
-
-    /// @brief Rotates the unit vector by the given amount.
-    ///
-    /// @param amount Expresses the angular difference from the right-ward oriented unit
-    ///   vector to rotate this unit vector by.
-    ///
-    /// @return Result of rotating this unit vector by the given amount.
-    ///
-    constexpr UnitVec Rotate(UnitVec amount) const noexcept
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const d2::UnitVec& value) noexcept
     {
-        return UnitVec{GetX() * amount.GetX() - GetY() * amount.GetY(),
-                        GetY() * amount.GetX() + GetX() * amount.GetY()};
+        return IsValid(value.GetX()) && IsValid(value.GetY()) && (value != d2::UnitVec::GetZero());
     }
 
-    /// @brief Gets a vector counter-clockwise (reverse-clockwise) perpendicular to this vector.
-    /// @details This returns the unit vector (-y, x).
-    /// @return A counter-clockwise 90-degree rotation of this vector.
-    /// @see GetFwdPerpendicular.
-    constexpr UnitVec GetRevPerpendicular() const noexcept
+}// namespace playrho
+
+namespace std
+{
+
+    /// @brief Tuple size info for <code>playrho::d2::UnitVec</code>.
+    template<>
+    class tuple_size<playrho::d2::UnitVec> : public std::integral_constant<std::size_t, 2>
     {
-        // See http://mathworld.wolfram.com/PerpendicularVector.html
-        return UnitVec{-GetY(), GetX()};
-    }
+    };
 
-    /// @brief Gets a vector clockwise (forward-clockwise) perpendicular to this vector.
-    /// @details This returns the unit vector (y, -x).
-    /// @return A clockwise 90-degree rotation of this vector.
-    /// @see GetRevPerpendicular.
-    constexpr UnitVec GetFwdPerpendicular() const noexcept
+    /// @brief Tuple element type info for <code>playrho::d2::UnitVec</code>.
+    template<std::size_t I>
+    class tuple_element<I, playrho::d2::UnitVec>
     {
-        // See http://mathworld.wolfram.com/PerpendicularVector.html
-        return UnitVec{GetY(), -GetX()};
-    }
+     public:
+        /// @brief Type alias revealing the actual type of the element.
+        using type = playrho::Real;
+    };
 
-    /// @brief Negation operator.
-    constexpr UnitVec operator-() const noexcept { return UnitVec{-GetX(), -GetY()}; }
+}// namespace std
 
-    /// @brief Positive operator.
-    constexpr UnitVec operator+() const noexcept { return UnitVec{+GetX(), +GetY()}; }
-
-    /// @brief Gets the absolute value.
-    constexpr UnitVec Absolute() const noexcept
-    {
-        return UnitVec{abs(GetX()), abs(GetY())};
-    }
-
-private:
-    
-    /// @brief Initializing constructor.
-    constexpr UnitVec(value_type x, value_type y) noexcept : m_elems{x, y}
-    {
-        // Intentionally empty.
-    }
-
-    value_type m_elems[2] = { value_type{0}, value_type{0} }; ///< Element values.
-};
-
-// Free functions...
-
-/// @brief Gets the "X-axis".
-constexpr UnitVec GetXAxis(UnitVec rot) noexcept { return rot; }
-
-/// @brief Gets the "Y-axis".
-/// @note This is the reverse perpendicular vector of the given unit vector.
-constexpr UnitVec GetYAxis(UnitVec rot) noexcept { return rot.GetRevPerpendicular(); }
-
-/// @brief Equality operator.
-constexpr bool operator==(const UnitVec a, const UnitVec b) noexcept
-{
-    return (a.GetX() == b.GetX()) && (a.GetY() == b.GetY());
-}
-
-/// @brief Inequality operator.
-constexpr bool operator!=(const UnitVec a, const UnitVec b) noexcept
-{
-    return (a.GetX() != b.GetX()) || (a.GetY() != b.GetY());
-}
-
-/// @brief Gets a vector counter-clockwise (reverse-clockwise) perpendicular to the
-///   given vector.
-/// @details This takes a vector of form (x, y) and returns the vector (-y, x).
-/// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
-/// @return A counter-clockwise 90-degree rotation of the given vector.
-/// @see GetFwdPerpendicular.
-constexpr UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
-{
-    return vector.GetRevPerpendicular();
-}
-
-/// @brief Gets a vector clockwise (forward-clockwise) perpendicular to the given vector.
-/// @details This takes a vector of form (x, y) and returns the vector (y, -x).
-/// @param vector Vector to return a clockwise perpendicular equivalent for.
-/// @return A clockwise 90-degree rotation of the given vector.
-/// @see GetRevPerpendicular.
-constexpr UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
-{
-    return vector.GetFwdPerpendicular();
-}
-
-/// @brief Rotates a unit vector by the angle expressed by the second unit vector.
-/// @return Unit vector for the angle that's the sum of the two angles expressed by
-///   the input unit vectors.
-constexpr UnitVec Rotate(const UnitVec vector, const UnitVec& angle) noexcept
-{
-    return vector.Rotate(angle);
-}
-
-/// @brief Inverse rotates a vector.
-constexpr UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noexcept
-{
-    return vector.Rotate(angle.FlipY());
-}
-
-/// @brief Gets the specified element of the given collection.
-template <std::size_t I>
-constexpr UnitVec::value_type get(UnitVec v) noexcept
-{
-    static_assert(I < 2, "Index out of bounds in playrho::get<> (playrho::UnitVec)");
-    switch (I)
-    {
-        case 0: return v.GetX();
-        case 1: return v.GetY();
-    }
-}
-
-/// @brief Gets element 0 of the given collection.
-template <>
-constexpr UnitVec::value_type get<0>(UnitVec v) noexcept
-{
-    return v.GetX();
-}
-
-/// @brief Gets element 1 of the given collection.
-template <>
-constexpr UnitVec::value_type get<1>(UnitVec v) noexcept
-{
-    return v.GetY();
-}
-
-/// @brief Output stream operator.
-inline ::std::ostream& operator<<(::std::ostream& os, const UnitVec& value)
-{
-    return os << "UnitVec(" << get<0>(value) << "," << get<1>(value) << ")";
-}
-
-} // namespace d2
-
-/// @brief Gets an invalid value for the <code>UnitVec</code> type.
-template <> constexpr d2::UnitVec GetInvalid() noexcept { return d2::UnitVec{}; }
-
-/// @brief Determines if the given value is valid.
-template <> constexpr bool IsValid(const d2::UnitVec& value) noexcept
-{
-    return IsValid(value.GetX()) && IsValid(value.GetY()) && (value != d2::UnitVec::GetZero());
-}
-
-} // namespace playrho
-
-namespace std {
-
-/// @brief Tuple size info for <code>playrho::d2::UnitVec</code>.
-template<>
-class tuple_size< playrho::d2::UnitVec >: public std::integral_constant<std::size_t, 2> {};
-
-/// @brief Tuple element type info for <code>playrho::d2::UnitVec</code>.
-template<std::size_t I>
-class tuple_element<I, playrho::d2::UnitVec>
-{
-public:
-    /// @brief Type alias revealing the actual type of the element.
-    using type = playrho::Real;
-};
-
-} // namespace std
-
-#endif // PLAYRHO_COMMON_UNITVEC2_HPP
+#endif// PLAYRHO_COMMON_UNITVEC2_HPP

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -40,47 +40,69 @@
 
 #include <PlayRho/Common/RealConstants.hpp>
 #include <PlayRho/Common/Templates.hpp>
-#include <type_traits>
 #include <cmath>
+#include <type_traits>
 
 // #define USE_BOOST_UNITS
 #if defined(USE_BOOST_UNITS)
+#include <boost/units/cmath.hpp>
 #include <boost/units/io.hpp>
 #include <boost/units/limits.hpp>
-#include <boost/units/cmath.hpp>
-#include <boost/units/systems/si/length.hpp>
-#include <boost/units/systems/si/time.hpp>
-#include <boost/units/systems/si/velocity.hpp>
+#include <boost/units/systems/angle/degrees.hpp>
 #include <boost/units/systems/si/acceleration.hpp>
-#include <boost/units/systems/si/frequency.hpp>
-#include <boost/units/systems/si/velocity.hpp>
-#include <boost/units/systems/si/mass.hpp>
-#include <boost/units/systems/si/momentum.hpp>
-#include <boost/units/systems/si/inverse_mass.hpp>
-#include <boost/units/systems/si/area.hpp>
-#include <boost/units/systems/si/plane_angle.hpp>
+#include <boost/units/systems/si/angular_acceleration.hpp>
 #include <boost/units/systems/si/angular_momentum.hpp>
 #include <boost/units/systems/si/angular_velocity.hpp>
-#include <boost/units/systems/si/angular_acceleration.hpp>
+#include <boost/units/systems/si/area.hpp>
+#include <boost/units/systems/si/force.hpp>
+#include <boost/units/systems/si/frequency.hpp>
+#include <boost/units/systems/si/inverse_mass.hpp>
+#include <boost/units/systems/si/inverse_moment_of_inertia.hpp>
+#include <boost/units/systems/si/length.hpp>
+#include <boost/units/systems/si/mass.hpp>
+#include <boost/units/systems/si/moment_of_inertia.hpp>
+#include <boost/units/systems/si/momentum.hpp>
+#include <boost/units/systems/si/plane_angle.hpp>
 #include <boost/units/systems/si/second_moment_of_area.hpp>
 #include <boost/units/systems/si/surface_density.hpp>
-#include <boost/units/systems/si/moment_of_inertia.hpp>
-#include <boost/units/systems/si/inverse_moment_of_inertia.hpp>
-#include <boost/units/systems/si/force.hpp>
+#include <boost/units/systems/si/time.hpp>
 #include <boost/units/systems/si/torque.hpp>
-#include <boost/units/systems/angle/degrees.hpp>
-#endif // defined(USE_BOOST_UNITS)
+#include <boost/units/systems/si/velocity.hpp>
+#endif// defined(USE_BOOST_UNITS)
 
 // Define quantity and unit related macros to abstract away C-preprocessor definitions
 #if defined(USE_BOOST_UNITS)
 #define PLAYRHO_QUANTITY(BoostDimension) boost::units::quantity<BoostDimension, Real>
-#define PLAYRHO_UNIT(Quantity, BoostUnit) Quantity{BoostUnit * Real{1}}
-#define PLAYRHO_DERIVED_UNIT(Quantity, BoostUnit, Ratio) Quantity{BoostUnit * Real{Ratio}}
-#else // defined(USE_BOOST_UNITS)
+#define PLAYRHO_UNIT(Quantity, BoostUnit) \
+    Quantity                              \
+    {                                     \
+        BoostUnit* Real                   \
+        {                                 \
+            1                             \
+        }                                 \
+    }
+#define PLAYRHO_DERIVED_UNIT(Quantity, BoostUnit, Ratio) \
+    Quantity                                             \
+    {                                                    \
+        BoostUnit* Real                                  \
+        {                                                \
+            Ratio                                        \
+        }                                                \
+    }
+#else// defined(USE_BOOST_UNITS)
 #define PLAYRHO_QUANTITY(BoostDimension) Real
-#define PLAYRHO_UNIT(Quantity, BoostUnit) Real{1}
-#define PLAYRHO_DERIVED_UNIT(Quantity, BoostUnit, Ratio) Real{Ratio}}
-#endif // defined(USE_BOOST_UNITS)
+#define PLAYRHO_UNIT(Quantity, BoostUnit) \
+    Real                                  \
+    {                                     \
+        1                                 \
+    }
+#define PLAYRHO_DERIVED_UNIT(Quantity, BoostUnit, Ratio) \
+    Real                                                 \
+    {                                                    \
+        Ratio                                            \
+    }                                                    \
+    }
+#endif// defined(USE_BOOST_UNITS)
 
 namespace playrho
 {
@@ -93,7 +115,7 @@ namespace playrho
     /// @see PhysicalUnits
     /// @see https://en.wikipedia.org/wiki/List_of_physical_quantities
     /// @{
-    
+
     /// @brief Time quantity.
     /// @details This is the type alias for the time base quantity.
     /// @note This quantity's dimension is: time (<code>T</code>).
@@ -101,7 +123,7 @@ namespace playrho
     /// @see Second.
     /// @see https://en.wikipedia.org/wiki/Time_in_physics
     using Time = PLAYRHO_QUANTITY(boost::units::si::time);
-    
+
     /// @brief Frequency quantity.
     /// @details This is the type alias for the frequency quantity. It's a derived quantity
     ///   that's the inverse of time.
@@ -111,7 +133,7 @@ namespace playrho
     /// @see Hertz.
     /// @see https://en.wikipedia.org/wiki/Frequency
     using Frequency = PLAYRHO_QUANTITY(boost::units::si::frequency);
-    
+
     /// @brief Length quantity.
     /// @details This is the type alias for the length base quantity.
     /// @note This quantity's dimension is: length (<code>L</code>).
@@ -119,7 +141,7 @@ namespace playrho
     /// @see Meter.
     /// @see https://en.wikipedia.org/wiki/Length
     using Length = PLAYRHO_QUANTITY(boost::units::si::length);
-    
+
     /// @brief Linear velocity quantity.
     /// @details This is the type alias for the linear velocity derived quantity.
     /// @note This quantity's dimensions are: length over time (<code>L T^-1</code>).
@@ -128,7 +150,7 @@ namespace playrho
     /// @see MeterPerSecond.
     /// @see https://en.wikipedia.org/wiki/Speed
     using LinearVelocity = PLAYRHO_QUANTITY(boost::units::si::velocity);
-    
+
     /// @brief Linear acceleration quantity.
     /// @details This is the type alias for the linear acceleration derived quantity.
     /// @note This quantity's dimensions are: length over time squared (<code>L T^-2</code>).
@@ -137,7 +159,7 @@ namespace playrho
     /// @see MeterPerSquareSecond.
     /// @see https://en.wikipedia.org/wiki/Acceleration
     using LinearAcceleration = PLAYRHO_QUANTITY(boost::units::si::acceleration);
-    
+
     /// @brief Mass quantity.
     /// @details This is the type alias for the mass base quantity.
     /// @note This quantity's dimension is: mass (<code>M</code>).
@@ -145,14 +167,14 @@ namespace playrho
     /// @see Kilogram.
     /// @see https://en.wikipedia.org/wiki/Mass
     using Mass = PLAYRHO_QUANTITY(boost::units::si::mass);
-    
+
     /// @brief Inverse mass quantity.
     /// @details This is the type alias for the inverse mass quantity. It's a derived quantity
     ///   that's the inverse of mass.
     /// @note This quantity's dimension is: inverse mass (<code>M^-1</code>).
     /// @see Mass.
     using InvMass = PLAYRHO_QUANTITY(boost::units::si::inverse_mass);
-    
+
     /// @brief Area quantity.
     /// @details This is the type alias for the area quantity. It's a derived quantity.
     /// @note This quantity's dimension is: length squared (<code>L^2</code>).
@@ -161,7 +183,7 @@ namespace playrho
     /// @see SquareMeter.
     /// @see https://en.wikipedia.org/wiki/Area
     using Area = PLAYRHO_QUANTITY(boost::units::si::area);
-    
+
     /// @brief Area (surface) density quantity.
     /// @details This is the type alias for the area density quantity. It's a derived quantity.
     /// @note This quantity's dimensions are: mass per area (<code>M L^-2</code>).
@@ -170,13 +192,13 @@ namespace playrho
     /// @see KilogramPerSquareMeter.
     /// @see https://en.wikipedia.org/wiki/Area_density
     using AreaDensity = PLAYRHO_QUANTITY(boost::units::si::surface_density);
-    
+
     /// @brief Angle quantity.
     /// @details This is the type alias for the plane angle base quantity.
     /// @note This quantity's dimension is: plane angle (<code>QP</code>).
     /// @see Radian, Degree.
     using Angle = PLAYRHO_QUANTITY(boost::units::si::plane_angle);
-    
+
     /// @brief Angular velocity quantity.
     /// @details This is the type alias for the plane angular velocity quantity. It's a
     ///   derived quantity.
@@ -186,7 +208,7 @@ namespace playrho
     /// @see RadianPerSecond, DegreePerSecond.
     /// @see https://en.wikipedia.org/wiki/Angular_velocity
     using AngularVelocity = PLAYRHO_QUANTITY(boost::units::si::angular_velocity);
-    
+
     /// @brief Angular acceleration quantity.
     /// @details This is the type alias for the angular acceleration quantity. It's a
     ///   derived quantity.
@@ -205,7 +227,7 @@ namespace playrho
     /// @see Newton.
     /// @see https://en.wikipedia.org/wiki/Force
     using Force = PLAYRHO_QUANTITY(boost::units::si::force);
-    
+
     /// @brief Torque quantity.
     /// @details This is the type alias for the torque quantity. It's a derived quantity
     ///   that's a rotational force.
@@ -216,7 +238,7 @@ namespace playrho
     /// @see NewtonMeter.
     /// @see https://en.wikipedia.org/wiki/Torque
     using Torque = PLAYRHO_QUANTITY(boost::units::si::torque);
-    
+
     /// @brief Second moment of area quantity.
     /// @details This is the type alias for the second moment of area quantity. It's a
     ///   derived quantity.
@@ -224,7 +246,7 @@ namespace playrho
     /// @see Length.
     /// @see https://en.wikipedia.org/wiki/Second_moment_of_area
     using SecondMomentOfArea = PLAYRHO_QUANTITY(boost::units::si::second_moment_of_area);
-    
+
     /// @brief Rotational inertia quantity.
     /// @details This is the type alias for the rotational inertia quantity. It's a
     ///   derived quantity that's also called the moment of inertia or angular mass.
@@ -235,7 +257,7 @@ namespace playrho
     /// @see Length, Mass, Angle, InvRotInertia.
     /// @see https://en.wikipedia.org/wiki/Moment_of_inertia
     using RotInertia = PLAYRHO_QUANTITY(boost::units::si::moment_of_inertia);
-    
+
     /// @brief Inverse rotational inertia quantity.
     /// @details This is the type alias for the inverse rotational inertia quantity. It's
     ///   a derived quantity.
@@ -243,7 +265,7 @@ namespace playrho
     ///    (<code>L^-2 M^-1 QP^2</code>).
     /// @see Length, Mass, Angle, RotInertia.
     using InvRotInertia = PLAYRHO_QUANTITY(boost::units::si::inverse_moment_of_inertia);
-    
+
     /// @brief Momentum quantity.
     /// @details This is the type alias for the momentum quantity. It's a derived quantity.
     /// @note This quantity's dimensions are: length mass per time (<code>L M T^-1</code>).
@@ -254,7 +276,7 @@ namespace playrho
     /// @see NewtonSecond.
     /// @see https://en.wikipedia.org/wiki/Momentum
     using Momentum = PLAYRHO_QUANTITY(boost::units::si::momentum);
-    
+
     /// @brief Angular momentum quantity.
     /// @details This is the type alias for the angular momentum quantity. It's a derived
     ///   quantity.
@@ -265,7 +287,7 @@ namespace playrho
     /// @see NewtonMeterSecond.
     /// @see https://en.wikipedia.org/wiki/Angular_momentum
     using AngularMomentum = PLAYRHO_QUANTITY(boost::units::si::angular_momentum);
-    
+
     /// @}
 
     /// @defgroup PhysicalUnits Units For Physical Quantities
@@ -302,12 +324,12 @@ namespace playrho
     /// @brief Meter per second unit of linear velocity.
     /// @see LinearVelocity.
     constexpr auto MeterPerSecond = PLAYRHO_UNIT(LinearVelocity,
-        boost::units::si::meter_per_second);
+                                                 boost::units::si::meter_per_second);
 
     /// @brief Meter per square second unit of linear acceleration.
     /// @see LinearAcceleration.
     constexpr auto MeterPerSquareSecond = PLAYRHO_UNIT(LinearAcceleration,
-        boost::units::si::meter_per_second_squared);
+                                                       boost::units::si::meter_per_second_squared);
 
     /// @brief Kilogram unit of mass.
     /// @note This is the SI base unit of mass.
@@ -325,18 +347,18 @@ namespace playrho
     /// @brief Kilogram per square meter unit of area density.
     /// @see AreaDensity.
     constexpr auto KilogramPerSquareMeter = PLAYRHO_UNIT(AreaDensity,
-        boost::units::si::kilogram_per_square_meter);
+                                                         boost::units::si::kilogram_per_square_meter);
 
     /// @brief Radian unit of angle.
     /// @see Angle.
     /// @see Degree.
     constexpr auto Radian = PLAYRHO_UNIT(Angle, boost::units::si::radian);
-    
+
     /// @brief Degree unit of angle quantity.
     /// @see Angle.
     /// @see Radian.
     constexpr auto Degree = Angle{Radian * Pi / Real{180}};
-    
+
     /// @brief Square radian unit type.
     /// @see Angle.
     /// @see Radian.
@@ -346,8 +368,8 @@ namespace playrho
     /// @see AngularVelocity.
     /// @see Radian, Second.
     constexpr auto RadianPerSecond = PLAYRHO_UNIT(AngularVelocity,
-        boost::units::si::radian_per_second);
-    
+                                                  boost::units::si::radian_per_second);
+
     /// @brief Degree per second unit of angular velocity.
     /// @see AngularVelocity.
     /// @see Degree, Second.
@@ -376,19 +398,19 @@ namespace playrho
     /// @see Momentum.
     /// @see Newton, Second.
     constexpr auto NewtonSecond = Newton * Second;
-    
+
     /// @brief Newton meter second unit of angular momentum.
     /// @see AngularMomentum.
     /// @see Newton, Meter, Second.
     constexpr auto NewtonMeterSecond = NewtonMeter * Second;
-    
+
     /// @brief Revolutions per minute units of angular velocity.
     /// @see AngularVelocity, Time
     /// @see Minute.
     constexpr auto RevolutionsPerMinute = 2 * Pi * Radian / (Real{60} * Second);
-    
+
     /// @}
-    
+
     /// @defgroup Unitsymbols Literals For Unit Symbols
     /// @brief User defined literals for more conveniently setting the value of physical
     ///   quantities.
@@ -402,7 +424,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * (Kilogram / Kilo);
     }
-    
+
     /// @brief SI unit symbol for a gram unit of Mass.
     /// @see https://en.wikipedia.org/wiki/Gram
     constexpr Mass operator"" _g(long double v) noexcept
@@ -417,7 +439,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Kilogram;
     }
-    
+
     /// @brief SI unit symbol for a kilogram unit of Mass.
     /// @see Kilogram
     /// @see https://en.wikipedia.org/wiki/Kilogram
@@ -425,7 +447,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Kilogram;
     }
-    
+
     /// @brief SI unit symbol for a petagram unit of Mass.
     /// @see https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
     constexpr Mass operator"" _Pg(unsigned long long int v) noexcept
@@ -446,14 +468,14 @@ namespace playrho
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
-    
+
     /// @brief SI unit symbol for a yottagram unit of Mass.
     /// @see https://en.wikipedia.org/wiki/Orders_of_magnitude_(mass)
     constexpr Mass operator"" _Yg(long double v) noexcept
     {
         return static_cast<Real>(v) * Yotta * (Kilogram / Kilo);
     }
-    
+
     /// @brief SI unit symbol for a meter of Length.
     /// @see Meter
     /// @see https://en.wikipedia.org/wiki/Metre
@@ -461,7 +483,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Meter;
     }
-    
+
     /// @brief SI unit symbol for a meter of Length.
     /// @see Meter
     /// @see https://en.wikipedia.org/wiki/Metre
@@ -469,77 +491,77 @@ namespace playrho
     {
         return static_cast<Real>(v) * Meter;
     }
-    
+
     /// @brief SI unit symbol for a decimeter of Length.
     /// @see https://en.wikipedia.org/wiki/Decimetre
     constexpr Length operator"" _dm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
-    
+
     /// @brief SI unit symbol for a decimeter of Length.
     /// @see https://en.wikipedia.org/wiki/Decimetre
     constexpr Length operator"" _dm(long double v) noexcept
     {
         return static_cast<Real>(v) * Deci * Meter;
     }
-    
+
     /// @brief SI unit symbol for a centimeter of Length.
     /// @see https://en.wikipedia.org/wiki/Centimetre
     constexpr Length operator"" _cm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
-    
+
     /// @brief SI unit symbol for a centimeter of Length.
     /// @see https://en.wikipedia.org/wiki/Centimetre
     constexpr Length operator"" _cm(long double v) noexcept
     {
         return static_cast<Real>(v) * Centi * Meter;
     }
-    
+
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @see https://en.wikipedia.org/wiki/Gigametre
-    constexpr Length operator"" _Gm (unsigned long long int v) noexcept
+    constexpr Length operator"" _Gm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
-    
+
     /// @brief SI unit symbol for a gigameter unit of Length.
     /// @see https://en.wikipedia.org/wiki/Gigametre
-    constexpr Length operator"" _Gm (long double v) noexcept
+    constexpr Length operator"" _Gm(long double v) noexcept
     {
         return static_cast<Real>(v) * Giga * Meter;
     }
-    
+
     /// @brief SI unit symbol for a megameter unit of Length.
     /// @see https://en.wikipedia.org/wiki/Megametre
-    constexpr Length operator"" _Mm (unsigned long long int v) noexcept
+    constexpr Length operator"" _Mm(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Mega * Meter;
     }
 
     /// @brief SI unit symbol for a megameter unit of Length.
     /// @see https://en.wikipedia.org/wiki/Megametre
-    constexpr Length operator"" _Mm (long double v) noexcept
+    constexpr Length operator"" _Mm(long double v) noexcept
     {
         return static_cast<Real>(v) * Mega * Meter;
     }
 
     /// @brief SI symbol for a kilometer unit of Length.
     /// @see https://en.wikipedia.org/wiki/Kilometre
-    constexpr Length operator"" _km (unsigned long long int v) noexcept
+    constexpr Length operator"" _km(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
-    
+
     /// @brief SI symbol for a kilometer unit of Length.
     /// @see https://en.wikipedia.org/wiki/Kilometre
-    constexpr Length operator"" _km (long double v) noexcept
+    constexpr Length operator"" _km(long double v) noexcept
     {
         return static_cast<Real>(v) * Kilo * Meter;
     }
-    
+
     /// @brief SI symbol for a second unit of Time.
     /// @see Second
     /// @see https://en.wikipedia.org/wiki/Second
@@ -547,7 +569,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Second;
     }
-    
+
     /// @brief SI symbol for a second unit of Time.
     /// @see Second
     /// @see https://en.wikipedia.org/wiki/Second
@@ -555,42 +577,42 @@ namespace playrho
     {
         return static_cast<Real>(v) * Second;
     }
-    
+
     /// @brief SI symbol for a minute unit of Time.
     /// @see https://en.wikipedia.org/wiki/Minute
     constexpr Time operator"" _min(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
-    
+
     /// @brief SI symbol for a minute unit of Time.
     /// @see https://en.wikipedia.org/wiki/Minute
     constexpr Time operator"" _min(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * Second;
     }
-    
+
     /// @brief Symbol for an hour unit of Time.
     /// @see https://en.wikipedia.org/wiki/Hour
     constexpr Time operator"" _h(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
-    
+
     /// @brief Symbol for an hour unit of Time.
     /// @see https://en.wikipedia.org/wiki/Hour
     constexpr Time operator"" _h(long double v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * Second;
     }
-    
+
     /// @brief Symbol for a day unit of Time.
     /// @see https://en.wikipedia.org/wiki/Day
     constexpr Time operator"" _d(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * 60 * 60 * 24 * Second;
     }
-    
+
     /// @brief Symbol for a day unit of Time.
     /// @see https://en.wikipedia.org/wiki/Day
     constexpr Time operator"" _d(long double v) noexcept
@@ -621,7 +643,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Degree;
     }
-    
+
     /// @brief Abbreviation for a degree unit of Angle.
     /// @see Degree.
     /// @see https://en.wikipedia.org/wiki/Degree_(angle)
@@ -637,7 +659,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Newton;
     }
-    
+
     /// @brief SI symbol for a newton unit of Force.
     /// @see Newton
     /// @see https://en.wikipedia.org/wiki/Newton_(unit)
@@ -645,21 +667,21 @@ namespace playrho
     {
         return static_cast<Real>(v) * Newton;
     }
-    
+
     /// @brief Abbreviation for meter squared unit of Area.
     /// @see SquareMeter
     constexpr Area operator"" _m2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * SquareMeter;
     }
-    
+
     /// @brief Abbreviation for meter squared unit of Area.
     /// @see SquareMeter
     constexpr Area operator"" _m2(long double v) noexcept
     {
         return static_cast<Real>(v) * SquareMeter;
     }
-    
+
     /// @brief Abbreviation for meter per second.
     /// @see https://en.wikipedia.org/wiki/Metre_per_second
     /// @see Meter
@@ -679,7 +701,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * MeterPerSecond;
     }
-    
+
     /// @brief Abbreviation for kilometer per second.
     /// @see https://en.wikipedia.org/wiki/Metre_per_second
     /// @see Second
@@ -687,7 +709,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
-    
+
     /// @brief Abbreviation for kilometer per second.
     /// @see https://en.wikipedia.org/wiki/Metre_per_second
     /// @see Second
@@ -695,7 +717,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Kilo * MeterPerSecond;
     }
-    
+
     /// @brief Abbreviation for meter per second squared.
     /// @see https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @see MeterPerSquareSecond
@@ -703,7 +725,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
-    
+
     /// @brief Abbreviation for meter per second squared.
     /// @see https://en.wikipedia.org/wiki/Metre_per_second_squared
     /// @see MeterPerSquareSecond
@@ -711,7 +733,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * MeterPerSquareSecond;
     }
-    
+
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @see Hertz
     /// @see https://en.wikipedia.org/wiki/Hertz
@@ -719,7 +741,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Hertz;
     }
-    
+
     /// @brief SI symbol for a hertz unit of Frequency.
     /// @see Hertz
     /// @see https://en.wikipedia.org/wiki/Hertz
@@ -727,7 +749,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * Hertz;
     }
-    
+
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @see NewtonMeter
     /// @see https://en.wikipedia.org/wiki/Newton_metre
@@ -735,7 +757,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
-    
+
     /// @brief Abbreviation for newton-meter unit of torque.
     /// @see NewtonMeter
     /// @see https://en.wikipedia.org/wiki/Newton_metre
@@ -743,7 +765,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * NewtonMeter;
     }
-    
+
     /// @brief SI symbol for a newton second of impulse.
     /// @see NewtonSecond
     /// @see https://en.wikipedia.org/wiki/Newton_second
@@ -751,7 +773,7 @@ namespace playrho
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
-    
+
     /// @brief SI symbol for a newton second of impulse.
     /// @see NewtonSecond
     /// @see https://en.wikipedia.org/wiki/Newton_second
@@ -759,13 +781,13 @@ namespace playrho
     {
         return static_cast<Real>(v) * NewtonSecond;
     }
-    
+
     /// @brief Abbreviation for kilogram per square meter.
     constexpr AreaDensity operator"" _kgpm2(unsigned long long int v) noexcept
     {
         return static_cast<Real>(v) * KilogramPerSquareMeter;
     }
-    
+
     /// @brief Abbreviation for kilogram per square meter.
     constexpr AreaDensity operator"" _kgpm2(long double v) noexcept
     {
@@ -787,7 +809,7 @@ namespace playrho
     }
 
     /// @}
-    
+
     /// @brief Strips the units off of the given value.
     constexpr Real StripUnit(const Real value)
     {
@@ -807,36 +829,36 @@ namespace playrho
     ///   distance relative to the Earth.
     /// @see https://en.wikipedia.org/wiki/Gravity_of_Earth
     constexpr auto EarthlyLinearAcceleration = Real{-9.8f} * MeterPerSquareSecond;
-    
+
     /// @brief Big "G".
     /// @details Gravitational constant used in calculating the attractive force on a mass
     ///   to another mass at a given distance due to gravity.
     /// @see https://en.wikipedia.org/wiki/Gravitational_constant
     constexpr auto BigG = Real{6.67408e-11f} * CubicMeter / (Kilogram * SquareSecond);
-    
+
     /// @}
 
 #if defined(USE_BOOST_UNITS)
+    using boost::units::cos;
     using boost::units::isfinite;
     using boost::units::isnormal;
-    using boost::units::cos;
     using boost::units::sin;
-    
+
     // Don't use boost's hypot since it does type promotion which is problematic.
     // using boost::units::hypot;
-    
+
     /// @brief Gets the hypotenuse.
     /// @note Don't use boost's hypot since it does type promotion which is problematic.
     /// @see https://en.cppreference.com/w/cpp/numeric/math/hypot
     /// @see https://en.wikipedia.org/wiki/Hypotenuse
     template<class Unit>
     inline auto
-    hypot(const boost::units::quantity<Unit,Real>& x, const boost::units::quantity<Unit,Real>& y)
+    hypot(const boost::units::quantity<Unit, Real>& x, const boost::units::quantity<Unit, Real>& y)
     {
         using std::hypot;
-        return boost::units::quantity<Unit,Real>::from_value(hypot(x.value(), y.value()));
+        return boost::units::quantity<Unit, Real>::from_value(hypot(x.value(), y.value()));
     }
-    
+
     /// @brief Square roots the given value.
     /// @note Don't use boost's sqrt implementation as it promotes the quantity's given
     ///   underlying floating-point type which seems contrary in this case to the
@@ -844,211 +866,202 @@ namespace playrho
     /// @see https://en.cppreference.com/w/cpp/numeric/math/sqrt
     template<class Unit>
     inline auto
-    sqrt(const boost::units::quantity<Unit,Real>& q)
+    sqrt(const boost::units::quantity<Unit, Real>& q)
     {
         using std::sqrt;
         using quantity_type = typename boost::units::root_typeof_helper<
-            boost::units::quantity<Unit,Real>,
-            boost::units::static_rational<2>
-            >::type;
+            boost::units::quantity<Unit, Real>,
+            boost::units::static_rational<2>>::type;
         using unit_type = typename quantity_type::unit_type;
-        
+
         return boost::units::quantity<unit_type, Real>::from_value(sqrt(q.value()));
     }
-    
+
     /// @brief Almost zero.
-    template <class Y>
+    template<class Y>
     inline auto AlmostZero(const boost::units::quantity<Y, Real> v)
     {
         return abs(v) < std::numeric_limits<boost::units::quantity<Y, Real>>::min();
     }
 
     /// @brief Strips the units off of the given value.
-    template<class Unit,class Y>
+    template<class Unit, class Y>
     constexpr auto StripUnit(const boost::units::quantity<Unit, Y> source)
     {
         return source.value();
     }
 
     /// @brief Gets an invalid value for the Angle type.
-    template <>
+    template<>
     constexpr Angle GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Radian;
     }
-    
+
     /// @brief Gets an invalid value for the Frequency type.
-    template <>
+    template<>
     constexpr Frequency GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Hertz;
     }
-    
+
     /// @brief Gets an invalid value for the AngularVelocity type.
-    template <>
+    template<>
     constexpr AngularVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSecond;
     }
-    
+
     /// @brief Gets an invalid value for the Time type.
-    template <>
+    template<>
     constexpr Time GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Second;
     }
-    
+
     /// @brief Gets an invalid value for the Length type.
-    template <>
+    template<>
     constexpr Length GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Meter;
     }
-    
+
     /// @brief Gets an invalid value for the Mass type.
-    template <>
+    template<>
     constexpr Mass GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram;
     }
-    
+
     /// @brief Gets an invalid value for the InvMass type.
-    template <>
+    template<>
     constexpr InvMass GetInvalid() noexcept
     {
         return GetInvalid<Real>() / Kilogram;
     }
-    
+
     /// @brief Gets an invalid value for the Momentum type.
-    template <>
+    template<>
     constexpr Momentum GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Kilogram * MeterPerSecond;
     }
-    
+
     /// @brief Gets an invalid value for the Force type.
-    template <>
+    template<>
     constexpr Force GetInvalid() noexcept
     {
         return GetInvalid<Real>() * Newton;
     }
-    
+
     /// @brief Gets an invalid value for the Torque type.
-    template <>
+    template<>
     constexpr Torque GetInvalid() noexcept
     {
         return GetInvalid<Real>() * NewtonMeter;
     }
-    
+
     /// @brief Gets an invalid value for the LinearVelocity type.
-    template <>
+    template<>
     constexpr LinearVelocity GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSecond;
     }
-    
+
     /// @brief Gets an invalid value for the LinearAcceleration type.
-    template <>
+    template<>
     constexpr LinearAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * MeterPerSquareSecond;
     }
-    
+
     /// @brief Gets an invalid value for the AngularAcceleration type.
-    template <>
+    template<>
     constexpr AngularAcceleration GetInvalid() noexcept
     {
         return GetInvalid<Real>() * RadianPerSquareSecond;
     }
-    
+
     /// @brief Gets an invalid value for the RotInertia type.
-    template <>
+    template<>
     constexpr RotInertia GetInvalid() noexcept
     {
         // RotInertia is L^2  M    QP^-2
         return GetInvalid<Real>() * SquareMeter * Kilogram / SquareRadian;
     }
-    
-#endif // defined(USE_BOOST_UNITS)
 
-} // namespace playrho
+#endif// defined(USE_BOOST_UNITS)
+
+}// namespace playrho
 
 #if defined(USE_BOOST_UNITS)
-namespace boost {
-namespace units {
-
-// Define division and multiplication templated operators in boost::units namespace since
-//   boost::units is the consistent namespace of operands for these and this aids with
-//   argument dependent lookup (ADL).
-//
-// Note that while boost::units already defines division and multiplication operator support,
-//   that's only for division or multiplication with the same type that the quantity is based
-//   on. For example when Real is float, Length{0.0f} * 2.0f is already supported but
-//   Length{0.0f} * 2 is not.
-
-/// @brief Division operator.
-///
-/// @details Supports the division of a playrho::Real based boost::units::quantity
-///   by any arithmetic type except playrho::Real.
-/// @note This intentionally excludes the playrho::Real type since the playrho::Real
-///   type is already supported and supporting it again in this template causes
-///   ambiguous overload support.
-///
-template <class Dimension, typename X, typename = std::enable_if_t<
-    playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
-    std::is_same<decltype(playrho::Real{} / X{}), playrho::Real>::value >
->
-constexpr auto operator/ (quantity<Dimension, playrho::Real> lhs, X rhs)
+namespace boost
 {
-    return lhs / playrho::Real(rhs);
-}
+    namespace units
+    {
 
-template <class Dimension, typename X, typename = std::enable_if_t<
-    playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
-    std::is_same<decltype(X{} / playrho::Real{}), playrho::Real>::value >
->
-constexpr auto operator/ (X lhs, quantity<Dimension, playrho::Real> rhs)
-{
-    return playrho::Real(lhs) / rhs;
-}
+        // Define division and multiplication templated operators in boost::units namespace since
+        //   boost::units is the consistent namespace of operands for these and this aids with
+        //   argument dependent lookup (ADL).
+        //
+        // Note that while boost::units already defines division and multiplication operator support,
+        //   that's only for division or multiplication with the same type that the quantity is based
+        //   on. For example when Real is float, Length{0.0f} * 2.0f is already supported but
+        //   Length{0.0f} * 2 is not.
 
-/// @brief Multiplication operator.
-///
-/// @details Supports the multiplication of a playrho::Real based boost::units::quantity
-///   by any arithmetic type except playrho::Real.
-/// @note This intentionally excludes the playrho::Real type since the playrho::Real
-///   type is already supported and supporting it again in this template causes
-///   ambiguous overload support.
-///
-template <class Dimension, typename X, typename = std::enable_if_t<
-    playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
-    std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-constexpr auto operator* (quantity<Dimension, playrho::Real> lhs, X rhs)
-{
-    return lhs * playrho::Real(rhs);
-}
+        /// @brief Division operator.
+        ///
+        /// @details Supports the division of a playrho::Real based boost::units::quantity
+        ///   by any arithmetic type except playrho::Real.
+        /// @note This intentionally excludes the playrho::Real type since the playrho::Real
+        ///   type is already supported and supporting it again in this template causes
+        ///   ambiguous overload support.
+        ///
+        template<class Dimension, typename X, typename = std::enable_if_t<playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value && std::is_same<decltype(playrho::Real{} / X{}), playrho::Real>::value>>
+        constexpr auto operator/(quantity<Dimension, playrho::Real> lhs, X rhs)
+        {
+            return lhs / playrho::Real(rhs);
+        }
 
-/// @brief Multiplication operator.
-///
-/// @details Supports the multiplication of a playrho::Real based boost::units::quantity
-///   by any arithmetic type except playrho::Real.
-/// @note This intentionally excludes the playrho::Real type since the playrho::Real
-///   type is already supported and supporting it again in this template causes
-///   ambiguous overload support.
-///
-template <class Dimension, typename X, typename = std::enable_if_t<
-    playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value &&
-    std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value> >
-constexpr auto operator* (X lhs, quantity<Dimension, playrho::Real> rhs)
-{
-    return playrho::Real(lhs) * rhs;
-}
+        template<class Dimension, typename X, typename = std::enable_if_t<playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value && std::is_same<decltype(X{} / playrho::Real{}), playrho::Real>::value>>
+        constexpr auto operator/(X lhs, quantity<Dimension, playrho::Real> rhs)
+        {
+            return playrho::Real(lhs) / rhs;
+        }
 
-} // namespace units
-} // namespace boost
-#endif // defined(USE_BOOST_UNITS)
+        /// @brief Multiplication operator.
+        ///
+        /// @details Supports the multiplication of a playrho::Real based boost::units::quantity
+        ///   by any arithmetic type except playrho::Real.
+        /// @note This intentionally excludes the playrho::Real type since the playrho::Real
+        ///   type is already supported and supporting it again in this template causes
+        ///   ambiguous overload support.
+        ///
+        template<class Dimension, typename X, typename = std::enable_if_t<playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value && std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value>>
+        constexpr auto operator*(quantity<Dimension, playrho::Real> lhs, X rhs)
+        {
+            return lhs * playrho::Real(rhs);
+        }
+
+        /// @brief Multiplication operator.
+        ///
+        /// @details Supports the multiplication of a playrho::Real based boost::units::quantity
+        ///   by any arithmetic type except playrho::Real.
+        /// @note This intentionally excludes the playrho::Real type since the playrho::Real
+        ///   type is already supported and supporting it again in this template causes
+        ///   ambiguous overload support.
+        ///
+        template<class Dimension, typename X, typename = std::enable_if_t<playrho::IsArithmetic<X>::value && !std::is_same<X, playrho::Real>::value && std::is_same<decltype(playrho::Real{} * X{}), playrho::Real>::value>>
+        constexpr auto operator*(X lhs, quantity<Dimension, playrho::Real> rhs)
+        {
+            return playrho::Real(lhs) * rhs;
+        }
+
+    }// namespace units
+}// namespace boost
+#endif// defined(USE_BOOST_UNITS)
 
 #undef PLAYRHO_QUANTITY
 #undef PLAYRHO_UNIT
 
-#endif // PLAYRHO_COMMON_UNITS_HPP
+#endif// PLAYRHO_COMMON_UNITS_HPP

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -22,551 +22,579 @@
 #ifndef PLAYRHO_COMMON_VECTOR_HPP
 #define PLAYRHO_COMMON_VECTOR_HPP
 
-#include <cassert>
-#include <cstddef>
-#include <type_traits>
-#include <iterator>
-#include <algorithm>
-#include <functional>
-#include <iostream>
 #include <PlayRho/Common/InvalidArgument.hpp>
 #include <PlayRho/Common/Real.hpp>
 #include <PlayRho/Common/Templates.hpp>
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <type_traits>
 
-namespace playrho {
-
-/// @brief Vector.
-/// @details This is a <code>constexpr</code> and constructor enhanced
-///   <code>std::array</code>-like template class for types supporting the +, -, *, /
-///   arithmetic operators ("arithmetic types" as defined by the <code>IsArithmetic</code>
-///   type trait) that itself comes with non-member arithmetic operator support making
-///   Vector instances arithmetic types as well.
-/// @note This type is trivially default constructible - i.e. default construction
-///   performs no actions (no initialization).
-/// @see IsArithmetic, VectorTraitsGroup
-template <typename T, std::size_t N>
-struct Vector
+namespace playrho
 {
-    /// @brief Value type.
-    using value_type = T;
 
-    /// @brief Size type.
-    using size_type = std::size_t;
-    
-    /// @brief Difference type.
-    using difference_type = std::ptrdiff_t;
-    
-    /// @brief Reference type.
-    using reference = value_type&;
-    
-    /// @brief Constant reference type.
-    using const_reference = const value_type&;
-    
-    /// @brief Pointer type.
-    using pointer = value_type*;
-    
-    /// @brief Constant pointer type.
-    using const_pointer = const value_type*;
-    
-    /// @brief Iterator type.
-    using iterator = value_type*;
-    
-    /// @brief Constant iterator type.
-    using const_iterator = const value_type*;
-    
-    /// @brief Reverse iterator type.
-    using reverse_iterator = std::reverse_iterator<iterator>;
-    
-    /// @brief Constant reverse iterator type.
-    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    
-    /// @brief Default constructor.
-    /// @note Defaulted explicitly.
-    /// @note This constructor performs no action.
-    constexpr Vector() = default;
-    
-    /// @brief Initializing constructor.
-    template<typename... Tail>
-    constexpr Vector(std::enable_if_t<sizeof...(Tail)+1 == N, T> head,
-                                    Tail... tail) noexcept: elements{head, T(tail)...}
+    /// @brief Vector.
+    /// @details This is a <code>constexpr</code> and constructor enhanced
+    ///   <code>std::array</code>-like template class for types supporting the +, -, *, /
+    ///   arithmetic operators ("arithmetic types" as defined by the <code>IsArithmetic</code>
+    ///   type trait) that itself comes with non-member arithmetic operator support making
+    ///   Vector instances arithmetic types as well.
+    /// @note This type is trivially default constructible - i.e. default construction
+    ///   performs no actions (no initialization).
+    /// @see IsArithmetic, VectorTraitsGroup
+    template<typename T, std::size_t N>
+    struct Vector
     {
-        // Intentionally empty.
-    }
+        /// @brief Value type.
+        using value_type = T;
 
-    /// @brief Gets the max size.
-    constexpr size_type max_size() const noexcept { return N; }
-    
-    /// @brief Gets the size.
-    constexpr size_type size() const noexcept { return N; }
-    
-    /// @brief Whether empty.
-    /// @note Always false for N > 0.
-    constexpr bool empty() const noexcept { return N == 0; }
-    
-    /// @brief Gets a "begin" iterator.
-    iterator begin() noexcept { return iterator(elements); }
+        /// @brief Size type.
+        using size_type = std::size_t;
 
-    /// @brief Gets an "end" iterator.
-    iterator end() noexcept { return iterator(elements + N); }
-    
-    /// @brief Gets a "begin" iterator.
-    const_iterator begin() const noexcept { return const_iterator(elements); }
-    
-    /// @brief Gets an "end" iterator.
-    const_iterator end() const noexcept { return const_iterator(elements + N); }
-    
-    /// @brief Gets a "begin" iterator.
-    const_iterator cbegin() const noexcept { return begin(); }
-    
-    /// @brief Gets an "end" iterator.
-    const_iterator cend() const noexcept { return end(); }
+        /// @brief Difference type.
+        using difference_type = std::ptrdiff_t;
 
-    /// @brief Gets a reverse "begin" iterator.
-    reverse_iterator rbegin() noexcept { return reverse_iterator{elements + N}; }
+        /// @brief Reference type.
+        using reference = value_type&;
 
-    /// @brief Gets a reverse "end" iterator.
-    reverse_iterator rend() noexcept { return reverse_iterator{elements}; }
-    
-    /// @brief Gets a reverse "begin" iterator.
-    const_reverse_iterator crbegin() const noexcept
-    {
-        return const_reverse_iterator{elements + N};
-    }
-    
-    /// @brief Gets a reverse "end" iterator.
-    const_reverse_iterator crend() const noexcept
-    {
-        return const_reverse_iterator{elements};
-    }
+        /// @brief Constant reference type.
+        using const_reference = const value_type&;
 
-    /// @brief Gets a reverse "begin" iterator.
-    const_reverse_iterator rbegin() const noexcept
-    {
-        return crbegin();
-    }
-    
-    /// @brief Gets a reverse "end" iterator.
-    const_reverse_iterator rend() const noexcept
-    {
-        return crend();
-    }
+        /// @brief Pointer type.
+        using pointer = value_type*;
 
-    /// @brief Gets a reference to the requested element.
-    /// @note No bounds checking is performed.
-    /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr reference operator[](size_type pos) noexcept
-    {
-        assert(pos < size());
-        return elements[pos];
-    }
-    
-    /// @brief Gets a constant reference to the requested element.
-    /// @note No bounds checking is performed.
-    /// @warning Behavior is undefined if given a position equal to or greater than size().
-    constexpr const_reference operator[](size_type pos) const noexcept
-    {
-        assert(pos < size());
-        return elements[pos];
-    }
-    
-    /// @brief Gets a reference to the requested element.
-    /// @throws InvalidArgument if given a position that's >= size().
-    constexpr reference at(size_type pos)
-    {
-        if (pos >= size())
+        /// @brief Constant pointer type.
+        using const_pointer = const value_type*;
+
+        /// @brief Iterator type.
+        using iterator = value_type*;
+
+        /// @brief Constant iterator type.
+        using const_iterator = const value_type*;
+
+        /// @brief Reverse iterator type.
+        using reverse_iterator = std::reverse_iterator<iterator>;
+
+        /// @brief Constant reverse iterator type.
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+        /// @brief Default constructor.
+        /// @note Defaulted explicitly.
+        /// @note This constructor performs no action.
+        constexpr Vector() = default;
+
+        /// @brief Initializing constructor.
+        template<typename... Tail>
+        constexpr Vector(std::enable_if_t<sizeof...(Tail) + 1 == N, T> head,
+                         Tail... tail) noexcept
+            : elements{head, T(tail)...}
         {
-            throw InvalidArgument("Vector::at: position >= size()");
+            // Intentionally empty.
         }
-        return elements[pos];
-    }
-    
-    /// @brief Gets a constant reference to the requested element.
-    /// @throws InvalidArgument if given a position that's >= size().
-    constexpr const_reference at(size_type pos) const
-    {
-        if (pos >= size())
+
+        /// @brief Gets the max size.
+        constexpr size_type max_size() const noexcept
         {
-            throw InvalidArgument("Vector::at: position >= size()");
+            return N;
         }
-        return elements[pos];
-    }
-    
-    /// @brief Direct access to data.
-    constexpr pointer data() noexcept
-    {
-        return elements;
-    }
-    
-    /// @brief Direct access to data.
-    constexpr const_pointer data() const noexcept
-    {
-        return elements;
-    }
-    
-    /// @brief Elements.
-    /// @details Array of N elements unless N is 0 in which case this is an array of 1 element.
-    /// @warning Don't access this directly!
-    /// @warning Data is not initialized on default construction. This is intentional
-    ///   to avoid any performance overhead that default initialization might incur.
-    value_type elements[N? N: 1]; // Never zero to avoid needing C++ extension capability.
-};
 
-/// @defgroup VectorTraitsGroup Vector Traits
-/// @brief Collection of trait classes for Vector.
-/// @{
-
-/// @brief Trait class for checking if type is a <code>Vector</code> type.
-/// @note This implements the default case where any arbitrary type *is not* a
-///   <code>Vector</code>.
-/// @note For example the following is false:
-/// @code{.cpp}
-/// IsVector<int>::value || IsVector<float>::value
-/// @endcode
-/// @see Vector
-template <typename>
-struct IsVector: std::false_type {};
-
-/// @brief Trait class specialization for checking if type is a <code>Vector</code> type..
-/// @note This implements the specialized case where the given type *is indeed* a
-///   <code>Vector</code>.
-/// @note For example the following is true:
-/// @code{.cpp}
-/// IsVector<Vector<int, 2>::value && IsVector<Vector<Vector<float, 1>, 1>>::value
-/// @endcode
-/// @see Vector
-template <typename T, std::size_t N>
-struct IsVector<Vector<T, N>>: std::true_type {};
-
-/// @}
-
-/// @brief Equality operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr bool operator== (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        if (lhs[i] != rhs[i])
+        /// @brief Gets the size.
+        constexpr size_type size() const noexcept
         {
-            return false;
+            return N;
         }
-    }
-    return true;
-}
 
-/// @brief Inequality operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr bool operator!= (const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
-{
-    return !(lhs == rhs);
-}
-
-/// @brief Unary plus operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T, decltype(+T{})>::value, Vector<T, N>>
-operator+ (Vector<T, N> v) noexcept
-{
-    return v;
-}
-
-/// @brief Unary negation operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T, decltype(-T{})>::value, Vector<T, N>>
-operator- (Vector<T, N> v) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        v[i] = -v[i];
-    }
-    return v;
-}
-
-/// @brief Increments the left hand side value by the right hand side value.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>&>
-operator+= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        lhs[i] += rhs[i];
-    }
-    return lhs;
-}
-
-/// @brief Decrements the left hand side value by the right hand side value.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>&>
-operator-= (Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        lhs[i] -= rhs[i];
-    }
-    return lhs;
-}
-
-/// @brief Adds two vectors component-wise.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>>
-operator+ (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
-{
-    return lhs += rhs;
-}
-
-/// @brief Subtracts two vectors component-wise.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>>
-operator- (Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
-{
-    return lhs -= rhs;
-}
-
-/// @brief Multiplication assignment operator.
-/// @relatedalso Vector
-template <typename T1, typename T2, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T1, decltype(T1{} * T2{})>::value, Vector<T1, N>&>
-operator*= (Vector<T1, N>& lhs, const T2 rhs) noexcept
-{
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        lhs[i] *= rhs;
-    }
-    return lhs;
-}
-
-/// @brief Division assignment operator.
-/// @relatedalso Vector
-template <typename T1, typename T2, std::size_t N>
-constexpr
-std::enable_if_t<std::is_same<T1, decltype(T1{} / T2{})>::value, Vector<T1, N>&>
-operator/= (Vector<T1, N>& lhs, const T2 rhs) noexcept
-{
-    const auto inverseRhs = Real{1} / rhs;
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        lhs[i] *= inverseRhs;
-    }
-    return lhs;
-}
-
-/// @brief Calculates the matrix product of the two given vector of vectors (matrices).
-/// @details Multiplies an A-by-B vector of vectors by a B-by-C vector of vectors returning
-///   an A-by-C vector of vectors.
-/// @note From Wikipedia:
-///   > Multiplication of two matrices is defined if and only if the number of columns
-///   > of the left matrix is the same as the number of rows of the right matrix.
-/// @note Matrix multiplication is not commutative.
-/// @note Algorithmically speaking, this implementation is called the "naive" algorithm.
-///   For small matrices, like 3-by-3 or smaller matrices, its complexity shouldn't be an issue.
-///   The matrix dimensions are compile time constants anyway which can help compilers
-///   automatically identify loop unrolling and hardware level parallelism opportunities.
-/// @param lhs Left-hand-side matrix.
-/// @param rhs Right-hand-side matrix.
-/// @return A-by-C matrix product of the left-hand-side matrix and the right-hand-side matrix.
-/// @see https://en.wikipedia.org/wiki/Matrix_multiplication
-/// @see https://en.wikipedia.org/wiki/Matrix_multiplication_algorithm
-/// @see https://en.wikipedia.org/wiki/Commutative_property
-/// @relatedalso Vector
-template <typename T1, typename T2, std::size_t A, std::size_t B, std::size_t C,
-    typename OT = decltype(T1{} * T2{})>
-constexpr
-std::enable_if_t<IsMultipliable<T1, T2>::value, Vector<Vector<OT, C>, A>>
-operator* (const Vector<Vector<T1, B>, A>& lhs, const Vector<Vector<T2, C>, B>& rhs) noexcept
-{
-    //using OT = decltype(T1{} * T2{});
-    auto result = Vector<Vector<OT, C>, A>{};
-    for (auto a = decltype(A){0}; a < A; ++a)
-    {
-        for (auto c = decltype(C){0}; c < C; ++c)
+        /// @brief Whether empty.
+        /// @note Always false for N > 0.
+        constexpr bool empty() const noexcept
         {
-            // So for 2x3 lhs matrix * 3*2 rhs matrix... result is 2x2 matrix:
-            // result[0][0] = lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0]
-            // result[0][1] = lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1]
-            // result[1][0] = lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0]
-            // result[1][1] = lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1]
-            // This is also: result[a][c] = row(lhs, a) * col(rhs, c)
-            auto element = OT{};
-            for (auto b = decltype(B){0}; b < B; ++b)
+            return N == 0;
+        }
+
+        /// @brief Gets a "begin" iterator.
+        iterator begin() noexcept
+        {
+            return iterator(elements);
+        }
+
+        /// @brief Gets an "end" iterator.
+        iterator end() noexcept
+        {
+            return iterator(elements + N);
+        }
+
+        /// @brief Gets a "begin" iterator.
+        const_iterator begin() const noexcept
+        {
+            return const_iterator(elements);
+        }
+
+        /// @brief Gets an "end" iterator.
+        const_iterator end() const noexcept
+        {
+            return const_iterator(elements + N);
+        }
+
+        /// @brief Gets a "begin" iterator.
+        const_iterator cbegin() const noexcept
+        {
+            return begin();
+        }
+
+        /// @brief Gets an "end" iterator.
+        const_iterator cend() const noexcept
+        {
+            return end();
+        }
+
+        /// @brief Gets a reverse "begin" iterator.
+        reverse_iterator rbegin() noexcept
+        {
+            return reverse_iterator{elements + N};
+        }
+
+        /// @brief Gets a reverse "end" iterator.
+        reverse_iterator rend() noexcept
+        {
+            return reverse_iterator{elements};
+        }
+
+        /// @brief Gets a reverse "begin" iterator.
+        const_reverse_iterator crbegin() const noexcept
+        {
+            return const_reverse_iterator{elements + N};
+        }
+
+        /// @brief Gets a reverse "end" iterator.
+        const_reverse_iterator crend() const noexcept
+        {
+            return const_reverse_iterator{elements};
+        }
+
+        /// @brief Gets a reverse "begin" iterator.
+        const_reverse_iterator rbegin() const noexcept
+        {
+            return crbegin();
+        }
+
+        /// @brief Gets a reverse "end" iterator.
+        const_reverse_iterator rend() const noexcept
+        {
+            return crend();
+        }
+
+        /// @brief Gets a reference to the requested element.
+        /// @note No bounds checking is performed.
+        /// @warning Behavior is undefined if given a position equal to or greater than size().
+        constexpr reference operator[](size_type pos) noexcept
+        {
+            assert(pos < size());
+            return elements[pos];
+        }
+
+        /// @brief Gets a constant reference to the requested element.
+        /// @note No bounds checking is performed.
+        /// @warning Behavior is undefined if given a position equal to or greater than size().
+        constexpr const_reference operator[](size_type pos) const noexcept
+        {
+            assert(pos < size());
+            return elements[pos];
+        }
+
+        /// @brief Gets a reference to the requested element.
+        /// @throws InvalidArgument if given a position that's >= size().
+        constexpr reference at(size_type pos)
+        {
+            if (pos >= size())
             {
-                element += lhs[a][b] * rhs[b][c];
+                throw InvalidArgument("Vector::at: position >= size()");
             }
-            result[a][c] = element;
+            return elements[pos];
         }
-    }
-    return result;
-}
 
-/// @brief Multiplies an A-element vector by a A-by-B vector of vectors.
-/// @note This algorithm favors column major ordering of the vector of vectors.
-/// @note This treats the left-hand-side argument as though it's a 1-by-A vector of vectors.
-/// @param lhs Left-hand-side vector treated as if it were of type:
-///   <code>Vector<Vector<T1, A>, 1></code>.
-/// @param rhs Right-hand-side vector of vectors.
-/// @return B-element vector product.
-template <typename T1, typename T2, std::size_t A, std::size_t B,
-    typename OT = decltype(T1{} * T2{})>
-constexpr
-std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, B>>
-operator* (const Vector<T1, A>& lhs, const Vector<Vector<T2, B>, A>& rhs) noexcept
-{
-    auto result = Vector<OT, B>{};
-    for (auto b = decltype(B){0}; b < B; ++b)
+        /// @brief Gets a constant reference to the requested element.
+        /// @throws InvalidArgument if given a position that's >= size().
+        constexpr const_reference at(size_type pos) const
+        {
+            if (pos >= size())
+            {
+                throw InvalidArgument("Vector::at: position >= size()");
+            }
+            return elements[pos];
+        }
+
+        /// @brief Direct access to data.
+        constexpr pointer data() noexcept
+        {
+            return elements;
+        }
+
+        /// @brief Direct access to data.
+        constexpr const_pointer data() const noexcept
+        {
+            return elements;
+        }
+
+        /// @brief Elements.
+        /// @details Array of N elements unless N is 0 in which case this is an array of 1 element.
+        /// @warning Don't access this directly!
+        /// @warning Data is not initialized on default construction. This is intentional
+        ///   to avoid any performance overhead that default initialization might incur.
+        value_type elements[N ? N : 1];// Never zero to avoid needing C++ extension capability.
+    };
+
+    /// @defgroup VectorTraitsGroup Vector Traits
+    /// @brief Collection of trait classes for Vector.
+    /// @{
+
+    /// @brief Trait class for checking if type is a <code>Vector</code> type.
+    /// @note This implements the default case where any arbitrary type *is not* a
+    ///   <code>Vector</code>.
+    /// @note For example the following is false:
+    /// @code{.cpp}
+    /// IsVector<int>::value || IsVector<float>::value
+    /// @endcode
+    /// @see Vector
+    template<typename>
+    struct IsVector : std::false_type
     {
-        auto element = OT{};
+    };
+
+    /// @brief Trait class specialization for checking if type is a <code>Vector</code> type..
+    /// @note This implements the specialized case where the given type *is indeed* a
+    ///   <code>Vector</code>.
+    /// @note For example the following is true:
+    /// @code{.cpp}
+    /// IsVector<Vector<int, 2>::value && IsVector<Vector<Vector<float, 1>, 1>>::value
+    /// @endcode
+    /// @see Vector
+    template<typename T, std::size_t N>
+    struct IsVector<Vector<T, N>> : std::true_type
+    {
+    };
+
+    /// @}
+
+    /// @brief Equality operator.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr bool operator==(const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+    {
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            if (lhs[i] != rhs[i])
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// @brief Inequality operator.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr bool operator!=(const Vector<T, N>& lhs, const Vector<T, N>& rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+    /// @brief Unary plus operator.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T, decltype(+T{})>::value, Vector<T, N>>
+    operator+(Vector<T, N> v) noexcept
+    {
+        return v;
+    }
+
+    /// @brief Unary negation operator.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T, decltype(-T{})>::value, Vector<T, N>>
+    operator-(Vector<T, N> v) noexcept
+    {
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            v[i] = -v[i];
+        }
+        return v;
+    }
+
+    /// @brief Increments the left hand side value by the right hand side value.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>&>
+    operator+=(Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
+    {
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            lhs[i] += rhs[i];
+        }
+        return lhs;
+    }
+
+    /// @brief Decrements the left hand side value by the right hand side value.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>&>
+    operator-=(Vector<T, N>& lhs, const Vector<T, N> rhs) noexcept
+    {
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            lhs[i] -= rhs[i];
+        }
+        return lhs;
+    }
+
+    /// @brief Adds two vectors component-wise.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T, decltype(T{} + T{})>::value, Vector<T, N>>
+    operator+(Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
+    {
+        return lhs += rhs;
+    }
+
+    /// @brief Subtracts two vectors component-wise.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T, decltype(T{} - T{})>::value, Vector<T, N>>
+    operator-(Vector<T, N> lhs, const Vector<T, N> rhs) noexcept
+    {
+        return lhs -= rhs;
+    }
+
+    /// @brief Multiplication assignment operator.
+    /// @relatedalso Vector
+    template<typename T1, typename T2, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T1, decltype(T1{} * T2{})>::value, Vector<T1, N>&>
+    operator*=(Vector<T1, N>& lhs, const T2 rhs) noexcept
+    {
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            lhs[i] *= rhs;
+        }
+        return lhs;
+    }
+
+    /// @brief Division assignment operator.
+    /// @relatedalso Vector
+    template<typename T1, typename T2, std::size_t N>
+    constexpr std::enable_if_t<std::is_same<T1, decltype(T1{} / T2{})>::value, Vector<T1, N>&>
+    operator/=(Vector<T1, N>& lhs, const T2 rhs) noexcept
+    {
+        const auto inverseRhs = Real{1} / rhs;
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            lhs[i] *= inverseRhs;
+        }
+        return lhs;
+    }
+
+    /// @brief Calculates the matrix product of the two given vector of vectors (matrices).
+    /// @details Multiplies an A-by-B vector of vectors by a B-by-C vector of vectors returning
+    ///   an A-by-C vector of vectors.
+    /// @note From Wikipedia:
+    ///   > Multiplication of two matrices is defined if and only if the number of columns
+    ///   > of the left matrix is the same as the number of rows of the right matrix.
+    /// @note Matrix multiplication is not commutative.
+    /// @note Algorithmically speaking, this implementation is called the "naive" algorithm.
+    ///   For small matrices, like 3-by-3 or smaller matrices, its complexity shouldn't be an issue.
+    ///   The matrix dimensions are compile time constants anyway which can help compilers
+    ///   automatically identify loop unrolling and hardware level parallelism opportunities.
+    /// @param lhs Left-hand-side matrix.
+    /// @param rhs Right-hand-side matrix.
+    /// @return A-by-C matrix product of the left-hand-side matrix and the right-hand-side matrix.
+    /// @see https://en.wikipedia.org/wiki/Matrix_multiplication
+    /// @see https://en.wikipedia.org/wiki/Matrix_multiplication_algorithm
+    /// @see https://en.wikipedia.org/wiki/Commutative_property
+    /// @relatedalso Vector
+    template<typename T1, typename T2, std::size_t A, std::size_t B, std::size_t C,
+             typename OT = decltype(T1{} * T2{})>
+    constexpr std::enable_if_t<IsMultipliable<T1, T2>::value, Vector<Vector<OT, C>, A>>
+    operator*(const Vector<Vector<T1, B>, A>& lhs, const Vector<Vector<T2, C>, B>& rhs) noexcept
+    {
+        //using OT = decltype(T1{} * T2{});
+        auto result = Vector<Vector<OT, C>, A>{};
         for (auto a = decltype(A){0}; a < A; ++a)
         {
-            element += lhs[a] * rhs[a][b];
+            for (auto c = decltype(C){0}; c < C; ++c)
+            {
+                // So for 2x3 lhs matrix * 3*2 rhs matrix... result is 2x2 matrix:
+                // result[0][0] = lhs[0][0] * rhs[0][0] + lhs[0][1] * rhs[1][0] + lhs[0][2] * rhs[2][0]
+                // result[0][1] = lhs[0][0] * rhs[0][1] + lhs[0][1] * rhs[1][1] + lhs[0][2] * rhs[2][1]
+                // result[1][0] = lhs[1][0] * rhs[0][0] + lhs[1][1] * rhs[1][0] + lhs[1][2] * rhs[2][0]
+                // result[1][1] = lhs[1][0] * rhs[0][1] + lhs[1][1] * rhs[1][1] + lhs[1][2] * rhs[2][1]
+                // This is also: result[a][c] = row(lhs, a) * col(rhs, c)
+                auto element = OT{};
+                for (auto b = decltype(B){0}; b < B; ++b)
+                {
+                    element += lhs[a][b] * rhs[b][c];
+                }
+                result[a][c] = element;
+            }
         }
-        result[b] = element;
+        return result;
     }
-    return result;
-}
 
-/// @brief Multiplies a B-by-A vector of vectors by an A-element vector.
-/// @note This algorithm favors row major ordering of the vector of vectors.
-/// @note This treats the right-hand-side argument as though it's an A-by-1 vector of vectors.
-/// @param lhs Left-hand-side vector of vectors.
-/// @param rhs Right-hand-side vector treated as if it were of type:
-///   <code>Vector<Vector<T2, 1>, A></code>.
-/// @return B-element vector product.
-template <typename T1, typename T2, std::size_t A, std::size_t B,
-    typename OT = decltype(T1{} * T2{})>
-constexpr
-std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, B>>
-operator* (const Vector<Vector<T1, A>, B>& lhs, const Vector<T2, A>& rhs) noexcept
-{
-    auto result = Vector<OT, B>{};
-    for (auto b = decltype(B){0}; b < B; ++b)
+    /// @brief Multiplies an A-element vector by a A-by-B vector of vectors.
+    /// @note This algorithm favors column major ordering of the vector of vectors.
+    /// @note This treats the left-hand-side argument as though it's a 1-by-A vector of vectors.
+    /// @param lhs Left-hand-side vector treated as if it were of type:
+    ///   <code>Vector<Vector<T1, A>, 1></code>.
+    /// @param rhs Right-hand-side vector of vectors.
+    /// @return B-element vector product.
+    template<typename T1, typename T2, std::size_t A, std::size_t B,
+             typename OT = decltype(T1{} * T2{})>
+    constexpr std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, B>>
+    operator*(const Vector<T1, A>& lhs, const Vector<Vector<T2, B>, A>& rhs) noexcept
     {
-        auto element = OT{};
-        for (auto a = decltype(A){0}; a < A; ++a)
+        auto result = Vector<OT, B>{};
+        for (auto b = decltype(B){0}; b < B; ++b)
         {
-            element += lhs[b][a] * rhs[a];
+            auto element = OT{};
+            for (auto a = decltype(A){0}; a < A; ++a)
+            {
+                element += lhs[a] * rhs[a][b];
+            }
+            result[b] = element;
         }
-        result[b] = element;
+        return result;
     }
-    return result;
-}
 
-/// @brief Multiplication operator for non-vector times vector.
-/// @relatedalso Vector
-/// @note Explicitly disabled for Vector * Vector to prevent this function from existing
-///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
-template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-constexpr
-std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, N>>
-operator* (const T1 s, Vector<T2, N> a) noexcept
-{
-    // Can't base this off of *= since result type in this case can be different
-    auto result = Vector<OT, N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
+    /// @brief Multiplies a B-by-A vector of vectors by an A-element vector.
+    /// @note This algorithm favors row major ordering of the vector of vectors.
+    /// @note This treats the right-hand-side argument as though it's an A-by-1 vector of vectors.
+    /// @param lhs Left-hand-side vector of vectors.
+    /// @param rhs Right-hand-side vector treated as if it were of type:
+    ///   <code>Vector<Vector<T2, 1>, A></code>.
+    /// @return B-element vector product.
+    template<typename T1, typename T2, std::size_t A, std::size_t B,
+             typename OT = decltype(T1{} * T2{})>
+    constexpr std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, B>>
+    operator*(const Vector<Vector<T1, A>, B>& lhs, const Vector<T2, A>& rhs) noexcept
     {
-        result[i] = s * a[i];
-    }
-    return result;
-}
-
-/// @brief Multiplication operator for vector times non-vector.
-/// @relatedalso Vector
-/// @note Explicitly disabled for Vector * Vector to prevent this function from existing
-///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
-template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
-constexpr
-std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
-operator* (Vector<T1, N> a, const T2 s) noexcept
-{
-    // Can't base this off of *= since result type in this case can be different
-    auto result = Vector<OT, N>{};
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        result[i] = a[i] * s;
-    }
-    return result;
-}
-
-/// @brief Division operator.
-/// @relatedalso Vector
-template <std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} / T2{})>
-constexpr
-std::enable_if_t<IsDivisable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
-operator/ (Vector<T1, N> a, const T2 s) noexcept
-{
-    // Can't base this off of /= since result type in this case can be different
-    auto result = Vector<OT, N>{};
-    const auto inverseS = Real{1} / s;
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        result[i] = a[i] * inverseS;
-    }
-    return result;
-}
-
-/// @brief Gets the specified element of the given collection.
-/// @relatedalso Vector
-template <std::size_t I, std::size_t N, typename T>
-constexpr auto& get(Vector<T, N>& v) noexcept
-{
-    static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
-    return v[I];
-}
-
-/// @brief Gets the specified element of the given collection.
-template <std::size_t I, std::size_t N, typename T>
-constexpr auto get(const Vector<T, N>& v) noexcept
-{
-    static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
-    return v[I];
-}
-
-/// @brief Output stream operator.
-/// @relatedalso Vector
-template <typename T, std::size_t N>
-::std::ostream& operator<< (::std::ostream& os, const Vector<T, N>& value)
-{
-    os << "{";
-    for (auto i = decltype(N){0}; i < N; ++i)
-    {
-        if (i > decltype(N){0})
+        auto result = Vector<OT, B>{};
+        for (auto b = decltype(B){0}; b < B; ++b)
         {
-            os << ',';
+            auto element = OT{};
+            for (auto a = decltype(A){0}; a < A; ++a)
+            {
+                element += lhs[b][a] * rhs[a];
+            }
+            result[b] = element;
         }
-        os << value[i];
+        return result;
     }
-    os << "}";
-    return os;
-}
 
-} // namespace playrho
+    /// @brief Multiplication operator for non-vector times vector.
+    /// @relatedalso Vector
+    /// @note Explicitly disabled for Vector * Vector to prevent this function from existing
+    ///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
+    template<std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
+    constexpr std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T1>::value, Vector<OT, N>>
+    operator*(const T1 s, Vector<T2, N> a) noexcept
+    {
+        // Can't base this off of *= since result type in this case can be different
+        auto result = Vector<OT, N>{};
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            result[i] = s * a[i];
+        }
+        return result;
+    }
 
-namespace std {
-    
+    /// @brief Multiplication operator for vector times non-vector.
+    /// @relatedalso Vector
+    /// @note Explicitly disabled for Vector * Vector to prevent this function from existing
+    ///   in that case and prevent errors like "use of overloaded operator '*' is ambiguous".
+    template<std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} * T2{})>
+    constexpr std::enable_if_t<IsMultipliable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
+    operator*(Vector<T1, N> a, const T2 s) noexcept
+    {
+        // Can't base this off of *= since result type in this case can be different
+        auto result = Vector<OT, N>{};
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            result[i] = a[i] * s;
+        }
+        return result;
+    }
+
+    /// @brief Division operator.
+    /// @relatedalso Vector
+    template<std::size_t N, typename T1, typename T2, typename OT = decltype(T1{} / T2{})>
+    constexpr std::enable_if_t<IsDivisable<T1, T2>::value && !IsVector<T2>::value, Vector<OT, N>>
+    operator/(Vector<T1, N> a, const T2 s) noexcept
+    {
+        // Can't base this off of /= since result type in this case can be different
+        auto result = Vector<OT, N>{};
+        const auto inverseS = Real{1} / s;
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            result[i] = a[i] * inverseS;
+        }
+        return result;
+    }
+
+    /// @brief Gets the specified element of the given collection.
+    /// @relatedalso Vector
+    template<std::size_t I, std::size_t N, typename T>
+    constexpr auto& get(Vector<T, N>& v) noexcept
+    {
+        static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
+        return v[I];
+    }
+
+    /// @brief Gets the specified element of the given collection.
+    template<std::size_t I, std::size_t N, typename T>
+    constexpr auto get(const Vector<T, N>& v) noexcept
+    {
+        static_assert(I < N, "Index out of bounds in playrho::get<> (playrho::Vector)");
+        return v[I];
+    }
+
+    /// @brief Output stream operator.
+    /// @relatedalso Vector
+    template<typename T, std::size_t N>
+    ::std::ostream& operator<<(::std::ostream& os, const Vector<T, N>& value)
+    {
+        os << "{";
+        for (auto i = decltype(N){0}; i < N; ++i)
+        {
+            if (i > decltype(N){0})
+            {
+                os << ',';
+            }
+            os << value[i];
+        }
+        os << "}";
+        return os;
+    }
+
+}// namespace playrho
+
+namespace std
+{
+
     /// @brief Tuple size info for <code>playrho::Vector</code>
     template<class T, std::size_t N>
-    class tuple_size< playrho::Vector<T, N> >: public std::integral_constant<std::size_t, N> {};
-    
+    class tuple_size<playrho::Vector<T, N>> : public std::integral_constant<std::size_t, N>
+    {
+    };
+
     /// @brief Tuple element type info for <code>playrho::Vector</code>
     template<std::size_t I, class T, std::size_t N>
     class tuple_element<I, playrho::Vector<T, N>>
     {
-    public:
+     public:
         /// @brief Type alias revealing the actual element type of the given Vector.
         using type = T;
     };
-    
-} // namespace std
 
-#endif // PLAYRHO_COMMON_VECTOR_HPP
+}// namespace std
+
+#endif// PLAYRHO_COMMON_VECTOR_HPP

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -22,139 +22,137 @@
 #ifndef PLAYRHO_COMMON_VECTOR2_HPP
 #define PLAYRHO_COMMON_VECTOR2_HPP
 
-#include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/InvalidArgument.hpp>
+#include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Vector.hpp>
 
-namespace playrho {
-
-/// @brief Vector with 2-elements.
-/// @note This is just a C++11 alias template for 2-element uses of the Vector template.
-template <typename T>
-using Vector2 = Vector<T, 2>;
-
-/// @brief Vector with 2 Real elements.
-/// @note This data structure is two-times the size of the <code>Real</code> type
-///   (or 8 using Real of float).
-using Vec2 = Vector2<Real>;
-
-/// @brief 2-element vector of Length quantities.
-/// @note Often used as a 2-dimensional distance or location vector.
-using Length2 = Vector2<Length>;
-
-/// @brief 2-element vector of linear velocity (<code>LinearVelocity</code>) quantities.
-/// @note Often used as a 2-dimensional speed vector.
-using LinearVelocity2 = Vector2<LinearVelocity>;
-
-/// @brief 2-element vector of linear acceleration (<code>LinearAcceleration</code>) quantities.
-/// @note Often used as a 2-dimensional linear acceleration vector.
-using LinearAcceleration2 = Vector2<LinearAcceleration>;
-
-/// @brief 2-element vector of Force quantities.
-/// @note Often used as a 2-dimensional force vector.
-using Force2 = Vector2<Force>;
-
-/// @brief 2-element vector of Mass quantities.
-using Mass2 = Vector2<Mass>;
-
-/// @brief 2-element vector of inverse mass (<code>InvMass</code>) quantities.
-using InvMass2 = Vector2<InvMass>;
-
-/// @brief 2-element vector of Momentum quantities.
-/// @note Often used as a 2-dimensional momentum vector.
-using Momentum2 = Vector2<Momentum>;
-
-/// @brief Gets the given value as a 2-element vector of reals (<code>Vec2</code>).
-constexpr Vec2 GetVec2(const Vector2<Real> value)
+namespace playrho
 {
-    return value;
-}
 
-/// @brief Gets an invalid value for the <code>Vec2</code> type.
-template <>
-constexpr Vec2 GetInvalid() noexcept
-{
-    return Vec2{GetInvalid<Vec2::value_type>(), GetInvalid<Vec2::value_type>()};
-}
+    /// @brief Vector with 2-elements.
+    /// @note This is just a C++11 alias template for 2-element uses of the Vector template.
+    template<typename T>
+    using Vector2 = Vector<T, 2>;
 
-/// @brief Determines whether the given vector contains finite coordinates.
-template <typename TYPE>
-constexpr bool IsValid(const Vector2<TYPE>& value) noexcept
-{
-    return IsValid(get<0>(value)) && IsValid(get<1>(value));
-}
+    /// @brief Vector with 2 Real elements.
+    /// @note This data structure is two-times the size of the <code>Real</code> type
+    ///   (or 8 using Real of float).
+    using Vec2 = Vector2<Real>;
+
+    /// @brief 2-element vector of Length quantities.
+    /// @note Often used as a 2-dimensional distance or location vector.
+    using Length2 = Vector2<Length>;
+
+    /// @brief 2-element vector of linear velocity (<code>LinearVelocity</code>) quantities.
+    /// @note Often used as a 2-dimensional speed vector.
+    using LinearVelocity2 = Vector2<LinearVelocity>;
+
+    /// @brief 2-element vector of linear acceleration (<code>LinearAcceleration</code>) quantities.
+    /// @note Often used as a 2-dimensional linear acceleration vector.
+    using LinearAcceleration2 = Vector2<LinearAcceleration>;
+
+    /// @brief 2-element vector of Force quantities.
+    /// @note Often used as a 2-dimensional force vector.
+    using Force2 = Vector2<Force>;
+
+    /// @brief 2-element vector of Mass quantities.
+    using Mass2 = Vector2<Mass>;
+
+    /// @brief 2-element vector of inverse mass (<code>InvMass</code>) quantities.
+    using InvMass2 = Vector2<InvMass>;
+
+    /// @brief 2-element vector of Momentum quantities.
+    /// @note Often used as a 2-dimensional momentum vector.
+    using Momentum2 = Vector2<Momentum>;
+
+    /// @brief Gets the given value as a 2-element vector of reals (<code>Vec2</code>).
+    constexpr Vec2 GetVec2(const Vector2<Real> value)
+    {
+        return value;
+    }
+
+    /// @brief Gets an invalid value for the <code>Vec2</code> type.
+    template<>
+    constexpr Vec2 GetInvalid() noexcept
+    {
+        return Vec2{GetInvalid<Vec2::value_type>(), GetInvalid<Vec2::value_type>()};
+    }
+
+    /// @brief Determines whether the given vector contains finite coordinates.
+    template<typename TYPE>
+    constexpr bool IsValid(const Vector2<TYPE>& value) noexcept
+    {
+        return IsValid(get<0>(value)) && IsValid(get<1>(value));
+    }
 
 #ifdef USE_BOOST_UNITS
-/// @brief Gets an invalid value for the Length2 type.
-template <>
-constexpr Length2 GetInvalid() noexcept
-{
-    return Length2{GetInvalid<Length>(), GetInvalid<Length>()};
-}
+    /// @brief Gets an invalid value for the Length2 type.
+    template<>
+    constexpr Length2 GetInvalid() noexcept
+    {
+        return Length2{GetInvalid<Length>(), GetInvalid<Length>()};
+    }
 
-/// @brief Gets an invalid value for the LinearVelocity2 type.
-template <>
-constexpr LinearVelocity2 GetInvalid() noexcept
-{
-    return LinearVelocity2{GetInvalid<LinearVelocity>(), GetInvalid<LinearVelocity>()};
-}
+    /// @brief Gets an invalid value for the LinearVelocity2 type.
+    template<>
+    constexpr LinearVelocity2 GetInvalid() noexcept
+    {
+        return LinearVelocity2{GetInvalid<LinearVelocity>(), GetInvalid<LinearVelocity>()};
+    }
 
-/// @brief Gets an invalid value for the Force2 type.
-template <>
-constexpr Force2 GetInvalid() noexcept
-{
-    return Force2{GetInvalid<Force>(), GetInvalid<Force>()};
-}
+    /// @brief Gets an invalid value for the Force2 type.
+    template<>
+    constexpr Force2 GetInvalid() noexcept
+    {
+        return Force2{GetInvalid<Force>(), GetInvalid<Force>()};
+    }
 
-/// @brief Gets an invalid value for the Momentum2 type.
-template <>
-constexpr Momentum2 GetInvalid() noexcept
-{
-    return Momentum2{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
-}
+    /// @brief Gets an invalid value for the Momentum2 type.
+    template<>
+    constexpr Momentum2 GetInvalid() noexcept
+    {
+        return Momentum2{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
+    }
 
-constexpr Vec2 GetVec2(const Length2 value)
-{
-    return Vec2{
-        get<0>(value) / Meter,
-        get<1>(value) / Meter
-    };
-}
+    constexpr Vec2 GetVec2(const Length2 value)
+    {
+        return Vec2{
+            get<0>(value) / Meter,
+            get<1>(value) / Meter};
+    }
 
-constexpr Vec2 GetVec2(const LinearVelocity2 value)
-{
-    return Vec2{
-        get<0>(value) / MeterPerSecond,
-        get<1>(value) / MeterPerSecond
-    };
-}
+    constexpr Vec2 GetVec2(const LinearVelocity2 value)
+    {
+        return Vec2{
+            get<0>(value) / MeterPerSecond,
+            get<1>(value) / MeterPerSecond};
+    }
 
-constexpr Vec2 GetVec2(const Momentum2 value)
-{
-    return Vec2{
-        get<0>(value) / (Kilogram * MeterPerSecond),
-        get<1>(value) / (Kilogram * MeterPerSecond)
-    };
-}
+    constexpr Vec2 GetVec2(const Momentum2 value)
+    {
+        return Vec2{
+            get<0>(value) / (Kilogram * MeterPerSecond),
+            get<1>(value) / (Kilogram * MeterPerSecond)};
+    }
 
-constexpr Vec2 GetVec2(const Force2 value)
-{
-    return Vec2{
-        get<0>(value) / Newton,
-        get<1>(value) / Newton
-    };
-}
+    constexpr Vec2 GetVec2(const Force2 value)
+    {
+        return Vec2{
+            get<0>(value) / Newton,
+            get<1>(value) / Newton};
+    }
 #endif
 
-namespace d2 {
-    
-    /// @brief Earthly gravity in 2-dimensions.
-    /// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
-    /// @see EarthlyLinearAcceleration
-    constexpr auto EarthlyGravity = LinearAcceleration2{
-        0_mps2, EarthlyLinearAcceleration};
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Earthly gravity in 2-dimensions.
+        /// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
+        /// @see EarthlyLinearAcceleration
+        constexpr auto EarthlyGravity = LinearAcceleration2{
+            0_mps2, EarthlyLinearAcceleration};
 
-#endif // PLAYRHO_COMMON_VECTOR2_HPP
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_VECTOR2_HPP

--- a/PlayRho/Common/Vector3.hpp
+++ b/PlayRho/Common/Vector3.hpp
@@ -25,38 +25,39 @@
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Vector.hpp>
 
-namespace playrho {
-
-/// @brief Vector with 3-elements.
-/// @note This is just a C++11 alias template for 3-element uses of the Vector template.
-template <typename T>
-using Vector3 = Vector<T, 3>;
-
-/// A 3-dimensional column vector with 3 elements.
-/// @note This data structure is 3 times the size of <code>Real</code> -
-///   i.e. 12-bytes (with 4-byte Real).
-using Vec3 = Vector3<Real>;
-
-/// @brief 3-element vector of Mass quantities.
-using Mass3 = Vector3<Mass>;
-
-/// @brief 3-element vector of inverse mass (<code>InvMass</code>) quantities.
-using InvMass3 = Vector3<InvMass>;
-
-/// @brief Gets an invalid value for the 3-element vector of real (<code>Vec3</code>) type.
-template <>
-constexpr Vec3 GetInvalid() noexcept
+namespace playrho
 {
-    return Vec3{GetInvalid<Real>(), GetInvalid<Real>(), GetInvalid<Real>()};
-}
 
-/// @brief Determines whether the given vector contains finite coordinates.
-template <>
-constexpr bool IsValid(const Vec3& value) noexcept
-{
-    return IsValid(get<0>(value)) && IsValid(get<1>(value)) && IsValid(get<2>(value));
-}
+    /// @brief Vector with 3-elements.
+    /// @note This is just a C++11 alias template for 3-element uses of the Vector template.
+    template<typename T>
+    using Vector3 = Vector<T, 3>;
 
-} // namespace playrho
+    /// A 3-dimensional column vector with 3 elements.
+    /// @note This data structure is 3 times the size of <code>Real</code> -
+    ///   i.e. 12-bytes (with 4-byte Real).
+    using Vec3 = Vector3<Real>;
 
-#endif // PLAYRHO_COMMON_VECTOR3_HPP
+    /// @brief 3-element vector of Mass quantities.
+    using Mass3 = Vector3<Mass>;
+
+    /// @brief 3-element vector of inverse mass (<code>InvMass</code>) quantities.
+    using InvMass3 = Vector3<InvMass>;
+
+    /// @brief Gets an invalid value for the 3-element vector of real (<code>Vec3</code>) type.
+    template<>
+    constexpr Vec3 GetInvalid() noexcept
+    {
+        return Vec3{GetInvalid<Real>(), GetInvalid<Real>(), GetInvalid<Real>()};
+    }
+
+    /// @brief Determines whether the given vector contains finite coordinates.
+    template<>
+    constexpr bool IsValid(const Vec3& value) noexcept
+    {
+        return IsValid(get<0>(value)) && IsValid(get<1>(value)) && IsValid(get<2>(value));
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_VECTOR3_HPP

--- a/PlayRho/Common/Velocity.cpp
+++ b/PlayRho/Common/Velocity.cpp
@@ -18,49 +18,50 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Common/Velocity.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Velocity.hpp>
 #include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
 
-namespace playrho {
-namespace d2 {
-
-VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc)
+namespace playrho
 {
-    auto vp = VelocityPair{
-        Velocity{LinearVelocity2{}, 0_rpm},
-        Velocity{LinearVelocity2{}, 0_rpm}
-    };
-    
-    const auto normal = vc.GetNormal();
-    const auto tangent = vc.GetTangent();
-    const auto pointCount = vc.GetPointCount();
-    const auto bodyA = vc.GetBodyA();
-    const auto bodyB = vc.GetBodyB();
-
-    const auto invMassA = bodyA->GetInvMass();
-    const auto invRotInertiaA = bodyA->GetInvRotInertia();
-    
-    const auto invMassB = bodyB->GetInvMass();
-    const auto invRotInertiaB = bodyB->GetInvRotInertia();
-    
-    for (auto j = decltype(pointCount){0}; j < pointCount; ++j)
+    namespace d2
     {
-        // inverse moment of inertia : L^-2 M^-1 QP^2
-        // P is M L T^-2
-        // GetPointRelPosA() is Length2
-        // Cross(Length2, P) is: M L^2 T^-2
-        // L^-2 M^-1 QP^2 M L^2 T^-2 is: QP^2 T^-2
-        const auto& vcp = vc.GetPointAt(j);
-        const auto P = vcp.normalImpulse * normal + vcp.tangentImpulse * tangent;
-        const auto LA = Cross(vcp.relA, P) / Radian;
-        const auto LB = Cross(vcp.relB, P) / Radian;
-        std::get<0>(vp) -= Velocity{invMassA * P, invRotInertiaA * LA};
-        std::get<1>(vp) += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    
-    return vp;
-}
 
-} // namespace d2
-} // namespace playrho
+        VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc)
+        {
+            auto vp = VelocityPair{
+                Velocity{LinearVelocity2{}, 0_rpm},
+                Velocity{LinearVelocity2{}, 0_rpm}};
+
+            const auto normal = vc.GetNormal();
+            const auto tangent = vc.GetTangent();
+            const auto pointCount = vc.GetPointCount();
+            const auto bodyA = vc.GetBodyA();
+            const auto bodyB = vc.GetBodyB();
+
+            const auto invMassA = bodyA->GetInvMass();
+            const auto invRotInertiaA = bodyA->GetInvRotInertia();
+
+            const auto invMassB = bodyB->GetInvMass();
+            const auto invRotInertiaB = bodyB->GetInvRotInertia();
+
+            for (auto j = decltype(pointCount){0}; j < pointCount; ++j)
+            {
+                // inverse moment of inertia : L^-2 M^-1 QP^2
+                // P is M L T^-2
+                // GetPointRelPosA() is Length2
+                // Cross(Length2, P) is: M L^2 T^-2
+                // L^-2 M^-1 QP^2 M L^2 T^-2 is: QP^2 T^-2
+                const auto& vcp = vc.GetPointAt(j);
+                const auto P = vcp.normalImpulse * normal + vcp.tangentImpulse * tangent;
+                const auto LA = Cross(vcp.relA, P) / Radian;
+                const auto LB = Cross(vcp.relB, P) / Radian;
+                std::get<0>(vp) -= Velocity{invMassA * P, invRotInertiaA * LA};
+                std::get<1>(vp) += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+
+            return vp;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Common/Velocity.hpp
+++ b/PlayRho/Common/Velocity.hpp
@@ -25,135 +25,137 @@
 #include <PlayRho/Common/Vector2.hpp>
 #include <utility>
 
-namespace playrho {
-namespace d2 {
-
-class VelocityConstraint;
-
-/// @brief 2-D velocity related data structure.
-/// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
-struct Velocity
+namespace playrho
 {
-    LinearVelocity2 linear; ///< Linear velocity.
-    AngularVelocity angular; ///< Angular velocity.
-};
+    namespace d2
+    {
 
-/// @brief Equality operator.
-/// @relatedalso Velocity
-constexpr bool operator==(const Velocity& lhs, const Velocity& rhs)
-{
-    return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
-}
+        class VelocityConstraint;
 
-/// @brief Inequality operator.
-/// @relatedalso Velocity
-constexpr bool operator!=(const Velocity& lhs, const Velocity& rhs)
-{
-    return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
-}
+        /// @brief 2-D velocity related data structure.
+        /// @note This data structure is 12-bytes (with 4-byte Real on at least one 64-bit platform).
+        struct Velocity
+        {
+            LinearVelocity2 linear; ///< Linear velocity.
+            AngularVelocity angular;///< Angular velocity.
+        };
 
-/// @brief Multiplication assignment operator.
-/// @relatedalso Velocity
-constexpr Velocity& operator*= (Velocity& lhs, const Real rhs)
-{
-    lhs.linear *= rhs;
-    lhs.angular *= rhs;
-    return lhs;
-}
+        /// @brief Equality operator.
+        /// @relatedalso Velocity
+        constexpr bool operator==(const Velocity& lhs, const Velocity& rhs)
+        {
+            return (lhs.linear == rhs.linear) && (lhs.angular == rhs.angular);
+        }
 
-/// @brief Division assignment operator.
-/// @relatedalso Velocity
-constexpr Velocity& operator/= (Velocity& lhs, const Real rhs)
-{
-    lhs.linear /= rhs;
-    lhs.angular /= rhs;
-    return lhs;
-}
+        /// @brief Inequality operator.
+        /// @relatedalso Velocity
+        constexpr bool operator!=(const Velocity& lhs, const Velocity& rhs)
+        {
+            return (lhs.linear != rhs.linear) || (lhs.angular != rhs.angular);
+        }
 
-/// @brief Addition assignment operator.
-/// @relatedalso Velocity
-constexpr Velocity& operator+= (Velocity& lhs, const Velocity& rhs)
-{
-    lhs.linear += rhs.linear;
-    lhs.angular += rhs.angular;
-    return lhs;
-}
+        /// @brief Multiplication assignment operator.
+        /// @relatedalso Velocity
+        constexpr Velocity& operator*=(Velocity& lhs, const Real rhs)
+        {
+            lhs.linear *= rhs;
+            lhs.angular *= rhs;
+            return lhs;
+        }
 
-/// @brief Addition operator.
-/// @relatedalso Velocity
-constexpr Velocity operator+ (const Velocity& lhs, const Velocity& rhs)
-{
-    return Velocity{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
-}
+        /// @brief Division assignment operator.
+        /// @relatedalso Velocity
+        constexpr Velocity& operator/=(Velocity& lhs, const Real rhs)
+        {
+            lhs.linear /= rhs;
+            lhs.angular /= rhs;
+            return lhs;
+        }
 
-/// @brief Subtraction assignment operator.
-/// @relatedalso Velocity
-constexpr Velocity& operator-= (Velocity& lhs, const Velocity& rhs)
-{
-    lhs.linear -= rhs.linear;
-    lhs.angular -= rhs.angular;
-    return lhs;
-}
+        /// @brief Addition assignment operator.
+        /// @relatedalso Velocity
+        constexpr Velocity& operator+=(Velocity& lhs, const Velocity& rhs)
+        {
+            lhs.linear += rhs.linear;
+            lhs.angular += rhs.angular;
+            return lhs;
+        }
 
-/// @brief Subtraction operator.
-/// @relatedalso Velocity
-constexpr Velocity operator- (const Velocity& lhs, const Velocity& rhs)
-{
-    return Velocity{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
-}
+        /// @brief Addition operator.
+        /// @relatedalso Velocity
+        constexpr Velocity operator+(const Velocity& lhs, const Velocity& rhs)
+        {
+            return Velocity{lhs.linear + rhs.linear, lhs.angular + rhs.angular};
+        }
 
-/// @brief Negation operator.
-/// @relatedalso Velocity
-constexpr Velocity operator- (const Velocity& value)
-{
-    return Velocity{-value.linear, -value.angular};
-}
+        /// @brief Subtraction assignment operator.
+        /// @relatedalso Velocity
+        constexpr Velocity& operator-=(Velocity& lhs, const Velocity& rhs)
+        {
+            lhs.linear -= rhs.linear;
+            lhs.angular -= rhs.angular;
+            return lhs;
+        }
 
-/// @brief Positive operator.
-/// @relatedalso Velocity
-constexpr Velocity operator+ (const Velocity& value)
-{
-    return value;
-}
+        /// @brief Subtraction operator.
+        /// @relatedalso Velocity
+        constexpr Velocity operator-(const Velocity& lhs, const Velocity& rhs)
+        {
+            return Velocity{lhs.linear - rhs.linear, lhs.angular - rhs.angular};
+        }
 
-/// @brief Multiplication operator.
-/// @relatedalso Velocity
-constexpr Velocity operator* (const Velocity& lhs, const Real rhs)
-{
-    return Velocity{lhs.linear * rhs, lhs.angular * rhs};
-}
+        /// @brief Negation operator.
+        /// @relatedalso Velocity
+        constexpr Velocity operator-(const Velocity& value)
+        {
+            return Velocity{-value.linear, -value.angular};
+        }
 
-/// @brief Multiplication operator.
-/// @relatedalso Velocity
-constexpr Velocity operator* (const Real lhs, const Velocity& rhs)
-{
-    return Velocity{rhs.linear * lhs, rhs.angular * lhs};
-}
+        /// @brief Positive operator.
+        /// @relatedalso Velocity
+        constexpr Velocity operator+(const Velocity& value)
+        {
+            return value;
+        }
 
-/// @brief Division operator.
-/// @relatedalso Velocity
-constexpr Velocity operator/ (const Velocity& lhs, const Real rhs)
-{
-    const auto inverseRhs = Real{1} / rhs;
-    return Velocity{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
-}
+        /// @brief Multiplication operator.
+        /// @relatedalso Velocity
+        constexpr Velocity operator*(const Velocity& lhs, const Real rhs)
+        {
+            return Velocity{lhs.linear * rhs, lhs.angular * rhs};
+        }
 
-/// @brief Velocity pair.
-using VelocityPair = std::pair<Velocity, Velocity>;
-    
-/// @brief Calculates the "warm start" velocity deltas for the given velocity constraint.
-VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc);
+        /// @brief Multiplication operator.
+        /// @relatedalso Velocity
+        constexpr Velocity operator*(const Real lhs, const Velocity& rhs)
+        {
+            return Velocity{rhs.linear * lhs, rhs.angular * lhs};
+        }
 
-} // namespace d2
+        /// @brief Division operator.
+        /// @relatedalso Velocity
+        constexpr Velocity operator/(const Velocity& lhs, const Real rhs)
+        {
+            const auto inverseRhs = Real{1} / rhs;
+            return Velocity{lhs.linear * inverseRhs, lhs.angular * inverseRhs};
+        }
 
-/// @brief Determines if the given value is valid.
-/// @relatedalso d2::Velocity
-template <>
-constexpr bool IsValid(const d2::Velocity& value) noexcept
-{
-    return IsValid(value.linear) && IsValid(value.angular);
-}
+        /// @brief Velocity pair.
+        using VelocityPair = std::pair<Velocity, Velocity>;
 
-} // namespace playrho
+        /// @brief Calculates the "warm start" velocity deltas for the given velocity constraint.
+        VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc);
 
-#endif // PLAYRHO_COMMON_VELOCITY_HPP
+    }// namespace d2
+
+    /// @brief Determines if the given value is valid.
+    /// @relatedalso d2::Velocity
+    template<>
+    constexpr bool IsValid(const d2::Velocity& value) noexcept
+    {
+        return IsValid(value.linear) && IsValid(value.angular);
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_VELOCITY_HPP

--- a/PlayRho/Common/Version.cpp
+++ b/PlayRho/Common/Version.cpp
@@ -19,22 +19,23 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Common/Version.hpp>
-#include <PlayRho/Common/TypeInfo.hpp> // for GetTypeName
 #include <PlayRho/Common/Real.hpp>
+#include <PlayRho/Common/TypeInfo.hpp>// for GetTypeName
+#include <PlayRho/Common/Version.hpp>
 
-#include <cstdio>
 #include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 #include <sstream>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     Version GetVersion() noexcept
     {
         return Version{0, 10, 0};
     }
-    
+
     std::string GetBuildDetails() noexcept
     {
         std::stringstream stream;
@@ -47,5 +48,5 @@ namespace playrho {
         stream << ", Real='" << GetTypeName<Real>() << "'";
         return stream.str();
     }
-        
-} // namespace playrho
+
+}// namespace playrho

--- a/PlayRho/Common/Version.hpp
+++ b/PlayRho/Common/Version.hpp
@@ -27,8 +27,9 @@
 #include <cstdint>
 #include <string>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     /// @brief Version numbering scheme.
     /// @details Version class for numbering the PlayRho library releases. Follows
     ///   Semantic Versioning 2.0.0.
@@ -38,7 +39,7 @@ namespace playrho {
     {
         /// @brief Revision number type.
         using Revnum = std::int32_t;
-        
+
         /// @brief Major version number.
         /// @details Changed to represent significant changes. Specifically this field
         ///   is incremented when backwards incompatible changes are introduced to the
@@ -46,38 +47,38 @@ namespace playrho {
         ///   is incremented.
         /// @note Started at 0.
         Revnum major;
-        
+
         /// @brief Minor version number.
         /// @details Changed to represent incremental changes. Specifically this field
         ///   is incremented when new, backwards compatible functionality is introduced
         ///   to the public API, or when any public API functionality is marked as
         ///   deprecated.
         Revnum minor;
-        
+
         /// @brief Revision version number.
         /// @details Changed to represent bug fixes.
         /// @note Also known as the patch version.
         Revnum revision;
     };
-    
+
     /// @brief Equality operator.
-    constexpr bool operator== (Version lhs, Version rhs)
+    constexpr bool operator==(Version lhs, Version rhs)
     {
         return lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.revision == rhs.revision;
     }
-    
+
     /// @brief Inequality operator.
-    constexpr bool operator!= (Version lhs, Version rhs)
+    constexpr bool operator!=(Version lhs, Version rhs)
     {
         return !(lhs == rhs);
     }
-    
+
     /// @brief Gets the version information of the library.
     Version GetVersion() noexcept;
-    
+
     /// @brief Gets the build details of the library.
     std::string GetBuildDetails() noexcept;
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_VERSION_HPP
+#endif// PLAYRHO_COMMON_VERSION_HPP

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -21,97 +21,110 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-#include <vector>
 #include <algorithm>
+#include <vector>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Vertex Set.
-///
-/// @details This is a container that enforces the invariant that no two
-/// vertices can be closer together than the minimum separation distance.
-///
-class VertexSet
+namespace playrho
 {
-public:
-    
-    /// @brief Constant pointer type.
-    using const_pointer = const Length2*;
-
-    /// @brief Gets the default minimum separation squared value.
-    static Area GetDefaultMinSeparationSquared()
+    namespace d2
     {
-        return sqrt(std::numeric_limits<Vec2::value_type>::min()) * SquareMeter;
-    }
-    
-    /// @brief Initializing constructor.
-    explicit VertexSet(Area minSepSquared = GetDefaultMinSeparationSquared()):
-        m_minSepSquared{minSepSquared}
-    {
-        assert(minSepSquared >= 0_m2);
-    }
 
-    /// @brief Gets the min separation squared.
-    Area GetMinSeparationSquared() const noexcept { return m_minSepSquared; }
-
-    /// @brief Adds the given vertex into the set if allowed.
-    bool add(Length2 value)
-    {
-        if (find(value) != end())
+        /// @brief Vertex Set.
+        ///
+        /// @details This is a container that enforces the invariant that no two
+        /// vertices can be closer together than the minimum separation distance.
+        ///
+        class VertexSet
         {
-            return false;
-        }
-        m_elements.push_back(value);
-        return true;
-    }
-    
-    /// @brief Clear this set.
-    void clear() noexcept
-    {
-        m_elements.clear();
-    }
+         public:
+            /// @brief Constant pointer type.
+            using const_pointer = const Length2*;
 
-    /// @brief Gets the current size of this set.
-    std::size_t size() const noexcept
-    {
-        return detail::Size(m_elements);
-    }
-    
-    /// @brief Gets the pointer to the data buffer.
-    const_pointer data() const { return detail::Data(m_elements); }
-    
-    /// @brief Gets the "begin" iterator value.
-    const_pointer begin() const { return data(); }
-    
-    /// @brief Gets the "end" iterator value.
-    const_pointer end() const { return data() + size(); }
+            /// @brief Gets the default minimum separation squared value.
+            static Area GetDefaultMinSeparationSquared()
+            {
+                return sqrt(std::numeric_limits<Vec2::value_type>::min()) * SquareMeter;
+            }
 
-    /// Finds contained point whose delta with the given point has a squared length less
-    /// than or equal to this set's minimum length squared value.
-    const_pointer find(Length2 value) const
-    {
-        // squaring anything smaller than the sqrt(std::numeric_limits<Vec2::data_type>::min())
-        // won't be reversible.
-        // i.e. won't obey the property that square(sqrt(a)) == a and sqrt(square(a)) == a.
-        return std::find_if(begin(), end(), [&](Length2 elem) {
-            // length squared must be large enough to have a reasonable enough unit vector.
-            return GetMagnitudeSquared(value - elem) <= m_minSepSquared;
-        });
-    }
+            /// @brief Initializing constructor.
+            explicit VertexSet(Area minSepSquared = GetDefaultMinSeparationSquared())
+                : m_minSepSquared{minSepSquared}
+            {
+                assert(minSepSquared >= 0_m2);
+            }
 
-    /// @brief Indexed access.
-    Length2 operator[](std::size_t index) const noexcept
-    {
-        return m_elements[index];
-    }
+            /// @brief Gets the min separation squared.
+            Area GetMinSeparationSquared() const noexcept
+            {
+                return m_minSepSquared;
+            }
 
-private:
-    std::vector<Length2> m_elements; ///< Elements.
-    const Area m_minSepSquared; ///< Minimum length squared. <code>sizeof(Vec2)/2</code> or 4-bytes.
-};
+            /// @brief Adds the given vertex into the set if allowed.
+            bool add(Length2 value)
+            {
+                if (find(value) != end())
+                {
+                    return false;
+                }
+                m_elements.push_back(value);
+                return true;
+            }
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Clear this set.
+            void clear() noexcept
+            {
+                m_elements.clear();
+            }
 
-#endif // PLAYRHO_COMMON_VERTEXSET_HPP
+            /// @brief Gets the current size of this set.
+            std::size_t size() const noexcept
+            {
+                return detail::Size(m_elements);
+            }
+
+            /// @brief Gets the pointer to the data buffer.
+            const_pointer data() const
+            {
+                return detail::Data(m_elements);
+            }
+
+            /// @brief Gets the "begin" iterator value.
+            const_pointer begin() const
+            {
+                return data();
+            }
+
+            /// @brief Gets the "end" iterator value.
+            const_pointer end() const
+            {
+                return data() + size();
+            }
+
+            /// Finds contained point whose delta with the given point has a squared length less
+            /// than or equal to this set's minimum length squared value.
+            const_pointer find(Length2 value) const
+            {
+                // squaring anything smaller than the sqrt(std::numeric_limits<Vec2::data_type>::min())
+                // won't be reversible.
+                // i.e. won't obey the property that square(sqrt(a)) == a and sqrt(square(a)) == a.
+                return std::find_if(begin(), end(), [&](Length2 elem) {
+                    // length squared must be large enough to have a reasonable enough unit vector.
+                    return GetMagnitudeSquared(value - elem) <= m_minSepSquared;
+                });
+            }
+
+            /// @brief Indexed access.
+            Length2 operator[](std::size_t index) const noexcept
+            {
+                return m_elements[index];
+            }
+
+         private:
+            std::vector<Length2> m_elements;///< Elements.
+            const Area m_minSepSquared;     ///< Minimum length squared. <code>sizeof(Vec2)/2</code> or 4-bytes.
+        };
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_COMMON_VERTEXSET_HPP

--- a/PlayRho/Common/Wider.hpp
+++ b/PlayRho/Common/Wider.hpp
@@ -108,4 +108,4 @@ template <> struct make_unsigned<PLAYRHO_INT128> {
 
 // clang-format on
 
-#endif // PLAYRHO_COMMON_WIDER_HPP
+#endif// PLAYRHO_COMMON_WIDER_HPP

--- a/PlayRho/Common/WrongState.hpp
+++ b/PlayRho/Common/WrongState.hpp
@@ -23,18 +23,19 @@
 
 #include <stdexcept>
 
-namespace playrho {
+namespace playrho
+{
 
     /// @brief Wrong state logic error.
     /// @details Indicates that a method was called on an object in the wrong state for
     ///   its operation.
     /// @ingroup ExceptionsGroup
-    class WrongState: public std::logic_error
+    class WrongState : public std::logic_error
     {
-    public:
+     public:
         using std::logic_error::logic_error;
     };
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_COMMON_WRONGSTATE_HPP
+#endif// PLAYRHO_COMMON_WRONGSTATE_HPP

--- a/PlayRho/Common/propagate_const.hpp
+++ b/PlayRho/Common/propagate_const.hpp
@@ -32,7 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #ifndef _MSC_VER
 #define PROPAGATE_CONST_CONSTEXPR constexpr
 #else
-#if _MSC_VER <= 1900 // MSVS 2015 and earlier
+#if _MSC_VER <= 1900// MSVS 2015 and earlier
 #define PROPAGATE_CONST_CONSTEXPR
 #define PROPAGATE_CONST_HAS_NO_EXPRESSION_SFINAE
 #else
@@ -40,470 +40,545 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #endif
 #endif
 
-namespace playrho {
+namespace playrho
+{
 
-/// @brief Constant propagating template wrapper type.
-template <class T>
-class propagate_const {
- public:
-     
- /// @brief Element type detecting trait.
- template<class U>
- struct detect_element_type {
-   /// @brief Detected element type alias.
-   using type = typename U::element_type;
- };
+    /// @brief Constant propagating template wrapper type.
+    template<class T>
+    class propagate_const
+    {
+     public:
+        /// @brief Element type detecting trait.
+        template<class U>
+        struct detect_element_type
+        {
+            /// @brief Detected element type alias.
+            using type = typename U::element_type;
+        };
 
- /// @brief Element type detecting trait.
- template<class U>
- struct detect_element_type<U*> {
-   /// @brief Detected element type alias.
-   using type = U;
- };
+        /// @brief Element type detecting trait.
+        template<class U>
+        struct detect_element_type<U*>
+        {
+            /// @brief Detected element type alias.
+            using type = U;
+        };
 
- /// @brief Element type alias.
- using element_type = typename detect_element_type<T>::type;
+        /// @brief Element type alias.
+        using element_type = typename detect_element_type<T>::type;
 
- private:
-  /// @brief Gets pointer.
-  template <class U>
-  static element_type* get_pointer(U* u) {
-    return u;
-  }
+     private:
+        /// @brief Gets pointer.
+        template<class U>
+        static element_type* get_pointer(U* u)
+        {
+            return u;
+        }
 
-  /// @brief Gets pointer.
-  template <class U>
-  static element_type* get_pointer(U& u) {
-    return get_pointer(u.get());
-  }
+        /// @brief Gets pointer.
+        template<class U>
+        static element_type* get_pointer(U& u)
+        {
+            return get_pointer(u.get());
+        }
 
-  /// @brief Gets pointer.
-  template <class U>
-  static const element_type* get_pointer(const U* u) {
-    return u;
-  }
+        /// @brief Gets pointer.
+        template<class U>
+        static const element_type* get_pointer(const U* u)
+        {
+            return u;
+        }
 
-  /// @brief Gets pointer.
-  template <class U>
-  static const element_type* get_pointer(const U& u) {
-    return get_pointer(u.get());
-  }
+        /// @brief Gets pointer.
+        template<class U>
+        static const element_type* get_pointer(const U& u)
+        {
+            return get_pointer(u.get());
+        }
 
-  /// @brief Trait for detecting that the given type is not this one.
-  template <class U>
-  struct is_propagate_const : ::std::false_type {};
+        /// @brief Trait for detecting that the given type is not this one.
+        template<class U>
+        struct is_propagate_const : ::std::false_type
+        {
+        };
 
-  /// @brief Trait for detecting that the given type is this one.
-  template <class U>
-  struct is_propagate_const<propagate_const<U>> : ::std::true_type {};
+        /// @brief Trait for detecting that the given type is this one.
+        template<class U>
+        struct is_propagate_const<propagate_const<U>> : ::std::true_type
+        {
+        };
 
- public:
-  // [propagate_const.ctor], constructors
-  /// @brief Default constructor.
-  PROPAGATE_CONST_CONSTEXPR propagate_const() = default;
+     public:
+        // [propagate_const.ctor], constructors
+        /// @brief Default constructor.
+        PROPAGATE_CONST_CONSTEXPR propagate_const() = default;
 
-  /// @brief Explicityly deleted copy constructor.
-  propagate_const(const propagate_const& p) = delete;
+        /// @brief Explicityly deleted copy constructor.
+        propagate_const(const propagate_const& p) = delete;
 
-  /// @brief Move constructor.
-  PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const&& p) = default;
+        /// @brief Move constructor.
+        PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const&& p) = default;
 
 #ifdef PROPAGATE_CONST_HAS_NO_EXPRESSION_SFINAE
-  //
-  // Make converting constructors explicit as we cannot use SFINAE to check.
-  //
+        //
+        // Make converting constructors explicit as we cannot use SFINAE to check.
+        //
 
-  template <class U, class = std::enable_if_t<is_constructible<T, U&&>::value>>
-  explicit PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const<U>&& pu)
-      : t_(std::move(pu.t_))
-  {
-  }
+        template<class U, class = std::enable_if_t<is_constructible<T, U&&>::value>>
+        explicit PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const<U>&& pu)
+            : t_(std::move(pu.t_))
+        {
+        }
 
-  template <class U,
-            class = std::enable_if_t<is_constructible<T, U&&>::value &&
-                                !is_propagate_const<std::decay_t<U>>::value>>
-  explicit PROPAGATE_CONST_CONSTEXPR propagate_const(U&& u)
-      : t_(std::forward<U>(u))
-  {
-  }
+        template<class U,
+                 class = std::enable_if_t<is_constructible<T, U&&>::value && !is_propagate_const<std::decay_t<U>>::value>>
+        explicit PROPAGATE_CONST_CONSTEXPR propagate_const(U&& u)
+            : t_(std::forward<U>(u))
+        {
+        }
 #else
-  //
-  // Use SFINAE to check if converting constructor should be explicit.
-  //
+        //
+        // Use SFINAE to check if converting constructor should be explicit.
+        //
 
-  /// @brief Move constructor.
-  template <class U, std::enable_if_t<!std::is_convertible<U&&, T>::value &&
-                                     std::is_constructible<T, U&&>::value,
-                                 bool> = true>
-  explicit PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const<U>&& pu)
-      : t_(std::move(pu.t_)) {}
+        /// @brief Move constructor.
+        template<class U, std::enable_if_t<!std::is_convertible<U&&, T>::value && std::is_constructible<T, U&&>::value,
+                                           bool> = true>
+        explicit PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const<U>&& pu)
+            : t_(std::move(pu.t_))
+        {
+        }
 
-  /// @brief Move constructor.
-  template <class U, std::enable_if_t<std::is_convertible<U&&, T>::value &&
-                                     std::is_constructible<T, U&&>::value,
-                                 bool> = false>
-  PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const<U>&& pu) : t_(std::move(pu.t_)) {}
+        /// @brief Move constructor.
+        template<class U, std::enable_if_t<std::is_convertible<U&&, T>::value && std::is_constructible<T, U&&>::value,
+                                           bool> = false>
+        PROPAGATE_CONST_CONSTEXPR propagate_const(propagate_const<U>&& pu)
+            : t_(std::move(pu.t_))
+        {
+        }
 
-  /// @brief Move constructor.
-  template <class U, std::enable_if_t<!std::is_convertible<U&&, T>::value &&
-                                     std::is_constructible<T, U&&>::value &&
-                                     !is_propagate_const<std::decay_t<U>>::value,
-                                 bool> = true>
-  explicit PROPAGATE_CONST_CONSTEXPR propagate_const(U&& u) : t_(std::forward<U>(u)) {}
+        /// @brief Move constructor.
+        template<class U, std::enable_if_t<!std::is_convertible<U&&, T>::value && std::is_constructible<T, U&&>::value && !is_propagate_const<std::decay_t<U>>::value,
+                                           bool> = true>
+        explicit PROPAGATE_CONST_CONSTEXPR propagate_const(U&& u)
+            : t_(std::forward<U>(u))
+        {
+        }
 
-  /// @brief Move constructor.
-  template <class U, std::enable_if_t<std::is_convertible<U&&, T>::value &&
-                                     std::is_constructible<T, U&&>::value &&
-                                     !is_propagate_const<std::decay_t<U>>::value,
-                                 bool> = false>
-  PROPAGATE_CONST_CONSTEXPR propagate_const(U&& u) : t_(std::forward<U>(u)) {}
+        /// @brief Move constructor.
+        template<class U, std::enable_if_t<std::is_convertible<U&&, T>::value && std::is_constructible<T, U&&>::value && !is_propagate_const<std::decay_t<U>>::value,
+                                           bool> = false>
+        PROPAGATE_CONST_CONSTEXPR propagate_const(U&& u)
+            : t_(std::forward<U>(u))
+        {
+        }
 #endif
 
-  // [propagate_const.assignment], assignment
-  /// @brief Explicitly deleted copy assignment.
-  propagate_const& operator=(const propagate_const& p) = delete;
+        // [propagate_const.assignment], assignment
+        /// @brief Explicitly deleted copy assignment.
+        propagate_const& operator=(const propagate_const& p) = delete;
 
-  /// @brief Move assignment operator.
-  PROPAGATE_CONST_CONSTEXPR propagate_const& operator=(propagate_const&& p) = default;
+        /// @brief Move assignment operator.
+        PROPAGATE_CONST_CONSTEXPR propagate_const& operator=(propagate_const&& p) = default;
 
-  /// @brief Move assignment operator for compatible <code>propagate_const</code> types.
-  template <class U>
-  PROPAGATE_CONST_CONSTEXPR propagate_const& operator=(propagate_const<U>&& pu) {
-    t_ = std::move(pu.t_);
-    return *this;
-  }
+        /// @brief Move assignment operator for compatible <code>propagate_const</code> types.
+        template<class U>
+        PROPAGATE_CONST_CONSTEXPR propagate_const& operator=(propagate_const<U>&& pu)
+        {
+            t_ = std::move(pu.t_);
+            return *this;
+        }
 
-  /// @brief Move assignment operator for compatible types.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  PROPAGATE_CONST_CONSTEXPR propagate_const& operator=(U&& u) {
-    t_ = std::move(u);
-    return *this;
-  }
+        /// @brief Move assignment operator for compatible types.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        PROPAGATE_CONST_CONSTEXPR propagate_const& operator=(U&& u)
+        {
+            t_ = std::move(u);
+            return *this;
+        }
 
-  // [propagate_const.const_observers], const observers
-  /// @brief Boolean observer operator.
-  explicit PROPAGATE_CONST_CONSTEXPR operator bool() const { return get() != nullptr; }
+        // [propagate_const.const_observers], const observers
+        /// @brief Boolean observer operator.
+        explicit PROPAGATE_CONST_CONSTEXPR operator bool() const
+        {
+            return get() != nullptr;
+        }
 
-  /// @brief Member-of operator support.
-  PROPAGATE_CONST_CONSTEXPR const element_type* operator->() const { return get(); }
+        /// @brief Member-of operator support.
+        PROPAGATE_CONST_CONSTEXPR const element_type* operator->() const
+        {
+            return get();
+        }
 
-  /// @brief Const-conversion operator support.
-  template <class T_ = T, class U = std::enable_if_t<std::is_convertible<
-                              const T_, const element_type*>::value>>
-  PROPAGATE_CONST_CONSTEXPR operator const element_type*() const  // Not always defined
-  {
-    return get();
-  }
+        /// @brief Const-conversion operator support.
+        template<class T_ = T, class U = std::enable_if_t<std::is_convertible<
+                                   const T_, const element_type*>::value>>
+        PROPAGATE_CONST_CONSTEXPR operator const element_type*() const// Not always defined
+        {
+            return get();
+        }
 
-  /// @brief Indirection operator support.
-  PROPAGATE_CONST_CONSTEXPR const element_type& operator*() const { return *get(); }
+        /// @brief Indirection operator support.
+        PROPAGATE_CONST_CONSTEXPR const element_type& operator*() const
+        {
+            return *get();
+        }
 
-  /// @brief Gets pointer content.
-  PROPAGATE_CONST_CONSTEXPR const element_type* get() const { return get_pointer(t_); }
+        /// @brief Gets pointer content.
+        PROPAGATE_CONST_CONSTEXPR const element_type* get() const
+        {
+            return get_pointer(t_);
+        }
 
-  // [propagate_const.non_const_observers], non-const observers
-  /// @brief Member-of operator support.
-  PROPAGATE_CONST_CONSTEXPR element_type* operator->() { return get(); }
+        // [propagate_const.non_const_observers], non-const observers
+        /// @brief Member-of operator support.
+        PROPAGATE_CONST_CONSTEXPR element_type* operator->()
+        {
+            return get();
+        }
 
-  /// @brief Indirection operator support.
-  template <class T_ = T,
-            class U = std::enable_if_t<std::is_convertible<T_, element_type*>::value>>
-  PROPAGATE_CONST_CONSTEXPR operator element_type*()  // Not always defined
-  {
-    return get();
-  }
+        /// @brief Indirection operator support.
+        template<class T_ = T,
+                 class U = std::enable_if_t<std::is_convertible<T_, element_type*>::value>>
+        PROPAGATE_CONST_CONSTEXPR operator element_type*()// Not always defined
+        {
+            return get();
+        }
 
-  /// @brief Indirection operator support.
-  PROPAGATE_CONST_CONSTEXPR element_type& operator*() { return *get(); }
+        /// @brief Indirection operator support.
+        PROPAGATE_CONST_CONSTEXPR element_type& operator*()
+        {
+            return *get();
+        }
 
-  /// @brief Gets pointer content.
-  PROPAGATE_CONST_CONSTEXPR element_type* get() { return get_pointer(t_); }
-  
-  // [propagate_const.modifiers], modifiers
-  /// @brief Swap support.
-  PROPAGATE_CONST_CONSTEXPR void swap(propagate_const& pt) noexcept(
-      noexcept(swap(std::declval<T&>(), std::declval<T&>()))) {
-    swap(t_, pt.t_);
-  }
+        /// @brief Gets pointer content.
+        PROPAGATE_CONST_CONSTEXPR element_type* get()
+        {
+            return get_pointer(t_);
+        }
 
- private:
-  T t_; ///< Underlying data.
+        // [propagate_const.modifiers], modifiers
+        /// @brief Swap support.
+        PROPAGATE_CONST_CONSTEXPR void swap(propagate_const& pt) noexcept(
+            noexcept(swap(std::declval<T&>(), std::declval<T&>())))
+        {
+            swap(t_, pt.t_);
+        }
 
-  friend struct std::hash<propagate_const<T>>;
-  friend struct std::equal_to<propagate_const<T>>;
-  friend struct std::not_equal_to<propagate_const<T>>;
-  friend struct std::greater<propagate_const<T>>;
-  friend struct std::less<propagate_const<T>>;
-  friend struct std::greater_equal<propagate_const<T>>;
-  friend struct std::less_equal<propagate_const<T>>;
+     private:
+        T t_;///< Underlying data.
 
-  // [propagate_const.relational], relational operators
+        friend struct std::hash<propagate_const<T>>;
+        friend struct std::equal_to<propagate_const<T>>;
+        friend struct std::not_equal_to<propagate_const<T>>;
+        friend struct std::greater<propagate_const<T>>;
+        friend struct std::less<propagate_const<T>>;
+        friend struct std::greater_equal<propagate_const<T>>;
+        friend struct std::less_equal<propagate_const<T>>;
 
-  /// @brief Equals operator.
-  friend PROPAGATE_CONST_CONSTEXPR bool operator==(const propagate_const& pt, std::nullptr_t) {
-    return pt.t_ == nullptr;
-  }
+        // [propagate_const.relational], relational operators
 
-  /// @brief Equals operator.
-  friend PROPAGATE_CONST_CONSTEXPR bool operator==(std::nullptr_t, const propagate_const& pu) {
-    return nullptr == pu.t_;
-  }
+        /// @brief Equals operator.
+        friend PROPAGATE_CONST_CONSTEXPR bool operator==(const propagate_const& pt, std::nullptr_t)
+        {
+            return pt.t_ == nullptr;
+        }
 
-  /// @brief Not-equals operator.
-  friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const propagate_const& pt, std::nullptr_t) {
-    return pt.t_ != nullptr;
-  }
+        /// @brief Equals operator.
+        friend PROPAGATE_CONST_CONSTEXPR bool operator==(std::nullptr_t, const propagate_const& pu)
+        {
+            return nullptr == pu.t_;
+        }
 
-  /// @brief Not-equals operator.
-  friend PROPAGATE_CONST_CONSTEXPR bool operator!=(std::nullptr_t, const propagate_const& pu) {
-    return nullptr != pu.t_;
-  }
+        /// @brief Not-equals operator.
+        friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const propagate_const& pt, std::nullptr_t)
+        {
+            return pt.t_ != nullptr;
+        }
 
-  /// @brief Equals operator.
-  template <class U>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator==(const propagate_const& pt,
-                                   const propagate_const<U>& pu) {
-    return pt.t_ == pu.t_;
-  }
+        /// @brief Not-equals operator.
+        friend PROPAGATE_CONST_CONSTEXPR bool operator!=(std::nullptr_t, const propagate_const& pu)
+        {
+            return nullptr != pu.t_;
+        }
 
-  /// @brief Not-equals operator.
-  template <class U>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const propagate_const& pt,
-                                   const propagate_const<U>& pu) {
-    return pt.t_ != pu.t_;
-  }
+        /// @brief Equals operator.
+        template<class U>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator==(const propagate_const& pt,
+                                                         const propagate_const<U>& pu)
+        {
+            return pt.t_ == pu.t_;
+        }
 
-  /// @brief Less-than operator.
-  template <class U>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator<(const propagate_const& pt,
-                                  const propagate_const<U>& pu) {
-    return pt.t_ < pu.t_;
-  }
+        /// @brief Not-equals operator.
+        template<class U>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const propagate_const& pt,
+                                                         const propagate_const<U>& pu)
+        {
+            return pt.t_ != pu.t_;
+        }
 
-  /// @brief Greater-than operator.
-  template <class U>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator>(const propagate_const& pt,
-                                  const propagate_const<U>& pu) {
-    return pt.t_ > pu.t_;
-  }
+        /// @brief Less-than operator.
+        template<class U>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator<(const propagate_const& pt,
+                                                        const propagate_const<U>& pu)
+        {
+            return pt.t_ < pu.t_;
+        }
 
-  /// @brief Less-than or equal-to operator.
-  template <class U>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator<=(const propagate_const& pt,
-                                   const propagate_const<U>& pu) {
-    return pt.t_ <= pu.t_;
-  }
+        /// @brief Greater-than operator.
+        template<class U>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator>(const propagate_const& pt,
+                                                        const propagate_const<U>& pu)
+        {
+            return pt.t_ > pu.t_;
+        }
 
-  /// @brief Greater-than or equal-to operator.
-  template <class U>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator>=(const propagate_const& pt,
-                                   const propagate_const<U>& pu) {
-    return pt.t_ >= pu.t_;
-  }
+        /// @brief Less-than or equal-to operator.
+        template<class U>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator<=(const propagate_const& pt,
+                                                         const propagate_const<U>& pu)
+        {
+            return pt.t_ <= pu.t_;
+        }
 
-  /// @brief Equals operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator==(const propagate_const& pt, const U& u) {
-    return pt.t_ == u;
-  }
+        /// @brief Greater-than or equal-to operator.
+        template<class U>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator>=(const propagate_const& pt,
+                                                         const propagate_const<U>& pu)
+        {
+            return pt.t_ >= pu.t_;
+        }
 
-  /// @brief Not-equals operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const propagate_const& pt, const U& u) {
-    return pt.t_ != u;
-  }
+        /// @brief Equals operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator==(const propagate_const& pt, const U& u)
+        {
+            return pt.t_ == u;
+        }
 
-  /// @brief Less-than operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator<(const propagate_const& pt, const U& u) {
-    return pt.t_ < u;
-  }
+        /// @brief Not-equals operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const propagate_const& pt, const U& u)
+        {
+            return pt.t_ != u;
+        }
 
-  /// @brief Greater-than operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator>(const propagate_const& pt, const U& u) {
-    return pt.t_ > u;
-  }
+        /// @brief Less-than operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator<(const propagate_const& pt, const U& u)
+        {
+            return pt.t_ < u;
+        }
 
-  /// @brief Less-than or equal-to operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator<=(const propagate_const& pt, const U& u) {
-    return pt.t_ <= u;
-  }
+        /// @brief Greater-than operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator>(const propagate_const& pt, const U& u)
+        {
+            return pt.t_ > u;
+        }
 
-  /// @brief Greater-than or equal-to operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator>=(const propagate_const& pt, const U& u) {
-    return pt.t_ >= u;
-  }
+        /// @brief Less-than or equal-to operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator<=(const propagate_const& pt, const U& u)
+        {
+            return pt.t_ <= u;
+        }
 
-  /// @brief Equals operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator==(const U& u, const propagate_const& pu) {
-    return u == pu.t_;
-  }
+        /// @brief Greater-than or equal-to operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator>=(const propagate_const& pt, const U& u)
+        {
+            return pt.t_ >= u;
+        }
 
-  /// @brief Not-equals operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const U& u, const propagate_const& pu) {
-    return u != pu.t_;
-  }
+        /// @brief Equals operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator==(const U& u, const propagate_const& pu)
+        {
+            return u == pu.t_;
+        }
 
-  /// @brief Less-than operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator<(const U& u, const propagate_const& pu) {
-    return u < pu.t_;
-  }
+        /// @brief Not-equals operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator!=(const U& u, const propagate_const& pu)
+        {
+            return u != pu.t_;
+        }
 
-  /// @brief Greater-than operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator>(const U& u, const propagate_const& pu) {
-    return u > pu.t_;
-  }
+        /// @brief Less-than operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator<(const U& u, const propagate_const& pu)
+        {
+            return u < pu.t_;
+        }
 
-  /// @brief Less-than or equal-to operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator<=(const U& u, const propagate_const& pu) {
-    return u <= pu.t_;
-  }
+        /// @brief Greater-than operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator>(const U& u, const propagate_const& pu)
+        {
+            return u > pu.t_;
+        }
 
-  /// @brief Greater-than or equal-to operator.
-  template <class U,
-            class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
-  friend PROPAGATE_CONST_CONSTEXPR bool operator>=(const U& u, const propagate_const& pu) {
-    return u >= pu.t_;
-  }
-};
+        /// @brief Less-than or equal-to operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator<=(const U& u, const propagate_const& pu)
+        {
+            return u <= pu.t_;
+        }
 
+        /// @brief Greater-than or equal-to operator.
+        template<class U,
+                 class = std::enable_if_t<!is_propagate_const<std::decay_t<U>>::value>>
+        friend PROPAGATE_CONST_CONSTEXPR bool operator>=(const U& u, const propagate_const& pu)
+        {
+            return u >= pu.t_;
+        }
+    };
 
-// [propagate_const.algorithms], specialized algorithms
+    // [propagate_const.algorithms], specialized algorithms
 
-/// @brief Support for swap operation.
-template <class T>
-PROPAGATE_CONST_CONSTEXPR void swap(propagate_const<T>& pt, propagate_const<T>& pu) noexcept(
-    noexcept(swap(std::declval<T&>(), std::declval<T&>())))
+    /// @brief Support for swap operation.
+    template<class T>
+    PROPAGATE_CONST_CONSTEXPR void swap(propagate_const<T>& pt, propagate_const<T>& pu) noexcept(
+        noexcept(swap(std::declval<T&>(), std::declval<T&>())))
+    {
+        swap(pt.underlying_ptr(), pu.underlying_ptr());
+    }
+
+}// end namespace playrho
+
+namespace std
 {
-  swap(pt.underlying_ptr(), pu.underlying_ptr());
-}
 
-}  // end namespace playrho
+    // [propagate_const.hash], hash support
 
-namespace std {
+    /// @brief Support for hash operation.
+    template<class T>
+    struct hash<::playrho::propagate_const<T>>
+    {
+        typedef size_t result_type;                         ///< Result type.
+        typedef ::playrho::propagate_const<T> argument_type;///< Argument type.
 
-// [propagate_const.hash], hash support
+        /// @brief Hash operation functor.
+        bool operator()(
+            const ::playrho::propagate_const<T>& pc) const
+        {
+            return std::hash<T>()(pc.t_);
+        }
+    };
 
-/// @brief Support for hash operation.
-template <class T>
-struct hash<::playrho::propagate_const<T>> {
-  typedef size_t result_type; ///< Result type.
-  typedef ::playrho::propagate_const<T> argument_type; ///< Argument type.
+    // [propagate_const.comparison_function_objects], comparison function objects
 
-  /// @brief Hash operation functor.
-  bool operator()(
-      const ::playrho::propagate_const<T>& pc) const {
-    return std::hash<T>()(pc.t_);
-  }
-};
+    /// @brief Support for equal-to operations.
+    template<class T>
+    struct equal_to<::playrho::propagate_const<T>>
+    {
+        typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
+        typedef ::playrho::propagate_const<T> second_argument_type;///< Second argument type.
 
-// [propagate_const.comparison_function_objects], comparison function objects
+        /// @brief Equal-to operation functor.
+        bool operator()(
+            const ::playrho::propagate_const<T>& pc1,
+            const ::playrho::propagate_const<T>& pc2) const
+        {
+            return std::equal_to<T>()(pc1.t_, pc2.t_);
+        }
+    };
 
-/// @brief Support for equal-to operations.
-template <class T>
-struct equal_to<::playrho::propagate_const<T>> {
-  typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
-  typedef ::playrho::propagate_const<T> second_argument_type; ///< Second argument type.
+    /// @brief Support for not-equal-to operations.
+    template<class T>
+    struct not_equal_to<::playrho::propagate_const<T>>
+    {
+        typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
+        typedef ::playrho::propagate_const<T> second_argument_type;///< Second argument type.
 
-  /// @brief Equal-to operation functor.
-  bool operator()(
-      const ::playrho::propagate_const<T>& pc1,
-      const ::playrho::propagate_const<T>& pc2) const {
-    return std::equal_to<T>()(pc1.t_, pc2.t_);
-  }
-};
+        /// @brief Not-equal-to operation functor.
+        bool operator()(
+            const ::playrho::propagate_const<T>& pc1,
+            const ::playrho::propagate_const<T>& pc2) const
+        {
+            return std::not_equal_to<T>()(pc1.t_, pc2.t_);
+        }
+    };
 
-/// @brief Support for not-equal-to operations.
-template <class T>
-struct not_equal_to<::playrho::propagate_const<T>> {
-  typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
-  typedef ::playrho::propagate_const<T> second_argument_type; ///< Second argument type.
+    /// @brief Support for less than operations.
+    template<class T>
+    struct less<::playrho::propagate_const<T>>
+    {
+        typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
+        typedef ::playrho::propagate_const<T> second_argument_type;///< Second argument type.
 
-  /// @brief Not-equal-to operation functor.
-  bool operator()(
-      const ::playrho::propagate_const<T>& pc1,
-      const ::playrho::propagate_const<T>& pc2) const {
-    return std::not_equal_to<T>()(pc1.t_, pc2.t_);
-  }
-};
+        /// @brief Less-than operation functor.
+        bool operator()(
+            const ::playrho::propagate_const<T>& pc1,
+            const ::playrho::propagate_const<T>& pc2) const
+        {
+            return std::less<T>()(pc1.t_, pc2.t_);
+        }
+    };
 
-/// @brief Support for less than operations.
-template <class T>
-struct less<::playrho::propagate_const<T>> {
-  typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
-  typedef ::playrho::propagate_const<T> second_argument_type; ///< Second argument type.
+    /// @brief Support for greater than operations.
+    template<class T>
+    struct greater<::playrho::propagate_const<T>>
+    {
+        typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
+        typedef ::playrho::propagate_const<T> second_argument_type;///< Second argument type.
 
-  /// @brief Less-than operation functor.
-  bool operator()(
-      const ::playrho::propagate_const<T>& pc1,
-      const ::playrho::propagate_const<T>& pc2) const {
-    return std::less<T>()(pc1.t_, pc2.t_);
-  }
-};
+        /// @brief Greater-than operation functor.
+        bool operator()(
+            const ::playrho::propagate_const<T>& pc1,
+            const ::playrho::propagate_const<T>& pc2) const
+        {
+            return std::greater<T>()(pc1.t_, pc2.t_);
+        }
+    };
 
-/// @brief Support for greater than operations.
-template <class T>
-struct greater<::playrho::propagate_const<T>> {
-  typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
-  typedef ::playrho::propagate_const<T> second_argument_type; ///< Second argument type.
+    /// @brief Support for less than or equal operations.
+    template<class T>
+    struct less_equal<::playrho::propagate_const<T>>
+    {
+        typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
+        typedef ::playrho::propagate_const<T> second_argument_type;///< Second argument type.
 
-  /// @brief Greater-than operation functor.
-  bool operator()(
-      const ::playrho::propagate_const<T>& pc1,
-      const ::playrho::propagate_const<T>& pc2) const {
-    return std::greater<T>()(pc1.t_, pc2.t_);
-  }
-};
+        /// @brief Lesser-than operation functor.
+        bool operator()(
+            const ::playrho::propagate_const<T>& pc1,
+            const ::playrho::propagate_const<T>& pc2) const
+        {
+            return std::less_equal<T>()(pc1.t_, pc2.t_);
+        }
+    };
 
-/// @brief Support for less than or equal operations.
-template <class T>
-struct less_equal<::playrho::propagate_const<T>> {
-  typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
-  typedef ::playrho::propagate_const<T> second_argument_type; ///< Second argument type.
+    /// @brief Support for greater than or equal operations.
+    template<class T>
+    struct greater_equal<::playrho::propagate_const<T>>
+    {
+        typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
+        typedef ::playrho::propagate_const<T> second_argument_type;///< Second argument type.
 
-  /// @brief Lesser-than operation functor.
-  bool operator()(
-      const ::playrho::propagate_const<T>& pc1,
-      const ::playrho::propagate_const<T>& pc2) const {
-    return std::less_equal<T>()(pc1.t_, pc2.t_);
-  }
-};
+        /// @brief Greater-than operation functor.
+        bool operator()(
+            const ::playrho::propagate_const<T>& pc1,
+            const ::playrho::propagate_const<T>& pc2) const
+        {
+            return std::greater_equal<T>()(pc1.t_, pc2.t_);
+        }
+    };
 
-/// @brief Support for greater than or equal operations.
-template <class T>
-struct greater_equal<::playrho::propagate_const<T>> {
-  typedef ::playrho::propagate_const<T> first_argument_type; ///< First argument type.
-  typedef ::playrho::propagate_const<T> second_argument_type; ///< Second argument type.
-
-  /// @brief Greater-than operation functor.
-  bool operator()(
-      const ::playrho::propagate_const<T>& pc1,
-      const ::playrho::propagate_const<T>& pc2) const {
-    return std::greater_equal<T>()(pc1.t_, pc2.t_);
-  }
-};
-
-}  // end namespace playrho
+}// namespace std
 
 #undef PROPAGATE_CONST_CONSTEXPR
-#endif // JBCOE_PROPAGATE_CONST_INCLUDED
+#endif// JBCOE_PROPAGATE_CONST_INCLUDED

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -25,1144 +25,1155 @@
 /// @file
 /// Declarations of the Body class, and free functions associated with it.
 
+#include <PlayRho/Collision/MassData.hpp>
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Common/Range.hpp>
-#include <PlayRho/Dynamics/BodyType.hpp>
 #include <PlayRho/Dynamics/BodyConf.hpp>
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
+#include <PlayRho/Dynamics/BodyType.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
 #include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp>
+#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 #include <PlayRho/Dynamics/MovementConf.hpp>
-#include <PlayRho/Collision/MassData.hpp>
 
-#include <vector>
-#include <memory>
 #include <cassert>
-#include <utility>
+#include <functional>// for std::function
 #include <iterator>
-#include <functional> // for std::function
+#include <memory>
+#include <utility>
+#include <vector>
 
-namespace playrho {
-namespace d2 {
-
-struct FixtureConf;
-class Shape;
-
-/// @brief Physical entity that exists within a World.
-///
-/// @details A rigid body entity created or destroyed through a World instance. These have
-///   physical properties like: position, velocity, acceleration, and mass.
-///
-/// @invariant Only bodies that allow sleeping, can be put to sleep.
-/// @invariant Only "speedable" bodies can be awake.
-/// @invariant Only "speedable" bodies can have non-zero velocities.
-/// @invariant Only "accelerable" bodies can have non-zero accelerations.
-/// @invariant Only "accelerable" bodies can have non-zero "under-active" times.
-///
-/// @note Create these using the <code>World::CreateBody</code> method.
-/// @note Destroy these using the <code>World::Destroy(BodyID)</code> method.
-/// @note From a memory management perspective, bodies own Fixture instances.
-/// @note On a 64-bit architecture with 4-byte Real, this data structure is at least
-///   192-bytes large.
-///
-/// @ingroup PhysicalEntities
-///
-/// @see World, Fixture
-///
-class Body
+namespace playrho
 {
-public:
-    /// @brief Container type for fixtures.
-    using Fixtures = std::vector<FixtureID>;
-
-    /// @brief Keyed joint pointer.
-    using KeyedJointPtr = std::pair<BodyID, JointID>;
-
-    /// @brief Container type for joints.
-    using Joints = std::vector<KeyedJointPtr>;
-
-    /// @brief Container type for contacts.
-    using Contacts = std::vector<KeyedContactPtr>;
-
-    /// @brief Initializing constructor.
-    explicit Body(const BodyConf& bd = GetDefaultBodyConf()) noexcept;
-
-    /// @brief Gets the body transform for the body's origin.
-    /// @return the world transform of the body's origin.
-    /// @see GetLocation, Body::SetTransformation.
-    Transformation GetTransformation() const noexcept;
-
-    /// Sets the body's transformation.
-    /// @note This sets what <code>Body::GetLocation</code> returns.
-    /// @see Body::GetLocation, Body::GetTransformation
-    void SetTransformation(Transformation value) noexcept
+    namespace d2
     {
-        m_xf = value;
-    }
 
-    /// @brief Gets the world body origin location.
-    /// @details This is the location of the body's origin relative to its world.
-    /// The location of the body after stepping the world's physics simulations is dependent on
-    /// a number of factors:
-    ///   1. Location at the last time step.
-    ///   2. Forces acting on the body (gravity, applied force, applied impulse).
-    ///   3. The mass data of the body.
-    ///   4. Damping of the body.
-    ///   5. Restitution and friction values of the body's fixtures when they experience collisions.
-    /// @return World location of the body's origin.
-    /// @see GetTransformation.
-    Length2 GetLocation() const noexcept;
-
-    /// @brief Gets the body's sweep.
-    const Sweep& GetSweep() const noexcept;
-
-    /// @brief Get the angle.
-    /// @return the current world rotation angle.
-    Angle GetAngle() const noexcept;
-
-    /// @brief Get the world position of the center of mass.
-    Length2 GetWorldCenter() const noexcept;
-
-    /// @brief Gets the local position of the center of mass.
-    Length2 GetLocalCenter() const noexcept;
-
-    /// @brief Gets the velocity.
-    Velocity GetVelocity() const noexcept;
-
-    /// @brief Sets the body's velocity (linear and angular velocity).
-    /// @note This method does nothing if this body is not speedable.
-    /// @note A non-zero velocity will awaken this body.
-    /// @see SetAwake, SetUnderActiveTime.
-    void SetVelocity(const Velocity& velocity) noexcept;
-
-    /// Sets the body's velocity.
-    /// @note This sets what <code>Body::GetVelocity</code> returns.
-    /// @see Body::GetVelocity
-    void JustSetVelocity(Velocity value) noexcept
-    {
-        m_linearVelocity = value.linear;
-        m_angularVelocity = value.angular;
-    }
-
-    /// @brief Sets the linear and rotational accelerations on this body.
-    /// @note This has no effect on non-accelerable bodies.
-    /// @note A non-zero acceleration will also awaken the body.
-    /// @param linear Linear acceleration.
-    /// @param angular Angular acceleration.
-    void SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angular) noexcept;
-
-    /// @brief Gets this body's linear acceleration.
-    LinearAcceleration2 GetLinearAcceleration() const noexcept;
-
-    /// @brief Gets this body's angular acceleration.
-    AngularAcceleration GetAngularAcceleration() const noexcept;
-
-    /// @brief Gets the inverse total mass of the body.
-    /// @details This is the cached result of dividing 1 by the body's mass.
-    /// Often floating division is much slower than multiplication.
-    /// As such, it's likely faster to multiply values by this inverse value than to redivide
-    /// them all the time by the mass.
-    /// @return Value of zero or more representing the body's inverse mass (in 1/kg).
-    /// @see SetMassData.
-    InvMass GetInvMass() const noexcept;
-
-    /// @brief Gets the inverse rotational inertia of the body.
-    /// @details This is the cached result of dividing 1 by the body's rotational inertia.
-    /// Often floating division is much slower than multiplication.
-    /// As such, it's likely faster to multiply values by this inverse value than to redivide
-    /// them all the time by the rotational inertia.
-    /// @return Inverse rotational inertia (in 1/kg-m^2).
-    InvRotInertia GetInvRotInertia() const noexcept;
-
-    /// @brief Gets the linear damping of the body.
-    Frequency GetLinearDamping() const noexcept;
-
-    /// @brief Sets the linear damping of the body.
-    void SetLinearDamping(NonNegative<Frequency> linearDamping) noexcept;
-
-    /// @brief Gets the angular damping of the body.
-    Frequency GetAngularDamping() const noexcept;
-
-    /// @brief Sets the angular damping of the body.
-    void SetAngularDamping(NonNegative<Frequency> angularDamping) noexcept;
-
-    /// @brief Gets the type of this body.
-    /// @see SetType.
-    BodyType GetType() const noexcept;
-
-    /// @brief Sets the type of this body.
-    /// @see GetType.
-    void SetType(BodyType value) noexcept;
-
-    /// @brief Is "speedable".
-    /// @details Is this body able to have a non-zero speed associated with it.
-    /// Kinematic and Dynamic bodies are speedable. Static bodies are not.
-    bool IsSpeedable() const noexcept;
-
-    /// @brief Is "accelerable".
-    /// @details Indicates whether this body is accelerable, i.e. whether it is effected by
-    ///   forces. Only Dynamic bodies are accelerable.
-    /// @return true if the body is accelerable, false otherwise.
-    bool IsAccelerable() const noexcept;
-
-    /// @brief Is this body treated like a bullet for continuous collision detection?
-    bool IsImpenetrable() const noexcept;
-
-    /// @brief Sets the impenetrable status of this body.
-    /// @details Sets whether or not this body should be treated like a bullet for continuous
-    ///   collision detection.
-    void SetImpenetrable() noexcept;
-
-    /// @brief Unsets the impenetrable status of this body.
-    /// @details Sets whether or not this body should be treated like a bullet for continuous
-    ///   collision detection.
-    void UnsetImpenetrable() noexcept;
-
-    /// @brief Gets whether or not this body allowed to sleep
-    bool IsSleepingAllowed() const noexcept;
-
-    /// You can disable sleeping on this body. If you disable sleeping, the
-    /// body will be woken.
-    void SetSleepingAllowed(bool flag) noexcept;
-
-    /// @brief Awakens this body.
-    ///
-    /// @details Sets this body to awake and resets its under-active time if it's a "speedable"
-    ///   body. This method has no effect otherwise.
-    ///
-    /// @post If this body is a "speedable" body, then this body's <code>IsAwake</code> method
-    ///   returns true.
-    /// @post If this body is a "speedable" body, then this body's <code>GetUnderActiveTime</code>
-    ///   method returns zero.
-    ///
-    void SetAwake() noexcept;
-
-    /// @brief Sets this body to asleep if sleeping is allowed.
-    ///
-    /// @details If this body is allowed to sleep, this: sets the sleep state of the body to
-    /// asleep, resets this body's under active time, and resets this body's velocity (linear
-    /// and angular).
-    ///
-    /// @post This body's <code>IsAwake</code> method returns false.
-    /// @post This body's <code>GetUnderActiveTime</code> method returns zero.
-    /// @post This body's <code>GetVelocity</code> method returns zero linear and zero angular
-    ///   speed.
-    ///
-    void UnsetAwake() noexcept;
-
-    /// @brief Gets the awake/asleep state of this body.
-    /// @warning Being awake may or may not imply being speedable.
-    /// @return true if the body is awake.
-    bool IsAwake() const noexcept;
-
-    /// @brief Gets this body's under-active time value.
-    /// @return Zero or more time in seconds (of step time) that this body has been
-    ///   "under-active" for.
-    Time GetUnderActiveTime() const noexcept;
-
-    /// @brief Sets the "under-active" time to the given value.
-    ///
-    /// @details Sets the "under-active" time to a value of zero or a non-zero value if the
-    ///   body is "accelerable". Otherwise it does nothing.
-    ///
-    /// @warning Behavior is undefined for negative values.
-    /// @note A non-zero time is only valid for an "accelerable" body.
-    ///
-    void SetUnderActiveTime(Time value) noexcept;
-
-    /// @brief Resets the under-active time for this body.
-    /// @note This has performance degrading potential and is best not called unless the
-    ///   caller is certain that it should be.
-    void ResetUnderActiveTime() noexcept;
-
-    /// @brief Gets the enabled/disabled state of the body.
-    /// @see SetEnabled.
-    bool IsEnabled() const noexcept;
-
-    /// @brief Sets this body to have fixed rotation.
-    /// @note This causes the mass to be reset.
-    void SetFixedRotation(bool flag);
-
-    /// @brief Does this body have fixed rotation?
-    bool IsFixedRotation() const noexcept;
-
-    /// @brief Gets the range of all constant fixtures attached to this body.
-    SizedRange<Fixtures::const_iterator> GetFixtures() const noexcept;
-
-    /// @brief Gets the range of all joints attached to this body.
-    SizedRange<Joints::const_iterator> GetJoints() const noexcept;
-
-    /// @brief Gets the container of all contacts attached to this body.
-    /// @warning This collection changes during the time step and you may
-    ///   miss some collisions if you don't use <code>ContactListener</code>.
-    SizedRange<Contacts::const_iterator> GetContacts() const noexcept;
-
-    /// @brief Gets whether the mass data for this body is "dirty".
-    bool IsMassDataDirty() const noexcept;
-
-    /// @brief Sets the body's awake flag.
-    /// @details This is done unconditionally.
-    /// @note This should **not** be called unless the body is "speedable".
-    /// @warning Behavior is undefined if called for a body that is not "speedable".
-    void SetAwakeFlag() noexcept;
-
-    /// @brief Unsets the body's awake flag.
-    void UnsetAwakeFlag() noexcept;
-
-    /// @brief Sets this body to have the mass data dirty state.
-    void SetMassDataDirty() noexcept;
-
-    /// @brief Unsets the body from being in the mass data dirty state.
-    void UnsetMassDataDirty() noexcept;
-
-    /// @brief Sets the enabled flag.
-    void SetEnabledFlag() noexcept;
-
-    /// @brief Unsets the enabled flag.
-    void UnsetEnabledFlag() noexcept;
-
-    /// @brief Inserts the given key and contact.
-    bool Insert(ContactKey key, ContactID contact);
-
-    /// @brief Inserts the given joint into this body's joints list.
-    bool Insert(JointID joint, BodyID other);
-
-    /// @brief Erases the given contact from this body's contacts list.
-    bool Erase(ContactID contact);
-
-    /// @brief Erases the contacts that the given function returns true for.
-    void Erase(const std::function<bool(ContactID)>& callback);
-
-    /// @brief Erases the given joint from this body's joints list.
-    bool Erase(JointID joint);
-
-    /// @brief Clears this body's contacts list.
-    void ClearContacts() noexcept
-    {
-        m_contacts.clear();
-    }
-
-    /// @brief Clears this body's joints list.
-    void ClearJoints() noexcept
-    {
-        m_joints.clear();
-    }
-
-    /// @brief Clears the fixtures.
-    void ClearFixtures() noexcept
-    {
-        m_fixtures.clear();
-    }
-
-    /// @brief Sets the inverse rotational inertia.
-    void SetInvRotI(InvRotInertia v) noexcept
-    {
-        m_invRotI = v;
-    }
-
-    /// @brief Sets the inverse mass.
-    void SetInvMass(InvMass v) noexcept
-    {
-        m_invMass = v;
-    }
-
-    /// @brief Sets the "position 0" value of the body to the given position.
-    void SetPosition0(const Position value) noexcept
-    {
-        assert(IsSpeedable() || m_sweep.pos0 == value);
-        m_sweep.pos0 = value;
-    }
-
-    /// @brief Sets the body sweep's "position 1" value.
-    /// @note This sets what <code>Body::GetWorldCenter</code> returns.
-    /// @see Body::GetWorldCenter
-    void SetPosition1(const Position value) noexcept
-    {
-        assert(IsSpeedable() || m_sweep.pos1 == value);
-        m_sweep.pos1 = value;
-    }
-
-    /// @brief Resets the given body's "alpha-0" value.
-    void ResetAlpha0() noexcept
-    {
-        m_sweep.ResetAlpha0();
-    }
-
-    /// @brief Sets the sweep value of the given body.
-    void SetSweep(const Sweep value) noexcept
-    {
-        assert(IsSpeedable() || value.pos0 == value.pos1);
-        m_sweep = value;
-    }
-
-    /// @brief Restores the given body's sweep to the given sweep value.
-    void Restore(const Sweep& value) noexcept
-    {
-        SetSweep(value);
-        SetTransformation(GetTransform1(value));
-    }
-
-    /// @brief Calls the body sweep's <code>Advance0</code> method to advance to
-    ///    the given value.
-    void Advance0(Real value) noexcept
-    {
-        // Note: Static bodies must **never** have different sweep position values.
-
-        // Confirm bodies don't have different sweep positions to begin with...
-        assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
-
-        m_sweep.Advance0(value);
-
-        // Confirm bodies don't have different sweep positions to end with...
-        assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
-    }
-
-    /// Advances the body by a given time ratio.
-    /// @details This method:
-    ///    1. advances the body's sweep to the given time ratio;
-    ///    2. updates the body's sweep positions (linear and angular) to the advanced ones; and
-    ///    3. updates the body's transform to the new sweep one settings.
-    /// @param value Valid new time factor in [0,1) to advance the sweep to.
-    void Advance(Real value) noexcept
-    {
-        //assert(m_sweep.GetAlpha0() <= alpha);
-        assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
-
-        // Advance to the new safe time. This doesn't sync the broad-phase.
-        m_sweep.Advance0(value);
-        m_sweep.pos1 = m_sweep.pos0;
-        m_xf = GetTransform1(m_sweep);
-    }
-
-    /// @brief Adds the given fixture to the given body.
-    void AddFixture(FixtureID fixture)
-    {
-        m_fixtures.push_back(fixture);
-    }
-
-    /// @brief Removes the given fixture from the given body.
-    bool RemoveFixture(FixtureID fixture)
-    {
-        const auto begIter = begin(m_fixtures);
-        const auto endIter = end(m_fixtures);
-        const auto it = std::find(begIter, endIter, fixture);
-        if (it != endIter)
+        struct FixtureConf;
+        class Shape;
+
+        /// @brief Physical entity that exists within a World.
+        ///
+        /// @details A rigid body entity created or destroyed through a World instance. These have
+        ///   physical properties like: position, velocity, acceleration, and mass.
+        ///
+        /// @invariant Only bodies that allow sleeping, can be put to sleep.
+        /// @invariant Only "speedable" bodies can be awake.
+        /// @invariant Only "speedable" bodies can have non-zero velocities.
+        /// @invariant Only "accelerable" bodies can have non-zero accelerations.
+        /// @invariant Only "accelerable" bodies can have non-zero "under-active" times.
+        ///
+        /// @note Create these using the <code>World::CreateBody</code> method.
+        /// @note Destroy these using the <code>World::Destroy(BodyID)</code> method.
+        /// @note From a memory management perspective, bodies own Fixture instances.
+        /// @note On a 64-bit architecture with 4-byte Real, this data structure is at least
+        ///   192-bytes large.
+        ///
+        /// @ingroup PhysicalEntities
+        ///
+        /// @see World, Fixture
+        ///
+        class Body
         {
-            m_fixtures.erase(it);
-            return true;
+         public:
+            /// @brief Container type for fixtures.
+            using Fixtures = std::vector<FixtureID>;
+
+            /// @brief Keyed joint pointer.
+            using KeyedJointPtr = std::pair<BodyID, JointID>;
+
+            /// @brief Container type for joints.
+            using Joints = std::vector<KeyedJointPtr>;
+
+            /// @brief Container type for contacts.
+            using Contacts = std::vector<KeyedContactPtr>;
+
+            /// @brief Initializing constructor.
+            explicit Body(const BodyConf& bd = GetDefaultBodyConf()) noexcept;
+
+            /// @brief Gets the body transform for the body's origin.
+            /// @return the world transform of the body's origin.
+            /// @see GetLocation, Body::SetTransformation.
+            Transformation GetTransformation() const noexcept;
+
+            /// Sets the body's transformation.
+            /// @note This sets what <code>Body::GetLocation</code> returns.
+            /// @see Body::GetLocation, Body::GetTransformation
+            void SetTransformation(Transformation value) noexcept
+            {
+                m_xf = value;
+            }
+
+            /// @brief Gets the world body origin location.
+            /// @details This is the location of the body's origin relative to its world.
+            /// The location of the body after stepping the world's physics simulations is dependent on
+            /// a number of factors:
+            ///   1. Location at the last time step.
+            ///   2. Forces acting on the body (gravity, applied force, applied impulse).
+            ///   3. The mass data of the body.
+            ///   4. Damping of the body.
+            ///   5. Restitution and friction values of the body's fixtures when they experience collisions.
+            /// @return World location of the body's origin.
+            /// @see GetTransformation.
+            Length2 GetLocation() const noexcept;
+
+            /// @brief Gets the body's sweep.
+            const Sweep& GetSweep() const noexcept;
+
+            /// @brief Get the angle.
+            /// @return the current world rotation angle.
+            Angle GetAngle() const noexcept;
+
+            /// @brief Get the world position of the center of mass.
+            Length2 GetWorldCenter() const noexcept;
+
+            /// @brief Gets the local position of the center of mass.
+            Length2 GetLocalCenter() const noexcept;
+
+            /// @brief Gets the velocity.
+            Velocity GetVelocity() const noexcept;
+
+            /// @brief Sets the body's velocity (linear and angular velocity).
+            /// @note This method does nothing if this body is not speedable.
+            /// @note A non-zero velocity will awaken this body.
+            /// @see SetAwake, SetUnderActiveTime.
+            void SetVelocity(const Velocity& velocity) noexcept;
+
+            /// Sets the body's velocity.
+            /// @note This sets what <code>Body::GetVelocity</code> returns.
+            /// @see Body::GetVelocity
+            void JustSetVelocity(Velocity value) noexcept
+            {
+                m_linearVelocity = value.linear;
+                m_angularVelocity = value.angular;
+            }
+
+            /// @brief Sets the linear and rotational accelerations on this body.
+            /// @note This has no effect on non-accelerable bodies.
+            /// @note A non-zero acceleration will also awaken the body.
+            /// @param linear Linear acceleration.
+            /// @param angular Angular acceleration.
+            void SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angular) noexcept;
+
+            /// @brief Gets this body's linear acceleration.
+            LinearAcceleration2 GetLinearAcceleration() const noexcept;
+
+            /// @brief Gets this body's angular acceleration.
+            AngularAcceleration GetAngularAcceleration() const noexcept;
+
+            /// @brief Gets the inverse total mass of the body.
+            /// @details This is the cached result of dividing 1 by the body's mass.
+            /// Often floating division is much slower than multiplication.
+            /// As such, it's likely faster to multiply values by this inverse value than to redivide
+            /// them all the time by the mass.
+            /// @return Value of zero or more representing the body's inverse mass (in 1/kg).
+            /// @see SetMassData.
+            InvMass GetInvMass() const noexcept;
+
+            /// @brief Gets the inverse rotational inertia of the body.
+            /// @details This is the cached result of dividing 1 by the body's rotational inertia.
+            /// Often floating division is much slower than multiplication.
+            /// As such, it's likely faster to multiply values by this inverse value than to redivide
+            /// them all the time by the rotational inertia.
+            /// @return Inverse rotational inertia (in 1/kg-m^2).
+            InvRotInertia GetInvRotInertia() const noexcept;
+
+            /// @brief Gets the linear damping of the body.
+            Frequency GetLinearDamping() const noexcept;
+
+            /// @brief Sets the linear damping of the body.
+            void SetLinearDamping(NonNegative<Frequency> linearDamping) noexcept;
+
+            /// @brief Gets the angular damping of the body.
+            Frequency GetAngularDamping() const noexcept;
+
+            /// @brief Sets the angular damping of the body.
+            void SetAngularDamping(NonNegative<Frequency> angularDamping) noexcept;
+
+            /// @brief Gets the type of this body.
+            /// @see SetType.
+            BodyType GetType() const noexcept;
+
+            /// @brief Sets the type of this body.
+            /// @see GetType.
+            void SetType(BodyType value) noexcept;
+
+            /// @brief Is "speedable".
+            /// @details Is this body able to have a non-zero speed associated with it.
+            /// Kinematic and Dynamic bodies are speedable. Static bodies are not.
+            bool IsSpeedable() const noexcept;
+
+            /// @brief Is "accelerable".
+            /// @details Indicates whether this body is accelerable, i.e. whether it is effected by
+            ///   forces. Only Dynamic bodies are accelerable.
+            /// @return true if the body is accelerable, false otherwise.
+            bool IsAccelerable() const noexcept;
+
+            /// @brief Is this body treated like a bullet for continuous collision detection?
+            bool IsImpenetrable() const noexcept;
+
+            /// @brief Sets the impenetrable status of this body.
+            /// @details Sets whether or not this body should be treated like a bullet for continuous
+            ///   collision detection.
+            void SetImpenetrable() noexcept;
+
+            /// @brief Unsets the impenetrable status of this body.
+            /// @details Sets whether or not this body should be treated like a bullet for continuous
+            ///   collision detection.
+            void UnsetImpenetrable() noexcept;
+
+            /// @brief Gets whether or not this body allowed to sleep
+            bool IsSleepingAllowed() const noexcept;
+
+            /// You can disable sleeping on this body. If you disable sleeping, the
+            /// body will be woken.
+            void SetSleepingAllowed(bool flag) noexcept;
+
+            /// @brief Awakens this body.
+            ///
+            /// @details Sets this body to awake and resets its under-active time if it's a "speedable"
+            ///   body. This method has no effect otherwise.
+            ///
+            /// @post If this body is a "speedable" body, then this body's <code>IsAwake</code> method
+            ///   returns true.
+            /// @post If this body is a "speedable" body, then this body's <code>GetUnderActiveTime</code>
+            ///   method returns zero.
+            ///
+            void SetAwake() noexcept;
+
+            /// @brief Sets this body to asleep if sleeping is allowed.
+            ///
+            /// @details If this body is allowed to sleep, this: sets the sleep state of the body to
+            /// asleep, resets this body's under active time, and resets this body's velocity (linear
+            /// and angular).
+            ///
+            /// @post This body's <code>IsAwake</code> method returns false.
+            /// @post This body's <code>GetUnderActiveTime</code> method returns zero.
+            /// @post This body's <code>GetVelocity</code> method returns zero linear and zero angular
+            ///   speed.
+            ///
+            void UnsetAwake() noexcept;
+
+            /// @brief Gets the awake/asleep state of this body.
+            /// @warning Being awake may or may not imply being speedable.
+            /// @return true if the body is awake.
+            bool IsAwake() const noexcept;
+
+            /// @brief Gets this body's under-active time value.
+            /// @return Zero or more time in seconds (of step time) that this body has been
+            ///   "under-active" for.
+            Time GetUnderActiveTime() const noexcept;
+
+            /// @brief Sets the "under-active" time to the given value.
+            ///
+            /// @details Sets the "under-active" time to a value of zero or a non-zero value if the
+            ///   body is "accelerable". Otherwise it does nothing.
+            ///
+            /// @warning Behavior is undefined for negative values.
+            /// @note A non-zero time is only valid for an "accelerable" body.
+            ///
+            void SetUnderActiveTime(Time value) noexcept;
+
+            /// @brief Resets the under-active time for this body.
+            /// @note This has performance degrading potential and is best not called unless the
+            ///   caller is certain that it should be.
+            void ResetUnderActiveTime() noexcept;
+
+            /// @brief Gets the enabled/disabled state of the body.
+            /// @see SetEnabled.
+            bool IsEnabled() const noexcept;
+
+            /// @brief Sets this body to have fixed rotation.
+            /// @note This causes the mass to be reset.
+            void SetFixedRotation(bool flag);
+
+            /// @brief Does this body have fixed rotation?
+            bool IsFixedRotation() const noexcept;
+
+            /// @brief Gets the range of all constant fixtures attached to this body.
+            SizedRange<Fixtures::const_iterator> GetFixtures() const noexcept;
+
+            /// @brief Gets the range of all joints attached to this body.
+            SizedRange<Joints::const_iterator> GetJoints() const noexcept;
+
+            /// @brief Gets the container of all contacts attached to this body.
+            /// @warning This collection changes during the time step and you may
+            ///   miss some collisions if you don't use <code>ContactListener</code>.
+            SizedRange<Contacts::const_iterator> GetContacts() const noexcept;
+
+            /// @brief Gets whether the mass data for this body is "dirty".
+            bool IsMassDataDirty() const noexcept;
+
+            /// @brief Sets the body's awake flag.
+            /// @details This is done unconditionally.
+            /// @note This should **not** be called unless the body is "speedable".
+            /// @warning Behavior is undefined if called for a body that is not "speedable".
+            void SetAwakeFlag() noexcept;
+
+            /// @brief Unsets the body's awake flag.
+            void UnsetAwakeFlag() noexcept;
+
+            /// @brief Sets this body to have the mass data dirty state.
+            void SetMassDataDirty() noexcept;
+
+            /// @brief Unsets the body from being in the mass data dirty state.
+            void UnsetMassDataDirty() noexcept;
+
+            /// @brief Sets the enabled flag.
+            void SetEnabledFlag() noexcept;
+
+            /// @brief Unsets the enabled flag.
+            void UnsetEnabledFlag() noexcept;
+
+            /// @brief Inserts the given key and contact.
+            bool Insert(ContactKey key, ContactID contact);
+
+            /// @brief Inserts the given joint into this body's joints list.
+            bool Insert(JointID joint, BodyID other);
+
+            /// @brief Erases the given contact from this body's contacts list.
+            bool Erase(ContactID contact);
+
+            /// @brief Erases the contacts that the given function returns true for.
+            void Erase(const std::function<bool(ContactID)>& callback);
+
+            /// @brief Erases the given joint from this body's joints list.
+            bool Erase(JointID joint);
+
+            /// @brief Clears this body's contacts list.
+            void ClearContacts() noexcept
+            {
+                m_contacts.clear();
+            }
+
+            /// @brief Clears this body's joints list.
+            void ClearJoints() noexcept
+            {
+                m_joints.clear();
+            }
+
+            /// @brief Clears the fixtures.
+            void ClearFixtures() noexcept
+            {
+                m_fixtures.clear();
+            }
+
+            /// @brief Sets the inverse rotational inertia.
+            void SetInvRotI(InvRotInertia v) noexcept
+            {
+                m_invRotI = v;
+            }
+
+            /// @brief Sets the inverse mass.
+            void SetInvMass(InvMass v) noexcept
+            {
+                m_invMass = v;
+            }
+
+            /// @brief Sets the "position 0" value of the body to the given position.
+            void SetPosition0(const Position value) noexcept
+            {
+                assert(IsSpeedable() || m_sweep.pos0 == value);
+                m_sweep.pos0 = value;
+            }
+
+            /// @brief Sets the body sweep's "position 1" value.
+            /// @note This sets what <code>Body::GetWorldCenter</code> returns.
+            /// @see Body::GetWorldCenter
+            void SetPosition1(const Position value) noexcept
+            {
+                assert(IsSpeedable() || m_sweep.pos1 == value);
+                m_sweep.pos1 = value;
+            }
+
+            /// @brief Resets the given body's "alpha-0" value.
+            void ResetAlpha0() noexcept
+            {
+                m_sweep.ResetAlpha0();
+            }
+
+            /// @brief Sets the sweep value of the given body.
+            void SetSweep(const Sweep value) noexcept
+            {
+                assert(IsSpeedable() || value.pos0 == value.pos1);
+                m_sweep = value;
+            }
+
+            /// @brief Restores the given body's sweep to the given sweep value.
+            void Restore(const Sweep& value) noexcept
+            {
+                SetSweep(value);
+                SetTransformation(GetTransform1(value));
+            }
+
+            /// @brief Calls the body sweep's <code>Advance0</code> method to advance to
+            ///    the given value.
+            void Advance0(Real value) noexcept
+            {
+                // Note: Static bodies must **never** have different sweep position values.
+
+                // Confirm bodies don't have different sweep positions to begin with...
+                assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
+
+                m_sweep.Advance0(value);
+
+                // Confirm bodies don't have different sweep positions to end with...
+                assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
+            }
+
+            /// Advances the body by a given time ratio.
+            /// @details This method:
+            ///    1. advances the body's sweep to the given time ratio;
+            ///    2. updates the body's sweep positions (linear and angular) to the advanced ones; and
+            ///    3. updates the body's transform to the new sweep one settings.
+            /// @param value Valid new time factor in [0,1) to advance the sweep to.
+            void Advance(Real value) noexcept
+            {
+                //assert(m_sweep.GetAlpha0() <= alpha);
+                assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
+
+                // Advance to the new safe time. This doesn't sync the broad-phase.
+                m_sweep.Advance0(value);
+                m_sweep.pos1 = m_sweep.pos0;
+                m_xf = GetTransform1(m_sweep);
+            }
+
+            /// @brief Adds the given fixture to the given body.
+            void AddFixture(FixtureID fixture)
+            {
+                m_fixtures.push_back(fixture);
+            }
+
+            /// @brief Removes the given fixture from the given body.
+            bool RemoveFixture(FixtureID fixture)
+            {
+                const auto begIter = begin(m_fixtures);
+                const auto endIter = end(m_fixtures);
+                const auto it = std::find(begIter, endIter, fixture);
+                if (it != endIter)
+                {
+                    m_fixtures.erase(it);
+                    return true;
+                }
+                return false;
+            }
+
+         private:
+            /// @brief Flags type.
+            /// @note For internal use. Made public to facilitate unit testing.
+            using FlagsType = std::uint16_t;
+
+            /// @brief Flag enumeration.
+            /// @note For internal use. Made public to facilitate unit testing.
+            enum Flag : FlagsType
+            {
+                /// @brief Awake flag.
+                e_awakeFlag = FlagsType(0x0002),
+
+                /// @brief Auto sleep flag.
+                e_autoSleepFlag = FlagsType(0x0004),
+
+                /// @brief Impenetrable flag.
+                /// @details Indicates whether CCD should be done for this body.
+                /// All static and kinematic bodies have this flag enabled.
+                e_impenetrableFlag = FlagsType(0x0008),
+
+                /// @brief Fixed rotation flag.
+                e_fixedRotationFlag = FlagsType(0x0010),
+
+                /// @brief Enabled flag.
+                e_enabledFlag = FlagsType(0x0020),
+
+                /// @brief Velocity flag.
+                /// @details Set this to enable changes in position due to velocity.
+                /// Bodies with this set are "speedable" - either kinematic or dynamic bodies.
+                e_velocityFlag = FlagsType(0x0080),
+
+                /// @brief Acceleration flag.
+                /// @details Set this to enable changes in velocity due to physical properties (like forces).
+                /// Bodies with this set are "accelerable" - dynamic bodies.
+                e_accelerationFlag = FlagsType(0x0100),
+
+                /// @brief Mass Data Dirty Flag.
+                e_massDataDirtyFlag = FlagsType(0x0200),
+            };
+
+            /// @brief Gets the flags for the given value.
+            static FlagsType GetFlags(BodyType type) noexcept;
+
+            /// @brief Gets the flags for the given value.
+            static FlagsType GetFlags(const BodyConf& bd) noexcept;
+
+            //
+            // Member variables. Try to keep total size small.
+            //
+
+            // These three aren't "essential parts". They don't contribute to this instance's "value".
+
+            /// Cache of associated fixtures (owned by world).
+            /// @todo Consider eliminating this variable since calling <code>GetFixtures()</code>
+            ///   isn't done within the <code>World::Step</code> except by
+            ///   <code>World::Synchronize</code> which may be replacable with iterating over the
+            ///   entire fixture array.
+            mutable Fixtures m_fixtures;
+
+            mutable Contacts m_contacts;///< Cache of associated contacts (owned by world).
+
+            mutable Joints m_joints;///< Cache of associated joints (owned by world).
+
+            /// Transformation for body origin.
+            /// @note Also availble from <code>GetTransform1(m_sweep)</code>.
+            /// @note 16-bytes.
+            Transformation m_xf;
+
+            Sweep m_sweep;///< Sweep motion for CCD. 36-bytes.
+
+            FlagsType m_flags = 0;///< Flags. 2-bytes.
+
+            /// @brief Linear velocity.
+            /// @note 8-bytes.
+            LinearVelocity2 m_linearVelocity = LinearVelocity2{};
+
+            /// @brief Linear acceleration.
+            /// @note 8-bytes.
+            LinearAcceleration2 m_linearAcceleration = LinearAcceleration2{};
+
+            /// @brief Angular velocity.
+            /// @note 4-bytes.
+            AngularVelocity m_angularVelocity = AngularVelocity{};
+
+            /// @brief Angular acceleration.
+            /// @note 4-bytes.
+            AngularAcceleration m_angularAcceleration = AngularAcceleration{0};
+
+            /// Inverse mass of the body.
+            /// @details A non-negative value.
+            /// Can only be zero for non-accelerable bodies.
+            /// @note 4-bytes.
+            InvMass m_invMass = 0;
+
+            /// Inverse rotational inertia about the center of mass.
+            /// @details A non-negative value.
+            /// @note 4-bytes.
+            InvRotInertia m_invRotI = 0;
+
+            NonNegative<Frequency> m_linearDamping{}; ///< Linear damping. 4-bytes.
+            NonNegative<Frequency> m_angularDamping{};///< Angular damping. 4-bytes.
+
+            /// Under-active time.
+            /// @details A body under-active for enough time should have their awake flag unset.
+            ///   I.e. if a body is under-active for long enough, it should go to sleep.
+            /// @note 4-bytes.
+            Time m_underActiveTime = 0;
+        };
+
+        inline Body::FlagsType Body::GetFlags(BodyType type) noexcept
+        {
+            auto flags = FlagsType{0};
+            switch (type)
+            {
+            case BodyType::Dynamic:
+                flags |= (e_velocityFlag | e_accelerationFlag);
+                break;
+            case BodyType::Kinematic:
+                flags |= (e_impenetrableFlag | e_velocityFlag);
+                break;
+            case BodyType::Static:
+                flags |= (e_impenetrableFlag);
+                break;
+            }
+            return flags;
         }
-        return false;
-    }
 
-private:
-    /// @brief Flags type.
-    /// @note For internal use. Made public to facilitate unit testing.
-    using FlagsType = std::uint16_t;
-
-    /// @brief Flag enumeration.
-    /// @note For internal use. Made public to facilitate unit testing.
-    enum Flag: FlagsType
-    {
-        /// @brief Awake flag.
-        e_awakeFlag = FlagsType(0x0002),
-
-        /// @brief Auto sleep flag.
-        e_autoSleepFlag = FlagsType(0x0004),
-
-        /// @brief Impenetrable flag.
-        /// @details Indicates whether CCD should be done for this body.
-        /// All static and kinematic bodies have this flag enabled.
-        e_impenetrableFlag = FlagsType(0x0008),
-
-        /// @brief Fixed rotation flag.
-        e_fixedRotationFlag = FlagsType(0x0010),
-
-        /// @brief Enabled flag.
-        e_enabledFlag = FlagsType(0x0020),
-
-        /// @brief Velocity flag.
-        /// @details Set this to enable changes in position due to velocity.
-        /// Bodies with this set are "speedable" - either kinematic or dynamic bodies.
-        e_velocityFlag = FlagsType(0x0080),
-
-        /// @brief Acceleration flag.
-        /// @details Set this to enable changes in velocity due to physical properties (like forces).
-        /// Bodies with this set are "accelerable" - dynamic bodies.
-        e_accelerationFlag = FlagsType(0x0100),
-
-        /// @brief Mass Data Dirty Flag.
-        e_massDataDirtyFlag = FlagsType(0x0200),
-    };
-
-    /// @brief Gets the flags for the given value.
-    static FlagsType GetFlags(BodyType type) noexcept;
-
-    /// @brief Gets the flags for the given value.
-    static FlagsType GetFlags(const BodyConf& bd) noexcept;
-
-    //
-    // Member variables. Try to keep total size small.
-    //
-
-    // These three aren't "essential parts". They don't contribute to this instance's "value".
-
-    /// Cache of associated fixtures (owned by world).
-    /// @todo Consider eliminating this variable since calling <code>GetFixtures()</code>
-    ///   isn't done within the <code>World::Step</code> except by
-    ///   <code>World::Synchronize</code> which may be replacable with iterating over the
-    ///   entire fixture array.
-    mutable Fixtures m_fixtures;
-
-    mutable Contacts m_contacts; ///< Cache of associated contacts (owned by world).
-
-    mutable Joints m_joints; ///< Cache of associated joints (owned by world).
-
-    /// Transformation for body origin.
-    /// @note Also availble from <code>GetTransform1(m_sweep)</code>.
-    /// @note 16-bytes.
-    Transformation m_xf;
-
-    Sweep m_sweep; ///< Sweep motion for CCD. 36-bytes.
-
-    FlagsType m_flags = 0; ///< Flags. 2-bytes.
-
-    /// @brief Linear velocity.
-    /// @note 8-bytes.
-    LinearVelocity2 m_linearVelocity = LinearVelocity2{};
-
-    /// @brief Linear acceleration.
-    /// @note 8-bytes.
-    LinearAcceleration2 m_linearAcceleration = LinearAcceleration2{};
-
-    /// @brief Angular velocity.
-    /// @note 4-bytes.
-    AngularVelocity m_angularVelocity = AngularVelocity{};
-
-    /// @brief Angular acceleration.
-    /// @note 4-bytes.
-    AngularAcceleration m_angularAcceleration = AngularAcceleration{0};
-
-    /// Inverse mass of the body.
-    /// @details A non-negative value.
-    /// Can only be zero for non-accelerable bodies.
-    /// @note 4-bytes.
-    InvMass m_invMass = 0;
-
-    /// Inverse rotational inertia about the center of mass.
-    /// @details A non-negative value.
-    /// @note 4-bytes.
-    InvRotInertia m_invRotI = 0;
-
-    NonNegative<Frequency> m_linearDamping{}; ///< Linear damping. 4-bytes.
-    NonNegative<Frequency> m_angularDamping{}; ///< Angular damping. 4-bytes.
-
-    /// Under-active time.
-    /// @details A body under-active for enough time should have their awake flag unset.
-    ///   I.e. if a body is under-active for long enough, it should go to sleep.
-    /// @note 4-bytes.
-    Time m_underActiveTime = 0;
-};
-
-inline Body::FlagsType Body::GetFlags(BodyType type) noexcept
-{
-    auto flags = FlagsType{0};
-    switch (type)
-    {
-        case BodyType::Dynamic:   flags |= (e_velocityFlag|e_accelerationFlag); break;
-        case BodyType::Kinematic: flags |= (e_impenetrableFlag|e_velocityFlag); break;
-        case BodyType::Static:    flags |= (e_impenetrableFlag); break;
-    }
-    return flags;
-}
-
-inline BodyType Body::GetType() const noexcept
-{
-    switch (m_flags & (e_accelerationFlag|e_velocityFlag))
-    {
-        case e_velocityFlag|e_accelerationFlag: return BodyType::Dynamic;
-        case e_velocityFlag: return BodyType::Kinematic;
-        default: break; // handle case 0 this way so compiler doesn't warn of no default handling.
-    }
-    return BodyType::Static;
-}
-
-inline void Body::SetType(BodyType value) noexcept
-{
-    m_flags &= ~(e_impenetrableFlag|e_velocityFlag|e_accelerationFlag);
-    m_flags |= GetFlags(value);
-    switch (value)
-    {
-        case BodyType::Dynamic:
-            break;
-        case BodyType::Kinematic:
-            break;
-        case BodyType::Static:
-            UnsetAwakeFlag();
-            m_underActiveTime = 0;
-            m_linearVelocity = LinearVelocity2{};
-            m_angularVelocity = 0_rpm;
-            m_sweep.pos0 = m_sweep.pos1;
-            break;
-    }
-}
-
-inline Transformation Body::GetTransformation() const noexcept
-{
-    return m_xf;
-}
-
-inline Length2 Body::GetLocation() const noexcept
-{
-    return GetTransformation().p;
-}
-
-inline const Sweep& Body::GetSweep() const noexcept
-{
-    return m_sweep;
-}
-
-inline Angle Body::GetAngle() const noexcept
-{
-    // Angle could also come from the body's transformation but that requires converting
-    // from its unit vector to an angle while that angle is already cached in position 1 of
-    // the sweep.
-    return GetSweep().pos1.angular;
-}
-
-inline Length2 Body::GetWorldCenter() const noexcept
-{
-    return GetSweep().pos1.linear;
-}
-
-inline Length2 Body::GetLocalCenter() const noexcept
-{
-    return GetSweep().GetLocalCenter();
-}
-
-inline Velocity Body::GetVelocity() const noexcept
-{
-    return Velocity{m_linearVelocity, m_angularVelocity};
-}
-
-inline InvMass Body::GetInvMass() const noexcept
-{
-    return m_invMass;
-}
-
-inline InvRotInertia Body::GetInvRotInertia() const noexcept
-{
-    return m_invRotI;
-}
-
-inline Frequency Body::GetLinearDamping() const noexcept
-{
-    return m_linearDamping;
-}
-
-inline void Body::SetLinearDamping(NonNegative<Frequency> linearDamping) noexcept
-{
-    m_linearDamping = linearDamping;
-}
-
-inline Frequency Body::GetAngularDamping() const noexcept
-{
-    return m_angularDamping;
-}
-
-inline void Body::SetAngularDamping(NonNegative<Frequency> angularDamping) noexcept
-{
-    m_angularDamping = angularDamping;
-}
-
-inline bool Body::IsImpenetrable() const noexcept
-{
-    return (m_flags & e_impenetrableFlag) != 0;
-}
-
-inline void Body::SetImpenetrable() noexcept
-{
-    m_flags |= e_impenetrableFlag;
-}
-
-inline void Body::UnsetImpenetrable() noexcept
-{
-    m_flags &= ~e_impenetrableFlag;
-}
-
-inline void Body::SetAwakeFlag() noexcept
-{
-    // Protect the body's invariant that only "speedable" bodies can be awake.
-    assert(IsSpeedable());
-
-    m_flags |= e_awakeFlag;
-}
-
-inline void Body::UnsetAwakeFlag() noexcept
-{
-    assert(!IsSpeedable() || IsSleepingAllowed());
-    m_flags &= ~e_awakeFlag;
-}
-
-inline void Body::SetAwake() noexcept
-{
-    // Ignore this request unless this body is speedable so as to maintain the body's invariant
-    // that only "speedable" bodies can be awake.
-    if (IsSpeedable())
-    {
-    	SetAwakeFlag();
-        ResetUnderActiveTime();
-    }
-}
-
-inline void Body::UnsetAwake() noexcept
-{
-    if (!IsSpeedable() || IsSleepingAllowed())
-    {
-        UnsetAwakeFlag();
-        m_underActiveTime = 0;
-        m_linearVelocity = LinearVelocity2{};
-        m_angularVelocity = 0_rpm;
-    }
-}
-
-inline bool Body::IsAwake() const noexcept
-{
-    return (m_flags & e_awakeFlag) != 0;
-}
-
-inline Time Body::GetUnderActiveTime() const noexcept
-{
-    return m_underActiveTime;
-}
-
-inline void Body::SetUnderActiveTime(Time value) noexcept
-{
-    if ((value == 0_s) || IsAccelerable())
-    {
-        m_underActiveTime = value;
-    }
-}
-
-inline void Body::ResetUnderActiveTime() noexcept
-{
-    m_underActiveTime = 0_s;
-}
-
-inline bool Body::IsEnabled() const noexcept
-{
-    return (m_flags & e_enabledFlag) != 0;
-}
-
-inline bool Body::IsFixedRotation() const noexcept
-{
-    return (m_flags & e_fixedRotationFlag) != 0;
-}
-
-inline bool Body::IsSpeedable() const noexcept
-{
-    return (m_flags & e_velocityFlag) != 0;
-}
-
-inline bool Body::IsAccelerable() const noexcept
-{
-    return (m_flags & e_accelerationFlag) != 0;
-}
-
-inline bool Body::IsSleepingAllowed() const noexcept
-{
-    return (m_flags & e_autoSleepFlag) != 0;
-}
-
-inline void Body::SetSleepingAllowed(bool flag) noexcept
-{
-    if (flag)
-    {
-        m_flags |= e_autoSleepFlag;
-    }
-    else if (IsSpeedable())
-    {
-        m_flags &= ~e_autoSleepFlag;
-        SetAwakeFlag();
-        ResetUnderActiveTime();
-    }
-}
-
-inline SizedRange<Body::Fixtures::const_iterator> Body::GetFixtures() const noexcept
-{
-    return {begin(m_fixtures), end(m_fixtures), size(m_fixtures)};
-}
-
-inline SizedRange<Body::Joints::const_iterator> Body::GetJoints() const noexcept
-{
-    return {begin(m_joints), end(m_joints), size(m_joints)};
-}
-
-inline SizedRange<Body::Contacts::const_iterator> Body::GetContacts() const noexcept
-{
-    return {begin(m_contacts), end(m_contacts), size(m_contacts)};
-}
-
-inline LinearAcceleration2 Body::GetLinearAcceleration() const noexcept
-{
-    return m_linearAcceleration;
-}
-
-inline AngularAcceleration Body::GetAngularAcceleration() const noexcept
-{
-    return m_angularAcceleration;
-}
-
-inline void Body::SetMassDataDirty() noexcept
-{
-    m_flags |= e_massDataDirtyFlag;
-}
-
-inline void Body::UnsetMassDataDirty() noexcept
-{
-    m_flags &= ~e_massDataDirtyFlag;
-}
-
-inline bool Body::IsMassDataDirty() const noexcept
-{
-    return (m_flags & e_massDataDirtyFlag) != 0;
-}
-
-inline void Body::SetEnabledFlag() noexcept
-{
-    m_flags |= e_enabledFlag;
-}
-
-inline void Body::UnsetEnabledFlag() noexcept
-{
-    m_flags &= ~e_enabledFlag;
-}
-
-// Free functions...
-
-/// @brief Gets the given body's acceleration.
-/// @param body Body whose acceleration should be returned.
-/// @relatedalso Body
-inline Acceleration GetAcceleration(const Body& body) noexcept
-{
-    return Acceleration{body.GetLinearAcceleration(), body.GetAngularAcceleration()};
-}
-
-/// @brief Sets the accelerations on the given body.
-/// @note This has no effect on non-accelerable bodies.
-/// @note A non-zero acceleration will also awaken the body.
-/// @param body Body whose acceleration should be set.
-/// @param value Acceleration value to set.
-/// @relatedalso Body
-inline void SetAcceleration(Body& body, Acceleration value) noexcept
-{
-    body.SetAcceleration(value.linear, value.angular);
-}
-    
-/// @brief Awakens the body if it's asleep.
-/// @relatedalso Body
-inline bool Awaken(Body& body) noexcept
-{
-    if (!body.IsAwake() && body.IsSpeedable())
-    {
-        body.SetAwake();
-        return true;
-    }
-    return false;
-}
-
-/// @brief Puts the body to sleep if it's awake.
-/// @relatedalso Body
-inline bool Unawaken(Body& body) noexcept
-{
-    if (body.IsAwake() && body.IsSleepingAllowed())
-    {
-        body.UnsetAwake();
-        return true;
-    }
-    return false;
-}
-
-/// @brief Gets the "position 1" Position information for the given body.
-/// @relatedalso Body
-inline Position GetPosition1(const Body& body) noexcept
-{
-    return body.GetSweep().pos1;
-}
-
-/// @brief Gets the mass of the body.
-/// @note This may be the total calculated mass or it may be the set mass of the body.
-/// @return Value of zero or more representing the body's mass.
-/// @see GetInvMass, SetMassData
-/// @relatedalso Body
-inline Mass GetMass(const Body& body) noexcept
-{
-    const auto invMass = body.GetInvMass();
-    return (invMass != InvMass{0})? Mass{Real{1} / invMass}: 0_kg;
-}
-
-/// @brief Sets the linear and rotational accelerations on this body.
-/// @note This has no effect on non-accelerable bodies.
-/// @note A non-zero acceleration will also awaken the body.
-/// @param body Body to set the acceleration of.
-/// @param linear Linear acceleration.
-/// @param angular Angular acceleration.
-inline void SetAcceleration(Body& body, LinearAcceleration2 linear, AngularAcceleration angular) noexcept
-{
-    body.SetAcceleration(linear, angular);
-}
-
-/// @brief Sets the given linear acceleration of the given body.
-/// @relatedalso Body
-inline void SetAcceleration(Body& body, LinearAcceleration2 value) noexcept
-{
-    body.SetAcceleration(value, body.GetAngularAcceleration());
-}
-
-/// @brief Sets the given angular acceleration of the given body.
-/// @relatedalso Body
-inline void SetAcceleration(Body& body, AngularAcceleration value) noexcept
-{
-    body.SetAcceleration(body.GetLinearAcceleration(), value);
-}
-
-/// @brief Applies an impulse at a point.
-/// @note This immediately modifies the velocity.
-/// @note This also modifies the angular velocity if the point of application
-///   is not at the center of mass.
-/// @note Non-zero impulses wakes up the body.
-/// @param body Body to apply the impulse to.
-/// @param impulse the world impulse vector.
-/// @param point the world position of the point of application.
-/// @relatedalso Body
-inline void ApplyLinearImpulse(Body& body, Momentum2 impulse, Length2 point) noexcept
-{
-    auto velocity = body.GetVelocity();
-    velocity.linear += body.GetInvMass() * impulse;
-    const auto invRotI = body.GetInvRotInertia();
-    const auto dp = point - body.GetWorldCenter();
-    velocity.angular += AngularVelocity{invRotI * Cross(dp, impulse) / Radian};
-    body.SetVelocity(velocity);
-}
-
-/// @brief Applies an angular impulse.
-/// @param body Body to apply the angular impulse to.
-/// @param impulse Angular impulse to be applied.
-/// @relatedalso Body
-inline void ApplyAngularImpulse(Body& body, AngularMomentum impulse) noexcept
-{
-    auto velocity = body.GetVelocity();
-    const auto invRotI = body.GetInvRotInertia();
-    velocity.angular += AngularVelocity{invRotI * impulse};
-    body.SetVelocity(velocity);
-}
-
-/// @brief Gets the rotational inertia of the body.
-/// @param body Body to get the rotational inertia for.
-/// @return the rotational inertia.
-/// @relatedalso Body
-inline RotInertia GetRotInertia(const Body& body) noexcept
-{
-    return Real{1} / body.GetInvRotInertia();
-}
-
-/// @brief Gets the rotational inertia of the body about the local origin.
-/// @return the rotational inertia.
-/// @relatedalso Body
-inline RotInertia GetLocalRotInertia(const Body& body) noexcept
-{
-    return GetRotInertia(body)
-         + GetMass(body) * GetMagnitudeSquared(body.GetLocalCenter()) / SquareRadian;
-}
-
-/// @brief Gets the linear velocity of the center of mass.
-/// @param body Body to get the linear velocity for.
-/// @return the linear velocity of the center of mass.
-/// @relatedalso Body
-inline LinearVelocity2 GetLinearVelocity(const Body& body) noexcept
-{
-    return body.GetVelocity().linear;
-}
-
-/// @brief Gets the angular velocity.
-/// @param body Body to get the angular velocity for.
-/// @return the angular velocity.
-/// @relatedalso Body
-inline AngularVelocity GetAngularVelocity(const Body& body) noexcept
-{
-    return body.GetVelocity().angular;
-}
-
-/// @brief Sets the linear velocity of the center of mass.
-/// @param body Body to set the linear velocity of.
-/// @param value the new linear velocity of the center of mass.
-/// @relatedalso Body
-inline void SetVelocity(Body& body, LinearVelocity2 value) noexcept
-{
-    body.SetVelocity(Velocity{value, GetAngularVelocity(body)});
-}
-
-/// @brief Sets the angular velocity.
-/// @param body Body to set the angular velocity of.
-/// @param value the new angular velocity.
-/// @relatedalso Body
-inline void SetVelocity(Body& body, AngularVelocity value) noexcept
-{
-    body.SetVelocity(Velocity{GetLinearVelocity(body), value});
-}
-
-/// @brief Gets the world coordinates of a point given in coordinates relative to the body's origin.
-/// @param body Body that the given point is relative to.
-/// @param localPoint a point measured relative the the body's origin.
-/// @return the same point expressed in world coordinates.
-/// @relatedalso Body
-inline Length2 GetWorldPoint(const Body& body, const Length2 localPoint) noexcept
-{
-    return Transform(localPoint, body.GetTransformation());
-}
-
-/// @brief Gets the world coordinates of a vector given the local coordinates.
-/// @param body Body that the given vector is relative to.
-/// @param localVector a vector fixed in the body.
-/// @return the same vector expressed in world coordinates.
-/// @relatedalso Body
-inline Length2 GetWorldVector(const Body& body, const Length2 localVector) noexcept
-{
-    return Rotate(localVector, body.GetTransformation().q);
-}
-
-/// @brief Gets the world vector for the given local vector from the given body's transformation.
-/// @relatedalso Body
-inline UnitVec GetWorldVector(const Body& body, const UnitVec localVector) noexcept
-{
-    return Rotate(localVector, body.GetTransformation().q);
-}
-
-/// @brief Gets a local point relative to the body's origin given a world point.
-/// @param body Body that the returned point should be relative to.
-/// @param worldPoint point in world coordinates.
-/// @return the corresponding local point relative to the body's origin.
-/// @relatedalso Body
-inline Length2 GetLocalPoint(const Body& body, const Length2 worldPoint) noexcept
-{
-    return InverseTransform(worldPoint, body.GetTransformation());
-}
-
-/// @brief Gets a locally oriented unit vector given a world oriented unit vector.
-/// @param body Body that the returned vector should be relative to.
-/// @param uv Unit vector in world orientation.
-/// @return the corresponding local vector.
-/// @relatedalso Body
-inline UnitVec GetLocalVector(const Body& body, const UnitVec uv) noexcept
-{
-    return InverseRotate(uv, body.GetTransformation().q);
-}
-
-/// @brief Gets the linear velocity from a world point attached to this body.
-/// @param body Body to get the linear velocity for.
-/// @param worldPoint point in world coordinates.
-/// @return the world velocity of a point.
-/// @relatedalso Body
-inline LinearVelocity2 GetLinearVelocityFromWorldPoint(const Body& body,
-                                                        const Length2 worldPoint) noexcept
-{
-    const auto velocity = body.GetVelocity();
-    const auto worldCtr = body.GetWorldCenter();
-    const auto dp = Length2{worldPoint - worldCtr};
-    const auto rlv = LinearVelocity2{GetRevPerpendicular(dp) * (velocity.angular / Radian)};
-    return velocity.linear + rlv;
-}
-
-/// @brief Gets the linear velocity from a local point.
-/// @param body Body to get the linear velocity for.
-/// @param localPoint point in local coordinates.
-/// @return the world velocity of a point.
-/// @relatedalso Body
-inline LinearVelocity2 GetLinearVelocityFromLocalPoint(const Body& body,
-                                                        const Length2 localPoint) noexcept
-{
-    return GetLinearVelocityFromWorldPoint(body, GetWorldPoint(body, localPoint));
-}
-
-/// @brief Gets the net force that the given body is currently experiencing.
-/// @relatedalso Body
-inline Force2 GetForce(const Body& body) noexcept
-{
-    return body.GetLinearAcceleration() * GetMass(body);
-}
-
-/// @brief Gets the net torque that the given body is currently experiencing.
-/// @relatedalso Body
-inline Torque GetTorque(const Body& body) noexcept
-{
-    return body.GetAngularAcceleration() * GetRotInertia(body);
-}
-
-/// @brief Caps velocity.
-/// @details Enforces maximums on the given velocity.
-/// @param velocity Velocity to cap. Behavior is undefined if this value is invalid.
-/// @param h Time elapsed to get velocity for. Behavior is undefined if this value is invalid.
-/// @param conf Movement configuration. This defines caps on linear and angular speeds.
-/// @relatedalso Velocity
-Velocity Cap(Velocity velocity, Time h, MovementConf conf) noexcept;
-
-/// @brief Gets the velocity of the body after the given time accounting for the body's
-///   acceleration and capped by the given configuration.
-/// @warning Behavior is undefined if the given elapsed time is an invalid value (like NaN).
-/// @param body Body to get the velocity for.
-/// @param h Time elapsed to get velocity for. Behavior is undefined if this value is invalid.
-/// @relatedalso Body
-Velocity GetVelocity(const Body& body, Time h) noexcept;
-
-/// @brief Gets the fixture count of the given body.
-/// @relatedalso Body
-FixtureCounter GetFixtureCount(const Body& body) noexcept;
-
-/// @brief Gets the body's origin location.
-/// @details This is the location of the body's origin relative to its world.
-/// The location of the body after stepping the world's physics simulations is dependent on
-/// a number of factors:
-///   1. Location at the last time step.
-///   2. Forces acting on the body (gravity, applied force, applied impulse).
-///   3. The mass data of the body.
-///   4. Damping of the body.
-///   5. Restitution and friction values of the body's fixtures when they experience collisions.
-/// @return World location of the body's origin.
-/// @see GetAngle.
-/// @relatedalso Body
-inline Length2 GetLocation(const Body& body) noexcept
-{
-    return body.GetTransformation().p;
-}
-
-/// @brief Gets the body's angle.
-/// @return Body's angle relative to its World.
-/// @relatedalso Body
-inline Angle GetAngle(const Body& body) noexcept
-{
-    return body.GetSweep().pos1.angular;
-}
-
-/// @brief Gets the body's transformation.
-/// @relatedalso Body
-inline Transformation GetTransformation(const Body& body) noexcept
-{
-    return body.GetTransformation();
-}
-
-/// @brief Gets the body's position.
-/// @relatedalso Body
-inline Position GetPosition(const Body& body) noexcept
-{
-    return Position{body.GetLocation(), body.GetAngle()};
-}
-
-/// @brief Gets the transformation associated with the given configuration.
-/// @relatedalso BodyConf
-Transformation GetTransformation(const BodyConf& conf);
-
-} // namespace d2
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_BODY_HPP
+        inline BodyType Body::GetType() const noexcept
+        {
+            switch (m_flags & (e_accelerationFlag | e_velocityFlag))
+            {
+            case e_velocityFlag | e_accelerationFlag:
+                return BodyType::Dynamic;
+            case e_velocityFlag:
+                return BodyType::Kinematic;
+            default:
+                break;// handle case 0 this way so compiler doesn't warn of no default handling.
+            }
+            return BodyType::Static;
+        }
+
+        inline void Body::SetType(BodyType value) noexcept
+        {
+            m_flags &= ~(e_impenetrableFlag | e_velocityFlag | e_accelerationFlag);
+            m_flags |= GetFlags(value);
+            switch (value)
+            {
+            case BodyType::Dynamic:
+                break;
+            case BodyType::Kinematic:
+                break;
+            case BodyType::Static:
+                UnsetAwakeFlag();
+                m_underActiveTime = 0;
+                m_linearVelocity = LinearVelocity2{};
+                m_angularVelocity = 0_rpm;
+                m_sweep.pos0 = m_sweep.pos1;
+                break;
+            }
+        }
+
+        inline Transformation Body::GetTransformation() const noexcept
+        {
+            return m_xf;
+        }
+
+        inline Length2 Body::GetLocation() const noexcept
+        {
+            return GetTransformation().p;
+        }
+
+        inline const Sweep& Body::GetSweep() const noexcept
+        {
+            return m_sweep;
+        }
+
+        inline Angle Body::GetAngle() const noexcept
+        {
+            // Angle could also come from the body's transformation but that requires converting
+            // from its unit vector to an angle while that angle is already cached in position 1 of
+            // the sweep.
+            return GetSweep().pos1.angular;
+        }
+
+        inline Length2 Body::GetWorldCenter() const noexcept
+        {
+            return GetSweep().pos1.linear;
+        }
+
+        inline Length2 Body::GetLocalCenter() const noexcept
+        {
+            return GetSweep().GetLocalCenter();
+        }
+
+        inline Velocity Body::GetVelocity() const noexcept
+        {
+            return Velocity{m_linearVelocity, m_angularVelocity};
+        }
+
+        inline InvMass Body::GetInvMass() const noexcept
+        {
+            return m_invMass;
+        }
+
+        inline InvRotInertia Body::GetInvRotInertia() const noexcept
+        {
+            return m_invRotI;
+        }
+
+        inline Frequency Body::GetLinearDamping() const noexcept
+        {
+            return m_linearDamping;
+        }
+
+        inline void Body::SetLinearDamping(NonNegative<Frequency> linearDamping) noexcept
+        {
+            m_linearDamping = linearDamping;
+        }
+
+        inline Frequency Body::GetAngularDamping() const noexcept
+        {
+            return m_angularDamping;
+        }
+
+        inline void Body::SetAngularDamping(NonNegative<Frequency> angularDamping) noexcept
+        {
+            m_angularDamping = angularDamping;
+        }
+
+        inline bool Body::IsImpenetrable() const noexcept
+        {
+            return (m_flags & e_impenetrableFlag) != 0;
+        }
+
+        inline void Body::SetImpenetrable() noexcept
+        {
+            m_flags |= e_impenetrableFlag;
+        }
+
+        inline void Body::UnsetImpenetrable() noexcept
+        {
+            m_flags &= ~e_impenetrableFlag;
+        }
+
+        inline void Body::SetAwakeFlag() noexcept
+        {
+            // Protect the body's invariant that only "speedable" bodies can be awake.
+            assert(IsSpeedable());
+
+            m_flags |= e_awakeFlag;
+        }
+
+        inline void Body::UnsetAwakeFlag() noexcept
+        {
+            assert(!IsSpeedable() || IsSleepingAllowed());
+            m_flags &= ~e_awakeFlag;
+        }
+
+        inline void Body::SetAwake() noexcept
+        {
+            // Ignore this request unless this body is speedable so as to maintain the body's invariant
+            // that only "speedable" bodies can be awake.
+            if (IsSpeedable())
+            {
+                SetAwakeFlag();
+                ResetUnderActiveTime();
+            }
+        }
+
+        inline void Body::UnsetAwake() noexcept
+        {
+            if (!IsSpeedable() || IsSleepingAllowed())
+            {
+                UnsetAwakeFlag();
+                m_underActiveTime = 0;
+                m_linearVelocity = LinearVelocity2{};
+                m_angularVelocity = 0_rpm;
+            }
+        }
+
+        inline bool Body::IsAwake() const noexcept
+        {
+            return (m_flags & e_awakeFlag) != 0;
+        }
+
+        inline Time Body::GetUnderActiveTime() const noexcept
+        {
+            return m_underActiveTime;
+        }
+
+        inline void Body::SetUnderActiveTime(Time value) noexcept
+        {
+            if ((value == 0_s) || IsAccelerable())
+            {
+                m_underActiveTime = value;
+            }
+        }
+
+        inline void Body::ResetUnderActiveTime() noexcept
+        {
+            m_underActiveTime = 0_s;
+        }
+
+        inline bool Body::IsEnabled() const noexcept
+        {
+            return (m_flags & e_enabledFlag) != 0;
+        }
+
+        inline bool Body::IsFixedRotation() const noexcept
+        {
+            return (m_flags & e_fixedRotationFlag) != 0;
+        }
+
+        inline bool Body::IsSpeedable() const noexcept
+        {
+            return (m_flags & e_velocityFlag) != 0;
+        }
+
+        inline bool Body::IsAccelerable() const noexcept
+        {
+            return (m_flags & e_accelerationFlag) != 0;
+        }
+
+        inline bool Body::IsSleepingAllowed() const noexcept
+        {
+            return (m_flags & e_autoSleepFlag) != 0;
+        }
+
+        inline void Body::SetSleepingAllowed(bool flag) noexcept
+        {
+            if (flag)
+            {
+                m_flags |= e_autoSleepFlag;
+            }
+            else if (IsSpeedable())
+            {
+                m_flags &= ~e_autoSleepFlag;
+                SetAwakeFlag();
+                ResetUnderActiveTime();
+            }
+        }
+
+        inline SizedRange<Body::Fixtures::const_iterator> Body::GetFixtures() const noexcept
+        {
+            return {begin(m_fixtures), end(m_fixtures), size(m_fixtures)};
+        }
+
+        inline SizedRange<Body::Joints::const_iterator> Body::GetJoints() const noexcept
+        {
+            return {begin(m_joints), end(m_joints), size(m_joints)};
+        }
+
+        inline SizedRange<Body::Contacts::const_iterator> Body::GetContacts() const noexcept
+        {
+            return {begin(m_contacts), end(m_contacts), size(m_contacts)};
+        }
+
+        inline LinearAcceleration2 Body::GetLinearAcceleration() const noexcept
+        {
+            return m_linearAcceleration;
+        }
+
+        inline AngularAcceleration Body::GetAngularAcceleration() const noexcept
+        {
+            return m_angularAcceleration;
+        }
+
+        inline void Body::SetMassDataDirty() noexcept
+        {
+            m_flags |= e_massDataDirtyFlag;
+        }
+
+        inline void Body::UnsetMassDataDirty() noexcept
+        {
+            m_flags &= ~e_massDataDirtyFlag;
+        }
+
+        inline bool Body::IsMassDataDirty() const noexcept
+        {
+            return (m_flags & e_massDataDirtyFlag) != 0;
+        }
+
+        inline void Body::SetEnabledFlag() noexcept
+        {
+            m_flags |= e_enabledFlag;
+        }
+
+        inline void Body::UnsetEnabledFlag() noexcept
+        {
+            m_flags &= ~e_enabledFlag;
+        }
+
+        // Free functions...
+
+        /// @brief Gets the given body's acceleration.
+        /// @param body Body whose acceleration should be returned.
+        /// @relatedalso Body
+        inline Acceleration GetAcceleration(const Body& body) noexcept
+        {
+            return Acceleration{body.GetLinearAcceleration(), body.GetAngularAcceleration()};
+        }
+
+        /// @brief Sets the accelerations on the given body.
+        /// @note This has no effect on non-accelerable bodies.
+        /// @note A non-zero acceleration will also awaken the body.
+        /// @param body Body whose acceleration should be set.
+        /// @param value Acceleration value to set.
+        /// @relatedalso Body
+        inline void SetAcceleration(Body& body, Acceleration value) noexcept
+        {
+            body.SetAcceleration(value.linear, value.angular);
+        }
+
+        /// @brief Awakens the body if it's asleep.
+        /// @relatedalso Body
+        inline bool Awaken(Body& body) noexcept
+        {
+            if (!body.IsAwake() && body.IsSpeedable())
+            {
+                body.SetAwake();
+                return true;
+            }
+            return false;
+        }
+
+        /// @brief Puts the body to sleep if it's awake.
+        /// @relatedalso Body
+        inline bool Unawaken(Body& body) noexcept
+        {
+            if (body.IsAwake() && body.IsSleepingAllowed())
+            {
+                body.UnsetAwake();
+                return true;
+            }
+            return false;
+        }
+
+        /// @brief Gets the "position 1" Position information for the given body.
+        /// @relatedalso Body
+        inline Position GetPosition1(const Body& body) noexcept
+        {
+            return body.GetSweep().pos1;
+        }
+
+        /// @brief Gets the mass of the body.
+        /// @note This may be the total calculated mass or it may be the set mass of the body.
+        /// @return Value of zero or more representing the body's mass.
+        /// @see GetInvMass, SetMassData
+        /// @relatedalso Body
+        inline Mass GetMass(const Body& body) noexcept
+        {
+            const auto invMass = body.GetInvMass();
+            return (invMass != InvMass{0}) ? Mass{Real{1} / invMass} : 0_kg;
+        }
+
+        /// @brief Sets the linear and rotational accelerations on this body.
+        /// @note This has no effect on non-accelerable bodies.
+        /// @note A non-zero acceleration will also awaken the body.
+        /// @param body Body to set the acceleration of.
+        /// @param linear Linear acceleration.
+        /// @param angular Angular acceleration.
+        inline void SetAcceleration(Body& body, LinearAcceleration2 linear, AngularAcceleration angular) noexcept
+        {
+            body.SetAcceleration(linear, angular);
+        }
+
+        /// @brief Sets the given linear acceleration of the given body.
+        /// @relatedalso Body
+        inline void SetAcceleration(Body& body, LinearAcceleration2 value) noexcept
+        {
+            body.SetAcceleration(value, body.GetAngularAcceleration());
+        }
+
+        /// @brief Sets the given angular acceleration of the given body.
+        /// @relatedalso Body
+        inline void SetAcceleration(Body& body, AngularAcceleration value) noexcept
+        {
+            body.SetAcceleration(body.GetLinearAcceleration(), value);
+        }
+
+        /// @brief Applies an impulse at a point.
+        /// @note This immediately modifies the velocity.
+        /// @note This also modifies the angular velocity if the point of application
+        ///   is not at the center of mass.
+        /// @note Non-zero impulses wakes up the body.
+        /// @param body Body to apply the impulse to.
+        /// @param impulse the world impulse vector.
+        /// @param point the world position of the point of application.
+        /// @relatedalso Body
+        inline void ApplyLinearImpulse(Body& body, Momentum2 impulse, Length2 point) noexcept
+        {
+            auto velocity = body.GetVelocity();
+            velocity.linear += body.GetInvMass() * impulse;
+            const auto invRotI = body.GetInvRotInertia();
+            const auto dp = point - body.GetWorldCenter();
+            velocity.angular += AngularVelocity{invRotI * Cross(dp, impulse) / Radian};
+            body.SetVelocity(velocity);
+        }
+
+        /// @brief Applies an angular impulse.
+        /// @param body Body to apply the angular impulse to.
+        /// @param impulse Angular impulse to be applied.
+        /// @relatedalso Body
+        inline void ApplyAngularImpulse(Body& body, AngularMomentum impulse) noexcept
+        {
+            auto velocity = body.GetVelocity();
+            const auto invRotI = body.GetInvRotInertia();
+            velocity.angular += AngularVelocity{invRotI * impulse};
+            body.SetVelocity(velocity);
+        }
+
+        /// @brief Gets the rotational inertia of the body.
+        /// @param body Body to get the rotational inertia for.
+        /// @return the rotational inertia.
+        /// @relatedalso Body
+        inline RotInertia GetRotInertia(const Body& body) noexcept
+        {
+            return Real{1} / body.GetInvRotInertia();
+        }
+
+        /// @brief Gets the rotational inertia of the body about the local origin.
+        /// @return the rotational inertia.
+        /// @relatedalso Body
+        inline RotInertia GetLocalRotInertia(const Body& body) noexcept
+        {
+            return GetRotInertia(body)
+                   + GetMass(body) * GetMagnitudeSquared(body.GetLocalCenter()) / SquareRadian;
+        }
+
+        /// @brief Gets the linear velocity of the center of mass.
+        /// @param body Body to get the linear velocity for.
+        /// @return the linear velocity of the center of mass.
+        /// @relatedalso Body
+        inline LinearVelocity2 GetLinearVelocity(const Body& body) noexcept
+        {
+            return body.GetVelocity().linear;
+        }
+
+        /// @brief Gets the angular velocity.
+        /// @param body Body to get the angular velocity for.
+        /// @return the angular velocity.
+        /// @relatedalso Body
+        inline AngularVelocity GetAngularVelocity(const Body& body) noexcept
+        {
+            return body.GetVelocity().angular;
+        }
+
+        /// @brief Sets the linear velocity of the center of mass.
+        /// @param body Body to set the linear velocity of.
+        /// @param value the new linear velocity of the center of mass.
+        /// @relatedalso Body
+        inline void SetVelocity(Body& body, LinearVelocity2 value) noexcept
+        {
+            body.SetVelocity(Velocity{value, GetAngularVelocity(body)});
+        }
+
+        /// @brief Sets the angular velocity.
+        /// @param body Body to set the angular velocity of.
+        /// @param value the new angular velocity.
+        /// @relatedalso Body
+        inline void SetVelocity(Body& body, AngularVelocity value) noexcept
+        {
+            body.SetVelocity(Velocity{GetLinearVelocity(body), value});
+        }
+
+        /// @brief Gets the world coordinates of a point given in coordinates relative to the body's origin.
+        /// @param body Body that the given point is relative to.
+        /// @param localPoint a point measured relative the the body's origin.
+        /// @return the same point expressed in world coordinates.
+        /// @relatedalso Body
+        inline Length2 GetWorldPoint(const Body& body, const Length2 localPoint) noexcept
+        {
+            return Transform(localPoint, body.GetTransformation());
+        }
+
+        /// @brief Gets the world coordinates of a vector given the local coordinates.
+        /// @param body Body that the given vector is relative to.
+        /// @param localVector a vector fixed in the body.
+        /// @return the same vector expressed in world coordinates.
+        /// @relatedalso Body
+        inline Length2 GetWorldVector(const Body& body, const Length2 localVector) noexcept
+        {
+            return Rotate(localVector, body.GetTransformation().q);
+        }
+
+        /// @brief Gets the world vector for the given local vector from the given body's transformation.
+        /// @relatedalso Body
+        inline UnitVec GetWorldVector(const Body& body, const UnitVec localVector) noexcept
+        {
+            return Rotate(localVector, body.GetTransformation().q);
+        }
+
+        /// @brief Gets a local point relative to the body's origin given a world point.
+        /// @param body Body that the returned point should be relative to.
+        /// @param worldPoint point in world coordinates.
+        /// @return the corresponding local point relative to the body's origin.
+        /// @relatedalso Body
+        inline Length2 GetLocalPoint(const Body& body, const Length2 worldPoint) noexcept
+        {
+            return InverseTransform(worldPoint, body.GetTransformation());
+        }
+
+        /// @brief Gets a locally oriented unit vector given a world oriented unit vector.
+        /// @param body Body that the returned vector should be relative to.
+        /// @param uv Unit vector in world orientation.
+        /// @return the corresponding local vector.
+        /// @relatedalso Body
+        inline UnitVec GetLocalVector(const Body& body, const UnitVec uv) noexcept
+        {
+            return InverseRotate(uv, body.GetTransformation().q);
+        }
+
+        /// @brief Gets the linear velocity from a world point attached to this body.
+        /// @param body Body to get the linear velocity for.
+        /// @param worldPoint point in world coordinates.
+        /// @return the world velocity of a point.
+        /// @relatedalso Body
+        inline LinearVelocity2 GetLinearVelocityFromWorldPoint(const Body& body,
+                                                               const Length2 worldPoint) noexcept
+        {
+            const auto velocity = body.GetVelocity();
+            const auto worldCtr = body.GetWorldCenter();
+            const auto dp = Length2{worldPoint - worldCtr};
+            const auto rlv = LinearVelocity2{GetRevPerpendicular(dp) * (velocity.angular / Radian)};
+            return velocity.linear + rlv;
+        }
+
+        /// @brief Gets the linear velocity from a local point.
+        /// @param body Body to get the linear velocity for.
+        /// @param localPoint point in local coordinates.
+        /// @return the world velocity of a point.
+        /// @relatedalso Body
+        inline LinearVelocity2 GetLinearVelocityFromLocalPoint(const Body& body,
+                                                               const Length2 localPoint) noexcept
+        {
+            return GetLinearVelocityFromWorldPoint(body, GetWorldPoint(body, localPoint));
+        }
+
+        /// @brief Gets the net force that the given body is currently experiencing.
+        /// @relatedalso Body
+        inline Force2 GetForce(const Body& body) noexcept
+        {
+            return body.GetLinearAcceleration() * GetMass(body);
+        }
+
+        /// @brief Gets the net torque that the given body is currently experiencing.
+        /// @relatedalso Body
+        inline Torque GetTorque(const Body& body) noexcept
+        {
+            return body.GetAngularAcceleration() * GetRotInertia(body);
+        }
+
+        /// @brief Caps velocity.
+        /// @details Enforces maximums on the given velocity.
+        /// @param velocity Velocity to cap. Behavior is undefined if this value is invalid.
+        /// @param h Time elapsed to get velocity for. Behavior is undefined if this value is invalid.
+        /// @param conf Movement configuration. This defines caps on linear and angular speeds.
+        /// @relatedalso Velocity
+        Velocity Cap(Velocity velocity, Time h, MovementConf conf) noexcept;
+
+        /// @brief Gets the velocity of the body after the given time accounting for the body's
+        ///   acceleration and capped by the given configuration.
+        /// @warning Behavior is undefined if the given elapsed time is an invalid value (like NaN).
+        /// @param body Body to get the velocity for.
+        /// @param h Time elapsed to get velocity for. Behavior is undefined if this value is invalid.
+        /// @relatedalso Body
+        Velocity GetVelocity(const Body& body, Time h) noexcept;
+
+        /// @brief Gets the fixture count of the given body.
+        /// @relatedalso Body
+        FixtureCounter GetFixtureCount(const Body& body) noexcept;
+
+        /// @brief Gets the body's origin location.
+        /// @details This is the location of the body's origin relative to its world.
+        /// The location of the body after stepping the world's physics simulations is dependent on
+        /// a number of factors:
+        ///   1. Location at the last time step.
+        ///   2. Forces acting on the body (gravity, applied force, applied impulse).
+        ///   3. The mass data of the body.
+        ///   4. Damping of the body.
+        ///   5. Restitution and friction values of the body's fixtures when they experience collisions.
+        /// @return World location of the body's origin.
+        /// @see GetAngle.
+        /// @relatedalso Body
+        inline Length2 GetLocation(const Body& body) noexcept
+        {
+            return body.GetTransformation().p;
+        }
+
+        /// @brief Gets the body's angle.
+        /// @return Body's angle relative to its World.
+        /// @relatedalso Body
+        inline Angle GetAngle(const Body& body) noexcept
+        {
+            return body.GetSweep().pos1.angular;
+        }
+
+        /// @brief Gets the body's transformation.
+        /// @relatedalso Body
+        inline Transformation GetTransformation(const Body& body) noexcept
+        {
+            return body.GetTransformation();
+        }
+
+        /// @brief Gets the body's position.
+        /// @relatedalso Body
+        inline Position GetPosition(const Body& body) noexcept
+        {
+            return Position{body.GetLocation(), body.GetAngle()};
+        }
+
+        /// @brief Gets the transformation associated with the given configuration.
+        /// @relatedalso BodyConf
+        Transformation GetTransformation(const BodyConf& conf);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_BODY_HPP

--- a/PlayRho/Dynamics/BodyConf.cpp
+++ b/PlayRho/Dynamics/BodyConf.cpp
@@ -19,32 +19,34 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/BodyConf.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
+#include <PlayRho/Dynamics/BodyConf.hpp>
 
-namespace playrho {
-namespace d2 {
-
-BodyConf GetBodyConf(const Body& body) noexcept
+namespace playrho
 {
-    auto def = BodyConf{};
-    def.type = body.GetType();
-    def.location = body.GetLocation();
-    def.angle = body.GetAngle();
-    def.linearVelocity = GetLinearVelocity(body);
-    def.angularVelocity = GetAngularVelocity(body);
-    def.linearAcceleration = body.GetLinearAcceleration();
-    def.angularAcceleration = body.GetAngularAcceleration();
-    def.linearDamping = body.GetLinearDamping();
-    def.angularDamping = body.GetAngularDamping();
-    def.underActiveTime = body.GetUnderActiveTime();
-    def.allowSleep = body.IsSleepingAllowed();
-    def.awake = body.IsAwake();
-    def.fixedRotation = body.IsFixedRotation();
-    def.bullet = body.IsAccelerable() && body.IsImpenetrable();
-    def.enabled = body.IsEnabled();
-    return def;
-}
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        BodyConf GetBodyConf(const Body& body) noexcept
+        {
+            auto def = BodyConf{};
+            def.type = body.GetType();
+            def.location = body.GetLocation();
+            def.angle = body.GetAngle();
+            def.linearVelocity = GetLinearVelocity(body);
+            def.angularVelocity = GetAngularVelocity(body);
+            def.linearAcceleration = body.GetLinearAcceleration();
+            def.angularAcceleration = body.GetAngularAcceleration();
+            def.linearDamping = body.GetLinearDamping();
+            def.angularDamping = body.GetAngularDamping();
+            def.underActiveTime = body.GetUnderActiveTime();
+            def.allowSleep = body.IsSleepingAllowed();
+            def.awake = body.IsAwake();
+            def.fixedRotation = body.IsFixedRotation();
+            def.bullet = body.IsAccelerable() && body.IsImpenetrable();
+            def.enabled = body.IsEnabled();
+            return def;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/BodyConf.hpp
+++ b/PlayRho/Dynamics/BodyConf.hpp
@@ -25,260 +25,262 @@
 /// @file
 /// Declarations of the BodyConf struct and free functions associated with it.
 
-#include <PlayRho/Common/Settings.hpp>
-#include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/NonNegative.hpp>
+#include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Dynamics/BodyType.hpp>
 
-namespace playrho {
-namespace d2 {
-
-class Body;
-
-/// @brief Body configuration.
-///
-/// @details A body configuration holds all the data needed to construct a rigid body.
-///   You can safely re-use body configurations.
-///
-/// @note This is a value class meant for passing in to the <code>World::CreateBody</code>
-///   method.
-///
-/// @see World.
-///
-struct BodyConf
+namespace playrho
 {
-    // Builder-styled methods...
+    namespace d2
+    {
 
-    /// @brief Use the given type.
-    constexpr BodyConf& UseType(BodyType t) noexcept;
+        class Body;
 
-    /// @brief Use the given location.
-    constexpr BodyConf& UseLocation(Length2 l) noexcept;
-    
-    /// @brief Use the given angle.
-    constexpr BodyConf& UseAngle(Angle a) noexcept;
-    
-    /// @brief Use the given linear velocity.
-    constexpr BodyConf& UseLinearVelocity(LinearVelocity2 v) noexcept;
-    
-    /// @brief Use the given angular velocity.
-    constexpr BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
-    
-    /// @brief Use the given position for the linear and angular positions.
-    constexpr BodyConf& Use(Position v) noexcept;
+        /// @brief Body configuration.
+        ///
+        /// @details A body configuration holds all the data needed to construct a rigid body.
+        ///   You can safely re-use body configurations.
+        ///
+        /// @note This is a value class meant for passing in to the <code>World::CreateBody</code>
+        ///   method.
+        ///
+        /// @see World.
+        ///
+        struct BodyConf
+        {
+            // Builder-styled methods...
 
-    /// @brief Use the given velocity for the linear and angular velocities.
-    constexpr BodyConf& Use(Velocity v) noexcept;
-    
-    /// @brief Use the given linear acceleration.
-    constexpr BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
-    
-    /// @brief Use the given angular acceleration.
-    constexpr BodyConf& UseAngularAcceleration(AngularAcceleration v) noexcept;
-    
-    /// @brief Use the given linear damping.
-    constexpr BodyConf& UseLinearDamping(NonNegative<Frequency> v) noexcept;
-    
-    /// @brief Use the given angular damping.
-    constexpr BodyConf& UseAngularDamping(NonNegative<Frequency> v) noexcept;
-    
-    /// @brief Use the given under active time.
-    constexpr BodyConf& UseUnderActiveTime(Time v) noexcept;
-    
-    /// @brief Use the given allow sleep value.
-    constexpr BodyConf& UseAllowSleep(bool value) noexcept;
-    
-    /// @brief Use the given awake value.
-    constexpr BodyConf& UseAwake(bool value) noexcept;
-    
-    /// @brief Use the given fixed rotation state.
-    constexpr BodyConf& UseFixedRotation(bool value) noexcept;
-    
-    /// @brief Use the given bullet state.
-    constexpr BodyConf& UseBullet(bool value) noexcept;
-    
-    /// @brief Use the given enabled state.
-    constexpr BodyConf& UseEnabled(bool value) noexcept;
-    
-    // Public member variables...
-    
-    /// @brief Type of the body: static, kinematic, or dynamic.
-    /// @note If a dynamic body would have zero mass, the mass is set to one.
-    BodyType type = BodyType::Static;
-    
-    /// The world location of the body. Avoid creating bodies at the origin
-    /// since this can lead to many overlapping shapes.
-    Length2 location = Length2{};
-    
-    /// The world angle of the body.
-    Angle angle = 0_deg;
-    
-    /// The linear velocity of the body's origin in world co-ordinates (in m/s).
-    LinearVelocity2 linearVelocity = LinearVelocity2{};
-    
-    /// The angular velocity of the body.
-    AngularVelocity angularVelocity = 0_rpm;
-    
-    /// Initial linear acceleration of the body.
-    /// @note Usually this should be 0.
-    LinearAcceleration2 linearAcceleration = LinearAcceleration2{};
-    
-    /// Initial angular acceleration of the body.
-    /// @note Usually this should be 0.
-    AngularAcceleration angularAcceleration = AngularAcceleration{0 * RadianPerSquareSecond};
-    
-    /// Linear damping is use to reduce the linear velocity. The damping parameter
-    /// can be larger than 1 but the damping effect becomes sensitive to the
-    /// time step when the damping parameter is large.
-    NonNegative<Frequency> linearDamping = NonNegative<Frequency>{0_Hz};
-    
-    /// Angular damping is use to reduce the angular velocity. The damping parameter
-    /// can be larger than 1 but the damping effect becomes sensitive to the
-    /// time step when the damping parameter is large.
-    NonNegative<Frequency> angularDamping = NonNegative<Frequency>{0_Hz};
-    
-    /// Under-active time.
-    /// @details Set this to the value retrieved from <code>Body::GetUnderActiveTime</code>
-    ///   or leave it as 0.
-    Time underActiveTime = 0_s;
-    
-    /// Set this flag to false if this body should never fall asleep. Note that
-    /// this increases CPU usage.
-    bool allowSleep = true;
-    
-    /// Is this body initially awake or sleeping?
-    bool awake = true;
-    
-    /// Should this body be prevented from rotating? Useful for characters.
-    bool fixedRotation = false;
-    
-    /// Is this a fast moving body that should be prevented from tunneling through
-    /// other moving bodies? Note that all bodies are prevented from tunneling through
-    /// kinematic and static bodies. This setting is only considered on dynamic bodies.
-    /// @note Use this flag sparingly since it increases processing time.
-    bool bullet = false;
-    
-    /// Does this body start out enabled?
-    bool enabled = true;
-};
+            /// @brief Use the given type.
+            constexpr BodyConf& UseType(BodyType t) noexcept;
 
-constexpr BodyConf& BodyConf::UseType(BodyType t) noexcept
-{
-    type = t;
-    return *this;
-}
+            /// @brief Use the given location.
+            constexpr BodyConf& UseLocation(Length2 l) noexcept;
 
-constexpr BodyConf& BodyConf::UseLocation(Length2 l) noexcept
-{
-    location = l;
-    return *this;
-}
+            /// @brief Use the given angle.
+            constexpr BodyConf& UseAngle(Angle a) noexcept;
 
-constexpr BodyConf& BodyConf::UseAngle(Angle a) noexcept
-{
-    angle = a;
-    return *this;
-}
+            /// @brief Use the given linear velocity.
+            constexpr BodyConf& UseLinearVelocity(LinearVelocity2 v) noexcept;
 
-constexpr BodyConf& BodyConf::Use(Position v) noexcept
-{
-    location = v.linear;
-    angle = v.angular;
-    return *this;
-}
+            /// @brief Use the given angular velocity.
+            constexpr BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
 
-constexpr BodyConf& BodyConf::Use(Velocity v) noexcept
-{
-    linearVelocity = v.linear;
-    angularVelocity = v.angular;
-    return *this;
-}
+            /// @brief Use the given position for the linear and angular positions.
+            constexpr BodyConf& Use(Position v) noexcept;
 
-constexpr BodyConf& BodyConf::UseLinearVelocity(LinearVelocity2 v) noexcept
-{
-    linearVelocity = v;
-    return *this;
-}
+            /// @brief Use the given velocity for the linear and angular velocities.
+            constexpr BodyConf& Use(Velocity v) noexcept;
 
-constexpr BodyConf& BodyConf::UseLinearAcceleration(LinearAcceleration2 v) noexcept
-{
-    linearAcceleration = v;
-    return *this;
-}
+            /// @brief Use the given linear acceleration.
+            constexpr BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
 
-constexpr BodyConf& BodyConf::UseAngularVelocity(AngularVelocity v) noexcept
-{
-    angularVelocity = v;
-    return *this;
-}
+            /// @brief Use the given angular acceleration.
+            constexpr BodyConf& UseAngularAcceleration(AngularAcceleration v) noexcept;
 
-constexpr BodyConf& BodyConf::UseAngularAcceleration(AngularAcceleration v) noexcept
-{
-    angularAcceleration = v;
-    return *this;
-}
+            /// @brief Use the given linear damping.
+            constexpr BodyConf& UseLinearDamping(NonNegative<Frequency> v) noexcept;
 
-constexpr BodyConf& BodyConf::UseLinearDamping(NonNegative<Frequency> v) noexcept
-{
-    linearDamping = v;
-    return *this;
-}
+            /// @brief Use the given angular damping.
+            constexpr BodyConf& UseAngularDamping(NonNegative<Frequency> v) noexcept;
 
-constexpr BodyConf& BodyConf::UseAngularDamping(NonNegative<Frequency> v) noexcept
-{
-    angularDamping = v;
-    return *this;
-}
+            /// @brief Use the given under active time.
+            constexpr BodyConf& UseUnderActiveTime(Time v) noexcept;
 
-constexpr BodyConf& BodyConf::UseUnderActiveTime(Time v) noexcept
-{
-    underActiveTime = v;
-    return *this;
-}
+            /// @brief Use the given allow sleep value.
+            constexpr BodyConf& UseAllowSleep(bool value) noexcept;
 
-constexpr BodyConf& BodyConf::UseAllowSleep(bool value) noexcept
-{
-    allowSleep = value;
-    return *this;
-}
+            /// @brief Use the given awake value.
+            constexpr BodyConf& UseAwake(bool value) noexcept;
 
-constexpr BodyConf& BodyConf::UseAwake(bool value) noexcept
-{
-    awake = value;
-    return *this;
-}
+            /// @brief Use the given fixed rotation state.
+            constexpr BodyConf& UseFixedRotation(bool value) noexcept;
 
-constexpr BodyConf& BodyConf::UseFixedRotation(bool value) noexcept
-{
-    fixedRotation = value;
-    return *this;
-}
+            /// @brief Use the given bullet state.
+            constexpr BodyConf& UseBullet(bool value) noexcept;
 
-constexpr BodyConf& BodyConf::UseBullet(bool value) noexcept
-{
-    bullet = value;
-    return *this;
-}
+            /// @brief Use the given enabled state.
+            constexpr BodyConf& UseEnabled(bool value) noexcept;
 
-constexpr BodyConf& BodyConf::UseEnabled(bool value) noexcept
-{
-    enabled = value;
-    return *this;
-}
+            // Public member variables...
 
-/// @brief Gets the default body definition.
-/// @relatedalso BodyConf
-constexpr BodyConf GetDefaultBodyConf() noexcept
-{
-    return BodyConf{};
-}
+            /// @brief Type of the body: static, kinematic, or dynamic.
+            /// @note If a dynamic body would have zero mass, the mass is set to one.
+            BodyType type = BodyType::Static;
 
-/// @brief Gets the body definition for the given body.
-/// @param body Body to get the <code>BodyConf</code> for.
-/// @relatedalso Body
-BodyConf GetBodyConf(const Body& body) noexcept;
+            /// The world location of the body. Avoid creating bodies at the origin
+            /// since this can lead to many overlapping shapes.
+            Length2 location = Length2{};
 
-} // namespace d2
-} // namespace playrho
+            /// The world angle of the body.
+            Angle angle = 0_deg;
 
-#endif // PLAYRHO_DYNAMICS_BODYCONF_HPP
+            /// The linear velocity of the body's origin in world co-ordinates (in m/s).
+            LinearVelocity2 linearVelocity = LinearVelocity2{};
+
+            /// The angular velocity of the body.
+            AngularVelocity angularVelocity = 0_rpm;
+
+            /// Initial linear acceleration of the body.
+            /// @note Usually this should be 0.
+            LinearAcceleration2 linearAcceleration = LinearAcceleration2{};
+
+            /// Initial angular acceleration of the body.
+            /// @note Usually this should be 0.
+            AngularAcceleration angularAcceleration = AngularAcceleration{0 * RadianPerSquareSecond};
+
+            /// Linear damping is use to reduce the linear velocity. The damping parameter
+            /// can be larger than 1 but the damping effect becomes sensitive to the
+            /// time step when the damping parameter is large.
+            NonNegative<Frequency> linearDamping = NonNegative<Frequency>{0_Hz};
+
+            /// Angular damping is use to reduce the angular velocity. The damping parameter
+            /// can be larger than 1 but the damping effect becomes sensitive to the
+            /// time step when the damping parameter is large.
+            NonNegative<Frequency> angularDamping = NonNegative<Frequency>{0_Hz};
+
+            /// Under-active time.
+            /// @details Set this to the value retrieved from <code>Body::GetUnderActiveTime</code>
+            ///   or leave it as 0.
+            Time underActiveTime = 0_s;
+
+            /// Set this flag to false if this body should never fall asleep. Note that
+            /// this increases CPU usage.
+            bool allowSleep = true;
+
+            /// Is this body initially awake or sleeping?
+            bool awake = true;
+
+            /// Should this body be prevented from rotating? Useful for characters.
+            bool fixedRotation = false;
+
+            /// Is this a fast moving body that should be prevented from tunneling through
+            /// other moving bodies? Note that all bodies are prevented from tunneling through
+            /// kinematic and static bodies. This setting is only considered on dynamic bodies.
+            /// @note Use this flag sparingly since it increases processing time.
+            bool bullet = false;
+
+            /// Does this body start out enabled?
+            bool enabled = true;
+        };
+
+        constexpr BodyConf& BodyConf::UseType(BodyType t) noexcept
+        {
+            type = t;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseLocation(Length2 l) noexcept
+        {
+            location = l;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseAngle(Angle a) noexcept
+        {
+            angle = a;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::Use(Position v) noexcept
+        {
+            location = v.linear;
+            angle = v.angular;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::Use(Velocity v) noexcept
+        {
+            linearVelocity = v.linear;
+            angularVelocity = v.angular;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseLinearVelocity(LinearVelocity2 v) noexcept
+        {
+            linearVelocity = v;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseLinearAcceleration(LinearAcceleration2 v) noexcept
+        {
+            linearAcceleration = v;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseAngularVelocity(AngularVelocity v) noexcept
+        {
+            angularVelocity = v;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseAngularAcceleration(AngularAcceleration v) noexcept
+        {
+            angularAcceleration = v;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseLinearDamping(NonNegative<Frequency> v) noexcept
+        {
+            linearDamping = v;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseAngularDamping(NonNegative<Frequency> v) noexcept
+        {
+            angularDamping = v;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseUnderActiveTime(Time v) noexcept
+        {
+            underActiveTime = v;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseAllowSleep(bool value) noexcept
+        {
+            allowSleep = value;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseAwake(bool value) noexcept
+        {
+            awake = value;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseFixedRotation(bool value) noexcept
+        {
+            fixedRotation = value;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseBullet(bool value) noexcept
+        {
+            bullet = value;
+            return *this;
+        }
+
+        constexpr BodyConf& BodyConf::UseEnabled(bool value) noexcept
+        {
+            enabled = value;
+            return *this;
+        }
+
+        /// @brief Gets the default body definition.
+        /// @relatedalso BodyConf
+        constexpr BodyConf GetDefaultBodyConf() noexcept
+        {
+            return BodyConf{};
+        }
+
+        /// @brief Gets the body definition for the given body.
+        /// @param body Body to get the <code>BodyConf</code> for.
+        /// @relatedalso Body
+        BodyConf GetBodyConf(const Body& body) noexcept;
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_BODYCONF_HPP

--- a/PlayRho/Dynamics/BodyID.hpp
+++ b/PlayRho/Dynamics/BodyID.hpp
@@ -21,31 +21,32 @@
 #ifndef PLAYRHO_DYNAMICS_BODYID_HPP
 #define PLAYRHO_DYNAMICS_BODYID_HPP
 
-#include <PlayRho/Common/StrongType.hpp>
 #include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/StrongType.hpp>
 
-namespace playrho {
-
-/// @brief Body identifier.
-using BodyID = strongtype::IndexingNamedType<BodyCounter, struct BodyIdentifier>;
-
-/// @brief Invalid body ID value.
-constexpr auto InvalidBodyID = static_cast<BodyID>(static_cast<BodyID::underlying_type>(-1));
-
-/// @brief Gets an invalid value for the BodyID type.
-template <>
-constexpr BodyID GetInvalid() noexcept
+namespace playrho
 {
-    return InvalidBodyID;
-}
 
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const BodyID& value) noexcept
-{
-    return value != GetInvalid<BodyID>();
-}
+    /// @brief Body identifier.
+    using BodyID = strongtype::IndexingNamedType<BodyCounter, struct BodyIdentifier>;
 
-}
+    /// @brief Invalid body ID value.
+    constexpr auto InvalidBodyID = static_cast<BodyID>(static_cast<BodyID::underlying_type>(-1));
 
-#endif // PLAYRHO_DYNAMICS_BODYID_HPP
+    /// @brief Gets an invalid value for the BodyID type.
+    template<>
+    constexpr BodyID GetInvalid() noexcept
+    {
+        return InvalidBodyID;
+    }
+
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const BodyID& value) noexcept
+    {
+        return value != GetInvalid<BodyID>();
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_BODYID_HPP

--- a/PlayRho/Dynamics/BodyType.hpp
+++ b/PlayRho/Dynamics/BodyType.hpp
@@ -20,64 +20,65 @@
 #ifndef PLAYRHO_DYNAMICS_BODYTYPE_HPP
 #define PLAYRHO_DYNAMICS_BODYTYPE_HPP
 
-namespace playrho {
-
-/// @brief Body Type.
-/// @note static: zero mass, zero velocity, may be manually moved.
-/// @note kinematic: zero mass, non-zero velocity set by user, moved by solver.
-/// @note dynamic: positive mass, non-zero velocity determined by forces, moved by solver.
-/// @see IsSpeedable(BodyType), IsAccelerable(BodyType).
-enum class BodyType
+namespace playrho
 {
-    /// Static body type.
-    /// @details
-    /// Static bodies have no mass, have no forces applied to them, and aren't moved by
-    /// physical processes. They are impenetrable.
-    /// @note Physics applied: none.
-    Static = 0,
-    
-    /// Kinematic body type.
-    /// @details
-    /// Kinematic bodies: have no mass, cannot have forces applied to them,
-    /// can move at set velocities (they are "speedable"), and are impenetrable.
-    /// @note Physics applied: velocity.
-    Kinematic,
-    
-    /// Dynamic body type.
-    /// @details
-    /// Dynamic bodies are fully simulated bodies - they are "speedable" and "accelerable".
-    /// Dynamic bodies always have a positive non-zero mass.
-    /// They may be penetrable.
-    /// @note Physics applied: velocity, acceleration.
-    Dynamic
-};
 
-/// @brief Is "speedable".
-/// @details Whether or not the given type value is for a body which can have a non-zero
-///   speed associated with it.
-/// @return <code>true</code> if the given type value represents a "speedable" type value,
-///   <code>false</code> otherwise.
-/// @note Would be nice if the Doxygen "relatedalso BodyType" command worked for this but
-///   seems that doesn't work for scoped enumeration.
-/// @see IsAccelerable(BodyType).
-inline bool IsSpeedable(BodyType type)
-{
-    return type != BodyType::Static;
-}
+    /// @brief Body Type.
+    /// @note static: zero mass, zero velocity, may be manually moved.
+    /// @note kinematic: zero mass, non-zero velocity set by user, moved by solver.
+    /// @note dynamic: positive mass, non-zero velocity determined by forces, moved by solver.
+    /// @see IsSpeedable(BodyType), IsAccelerable(BodyType).
+    enum class BodyType
+    {
+        /// Static body type.
+        /// @details
+        /// Static bodies have no mass, have no forces applied to them, and aren't moved by
+        /// physical processes. They are impenetrable.
+        /// @note Physics applied: none.
+        Static = 0,
 
-/// @brief Is "accelerable".
-/// @details Whether or not the given type value is for a body which can have a non-zero
-///   acceleration associated with it.
-/// @return <code>true</code> if the given type value represents an "accelerable" type value,
-///   <code>false</code> otherwise.
-/// @note Would be nice if the Doxygen "relatedalso BodyType" command worked for this but
-///   seems that doesn't work for scoped enumeration.
-/// @see IsSpeedable(BodyType).
-inline bool IsAccelerable(BodyType type)
-{
-    return type == BodyType::Dynamic;
-}
+        /// Kinematic body type.
+        /// @details
+        /// Kinematic bodies: have no mass, cannot have forces applied to them,
+        /// can move at set velocities (they are "speedable"), and are impenetrable.
+        /// @note Physics applied: velocity.
+        Kinematic,
 
-} // namespace playrho
+        /// Dynamic body type.
+        /// @details
+        /// Dynamic bodies are fully simulated bodies - they are "speedable" and "accelerable".
+        /// Dynamic bodies always have a positive non-zero mass.
+        /// They may be penetrable.
+        /// @note Physics applied: velocity, acceleration.
+        Dynamic
+    };
 
-#endif // PLAYRHO_DYNAMICS_BODYTYPE_HPP
+    /// @brief Is "speedable".
+    /// @details Whether or not the given type value is for a body which can have a non-zero
+    ///   speed associated with it.
+    /// @return <code>true</code> if the given type value represents a "speedable" type value,
+    ///   <code>false</code> otherwise.
+    /// @note Would be nice if the Doxygen "relatedalso BodyType" command worked for this but
+    ///   seems that doesn't work for scoped enumeration.
+    /// @see IsAccelerable(BodyType).
+    inline bool IsSpeedable(BodyType type)
+    {
+        return type != BodyType::Static;
+    }
+
+    /// @brief Is "accelerable".
+    /// @details Whether or not the given type value is for a body which can have a non-zero
+    ///   acceleration associated with it.
+    /// @return <code>true</code> if the given type value represents an "accelerable" type value,
+    ///   <code>false</code> otherwise.
+    /// @note Would be nice if the Doxygen "relatedalso BodyType" command worked for this but
+    ///   seems that doesn't work for scoped enumeration.
+    /// @see IsSpeedable(BodyType).
+    inline bool IsAccelerable(BodyType type)
+    {
+        return type == BodyType::Dynamic;
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_BODYTYPE_HPP

--- a/PlayRho/Dynamics/ContactImpulsesList.cpp
+++ b/PlayRho/Dynamics/ContactImpulsesList.cpp
@@ -21,20 +21,22 @@
 #include <PlayRho/Dynamics/ContactImpulsesList.hpp>
 #include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Gets the contact impulses for the given velocity constraint.
-ContactImpulsesList GetContactImpulses(const VelocityConstraint& vc)
+namespace playrho
 {
-    ContactImpulsesList impulse;
-    const auto count = vc.GetPointCount();
-    for (auto j = decltype(count){0}; j < count; ++j)
+    namespace d2
     {
-        impulse.AddEntry(GetNormalImpulseAtPoint(vc, j), GetTangentImpulseAtPoint(vc, j));
-    }
-    return impulse;
-}
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Gets the contact impulses for the given velocity constraint.
+        ContactImpulsesList GetContactImpulses(const VelocityConstraint& vc)
+        {
+            ContactImpulsesList impulse;
+            const auto count = vc.GetPointCount();
+            for (auto j = decltype(count){0}; j < count; ++j)
+            {
+                impulse.AddEntry(GetNormalImpulseAtPoint(vc, j), GetTangentImpulseAtPoint(vc, j));
+            }
+            return impulse;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/ContactImpulsesList.hpp
+++ b/PlayRho/Dynamics/ContactImpulsesList.hpp
@@ -24,64 +24,74 @@
 #include <PlayRho/Common/Settings.hpp>
 #include <algorithm>
 
-namespace playrho {
-namespace d2 {
-
-class VelocityConstraint;
-
-/// Contact Impulse.
-/// @details
-/// Used for reporting. Impulses are used instead of forces because
-/// sub-step forces may approach infinity for rigid body collisions. These
-/// match up one-to-one with the contact points in Manifold.
-class ContactImpulsesList
+namespace playrho
 {
-public:
-    
-    /// @brief Counter type.
-    using Counter = std::remove_const<decltype(MaxManifoldPoints)>::type;
-    
-    /// @brief Gets the count.
-    Counter GetCount() const noexcept { return count; }
-    
-    /// @brief Gets the given indexed entry normal.
-    Momentum GetEntryNormal(Counter index) const noexcept { return normalImpulses[index]; }
-    
-    /// @brief Gets the given indexed entry tangent.
-    Momentum GetEntryTanget(Counter index) const noexcept { return tangentImpulses[index]; }
-    
-    /// @brief Adds an entry of the given data.
-    void AddEntry(Momentum normal, Momentum tangent) noexcept
+    namespace d2
     {
-        assert(count < MaxManifoldPoints);
-        normalImpulses[count] = normal;
-        tangentImpulses[count] = tangent;
-        ++count;
-    }
-    
-private:
-    Momentum normalImpulses[MaxManifoldPoints]; ///< Normal impulses.
-    Momentum tangentImpulses[MaxManifoldPoints]; ///< Tangent impulses.
-    Counter count = 0; ///< Count of entries added.
-};
 
-/// @brief Gets the maximum normal impulse from the given contact impulses list.
-/// @relatedalso ContactImpulsesList
-inline Momentum GetMaxNormalImpulse(const ContactImpulsesList& impulses) noexcept
-{
-    auto maxImpulse = 0_Ns;
-    const auto count = impulses.GetCount();
-    for (auto i = decltype(count){0}; i < count; ++i)
-    {
-        maxImpulse = std::max(maxImpulse, impulses.GetEntryNormal(i));
-    }
-    return maxImpulse;
-}
+        class VelocityConstraint;
 
-/// @brief Gets the contact impulses for the given velocity constraint.
-ContactImpulsesList GetContactImpulses(const VelocityConstraint& vc);
+        /// Contact Impulse.
+        /// @details
+        /// Used for reporting. Impulses are used instead of forces because
+        /// sub-step forces may approach infinity for rigid body collisions. These
+        /// match up one-to-one with the contact points in Manifold.
+        class ContactImpulsesList
+        {
+         public:
+            /// @brief Counter type.
+            using Counter = std::remove_const<decltype(MaxManifoldPoints)>::type;
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Gets the count.
+            Counter GetCount() const noexcept
+            {
+                return count;
+            }
 
-#endif // PLAYRHO_DYNAMICS_CONTACTIMPULSESLIST_HPP
+            /// @brief Gets the given indexed entry normal.
+            Momentum GetEntryNormal(Counter index) const noexcept
+            {
+                return normalImpulses[index];
+            }
+
+            /// @brief Gets the given indexed entry tangent.
+            Momentum GetEntryTanget(Counter index) const noexcept
+            {
+                return tangentImpulses[index];
+            }
+
+            /// @brief Adds an entry of the given data.
+            void AddEntry(Momentum normal, Momentum tangent) noexcept
+            {
+                assert(count < MaxManifoldPoints);
+                normalImpulses[count] = normal;
+                tangentImpulses[count] = tangent;
+                ++count;
+            }
+
+         private:
+            Momentum normalImpulses[MaxManifoldPoints]; ///< Normal impulses.
+            Momentum tangentImpulses[MaxManifoldPoints];///< Tangent impulses.
+            Counter count = 0;                          ///< Count of entries added.
+        };
+
+        /// @brief Gets the maximum normal impulse from the given contact impulses list.
+        /// @relatedalso ContactImpulsesList
+        inline Momentum GetMaxNormalImpulse(const ContactImpulsesList& impulses) noexcept
+        {
+            auto maxImpulse = 0_Ns;
+            const auto count = impulses.GetCount();
+            for (auto i = decltype(count){0}; i < count; ++i)
+            {
+                maxImpulse = std::max(maxImpulse, impulses.GetEntryNormal(i));
+            }
+            return maxImpulse;
+        }
+
+        /// @brief Gets the contact impulses for the given velocity constraint.
+        ContactImpulsesList GetContactImpulses(const VelocityConstraint& vc);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTIMPULSESLIST_HPP

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -21,135 +21,135 @@
 #define PLAYRHO_DYNAMICS_CONTACTS_BODYCONSTRAINT_HPP
 
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Dynamics/MovementConf.hpp>
 #include <PlayRho/Dynamics/Body.hpp>
+#include <PlayRho/Dynamics/MovementConf.hpp>
 
-namespace playrho {
-namespace d2 {
-
-    /// @brief Body Constraint.
-    /// @details Body data related to constraint processing.
-    /// @note Only position and velocity is independently changeable after construction.
-    /// @note This data structure is 40-bytes large (with 4-byte Real on at least one
-    ///   64-bit platform).
-    class BodyConstraint
+namespace playrho
+{
+    namespace d2
     {
-    public:
-        // Note: Seeing World.TilesComesToRest times of around 5686 ms with this setup.
 
-        /// @brief Index type.
-        using index_type = std::remove_const<decltype(MaxBodies)>::type;
-        
-        BodyConstraint() = default;
-        
-        /// @brief Initializing constructor.
-        constexpr
-        BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
-                         Position position, Velocity velocity) noexcept:
-            m_position{position},
-            m_velocity{velocity},
-            m_localCenter{localCenter},
-            m_invMass{invMass},
-            m_invRotI{invRotI}
+        /// @brief Body Constraint.
+        /// @details Body data related to constraint processing.
+        /// @note Only position and velocity is independently changeable after construction.
+        /// @note This data structure is 40-bytes large (with 4-byte Real on at least one
+        ///   64-bit platform).
+        class BodyConstraint
         {
-            assert(IsValid(position));
-            assert(IsValid(velocity));
-            assert(IsValid(localCenter));
-            assert(invMass >= InvMass{0});
-            assert(invRotI >= InvRotInertia{0});
-        }
-        
-        /// @brief Gets the inverse mass of this body representation.
-        /// @return Value >= 0.
-        InvMass GetInvMass() const noexcept;
-        
-        /// @brief Gets the inverse rotational inertia of this body representation.
-        /// @return Value >= 0.
-        InvRotInertia GetInvRotInertia() const noexcept;
-        
-        /// @brief Gets the location of the body's center of mass in local coordinates.
-        Length2 GetLocalCenter() const noexcept;
-        
-        /// @brief Gets the position of the body.
-        Position GetPosition() const noexcept;
-        
-        /// @brief Gets the velocity of the body.
-        Velocity GetVelocity() const noexcept;
-        
-        /// @brief Sets the position of the body.
-        /// @param value A valid position value to set for the represented body.
-        /// @warning Behavior is undefined if the given value is not valid.
-        BodyConstraint& SetPosition(Position value) noexcept;
-        
-        /// @brief Sets the velocity of the body.
-        /// @param value A valid velocity value to set for the represented body.
-        /// @warning Behavior is undefined if the given value is not valid.
-        BodyConstraint& SetVelocity(Velocity value) noexcept;
-        
-    private:
-        Position m_position; ///< Body position data.
-        Velocity m_velocity; ///< Body velocity data.
-        Length2 m_localCenter; ///< Local center of the associated body's sweep.
-        InvMass m_invMass; ///< Inverse mass of associated body (a non-negative value).
+         public:
+            // Note: Seeing World.TilesComesToRest times of around 5686 ms with this setup.
 
-        /// Inverse rotational inertia about the center of mass of the associated body
-        /// (a non-negative value).
-        InvRotInertia m_invRotI;
-    };
-    
-    inline InvMass BodyConstraint::GetInvMass() const noexcept
-    {
-        return m_invMass;
-    }
-    
-    inline InvRotInertia BodyConstraint::GetInvRotInertia() const noexcept
-    {
-        return m_invRotI;
-    }
-    
-    inline Length2 BodyConstraint::GetLocalCenter() const noexcept
-    {
-        return m_localCenter;
-    }
-    
-    inline Position BodyConstraint::GetPosition() const noexcept
-    {
-        return m_position;
-    }
-    
-    inline Velocity BodyConstraint::GetVelocity() const noexcept
-    {
-        return m_velocity;
-    }
-    
-    inline BodyConstraint& BodyConstraint::SetPosition(Position value) noexcept
-    {
-        assert(IsValid(value));
-        m_position = value;
-        return *this;
-    }
-    
-    inline BodyConstraint& BodyConstraint::SetVelocity(Velocity value) noexcept
-    {
-        assert(IsValid(value));
-        m_velocity = value;
-        return *this;
-    }
-    
-    /// @brief Gets the <code>BodyConstraint</code> based on the given parameters.
-    inline BodyConstraint GetBodyConstraint(const Body& body, Time time,
-                                            MovementConf conf) noexcept
-    {
-        return BodyConstraint{
-            body.GetInvMass(),
-            body.GetInvRotInertia(),
-            body.GetLocalCenter(),
-            GetPosition1(body),
-            Cap(GetVelocity(body, time), time, conf)
+            /// @brief Index type.
+            using index_type = std::remove_const<decltype(MaxBodies)>::type;
+
+            BodyConstraint() = default;
+
+            /// @brief Initializing constructor.
+            constexpr BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
+                                     Position position, Velocity velocity) noexcept
+                : m_position{position},
+                  m_velocity{velocity},
+                  m_localCenter{localCenter},
+                  m_invMass{invMass},
+                  m_invRotI{invRotI}
+            {
+                assert(IsValid(position));
+                assert(IsValid(velocity));
+                assert(IsValid(localCenter));
+                assert(invMass >= InvMass{0});
+                assert(invRotI >= InvRotInertia{0});
+            }
+
+            /// @brief Gets the inverse mass of this body representation.
+            /// @return Value >= 0.
+            InvMass GetInvMass() const noexcept;
+
+            /// @brief Gets the inverse rotational inertia of this body representation.
+            /// @return Value >= 0.
+            InvRotInertia GetInvRotInertia() const noexcept;
+
+            /// @brief Gets the location of the body's center of mass in local coordinates.
+            Length2 GetLocalCenter() const noexcept;
+
+            /// @brief Gets the position of the body.
+            Position GetPosition() const noexcept;
+
+            /// @brief Gets the velocity of the body.
+            Velocity GetVelocity() const noexcept;
+
+            /// @brief Sets the position of the body.
+            /// @param value A valid position value to set for the represented body.
+            /// @warning Behavior is undefined if the given value is not valid.
+            BodyConstraint& SetPosition(Position value) noexcept;
+
+            /// @brief Sets the velocity of the body.
+            /// @param value A valid velocity value to set for the represented body.
+            /// @warning Behavior is undefined if the given value is not valid.
+            BodyConstraint& SetVelocity(Velocity value) noexcept;
+
+         private:
+            Position m_position;  ///< Body position data.
+            Velocity m_velocity;  ///< Body velocity data.
+            Length2 m_localCenter;///< Local center of the associated body's sweep.
+            InvMass m_invMass;    ///< Inverse mass of associated body (a non-negative value).
+
+            /// Inverse rotational inertia about the center of mass of the associated body
+            /// (a non-negative value).
+            InvRotInertia m_invRotI;
         };
-    }
 
-} // namespace d2
-} // namespace playrho
+        inline InvMass BodyConstraint::GetInvMass() const noexcept
+        {
+            return m_invMass;
+        }
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_BODYCONSTRAINT_HPP
+        inline InvRotInertia BodyConstraint::GetInvRotInertia() const noexcept
+        {
+            return m_invRotI;
+        }
+
+        inline Length2 BodyConstraint::GetLocalCenter() const noexcept
+        {
+            return m_localCenter;
+        }
+
+        inline Position BodyConstraint::GetPosition() const noexcept
+        {
+            return m_position;
+        }
+
+        inline Velocity BodyConstraint::GetVelocity() const noexcept
+        {
+            return m_velocity;
+        }
+
+        inline BodyConstraint& BodyConstraint::SetPosition(Position value) noexcept
+        {
+            assert(IsValid(value));
+            m_position = value;
+            return *this;
+        }
+
+        inline BodyConstraint& BodyConstraint::SetVelocity(Velocity value) noexcept
+        {
+            assert(IsValid(value));
+            m_velocity = value;
+            return *this;
+        }
+
+        /// @brief Gets the <code>BodyConstraint</code> based on the given parameters.
+        inline BodyConstraint GetBodyConstraint(const Body& body, Time time,
+                                                MovementConf conf) noexcept
+        {
+            return BodyConstraint{
+                body.GetInvMass(),
+                body.GetInvRotInertia(),
+                body.GetLocalCenter(),
+                GetPosition1(body),
+                Cap(GetVelocity(body, time), time, conf)};
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_BODYCONSTRAINT_HPP

--- a/PlayRho/Dynamics/Contacts/Contact.cpp
+++ b/PlayRho/Dynamics/Contacts/Contact.cpp
@@ -26,31 +26,33 @@
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<Contact>::value,
-              "Contact must be default constructible!");
-static_assert(std::is_copy_constructible<Contact>::value,
-              "Contact must be copy constructible!");
-static_assert(std::is_move_constructible<Contact>::value,
-              "Contact must be move constructible!");
-static_assert(std::is_copy_assignable<Contact>::value,
-              "Contact must be copy assignable!");
-static_assert(std::is_move_assignable<Contact>::value,
-              "Contact must be move assignable!");
-static_assert(std::is_nothrow_destructible<Contact>::value,
-              "Contact must be nothrow destructible!");
-
-Contact::Contact(BodyID bA, FixtureID fA, ChildCounter iA,
-                 BodyID bB, FixtureID fB, ChildCounter iB) noexcept:
-    m_bodyA{bA}, m_bodyB{bB}, m_fixtureA{fA}, m_fixtureB{fB}, m_indexA{iA}, m_indexB{iB}
+namespace playrho
 {
-    assert(bA != bB);
-    assert(fA != fB);
-}
+    namespace d2
+    {
 
-// Free functions...
+        static_assert(std::is_default_constructible<Contact>::value,
+                      "Contact must be default constructible!");
+        static_assert(std::is_copy_constructible<Contact>::value,
+                      "Contact must be copy constructible!");
+        static_assert(std::is_move_constructible<Contact>::value,
+                      "Contact must be move constructible!");
+        static_assert(std::is_copy_assignable<Contact>::value,
+                      "Contact must be copy assignable!");
+        static_assert(std::is_move_assignable<Contact>::value,
+                      "Contact must be move assignable!");
+        static_assert(std::is_nothrow_destructible<Contact>::value,
+                      "Contact must be nothrow destructible!");
 
-} // namespace d2
-} // namespace playrho
+        Contact::Contact(BodyID bA, FixtureID fA, ChildCounter iA,
+                         BodyID bB, FixtureID fB, ChildCounter iB) noexcept
+            : m_bodyA{bA}, m_bodyB{bB}, m_fixtureA{fA}, m_fixtureB{fB}, m_indexA{iA}, m_indexB{iB}
+        {
+            assert(bA != bB);
+            assert(fA != fB);
+        }
+
+        // Free functions...
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -25,625 +25,627 @@
 #include <PlayRho/Common/Math.hpp>
 
 #include <PlayRho/Collision/Distance.hpp>
-#include <PlayRho/Collision/TimeOfImpact.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
+#include <PlayRho/Collision/TimeOfImpact.hpp>
 
 #include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/FixtureID.hpp>
 
-namespace playrho {
-
-/// @brief Mixes friction.
-///
-/// @details Friction mixing formula. The idea is to allow either fixture to drive the
-///   resulting friction to zero. For example, anything slides on ice.
-///
-/// @warning Behavior is undefined if either friction values is less than zero.
-///
-/// @param friction1 A zero or greater value.
-/// @param friction2 A zero or greater value.
-///
-inline Real MixFriction(Real friction1, Real friction2)
+namespace playrho
 {
-    assert(friction1 >= 0 && friction2 >= 0);
-    return sqrt(friction1 * friction2);
-}
 
-/// @brief Mixes restitution.
-///
-/// @details Restitution mixing law. The idea is allow for anything to bounce off an inelastic
-///   surface. For example, a super ball bounces on anything.
-///
-inline Real MixRestitution(Real restitution1, Real restitution2) noexcept
-{
-    return (restitution1 > restitution2) ? restitution1 : restitution2;
-}
-
-struct ToiConf;
-
-namespace d2 {
-
-/// @brief A potential contact between the children of two Fixture objects.
-///
-/// @details The class manages contact between two shapes. A contact exists for each overlapping
-///   AABB in the broad-phase (except if filtered). Therefore a contact object may exist
-///   that has no actual contact points.
-///
-/// @ingroup PhysicalEntities
-/// @ingroup ConstraintsGroup
-///
-class Contact
-{
-public:
-    /// @brief Substep type.
-    using substep_type = TimestepIters;
-
-    /// @brief Default construction not allowed.
-    Contact() noexcept = default;
-
-    /// @brief Initializing constructor.
+    /// @brief Mixes friction.
     ///
-    /// @param fA Non-null pointer to fixture A that must have a shape
-    ///   and may not be the same or have the same body as the other fixture.
-    /// @param iA Child index A.
-    /// @param fB Non-null pointer to fixture B that must have a shape
-    ///   and may not be the same or have the same body as the other fixture.
-    /// @param iB Child index B.
+    /// @details Friction mixing formula. The idea is to allow either fixture to drive the
+    ///   resulting friction to zero. For example, anything slides on ice.
     ///
-    /// @note This need never be called directly by a user.
-    /// @warning Behavior is undefined if <code>fA</code> is null.
-    /// @warning Behavior is undefined if <code>fB</code> is null.
-    /// @warning Behavior is undefined if <code>fA == fB</code>.
-    /// @warning Behavior is undefined if both fixture's have the same body.
+    /// @warning Behavior is undefined if either friction values is less than zero.
     ///
-    Contact(BodyID bA, FixtureID fA, ChildCounter iA,
-            BodyID bB, FixtureID fB, ChildCounter iB) noexcept;
-
-    /// @brief Is this contact touching?
-    /// @details
-    /// Touching is defined as either:
-    ///   1. This contact's manifold has more than 0 contact points, or
-    ///   2. This contact has sensors and the two shapes of this contact are found to be
-    ///      overlapping.
-    /// @return true if this contact is said to be touching, false otherwise.
-    bool IsTouching() const noexcept;
-
-    /// @brief Sets the touching flag state.
-    /// @note This should only be called if either:
-    ///   1. The contact's manifold has more than 0 contact points, or
-    ///   2. The contact has sensors and the two shapes of this contact are found to be overlapping.
-    /// @see IsTouching().
-    void SetTouching() noexcept;
-
-    /// @brief Unsets the touching flag state.
-    void UnsetTouching() noexcept;
-
-    /// @brief Enables or disables this contact.
-    /// @note This can be used inside the pre-solve contact listener.
-    ///   The contact is only disabled for the current time step (or sub-step in continuous
-    ///   collisions).
-    [[deprecated]] void SetEnabled(bool flag) noexcept;
-
-    /// @brief Has this contact been disabled?
-    bool IsEnabled() const noexcept;
-
-    /// @brief Enables this contact.
-    void SetEnabled() noexcept;
-
-    /// @brief Disables this contact.
-    void UnsetEnabled() noexcept;
-
-    BodyID GetBodyA() const noexcept;
-
-    /// @brief Gets fixture A in this contact.
-    FixtureID GetFixtureA() const noexcept;
-
-    /// @brief Get the child primitive index for fixture A.
-    ChildCounter GetChildIndexA() const noexcept;
-
-    BodyID GetBodyB() const noexcept;
-
-    /// @brief Gets fixture B in this contact.
-    FixtureID GetFixtureB() const noexcept;
-
-    /// @brief Get the child primitive index for fixture B.
-    ChildCounter GetChildIndexB() const noexcept;
-
-    /// @brief Sets the friction value for this contact.
-    /// @details Override the default friction mixture.
-    /// @note You can call this in "pre-solve" listeners.
-    /// @note This value persists until set or reset.
-    /// @warning Behavior is undefined if given a negative friction value.
-    /// @param friction Co-efficient of friction value of zero or greater.
-    void SetFriction(Real friction) noexcept;
-
-    /// @brief Gets the coefficient of friction.
-    /// @details Gets the combined friction of the two fixtures associated with this contact.
-    /// @return Value of 0 or higher.
-    /// @see MixFriction.
-    Real GetFriction() const noexcept;
-
-    /// @brief Sets the restitution.
-    /// @details This override the default restitution mixture.
-    /// @note You can call this in "pre-solve" listeners.
-    /// @note The value persists until you set or reset.
-    void SetRestitution(Real restitution) noexcept;
-
-    /// @brief Gets the restitution.
-    Real GetRestitution() const noexcept;
-
-    /// @brief Sets the desired tangent speed for a conveyor belt behavior.
-    void SetTangentSpeed(LinearVelocity speed) noexcept;
-
-    /// @brief Gets the desired tangent speed.
-    LinearVelocity GetTangentSpeed() const noexcept;
-
-    /// @brief Gets the time of impact count.
-    substep_type GetToiCount() const noexcept;
-
-    /// @brief Gets whether a TOI is set.
-    /// @return true if this object has a TOI set for it, false otherwise.
-    bool HasValidToi() const noexcept;
-
-    /// @brief Gets the time of impact (TOI) as a fraction.
-    /// @note This is only valid if a TOI has been set.
-    /// @see void SetToi(Real toi).
-    /// @return Time of impact fraction in the range of 0 to 1 if set (where 1
-    ///   means no actual impact in current time slot), otherwise undefined.
-    Real GetToi() const;
-
-    /// @brief Flags the contact for filtering.
-    void FlagForFiltering() noexcept;
-
-    /// @brief Whether or not the contact needs filtering.
-    bool NeedsFiltering() const noexcept;
-
-    /// @brief Flags the contact for updating.
-    void FlagForUpdating() noexcept;
-
-    /// @brief Whether or not the contact needs updating.
-    bool NeedsUpdating() const noexcept;
-
-    /// @brief Whether or not this contact is a "sensor".
-    /// @note This should be true whenever fixture A or fixture B is a sensor.
-    bool IsSensor() const noexcept;
-
-    /// @brief Sets the sensor state of this contact.
-    /// @attention Call this if fixture A or fixture B is a sensor.
-    void SetIsSensor() noexcept;
-
-    void UnsetIsSensor() noexcept;
-
-    /// @brief Whether or not this contact is "impenetrable".
-    /// @note This should be true whenever body A or body B are impenetrable.
-    bool IsImpenetrable() const noexcept;
-
-    /// @brief Sets the impenetrability of this contact.
-    /// @attention Call this if body A or body B are impenetrable.
-    void SetImpenetrable() noexcept;
-
-    void UnsetImpenetrable() noexcept;
-
-    /// @brief Whether or not this contact is "active".
-    /// @note This should be true whenever body A or body B are "awake".
-    bool IsActive() const noexcept;
-
-    /// @brief Sets the active state of this contact.
-    /// @attention Call this if body A or body B are "awake".
-    void SetIsActive() noexcept;
-
-    void UnsetIsActive() noexcept;
-
-    /// Flags type data type.
-    using FlagsType = std::uint8_t;
-
-    /// @brief Flags stored in m_flags
-    enum: FlagsType
+    /// @param friction1 A zero or greater value.
+    /// @param friction2 A zero or greater value.
+    ///
+    inline Real MixFriction(Real friction1, Real friction2)
     {
-        // Set when the shapes are touching.
-        e_touchingFlag = 0x01,
-
-        // This contact can be disabled (by user)
-        e_enabledFlag = 0x02,
-
-        // This contact needs filtering because a fixture filter was changed.
-        e_filterFlag = 0x04,
-
-        // This contact has a valid TOI in m_toi
-        e_toiFlag = 0x08,
-        
-        // This contacts needs its touching state updated.
-        e_dirtyFlag = 0x10,
-
-        /// Indicates whether the contact is to be treated as a sensor or not.
-        e_sensorFlag = 0x20,
-
-        /// Indicates whether the contact is to be treated as active or not.
-        e_activeFlag = 0x40,
-
-        /// Indicates whether the contact is to be treated as between impenetrable bodies.
-        e_impenetrableFlag = 0x80,
-    };
-    
-    /// @brief Flags this contact for filtering.
-    /// @note Filtering will occur the next time step.
-    void UnflagForFiltering() noexcept;
-
-    /// @brief Unflags this contact for updating.
-    void UnflagForUpdating() noexcept;
-
-    /// @brief Sets the time of impact (TOI).
-    /// @details After returning, this object will have a TOI that is set as indicated by <code>HasValidToi()</code>.
-    /// @note Behavior is undefined if the value assigned is less than 0 or greater than 1.
-    /// @see Real GetToi() const.
-    /// @see HasValidToi.
-    /// @param toi Time of impact as a fraction between 0 and 1 where 1 indicates no actual impact in the current time slot.
-    void SetToi(Real toi) noexcept;
-
-    /// @brief Unsets the TOI.
-    void UnsetToi() noexcept;
-
-    /// @brief Sets the TOI count to the given value.
-    void SetToiCount(substep_type value) noexcept;
-
-    void IncrementToiCount() noexcept;
-
-private:
-    // Need to be able to identify two different fixtures, the child shape per fixture,
-    // and the two different bodies that each fixture is associated with. This could be
-    // done by storing whatever information is needed to lookup this information. For
-    // instance, if the dynamic tree's two leaf nodes for this contact contained this
-    // info then minimally only those two indexes are needed. That may be sub-optimal
-    // however depending the speed of cache and memory access.
-
-    /// Body A.
-    /// @note Field is 2-bytes.
-    /// @warning Should only be body of fixture A.
-    BodyID m_bodyA = InvalidBodyID;
-
-    /// Body B.
-    /// @note Field is 2-bytes.
-    /// @warning Should only be body of fixture B.
-    BodyID m_bodyB = InvalidBodyID;
-
-    /// Identifier of fixture A.
-    /// @note Field is 2-bytes.
-    FixtureID m_fixtureA = InvalidFixtureID;
-
-    /// Identifier of fixture B.
-    /// @note Field is 2-bytes.
-    FixtureID m_fixtureB = InvalidFixtureID;
-
-    ChildCounter m_indexA; ///< Index A. 4-bytes.
-    ChildCounter m_indexB; ///< Index B. 4-bytes.
-
-    // initialized on construction (construction-time depedent)
-
-    /// Mix of frictions of associated fixtures.
-    /// @note Field is 4-bytes (with 4-byte Real).
-    /// @see MixFriction.
-    Real m_friction = 0;
-
-    /// Mix of restitutions of associated fixtures.
-    /// @note Field is 4-bytes (with 4-byte Real).
-    /// @see MixRestitution.
-    Real m_restitution = 0;
-
-    /// Tangent speed.
-    /// @note Field is 4-bytes (with 4-byte Real).
-   LinearVelocity m_tangentSpeed = 0;
-
-    /// Time of impact.
-    /// @note This is a unit interval of time (a value between 0 and 1).
-    /// @note Only valid if <code>m_flags & e_toiFlag</code>.
-    Real m_toi = 0;
-
-    // 32-bytes to here.
-
-    /// Count of TOI calculations contact has gone through since last reset.
-    substep_type m_toiCount = 0;
-
-    FlagsType m_flags = e_enabledFlag|e_dirtyFlag; ///< Flags.
-};
-
-inline void Contact::SetEnabled(bool flag) noexcept
-{
-    if (flag)
-    {
-        SetEnabled();
+        assert(friction1 >= 0 && friction2 >= 0);
+        return sqrt(friction1 * friction2);
     }
-    else
+
+    /// @brief Mixes restitution.
+    ///
+    /// @details Restitution mixing law. The idea is allow for anything to bounce off an inelastic
+    ///   surface. For example, a super ball bounces on anything.
+    ///
+    inline Real MixRestitution(Real restitution1, Real restitution2) noexcept
     {
-        UnsetEnabled();
+        return (restitution1 > restitution2) ? restitution1 : restitution2;
     }
-}
 
-inline void Contact::SetEnabled() noexcept
-{
-    m_flags |= e_enabledFlag;
-}
+    struct ToiConf;
 
-inline void Contact::UnsetEnabled() noexcept
-{
-    m_flags &= ~e_enabledFlag;
-}
+    namespace d2
+    {
 
-inline bool Contact::IsEnabled() const noexcept
-{
-    return (m_flags & e_enabledFlag) != 0;
-}
+        /// @brief A potential contact between the children of two Fixture objects.
+        ///
+        /// @details The class manages contact between two shapes. A contact exists for each overlapping
+        ///   AABB in the broad-phase (except if filtered). Therefore a contact object may exist
+        ///   that has no actual contact points.
+        ///
+        /// @ingroup PhysicalEntities
+        /// @ingroup ConstraintsGroup
+        ///
+        class Contact
+        {
+         public:
+            /// @brief Substep type.
+            using substep_type = TimestepIters;
 
-inline bool Contact::IsTouching() const noexcept
-{
-    // XXX: What to do if needs-updating?
-    // assert(!NeedsUpdating());
-    return (m_flags & e_touchingFlag) != 0;
-}
+            /// @brief Default construction not allowed.
+            Contact() noexcept = default;
 
-inline void Contact::SetTouching() noexcept
-{
-    m_flags |= e_touchingFlag;
-}
+            /// @brief Initializing constructor.
+            ///
+            /// @param fA Non-null pointer to fixture A that must have a shape
+            ///   and may not be the same or have the same body as the other fixture.
+            /// @param iA Child index A.
+            /// @param fB Non-null pointer to fixture B that must have a shape
+            ///   and may not be the same or have the same body as the other fixture.
+            /// @param iB Child index B.
+            ///
+            /// @note This need never be called directly by a user.
+            /// @warning Behavior is undefined if <code>fA</code> is null.
+            /// @warning Behavior is undefined if <code>fB</code> is null.
+            /// @warning Behavior is undefined if <code>fA == fB</code>.
+            /// @warning Behavior is undefined if both fixture's have the same body.
+            ///
+            Contact(BodyID bA, FixtureID fA, ChildCounter iA,
+                    BodyID bB, FixtureID fB, ChildCounter iB) noexcept;
 
-inline void Contact::UnsetTouching() noexcept
-{
-    m_flags &= ~e_touchingFlag;
-}
+            /// @brief Is this contact touching?
+            /// @details
+            /// Touching is defined as either:
+            ///   1. This contact's manifold has more than 0 contact points, or
+            ///   2. This contact has sensors and the two shapes of this contact are found to be
+            ///      overlapping.
+            /// @return true if this contact is said to be touching, false otherwise.
+            bool IsTouching() const noexcept;
 
-inline BodyID Contact::GetBodyA() const noexcept
-{
-    return m_bodyA;
-}
+            /// @brief Sets the touching flag state.
+            /// @note This should only be called if either:
+            ///   1. The contact's manifold has more than 0 contact points, or
+            ///   2. The contact has sensors and the two shapes of this contact are found to be overlapping.
+            /// @see IsTouching().
+            void SetTouching() noexcept;
 
-inline BodyID Contact::GetBodyB() const noexcept
-{
-    return m_bodyB;
-}
+            /// @brief Unsets the touching flag state.
+            void UnsetTouching() noexcept;
 
-inline FixtureID Contact::GetFixtureA() const noexcept
-{
-    return m_fixtureA;
-}
+            /// @brief Enables or disables this contact.
+            /// @note This can be used inside the pre-solve contact listener.
+            ///   The contact is only disabled for the current time step (or sub-step in continuous
+            ///   collisions).
+            [[deprecated]] void SetEnabled(bool flag) noexcept;
 
-inline FixtureID Contact::GetFixtureB() const noexcept
-{
-    return m_fixtureB;
-}
+            /// @brief Has this contact been disabled?
+            bool IsEnabled() const noexcept;
 
-inline void Contact::FlagForFiltering() noexcept
-{
-    m_flags |= e_filterFlag;
-}
+            /// @brief Enables this contact.
+            void SetEnabled() noexcept;
 
-inline void Contact::UnflagForFiltering() noexcept
-{
-    m_flags &= ~e_filterFlag;
-}
+            /// @brief Disables this contact.
+            void UnsetEnabled() noexcept;
 
-inline bool Contact::NeedsFiltering() const noexcept
-{
-    return (m_flags & e_filterFlag) != 0;
-}
+            BodyID GetBodyA() const noexcept;
 
-inline void Contact::FlagForUpdating() noexcept
-{
-    m_flags |= e_dirtyFlag;
-}
+            /// @brief Gets fixture A in this contact.
+            FixtureID GetFixtureA() const noexcept;
 
-inline void Contact::UnflagForUpdating() noexcept
-{
-    m_flags &= ~e_dirtyFlag;
-}
+            /// @brief Get the child primitive index for fixture A.
+            ChildCounter GetChildIndexA() const noexcept;
 
-inline bool Contact::NeedsUpdating() const noexcept
-{
-    return (m_flags & e_dirtyFlag) != 0;
-}
+            BodyID GetBodyB() const noexcept;
 
-inline void Contact::SetFriction(Real friction) noexcept
-{
-    assert(friction >= 0);
-    m_friction = friction;
-}
+            /// @brief Gets fixture B in this contact.
+            FixtureID GetFixtureB() const noexcept;
 
-inline Real Contact::GetFriction() const noexcept
-{
-    return m_friction;
-}
+            /// @brief Get the child primitive index for fixture B.
+            ChildCounter GetChildIndexB() const noexcept;
 
-inline void Contact::SetRestitution(Real restitution) noexcept
-{
-    m_restitution = restitution;
-}
+            /// @brief Sets the friction value for this contact.
+            /// @details Override the default friction mixture.
+            /// @note You can call this in "pre-solve" listeners.
+            /// @note This value persists until set or reset.
+            /// @warning Behavior is undefined if given a negative friction value.
+            /// @param friction Co-efficient of friction value of zero or greater.
+            void SetFriction(Real friction) noexcept;
 
-inline Real Contact::GetRestitution() const noexcept
-{
-    return m_restitution;
-}
+            /// @brief Gets the coefficient of friction.
+            /// @details Gets the combined friction of the two fixtures associated with this contact.
+            /// @return Value of 0 or higher.
+            /// @see MixFriction.
+            Real GetFriction() const noexcept;
 
-inline void Contact::SetTangentSpeed(LinearVelocity speed) noexcept
-{
-    m_tangentSpeed = speed;
-}
+            /// @brief Sets the restitution.
+            /// @details This override the default restitution mixture.
+            /// @note You can call this in "pre-solve" listeners.
+            /// @note The value persists until you set or reset.
+            void SetRestitution(Real restitution) noexcept;
 
-inline LinearVelocity Contact::GetTangentSpeed() const noexcept
-{
-    return m_tangentSpeed;
-}
+            /// @brief Gets the restitution.
+            Real GetRestitution() const noexcept;
 
-inline bool Contact::HasValidToi() const noexcept
-{
-    return (m_flags & Contact::e_toiFlag) != 0;
-}
+            /// @brief Sets the desired tangent speed for a conveyor belt behavior.
+            void SetTangentSpeed(LinearVelocity speed) noexcept;
 
-inline Real Contact::GetToi() const
-{
-    assert(HasValidToi());
-    return m_toi;
-}
+            /// @brief Gets the desired tangent speed.
+            LinearVelocity GetTangentSpeed() const noexcept;
 
-inline void Contact::SetToi(Real toi) noexcept
-{
-    assert(toi >= 0 && toi <= 1);
-    m_toi = toi;
-    m_flags |= Contact::e_toiFlag;
-}
+            /// @brief Gets the time of impact count.
+            substep_type GetToiCount() const noexcept;
 
-inline void Contact::UnsetToi() noexcept
-{
-    m_flags &= ~Contact::e_toiFlag;
-}
+            /// @brief Gets whether a TOI is set.
+            /// @return true if this object has a TOI set for it, false otherwise.
+            bool HasValidToi() const noexcept;
 
-inline void Contact::SetToiCount(substep_type value) noexcept
-{
-    m_toiCount = value;
-}
+            /// @brief Gets the time of impact (TOI) as a fraction.
+            /// @note This is only valid if a TOI has been set.
+            /// @see void SetToi(Real toi).
+            /// @return Time of impact fraction in the range of 0 to 1 if set (where 1
+            ///   means no actual impact in current time slot), otherwise undefined.
+            Real GetToi() const;
 
-inline Contact::substep_type Contact::GetToiCount() const noexcept
-{
-    return m_toiCount;
-}
+            /// @brief Flags the contact for filtering.
+            void FlagForFiltering() noexcept;
 
-inline ChildCounter Contact::GetChildIndexA() const noexcept
-{
-    return m_indexA;
-}
+            /// @brief Whether or not the contact needs filtering.
+            bool NeedsFiltering() const noexcept;
 
-inline ChildCounter Contact::GetChildIndexB() const noexcept
-{
-    return m_indexB;
-}
+            /// @brief Flags the contact for updating.
+            void FlagForUpdating() noexcept;
 
-inline bool Contact::IsSensor() const noexcept
-{
-    return m_flags & e_sensorFlag;
-}
+            /// @brief Whether or not the contact needs updating.
+            bool NeedsUpdating() const noexcept;
 
-inline void Contact::SetIsSensor() noexcept
-{
-    m_flags |= e_sensorFlag;
-}
+            /// @brief Whether or not this contact is a "sensor".
+            /// @note This should be true whenever fixture A or fixture B is a sensor.
+            bool IsSensor() const noexcept;
 
-inline void Contact::UnsetIsSensor() noexcept
-{
-    m_flags &= ~e_sensorFlag;
-}
+            /// @brief Sets the sensor state of this contact.
+            /// @attention Call this if fixture A or fixture B is a sensor.
+            void SetIsSensor() noexcept;
 
-inline bool Contact::IsImpenetrable() const noexcept
-{
-    return m_flags & e_impenetrableFlag;
-}
+            void UnsetIsSensor() noexcept;
 
-inline void Contact::SetImpenetrable() noexcept
-{
-    m_flags |= e_impenetrableFlag;
-}
+            /// @brief Whether or not this contact is "impenetrable".
+            /// @note This should be true whenever body A or body B are impenetrable.
+            bool IsImpenetrable() const noexcept;
 
-inline void Contact::UnsetImpenetrable() noexcept
-{
-    m_flags &= ~e_impenetrableFlag;
-}
+            /// @brief Sets the impenetrability of this contact.
+            /// @attention Call this if body A or body B are impenetrable.
+            void SetImpenetrable() noexcept;
 
-inline bool Contact::IsActive() const noexcept
-{
-    return m_flags & e_activeFlag;
-}
+            void UnsetImpenetrable() noexcept;
 
-inline void Contact::SetIsActive() noexcept
-{
-    m_flags |= e_activeFlag;
-}
+            /// @brief Whether or not this contact is "active".
+            /// @note This should be true whenever body A or body B are "awake".
+            bool IsActive() const noexcept;
 
-inline void Contact::UnsetIsActive() noexcept
-{
-    m_flags &= ~e_activeFlag;
-}
+            /// @brief Sets the active state of this contact.
+            /// @attention Call this if body A or body B are "awake".
+            void SetIsActive() noexcept;
 
-inline void Contact::IncrementToiCount() noexcept
-{
-    ++m_toiCount;
-}
+            void UnsetIsActive() noexcept;
 
-// Free functions...
+            /// Flags type data type.
+            using FlagsType = std::uint8_t;
 
-/// @brief Gets the body A ID of the given contact.
-/// @relatedalso Contact
-inline BodyID GetBodyA(const Contact& contact) noexcept
-{
-    return contact.GetBodyA();
-}
+            /// @brief Flags stored in m_flags
+            enum : FlagsType
+            {
+                // Set when the shapes are touching.
+                e_touchingFlag = 0x01,
 
-/// @brief Gets the body B ID of the given contact.
-/// @relatedalso Contact
-inline BodyID GetBodyB(const Contact& contact) noexcept
-{
-    return contact.GetBodyB();
-}
+                // This contact can be disabled (by user)
+                e_enabledFlag = 0x02,
 
-/// @brief Gets the fixture A associated with the given contact.
-/// @relatedalso Contact
-inline FixtureID GetFixtureA(const Contact& contact) noexcept
-{
-    return contact.GetFixtureA();
-}
+                // This contact needs filtering because a fixture filter was changed.
+                e_filterFlag = 0x04,
 
-/// @brief Gets the fixture B associated with the given contact.
-/// @relatedalso Contact
-inline FixtureID GetFixtureB(const Contact& contact) noexcept
-{
-    return contact.GetFixtureB();
-}
+                // This contact has a valid TOI in m_toi
+                e_toiFlag = 0x08,
 
-/// @brief Gets the child index A of the given contact.
-/// @relatedalso Contact
-inline ChildCounter GetChildIndexA(const Contact& contact) noexcept
-{
-    return contact.GetChildIndexA();
-}
+                // This contacts needs its touching state updated.
+                e_dirtyFlag = 0x10,
 
-/// @brief Gets the child index B of the given contact.
-/// @relatedalso Contact
-inline ChildCounter GetChildIndexB(const Contact& contact) noexcept
-{
-    return contact.GetChildIndexB();
-}
+                /// Indicates whether the contact is to be treated as a sensor or not.
+                e_sensorFlag = 0x20,
 
-/// @brief Whether the given contact is "impenetrable".
-/// @relatedalso Contact
-inline bool IsImpenetrable(const Contact& contact) noexcept
-{
-    return contact.IsImpenetrable();
-}
+                /// Indicates whether the contact is to be treated as active or not.
+                e_activeFlag = 0x40,
 
-/// @brief Determines whether the given contact is "active".
-/// @relatedalso Contact
-inline bool IsActive(const Contact& contact) noexcept
-{
-    return contact.IsActive();
-}
+                /// Indicates whether the contact is to be treated as between impenetrable bodies.
+                e_impenetrableFlag = 0x80,
+            };
 
-/// @brief Gets whether the given contact is enabled or not.
-/// @relatedalso Contact
-inline bool IsEnabled(const Contact& contact) noexcept
-{
-    return contact.IsEnabled();
-}
+            /// @brief Flags this contact for filtering.
+            /// @note Filtering will occur the next time step.
+            void UnflagForFiltering() noexcept;
 
-/// @brief Gets whether the given contact is touching or not.
-/// @relatedalso Contact
-inline bool IsTouching(const Contact& contact) noexcept
-{
-    return contact.IsTouching();
-}
+            /// @brief Unflags this contact for updating.
+            void UnflagForUpdating() noexcept;
 
-/// @brief Gets whether the given contact is for sensors or not.
-/// @relatedalso Contact
-inline bool IsSensor(const Contact& contact) noexcept
-{
-    return contact.IsSensor();
-}
+            /// @brief Sets the time of impact (TOI).
+            /// @details After returning, this object will have a TOI that is set as indicated by <code>HasValidToi()</code>.
+            /// @note Behavior is undefined if the value assigned is less than 0 or greater than 1.
+            /// @see Real GetToi() const.
+            /// @see HasValidToi.
+            /// @param toi Time of impact as a fraction between 0 and 1 where 1 indicates no actual impact in the current time slot.
+            void SetToi(Real toi) noexcept;
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Unsets the TOI.
+            void UnsetToi() noexcept;
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_CONTACT_HPP
+            /// @brief Sets the TOI count to the given value.
+            void SetToiCount(substep_type value) noexcept;
+
+            void IncrementToiCount() noexcept;
+
+         private:
+            // Need to be able to identify two different fixtures, the child shape per fixture,
+            // and the two different bodies that each fixture is associated with. This could be
+            // done by storing whatever information is needed to lookup this information. For
+            // instance, if the dynamic tree's two leaf nodes for this contact contained this
+            // info then minimally only those two indexes are needed. That may be sub-optimal
+            // however depending the speed of cache and memory access.
+
+            /// Body A.
+            /// @note Field is 2-bytes.
+            /// @warning Should only be body of fixture A.
+            BodyID m_bodyA = InvalidBodyID;
+
+            /// Body B.
+            /// @note Field is 2-bytes.
+            /// @warning Should only be body of fixture B.
+            BodyID m_bodyB = InvalidBodyID;
+
+            /// Identifier of fixture A.
+            /// @note Field is 2-bytes.
+            FixtureID m_fixtureA = InvalidFixtureID;
+
+            /// Identifier of fixture B.
+            /// @note Field is 2-bytes.
+            FixtureID m_fixtureB = InvalidFixtureID;
+
+            ChildCounter m_indexA;///< Index A. 4-bytes.
+            ChildCounter m_indexB;///< Index B. 4-bytes.
+
+            // initialized on construction (construction-time depedent)
+
+            /// Mix of frictions of associated fixtures.
+            /// @note Field is 4-bytes (with 4-byte Real).
+            /// @see MixFriction.
+            Real m_friction = 0;
+
+            /// Mix of restitutions of associated fixtures.
+            /// @note Field is 4-bytes (with 4-byte Real).
+            /// @see MixRestitution.
+            Real m_restitution = 0;
+
+            /// Tangent speed.
+            /// @note Field is 4-bytes (with 4-byte Real).
+            LinearVelocity m_tangentSpeed = 0;
+
+            /// Time of impact.
+            /// @note This is a unit interval of time (a value between 0 and 1).
+            /// @note Only valid if <code>m_flags & e_toiFlag</code>.
+            Real m_toi = 0;
+
+            // 32-bytes to here.
+
+            /// Count of TOI calculations contact has gone through since last reset.
+            substep_type m_toiCount = 0;
+
+            FlagsType m_flags = e_enabledFlag | e_dirtyFlag;///< Flags.
+        };
+
+        inline void Contact::SetEnabled(bool flag) noexcept
+        {
+            if (flag)
+            {
+                SetEnabled();
+            }
+            else
+            {
+                UnsetEnabled();
+            }
+        }
+
+        inline void Contact::SetEnabled() noexcept
+        {
+            m_flags |= e_enabledFlag;
+        }
+
+        inline void Contact::UnsetEnabled() noexcept
+        {
+            m_flags &= ~e_enabledFlag;
+        }
+
+        inline bool Contact::IsEnabled() const noexcept
+        {
+            return (m_flags & e_enabledFlag) != 0;
+        }
+
+        inline bool Contact::IsTouching() const noexcept
+        {
+            // XXX: What to do if needs-updating?
+            // assert(!NeedsUpdating());
+            return (m_flags & e_touchingFlag) != 0;
+        }
+
+        inline void Contact::SetTouching() noexcept
+        {
+            m_flags |= e_touchingFlag;
+        }
+
+        inline void Contact::UnsetTouching() noexcept
+        {
+            m_flags &= ~e_touchingFlag;
+        }
+
+        inline BodyID Contact::GetBodyA() const noexcept
+        {
+            return m_bodyA;
+        }
+
+        inline BodyID Contact::GetBodyB() const noexcept
+        {
+            return m_bodyB;
+        }
+
+        inline FixtureID Contact::GetFixtureA() const noexcept
+        {
+            return m_fixtureA;
+        }
+
+        inline FixtureID Contact::GetFixtureB() const noexcept
+        {
+            return m_fixtureB;
+        }
+
+        inline void Contact::FlagForFiltering() noexcept
+        {
+            m_flags |= e_filterFlag;
+        }
+
+        inline void Contact::UnflagForFiltering() noexcept
+        {
+            m_flags &= ~e_filterFlag;
+        }
+
+        inline bool Contact::NeedsFiltering() const noexcept
+        {
+            return (m_flags & e_filterFlag) != 0;
+        }
+
+        inline void Contact::FlagForUpdating() noexcept
+        {
+            m_flags |= e_dirtyFlag;
+        }
+
+        inline void Contact::UnflagForUpdating() noexcept
+        {
+            m_flags &= ~e_dirtyFlag;
+        }
+
+        inline bool Contact::NeedsUpdating() const noexcept
+        {
+            return (m_flags & e_dirtyFlag) != 0;
+        }
+
+        inline void Contact::SetFriction(Real friction) noexcept
+        {
+            assert(friction >= 0);
+            m_friction = friction;
+        }
+
+        inline Real Contact::GetFriction() const noexcept
+        {
+            return m_friction;
+        }
+
+        inline void Contact::SetRestitution(Real restitution) noexcept
+        {
+            m_restitution = restitution;
+        }
+
+        inline Real Contact::GetRestitution() const noexcept
+        {
+            return m_restitution;
+        }
+
+        inline void Contact::SetTangentSpeed(LinearVelocity speed) noexcept
+        {
+            m_tangentSpeed = speed;
+        }
+
+        inline LinearVelocity Contact::GetTangentSpeed() const noexcept
+        {
+            return m_tangentSpeed;
+        }
+
+        inline bool Contact::HasValidToi() const noexcept
+        {
+            return (m_flags & Contact::e_toiFlag) != 0;
+        }
+
+        inline Real Contact::GetToi() const
+        {
+            assert(HasValidToi());
+            return m_toi;
+        }
+
+        inline void Contact::SetToi(Real toi) noexcept
+        {
+            assert(toi >= 0 && toi <= 1);
+            m_toi = toi;
+            m_flags |= Contact::e_toiFlag;
+        }
+
+        inline void Contact::UnsetToi() noexcept
+        {
+            m_flags &= ~Contact::e_toiFlag;
+        }
+
+        inline void Contact::SetToiCount(substep_type value) noexcept
+        {
+            m_toiCount = value;
+        }
+
+        inline Contact::substep_type Contact::GetToiCount() const noexcept
+        {
+            return m_toiCount;
+        }
+
+        inline ChildCounter Contact::GetChildIndexA() const noexcept
+        {
+            return m_indexA;
+        }
+
+        inline ChildCounter Contact::GetChildIndexB() const noexcept
+        {
+            return m_indexB;
+        }
+
+        inline bool Contact::IsSensor() const noexcept
+        {
+            return m_flags & e_sensorFlag;
+        }
+
+        inline void Contact::SetIsSensor() noexcept
+        {
+            m_flags |= e_sensorFlag;
+        }
+
+        inline void Contact::UnsetIsSensor() noexcept
+        {
+            m_flags &= ~e_sensorFlag;
+        }
+
+        inline bool Contact::IsImpenetrable() const noexcept
+        {
+            return m_flags & e_impenetrableFlag;
+        }
+
+        inline void Contact::SetImpenetrable() noexcept
+        {
+            m_flags |= e_impenetrableFlag;
+        }
+
+        inline void Contact::UnsetImpenetrable() noexcept
+        {
+            m_flags &= ~e_impenetrableFlag;
+        }
+
+        inline bool Contact::IsActive() const noexcept
+        {
+            return m_flags & e_activeFlag;
+        }
+
+        inline void Contact::SetIsActive() noexcept
+        {
+            m_flags |= e_activeFlag;
+        }
+
+        inline void Contact::UnsetIsActive() noexcept
+        {
+            m_flags &= ~e_activeFlag;
+        }
+
+        inline void Contact::IncrementToiCount() noexcept
+        {
+            ++m_toiCount;
+        }
+
+        // Free functions...
+
+        /// @brief Gets the body A ID of the given contact.
+        /// @relatedalso Contact
+        inline BodyID GetBodyA(const Contact& contact) noexcept
+        {
+            return contact.GetBodyA();
+        }
+
+        /// @brief Gets the body B ID of the given contact.
+        /// @relatedalso Contact
+        inline BodyID GetBodyB(const Contact& contact) noexcept
+        {
+            return contact.GetBodyB();
+        }
+
+        /// @brief Gets the fixture A associated with the given contact.
+        /// @relatedalso Contact
+        inline FixtureID GetFixtureA(const Contact& contact) noexcept
+        {
+            return contact.GetFixtureA();
+        }
+
+        /// @brief Gets the fixture B associated with the given contact.
+        /// @relatedalso Contact
+        inline FixtureID GetFixtureB(const Contact& contact) noexcept
+        {
+            return contact.GetFixtureB();
+        }
+
+        /// @brief Gets the child index A of the given contact.
+        /// @relatedalso Contact
+        inline ChildCounter GetChildIndexA(const Contact& contact) noexcept
+        {
+            return contact.GetChildIndexA();
+        }
+
+        /// @brief Gets the child index B of the given contact.
+        /// @relatedalso Contact
+        inline ChildCounter GetChildIndexB(const Contact& contact) noexcept
+        {
+            return contact.GetChildIndexB();
+        }
+
+        /// @brief Whether the given contact is "impenetrable".
+        /// @relatedalso Contact
+        inline bool IsImpenetrable(const Contact& contact) noexcept
+        {
+            return contact.IsImpenetrable();
+        }
+
+        /// @brief Determines whether the given contact is "active".
+        /// @relatedalso Contact
+        inline bool IsActive(const Contact& contact) noexcept
+        {
+            return contact.IsActive();
+        }
+
+        /// @brief Gets whether the given contact is enabled or not.
+        /// @relatedalso Contact
+        inline bool IsEnabled(const Contact& contact) noexcept
+        {
+            return contact.IsEnabled();
+        }
+
+        /// @brief Gets whether the given contact is touching or not.
+        /// @relatedalso Contact
+        inline bool IsTouching(const Contact& contact) noexcept
+        {
+            return contact.IsTouching();
+        }
+
+        /// @brief Gets whether the given contact is for sensors or not.
+        /// @relatedalso Contact
+        inline bool IsSensor(const Contact& contact) noexcept
+        {
+            return contact.IsSensor();
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_CONTACT_HPP

--- a/PlayRho/Dynamics/Contacts/ContactID.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactID.hpp
@@ -21,31 +21,32 @@
 #ifndef PLAYRHO_DYNAMICS_CONTACTS_CONTACTID_HPP
 #define PLAYRHO_DYNAMICS_CONTACTS_CONTACTID_HPP
 
-#include <PlayRho/Common/StrongType.hpp>
 #include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/StrongType.hpp>
 
-namespace playrho {
-
-/// @brief Contact identifier.
-using ContactID = strongtype::IndexingNamedType<ContactCounter, struct ContactIdentifier>;
-
-/// @brief Invalid contact ID value.
-constexpr auto InvalidContactID = static_cast<ContactID>(static_cast<ContactID::underlying_type>(-1));
-
-/// @brief Gets an invalid value for the ContactID type.
-template <>
-constexpr ContactID GetInvalid() noexcept
+namespace playrho
 {
-    return InvalidContactID;
-}
 
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const ContactID& value) noexcept
-{
-    return value != GetInvalid<ContactID>();
-}
+    /// @brief Contact identifier.
+    using ContactID = strongtype::IndexingNamedType<ContactCounter, struct ContactIdentifier>;
 
-} // namespace playrho
+    /// @brief Invalid contact ID value.
+    constexpr auto InvalidContactID = static_cast<ContactID>(static_cast<ContactID::underlying_type>(-1));
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_CONTACTID_HPP
+    /// @brief Gets an invalid value for the ContactID type.
+    template<>
+    constexpr ContactID GetInvalid() noexcept
+    {
+        return InvalidContactID;
+    }
+
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const ContactID& value) noexcept
+    {
+        return value != GetInvalid<ContactID>();
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_CONTACTID_HPP

--- a/PlayRho/Dynamics/Contacts/ContactKey.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.cpp
@@ -20,8 +20,10 @@
 
 #include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -25,101 +25,101 @@
 /// Declaration of the <code>ContactKey</code> class.
 
 #include <PlayRho/Common/Settings.hpp>
-#include <utility>
 #include <algorithm>
-#include <functional>
 #include <cassert>
+#include <functional>
+#include <utility>
 
-namespace playrho {
-
-/// @brief Key value class for contacts.
-class ContactKey
+namespace playrho
 {
-public:
-    constexpr ContactKey() noexcept
-    {
-        // Intentionally empty
-    }
-    
-    /// @brief Initializing constructor.
-    constexpr ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept:
-        m_ids{std::minmax(fp1, fp2)}
-    {
-        // Intentionally empty
-    }
 
-    /// @brief Gets the minimum index value.
-    constexpr ContactCounter GetMin() const noexcept
+    /// @brief Key value class for contacts.
+    class ContactKey
     {
-        return std::get<0>(m_ids);
-    }
-    
-    /// @brief Gets the maximum index value.
-    constexpr ContactCounter GetMax() const noexcept
-    {
-        return std::get<1>(m_ids);
-    }
+     public:
+        constexpr ContactKey() noexcept
+        {
+            // Intentionally empty
+        }
 
-private:
-    /// @brief Contact counter ID pair.
-    /// @note Uses <code>std::pair</code> given that <code>std::minmax</code> returns
-    ///   this type making it the most natural type for this class.
-    std::pair<ContactCounter, ContactCounter> m_ids{
-        static_cast<ContactCounter>(-1), static_cast<ContactCounter>(-1)
+        /// @brief Initializing constructor.
+        constexpr ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept
+            : m_ids{std::minmax(fp1, fp2)}
+        {
+            // Intentionally empty
+        }
+
+        /// @brief Gets the minimum index value.
+        constexpr ContactCounter GetMin() const noexcept
+        {
+            return std::get<0>(m_ids);
+        }
+
+        /// @brief Gets the maximum index value.
+        constexpr ContactCounter GetMax() const noexcept
+        {
+            return std::get<1>(m_ids);
+        }
+
+     private:
+        /// @brief Contact counter ID pair.
+        /// @note Uses <code>std::pair</code> given that <code>std::minmax</code> returns
+        ///   this type making it the most natural type for this class.
+        std::pair<ContactCounter, ContactCounter> m_ids{
+            static_cast<ContactCounter>(-1), static_cast<ContactCounter>(-1)};
     };
-};
 
-/// @brief Equality operator.
-constexpr bool operator== (const ContactKey lhs, const ContactKey rhs) noexcept
-{
-    return lhs.GetMin() == rhs.GetMin() && lhs.GetMax() == rhs.GetMax();
-}
+    /// @brief Equality operator.
+    constexpr bool operator==(const ContactKey lhs, const ContactKey rhs) noexcept
+    {
+        return lhs.GetMin() == rhs.GetMin() && lhs.GetMax() == rhs.GetMax();
+    }
 
-/// @brief Inequality operator.
-constexpr bool operator!= (const ContactKey lhs, const ContactKey rhs) noexcept
-{
-    return !(lhs == rhs);
-}
+    /// @brief Inequality operator.
+    constexpr bool operator!=(const ContactKey lhs, const ContactKey rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
 
-/// @brief Less-than operator.
-constexpr bool operator< (const ContactKey lhs, const ContactKey rhs) noexcept
-{
-    return (lhs.GetMin() < rhs.GetMin())
-        || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() < rhs.GetMax()));
-}
+    /// @brief Less-than operator.
+    constexpr bool operator<(const ContactKey lhs, const ContactKey rhs) noexcept
+    {
+        return (lhs.GetMin() < rhs.GetMin())
+               || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() < rhs.GetMax()));
+    }
 
-/// @brief Less-than or equal-to operator.
-constexpr bool operator<= (const ContactKey lhs, const ContactKey rhs) noexcept
-{
-    return (lhs.GetMin() < rhs.GetMin())
-    || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() <= rhs.GetMax()));
-}
+    /// @brief Less-than or equal-to operator.
+    constexpr bool operator<=(const ContactKey lhs, const ContactKey rhs) noexcept
+    {
+        return (lhs.GetMin() < rhs.GetMin())
+               || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() <= rhs.GetMax()));
+    }
 
-/// @brief Greater-than operator.
-constexpr bool operator> (const ContactKey lhs, const ContactKey rhs) noexcept
-{
-    return (lhs.GetMin() > rhs.GetMin())
-        || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() > rhs.GetMax()));
-}
+    /// @brief Greater-than operator.
+    constexpr bool operator>(const ContactKey lhs, const ContactKey rhs) noexcept
+    {
+        return (lhs.GetMin() > rhs.GetMin())
+               || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() > rhs.GetMax()));
+    }
 
-/// @brief Greater-than or equal-to operator.
-constexpr bool operator>= (const ContactKey lhs, const ContactKey rhs) noexcept
-{
-    return (lhs.GetMin() > rhs.GetMin())
-    || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() >= rhs.GetMax()));
-}
+    /// @brief Greater-than or equal-to operator.
+    constexpr bool operator>=(const ContactKey lhs, const ContactKey rhs) noexcept
+    {
+        return (lhs.GetMin() > rhs.GetMin())
+               || ((lhs.GetMin() == rhs.GetMin()) && (lhs.GetMax() >= rhs.GetMax()));
+    }
 
-} // namespace playrho
+}// namespace playrho
 
 namespace std
 {
     /// @brief Hash function object specialization for <code>ContactKey</code>.
-    template <>
+    template<>
     struct hash<playrho::ContactKey>
     {
         /// @brief Argument type.
         using argument_type = playrho::ContactKey;
-        
+
         /// @brief Result type.
         using result_type = std::size_t;
 
@@ -132,6 +132,6 @@ namespace std
             return a ^ b;
         }
     };
-} // namespace std
+}// namespace std
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_CONTACTKEY_HPP
+#endif// PLAYRHO_DYNAMICS_CONTACTS_CONTACTKEY_HPP

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -17,14 +17,14 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
 #include <PlayRho/Collision/Collision.hpp>
 #include <PlayRho/Collision/WorldManifold.hpp>
+#include <PlayRho/Common/OptionalValue.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
+#include <PlayRho/Dynamics/Contacts/PositionConstraint.hpp>
 #include <PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp>
 #include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/PositionConstraint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Common/OptionalValue.hpp>
 
 #include <algorithm>
 
@@ -34,547 +34,542 @@
 //#define PLAYRHO_DEBUG_SOLVER 1
 #endif
 
-namespace playrho {
-namespace d2 {
-namespace {
+namespace playrho
+{
+    namespace d2
+    {
+        namespace
+        {
 
 #if defined(B2_DEBUG_SOLVER)
-static constexpr auto k_errorTol = 1e-3_mps; ///< error tolerance
+            static constexpr auto k_errorTol = 1e-3_mps;///< error tolerance
 #endif
 
-/// Impulse change.
-///
-/// @details
-/// This describes the change in impulse necessary for a solution.
-/// To apply this: let P = magnitude * direction, then
-///   the change to body A's velocity is
-///   -Velocity{vc.GetBodyA()->GetInvMass() * P,
-///       Radian * vc.GetBodyA()->GetInvRotInertia() * Cross(vcp.relA, P)}
-///   the change to body B's velocity is
-///   +Velocity{vc.GetBodyB()->GetInvMass() * P,
-///       Radian * vc.GetBodyB()->GetInvRotInertia() * Cross(vcp.relB, P)}
-///   and the new impulse = oldImpulse + magnitude.
-///
-struct ImpulseChange
-{
-    Momentum magnitude; ///< Magnitude.
-    UnitVec direction; ///< Direction.
-};
+            /// Impulse change.
+            ///
+            /// @details
+            /// This describes the change in impulse necessary for a solution.
+            /// To apply this: let P = magnitude * direction, then
+            ///   the change to body A's velocity is
+            ///   -Velocity{vc.GetBodyA()->GetInvMass() * P,
+            ///       Radian * vc.GetBodyA()->GetInvRotInertia() * Cross(vcp.relA, P)}
+            ///   the change to body B's velocity is
+            ///   +Velocity{vc.GetBodyB()->GetInvMass() * P,
+            ///       Radian * vc.GetBodyB()->GetInvRotInertia() * Cross(vcp.relB, P)}
+            ///   and the new impulse = oldImpulse + magnitude.
+            ///
+            struct ImpulseChange
+            {
+                Momentum magnitude;///< Magnitude.
+                UnitVec direction; ///< Direction.
+            };
 
-VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impulses)
-{
-    assert(IsValid(impulses));
+            VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impulses)
+            {
+                assert(IsValid(impulses));
 
-    const auto bodyA = vc.GetBodyA();
-    const auto bodyB = vc.GetBodyB();
-    const auto normal = vc.GetNormal();
+                const auto bodyA = vc.GetBodyA();
+                const auto bodyB = vc.GetBodyB();
+                const auto normal = vc.GetNormal();
 
-    const auto invRotInertiaA = bodyA->GetInvRotInertia();
-    const auto invMassA = bodyA->GetInvMass();
+                const auto invRotInertiaA = bodyA->GetInvRotInertia();
+                const auto invMassA = bodyA->GetInvMass();
 
-    const auto invRotInertiaB = bodyB->GetInvRotInertia();
-    const auto invMassB = bodyB->GetInvMass();
+                const auto invRotInertiaB = bodyB->GetInvRotInertia();
+                const auto invMassB = bodyB->GetInvMass();
 
-    // Apply incremental impulse
-    const auto P0 = impulses[0] * normal;
-    const auto P1 = impulses[1] * normal;
-    const auto P = P0 + P1;
-    const auto LA = AngularMomentum{
-        (Cross(GetPointRelPosA(vc, 0), P0) + Cross(GetPointRelPosA(vc, 1), P1)) / Radian
-    };
-    const auto LB = AngularMomentum{
-        (Cross(GetPointRelPosB(vc, 0), P0) + Cross(GetPointRelPosB(vc, 1), P1)) / Radian
-    };
-    return VelocityPair{
-        -Velocity{invMassA * P, invRotInertiaA * LA},
-        +Velocity{invMassB * P, invRotInertiaB * LB}
-    };
-}
+                // Apply incremental impulse
+                const auto P0 = impulses[0] * normal;
+                const auto P1 = impulses[1] * normal;
+                const auto P = P0 + P1;
+                const auto LA = AngularMomentum{
+                    (Cross(GetPointRelPosA(vc, 0), P0) + Cross(GetPointRelPosA(vc, 1), P1)) / Radian};
+                const auto LB = AngularMomentum{
+                    (Cross(GetPointRelPosB(vc, 0), P0) + Cross(GetPointRelPosB(vc, 1), P1)) / Radian};
+                return VelocityPair{
+                    -Velocity{invMassA * P, invRotInertiaA * LA},
+                    +Velocity{invMassB * P, invRotInertiaB * LB}};
+            }
 
-Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2 newImpulses)
-{
-    const auto delta_v = GetVelocityDelta(vc, newImpulses - GetNormalImpulses(vc));
-    vc.GetBodyA()->SetVelocity(vc.GetBodyA()->GetVelocity() + std::get<0>(delta_v));
-    vc.GetBodyB()->SetVelocity(vc.GetBodyB()->GetVelocity() + std::get<1>(delta_v));
-    SetNormalImpulses(vc, newImpulses);
-    return std::max(abs(newImpulses[0]), abs(newImpulses[1]));
-}
+            Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2 newImpulses)
+            {
+                const auto delta_v = GetVelocityDelta(vc, newImpulses - GetNormalImpulses(vc));
+                vc.GetBodyA()->SetVelocity(vc.GetBodyA()->GetVelocity() + std::get<0>(delta_v));
+                vc.GetBodyB()->SetVelocity(vc.GetBodyB()->GetVelocity() + std::get<1>(delta_v));
+                SetNormalImpulses(vc, newImpulses);
+                return std::max(abs(newImpulses[0]), abs(newImpulses[1]));
+            }
 
-Optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
-                                         const LinearVelocity2 b_prime)
-{
-    //
-    // Case 1: vn = 0
-    //
-    // 0 = A * x + b'
-    //
-    // Solve for x:
-    //
-    // x = -inv(A) * b'
-    //
-    const auto normalMass = vc.GetNormalMass();
-    const auto newImpulses = -Transform(b_prime, normalMass);
-    if ((newImpulses[0] >= 0_Ns) && (newImpulses[1] >= 0_Ns))
-    {
-        const auto max = BlockSolveUpdate(vc, newImpulses);
+            Optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
+                                                     const LinearVelocity2 b_prime)
+            {
+                //
+                // Case 1: vn = 0
+                //
+                // 0 = A * x + b'
+                //
+                // Solve for x:
+                //
+                // x = -inv(A) * b'
+                //
+                const auto normalMass = vc.GetNormalMass();
+                const auto newImpulses = -Transform(b_prime, normalMass);
+                if ((newImpulses[0] >= 0_Ns) && (newImpulses[1] >= 0_Ns))
+                {
+                    const auto max = BlockSolveUpdate(vc, newImpulses);
 
 #if defined(B2_DEBUG_SOLVER)
-        auto& vcp0 = vc.GetPointAt(0);
-        auto& vcp1 = vc.GetPointAt(1);
-        const auto velA = vc.GetBodyA()->GetVelocity();
-        const auto velB = vc.GetBodyB()->GetVelocity();
+                    auto& vcp0 = vc.GetPointAt(0);
+                    auto& vcp1 = vc.GetPointAt(1);
+                    const auto velA = vc.GetBodyA()->GetVelocity();
+                    const auto velB = vc.GetBodyB()->GetVelocity();
 
-        // Postconditions
-        const auto dv0 = GetContactRelVelocity(velA, vcp0.relA, velB, vcp0.relB);
-        const auto dv1 = GetContactRelVelocity(velA, vcp1.relA, velB, vcp1.relB);
+                    // Postconditions
+                    const auto dv0 = GetContactRelVelocity(velA, vcp0.relA, velB, vcp0.relB);
+                    const auto dv1 = GetContactRelVelocity(velA, vcp1.relA, velB, vcp1.relB);
 
-        // Compute normal velocity
-        const auto vn0 = Dot(dv0, vc.GetNormal());
-        const auto vn1 = Dot(dv1, vc.GetNormal());
+                    // Compute normal velocity
+                    const auto vn0 = Dot(dv0, vc.GetNormal());
+                    const auto vn1 = Dot(dv1, vc.GetNormal());
 
-        assert(abs(vn0 - vcp0.velocityBias) < k_errorTol);
-        assert(abs(vn1 - vcp1.velocityBias) < k_errorTol);
+                    assert(abs(vn0 - vcp0.velocityBias) < k_errorTol);
+                    assert(abs(vn1 - vcp1.velocityBias) < k_errorTol);
 #endif
-        return Optional<Momentum>{max};
-    }
-    return Optional<Momentum>{};
-}
+                    return Optional<Momentum>{max};
+                }
+                return Optional<Momentum>{};
+            }
 
-Optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc, const LinearVelocity2 b_prime)
-{
-    //
-    // Case 2: vn1 = 0 and x2 = 0
-    //
-    //   0 = a11 * x1 + a12 * 0 + b1'
-    // vn2 = a21 * x1 + a22 * 0 + b2'
-    //
-    const auto newImpulses = Momentum2{
-        -GetNormalMassAtPoint(vc, 0) * get<0>(b_prime), 0_Ns
-    };
-    const auto K = vc.GetK();
-    const auto vn2 = get<1>(get<0>(K)) * get<0>(newImpulses) + get<1>(b_prime);
-    if ((get<0>(newImpulses) >= 0_Ns) && (vn2 >= 0_mps))
-    {
-        const auto max = BlockSolveUpdate(vc, newImpulses);
+            Optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc, const LinearVelocity2 b_prime)
+            {
+                //
+                // Case 2: vn1 = 0 and x2 = 0
+                //
+                //   0 = a11 * x1 + a12 * 0 + b1'
+                // vn2 = a21 * x1 + a22 * 0 + b2'
+                //
+                const auto newImpulses = Momentum2{
+                    -GetNormalMassAtPoint(vc, 0) * get<0>(b_prime), 0_Ns};
+                const auto K = vc.GetK();
+                const auto vn2 = get<1>(get<0>(K)) * get<0>(newImpulses) + get<1>(b_prime);
+                if ((get<0>(newImpulses) >= 0_Ns) && (vn2 >= 0_mps))
+                {
+                    const auto max = BlockSolveUpdate(vc, newImpulses);
 
 #if defined(B2_DEBUG_SOLVER)
-        auto& vcp1 = vc.GetPointAt(0);
-        const auto velA = vc.GetBodyA()->GetVelocity();
-        const auto velB = vc.GetBodyB()->GetVelocity();
+                    auto& vcp1 = vc.GetPointAt(0);
+                    const auto velA = vc.GetBodyA()->GetVelocity();
+                    const auto velB = vc.GetBodyB()->GetVelocity();
 
-        // Postconditions
-        const auto dv1 = GetContactRelVelocity(velA, vcp1.relA, velB, vcp1.relB);
-        
-        // Compute normal velocity
-        const auto vn1 = Dot(dv1, vc.GetNormal());
+                    // Postconditions
+                    const auto dv1 = GetContactRelVelocity(velA, vcp1.relA, velB, vcp1.relB);
 
-        assert(abs(vn1 - vcp1.velocityBias) < k_errorTol);
+                    // Compute normal velocity
+                    const auto vn1 = Dot(dv1, vc.GetNormal());
+
+                    assert(abs(vn1 - vcp1.velocityBias) < k_errorTol);
 #endif
-        return Optional<Momentum>{max};
-    }
-    return Optional<Momentum>{};
-}
+                    return Optional<Momentum>{max};
+                }
+                return Optional<Momentum>{};
+            }
 
-Optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc, const LinearVelocity2 b_prime)
-{
-    //
-    // Case 3: vn2 = 0 and x1 = 0
-    //
-    // vn1 = a11 * 0 + a12 * x2 + b1'
-    //   0 = a21 * 0 + a22 * x2 + b2'
-    //
-    const auto newImpulses = Momentum2{
-        0_Ns, -GetNormalMassAtPoint(vc, 1) * get<1>(b_prime)
-    };
-    const auto K = vc.GetK();
-    const auto vn1 = get<0>(get<1>(K)) * get<1>(newImpulses) + get<0>(b_prime);
-    if ((get<1>(newImpulses) >= 0_Ns) && (vn1 >= 0_mps))
-    {
-        const auto max = BlockSolveUpdate(vc, newImpulses);
+            Optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc, const LinearVelocity2 b_prime)
+            {
+                //
+                // Case 3: vn2 = 0 and x1 = 0
+                //
+                // vn1 = a11 * 0 + a12 * x2 + b1'
+                //   0 = a21 * 0 + a22 * x2 + b2'
+                //
+                const auto newImpulses = Momentum2{
+                    0_Ns, -GetNormalMassAtPoint(vc, 1) * get<1>(b_prime)};
+                const auto K = vc.GetK();
+                const auto vn1 = get<0>(get<1>(K)) * get<1>(newImpulses) + get<0>(b_prime);
+                if ((get<1>(newImpulses) >= 0_Ns) && (vn1 >= 0_mps))
+                {
+                    const auto max = BlockSolveUpdate(vc, newImpulses);
 
 #if defined(B2_DEBUG_SOLVER)
-        auto& vcp2 = vc.GetPointAt(1);
-        const auto velA = vc.GetBodyA()->GetVelocity();
-        const auto velB = vc.GetBodyB()->GetVelocity();
+                    auto& vcp2 = vc.GetPointAt(1);
+                    const auto velA = vc.GetBodyA()->GetVelocity();
+                    const auto velB = vc.GetBodyB()->GetVelocity();
 
-        // Postconditions
-        const auto dv2 = GetContactRelVelocity(velA, vcp2.relA, velB, vcp2.relB);
+                    // Postconditions
+                    const auto dv2 = GetContactRelVelocity(velA, vcp2.relA, velB, vcp2.relB);
 
-        // Compute normal velocity
-        const auto vn2 = Dot(dv2, vc.GetNormal());
+                    // Compute normal velocity
+                    const auto vn2 = Dot(dv2, vc.GetNormal());
 
-        assert(abs(vn2 - vcp2.velocityBias) < k_errorTol);
+                    assert(abs(vn2 - vcp2.velocityBias) < k_errorTol);
 #endif
-        return Optional<Momentum>{max};
-    }
-    return Optional<Momentum>{};
-}
+                    return Optional<Momentum>{max};
+                }
+                return Optional<Momentum>{};
+            }
 
-Optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc, const LinearVelocity2 b_prime)
-{
-    //
-    // Case 4: x1 = 0 and x2 = 0
-    //
-    // vn1 = b1
-    // vn2 = b2;
-    const auto vn1 = get<0>(b_prime);
-    const auto vn2 = get<1>(b_prime);
-    if ((vn1 >= 0_mps) && (vn2 >= 0_mps))
-    {
-        return Optional<Momentum>{BlockSolveUpdate(vc, Momentum2{0_Ns, 0_Ns})};
-    }
-    return Optional<Momentum>{};
-}
+            Optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc, const LinearVelocity2 b_prime)
+            {
+                //
+                // Case 4: x1 = 0 and x2 = 0
+                //
+                // vn1 = b1
+                // vn2 = b2;
+                const auto vn1 = get<0>(b_prime);
+                const auto vn2 = get<1>(b_prime);
+                if ((vn1 >= 0_mps) && (vn2 >= 0_mps))
+                {
+                    return Optional<Momentum>{BlockSolveUpdate(vc, Momentum2{0_Ns, 0_Ns})};
+                }
+                return Optional<Momentum>{};
+            }
 
-inline Momentum BlockSolveNormalConstraint(VelocityConstraint& vc)
-{
-    assert(vc.GetPointCount() == 2);
+            inline Momentum BlockSolveNormalConstraint(VelocityConstraint& vc)
+            {
+                assert(vc.GetPointCount() == 2);
 
-    // Block solver developed in collaboration with Dirk Gregorius (back in 01/07 on Box2D_Lite).
-    // Build the mini LCP for this contact patch
-    //
-    // vn = A * x + b, vn >= 0, x >= 0 and vn_i * x_i = 0 with i = 1..2
-    //
-    // A = J * W * JT and J = ( -n, -r1 x n, n, r2 x n )
-    // b = vn0 - velocityBias
-    //
-    // The system is solved using the "Total enumeration method" (s. Murty). The complementary constraint vn_i * x_i
-    // implies that we must have in any solution either vn_i = 0 or x_i = 0. So for the 2-D contact problem the cases
-    // vn1 = 0 and vn2 = 0, x1 = 0 and x2 = 0, x1 = 0 and vn2 = 0, x2 = 0 and vn1 = 0 need to be tested. The first valid
-    // solution that satisfies the problem is chosen.
-    //
-    // In order to account of the accumulated impulse 'a' (because of the iterative nature of the solver which only requires
-    // that the accumulated impulse is clamped and not the incremental impulse) we change the impulse variable (x_i).
-    //
-    // Substitute:
-    //
-    // x = a + d
-    //
-    // a := old total impulse
-    // x := new total impulse
-    // d := incremental impulse
-    //
-    // For the current iteration we extend the formula for the incremental impulse
-    // to compute the new total impulse:
-    //
-    // vn = A * d + b
-    //    = A * (x - a) + b
-    //    = A * x + b - A * a
-    //    = A * x + b'
-    // b' = b - A * a;
-    
-    const auto b_prime = [=]() {
-        const auto normal = vc.GetNormal();
-        
-        const auto velA = vc.GetBodyA()->GetVelocity();
-        const auto velB = vc.GetBodyB()->GetVelocity();
-        const auto ra0 = vc.GetPointRelPosA(0);
-        const auto rb0 = vc.GetPointRelPosB(0);
-        const auto ra1 = vc.GetPointRelPosA(1);
-        const auto rb1 = vc.GetPointRelPosB(1);
-        
-        const auto dv0 = GetContactRelVelocity(velA, ra0, velB, rb0);
-        const auto dv1 = GetContactRelVelocity(velA, ra1, velB, rb1);
-        
-        // Compute normal velocities
-        const auto vn0 = Dot(dv0, normal);
-        const auto vn1 = Dot(dv1, normal);
-        
-        // Compute b
-        const auto b = LinearVelocity2{
-            vn0 - vc.GetVelocityBiasAtPoint(0),
-            vn1 - vc.GetVelocityBiasAtPoint(1)
-        };
-        
-        // Return b'
-        const auto K = vc.GetK();
-        return b - Transform(GetNormalImpulses(vc), K);
-    }();
-    
-    auto maxIncImpulse = Optional<Momentum>{};
-    maxIncImpulse = BlockSolveNormalCase1(vc, b_prime);
-    if (maxIncImpulse.has_value())
-    {
-        return *maxIncImpulse;
-    }
-    maxIncImpulse = BlockSolveNormalCase2(vc, b_prime);
-    if (maxIncImpulse.has_value())
-    {
-        return *maxIncImpulse;
-    }
-    maxIncImpulse = BlockSolveNormalCase3(vc, b_prime);
-    if (maxIncImpulse.has_value())
-    {
-        return *maxIncImpulse;
-    }
-    maxIncImpulse = BlockSolveNormalCase4(vc, b_prime);
-    if (maxIncImpulse.has_value())
-    {
-        return *maxIncImpulse;
-    }
-    
-    // No solution, give up. This is hit sometimes, but it doesn't seem to matter.
-    return 0;
-}
+                // Block solver developed in collaboration with Dirk Gregorius (back in 01/07 on Box2D_Lite).
+                // Build the mini LCP for this contact patch
+                //
+                // vn = A * x + b, vn >= 0, x >= 0 and vn_i * x_i = 0 with i = 1..2
+                //
+                // A = J * W * JT and J = ( -n, -r1 x n, n, r2 x n )
+                // b = vn0 - velocityBias
+                //
+                // The system is solved using the "Total enumeration method" (s. Murty). The complementary constraint vn_i * x_i
+                // implies that we must have in any solution either vn_i = 0 or x_i = 0. So for the 2-D contact problem the cases
+                // vn1 = 0 and vn2 = 0, x1 = 0 and x2 = 0, x1 = 0 and vn2 = 0, x2 = 0 and vn1 = 0 need to be tested. The first valid
+                // solution that satisfies the problem is chosen.
+                //
+                // In order to account of the accumulated impulse 'a' (because of the iterative nature of the solver which only requires
+                // that the accumulated impulse is clamped and not the incremental impulse) we change the impulse variable (x_i).
+                //
+                // Substitute:
+                //
+                // x = a + d
+                //
+                // a := old total impulse
+                // x := new total impulse
+                // d := incremental impulse
+                //
+                // For the current iteration we extend the formula for the incremental impulse
+                // to compute the new total impulse:
+                //
+                // vn = A * d + b
+                //    = A * (x - a) + b
+                //    = A * x + b - A * a
+                //    = A * x + b'
+                // b' = b - A * a;
 
-inline Momentum SeqSolveNormalConstraint(VelocityConstraint& vc)
-{
-    auto maxIncImpulse = 0_Ns;
-    
-    const auto direction = vc.GetNormal();
-    const auto count = vc.GetPointCount();
-    const auto bodyA = vc.GetBodyA();
-    const auto bodyB = vc.GetBodyB();
-    
-    const auto invRotInertiaA = bodyA->GetInvRotInertia();
-    const auto invMassA = bodyA->GetInvMass();
-    const auto oldVelA = bodyA->GetVelocity();
-    
-    const auto invRotInertiaB = bodyB->GetInvRotInertia();
-    const auto invMassB = bodyB->GetInvMass();
-    const auto oldVelB = bodyB->GetVelocity();
-    
-    auto newVelA = oldVelA;
-    auto newVelB = oldVelB;
-    
-    auto solverProc = [&](VelocityConstraint::size_type index) {
-        const auto vcp = vc.GetPointAt(index);
-        const auto closingVel = GetContactRelVelocity(newVelA, vcp.relA, newVelB, vcp.relB);
-        const auto directionalVel = LinearVelocity{Dot(closingVel, direction)};
-        const auto lambda = Momentum{vcp.normalMass * (vcp.velocityBias - directionalVel)};
-        const auto oldImpulse = vcp.normalImpulse;
-        const auto newImpulse = std::max(oldImpulse + lambda, 0_Ns);
+                const auto b_prime = [=]() {
+                    const auto normal = vc.GetNormal();
+
+                    const auto velA = vc.GetBodyA()->GetVelocity();
+                    const auto velB = vc.GetBodyB()->GetVelocity();
+                    const auto ra0 = vc.GetPointRelPosA(0);
+                    const auto rb0 = vc.GetPointRelPosB(0);
+                    const auto ra1 = vc.GetPointRelPosA(1);
+                    const auto rb1 = vc.GetPointRelPosB(1);
+
+                    const auto dv0 = GetContactRelVelocity(velA, ra0, velB, rb0);
+                    const auto dv1 = GetContactRelVelocity(velA, ra1, velB, rb1);
+
+                    // Compute normal velocities
+                    const auto vn0 = Dot(dv0, normal);
+                    const auto vn1 = Dot(dv1, normal);
+
+                    // Compute b
+                    const auto b = LinearVelocity2{
+                        vn0 - vc.GetVelocityBiasAtPoint(0),
+                        vn1 - vc.GetVelocityBiasAtPoint(1)};
+
+                    // Return b'
+                    const auto K = vc.GetK();
+                    return b - Transform(GetNormalImpulses(vc), K);
+                }();
+
+                auto maxIncImpulse = Optional<Momentum>{};
+                maxIncImpulse = BlockSolveNormalCase1(vc, b_prime);
+                if (maxIncImpulse.has_value())
+                {
+                    return *maxIncImpulse;
+                }
+                maxIncImpulse = BlockSolveNormalCase2(vc, b_prime);
+                if (maxIncImpulse.has_value())
+                {
+                    return *maxIncImpulse;
+                }
+                maxIncImpulse = BlockSolveNormalCase3(vc, b_prime);
+                if (maxIncImpulse.has_value())
+                {
+                    return *maxIncImpulse;
+                }
+                maxIncImpulse = BlockSolveNormalCase4(vc, b_prime);
+                if (maxIncImpulse.has_value())
+                {
+                    return *maxIncImpulse;
+                }
+
+                // No solution, give up. This is hit sometimes, but it doesn't seem to matter.
+                return 0;
+            }
+
+            inline Momentum SeqSolveNormalConstraint(VelocityConstraint& vc)
+            {
+                auto maxIncImpulse = 0_Ns;
+
+                const auto direction = vc.GetNormal();
+                const auto count = vc.GetPointCount();
+                const auto bodyA = vc.GetBodyA();
+                const auto bodyB = vc.GetBodyB();
+
+                const auto invRotInertiaA = bodyA->GetInvRotInertia();
+                const auto invMassA = bodyA->GetInvMass();
+                const auto oldVelA = bodyA->GetVelocity();
+
+                const auto invRotInertiaB = bodyB->GetInvRotInertia();
+                const auto invMassB = bodyB->GetInvMass();
+                const auto oldVelB = bodyB->GetVelocity();
+
+                auto newVelA = oldVelA;
+                auto newVelB = oldVelB;
+
+                auto solverProc = [&](VelocityConstraint::size_type index) {
+                    const auto vcp = vc.GetPointAt(index);
+                    const auto closingVel = GetContactRelVelocity(newVelA, vcp.relA, newVelB, vcp.relB);
+                    const auto directionalVel = LinearVelocity{Dot(closingVel, direction)};
+                    const auto lambda = Momentum{vcp.normalMass * (vcp.velocityBias - directionalVel)};
+                    const auto oldImpulse = vcp.normalImpulse;
+                    const auto newImpulse = std::max(oldImpulse + lambda, 0_Ns);
 #if 0
         // Note: using AlmostEqual here results in increased iteration counts and is slower.
         const auto incImpulse = AlmostEqual(newImpulse, oldImpulse)? 0_Ns: newImpulse - oldImpulse;
 #else
-        const auto incImpulse = newImpulse - oldImpulse;
+                    const auto incImpulse = newImpulse - oldImpulse;
 #endif
-        const auto P = incImpulse * direction;
-        const auto LA = AngularMomentum{Cross(vcp.relA, P) / Radian};
-        const auto LB = AngularMomentum{Cross(vcp.relB, P) / Radian};
-        newVelA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        newVelB += Velocity{invMassB * P, invRotInertiaB * LB};
-        maxIncImpulse = std::max(maxIncImpulse, abs(incImpulse));
+                    const auto P = incImpulse * direction;
+                    const auto LA = AngularMomentum{Cross(vcp.relA, P) / Radian};
+                    const auto LB = AngularMomentum{Cross(vcp.relB, P) / Radian};
+                    newVelA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                    newVelB += Velocity{invMassB * P, invRotInertiaB * LB};
+                    maxIncImpulse = std::max(maxIncImpulse, abs(incImpulse));
 
-        // Note: using newImpulse, instead of oldImpulse + incImpulse, results in
-        //   iteration count increases for the World.TilesComesToRest unit test.
-        vc.SetNormalImpulseAtPoint(index, oldImpulse + incImpulse);
-    };
+                    // Note: using newImpulse, instead of oldImpulse + incImpulse, results in
+                    //   iteration count increases for the World.TilesComesToRest unit test.
+                    vc.SetNormalImpulseAtPoint(index, oldImpulse + incImpulse);
+                };
 
-    if (count == 2)
-    {
-        solverProc(1);
-    }
-    solverProc(0);
-    
-    bodyA->SetVelocity(newVelA);
-    bodyB->SetVelocity(newVelB);
-    
-    return maxIncImpulse;
-}
+                if (count == 2)
+                {
+                    solverProc(1);
+                }
+                solverProc(0);
 
-inline Momentum SolveTangentConstraint(VelocityConstraint& vc)
-{
-    auto maxIncImpulse = 0_Ns;
-    
-    const auto direction = vc.GetTangent();
-    const auto friction = vc.GetFriction();
-    const auto tangentSpeed = vc.GetTangentSpeed();
-    const auto count = vc.GetPointCount();
-    const auto bodyA = vc.GetBodyA();
-    const auto bodyB = vc.GetBodyB();
-    
-    const auto invRotInertiaA = bodyA->GetInvRotInertia();
-    const auto invMassA = bodyA->GetInvMass();
-    const auto oldVelA = bodyA->GetVelocity();
-    
-    const auto invRotInertiaB = bodyB->GetInvRotInertia();
-    const auto invMassB = bodyB->GetInvMass();
-    const auto oldVelB = bodyB->GetVelocity();
-    
-    auto newVelA = oldVelA;
-    auto newVelB = oldVelB;
-    
-    auto solverProc = [&](VelocityConstraint::size_type index) {
-        const auto vcp = vc.GetPointAt(index);
-        const auto closingVel = GetContactRelVelocity(newVelA, vcp.relA, newVelB, vcp.relB);
-        const auto directionalVel = LinearVelocity{tangentSpeed - Dot(closingVel, direction)};
-        const auto lambda = vcp.tangentMass * directionalVel;
-        const auto maxImpulse = friction * vcp.normalImpulse;
-        const auto oldImpulse = vcp.tangentImpulse;
-        const auto newImpulse = std::clamp(oldImpulse + lambda, -maxImpulse, maxImpulse);
+                bodyA->SetVelocity(newVelA);
+                bodyB->SetVelocity(newVelB);
+
+                return maxIncImpulse;
+            }
+
+            inline Momentum SolveTangentConstraint(VelocityConstraint& vc)
+            {
+                auto maxIncImpulse = 0_Ns;
+
+                const auto direction = vc.GetTangent();
+                const auto friction = vc.GetFriction();
+                const auto tangentSpeed = vc.GetTangentSpeed();
+                const auto count = vc.GetPointCount();
+                const auto bodyA = vc.GetBodyA();
+                const auto bodyB = vc.GetBodyB();
+
+                const auto invRotInertiaA = bodyA->GetInvRotInertia();
+                const auto invMassA = bodyA->GetInvMass();
+                const auto oldVelA = bodyA->GetVelocity();
+
+                const auto invRotInertiaB = bodyB->GetInvRotInertia();
+                const auto invMassB = bodyB->GetInvMass();
+                const auto oldVelB = bodyB->GetVelocity();
+
+                auto newVelA = oldVelA;
+                auto newVelB = oldVelB;
+
+                auto solverProc = [&](VelocityConstraint::size_type index) {
+                    const auto vcp = vc.GetPointAt(index);
+                    const auto closingVel = GetContactRelVelocity(newVelA, vcp.relA, newVelB, vcp.relB);
+                    const auto directionalVel = LinearVelocity{tangentSpeed - Dot(closingVel, direction)};
+                    const auto lambda = vcp.tangentMass * directionalVel;
+                    const auto maxImpulse = friction * vcp.normalImpulse;
+                    const auto oldImpulse = vcp.tangentImpulse;
+                    const auto newImpulse = std::clamp(oldImpulse + lambda, -maxImpulse, maxImpulse);
 #if 0
         // Note: using AlmostEqual here results in increased iteration counts and is slower.
         const auto incImpulse = AlmostEqual(newImpulse, oldImpulse)? 0_Ns: newImpulse - oldImpulse;
 #else
-        const auto incImpulse = newImpulse - oldImpulse;
+                    const auto incImpulse = newImpulse - oldImpulse;
 #endif
-        const auto P = incImpulse * direction;
-        const auto LA = AngularMomentum{Cross(vcp.relA, P) / Radian};
-        const auto LB = AngularMomentum{Cross(vcp.relB, P) / Radian};
-        newVelA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        newVelB += Velocity{invMassB * P, invRotInertiaB * LB};
-        maxIncImpulse = std::max(maxIncImpulse, abs(incImpulse));
-        
-        // Note: using newImpulse, instead of oldImpulse + incImpulse, results in
-        //   iteration count increases for the World.TilesComesToRest unit test.
-        vc.SetTangentImpulseAtPoint(index, oldImpulse + incImpulse);
-    };
-    assert((count == 1) || (count == 2));
-    if (count == 2)
-    {
-        solverProc(1);
-    }
-    solverProc(0);
+                    const auto P = incImpulse * direction;
+                    const auto LA = AngularMomentum{Cross(vcp.relA, P) / Radian};
+                    const auto LB = AngularMomentum{Cross(vcp.relB, P) / Radian};
+                    newVelA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                    newVelB += Velocity{invMassB * P, invRotInertiaB * LB};
+                    maxIncImpulse = std::max(maxIncImpulse, abs(incImpulse));
 
-    bodyA->SetVelocity(newVelA);
-    bodyB->SetVelocity(newVelB);
-    
-    return maxIncImpulse;
-}
+                    // Note: using newImpulse, instead of oldImpulse + incImpulse, results in
+                    //   iteration count increases for the World.TilesComesToRest unit test.
+                    vc.SetTangentImpulseAtPoint(index, oldImpulse + incImpulse);
+                };
+                assert((count == 1) || (count == 2));
+                if (count == 2)
+                {
+                    solverProc(1);
+                }
+                solverProc(0);
 
-inline Momentum SolveNormalConstraint(VelocityConstraint& vc)
-{
+                bodyA->SetVelocity(newVelA);
+                bodyB->SetVelocity(newVelB);
+
+                return maxIncImpulse;
+            }
+
+            inline Momentum SolveNormalConstraint(VelocityConstraint& vc)
+            {
 #if 1
-    // Note: Block solving reduces World.TilesComesToRest iteration counts and is faster.
-    //   This is because the block solver provides more stable solutions per iteration.
-    //   The difference is especially pronounced in the Vertical Stack Testbed demo.
-    const auto count = vc.GetPointCount();
-    assert((count == 1) || (count == 2));
-    if ((count == 1) || (vc.GetK() == InvMass22{}))
-    {
-        return SeqSolveNormalConstraint(vc);
-    }
-    return BlockSolveNormalConstraint(vc);
+                // Note: Block solving reduces World.TilesComesToRest iteration counts and is faster.
+                //   This is because the block solver provides more stable solutions per iteration.
+                //   The difference is especially pronounced in the Vertical Stack Testbed demo.
+                const auto count = vc.GetPointCount();
+                assert((count == 1) || (count == 2));
+                if ((count == 1) || (vc.GetK() == InvMass22{}))
+                {
+                    return SeqSolveNormalConstraint(vc);
+                }
+                return BlockSolveNormalConstraint(vc);
 #else
-    return SeqSolveNormalConstraint(vc);
+                return SeqSolveNormalConstraint(vc);
 #endif
-}
+            }
 
-}; // anonymous namespace
-    
-} // namespace d2
+        };// anonymous namespace
 
-ConstraintSolverConf GetRegConstraintSolverConf(const StepConf& conf) noexcept
-{
-    return ConstraintSolverConf{}
-        .UseResolutionRate(conf.regResolutionRate)
-        .UseLinearSlop(conf.linearSlop)
-        .UseAngularSlop(conf.angularSlop)
-        .UseMaxLinearCorrection(conf.maxLinearCorrection)
-        .UseMaxAngularCorrection(conf.maxAngularCorrection);
-}
+    }// namespace d2
 
-ConstraintSolverConf GetToiConstraintSolverConf(const StepConf& conf) noexcept
-{
-    return ConstraintSolverConf{}
-        .UseResolutionRate(conf.toiResolutionRate)
-        .UseLinearSlop(conf.linearSlop)
-        .UseAngularSlop(conf.angularSlop)
-        .UseMaxLinearCorrection(conf.maxLinearCorrection)
-        .UseMaxAngularCorrection(conf.maxAngularCorrection);
-}
-
-namespace GaussSeidel {
-
-Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc)
-{
-    auto maxIncImpulse = 0_Ns;
-    
-    // Applies frictional changes to velocity.
-    maxIncImpulse = std::max(maxIncImpulse, d2::SolveTangentConstraint(vc));
-    
-    // Applies restitutional changes to velocity.
-    maxIncImpulse = std::max(maxIncImpulse, d2::SolveNormalConstraint(vc));
-    
-    return maxIncImpulse;
-}
-
-d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
-                                           const bool moveA, const bool moveB,
-                                           ConstraintSolverConf conf)
-{
-    assert(IsValid(conf.resolutionRate));
-    assert(IsValid(conf.linearSlop));
-    assert(IsValid(conf.maxLinearCorrection));
-    
-    const auto bodyA = pc.GetBodyA();
-    const auto bodyB = pc.GetBodyB();
-    
-    const auto invMassA = moveA? bodyA->GetInvMass(): InvMass{0};
-    const auto invRotInertiaA = moveA? bodyA->GetInvRotInertia(): InvRotInertia{0};
-    const auto localCenterA = bodyA->GetLocalCenter();
-    
-    const auto invMassB = moveB? bodyB->GetInvMass(): InvMass{0};
-    const auto invRotInertiaB = moveB? bodyB->GetInvRotInertia(): InvRotInertia{0};
-    const auto localCenterB = bodyB->GetLocalCenter();
-    
-    // Compute inverse mass total.
-    // This must be > 0 unless doing TOI solving and neither bodies were the bodies specified.
-    const auto invMassTotal = invMassA + invMassB;
-    assert(invMassTotal >= InvMass{0});
-    
-    const auto totalRadius = pc.GetRadiusA() + pc.GetRadiusB();
-    
-    const auto solver_fn = [&](const d2::PositionSolverManifold psm,
-                               const Length2 pA, const Length2 pB) {
-        const auto separation = psm.m_separation - totalRadius;
-        // Positive separation means shapes not overlapping and not touching.
-        // Zero separation means shapes are touching.
-        // Negative separation means shapes are overlapping.
-        
-        const auto rA = Length2{psm.m_point - pA};
-        const auto rB = Length2{psm.m_point - pB};
-        
-        // Compute the effective mass.
-        const auto K = InvMass{[&]() {
-            const auto rnA = Length{Cross(rA, psm.m_normal)} / Radian;
-            const auto rnB = Length{Cross(rB, psm.m_normal)} / Radian;
-            // InvRotInertia is L^-2 M^-1 QP^2
-            // L^-2 M^-1 QP^2 * L^2 is: M^-1 QP^2
-            const auto invRotMassA = InvMass{invRotInertiaA * Square(rnA)};
-            const auto invRotMassB = InvMass{invRotInertiaB * Square(rnB)};
-            return invMassTotal + invRotMassA + invRotMassB;
-        }()};
-        
-        assert(K >= InvMass{0});
-        
-        // Prevent large corrections & don't push separation above -conf.linearSlop.
-        const auto C = -std::clamp(conf.resolutionRate * (separation + conf.linearSlop),
-                                   -conf.maxLinearCorrection, 0_m);
-        
-        // Compute response factors...
-        const auto P = Length2{psm.m_normal * C} / K; // L M
-        const auto LA = Cross(rA, P) / Radian; // L^2 M QP^-1
-        const auto LB = Cross(rB, P) / Radian; // L^2 M QP^-1
-        
-        // InvMass is M^-1, and InvRotInertia is L^-2 M^-1 QP^2.
-        // Product of InvMass * P is: L
-        // Product of InvRotInertia * L{A,B} is: QP
-        return d2::PositionSolution{
-            -d2::Position{invMassA * P, invRotInertiaA * LA},
-            +d2::Position{invMassB * P, invRotInertiaB * LB},
-            separation
-        };
-    };
-    
-    auto posA = bodyA->GetPosition();
-    auto posB = bodyB->GetPosition();
-    
-    // Solve normal constraints
-    const auto pointCount = pc.manifold.GetPointCount();
-    switch (pointCount)
+    ConstraintSolverConf GetRegConstraintSolverConf(const StepConf& conf) noexcept
     {
-        case 1:
+        return ConstraintSolverConf{}
+            .UseResolutionRate(conf.regResolutionRate)
+            .UseLinearSlop(conf.linearSlop)
+            .UseAngularSlop(conf.angularSlop)
+            .UseMaxLinearCorrection(conf.maxLinearCorrection)
+            .UseMaxAngularCorrection(conf.maxAngularCorrection);
+    }
+
+    ConstraintSolverConf GetToiConstraintSolverConf(const StepConf& conf) noexcept
+    {
+        return ConstraintSolverConf{}
+            .UseResolutionRate(conf.toiResolutionRate)
+            .UseLinearSlop(conf.linearSlop)
+            .UseAngularSlop(conf.angularSlop)
+            .UseMaxLinearCorrection(conf.maxLinearCorrection)
+            .UseMaxAngularCorrection(conf.maxAngularCorrection);
+    }
+
+    namespace GaussSeidel
+    {
+
+        Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc)
         {
-            const auto psm0 = GetPSM(pc.manifold, 0,
-                                     GetTransformation(posA, localCenterA),
-                                     GetTransformation(posB, localCenterB));
-            return d2::PositionSolution{posA, posB, 0} + solver_fn(psm0, posA.linear, posB.linear);
+            auto maxIncImpulse = 0_Ns;
+
+            // Applies frictional changes to velocity.
+            maxIncImpulse = std::max(maxIncImpulse, d2::SolveTangentConstraint(vc));
+
+            // Applies restitutional changes to velocity.
+            maxIncImpulse = std::max(maxIncImpulse, d2::SolveNormalConstraint(vc));
+
+            return maxIncImpulse;
         }
-        case 2:
+
+        d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
+                                                     const bool moveA, const bool moveB,
+                                                     ConstraintSolverConf conf)
         {
+            assert(IsValid(conf.resolutionRate));
+            assert(IsValid(conf.linearSlop));
+            assert(IsValid(conf.maxLinearCorrection));
+
+            const auto bodyA = pc.GetBodyA();
+            const auto bodyB = pc.GetBodyB();
+
+            const auto invMassA = moveA ? bodyA->GetInvMass() : InvMass{0};
+            const auto invRotInertiaA = moveA ? bodyA->GetInvRotInertia() : InvRotInertia{0};
+            const auto localCenterA = bodyA->GetLocalCenter();
+
+            const auto invMassB = moveB ? bodyB->GetInvMass() : InvMass{0};
+            const auto invRotInertiaB = moveB ? bodyB->GetInvRotInertia() : InvRotInertia{0};
+            const auto localCenterB = bodyB->GetLocalCenter();
+
+            // Compute inverse mass total.
+            // This must be > 0 unless doing TOI solving and neither bodies were the bodies specified.
+            const auto invMassTotal = invMassA + invMassB;
+            assert(invMassTotal >= InvMass{0});
+
+            const auto totalRadius = pc.GetRadiusA() + pc.GetRadiusB();
+
+            const auto solver_fn = [&](const d2::PositionSolverManifold psm,
+                                       const Length2 pA, const Length2 pB) {
+                const auto separation = psm.m_separation - totalRadius;
+                // Positive separation means shapes not overlapping and not touching.
+                // Zero separation means shapes are touching.
+                // Negative separation means shapes are overlapping.
+
+                const auto rA = Length2{psm.m_point - pA};
+                const auto rB = Length2{psm.m_point - pB};
+
+                // Compute the effective mass.
+                const auto K = InvMass{[&]() {
+                    const auto rnA = Length{Cross(rA, psm.m_normal)} / Radian;
+                    const auto rnB = Length{Cross(rB, psm.m_normal)} / Radian;
+                    // InvRotInertia is L^-2 M^-1 QP^2
+                    // L^-2 M^-1 QP^2 * L^2 is: M^-1 QP^2
+                    const auto invRotMassA = InvMass{invRotInertiaA * Square(rnA)};
+                    const auto invRotMassB = InvMass{invRotInertiaB * Square(rnB)};
+                    return invMassTotal + invRotMassA + invRotMassB;
+                }()};
+
+                assert(K >= InvMass{0});
+
+                // Prevent large corrections & don't push separation above -conf.linearSlop.
+                const auto C = -std::clamp(conf.resolutionRate * (separation + conf.linearSlop),
+                                           -conf.maxLinearCorrection, 0_m);
+
+                // Compute response factors...
+                const auto P = Length2{psm.m_normal * C} / K;// L M
+                const auto LA = Cross(rA, P) / Radian;       // L^2 M QP^-1
+                const auto LB = Cross(rB, P) / Radian;       // L^2 M QP^-1
+
+                // InvMass is M^-1, and InvRotInertia is L^-2 M^-1 QP^2.
+                // Product of InvMass * P is: L
+                // Product of InvRotInertia * L{A,B} is: QP
+                return d2::PositionSolution{
+                    -d2::Position{invMassA * P, invRotInertiaA * LA},
+                    +d2::Position{invMassB * P, invRotInertiaB * LB},
+                    separation};
+            };
+
+            auto posA = bodyA->GetPosition();
+            auto posB = bodyB->GetPosition();
+
+            // Solve normal constraints
+            const auto pointCount = pc.manifold.GetPointCount();
+            switch (pointCount)
+            {
+            case 1: {
+                const auto psm0 = GetPSM(pc.manifold, 0,
+                                         GetTransformation(posA, localCenterA),
+                                         GetTransformation(posB, localCenterB));
+                return d2::PositionSolution{posA, posB, 0} + solver_fn(psm0, posA.linear, posB.linear);
+            }
+            case 2: {
 #if 0
             const auto psm0 = GetPSM(pc.manifold, 0,
                                      GetTransformation(posA, localCenterA),
@@ -592,61 +587,61 @@ d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
             
             return PositionSolution{posA, posB, std::min(s0.min_separation, s1.min_separation)};
 #else
-            const auto xfA = GetTransformation(posA, localCenterA);
-            const auto xfB = GetTransformation(posB, localCenterB);
-            
-            // solve most penatrating point first or solve simultaneously if about the same penetration
-            const auto psm0 = GetPSM(pc.manifold, 0, xfA, xfB);
-            const auto psm1 = GetPSM(pc.manifold, 1, xfA, xfB);
-            
-            assert(IsValid(psm0.m_separation) && IsValid(psm1.m_separation));
-            
-            if (AlmostEqual(StripUnit(psm0.m_separation), StripUnit(psm1.m_separation)))
-            {
-                const auto s0 = solver_fn(psm0, posA.linear, posB.linear);
-                const auto s1 = solver_fn(psm1, posA.linear, posB.linear);
-                //assert(s0.pos_a.angular == -s1.pos_a.angular);
-                //assert(s0.pos_b.angular == -s1.pos_b.angular);
-                return d2::PositionSolution{
-                    posA + s0.pos_a + s1.pos_a,
-                    posB + s0.pos_b + s1.pos_b,
-                    s0.min_separation
-                };
-            }
-            if (psm0.m_separation < psm1.m_separation)
-            {
-                const auto s0 = solver_fn(psm0, posA.linear, posB.linear);
-                posA += s0.pos_a;
-                posB += s0.pos_b;
-                const auto psm1_prime = GetPSM(pc.manifold, 1,
-                                               GetTransformation(posA, localCenterA),
-                                               GetTransformation(posB, localCenterB));
-                const auto s1 = solver_fn(psm1_prime, posA.linear, posB.linear);
-                posA += s1.pos_a;
-                posB += s1.pos_b;
-                return d2::PositionSolution{posA, posB, s0.min_separation};
-            }
-            if (psm1.m_separation < psm0.m_separation)
-            {
-                const auto s1 = solver_fn(psm1, posA.linear, posB.linear);
-                posA += s1.pos_a;
-                posB += s1.pos_b;
-                const auto psm0_prime = GetPSM(pc.manifold, 0,
-                                               GetTransformation(posA, localCenterA),
-                                               GetTransformation(posB, localCenterB));
-                const auto s0 = solver_fn(psm0_prime, posA.linear, posB.linear);
-                posA += s0.pos_a;
-                posB += s0.pos_b;
-                return d2::PositionSolution{posA, posB, s1.min_separation};
-            }
+                const auto xfA = GetTransformation(posA, localCenterA);
+                const auto xfB = GetTransformation(posB, localCenterB);
+
+                // solve most penatrating point first or solve simultaneously if about the same penetration
+                const auto psm0 = GetPSM(pc.manifold, 0, xfA, xfB);
+                const auto psm1 = GetPSM(pc.manifold, 1, xfA, xfB);
+
+                assert(IsValid(psm0.m_separation) && IsValid(psm1.m_separation));
+
+                if (AlmostEqual(StripUnit(psm0.m_separation), StripUnit(psm1.m_separation)))
+                {
+                    const auto s0 = solver_fn(psm0, posA.linear, posB.linear);
+                    const auto s1 = solver_fn(psm1, posA.linear, posB.linear);
+                    //assert(s0.pos_a.angular == -s1.pos_a.angular);
+                    //assert(s0.pos_b.angular == -s1.pos_b.angular);
+                    return d2::PositionSolution{
+                        posA + s0.pos_a + s1.pos_a,
+                        posB + s0.pos_b + s1.pos_b,
+                        s0.min_separation};
+                }
+                if (psm0.m_separation < psm1.m_separation)
+                {
+                    const auto s0 = solver_fn(psm0, posA.linear, posB.linear);
+                    posA += s0.pos_a;
+                    posB += s0.pos_b;
+                    const auto psm1_prime = GetPSM(pc.manifold, 1,
+                                                   GetTransformation(posA, localCenterA),
+                                                   GetTransformation(posB, localCenterB));
+                    const auto s1 = solver_fn(psm1_prime, posA.linear, posB.linear);
+                    posA += s1.pos_a;
+                    posB += s1.pos_b;
+                    return d2::PositionSolution{posA, posB, s0.min_separation};
+                }
+                if (psm1.m_separation < psm0.m_separation)
+                {
+                    const auto s1 = solver_fn(psm1, posA.linear, posB.linear);
+                    posA += s1.pos_a;
+                    posB += s1.pos_b;
+                    const auto psm0_prime = GetPSM(pc.manifold, 0,
+                                                   GetTransformation(posA, localCenterA),
+                                                   GetTransformation(posB, localCenterB));
+                    const auto s0 = solver_fn(psm0_prime, posA.linear, posB.linear);
+                    posA += s0.pos_a;
+                    posB += s0.pos_b;
+                    return d2::PositionSolution{posA, posB, s1.min_separation};
+                }
 #endif
-            // reaches here if one or both psm separation values was NaN (and NDEBUG is defined).
+                // reaches here if one or both psm separation values was NaN (and NDEBUG is defined).
+            }
+            default:
+                break;
+            }
+            return d2::PositionSolution{posA, posB, std::numeric_limits<Length>::infinity()};
         }
-        default: break;
-    }
-    return d2::PositionSolution{posA, posB, std::numeric_limits<Length>::infinity()};
-}
 
-} // namespace GaussSeidel
+    }// namespace GaussSeidel
 
-} // namespace playrho
+}// namespace playrho

--- a/PlayRho/Dynamics/Contacts/ContactSolver.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.hpp
@@ -22,181 +22,181 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-struct StepConf;
-
-namespace d2 {
-
-class VelocityConstraint;
-class PositionConstraint;
-class BodyConstraint;
-
-/// @brief Solution for position constraint.
-struct PositionSolution
+namespace playrho
 {
-    Position pos_a; ///< Position A.
-    Position pos_b; ///< Position B.
-    Length min_separation; ///< Min separation.
-};
 
-/// @brief Addition operator.
-inline PositionSolution operator+ (PositionSolution lhs, PositionSolution rhs)
-{
-    return PositionSolution{
-        lhs.pos_a + rhs.pos_a,
-        lhs.pos_b + rhs.pos_b,
-        lhs.min_separation + rhs.min_separation
-    };
-}
+    struct StepConf;
 
-/// @brief Subtraction operator.
-inline PositionSolution operator- (PositionSolution lhs, PositionSolution rhs)
-{
-    return PositionSolution{
-        lhs.pos_a - rhs.pos_a,
-        lhs.pos_b - rhs.pos_b,
-        lhs.min_separation - rhs.min_separation
-    };
-}
+    namespace d2
+    {
 
-} // namespace d2
+        class VelocityConstraint;
+        class PositionConstraint;
+        class BodyConstraint;
 
-/// Constraint solver configuration data.
-/// @details
-/// Defines how a constraint solver should resolve a given constraint.
-/// @see SolvePositionConstraint.
-struct ConstraintSolverConf
-{
-    /// @brief Uses the given resolution rate.
-    ConstraintSolverConf& UseResolutionRate(Real value) noexcept;
-    
-    /// @brief Uses the given linear slop.
-    ConstraintSolverConf& UseLinearSlop(Length value) noexcept;
-    
-    /// @brief Uses the given angular slop.
-    ConstraintSolverConf& UseAngularSlop(Angle value) noexcept;
-    
-    /// @brief Uses the given max linear correction.
-    ConstraintSolverConf& UseMaxLinearCorrection(Length value) noexcept;
-    
-    /// @brief Uses the given max angular correction.
-    ConstraintSolverConf& UseMaxAngularCorrection(Angle value) noexcept;
-    
-    /// Resolution rate.
+        /// @brief Solution for position constraint.
+        struct PositionSolution
+        {
+            Position pos_a;       ///< Position A.
+            Position pos_b;       ///< Position B.
+            Length min_separation;///< Min separation.
+        };
+
+        /// @brief Addition operator.
+        inline PositionSolution operator+(PositionSolution lhs, PositionSolution rhs)
+        {
+            return PositionSolution{
+                lhs.pos_a + rhs.pos_a,
+                lhs.pos_b + rhs.pos_b,
+                lhs.min_separation + rhs.min_separation};
+        }
+
+        /// @brief Subtraction operator.
+        inline PositionSolution operator-(PositionSolution lhs, PositionSolution rhs)
+        {
+            return PositionSolution{
+                lhs.pos_a - rhs.pos_a,
+                lhs.pos_b - rhs.pos_b,
+                lhs.min_separation - rhs.min_separation};
+        }
+
+    }// namespace d2
+
+    /// Constraint solver configuration data.
     /// @details
-    /// Defines the percentage of the overlap that should get resolved in a single solver call.
-    /// Value greater than zero and less than or equal to one.
-    /// Ideally this would be 1 so that overlap is removed in one time step.
-    /// However using values close to 1 often leads to overshoot.
-    /// @note Recommended values are: <code>0.2</code> for solving regular constraints
-    ///   or <code>0.75</code> for solving TOI constraints.
-    Real resolutionRate = Real(0.2);
-    
-    /// Linear slop.
-    /// @note The negative of this amount is the maximum amount of separation to create.
-    /// @note Recommended value: <code>DefaultLinearSlop</code>.
-    Length linearSlop = DefaultLinearSlop;
-    
-    /// Angular slop.
-    /// @note Recommended value: <code>DefaultAngularSlop</code>.
-    Angle angularSlop = DefaultAngularSlop;
-    
-    /// Maximum linear correction.
-    /// @details
-    /// Maximum amount of overlap to resolve in a single solver call. Helps prevent overshoot.
-    /// @note Recommended value: <code>linearSlop * 40</code>.
-    Length maxLinearCorrection = DefaultLinearSlop * Real{20};
-    
-    /// Maximum angular correction.
-    /// @details Maximum angular position correction used when solving constraints.
-    /// Helps to prevent overshoot.
-    /// @note Recommended value: <code>angularSlop * 4</code>.
-    Angle maxAngularCorrection = DefaultAngularSlop * Real{4};
-};
+    /// Defines how a constraint solver should resolve a given constraint.
+    /// @see SolvePositionConstraint.
+    struct ConstraintSolverConf
+    {
+        /// @brief Uses the given resolution rate.
+        ConstraintSolverConf& UseResolutionRate(Real value) noexcept;
 
-inline ConstraintSolverConf& ConstraintSolverConf::UseResolutionRate(Real value) noexcept
-{
-    resolutionRate = value;
-    return *this;
-}
+        /// @brief Uses the given linear slop.
+        ConstraintSolverConf& UseLinearSlop(Length value) noexcept;
 
-inline ConstraintSolverConf& ConstraintSolverConf::UseLinearSlop(Length value) noexcept
-{
-    linearSlop = value;
-    return *this;
-}
+        /// @brief Uses the given angular slop.
+        ConstraintSolverConf& UseAngularSlop(Angle value) noexcept;
 
-inline ConstraintSolverConf& ConstraintSolverConf::UseAngularSlop(Angle value) noexcept
-{
-    angularSlop = value;
-    return *this;
-}
+        /// @brief Uses the given max linear correction.
+        ConstraintSolverConf& UseMaxLinearCorrection(Length value) noexcept;
 
-inline ConstraintSolverConf& ConstraintSolverConf::UseMaxLinearCorrection(Length value) noexcept
-{
-    maxLinearCorrection = value;
-    return *this;
-}
+        /// @brief Uses the given max angular correction.
+        ConstraintSolverConf& UseMaxAngularCorrection(Angle value) noexcept;
 
-inline ConstraintSolverConf& ConstraintSolverConf::UseMaxAngularCorrection(Angle value) noexcept
-{
-    maxAngularCorrection = value;
-    return *this;
-}
+        /// Resolution rate.
+        /// @details
+        /// Defines the percentage of the overlap that should get resolved in a single solver call.
+        /// Value greater than zero and less than or equal to one.
+        /// Ideally this would be 1 so that overlap is removed in one time step.
+        /// However using values close to 1 often leads to overshoot.
+        /// @note Recommended values are: <code>0.2</code> for solving regular constraints
+        ///   or <code>0.75</code> for solving TOI constraints.
+        Real resolutionRate = Real(0.2);
 
-/// @brief Gets the default position solver configuration.
-inline ConstraintSolverConf GetDefaultPositionSolverConf()
-{
-    return ConstraintSolverConf{}.UseResolutionRate(Real(0.2));
-}
+        /// Linear slop.
+        /// @note The negative of this amount is the maximum amount of separation to create.
+        /// @note Recommended value: <code>DefaultLinearSlop</code>.
+        Length linearSlop = DefaultLinearSlop;
 
-/// @brief Gets the default TOI position solver configuration.
-inline ConstraintSolverConf GetDefaultToiPositionSolverConf()
-{
-    // For solving TOI events, use a faster/higher resolution rate than normally used.
-    return ConstraintSolverConf{}.UseResolutionRate(Real(0.75));
-}
+        /// Angular slop.
+        /// @note Recommended value: <code>DefaultAngularSlop</code>.
+        Angle angularSlop = DefaultAngularSlop;
 
-/// @brief Gets the regular phase constraint solver configuration for the given step configuration.
-ConstraintSolverConf GetRegConstraintSolverConf(const StepConf& conf) noexcept;
+        /// Maximum linear correction.
+        /// @details
+        /// Maximum amount of overlap to resolve in a single solver call. Helps prevent overshoot.
+        /// @note Recommended value: <code>linearSlop * 40</code>.
+        Length maxLinearCorrection = DefaultLinearSlop * Real{20};
 
-/// @brief Gets the TOI phase constraint solver configuration for the given step configuration.
-ConstraintSolverConf GetToiConstraintSolverConf(const StepConf& conf) noexcept;
+        /// Maximum angular correction.
+        /// @details Maximum angular position correction used when solving constraints.
+        /// Helps to prevent overshoot.
+        /// @note Recommended value: <code>angularSlop * 4</code>.
+        Angle maxAngularCorrection = DefaultAngularSlop * Real{4};
+    };
 
-namespace GaussSeidel {
+    inline ConstraintSolverConf& ConstraintSolverConf::UseResolutionRate(Real value) noexcept
+    {
+        resolutionRate = value;
+        return *this;
+    }
 
-/// Solves the velocity constraint.
-///
-/// @details This updates the tangent and normal impulses of the velocity constraint
-///   points of the given velocity constraint and updates the given velocities.
-///
-/// @warning Behavior is undefined unless the velocity constraint point count is 1 or 2.
-/// @note Linear velocity is only changed if the inverse mass of either body is non-zero.
-/// @note Angular velocity is only changed if the inverse rotational inertia of either
-///   body is non-zero.
-/// @note Inlining this function may yield a 10% speed boost in the
-///   <code>World.TilesComesToRest</code> unit test.
-///
-/// @pre The velocity constraint must have a valid normal, a valid tangent,
-///   valid point relative positions, and valid velocity biases.
-///
-Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc);
+    inline ConstraintSolverConf& ConstraintSolverConf::UseLinearSlop(Length value) noexcept
+    {
+        linearSlop = value;
+        return *this;
+    }
 
-/// Solves the given position constraint.
-/// @details
-/// This pushes apart the two given positions for every point in the contact position constraint
-/// and returns the minimum separation value from the position solver manifold for each point.
-/// @see http://allenchou.net/2013/12/game-physics-resolution-contact-constraints/
-/// @return Minimum separation distance of the position constraint's manifold points
-///   (prior to "solving").
-d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
-                                     const bool moveA, const bool moveB,
-                                     ConstraintSolverConf conf);
+    inline ConstraintSolverConf& ConstraintSolverConf::UseAngularSlop(Angle value) noexcept
+    {
+        angularSlop = value;
+        return *this;
+    }
 
-} // namespace GaussSidel
+    inline ConstraintSolverConf& ConstraintSolverConf::UseMaxLinearCorrection(Length value) noexcept
+    {
+        maxLinearCorrection = value;
+        return *this;
+    }
 
-} // namespace playrho
+    inline ConstraintSolverConf& ConstraintSolverConf::UseMaxAngularCorrection(Angle value) noexcept
+    {
+        maxAngularCorrection = value;
+        return *this;
+    }
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_CONTACTSOLVER_HPP
+    /// @brief Gets the default position solver configuration.
+    inline ConstraintSolverConf GetDefaultPositionSolverConf()
+    {
+        return ConstraintSolverConf{}.UseResolutionRate(Real(0.2));
+    }
 
+    /// @brief Gets the default TOI position solver configuration.
+    inline ConstraintSolverConf GetDefaultToiPositionSolverConf()
+    {
+        // For solving TOI events, use a faster/higher resolution rate than normally used.
+        return ConstraintSolverConf{}.UseResolutionRate(Real(0.75));
+    }
+
+    /// @brief Gets the regular phase constraint solver configuration for the given step configuration.
+    ConstraintSolverConf GetRegConstraintSolverConf(const StepConf& conf) noexcept;
+
+    /// @brief Gets the TOI phase constraint solver configuration for the given step configuration.
+    ConstraintSolverConf GetToiConstraintSolverConf(const StepConf& conf) noexcept;
+
+    namespace GaussSeidel
+    {
+
+        /// Solves the velocity constraint.
+        ///
+        /// @details This updates the tangent and normal impulses of the velocity constraint
+        ///   points of the given velocity constraint and updates the given velocities.
+        ///
+        /// @warning Behavior is undefined unless the velocity constraint point count is 1 or 2.
+        /// @note Linear velocity is only changed if the inverse mass of either body is non-zero.
+        /// @note Angular velocity is only changed if the inverse rotational inertia of either
+        ///   body is non-zero.
+        /// @note Inlining this function may yield a 10% speed boost in the
+        ///   <code>World.TilesComesToRest</code> unit test.
+        ///
+        /// @pre The velocity constraint must have a valid normal, a valid tangent,
+        ///   valid point relative positions, and valid velocity biases.
+        ///
+        Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc);
+
+        /// Solves the given position constraint.
+        /// @details
+        /// This pushes apart the two given positions for every point in the contact position constraint
+        /// and returns the minimum separation value from the position solver manifold for each point.
+        /// @see http://allenchou.net/2013/12/game-physics-resolution-contact-constraints/
+        /// @return Minimum separation distance of the position constraint's manifold points
+        ///   (prior to "solving").
+        d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
+                                                     const bool moveA, const bool moveB,
+                                                     ConstraintSolverConf conf);
+
+    }// namespace GaussSeidel
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_CONTACTSOLVER_HPP

--- a/PlayRho/Dynamics/Contacts/KeyedContactID.hpp
+++ b/PlayRho/Dynamics/Contacts/KeyedContactID.hpp
@@ -24,22 +24,24 @@
 /// @file
 /// Declaration of the <code>KeyedContactPtr</code> alias.
 
-#include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactID.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Keyed contact pointer.
-using KeyedContactPtr = std::pair<ContactKey, ContactID>;
-
-/// @brief Gets the contact ID for the given value.
-inline ContactID GetContactPtr(KeyedContactPtr value)
+namespace playrho
 {
-    return std::get<1>(value);
-}
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Keyed contact pointer.
+        using KeyedContactPtr = std::pair<ContactKey, ContactID>;
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_KEYEDCONTACTID_HPP
+        /// @brief Gets the contact ID for the given value.
+        inline ContactID GetContactPtr(KeyedContactPtr value)
+        {
+            return std::get<1>(value);
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_KEYEDCONTACTID_HPP

--- a/PlayRho/Dynamics/Contacts/PositionConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/PositionConstraint.hpp
@@ -23,61 +23,74 @@
 #include <PlayRho/Collision/Manifold.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-namespace playrho {
-namespace d2 {
-
-    /// Contact Position Constraint.
-    /// @note This structure is 88-bytes large on at least one 64-bit platform.
-    class PositionConstraint
+namespace playrho
+{
+    namespace d2
     {
-    public:
-        /// @brief Size type.
-        using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
-        
-        PositionConstraint() = default;
-        
-        /// @brief Initializing constructor.
-        PositionConstraint(const Manifold& m,
-                           BodyConstraint& bA, Length rA,
-                           BodyConstraint& bB, Length rB):
-            manifold{m}, m_bodyA{&bA}, m_bodyB{&bB}, m_radiusA{rA}, m_radiusB{rB}
+
+        /// Contact Position Constraint.
+        /// @note This structure is 88-bytes large on at least one 64-bit platform.
+        class PositionConstraint
         {
-            assert(m.GetPointCount() > 0);
-            assert(&bA != &bB);
-            assert(rA >= 0_m);
-            assert(rB >= 0_m);
-        }
-        
-        Manifold manifold; ///< Copy of contact's manifold with 1 or more contact points (64-bytes).
+         public:
+            /// @brief Size type.
+            using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
 
-        /// @brief Gets body A.
-        BodyConstraint* GetBodyA() const noexcept { return m_bodyA; }
-        
-        /// @brief Gets body B.
-        BodyConstraint* GetBodyB() const noexcept { return m_bodyB; }
+            PositionConstraint() = default;
 
-        /// @brief Gets radius A.
-        Length GetRadiusA() const noexcept { return m_radiusA; }
-        
-        /// @brief Gets radius B.
-        Length GetRadiusB() const noexcept { return m_radiusB; }
+            /// @brief Initializing constructor.
+            PositionConstraint(const Manifold& m,
+                               BodyConstraint& bA, Length rA,
+                               BodyConstraint& bB, Length rB)
+                : manifold{m}, m_bodyA{&bA}, m_bodyB{&bB}, m_radiusA{rA}, m_radiusB{rB}
+            {
+                assert(m.GetPointCount() > 0);
+                assert(&bA != &bB);
+                assert(rA >= 0_m);
+                assert(rB >= 0_m);
+            }
 
-    private:
-        
-        BodyConstraint* m_bodyA; ///< Body A data (8-bytes).
-        
-        BodyConstraint* m_bodyB; ///< Body B data (8-bytes).
+            Manifold manifold;///< Copy of contact's manifold with 1 or more contact points (64-bytes).
 
-        /// @brief "Radius" distance from the associated shape of fixture A.
-        /// @note 0 or greater.
-        Length m_radiusA; // 4-bytes.
+            /// @brief Gets body A.
+            BodyConstraint* GetBodyA() const noexcept
+            {
+                return m_bodyA;
+            }
 
-        /// @brief "Radius" distance from the associated shape of fixture B.
-        /// @note 0 or greater.
-        Length m_radiusB; // 4-bytes.
-    };
+            /// @brief Gets body B.
+            BodyConstraint* GetBodyB() const noexcept
+            {
+                return m_bodyB;
+            }
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Gets radius A.
+            Length GetRadiusA() const noexcept
+            {
+                return m_radiusA;
+            }
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_POSITIONCONSTRAINT_HPP
+            /// @brief Gets radius B.
+            Length GetRadiusB() const noexcept
+            {
+                return m_radiusB;
+            }
+
+         private:
+            BodyConstraint* m_bodyA;///< Body A data (8-bytes).
+
+            BodyConstraint* m_bodyB;///< Body B data (8-bytes).
+
+            /// @brief "Radius" distance from the associated shape of fixture A.
+            /// @note 0 or greater.
+            Length m_radiusA;// 4-bytes.
+
+            /// @brief "Radius" distance from the associated shape of fixture B.
+            /// @note 0 or greater.
+            Length m_radiusB;// 4-bytes.
+        };
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_POSITIONCONSTRAINT_HPP

--- a/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
+++ b/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
@@ -19,91 +19,94 @@
 
 #include <PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp>
 
-namespace playrho {
-namespace d2 {
-
-namespace {
-
-/// Gets the position solver manifold in world coordinates for a circles-type manifold.
-/// @param xfA Transformation for body A.
-/// @param lp Local point. Location of shape A in local coordinates.
-/// @param xfB Transformation for body B.
-/// @param plp Point's local point. Location of shape B in local coordinates.
-/// @note The returned separation is the magnitude of the positional difference of the two points.
-///   This is always a non-negative amount.
-inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2 lp,
-                                            const Transformation& xfB, Length2 plp)
+namespace playrho
 {
-    const auto pointA = Transform(lp, xfA);
-    const auto pointB = Transform(plp, xfB);
-    const auto delta = pointB - pointA; // The edge from pointA to pointB
-    const auto normal = GetUnitVector(delta, UnitVec::GetZero()); // The direction of the edge.
-    const auto midpoint = (pointA + pointB) / Real{2};
-    const auto separation = Dot(delta, normal); // The length of edge without doing sqrt again.
-    return PositionSolverManifold{normal, midpoint, separation};
-}
-
-/// Gets the position solver manifold in world coordinates for a face-a-type manifold.
-/// @param xfA Transformation for shape A.
-/// @param lp Local point. Location for shape A in local coordinates.
-/// @param ln Local normal for shape A to be transformed into a world normal based on the
-///   transformation for shape A.
-/// @param xfB Transformation for shape B.
-/// @param plp Point's local point. Location for shape B in local coordinates.
-/// @return Separation is the dot-product of the positional difference between the two points in
-///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2 lp, UnitVec ln,
-                                          const Transformation& xfB, Length2 plp)
-{
-    const auto planePoint = Transform(lp, xfA);
-    const auto normal = Rotate(ln, xfA.q);
-    const auto clipPoint = Transform(plp, xfB);
-    const auto separation = Dot(clipPoint - planePoint, normal);
-    return PositionSolverManifold{normal, clipPoint, separation};
-}
-
-/// Gets the position solver manifold in world coordinates for a face-b-type manifold.
-/// @param xfB Transformation for body B.
-/// @param lp Local point.
-/// @param ln Local normal for shape B to be transformed into a world normal based on the
-///   transformation for shape B.
-/// @param xfA Transformation for body A.
-/// @param plp Point's local point. Location for shape A in local coordinates.
-/// @return Separation is the dot-product of the positional difference between the two points in
-///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceB(const Transformation& xfB, Length2 lp, UnitVec ln,
-                                          const Transformation& xfA, Length2 plp)
-{
-    const auto planePoint = Transform(lp, xfB);
-    const auto normal = Rotate(ln, xfB.q);
-    const auto clipPoint = Transform(plp, xfA);
-    const auto separation = Dot(clipPoint - planePoint, normal);
-    // Negate normal to ensure the PSM normal points from A to B
-    return PositionSolverManifold{-normal, clipPoint, separation};
-}
-
-} // unnamed namespace
-
-PositionSolverManifold GetPSM(const Manifold& manifold, Manifold::size_type index,
-                              const Transformation& xfA, const Transformation& xfB)
-{
-    switch (manifold.GetType())
+    namespace d2
     {
-    case Manifold::e_circles:
-        return GetForCircles(xfA, manifold.GetLocalPoint(),
-                             xfB, manifold.GetPoint(index).localPoint);
-    case Manifold::e_faceA:
-        return GetForFaceA(xfA, manifold.GetLocalPoint(), manifold.GetLocalNormal(),
-                           xfB, manifold.GetPoint(index).localPoint);
-    case Manifold::e_faceB:
-        return GetForFaceB(xfB, manifold.GetLocalPoint(), manifold.GetLocalNormal(),
-                           xfA, manifold.GetPoint(index).localPoint);
-    case Manifold::e_unset:
-        break;
-    }
-    assert(manifold.GetType() == Manifold::e_unset);
-    return PositionSolverManifold{GetInvalid<UnitVec>(), GetInvalid<Length2>(), GetInvalid<Length>()};
-}
 
-} // namespace d2
-} // namespace playrho
+        namespace
+        {
+
+            /// Gets the position solver manifold in world coordinates for a circles-type manifold.
+            /// @param xfA Transformation for body A.
+            /// @param lp Local point. Location of shape A in local coordinates.
+            /// @param xfB Transformation for body B.
+            /// @param plp Point's local point. Location of shape B in local coordinates.
+            /// @note The returned separation is the magnitude of the positional difference of the two points.
+            ///   This is always a non-negative amount.
+            inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2 lp,
+                                                        const Transformation& xfB, Length2 plp)
+            {
+                const auto pointA = Transform(lp, xfA);
+                const auto pointB = Transform(plp, xfB);
+                const auto delta = pointB - pointA;                          // The edge from pointA to pointB
+                const auto normal = GetUnitVector(delta, UnitVec::GetZero());// The direction of the edge.
+                const auto midpoint = (pointA + pointB) / Real{2};
+                const auto separation = Dot(delta, normal);// The length of edge without doing sqrt again.
+                return PositionSolverManifold{normal, midpoint, separation};
+            }
+
+            /// Gets the position solver manifold in world coordinates for a face-a-type manifold.
+            /// @param xfA Transformation for shape A.
+            /// @param lp Local point. Location for shape A in local coordinates.
+            /// @param ln Local normal for shape A to be transformed into a world normal based on the
+            ///   transformation for shape A.
+            /// @param xfB Transformation for shape B.
+            /// @param plp Point's local point. Location for shape B in local coordinates.
+            /// @return Separation is the dot-product of the positional difference between the two points in
+            ///   the direction of the world normal.
+            inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2 lp, UnitVec ln,
+                                                      const Transformation& xfB, Length2 plp)
+            {
+                const auto planePoint = Transform(lp, xfA);
+                const auto normal = Rotate(ln, xfA.q);
+                const auto clipPoint = Transform(plp, xfB);
+                const auto separation = Dot(clipPoint - planePoint, normal);
+                return PositionSolverManifold{normal, clipPoint, separation};
+            }
+
+            /// Gets the position solver manifold in world coordinates for a face-b-type manifold.
+            /// @param xfB Transformation for body B.
+            /// @param lp Local point.
+            /// @param ln Local normal for shape B to be transformed into a world normal based on the
+            ///   transformation for shape B.
+            /// @param xfA Transformation for body A.
+            /// @param plp Point's local point. Location for shape A in local coordinates.
+            /// @return Separation is the dot-product of the positional difference between the two points in
+            ///   the direction of the world normal.
+            inline PositionSolverManifold GetForFaceB(const Transformation& xfB, Length2 lp, UnitVec ln,
+                                                      const Transformation& xfA, Length2 plp)
+            {
+                const auto planePoint = Transform(lp, xfB);
+                const auto normal = Rotate(ln, xfB.q);
+                const auto clipPoint = Transform(plp, xfA);
+                const auto separation = Dot(clipPoint - planePoint, normal);
+                // Negate normal to ensure the PSM normal points from A to B
+                return PositionSolverManifold{-normal, clipPoint, separation};
+            }
+
+        }// unnamed namespace
+
+        PositionSolverManifold GetPSM(const Manifold& manifold, Manifold::size_type index,
+                                      const Transformation& xfA, const Transformation& xfB)
+        {
+            switch (manifold.GetType())
+            {
+            case Manifold::e_circles:
+                return GetForCircles(xfA, manifold.GetLocalPoint(),
+                                     xfB, manifold.GetPoint(index).localPoint);
+            case Manifold::e_faceA:
+                return GetForFaceA(xfA, manifold.GetLocalPoint(), manifold.GetLocalNormal(),
+                                   xfB, manifold.GetPoint(index).localPoint);
+            case Manifold::e_faceB:
+                return GetForFaceB(xfB, manifold.GetLocalPoint(), manifold.GetLocalNormal(),
+                                   xfA, manifold.GetPoint(index).localPoint);
+            case Manifold::e_unset:
+                break;
+            }
+            assert(manifold.GetType() == Manifold::e_unset);
+            return PositionSolverManifold{GetInvalid<UnitVec>(), GetInvalid<Length2>(), GetInvalid<Length>()};
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp
+++ b/PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp
@@ -20,46 +20,48 @@
 #ifndef PLAYRHO_DYNAMICS_CONTACTS_POSITIONSOLVERMANIFOLD_HPP
 #define PLAYRHO_DYNAMICS_CONTACTS_POSITIONSOLVERMANIFOLD_HPP
 
-#include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Settings.hpp>
 
 #include <PlayRho/Collision/Manifold.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// Position solver manifold.
-/// @details
-/// This is a normal-point-separation composition of data for position constraint resolution.
-/// @note This data structure is 20-bytes large.
-struct PositionSolverManifold
+namespace playrho
 {
-    /// Normal.
-    /// @details Normal of the contact between two points. This is the axis upon which impulses
-    ///    should be applied to resolve the negative separations of overlapping shapes.
-    /// @note This field is 8-bytes large.
-    UnitVec m_normal;
+    namespace d2
+    {
 
-    /// Point.
-    /// @details Point at which position resolution should be relatively applied.
-    /// @note This field is 8-bytes large.
-    Length2 m_point;
-    
-    /// Separation.
-    /// @details Separation between two points (i.e. penetration if negative).
-    /// @note This field is 4-bytes large.
-    Length m_separation;
-};
+        /// Position solver manifold.
+        /// @details
+        /// This is a normal-point-separation composition of data for position constraint resolution.
+        /// @note This data structure is 20-bytes large.
+        struct PositionSolverManifold
+        {
+            /// Normal.
+            /// @details Normal of the contact between two points. This is the axis upon which impulses
+            ///    should be applied to resolve the negative separations of overlapping shapes.
+            /// @note This field is 8-bytes large.
+            UnitVec m_normal;
 
-/// Gets the normal-point-separation data in world coordinates for the given inputs.
-/// @note The returned normal is in the direction of shape A to shape B.
-/// @note The returned separation distance does not account for vertex radiuses. It's simply
-///   the separation between the points of the manifold. To account for the vertex radiuses,
-///   the total vertex radius must be subtracted from this separation distance.
-PositionSolverManifold GetPSM(const Manifold& manifold, Manifold::size_type index,
-                              const Transformation& xfA, const Transformation& xfB);
+            /// Point.
+            /// @details Point at which position resolution should be relatively applied.
+            /// @note This field is 8-bytes large.
+            Length2 m_point;
 
-} // namespace d2
-} // namespace playrho
+            /// Separation.
+            /// @details Separation between two points (i.e. penetration if negative).
+            /// @note This field is 4-bytes large.
+            Length m_separation;
+        };
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_POSITIONSOLVERMANIFOLD_HPP
+        /// Gets the normal-point-separation data in world coordinates for the given inputs.
+        /// @note The returned normal is in the direction of shape A to shape B.
+        /// @note The returned separation distance does not account for vertex radiuses. It's simply
+        ///   the separation between the points of the manifold. To account for the vertex radiuses,
+        ///   the total vertex radius must be subtracted from this separation distance.
+        PositionSolverManifold GetPSM(const Manifold& manifold, Manifold::size_type index,
+                                      const Transformation& xfA, const Transformation& xfB);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_POSITIONSOLVERMANIFOLD_HPP

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
@@ -17,186 +17,188 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#include <PlayRho/Collision/Manifold.hpp>
+#include <PlayRho/Collision/WorldManifold.hpp>
 #include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Collision/WorldManifold.hpp>
-#include <PlayRho/Collision/Manifold.hpp>
 
 #define PLAYRHO_MAGIC(x) (x)
 
-namespace playrho {
-namespace d2 {
-
-namespace {
-
-inline InvMass3 ComputeK(const VelocityConstraint& vc) noexcept
+namespace playrho
 {
-    assert(vc.GetPointCount() == 2);
-
-    const auto normal = vc.GetNormal();
-    const auto bodyA = vc.GetBodyA();
-    const auto bodyB = vc.GetBodyB();
-
-    const auto relA0 = vc.GetPointRelPosA(0);
-    const auto relB0 = vc.GetPointRelPosB(0);
-    const auto relA1 = vc.GetPointRelPosA(1);
-    const auto relB1 = vc.GetPointRelPosB(1);
-    
-    const auto rnA0 = Length{Cross(relA0, normal)};
-    const auto rnB0 = Length{Cross(relB0, normal)};
-    const auto rnA1 = Length{Cross(relA1, normal)};
-    const auto rnB1 = Length{Cross(relB1, normal)};
-
-    const auto invRotInertiaA = bodyA->GetInvRotInertia();
-    const auto invMassA = bodyA->GetInvMass();
-    
-    const auto invRotInertiaB = bodyB->GetInvRotInertia();
-    const auto invMassB = bodyB->GetInvMass();
-    
-    const auto invMass = invMassA + invMassB;
-    assert(invMass > InvMass{0});
-    
-    const auto invRotMassA0 = InvMass{(invRotInertiaA * Square(rnA0)) / SquareRadian};
-    const auto invRotMassA1 = InvMass{(invRotInertiaA * Square(rnA1)) / SquareRadian};
-    const auto invRotMassB0 = InvMass{(invRotInertiaB * Square(rnB0)) / SquareRadian};
-    const auto invRotMassB1 = InvMass{(invRotInertiaB * Square(rnB1)) / SquareRadian};
-    const auto invRotMassA = InvMass{(invRotInertiaA * rnA0 * rnA1) / SquareRadian};
-    const auto invRotMassB = InvMass{(invRotInertiaB * rnB0 * rnB1) / SquareRadian};
-    
-    const auto k00 = invMass + invRotMassA0 + invRotMassB0;
-    const auto k11 = invMass + invRotMassA1 + invRotMassB1;
-    const auto k01 = invMass + invRotMassA + invRotMassB;
-    
-    return InvMass3{k00, k11, k01};
-}
-
-} // anonymous namespace
-
-VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
-                                       LinearVelocity tangentSpeed,
-                                       const WorldManifold& worldManifold,
-                                       BodyConstraint& bA,
-                                       BodyConstraint& bB,
-                                       Conf conf):
-    m_bodyA{&bA}, m_bodyB{&bB},
-    m_normal{worldManifold.GetNormal()},
-    m_friction{friction}, m_restitution{restitution}, m_tangentSpeed{tangentSpeed}
-{
-    assert(IsValid(friction));
-    assert(IsValid(restitution));
-    assert(IsValid(tangentSpeed));
-    assert(IsValid(m_normal));
-    
-    const auto pointCount = worldManifold.GetPointCount();
-    assert(pointCount > 0);
-    for (auto j = decltype(pointCount){0}; j < pointCount; ++j)
+    namespace d2
     {
-        const auto ci = worldManifold.GetImpulses(j);
-        const auto worldPoint = worldManifold.GetPoint(j);
-        const auto relA = worldPoint - bA.GetPosition().linear;
-        const auto relB = worldPoint - bB.GetPosition().linear;
-        AddPoint(get<0>(ci), get<1>(ci), relA, relB, conf);
-    }
-    
-    if (conf.blockSolve && (pointCount == 2))
-    {
-        const auto k = ComputeK(*this);
-        
-        // Ensure a reasonable condition number.
-        const auto k00_squared = Square(get<0>(k));
-        const auto k00_times_k11 = get<0>(k) * get<1>(k);
-        const auto k01_squared = Square(get<2>(k));
-        const auto k_diff = k00_times_k11 - k01_squared;
-        constexpr auto maxCondNum = PLAYRHO_MAGIC(Real(1000.0f));
-        if (k00_squared < maxCondNum * k_diff)
+
+        namespace
         {
-            // K is safe to invert.
-            // Prepare the block solver.
-            m_K = k;
-            const auto normalMass = Invert(InvMass22{InvMass2{get<0>(k), get<2>(k)}, InvMass2{get<2>(k), get<1>(k)}});
-            m_normalMass = Mass3{get<0>(get<0>(normalMass)), get<1>(get<1>(normalMass)), get<1>(get<0>(normalMass))};
-        }
-        else
+
+            inline InvMass3 ComputeK(const VelocityConstraint& vc) noexcept
+            {
+                assert(vc.GetPointCount() == 2);
+
+                const auto normal = vc.GetNormal();
+                const auto bodyA = vc.GetBodyA();
+                const auto bodyB = vc.GetBodyB();
+
+                const auto relA0 = vc.GetPointRelPosA(0);
+                const auto relB0 = vc.GetPointRelPosB(0);
+                const auto relA1 = vc.GetPointRelPosA(1);
+                const auto relB1 = vc.GetPointRelPosB(1);
+
+                const auto rnA0 = Length{Cross(relA0, normal)};
+                const auto rnB0 = Length{Cross(relB0, normal)};
+                const auto rnA1 = Length{Cross(relA1, normal)};
+                const auto rnB1 = Length{Cross(relB1, normal)};
+
+                const auto invRotInertiaA = bodyA->GetInvRotInertia();
+                const auto invMassA = bodyA->GetInvMass();
+
+                const auto invRotInertiaB = bodyB->GetInvRotInertia();
+                const auto invMassB = bodyB->GetInvMass();
+
+                const auto invMass = invMassA + invMassB;
+                assert(invMass > InvMass{0});
+
+                const auto invRotMassA0 = InvMass{(invRotInertiaA * Square(rnA0)) / SquareRadian};
+                const auto invRotMassA1 = InvMass{(invRotInertiaA * Square(rnA1)) / SquareRadian};
+                const auto invRotMassB0 = InvMass{(invRotInertiaB * Square(rnB0)) / SquareRadian};
+                const auto invRotMassB1 = InvMass{(invRotInertiaB * Square(rnB1)) / SquareRadian};
+                const auto invRotMassA = InvMass{(invRotInertiaA * rnA0 * rnA1) / SquareRadian};
+                const auto invRotMassB = InvMass{(invRotInertiaB * rnB0 * rnB1) / SquareRadian};
+
+                const auto k00 = invMass + invRotMassA0 + invRotMassB0;
+                const auto k11 = invMass + invRotMassA1 + invRotMassB1;
+                const auto k01 = invMass + invRotMassA + invRotMassB;
+
+                return InvMass3{k00, k11, k01};
+            }
+
+        }// anonymous namespace
+
+        VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
+                                               LinearVelocity tangentSpeed,
+                                               const WorldManifold& worldManifold,
+                                               BodyConstraint& bA,
+                                               BodyConstraint& bB,
+                                               Conf conf)
+            : m_bodyA{&bA}, m_bodyB{&bB},
+              m_normal{worldManifold.GetNormal()},
+              m_friction{friction}, m_restitution{restitution}, m_tangentSpeed{tangentSpeed}
         {
-            // The constraints are redundant, just use one.
-            // TODO(lou) use deepest?
-            RemovePoint();
+            assert(IsValid(friction));
+            assert(IsValid(restitution));
+            assert(IsValid(tangentSpeed));
+            assert(IsValid(m_normal));
+
+            const auto pointCount = worldManifold.GetPointCount();
+            assert(pointCount > 0);
+            for (auto j = decltype(pointCount){0}; j < pointCount; ++j)
+            {
+                const auto ci = worldManifold.GetImpulses(j);
+                const auto worldPoint = worldManifold.GetPoint(j);
+                const auto relA = worldPoint - bA.GetPosition().linear;
+                const auto relB = worldPoint - bB.GetPosition().linear;
+                AddPoint(get<0>(ci), get<1>(ci), relA, relB, conf);
+            }
+
+            if (conf.blockSolve && (pointCount == 2))
+            {
+                const auto k = ComputeK(*this);
+
+                // Ensure a reasonable condition number.
+                const auto k00_squared = Square(get<0>(k));
+                const auto k00_times_k11 = get<0>(k) * get<1>(k);
+                const auto k01_squared = Square(get<2>(k));
+                const auto k_diff = k00_times_k11 - k01_squared;
+                constexpr auto maxCondNum = PLAYRHO_MAGIC(Real(1000.0f));
+                if (k00_squared < maxCondNum * k_diff)
+                {
+                    // K is safe to invert.
+                    // Prepare the block solver.
+                    m_K = k;
+                    const auto normalMass = Invert(InvMass22{InvMass2{get<0>(k), get<2>(k)}, InvMass2{get<2>(k), get<1>(k)}});
+                    m_normalMass = Mass3{get<0>(get<0>(normalMass)), get<1>(get<1>(normalMass)), get<1>(get<0>(normalMass))};
+                }
+                else
+                {
+                    // The constraints are redundant, just use one.
+                    // TODO(lou) use deepest?
+                    RemovePoint();
+                }
+            }
         }
-    }
-}
 
-VelocityConstraint::Point
-VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                             Length2 relA, Length2 relB, Conf conf) const noexcept
-{
-    assert(IsValid(normalImpulse));
-    assert(IsValid(tangentImpulse));
-    assert(IsValid(relA));
-    assert(IsValid(relB));
-    
-    const auto bodyA = GetBodyA();
-    const auto bodyB = GetBodyB();
-    
-    const auto invRotInertiaA = bodyA->GetInvRotInertia();
-    const auto invMassA = bodyA->GetInvMass();
-    const auto invRotInertiaB = bodyB->GetInvRotInertia();
-    const auto invMassB = bodyB->GetInvMass();
-    const auto invMass = invMassA + invMassB;
+        VelocityConstraint::Point
+        VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
+                                     Length2 relA, Length2 relB, Conf conf) const noexcept
+        {
+            assert(IsValid(normalImpulse));
+            assert(IsValid(tangentImpulse));
+            assert(IsValid(relA));
+            assert(IsValid(relB));
 
-    Point point;
-    point.normalImpulse = normalImpulse;
-    point.tangentImpulse = tangentImpulse;
-    point.velocityBias = [&]() {
-        // Get the magnitude of the contact relative velocity in direction of the normal.
-        // This will be an invalid value if the normal is invalid. The comparison in this
-        // case will fail and this lambda will return 0. And that's fine. There's no need
-        // to have a check that the normal is valid and possibly incur the overhead of a
-        // conditional branch here.
-        const auto dv = GetContactRelVelocity(bodyA->GetVelocity(), relA,
-                                              bodyB->GetVelocity(), relB);
-        const auto vn = LinearVelocity{Dot(dv, GetNormal())};
-        return (vn < -conf.velocityThreshold)? -GetRestitution() * vn: 0_mps;
-    }();
-    point.relA = relA;
-    point.relB = relB;
-    point.normalMass = [&](){
-        const auto invRotMassA = invRotInertiaA * Square(Cross(relA, GetNormal())) / SquareRadian;
-        const auto invRotMassB = invRotInertiaB * Square(Cross(relB, GetNormal())) / SquareRadian;
-        const auto value = invMass + invRotMassA + invRotMassB;
-        return (value != InvMass{0})? Real{1} / value : 0_kg;
-    }();
-    point.tangentMass = [&]() {
-        const auto invRotMassA = invRotInertiaA * Square(Cross(relA, GetTangent())) / SquareRadian;
-        const auto invRotMassB = invRotInertiaB * Square(Cross(relB, GetTangent())) / SquareRadian;
-        const auto value = invMass + invRotMassA + invRotMassB;
-        return (value != InvMass{0})? Real{1} / value : 0_kg;
-    }();
+            const auto bodyA = GetBodyA();
+            const auto bodyB = GetBodyB();
 
-    return point;
-}
+            const auto invRotInertiaA = bodyA->GetInvRotInertia();
+            const auto invMassA = bodyA->GetInvMass();
+            const auto invRotInertiaB = bodyB->GetInvRotInertia();
+            const auto invMassB = bodyB->GetInvMass();
+            const auto invMass = invMassA + invMassB;
 
-void VelocityConstraint::AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                                  Length2 relA, Length2 relB, Conf conf)
-{
-    assert(m_pointCount < MaxManifoldPoints);
-    m_points[m_pointCount] = GetPoint(normalImpulse * conf.dtRatio, tangentImpulse * conf.dtRatio,
-                                      relA, relB, conf);
-    ++m_pointCount;
-}
+            Point point;
+            point.normalImpulse = normalImpulse;
+            point.tangentImpulse = tangentImpulse;
+            point.velocityBias = [&]() {
+                // Get the magnitude of the contact relative velocity in direction of the normal.
+                // This will be an invalid value if the normal is invalid. The comparison in this
+                // case will fail and this lambda will return 0. And that's fine. There's no need
+                // to have a check that the normal is valid and possibly incur the overhead of a
+                // conditional branch here.
+                const auto dv = GetContactRelVelocity(bodyA->GetVelocity(), relA,
+                                                      bodyB->GetVelocity(), relB);
+                const auto vn = LinearVelocity{Dot(dv, GetNormal())};
+                return (vn < -conf.velocityThreshold) ? -GetRestitution() * vn : 0_mps;
+            }();
+            point.relA = relA;
+            point.relB = relB;
+            point.normalMass = [&]() {
+                const auto invRotMassA = invRotInertiaA * Square(Cross(relA, GetNormal())) / SquareRadian;
+                const auto invRotMassB = invRotInertiaB * Square(Cross(relB, GetNormal())) / SquareRadian;
+                const auto value = invMass + invRotMassA + invRotMassB;
+                return (value != InvMass{0}) ? Real{1} / value : 0_kg;
+            }();
+            point.tangentMass = [&]() {
+                const auto invRotMassA = invRotInertiaA * Square(Cross(relA, GetTangent())) / SquareRadian;
+                const auto invRotMassB = invRotInertiaB * Square(Cross(relB, GetTangent())) / SquareRadian;
+                const auto value = invMass + invRotMassA + invRotMassB;
+                return (value != InvMass{0}) ? Real{1} / value : 0_kg;
+            }();
 
-VelocityConstraint::Conf GetRegVelocityConstraintConf(const StepConf& conf) noexcept
-{
-    return VelocityConstraint::Conf{
-        conf.doWarmStart? conf.dtRatio: 0,
-        conf.velocityThreshold,
-        conf.doBlocksolve
-    };
-}
+            return point;
+        }
 
-VelocityConstraint::Conf GetToiVelocityConstraintConf(const StepConf& conf) noexcept
-{
-    return VelocityConstraint::Conf{0, conf.velocityThreshold, conf.doBlocksolve};
-}
+        void VelocityConstraint::AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
+                                          Length2 relA, Length2 relB, Conf conf)
+        {
+            assert(m_pointCount < MaxManifoldPoints);
+            m_points[m_pointCount] = GetPoint(normalImpulse * conf.dtRatio, tangentImpulse * conf.dtRatio,
+                                              relA, relB, conf);
+            ++m_pointCount;
+        }
 
-} // namespace d2
-} // namespace playrho
+        VelocityConstraint::Conf GetRegVelocityConstraintConf(const StepConf& conf) noexcept
+        {
+            return VelocityConstraint::Conf{
+                conf.doWarmStart ? conf.dtRatio : 0,
+                conf.velocityThreshold,
+                conf.doBlocksolve};
+        }
+
+        VelocityConstraint::Conf GetToiVelocityConstraintConf(const StepConf& conf) noexcept
+        {
+            return VelocityConstraint::Conf{0, conf.velocityThreshold, conf.doBlocksolve};
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -23,460 +23,482 @@
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
-namespace playrho {
-
-struct StepConf;
-
-namespace d2 {
-
-class WorldManifold;
-
-/// Contact velocity constraint.
-///
-/// @note A valid contact velocity constraint must have a point count of either 1 or 2.
-/// @note This data structure is 136-bytes large (on at least one 64-bit platform).
-///
-/// @invariant The "K" value cannot be changed independent of: the total inverse mass,
-///   the normal, and the point relative positions.
-/// @invariant The normal mass cannot be changed independent of: the "K" value.
-/// @invariant The velocity biases cannot be changed independent of: the normal, and the
-///   point relative positions.
-///
-class VelocityConstraint
+namespace playrho
 {
-public:
-    
-    /// @brief Size type.
-    using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
-    
-    /// @brief Configuration data for velocity constraints.
-    struct Conf
+
+    struct StepConf;
+
+    namespace d2
     {
-        Real dtRatio = 1; ///< Delta time ratio.
-        LinearVelocity velocityThreshold = DefaultVelocityThreshold; ///< Velocity threshold.
-        bool blockSolve = true; ///< Whether to block solve.
-    };
-    
-    /// @brief Gets the default configuration for a <code>VelocityConstraint</code>.
-    static constexpr Conf GetDefaultConf() noexcept
-    {
-        return Conf{};
-    }
 
-    /// Default constructor.
-    /// @details
-    /// Initializes object with: a zero point count, an invalid K, an invalid normal mass,
-    /// an invalid normal, invalid friction, invalid restitution, an invalid tangent speed.
-    VelocityConstraint() = default;
-    
-    /// @brief Copy constructor.
-    VelocityConstraint(const VelocityConstraint& copy) = default;
-    
-    /// @brief Assignment operator.
-    VelocityConstraint& operator= (const VelocityConstraint& copy) = default;
-    
-    /// @brief Initializing constructor.
-    VelocityConstraint(Real friction, Real restitution, LinearVelocity tangentSpeed,
-                       const WorldManifold& worldManifold,
-                       BodyConstraint& bA,
-                       BodyConstraint& bB,
-                       Conf conf = GetDefaultConf());
-    
-    /// Gets the normal of the contact in world coordinates.
-    /// @note This value is set on construction.
-    /// @return Contact normal (in world coordinates) if previously set, an invalid value
-    ///   otherwise.
-    UnitVec GetNormal() const noexcept { return m_normal; }
-    
-    /// @brief Gets the tangent.
-    UnitVec GetTangent() const noexcept { return GetFwdPerpendicular(m_normal); }
-    
-    /// Gets the count of points added to this object.
-    /// @return Value between 0 and <code>MaxManifoldPoints</code>.
-    /// @see MaxManifoldPoints.
-    /// @see AddPoint.
-    size_type GetPointCount() const noexcept { return m_pointCount; }
-    
-    /// Gets the "K" value.
-    /// @note This value is only valid if previously set to a valid value.
-    /// @return "K" value previously set or the zero initialized value.
-    InvMass22 GetK() const noexcept;
-    
-    /// Gets the normal mass.
-    /// @note This value is only valid if previously set.
-    /// @return normal mass previously set or the zero initialized value.
-    Mass22 GetNormalMass() const noexcept;
-    
-    /// Gets the combined friction of the associated contact.
-    Real GetFriction() const noexcept { return m_friction; }
-    
-    /// Gets the combined restitution of the associated contact.
-    Real GetRestitution() const noexcept { return m_restitution; }
-    
-    /// Gets the tangent speed of the associated contact.
-    LinearVelocity GetTangentSpeed() const noexcept { return m_tangentSpeed; }
-    
-    /// @brief Gets body A.
-    BodyConstraint* GetBodyA() const noexcept { return m_bodyA; }
-    
-    /// @brief Gets body B.
-    BodyConstraint* GetBodyB() const noexcept { return m_bodyB; }
-    
-    /// Gets the normal impulse at the given point.
-    /// @note Call the <code>AddPoint</code> or <code>SetNormalImpulseAtPoint</code> method
-    ///   to set this value.
-    /// @return Value previously set, or an invalid value.
-    /// @see SetNormalImpulseAtPoint.
-    Momentum GetNormalImpulseAtPoint(size_type index) const noexcept;
-    
-    /// Gets the tangent impulse at the given point.
-    /// @note Call the <code>AddPoint</code> or <code>SetTangentImpulseAtPoint</code> method
-    ///   to set this value.
-    /// @return Value previously set, or an invalid value.
-    /// @see SetTangentImpulseAtPoint.
-    Momentum GetTangentImpulseAtPoint(size_type index) const noexcept;
-    
-    /// Gets the velocity bias at the given point.
-    /// @note The <code>AddPoint</code> method sets this value.
-    /// @return Previously set value or an invalid value.
-    LinearVelocity GetVelocityBiasAtPoint(size_type index) const noexcept;
-    
-    /// Gets the normal mass at the given point.
-    /// @note This value depends on the values of:
-    ///   the sum of the inverse-masses of the two bodies,
-    ///   the bodies' inverse-rotational-inertia,
-    ///   the point-relative A and B positions, and
-    ///   the normal.
-    /// @note The <code>AddPoint</code> method sets this value.
-    Mass GetNormalMassAtPoint(size_type index) const noexcept;
-    
-    /// Gets the tangent mass at the given point.
-    /// @note This value depends on the values of:
-    ///   the sum of the inverse-masses of the two bodies,
-    ///   the bodies' inverse-rotational-inertia,
-    ///   the point-relative A and B positions, and
-    ///   the tangent.
-    /// @note The <code>AddPoint</code> method sets this value.
-    Mass GetTangentMassAtPoint(size_type index) const noexcept;
-    
-    /// Gets the point relative position of A.
-    /// @note The <code>AddPoint</code> method sets this value.
-    /// @return Previously set value or an invalid value.
-    Length2 GetPointRelPosA(size_type index) const noexcept;
-    
-    /// Gets the point relative position of B.
-    /// @note The <code>AddPoint</code> method sets this value.
-    /// @return Previously set value or an invalid value.
-    Length2 GetPointRelPosB(size_type index) const noexcept;
-    
-    /// @brief Sets the normal impulse at the given point.
-    void SetNormalImpulseAtPoint(size_type index, Momentum value);
-    
-    /// @brief Sets the tangent impulse at the given point.
-    void SetTangentImpulseAtPoint(size_type index, Momentum value);
-    
-    /// @brief Velocity constraint point.
-    ///
-    /// @note Default initialized to values that make this point ineffective if it got
-    ///   processed counter to being a valid point per the point count property.
-    ///   This allows both points to be unconditionally processed which may be faster
-    ///   if it'd otherwise cause branch misprediction and depending on the cost of
-    ///   branch misprediction.
-    /// @note This structure is at least 36-bytes large.
-    ///
-    struct Point
-    {
-        /// Position of body A relative to world manifold point.
-        Length2 relA = Length2{};
-        
-        /// Position of body B relative to world manifold point.
-        Length2 relB = Length2{};
-        
-        /// Normal impulse.
-        Momentum normalImpulse = 0_Ns;
-        
-        /// Tangent impulse.
-        Momentum tangentImpulse = 0_Ns;
-        
-        /// Normal mass.
-        /// @note 0 or greater.
-        /// @note Dependent on <code>relA</code> and <code>relB</code>.
-        Mass normalMass = 0_kg;
-        
-        /// Tangent mass.
-        /// @note 0 or greater.
-        /// @note Dependent on <code>relA</code> and <code>relB</code>.
-        Mass tangentMass = 0_kg;
-        
-        /// Velocity bias.
-        /// @note A product of the contact restitution.
-        LinearVelocity velocityBias = 0_mps;
-    };
-    
-    /// @brief Accesses the point identified by the given index.
-    /// @warning Behavior is undefined if given index is not less than
-    ///   <code>MaxManifoldPoints</code>.
-    /// @param index Index of the point to return. This should be a value less than returned
-    ///   by <code>GetPointCount</code>.
-    /// @return velocity constraint point for the given index. This point's data will be invalid
-    ///   unless previously added and set.
-    /// @see GetPointCount.
-    const Point& GetPointAt(size_type index) const
-    {
-        assert(index < MaxManifoldPoints);
-        return m_points[index];
-    }
-    
-private:
-    
-    /// @brief Adds the given point to this contact velocity constraint object.
-    /// @details Adds up to <code>MaxManifoldPoints</code> points. To find out how many points
-    ///   have already been added, call <code>GetPointCount</code>.
-    /// @warning Behavior is undefined if an attempt is made to add more than
-    ///   <code>MaxManifoldPoints</code> points.
-    /// @see GetPointCount().
-    void AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                  Length2 relA, Length2 relB, Conf conf);
-    
-    /// Removes the last point added.
-    void RemovePoint() noexcept;
-    
-    /// @brief Gets a point instance for the given parameters.
-    Point GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                   Length2 relA, Length2 relB, Conf conf) const noexcept;
-    
-    /// Accesses the point identified by the given index.
-    /// @warning Behavior is undefined if given index is not less than
-    ///   <code>MaxManifoldPoints</code>.
-    /// @param index Index of the point to return. This should be a value less than returned
-    ///   by <code>GetPointCount</code>.
-    /// @return velocity constraint point for the given index. This point's data will be invalid
-    ///   unless previously added and set.
-    /// @see GetPointCount.
-    Point& PointAt(size_type index)
-    {
-        assert(index < MaxManifoldPoints);
-        return m_points[index];
-    }
-    
-    Point m_points[MaxManifoldPoints]; ///< Velocity constraint points array (at least 72-bytes).
-    
-    // K and normalMass fields are only used for the block solver.
-    
-    /// Block solver "K" info.
-    /// @note Depends on the total inverse mass, the normal, and the point relative positions.
-    /// @note Only used by block solver.
-    /// @note This field is 12-bytes (on at least one 64-bit platform).
-    InvMass3 m_K = InvMass3{};
-    
-    /// Normal mass information.
-    /// @details This is the cached inverse of the K value or the zero initialized value.
-    /// @note Depends on the K value.
-    /// @note Only used by block solver.
-    /// @note This field is 12-bytes (on at least one 64-bit platform).
-    Mass3 m_normalMass = Mass3{};
-    
-    BodyConstraint* m_bodyA = nullptr; ///< Body A contact velocity constraint data.
-    BodyConstraint* m_bodyB = nullptr; ///< Body B contact velocity constraint data.
-    
-    UnitVec m_normal = GetInvalid<UnitVec>(); ///< Normal of the world manifold. 8-bytes.
-    
-    /// Friction coefficient (4-bytes). Usually in the range of [0,1].
-    Real m_friction = GetInvalid<Real>();
-    
-    Real m_restitution = GetInvalid<Real>(); ///< Restitution coefficient (4-bytes).
-    
-    LinearVelocity m_tangentSpeed = GetInvalid<decltype(m_tangentSpeed)>(); ///< Tangent speed (4-bytes).
-    
-    size_type m_pointCount = 0; ///< Point count (at least 1-byte).
-};
+        class WorldManifold;
 
-inline void VelocityConstraint::RemovePoint() noexcept
-{
-    assert(m_pointCount > 0);
-    m_points[m_pointCount - 1] = Point{};
-    --m_pointCount;
-}
+        /// Contact velocity constraint.
+        ///
+        /// @note A valid contact velocity constraint must have a point count of either 1 or 2.
+        /// @note This data structure is 136-bytes large (on at least one 64-bit platform).
+        ///
+        /// @invariant The "K" value cannot be changed independent of: the total inverse mass,
+        ///   the normal, and the point relative positions.
+        /// @invariant The normal mass cannot be changed independent of: the "K" value.
+        /// @invariant The velocity biases cannot be changed independent of: the normal, and the
+        ///   point relative positions.
+        ///
+        class VelocityConstraint
+        {
+         public:
+            /// @brief Size type.
+            using size_type = std::remove_const<decltype(MaxManifoldPoints)>::type;
 
-inline InvMass22 VelocityConstraint::GetK() const noexcept
-{
-    return InvMass22{
-        InvMass2{get<0>(m_K), get<2>(m_K)},
-        InvMass2{get<2>(m_K), get<1>(m_K)}
-    };
-}
+            /// @brief Configuration data for velocity constraints.
+            struct Conf
+            {
+                Real dtRatio = 1;                                           ///< Delta time ratio.
+                LinearVelocity velocityThreshold = DefaultVelocityThreshold;///< Velocity threshold.
+                bool blockSolve = true;                                     ///< Whether to block solve.
+            };
 
-inline Mass22 VelocityConstraint::GetNormalMass() const noexcept
-{
-    return Mass22{
-        Mass2{get<0>(m_normalMass), get<2>(m_normalMass)},
-        Mass2{get<2>(m_normalMass), get<1>(m_normalMass)}
-    };
-}
+            /// @brief Gets the default configuration for a <code>VelocityConstraint</code>.
+            static constexpr Conf GetDefaultConf() noexcept
+            {
+                return Conf{};
+            }
 
-inline Length2 VelocityConstraint::GetPointRelPosA(VelocityConstraint::size_type index) const noexcept
-{
-    return GetPointAt(index).relA;
-}
+            /// Default constructor.
+            /// @details
+            /// Initializes object with: a zero point count, an invalid K, an invalid normal mass,
+            /// an invalid normal, invalid friction, invalid restitution, an invalid tangent speed.
+            VelocityConstraint() = default;
 
-inline Length2 VelocityConstraint::GetPointRelPosB(VelocityConstraint::size_type index) const noexcept
-{
-    return GetPointAt(index).relB;
-}
+            /// @brief Copy constructor.
+            VelocityConstraint(const VelocityConstraint& copy) = default;
 
-inline LinearVelocity VelocityConstraint::GetVelocityBiasAtPoint(size_type index) const noexcept
-{
-    return GetPointAt(index).velocityBias;
-}
+            /// @brief Assignment operator.
+            VelocityConstraint& operator=(const VelocityConstraint& copy) = default;
 
-inline Mass VelocityConstraint::GetNormalMassAtPoint(VelocityConstraint::size_type index) const noexcept
-{
-    return GetPointAt(index).normalMass;
-}
+            /// @brief Initializing constructor.
+            VelocityConstraint(Real friction, Real restitution, LinearVelocity tangentSpeed,
+                               const WorldManifold& worldManifold,
+                               BodyConstraint& bA,
+                               BodyConstraint& bB,
+                               Conf conf = GetDefaultConf());
 
-inline Mass VelocityConstraint::GetTangentMassAtPoint(VelocityConstraint::size_type index) const noexcept
-{
-    return GetPointAt(index).tangentMass;
-}
+            /// Gets the normal of the contact in world coordinates.
+            /// @note This value is set on construction.
+            /// @return Contact normal (in world coordinates) if previously set, an invalid value
+            ///   otherwise.
+            UnitVec GetNormal() const noexcept
+            {
+                return m_normal;
+            }
 
-inline Momentum VelocityConstraint::GetNormalImpulseAtPoint(VelocityConstraint::size_type index) const noexcept
-{
-    return GetPointAt(index).normalImpulse;
-}
+            /// @brief Gets the tangent.
+            UnitVec GetTangent() const noexcept
+            {
+                return GetFwdPerpendicular(m_normal);
+            }
 
-inline Momentum VelocityConstraint::GetTangentImpulseAtPoint(VelocityConstraint::size_type index) const noexcept
-{
-    return GetPointAt(index).tangentImpulse;
-}
+            /// Gets the count of points added to this object.
+            /// @return Value between 0 and <code>MaxManifoldPoints</code>.
+            /// @see MaxManifoldPoints.
+            /// @see AddPoint.
+            size_type GetPointCount() const noexcept
+            {
+                return m_pointCount;
+            }
 
-inline void VelocityConstraint::SetNormalImpulseAtPoint(VelocityConstraint::size_type index, Momentum value)
-{
-    PointAt(index).normalImpulse = value;
-}
+            /// Gets the "K" value.
+            /// @note This value is only valid if previously set to a valid value.
+            /// @return "K" value previously set or the zero initialized value.
+            InvMass22 GetK() const noexcept;
 
-inline void VelocityConstraint::SetTangentImpulseAtPoint(VelocityConstraint::size_type index, Momentum value)
-{
-    PointAt(index).tangentImpulse = value;
-}
+            /// Gets the normal mass.
+            /// @note This value is only valid if previously set.
+            /// @return normal mass previously set or the zero initialized value.
+            Mass22 GetNormalMass() const noexcept;
 
-// Free functions...
+            /// Gets the combined friction of the associated contact.
+            Real GetFriction() const noexcept
+            {
+                return m_friction;
+            }
 
-/// @brief Gets the regular phase velocity constraint configuration from the given
-///   step configuration.
-VelocityConstraint::Conf GetRegVelocityConstraintConf(const StepConf& conf) noexcept;
+            /// Gets the combined restitution of the associated contact.
+            Real GetRestitution() const noexcept
+            {
+                return m_restitution;
+            }
 
-/// @brief Gets the TOI phase velocity constraint configuration from the given
-///   step configuration.
-VelocityConstraint::Conf GetToiVelocityConstraintConf(const StepConf& conf) noexcept;
+            /// Gets the tangent speed of the associated contact.
+            LinearVelocity GetTangentSpeed() const noexcept
+            {
+                return m_tangentSpeed;
+            }
 
-/// Gets the normal of the velocity constraint contact in world coordinates.
-/// @note This value is set via the velocity constraint's <code>SetNormal</code> method.
-/// @return Contact normal (in world coordinates) if previously set, an invalid value
-///   otherwise.
-inline UnitVec GetNormal(const VelocityConstraint& vc) noexcept
-{
-    return vc.GetNormal();
-}
+            /// @brief Gets body A.
+            BodyConstraint* GetBodyA() const noexcept
+            {
+                return m_bodyA;
+            }
 
-/// @brief Gets the tangent from the given velocity constraint data.
-inline UnitVec GetTangent(const VelocityConstraint& vc) noexcept
-{
-    return vc.GetTangent();
-}
+            /// @brief Gets body B.
+            BodyConstraint* GetBodyB() const noexcept
+            {
+                return m_bodyB;
+            }
 
-/// @brief Gets the inverse mass from the given velocity constraint data.
-inline InvMass GetInvMass(const VelocityConstraint& vc) noexcept
-{
-    return vc.GetBodyA()->GetInvMass() + vc.GetBodyB()->GetInvMass();
-}
+            /// Gets the normal impulse at the given point.
+            /// @note Call the <code>AddPoint</code> or <code>SetNormalImpulseAtPoint</code> method
+            ///   to set this value.
+            /// @return Value previously set, or an invalid value.
+            /// @see SetNormalImpulseAtPoint.
+            Momentum GetNormalImpulseAtPoint(size_type index) const noexcept;
 
-/// @brief Gets the point relative position A data.
-inline Length2 GetPointRelPosA(const VelocityConstraint& vc,
-                                VelocityConstraint::size_type index)
-{
-    return vc.GetPointRelPosA(index);
-}
+            /// Gets the tangent impulse at the given point.
+            /// @note Call the <code>AddPoint</code> or <code>SetTangentImpulseAtPoint</code> method
+            ///   to set this value.
+            /// @return Value previously set, or an invalid value.
+            /// @see SetTangentImpulseAtPoint.
+            Momentum GetTangentImpulseAtPoint(size_type index) const noexcept;
 
-/// @brief Gets the point relative position B data.
-inline Length2 GetPointRelPosB(const VelocityConstraint& vc,
-                                VelocityConstraint::size_type index)
-{
-    return vc.GetPointRelPosB(index);
-}
+            /// Gets the velocity bias at the given point.
+            /// @note The <code>AddPoint</code> method sets this value.
+            /// @return Previously set value or an invalid value.
+            LinearVelocity GetVelocityBiasAtPoint(size_type index) const noexcept;
 
-/// @brief Gets the velocity bias at the given point from the given velocity constraint.
-inline LinearVelocity GetVelocityBiasAtPoint(const VelocityConstraint& vc, VelocityConstraint::size_type index)
-{
-    return vc.GetVelocityBiasAtPoint(index);
-}
+            /// Gets the normal mass at the given point.
+            /// @note This value depends on the values of:
+            ///   the sum of the inverse-masses of the two bodies,
+            ///   the bodies' inverse-rotational-inertia,
+            ///   the point-relative A and B positions, and
+            ///   the normal.
+            /// @note The <code>AddPoint</code> method sets this value.
+            Mass GetNormalMassAtPoint(size_type index) const noexcept;
 
-/// @brief Gets the normal mass at the given point from the given velocity constraint.
-inline Mass GetNormalMassAtPoint(const VelocityConstraint& vc,
-                                 VelocityConstraint::size_type index)
-{
-    return vc.GetNormalMassAtPoint(index);
-}
+            /// Gets the tangent mass at the given point.
+            /// @note This value depends on the values of:
+            ///   the sum of the inverse-masses of the two bodies,
+            ///   the bodies' inverse-rotational-inertia,
+            ///   the point-relative A and B positions, and
+            ///   the tangent.
+            /// @note The <code>AddPoint</code> method sets this value.
+            Mass GetTangentMassAtPoint(size_type index) const noexcept;
 
-/// @brief Gets the tangent mass at the given point from the given velocity constraint.
-inline Mass GetTangentMassAtPoint(const VelocityConstraint& vc,
-                                  VelocityConstraint::size_type index)
-{
-    return vc.GetTangentMassAtPoint(index);
-}
+            /// Gets the point relative position of A.
+            /// @note The <code>AddPoint</code> method sets this value.
+            /// @return Previously set value or an invalid value.
+            Length2 GetPointRelPosA(size_type index) const noexcept;
 
-/// @brief Gets the normal impulse at the given point from the given velocity constraint.
-inline Momentum GetNormalImpulseAtPoint(const VelocityConstraint& vc,
-                                        VelocityConstraint::size_type index)
-{
-    return vc.GetNormalImpulseAtPoint(index);
-}
+            /// Gets the point relative position of B.
+            /// @note The <code>AddPoint</code> method sets this value.
+            /// @return Previously set value or an invalid value.
+            Length2 GetPointRelPosB(size_type index) const noexcept;
 
-/// @brief Gets the tangent impulse at the given point from the given velocity constraint.
-inline Momentum GetTangentImpulseAtPoint(const VelocityConstraint& vc,
+            /// @brief Sets the normal impulse at the given point.
+            void SetNormalImpulseAtPoint(size_type index, Momentum value);
+
+            /// @brief Sets the tangent impulse at the given point.
+            void SetTangentImpulseAtPoint(size_type index, Momentum value);
+
+            /// @brief Velocity constraint point.
+            ///
+            /// @note Default initialized to values that make this point ineffective if it got
+            ///   processed counter to being a valid point per the point count property.
+            ///   This allows both points to be unconditionally processed which may be faster
+            ///   if it'd otherwise cause branch misprediction and depending on the cost of
+            ///   branch misprediction.
+            /// @note This structure is at least 36-bytes large.
+            ///
+            struct Point
+            {
+                /// Position of body A relative to world manifold point.
+                Length2 relA = Length2{};
+
+                /// Position of body B relative to world manifold point.
+                Length2 relB = Length2{};
+
+                /// Normal impulse.
+                Momentum normalImpulse = 0_Ns;
+
+                /// Tangent impulse.
+                Momentum tangentImpulse = 0_Ns;
+
+                /// Normal mass.
+                /// @note 0 or greater.
+                /// @note Dependent on <code>relA</code> and <code>relB</code>.
+                Mass normalMass = 0_kg;
+
+                /// Tangent mass.
+                /// @note 0 or greater.
+                /// @note Dependent on <code>relA</code> and <code>relB</code>.
+                Mass tangentMass = 0_kg;
+
+                /// Velocity bias.
+                /// @note A product of the contact restitution.
+                LinearVelocity velocityBias = 0_mps;
+            };
+
+            /// @brief Accesses the point identified by the given index.
+            /// @warning Behavior is undefined if given index is not less than
+            ///   <code>MaxManifoldPoints</code>.
+            /// @param index Index of the point to return. This should be a value less than returned
+            ///   by <code>GetPointCount</code>.
+            /// @return velocity constraint point for the given index. This point's data will be invalid
+            ///   unless previously added and set.
+            /// @see GetPointCount.
+            const Point& GetPointAt(size_type index) const
+            {
+                assert(index < MaxManifoldPoints);
+                return m_points[index];
+            }
+
+         private:
+            /// @brief Adds the given point to this contact velocity constraint object.
+            /// @details Adds up to <code>MaxManifoldPoints</code> points. To find out how many points
+            ///   have already been added, call <code>GetPointCount</code>.
+            /// @warning Behavior is undefined if an attempt is made to add more than
+            ///   <code>MaxManifoldPoints</code> points.
+            /// @see GetPointCount().
+            void AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
+                          Length2 relA, Length2 relB, Conf conf);
+
+            /// Removes the last point added.
+            void RemovePoint() noexcept;
+
+            /// @brief Gets a point instance for the given parameters.
+            Point GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
+                           Length2 relA, Length2 relB, Conf conf) const noexcept;
+
+            /// Accesses the point identified by the given index.
+            /// @warning Behavior is undefined if given index is not less than
+            ///   <code>MaxManifoldPoints</code>.
+            /// @param index Index of the point to return. This should be a value less than returned
+            ///   by <code>GetPointCount</code>.
+            /// @return velocity constraint point for the given index. This point's data will be invalid
+            ///   unless previously added and set.
+            /// @see GetPointCount.
+            Point& PointAt(size_type index)
+            {
+                assert(index < MaxManifoldPoints);
+                return m_points[index];
+            }
+
+            Point m_points[MaxManifoldPoints];///< Velocity constraint points array (at least 72-bytes).
+
+            // K and normalMass fields are only used for the block solver.
+
+            /// Block solver "K" info.
+            /// @note Depends on the total inverse mass, the normal, and the point relative positions.
+            /// @note Only used by block solver.
+            /// @note This field is 12-bytes (on at least one 64-bit platform).
+            InvMass3 m_K = InvMass3{};
+
+            /// Normal mass information.
+            /// @details This is the cached inverse of the K value or the zero initialized value.
+            /// @note Depends on the K value.
+            /// @note Only used by block solver.
+            /// @note This field is 12-bytes (on at least one 64-bit platform).
+            Mass3 m_normalMass = Mass3{};
+
+            BodyConstraint* m_bodyA = nullptr;///< Body A contact velocity constraint data.
+            BodyConstraint* m_bodyB = nullptr;///< Body B contact velocity constraint data.
+
+            UnitVec m_normal = GetInvalid<UnitVec>();///< Normal of the world manifold. 8-bytes.
+
+            /// Friction coefficient (4-bytes). Usually in the range of [0,1].
+            Real m_friction = GetInvalid<Real>();
+
+            Real m_restitution = GetInvalid<Real>();///< Restitution coefficient (4-bytes).
+
+            LinearVelocity m_tangentSpeed = GetInvalid<decltype(m_tangentSpeed)>();///< Tangent speed (4-bytes).
+
+            size_type m_pointCount = 0;///< Point count (at least 1-byte).
+        };
+
+        inline void VelocityConstraint::RemovePoint() noexcept
+        {
+            assert(m_pointCount > 0);
+            m_points[m_pointCount - 1] = Point{};
+            --m_pointCount;
+        }
+
+        inline InvMass22 VelocityConstraint::GetK() const noexcept
+        {
+            return InvMass22{
+                InvMass2{get<0>(m_K), get<2>(m_K)},
+                InvMass2{get<2>(m_K), get<1>(m_K)}};
+        }
+
+        inline Mass22 VelocityConstraint::GetNormalMass() const noexcept
+        {
+            return Mass22{
+                Mass2{get<0>(m_normalMass), get<2>(m_normalMass)},
+                Mass2{get<2>(m_normalMass), get<1>(m_normalMass)}};
+        }
+
+        inline Length2 VelocityConstraint::GetPointRelPosA(VelocityConstraint::size_type index) const noexcept
+        {
+            return GetPointAt(index).relA;
+        }
+
+        inline Length2 VelocityConstraint::GetPointRelPosB(VelocityConstraint::size_type index) const noexcept
+        {
+            return GetPointAt(index).relB;
+        }
+
+        inline LinearVelocity VelocityConstraint::GetVelocityBiasAtPoint(size_type index) const noexcept
+        {
+            return GetPointAt(index).velocityBias;
+        }
+
+        inline Mass VelocityConstraint::GetNormalMassAtPoint(VelocityConstraint::size_type index) const noexcept
+        {
+            return GetPointAt(index).normalMass;
+        }
+
+        inline Mass VelocityConstraint::GetTangentMassAtPoint(VelocityConstraint::size_type index) const noexcept
+        {
+            return GetPointAt(index).tangentMass;
+        }
+
+        inline Momentum VelocityConstraint::GetNormalImpulseAtPoint(VelocityConstraint::size_type index) const noexcept
+        {
+            return GetPointAt(index).normalImpulse;
+        }
+
+        inline Momentum VelocityConstraint::GetTangentImpulseAtPoint(VelocityConstraint::size_type index) const noexcept
+        {
+            return GetPointAt(index).tangentImpulse;
+        }
+
+        inline void VelocityConstraint::SetNormalImpulseAtPoint(VelocityConstraint::size_type index, Momentum value)
+        {
+            PointAt(index).normalImpulse = value;
+        }
+
+        inline void VelocityConstraint::SetTangentImpulseAtPoint(VelocityConstraint::size_type index, Momentum value)
+        {
+            PointAt(index).tangentImpulse = value;
+        }
+
+        // Free functions...
+
+        /// @brief Gets the regular phase velocity constraint configuration from the given
+        ///   step configuration.
+        VelocityConstraint::Conf GetRegVelocityConstraintConf(const StepConf& conf) noexcept;
+
+        /// @brief Gets the TOI phase velocity constraint configuration from the given
+        ///   step configuration.
+        VelocityConstraint::Conf GetToiVelocityConstraintConf(const StepConf& conf) noexcept;
+
+        /// Gets the normal of the velocity constraint contact in world coordinates.
+        /// @note This value is set via the velocity constraint's <code>SetNormal</code> method.
+        /// @return Contact normal (in world coordinates) if previously set, an invalid value
+        ///   otherwise.
+        inline UnitVec GetNormal(const VelocityConstraint& vc) noexcept
+        {
+            return vc.GetNormal();
+        }
+
+        /// @brief Gets the tangent from the given velocity constraint data.
+        inline UnitVec GetTangent(const VelocityConstraint& vc) noexcept
+        {
+            return vc.GetTangent();
+        }
+
+        /// @brief Gets the inverse mass from the given velocity constraint data.
+        inline InvMass GetInvMass(const VelocityConstraint& vc) noexcept
+        {
+            return vc.GetBodyA()->GetInvMass() + vc.GetBodyB()->GetInvMass();
+        }
+
+        /// @brief Gets the point relative position A data.
+        inline Length2 GetPointRelPosA(const VelocityConstraint& vc,
+                                       VelocityConstraint::size_type index)
+        {
+            return vc.GetPointRelPosA(index);
+        }
+
+        /// @brief Gets the point relative position B data.
+        inline Length2 GetPointRelPosB(const VelocityConstraint& vc,
+                                       VelocityConstraint::size_type index)
+        {
+            return vc.GetPointRelPosB(index);
+        }
+
+        /// @brief Gets the velocity bias at the given point from the given velocity constraint.
+        inline LinearVelocity GetVelocityBiasAtPoint(const VelocityConstraint& vc, VelocityConstraint::size_type index)
+        {
+            return vc.GetVelocityBiasAtPoint(index);
+        }
+
+        /// @brief Gets the normal mass at the given point from the given velocity constraint.
+        inline Mass GetNormalMassAtPoint(const VelocityConstraint& vc,
                                          VelocityConstraint::size_type index)
-{
-    return vc.GetTangentImpulseAtPoint(index);
-}
+        {
+            return vc.GetNormalMassAtPoint(index);
+        }
 
-/// @brief Gets the normal impulses of the given velocity constraint.
-inline Momentum2 GetNormalImpulses(const VelocityConstraint& vc)
-{
-    return Momentum2{GetNormalImpulseAtPoint(vc, 0), GetNormalImpulseAtPoint(vc, 1)};
-}
+        /// @brief Gets the tangent mass at the given point from the given velocity constraint.
+        inline Mass GetTangentMassAtPoint(const VelocityConstraint& vc,
+                                          VelocityConstraint::size_type index)
+        {
+            return vc.GetTangentMassAtPoint(index);
+        }
 
-/// @brief Gets the tangent impulses of the given velocity constraint.
-inline Momentum2 GetTangentImpulses(const VelocityConstraint& vc)
-{
-    return Momentum2{GetTangentImpulseAtPoint(vc, 0), GetTangentImpulseAtPoint(vc, 1)};
-}
+        /// @brief Gets the normal impulse at the given point from the given velocity constraint.
+        inline Momentum GetNormalImpulseAtPoint(const VelocityConstraint& vc,
+                                                VelocityConstraint::size_type index)
+        {
+            return vc.GetNormalImpulseAtPoint(index);
+        }
 
-/// @brief Sets the normal impulse at the given point of the given velocity constraint.
-inline void SetNormalImpulseAtPoint(VelocityConstraint& vc, VelocityConstraint::size_type index, Momentum value)
-{
-    vc.SetNormalImpulseAtPoint(index, value);
-}
+        /// @brief Gets the tangent impulse at the given point from the given velocity constraint.
+        inline Momentum GetTangentImpulseAtPoint(const VelocityConstraint& vc,
+                                                 VelocityConstraint::size_type index)
+        {
+            return vc.GetTangentImpulseAtPoint(index);
+        }
 
-/// @brief Sets the tangent impulse at the given point of the given velocity constraint.
-inline void SetTangentImpulseAtPoint(VelocityConstraint& vc, VelocityConstraint::size_type index, Momentum value)
-{
-    vc.SetTangentImpulseAtPoint(index, value);
-}
+        /// @brief Gets the normal impulses of the given velocity constraint.
+        inline Momentum2 GetNormalImpulses(const VelocityConstraint& vc)
+        {
+            return Momentum2{GetNormalImpulseAtPoint(vc, 0), GetNormalImpulseAtPoint(vc, 1)};
+        }
 
-/// @brief Sets the normal impulses of the given velocity constraint.
-inline void SetNormalImpulses(VelocityConstraint& vc, const Momentum2 impulses)
-{
-    SetNormalImpulseAtPoint(vc, 0, impulses[0]);
-    SetNormalImpulseAtPoint(vc, 1, impulses[1]);
-}
+        /// @brief Gets the tangent impulses of the given velocity constraint.
+        inline Momentum2 GetTangentImpulses(const VelocityConstraint& vc)
+        {
+            return Momentum2{GetTangentImpulseAtPoint(vc, 0), GetTangentImpulseAtPoint(vc, 1)};
+        }
 
-/// @brief Sets the tangent impulses of the given velocity constraint.
-inline void SetTangentImpulses(VelocityConstraint& vc, const Momentum2 impulses)
-{
-    SetTangentImpulseAtPoint(vc, 0, impulses[0]);
-    SetTangentImpulseAtPoint(vc, 1, impulses[1]);
-}
+        /// @brief Sets the normal impulse at the given point of the given velocity constraint.
+        inline void SetNormalImpulseAtPoint(VelocityConstraint& vc, VelocityConstraint::size_type index, Momentum value)
+        {
+            vc.SetNormalImpulseAtPoint(index, value);
+        }
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Sets the tangent impulse at the given point of the given velocity constraint.
+        inline void SetTangentImpulseAtPoint(VelocityConstraint& vc, VelocityConstraint::size_type index, Momentum value)
+        {
+            vc.SetTangentImpulseAtPoint(index, value);
+        }
 
-#endif // PLAYRHO_DYNAMICS_CONTACTS_VELOCITYCONSTRAINT_HPP
+        /// @brief Sets the normal impulses of the given velocity constraint.
+        inline void SetNormalImpulses(VelocityConstraint& vc, const Momentum2 impulses)
+        {
+            SetNormalImpulseAtPoint(vc, 0, impulses[0]);
+            SetNormalImpulseAtPoint(vc, 1, impulses[1]);
+        }
+
+        /// @brief Sets the tangent impulses of the given velocity constraint.
+        inline void SetTangentImpulses(VelocityConstraint& vc, const Momentum2 impulses)
+        {
+            SetTangentImpulseAtPoint(vc, 0, impulses[0]);
+            SetTangentImpulseAtPoint(vc, 1, impulses[1]);
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_CONTACTS_VELOCITYCONSTRAINT_HPP

--- a/PlayRho/Dynamics/Filter.hpp
+++ b/PlayRho/Dynamics/Filter.hpp
@@ -26,8 +26,9 @@
 #include <PlayRho/Defines.hpp>
 #include <cstdint>
 
-namespace playrho {
-    
+namespace playrho
+{
+
     /// @brief A holder for contact filtering data.
     /// @note This data structure size is 6-bytes.
     struct Filter
@@ -39,19 +40,19 @@ namespace playrho {
         /// @brief Index type definition.
         ///
         using index_type = std::int16_t;
-        
+
         /// @brief The collision category bits.
         ///
         /// @note Normally you would just set one bit.
         ///
         bits_type categoryBits = 0x0001;
-        
+
         /// @brief The collision mask bits.
         ///
         /// @details This states the categories that this shape would accept for collision.
         ///
         bits_type maskBits = 0xFFFF;
-        
+
         /// @brief Group index.
         ///
         /// @details Collision groups allow a certain group of objects to never collide
@@ -60,19 +61,19 @@ namespace playrho {
         ///
         index_type groupIndex = 0;
     };
-    
+
     /// @brief Equality operator.
     /// @relatedalso Filter
-    constexpr bool operator== (const Filter lhs, const Filter rhs) noexcept
+    constexpr bool operator==(const Filter lhs, const Filter rhs) noexcept
     {
         return lhs.categoryBits == rhs.categoryBits
-            && lhs.maskBits == rhs.maskBits
-            && lhs.groupIndex == rhs.groupIndex;
+               && lhs.maskBits == rhs.maskBits
+               && lhs.groupIndex == rhs.groupIndex;
     }
 
     /// @brief Inequality operator.
     /// @relatedalso Filter
-    constexpr bool operator!= (const Filter lhs, const Filter rhs) noexcept
+    constexpr bool operator!=(const Filter lhs, const Filter rhs) noexcept
     {
         return !(lhs == rhs);
     }
@@ -85,10 +86,9 @@ namespace playrho {
         {
             return filterA.groupIndex > 0;
         }
-        return ((filterA.maskBits & filterB.categoryBits) != 0) &&
-               ((filterB.maskBits & filterA.categoryBits) != 0);
+        return ((filterA.maskBits & filterB.categoryBits) != 0) && ((filterB.maskBits & filterA.categoryBits) != 0);
     }
 
-} // namespace playrho
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_FILTER_HPP
+#endif// PLAYRHO_DYNAMICS_FILTER_HPP

--- a/PlayRho/Dynamics/Fixture.cpp
+++ b/PlayRho/Dynamics/Fixture.cpp
@@ -21,28 +21,30 @@
 
 #include <PlayRho/Dynamics/Fixture.hpp>
 
-#include <PlayRho/Dynamics/Contacts/Contact.hpp> // for MixFriction, MixRestitution
+#include <PlayRho/Dynamics/Contacts/Contact.hpp>// for MixFriction, MixRestitution
 
 #include <type_traits>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<Fixture>::value, "Fixture must be default constructible!");
-static_assert(std::is_copy_constructible<Fixture>::value, "Fixture must be copy constructible!");
-static_assert(std::is_move_constructible<Fixture>::value, "Fixture must be move constructible!");
-static_assert(std::is_copy_assignable<Fixture>::value, "Fixture must be copy assignable!");
-static_assert(std::is_move_assignable<Fixture>::value, "Fixture must be move assignable!");
-
-Real GetDefaultFriction(const Fixture& fixtureA, const Fixture& fixtureB)
+namespace playrho
 {
-    return MixFriction(fixtureA.GetFriction(), fixtureB.GetFriction());
-}
+    namespace d2
+    {
 
-Real GetDefaultRestitution(const Fixture& fixtureA, const Fixture& fixtureB)
-{
-    return MixRestitution(fixtureA.GetRestitution(), fixtureB.GetRestitution());
-}
+        static_assert(std::is_default_constructible<Fixture>::value, "Fixture must be default constructible!");
+        static_assert(std::is_copy_constructible<Fixture>::value, "Fixture must be copy constructible!");
+        static_assert(std::is_move_constructible<Fixture>::value, "Fixture must be move constructible!");
+        static_assert(std::is_copy_assignable<Fixture>::value, "Fixture must be copy assignable!");
+        static_assert(std::is_move_assignable<Fixture>::value, "Fixture must be move assignable!");
 
-} // namespace d2
-} // namespace playrho
+        Real GetDefaultFriction(const Fixture& fixtureA, const Fixture& fixtureB)
+        {
+            return MixFriction(fixtureA.GetFriction(), fixtureB.GetFriction());
+        }
+
+        Real GetDefaultRestitution(const Fixture& fixtureA, const Fixture& fixtureB)
+        {
+            return MixRestitution(fixtureA.GetRestitution(), fixtureB.GetRestitution());
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Fixture.hpp
+++ b/PlayRho/Dynamics/Fixture.hpp
@@ -25,197 +25,199 @@
 /// @file
 /// Declarations of the Fixture class, and free functions associated with it.
 
+#include <PlayRho/Collision/Shapes/Shape.hpp>
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Span.hpp>
 #include <PlayRho/Common/NonZero.hpp>
+#include <PlayRho/Common/Span.hpp>
 #include <PlayRho/Dynamics/Filter.hpp>
 #include <PlayRho/Dynamics/FixtureConf.hpp>
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
-#include <PlayRho/Collision/Shapes/Shape.hpp>
 
+#include <array>
 #include <limits>
 #include <memory>
 #include <vector>
-#include <array>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief An association between a body and a shape.
-///
-/// @details A fixture is used to attach a shape to a body for collision detection. A fixture
-/// inherits its transform from its parent. Fixtures hold additional non-geometric data
-/// such as collision filters, etc.
-///
-/// @warning you cannot reuse fixtures.
-/// @note Fixtures should be created using the <code>Body::CreateFixture</code> method.
-/// @note Destroy these using the <code>Body::Destroy(Fixture*, bool)</code> method.
-/// @note This structure is 56-bytes large (using a 4-byte Real on at least one 64-bit
-///   architecture/build).
-///
-/// @ingroup PhysicalEntities
-///
-/// @see Body, Shape
-///
-class Fixture
+namespace playrho
 {
-public:
-    /// @brief Fixture proxies container.
-    using Proxies = std::vector<FixtureProxy>;
-
-    Fixture() = default;
-
-    /// @brief Initializing constructor.
-    ///
-    /// @note This is not meant to be called by normal user code. Use the
-    ///   <code>Body::CreateFixture</code> method instead.
-    ///
-    /// @param body Body the new fixture is to be associated with.
-    /// @param shape Shareable shape to associate fixture with. Must be non-null.
-    /// @param def Initial optional fixture settings.
-    ///    Friction must be greater-than-or-equal-to zero.
-    ///    <code>AreaDensity</code> must be greater-than-or-equal-to zero.
-    ///
-    Fixture(BodyID body, const Shape& shape, const FixtureConf& def = GetDefaultFixtureConf()):
-        m_shape{shape},
-        m_body{body},
-        m_filter{def.filter},
-        m_isSensor{def.isSensor}
+    namespace d2
     {
-        // Intentionally empty.
-    }
 
-    /// @brief Copy constructor (explicitly deleted).
-    Fixture(const Fixture& other) = default;
+        /// @brief An association between a body and a shape.
+        ///
+        /// @details A fixture is used to attach a shape to a body for collision detection. A fixture
+        /// inherits its transform from its parent. Fixtures hold additional non-geometric data
+        /// such as collision filters, etc.
+        ///
+        /// @warning you cannot reuse fixtures.
+        /// @note Fixtures should be created using the <code>Body::CreateFixture</code> method.
+        /// @note Destroy these using the <code>Body::Destroy(Fixture*, bool)</code> method.
+        /// @note This structure is 56-bytes large (using a 4-byte Real on at least one 64-bit
+        ///   architecture/build).
+        ///
+        /// @ingroup PhysicalEntities
+        ///
+        /// @see Body, Shape
+        ///
+        class Fixture
+        {
+         public:
+            /// @brief Fixture proxies container.
+            using Proxies = std::vector<FixtureProxy>;
 
-    /// @brief Gets the parent body of this fixture.
-    /// @return Non-null pointer to the parent body.
-    BodyID GetBody() const noexcept;
+            Fixture() = default;
 
-    /// @brief Gets the child shape.
-    /// @details The shape is not modifiable. Use a new fixture instead.
-    Shape GetShape() const noexcept;
+            /// @brief Initializing constructor.
+            ///
+            /// @note This is not meant to be called by normal user code. Use the
+            ///   <code>Body::CreateFixture</code> method instead.
+            ///
+            /// @param body Body the new fixture is to be associated with.
+            /// @param shape Shareable shape to associate fixture with. Must be non-null.
+            /// @param def Initial optional fixture settings.
+            ///    Friction must be greater-than-or-equal-to zero.
+            ///    <code>AreaDensity</code> must be greater-than-or-equal-to zero.
+            ///
+            Fixture(BodyID body, const Shape& shape, const FixtureConf& def = GetDefaultFixtureConf())
+                : m_shape{shape},
+                  m_body{body},
+                  m_filter{def.filter},
+                  m_isSensor{def.isSensor}
+            {
+                // Intentionally empty.
+            }
 
-    /// @brief Set if this fixture is a sensor.
-    void SetSensor(bool sensor) noexcept;
+            /// @brief Copy constructor (explicitly deleted).
+            Fixture(const Fixture& other) = default;
 
-    /// @brief Is this fixture a sensor (non-solid)?
-    /// @return the true if the shape is a sensor.
-    bool IsSensor() const noexcept;
+            /// @brief Gets the parent body of this fixture.
+            /// @return Non-null pointer to the parent body.
+            BodyID GetBody() const noexcept;
 
-    /// @brief Gets the contact filtering data.
-    Filter GetFilterData() const noexcept;
+            /// @brief Gets the child shape.
+            /// @details The shape is not modifiable. Use a new fixture instead.
+            Shape GetShape() const noexcept;
 
-    /// @brief Sets the contact filtering data.
-    void SetFilterData(Filter filter) noexcept;
+            /// @brief Set if this fixture is a sensor.
+            void SetSensor(bool sensor) noexcept;
 
-    /// @brief Gets the density of this fixture.
-    /// @return Non-negative density (in mass per area).
-    AreaDensity GetDensity() const noexcept;
+            /// @brief Is this fixture a sensor (non-solid)?
+            /// @return the true if the shape is a sensor.
+            bool IsSensor() const noexcept;
 
-    /// @brief Gets the coefficient of friction.
-    /// @return Value of 0 or higher.
-    Real GetFriction() const noexcept;
+            /// @brief Gets the contact filtering data.
+            Filter GetFilterData() const noexcept;
 
-    /// @brief Gets the coefficient of restitution.
-    Real GetRestitution() const noexcept;
+            /// @brief Sets the contact filtering data.
+            void SetFilterData(Filter filter) noexcept;
 
-    /// @brief Gets the proxies associated with this fixture.
-    const Proxies& GetProxies() const noexcept;
+            /// @brief Gets the density of this fixture.
+            /// @return Non-negative density (in mass per area).
+            AreaDensity GetDensity() const noexcept;
 
-    /// @brief Sets the proxies associated with this fixture.
-    void SetProxies(Proxies value) noexcept;
+            /// @brief Gets the coefficient of friction.
+            /// @return Value of 0 or higher.
+            Real GetFriction() const noexcept;
 
-private:
-    // Data ordered here for memory compaction.
+            /// @brief Gets the coefficient of restitution.
+            Real GetRestitution() const noexcept;
 
-    /// Shape (of fixture).
-    /// @note Set on construction.
-    /// @note 16-bytes.
-    Shape m_shape;
+            /// @brief Gets the proxies associated with this fixture.
+            const Proxies& GetProxies() const noexcept;
 
-    Proxies m_proxies; ///< Cache of fixture proxies for the assigned shape. 16+ bytes.
+            /// @brief Sets the proxies associated with this fixture.
+            void SetProxies(Proxies value) noexcept;
 
-    BodyID m_body = InvalidBodyID; ///< Parent body. 2-bytes.
+         private:
+            // Data ordered here for memory compaction.
 
-    Filter m_filter; ///< Filter object. 6-bytes.
+            /// Shape (of fixture).
+            /// @note Set on construction.
+            /// @note 16-bytes.
+            Shape m_shape;
 
-    bool m_isSensor = false; ///< Is/is-not sensor. 1-bytes.
-};
+            Proxies m_proxies;///< Cache of fixture proxies for the assigned shape. 16+ bytes.
 
-inline Shape Fixture::GetShape() const noexcept
-{
-    return m_shape;
-}
+            BodyID m_body = InvalidBodyID;///< Parent body. 2-bytes.
 
-inline bool Fixture::IsSensor() const noexcept
-{
-    return m_isSensor;
-}
+            Filter m_filter;///< Filter object. 6-bytes.
 
-inline Filter Fixture::GetFilterData() const noexcept
-{
-    return m_filter;
-}
+            bool m_isSensor = false;///< Is/is-not sensor. 1-bytes.
+        };
 
-inline void Fixture::SetFilterData(Filter filter) noexcept
-{
-    m_filter = filter;
-}
+        inline Shape Fixture::GetShape() const noexcept
+        {
+            return m_shape;
+        }
 
-inline BodyID Fixture::GetBody() const noexcept
-{
-    return m_body;
-}
+        inline bool Fixture::IsSensor() const noexcept
+        {
+            return m_isSensor;
+        }
 
-inline const Fixture::Proxies& Fixture::GetProxies() const noexcept
-{
-    return m_proxies;
-}
+        inline Filter Fixture::GetFilterData() const noexcept
+        {
+            return m_filter;
+        }
 
-inline void Fixture::SetProxies(Proxies value) noexcept
-{
-    m_proxies = std::move(value);
-}
+        inline void Fixture::SetFilterData(Filter filter) noexcept
+        {
+            m_filter = filter;
+        }
 
-inline Real Fixture::GetFriction() const noexcept
-{
-    return playrho::d2::GetFriction(m_shape);
-}
+        inline BodyID Fixture::GetBody() const noexcept
+        {
+            return m_body;
+        }
 
-inline Real Fixture::GetRestitution() const noexcept
-{
-    return playrho::d2::GetRestitution(m_shape);
-}
+        inline const Fixture::Proxies& Fixture::GetProxies() const noexcept
+        {
+            return m_proxies;
+        }
 
-inline AreaDensity Fixture::GetDensity() const noexcept
-{
-    return playrho::d2::GetDensity(m_shape);
-}
+        inline void Fixture::SetProxies(Proxies value) noexcept
+        {
+            m_proxies = std::move(value);
+        }
 
-inline void Fixture::SetSensor(bool sensor) noexcept
-{
-    m_isSensor = sensor;
-}
+        inline Real Fixture::GetFriction() const noexcept
+        {
+            return playrho::d2::GetFriction(m_shape);
+        }
 
-// Free functions...
+        inline Real Fixture::GetRestitution() const noexcept
+        {
+            return playrho::d2::GetRestitution(m_shape);
+        }
 
-/// @brief Whether contact calculations should be performed between the two fixtures.
-/// @return <code>true</code> if contact calculations should be performed between these
-///   two fixtures; <code>false</code> otherwise.
-/// @relatedalso Fixture
-inline bool ShouldCollide(const Fixture& fixtureA, const Fixture& fixtureB) noexcept
-{
-    return ShouldCollide(fixtureA.GetFilterData(), fixtureB.GetFilterData());
-}
+        inline AreaDensity Fixture::GetDensity() const noexcept
+        {
+            return playrho::d2::GetDensity(m_shape);
+        }
 
-/// @brief Gets the default friction amount for the given fixtures.
-Real GetDefaultFriction(const Fixture& fixtureA, const Fixture& fixtureB);
+        inline void Fixture::SetSensor(bool sensor) noexcept
+        {
+            m_isSensor = sensor;
+        }
 
-/// @brief Gets the default restitution amount for the given fixtures.
-Real GetDefaultRestitution(const Fixture& fixtureA, const Fixture& fixtureB);
+        // Free functions...
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Whether contact calculations should be performed between the two fixtures.
+        /// @return <code>true</code> if contact calculations should be performed between these
+        ///   two fixtures; <code>false</code> otherwise.
+        /// @relatedalso Fixture
+        inline bool ShouldCollide(const Fixture& fixtureA, const Fixture& fixtureB) noexcept
+        {
+            return ShouldCollide(fixtureA.GetFilterData(), fixtureB.GetFilterData());
+        }
 
-#endif // PLAYRHO_DYNAMICS_FIXTURE_HPP
+        /// @brief Gets the default friction amount for the given fixtures.
+        Real GetDefaultFriction(const Fixture& fixtureA, const Fixture& fixtureB);
+
+        /// @brief Gets the default restitution amount for the given fixtures.
+        Real GetDefaultRestitution(const Fixture& fixtureA, const Fixture& fixtureB);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_FIXTURE_HPP

--- a/PlayRho/Dynamics/FixtureConf.cpp
+++ b/PlayRho/Dynamics/FixtureConf.cpp
@@ -19,16 +19,18 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/FixtureConf.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
+#include <PlayRho/Dynamics/FixtureConf.hpp>
 
-namespace playrho {
-namespace d2 {
-
-FixtureConf GetFixtureConf(const Fixture& fixture) noexcept
+namespace playrho
 {
-    return FixtureConf{fixture.IsSensor(), fixture.GetFilterData()};
-}
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        FixtureConf GetFixtureConf(const Fixture& fixture) noexcept
+        {
+            return FixtureConf{fixture.IsSensor(), fixture.GetFilterData()};
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/FixtureConf.hpp
+++ b/PlayRho/Dynamics/FixtureConf.hpp
@@ -27,57 +27,59 @@
 
 #include <PlayRho/Dynamics/Filter.hpp>
 
-namespace playrho {
-namespace d2 {
-
-class Fixture;
-
-/// @brief Fixture definition.
-///
-/// @details A fixture definition is used to create a fixture.
-/// @see Body::CreateFixture.
-///
-struct FixtureConf
+namespace playrho
 {
-    /// @brief Uses the given sensor state value.
-    constexpr FixtureConf& UseIsSensor(bool value) noexcept;
-    
-    /// @brief Uses the given filter value.
-    constexpr FixtureConf& UseFilter(Filter value) noexcept;
+    namespace d2
+    {
 
-    /// A sensor shape collects contact information but never generates a collision
-    /// response.
-    bool isSensor = false;
-    
-    /// Contact filtering data.
-    Filter filter;
-};
+        class Fixture;
 
-constexpr FixtureConf& FixtureConf::UseIsSensor(bool value) noexcept
-{
-    isSensor = value;
-    return *this;
-}
+        /// @brief Fixture definition.
+        ///
+        /// @details A fixture definition is used to create a fixture.
+        /// @see Body::CreateFixture.
+        ///
+        struct FixtureConf
+        {
+            /// @brief Uses the given sensor state value.
+            constexpr FixtureConf& UseIsSensor(bool value) noexcept;
 
-constexpr FixtureConf& FixtureConf::UseFilter(Filter value) noexcept
-{
-    filter = value;
-    return *this;
-}
+            /// @brief Uses the given filter value.
+            constexpr FixtureConf& UseFilter(Filter value) noexcept;
 
-/// @brief Gets the default fixture definition.
-/// @relatedalso FixtureConf
-constexpr FixtureConf GetDefaultFixtureConf() noexcept
-{
-    return FixtureConf{};
-}
+            /// A sensor shape collects contact information but never generates a collision
+            /// response.
+            bool isSensor = false;
 
-/// @brief Gets the fixture definition for the given fixture.
-/// @param fixture Fixture to get the definition for.
-/// @relatedalso Fixture
-FixtureConf GetFixtureConf(const Fixture& fixture) noexcept;
+            /// Contact filtering data.
+            Filter filter;
+        };
 
-} // namespace d2
-} // namespace playrho
+        constexpr FixtureConf& FixtureConf::UseIsSensor(bool value) noexcept
+        {
+            isSensor = value;
+            return *this;
+        }
 
-#endif // PLAYRHO_DYNAMICS_FIXTURECONF_HPP
+        constexpr FixtureConf& FixtureConf::UseFilter(Filter value) noexcept
+        {
+            filter = value;
+            return *this;
+        }
+
+        /// @brief Gets the default fixture definition.
+        /// @relatedalso FixtureConf
+        constexpr FixtureConf GetDefaultFixtureConf() noexcept
+        {
+            return FixtureConf{};
+        }
+
+        /// @brief Gets the fixture definition for the given fixture.
+        /// @param fixture Fixture to get the definition for.
+        /// @relatedalso Fixture
+        FixtureConf GetFixtureConf(const Fixture& fixture) noexcept;
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_FIXTURECONF_HPP

--- a/PlayRho/Dynamics/FixtureID.hpp
+++ b/PlayRho/Dynamics/FixtureID.hpp
@@ -21,31 +21,32 @@
 #ifndef PLAYRHO_DYNAMICS_FIXTUREID_HPP
 #define PLAYRHO_DYNAMICS_FIXTUREID_HPP
 
-#include <PlayRho/Common/StrongType.hpp>
 #include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/StrongType.hpp>
 
-namespace playrho {
-
-/// @brief Fixture identifier.
-using FixtureID = strongtype::IndexingNamedType<FixtureCounter, struct FixtureIdentifier>;
-
-/// @brief Invalid fixture ID value.
-constexpr auto InvalidFixtureID = static_cast<FixtureID>(static_cast<FixtureID::underlying_type>(-1));
-
-/// @brief Gets an invalid value for the FixtureID type.
-template <>
-constexpr FixtureID GetInvalid() noexcept
+namespace playrho
 {
-    return InvalidFixtureID;
-}
 
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const FixtureID& value) noexcept
-{
-    return value != GetInvalid<FixtureID>();
-}
+    /// @brief Fixture identifier.
+    using FixtureID = strongtype::IndexingNamedType<FixtureCounter, struct FixtureIdentifier>;
 
-}
+    /// @brief Invalid fixture ID value.
+    constexpr auto InvalidFixtureID = static_cast<FixtureID>(static_cast<FixtureID::underlying_type>(-1));
 
-#endif // PLAYRHO_DYNAMICS_FIXTUREID_HPP
+    /// @brief Gets an invalid value for the FixtureID type.
+    template<>
+    constexpr FixtureID GetInvalid() noexcept
+    {
+        return InvalidFixtureID;
+    }
+
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const FixtureID& value) noexcept
+    {
+        return value != GetInvalid<FixtureID>();
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_FIXTUREID_HPP

--- a/PlayRho/Dynamics/FixtureProxy.hpp
+++ b/PlayRho/Dynamics/FixtureProxy.hpp
@@ -20,40 +20,41 @@
 #ifndef PLAYRHO_DYNAMICS_FIXTUREPROXY_HPP
 #define PLAYRHO_DYNAMICS_FIXTUREPROXY_HPP
 
-#include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Collision/AABB.hpp>
+#include <PlayRho/Common/Settings.hpp>
 
-namespace playrho {
-
-/// @brief Fixture proxy.
-/// @details This proxy is used internally to connect fixtures to the broad-phase.
-/// @note This data structure is 4-bytes large (on at least one 64-bit platform).
-struct FixtureProxy
+namespace playrho
 {
-    
-    /// @brief Size type.
-    using size_type = std::remove_const<decltype(MaxContacts)>::type;
 
-    /// @brief Tree ID.
-    /// @details This is the ID of the leaf node in the dynamic tree for this "proxy".
-    /// @note 4-bytes.
-    size_type treeId;
-};
+    /// @brief Fixture proxy.
+    /// @details This proxy is used internally to connect fixtures to the broad-phase.
+    /// @note This data structure is 4-bytes large (on at least one 64-bit platform).
+    struct FixtureProxy
+    {
 
-/// @brief Equality operator
-/// @relatedalso FixtureProxy
-constexpr bool operator== (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
-{
-    return lhs.treeId == rhs.treeId;
-}
+        /// @brief Size type.
+        using size_type = std::remove_const<decltype(MaxContacts)>::type;
 
-/// @brief Inequality operator
-/// @relatedalso FixtureProxy
-constexpr bool operator!= (const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
-{
-    return !(lhs.treeId == rhs.treeId);
-}
+        /// @brief Tree ID.
+        /// @details This is the ID of the leaf node in the dynamic tree for this "proxy".
+        /// @note 4-bytes.
+        size_type treeId;
+    };
 
-} // namespace playrho
+    /// @brief Equality operator
+    /// @relatedalso FixtureProxy
+    constexpr bool operator==(const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+    {
+        return lhs.treeId == rhs.treeId;
+    }
 
-#endif // PLAYRHO_DYNAMICS_FIXTUREPROXY_HPP
+    /// @brief Inequality operator
+    /// @relatedalso FixtureProxy
+    constexpr bool operator!=(const FixtureProxy& lhs, const FixtureProxy& rhs) noexcept
+    {
+        return !(lhs.treeId == rhs.treeId);
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_FIXTUREPROXY_HPP

--- a/PlayRho/Dynamics/Island.cpp
+++ b/PlayRho/Dynamics/Island.cpp
@@ -117,52 +117,54 @@ arrays to increase the number of cache hits. Linear and angular velocity are
 stored in a single array since multiple arrays lead to multiple misses.
 */
 
-namespace playrho {
-namespace d2 {
-
-using std::count;
-
-static_assert(std::is_default_constructible<Island>::value,
-              "Must be default constructible.");
-static_assert(std::is_copy_constructible<Island>::value,
-              "Must be copy constructible.");
-static_assert(std::is_copy_assignable<Island>::value,
-              "Must be copy assignable.");
-static_assert(std::is_nothrow_move_constructible<Island>::value,
-              "Must be nothrow move constructible.");
-static_assert(std::is_nothrow_move_assignable<Island>::value,
-              "Must be nothrow move assignable.");
-static_assert(std::is_nothrow_destructible<Island>::value,
-              "Must be nothrow destructible.");
-
-void Reserve(Island& island, BodyCounter bodies, ContactCounter contacts, JointCounter joints)
+namespace playrho
 {
-    island.bodies.reserve(bodies);
-    island.contacts.reserve(contacts);
-    island.joints.reserve(joints);
-}
+    namespace d2
+    {
 
-void Clear(Island& island) noexcept
-{
-    island.bodies.clear();
-    island.contacts.clear();
-    island.joints.clear();
-}
+        using std::count;
 
-std::size_t Count(const Island& island, BodyID entry)
-{
-    return MakeUnsigned(count(cbegin(island.bodies), cend(island.bodies), entry));
-}
+        static_assert(std::is_default_constructible<Island>::value,
+                      "Must be default constructible.");
+        static_assert(std::is_copy_constructible<Island>::value,
+                      "Must be copy constructible.");
+        static_assert(std::is_copy_assignable<Island>::value,
+                      "Must be copy assignable.");
+        static_assert(std::is_nothrow_move_constructible<Island>::value,
+                      "Must be nothrow move constructible.");
+        static_assert(std::is_nothrow_move_assignable<Island>::value,
+                      "Must be nothrow move assignable.");
+        static_assert(std::is_nothrow_destructible<Island>::value,
+                      "Must be nothrow destructible.");
 
-std::size_t Count(const Island& island, ContactID entry)
-{
-    return MakeUnsigned(count(cbegin(island.contacts), cend(island.contacts), entry));
-}
+        void Reserve(Island& island, BodyCounter bodies, ContactCounter contacts, JointCounter joints)
+        {
+            island.bodies.reserve(bodies);
+            island.contacts.reserve(contacts);
+            island.joints.reserve(joints);
+        }
 
-std::size_t Count(const Island& island, JointID entry)
-{
-    return MakeUnsigned(count(cbegin(island.joints), cend(island.joints), entry));
-}
+        void Clear(Island& island) noexcept
+        {
+            island.bodies.clear();
+            island.contacts.clear();
+            island.joints.clear();
+        }
 
-} // namespace d2
-} // namespace playrho
+        std::size_t Count(const Island& island, BodyID entry)
+        {
+            return MakeUnsigned(count(cbegin(island.bodies), cend(island.bodies), entry));
+        }
+
+        std::size_t Count(const Island& island, ContactID entry)
+        {
+            return MakeUnsigned(count(cbegin(island.contacts), cend(island.contacts), entry));
+        }
+
+        std::size_t Count(const Island& island, JointID entry)
+        {
+            return MakeUnsigned(count(cbegin(island.joints), cend(island.joints), entry));
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Island.hpp
+++ b/PlayRho/Dynamics/Island.hpp
@@ -20,73 +20,75 @@
 #ifndef PLAYRHO_DYNAMICS_ISLAND_HPP
 #define PLAYRHO_DYNAMICS_ISLAND_HPP
 
-#include <PlayRho/Common/Templates.hpp> // IsFull
 #include <PlayRho/Common/Settings.hpp> // BodyCounter, ContactCounter, JointCounter
+#include <PlayRho/Common/Templates.hpp>// IsFull
 
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/Joints/JointID.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactID.hpp>
+#include <PlayRho/Dynamics/Joints/JointID.hpp>
 
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Definition of a self-contained constraint "island".
-/// @details A container of bodies contacts and joints relevant to handling world dynamics.
-/// @note This is an internal class.
-/// @note This data structure is 72-bytes large (on at least one 64-bit platform).
-struct Island
-{   
-    /// @brief Body container type.
-    using Bodies = std::vector<BodyID>;
-
-    /// @brief Contact container type.
-    using Contacts = std::vector<ContactID>;
-
-    /// @brief Joint container type.
-    using Joints = std::vector<JointID>;
-
-    Bodies bodies; ///< Body container.
-    Contacts contacts; ///< Contact container.
-    Joints joints; ///< Joint container.
-};
-
-/// @brief Reserves space ahead of time.
-/// @relatedalso Island
-void Reserve(Island& island, BodyCounter bodies, ContactCounter contacts, JointCounter joints);
-
-/// @brief Clears the island containers.
-/// @relatedalso Island
-void Clear(Island& island) noexcept;
-
-/// @brief Determines whether the given island is full of bodies.
-/// @relatedalso Island
-inline bool IsFullOfBodies(const Island& island)
+namespace playrho
 {
-    return IsFull(island.bodies);
-}
+    namespace d2
+    {
 
-/// @brief Determines whether the given island is full of contacts.
-/// @relatedalso Island
-inline bool IsFullOfContacts(const Island& island)
-{
-    return IsFull(island.contacts);
-}
+        /// @brief Definition of a self-contained constraint "island".
+        /// @details A container of bodies contacts and joints relevant to handling world dynamics.
+        /// @note This is an internal class.
+        /// @note This data structure is 72-bytes large (on at least one 64-bit platform).
+        struct Island
+        {
+            /// @brief Body container type.
+            using Bodies = std::vector<BodyID>;
 
-/// @brief Counts the number of occurrences of the given entry in the given island.
-/// @relatedalso Island
-std::size_t Count(const Island& island, BodyID entry);
+            /// @brief Contact container type.
+            using Contacts = std::vector<ContactID>;
 
-/// @brief Counts the number of occurrences of the given entry in the given island.
-/// @relatedalso Island
-std::size_t Count(const Island& island, ContactID entry);
+            /// @brief Joint container type.
+            using Joints = std::vector<JointID>;
 
-/// @brief Counts the number of occurrences of the given entry in the given island.
-/// @relatedalso Island
-std::size_t Count(const Island& island, JointID entry);
+            Bodies bodies;    ///< Body container.
+            Contacts contacts;///< Contact container.
+            Joints joints;    ///< Joint container.
+        };
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Reserves space ahead of time.
+        /// @relatedalso Island
+        void Reserve(Island& island, BodyCounter bodies, ContactCounter contacts, JointCounter joints);
 
-#endif // PLAYRHO_DYNAMICS_ISLAND_HPP
+        /// @brief Clears the island containers.
+        /// @relatedalso Island
+        void Clear(Island& island) noexcept;
+
+        /// @brief Determines whether the given island is full of bodies.
+        /// @relatedalso Island
+        inline bool IsFullOfBodies(const Island& island)
+        {
+            return IsFull(island.bodies);
+        }
+
+        /// @brief Determines whether the given island is full of contacts.
+        /// @relatedalso Island
+        inline bool IsFullOfContacts(const Island& island)
+        {
+            return IsFull(island.contacts);
+        }
+
+        /// @brief Counts the number of occurrences of the given entry in the given island.
+        /// @relatedalso Island
+        std::size_t Count(const Island& island, BodyID entry);
+
+        /// @brief Counts the number of occurrences of the given entry in the given island.
+        /// @relatedalso Island
+        std::size_t Count(const Island& island, ContactID entry);
+
+        /// @brief Counts the number of occurrences of the given entry in the given island.
+        /// @relatedalso Island
+        std::size_t Count(const Island& island, JointID entry);
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_ISLAND_HPP

--- a/PlayRho/Dynamics/IslandStats.hpp
+++ b/PlayRho/Dynamics/IslandStats.hpp
@@ -21,24 +21,25 @@
 #ifndef PLAYRHO_DYNAMICS_ISLANDSTATS_HPP
 #define PLAYRHO_DYNAMICS_ISLANDSTATS_HPP
 
-#include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/Units.hpp>
 
-namespace playrho {
-
-/// @brief Island solver statistics.
-struct IslandStats
+namespace playrho
 {
-    Length minSeparation = std::numeric_limits<Length>::infinity(); ///< Minimum separation.
-    Momentum maxIncImpulse = 0; ///< Maximum incremental impulse.
-    BodyCounter bodiesSlept = 0; ///< Bodies slept.
-    ContactCounter contactsUpdated = 0; ///< Contacts updated.
-    ContactCounter contactsSkipped = 0; ///< Contacts skipped.
-    bool solved = false; ///< Solved. <code>true</code> if position constraints solved, <code>false</code> otherwise.
-    TimestepIters positionIterations = 0; ///< Position iterations actually performed.
-    TimestepIters velocityIterations = 0; ///< Velocity iterations actually performed.
-};
 
-} // namespace playrho
+    /// @brief Island solver statistics.
+    struct IslandStats
+    {
+        Length minSeparation = std::numeric_limits<Length>::infinity();///< Minimum separation.
+        Momentum maxIncImpulse = 0;                                    ///< Maximum incremental impulse.
+        BodyCounter bodiesSlept = 0;                                   ///< Bodies slept.
+        ContactCounter contactsUpdated = 0;                            ///< Contacts updated.
+        ContactCounter contactsSkipped = 0;                            ///< Contacts skipped.
+        bool solved = false;                                           ///< Solved. <code>true</code> if position constraints solved, <code>false</code> otherwise.
+        TimestepIters positionIterations = 0;                          ///< Position iterations actually performed.
+        TimestepIters velocityIterations = 0;                          ///< Velocity iterations actually performed.
+    };
 
-#endif // PLAYRHO_DYNAMICS_ISLANDSTATS_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_ISLANDSTATS_HPP

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.cpp
@@ -21,227 +21,228 @@
 
 #include <PlayRho/Dynamics/Joints/DistanceJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<DistanceJointConf>::value,
-              "DistanceJointConf must be nothrow default constructible!");
-static_assert(std::is_copy_constructible<DistanceJointConf>::value,
-              "DistanceJointConf must be copy constructible!");
-static_assert(std::is_move_constructible<DistanceJointConf>::value,
-              "DistanceJointConf must be move constructible!");
-static_assert(std::is_copy_assignable<DistanceJointConf>::value,
-              "DistanceJointConf must be copy assignable!");
-static_assert(std::is_move_assignable<DistanceJointConf>::value,
-              "DistanceJointConf must be move assignable!");
-static_assert(std::is_nothrow_destructible<DistanceJointConf>::value,
-              "DistanceJointConf must be nothrow destructible!");
-
-// 1-D constrained system
-// m (v2 - v1) = lambda
-// v2 + (beta/h) * x1 + gamma * lambda = 0, gamma has units of inverse mass.
-// x2 = x1 + h * v2
-
-// 1-D mass-damper-spring system
-// m (v2 - v1) + h * d * v2 + h * k *
-
-// C = norm(p2 - p1) - L
-// u = (p2 - p1) / norm(p2 - p1)
-// Cdot = dot(u, v2 + cross(w2, r2) - v1 - cross(w1, r1))
-// J = [-u -cross(r1, u) u cross(r2, u)]
-// K = J * invM * JT
-//   = invMass1 + invI1 * cross(r1, u)^2 + invMass2 + invI2 * cross(r2, u)^2
-
-DistanceJointConf::DistanceJointConf(BodyID bA, BodyID bB,
-                                     Length2 laA, Length2 laB, Length l) noexcept :
-    super{super{}.UseBodyA(bA).UseBodyB(bB)},
-    localAnchorA{laA}, localAnchorB{laB}, length{l}
+namespace playrho
 {
-    // Intentionally empty.
-}
-
-DistanceJointConf GetDistanceJointConf(const Joint& joint) noexcept
-{
-    return TypeCast<DistanceJointConf>(joint);
-}
-
-DistanceJointConf GetDistanceJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchorA, Length2 anchorB)
-{
-    return DistanceJointConf{
-        bodyA, bodyB,
-        GetLocalPoint(world, bodyA, anchorA),
-        GetLocalPoint(world, bodyB, anchorB),
-        GetMagnitude(anchorB - anchorA)
-    };
-}
-
-void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia(); // L^-2 M^-1 QP^2
-    const auto posA = bodyConstraintA.GetPosition();
-    auto velA = bodyConstraintA.GetVelocity();
-
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia(); // L^-2 M^-1 QP^2
-    const auto posB = bodyConstraintB.GetPosition();
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-    const auto deltaLocation = Length2{(posB.linear + object.rB) - (posA.linear + object.rA)};
-
-    const auto uvresult = UnitVec::Get(deltaLocation[0], deltaLocation[1]);
-    object.u = std::get<UnitVec>(uvresult);
-    const auto length = std::get<Length>(uvresult);
-
-    const auto crAu = Length{Cross(object.rA, object.u)} / Radian;
-    const auto crBu = Length{Cross(object.rB, object.u)} / Radian;
-    const auto invRotMassA = InvMass{invRotInertiaA * Square(crAu)};
-    const auto invRotMassB = InvMass{invRotInertiaB * Square(crBu)};
-    auto invMass = invMassA + invRotMassA + invMassB + invRotMassB;
-
-    object.mass = (invMass != InvMass{0}) ? Real{1} / invMass: 0_kg;
-
-    if (object.frequency > 0_Hz)
+    namespace d2
     {
-        const auto C = length - object.length; // L
 
-        // Frequency
-        const auto omega = Real{2} * Pi * object.frequency;
+        static_assert(std::is_default_constructible<DistanceJointConf>::value,
+                      "DistanceJointConf must be nothrow default constructible!");
+        static_assert(std::is_copy_constructible<DistanceJointConf>::value,
+                      "DistanceJointConf must be copy constructible!");
+        static_assert(std::is_move_constructible<DistanceJointConf>::value,
+                      "DistanceJointConf must be move constructible!");
+        static_assert(std::is_copy_assignable<DistanceJointConf>::value,
+                      "DistanceJointConf must be copy assignable!");
+        static_assert(std::is_move_assignable<DistanceJointConf>::value,
+                      "DistanceJointConf must be move assignable!");
+        static_assert(std::is_nothrow_destructible<DistanceJointConf>::value,
+                      "DistanceJointConf must be nothrow destructible!");
 
-        // Damping coefficient
-        const auto d = Real{2} * object.mass * object.dampingRatio * omega; // M T^-1
+        // 1-D constrained system
+        // m (v2 - v1) = lambda
+        // v2 + (beta/h) * x1 + gamma * lambda = 0, gamma has units of inverse mass.
+        // x2 = x1 + h * v2
 
-        // Spring stiffness
-        const auto k = object.mass * Square(omega); // M T^-2
+        // 1-D mass-damper-spring system
+        // m (v2 - v1) + h * d * v2 + h * k *
 
-        // magic formulas
-        const auto h = step.deltaTime;
-        const auto gamma = Mass{h * (d + h * k)}; // T (M T^-1 + T M T^-2) = M
-        object.invGamma = (gamma != 0_kg)? Real{1} / gamma: 0;
-        object.bias = C * h * k * object.invGamma; // L T M T^-2 M^-1 = L T^-1
+        // C = norm(p2 - p1) - L
+        // u = (p2 - p1) / norm(p2 - p1)
+        // Cdot = dot(u, v2 + cross(w2, r2) - v1 - cross(w1, r1))
+        // J = [-u -cross(r1, u) u cross(r2, u)]
+        // K = J * invM * JT
+        //   = invMass1 + invI1 * cross(r1, u)^2 + invMass2 + invI2 * cross(r2, u)^2
 
-        invMass += object.invGamma;
-        object.mass = (invMass != InvMass{0}) ? Real{1} / invMass: 0;
-    }
-    else
-    {
-        object.invGamma = InvMass{0};
-        object.bias = 0_mps;
-    }
+        DistanceJointConf::DistanceJointConf(BodyID bA, BodyID bB,
+                                             Length2 laA, Length2 laB, Length l) noexcept
+            : super{super{}.UseBodyA(bA).UseBodyB(bB)},
+              localAnchorA{laA}, localAnchorB{laB}, length{l}
+        {
+            // Intentionally empty.
+        }
 
-    if (step.doWarmStart)
-    {
-        // Scale the impulse to support a variable time step.
-        object.impulse *= step.dtRatio;
+        DistanceJointConf GetDistanceJointConf(const Joint& joint) noexcept
+        {
+            return TypeCast<DistanceJointConf>(joint);
+        }
 
-        const auto P = object.impulse * object.u;
+        DistanceJointConf GetDistanceJointConf(const World& world, BodyID bodyA, BodyID bodyB,
+                                               Length2 anchorA, Length2 anchorB)
+        {
+            return DistanceJointConf{
+                bodyA, bodyB,
+                GetLocalPoint(world, bodyA, anchorA),
+                GetLocalPoint(world, bodyB, anchorB),
+                GetMagnitude(anchorB - anchorA)};
+        }
 
-        // P is M L T^-2
-        // Cross(Length2, P) is: M L^2 T^-1
-        // inv rotational inertia is: L^-2 M^-1 QP^2
-        // Product is: L^-2 M^-1 QP^2 M L^2 T^-1 = QP^2 T^-1
-        const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
-        const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        object.impulse = 0;
-    }
+        void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();// L^-2 M^-1 QP^2
+            const auto posA = bodyConstraintA.GetPosition();
+            auto velA = bodyConstraintA.GetVelocity();
 
-bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();// L^-2 M^-1 QP^2
+            const auto posB = bodyConstraintB.GetPosition();
+            auto velB = bodyConstraintB.GetVelocity();
 
-    auto velA = bodyConstraintA.GetVelocity();
-    auto velB = bodyConstraintB.GetVelocity();
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
 
-    // Cdot = dot(u, v + cross(w, r))
-    const auto vpA = velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian);
-    const auto vpB = velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian);
-    const auto Cdot = LinearVelocity{Dot(object.u, vpB - vpA)};
+            object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+            const auto deltaLocation = Length2{(posB.linear + object.rB) - (posA.linear + object.rA)};
 
-    const auto impulse = Momentum{-object.mass * (Cdot + object.bias + object.invGamma * object.impulse)};
-    object.impulse += impulse;
+            const auto uvresult = UnitVec::Get(deltaLocation[0], deltaLocation[1]);
+            object.u = std::get<UnitVec>(uvresult);
+            const auto length = std::get<Length>(uvresult);
 
-    const auto P = impulse * object.u;
-    const auto LA = Cross(object.rA, P) / Radian;
-    const auto LB = Cross(object.rB, P) / Radian;
+            const auto crAu = Length{Cross(object.rA, object.u)} / Radian;
+            const auto crBu = Length{Cross(object.rB, object.u)} / Radian;
+            const auto invRotMassA = InvMass{invRotInertiaA * Square(crAu)};
+            const auto invRotMassB = InvMass{invRotInertiaB * Square(crBu)};
+            auto invMass = invMassA + invRotMassA + invMassB + invRotMassB;
 
-    velA -= Velocity{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
-    velB += Velocity{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
+            object.mass = (invMass != InvMass{0}) ? Real{1} / invMass : 0_kg;
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
+            if (object.frequency > 0_Hz)
+            {
+                const auto C = length - object.length;// L
 
-    return impulse == 0_Ns;
-}
+                // Frequency
+                const auto omega = Real{2} * Pi * object.frequency;
 
-bool SolvePosition(const DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    if (object.frequency > 0_Hz)
-    {
-        // There is no position correction for soft distance constraints.
-        return true;
-    }
+                // Damping coefficient
+                const auto d = Real{2} * object.mass * object.dampingRatio * omega;// M T^-1
 
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+                // Spring stiffness
+                const auto k = object.mass * Square(omega);// M T^-2
 
-    auto posA = bodyConstraintA.GetPosition();
-    auto posB = bodyConstraintB.GetPosition();
+                // magic formulas
+                const auto h = step.deltaTime;
+                const auto gamma = Mass{h * (d + h * k)};// T (M T^-1 + T M T^-2) = M
+                object.invGamma = (gamma != 0_kg) ? Real{1} / gamma : 0;
+                object.bias = C * h * k * object.invGamma;// L T M T^-2 M^-1 = L T^-1
 
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
+                invMass += object.invGamma;
+                object.mass = (invMass != InvMass{0}) ? Real{1} / invMass : 0;
+            }
+            else
+            {
+                object.invGamma = InvMass{0};
+                object.bias = 0_mps;
+            }
 
-    const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
-    const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
-    const auto relLoc = Length2{(posB.linear + rB) - (posA.linear + rA)};
+            if (step.doWarmStart)
+            {
+                // Scale the impulse to support a variable time step.
+                object.impulse *= step.dtRatio;
 
-    const auto uvresult = UnitVec::Get(relLoc[0], relLoc[1]);
-    const auto u = std::get<UnitVec>(uvresult);
-    const auto length = std::get<Length>(uvresult);
-    const auto deltaLength = length - object.length;
-    const auto C = std::clamp(deltaLength, -conf.maxLinearCorrection, conf.maxLinearCorrection);
+                const auto P = object.impulse * object.u;
 
-    const auto impulse = -object.mass * C;
-    const auto P = impulse * u;
-    const auto LA = Cross(rA, P) / Radian;
-    const auto LB = Cross(rB, P) / Radian;
+                // P is M L T^-2
+                // Cross(Length2, P) is: M L^2 T^-1
+                // inv rotational inertia is: L^-2 M^-1 QP^2
+                // Product is: L^-2 M^-1 QP^2 M L^2 T^-1 = QP^2 T^-1
+                const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
+                const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                object.impulse = 0;
+            }
 
-    posA -= Position{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
-    posB += Position{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
 
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
+        bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    return abs(C) < conf.linearSlop;
-}
+            auto velA = bodyConstraintA.GetVelocity();
+            auto velB = bodyConstraintB.GetVelocity();
 
-} // namespace d2
-} // namespace playrho
+            // Cdot = dot(u, v + cross(w, r))
+            const auto vpA = velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian);
+            const auto vpB = velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian);
+            const auto Cdot = LinearVelocity{Dot(object.u, vpB - vpA)};
+
+            const auto impulse = Momentum{-object.mass * (Cdot + object.bias + object.invGamma * object.impulse)};
+            object.impulse += impulse;
+
+            const auto P = impulse * object.u;
+            const auto LA = Cross(object.rA, P) / Radian;
+            const auto LB = Cross(object.rB, P) / Radian;
+
+            velA -= Velocity{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
+            velB += Velocity{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
+
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+
+            return impulse == 0_Ns;
+        }
+
+        bool SolvePosition(const DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
+        {
+            if (object.frequency > 0_Hz)
+            {
+                // There is no position correction for soft distance constraints.
+                return true;
+            }
+
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            auto posA = bodyConstraintA.GetPosition();
+            auto posB = bodyConstraintB.GetPosition();
+
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
+            const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
+            const auto relLoc = Length2{(posB.linear + rB) - (posA.linear + rA)};
+
+            const auto uvresult = UnitVec::Get(relLoc[0], relLoc[1]);
+            const auto u = std::get<UnitVec>(uvresult);
+            const auto length = std::get<Length>(uvresult);
+            const auto deltaLength = length - object.length;
+            const auto C = std::clamp(deltaLength, -conf.maxLinearCorrection, conf.maxLinearCorrection);
+
+            const auto impulse = -object.mass * C;
+            const auto P = impulse * u;
+            const auto LA = Cross(rA, P) / Radian;
+            const auto LB = Cross(rB, P) / Radian;
+
+            posA -= Position{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
+            posB += Position{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+
+            return abs(C) < conf.linearSlop;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
@@ -22,193 +22,195 @@
 #ifndef PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINTCONF_HPP
 #define PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINTCONF_HPP
 
-#include <PlayRho/Dynamics/Joints/JointConf.hpp>
-#include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/NonNegative.hpp>
+#include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class World;
-class BodyConstraint;
-
-/// @brief Distance joint definition.
-/// @details This requires defining an anchor point on both bodies and the non-zero
-///   length of the distance joint. The definition uses local anchor points so that
-///   the initial configuration can violate the constraint slightly. This helps when
-///   saving and loading a game.
-/// @warning Do not use a zero or short length.
-/// @see Joint, World::CreateJoint
-/// @ingroup JointsGroup
-/// @image html distanceJoint.gif
-struct DistanceJointConf : public JointBuilder<DistanceJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<DistanceJointConf>;
 
-    /// @brief Default constructor.
-    constexpr DistanceJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Copy constructor.
-    DistanceJointConf(const DistanceJointConf& copy) = default;
-
-    /// @brief Initializing constructor.
-    /// @details Initialize the bodies, anchors, and length using the world anchors.
-    DistanceJointConf(BodyID bA, BodyID bB,
-                      Length2 laA = Length2{}, Length2 laB = Length2{}, Length l = 1_m) noexcept;
-
-    /// @brief Uses the given length.
-    /// @note Manipulating the length when the frequency is zero can lead to non-physical behavior.
-    constexpr auto& UseLength(Length v) noexcept
+    namespace d2
     {
-        length = v;
-        return *this;
-    }
 
-    /// @brief Uses the given frequency.
-    constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
+        class World;
+        class BodyConstraint;
+
+        /// @brief Distance joint definition.
+        /// @details This requires defining an anchor point on both bodies and the non-zero
+        ///   length of the distance joint. The definition uses local anchor points so that
+        ///   the initial configuration can violate the constraint slightly. This helps when
+        ///   saving and loading a game.
+        /// @warning Do not use a zero or short length.
+        /// @see Joint, World::CreateJoint
+        /// @ingroup JointsGroup
+        /// @image html distanceJoint.gif
+        struct DistanceJointConf : public JointBuilder<DistanceJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<DistanceJointConf>;
+
+            /// @brief Default constructor.
+            constexpr DistanceJointConf() = default;
+
+            /// @brief Copy constructor.
+            DistanceJointConf(const DistanceJointConf& copy) = default;
+
+            /// @brief Initializing constructor.
+            /// @details Initialize the bodies, anchors, and length using the world anchors.
+            DistanceJointConf(BodyID bA, BodyID bB,
+                              Length2 laA = Length2{}, Length2 laB = Length2{}, Length l = 1_m) noexcept;
+
+            /// @brief Uses the given length.
+            /// @note Manipulating the length when the frequency is zero can lead to non-physical behavior.
+            constexpr auto& UseLength(Length v) noexcept
+            {
+                length = v;
+                return *this;
+            }
+
+            /// @brief Uses the given frequency.
+            constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
+            {
+                frequency = v;
+                return *this;
+            }
+
+            /// @brief Uses the given damping ratio.
+            constexpr auto& UseDampingRatio(Real v) noexcept
+            {
+                dampingRatio = v;
+                return *this;
+            }
+
+            /// @brief Local anchor point relative to body A's origin.
+            /// @note 8-bytes (with 4-byte Real).
+            Length2 localAnchorA = Length2{};
+
+            /// @brief Local anchor point relative to body B's origin.
+            /// @note 8-bytes (with 4-byte Real).
+            Length2 localAnchorB = Length2{};
+
+            /// @brief Natural length between the anchor points.
+            /// @note 4-bytes (with 4-byte Real).
+            Length length = 1_m;
+
+            /// @brief Mass-spring-damper frequency.
+            /// @note 0 disables softness.
+            /// @note 4-bytes (with 4-byte Real).
+            NonNegative<Frequency> frequency{};
+
+            /// @brief Damping ratio.
+            /// @note 0 = no damping, 1 = critical damping.
+            /// @note 4-bytes (with 4-byte Real).
+            Real dampingRatio = 0;
+
+            // Solver shared.
+
+            Momentum impulse = 0_Ns;///< Impulse. 4-bytes (with 4-byte Real).
+
+            // Solver temp (4 * 3 + 8 * 3 = 36 bytes minimally).
+
+            UnitVec u;               ///< "u" directional. 8-bytes (with 4-byte Real).
+            Length2 rA = {};         ///< Relative A position. 8-bytes (with 4-byte Real).
+            Length2 rB = {};         ///< Relative B position. 8-bytes (with 4-byte Real).
+            InvMass invGamma = {};   ///< Inverse gamma. 4-bytes (with 4-byte Real).
+            LinearVelocity bias = {};///< Bias. 4-bytes (with 4-byte Real).
+            Mass mass = 0_kg;        ///< Mass. 4-bytes (with 4-byte Real).
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        DistanceJointConf GetDistanceJointConf(const Joint& joint) noexcept;
+
+        /// @brief Gets the configuration for the given parameters.
+        /// @relatedalso World
+        DistanceJointConf GetDistanceJointConf(const World& world, BodyID bodyA, BodyID bodyB,
+                                               Length2 anchorA = Length2{}, Length2 anchorB = Length2{});
+
+        /// @brief Gets the current linear reaction for the given configuration.
+        /// @relatedalso DistanceJointConf
+        constexpr Momentum2 GetLinearReaction(const DistanceJointConf& object) noexcept
+        {
+            return object.impulse * object.u;
+        }
+
+        /// @brief Gets the current angular reaction for the given configuration.
+        /// @relatedalso DistanceJointConf
+        constexpr AngularMomentum GetAngularReaction(const DistanceJointConf&) noexcept
+        {
+            return AngularMomentum{0};
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso DistanceJointConf
+        constexpr bool ShiftOrigin(DistanceJointConf&, Length2) noexcept
+        {
+            return false;
+        }
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso DistanceJointConf
+        void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso DistanceJointConf
+        bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso DistanceJointConf
+        bool SolvePosition(const DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for setting the frequency value of the given configuration.
+        /// @relatedalso DistanceJointConf
+        constexpr void SetFrequency(DistanceJointConf& object, NonNegative<Frequency> value) noexcept
+        {
+            object.UseFrequency(value);
+        }
+
+        /// @brief Free function for setting the damping ratio value of the given configuration.
+        /// @relatedalso DistanceJointConf
+        constexpr void SetDampingRatio(DistanceJointConf& object, Real value) noexcept
+        {
+            object.UseDampingRatio(value);
+        }
+
+        /// @brief Free function for getting the length value of the given configuration.
+        /// @relatedalso DistanceJointConf
+        constexpr auto GetLength(const DistanceJointConf& object) noexcept
+        {
+            return object.length;
+        }
+
+        /// @brief Free function for setting the length value of the given configuration.
+        /// @relatedalso DistanceJointConf
+        constexpr auto SetLength(DistanceJointConf& object, Length value) noexcept
+        {
+            object.UseLength(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::DistanceJointConf</code>.
+    template<>
+    struct TypeInfo<d2::DistanceJointConf>
     {
-        frequency = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::DistanceJointConf";
+    };
 
-    /// @brief Uses the given damping ratio.
-    constexpr auto& UseDampingRatio(Real v) noexcept
-    {
-        dampingRatio = v;
-        return *this;
-    }
+}// namespace playrho
 
-    /// @brief Local anchor point relative to body A's origin.
-    /// @note 8-bytes (with 4-byte Real).
-    Length2 localAnchorA = Length2{};
-    
-    /// @brief Local anchor point relative to body B's origin.
-    /// @note 8-bytes (with 4-byte Real).
-    Length2 localAnchorB = Length2{};
-    
-    /// @brief Natural length between the anchor points.
-    /// @note 4-bytes (with 4-byte Real).
-    Length length = 1_m;
-    
-    /// @brief Mass-spring-damper frequency.
-    /// @note 0 disables softness.
-    /// @note 4-bytes (with 4-byte Real).
-    NonNegative<Frequency> frequency{};
-    
-    /// @brief Damping ratio.
-    /// @note 0 = no damping, 1 = critical damping.
-    /// @note 4-bytes (with 4-byte Real).
-    Real dampingRatio = 0;
-
-    // Solver shared.
-
-    Momentum impulse = 0_Ns; ///< Impulse. 4-bytes (with 4-byte Real).
-
-    // Solver temp (4 * 3 + 8 * 3 = 36 bytes minimally).
-
-    UnitVec u; ///< "u" directional. 8-bytes (with 4-byte Real).
-    Length2 rA = {}; ///< Relative A position. 8-bytes (with 4-byte Real).
-    Length2 rB = {}; ///< Relative B position. 8-bytes (with 4-byte Real).
-    InvMass invGamma = {}; ///< Inverse gamma. 4-bytes (with 4-byte Real).
-    LinearVelocity bias = {}; ///< Bias. 4-bytes (with 4-byte Real).
-    Mass mass = 0_kg; ///< Mass. 4-bytes (with 4-byte Real).
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-DistanceJointConf GetDistanceJointConf(const Joint& joint) noexcept;
-
-/// @brief Gets the configuration for the given parameters.
-/// @relatedalso World
-DistanceJointConf GetDistanceJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchorA = Length2{}, Length2 anchorB = Length2{});
-
-/// @brief Gets the current linear reaction for the given configuration.
-/// @relatedalso DistanceJointConf
-constexpr Momentum2 GetLinearReaction(const DistanceJointConf& object) noexcept
-{
-    return object.impulse * object.u;
-}
-
-/// @brief Gets the current angular reaction for the given configuration.
-/// @relatedalso DistanceJointConf
-constexpr AngularMomentum GetAngularReaction(const DistanceJointConf&) noexcept
-{
-    return AngularMomentum{0};
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso DistanceJointConf
-constexpr bool ShiftOrigin(DistanceJointConf&, Length2) noexcept
-{
-    return false;
-}
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso DistanceJointConf
-void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso DistanceJointConf
-bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso DistanceJointConf
-bool SolvePosition(const DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for setting the frequency value of the given configuration.
-/// @relatedalso DistanceJointConf
-constexpr void SetFrequency(DistanceJointConf& object, NonNegative<Frequency> value) noexcept
-{
-    object.UseFrequency(value);
-}
-
-/// @brief Free function for setting the damping ratio value of the given configuration.
-/// @relatedalso DistanceJointConf
-constexpr void SetDampingRatio(DistanceJointConf& object, Real value) noexcept
-{
-    object.UseDampingRatio(value);
-}
-
-/// @brief Free function for getting the length value of the given configuration.
-/// @relatedalso DistanceJointConf
-constexpr auto GetLength(const DistanceJointConf& object) noexcept
-{
-    return object.length;
-}
-
-/// @brief Free function for setting the length value of the given configuration.
-/// @relatedalso DistanceJointConf
-constexpr auto SetLength(DistanceJointConf& object, Length value) noexcept
-{
-    object.UseLength(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::DistanceJointConf</code>.
-template <>
-struct TypeInfo<d2::DistanceJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::DistanceJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_DISTANCEJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
@@ -24,165 +24,167 @@
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
-#include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/NonNegative.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class World;
-class BodyConstraint;
-
-/// @brief Friction joint definition.
-/// @details This is used for top-down friction. It provides 2-D translational friction
-///   and angular friction.
-/// @see Joint, World::CreateJoint
-/// @ingroup JointsGroup
-struct FrictionJointConf : public JointBuilder<FrictionJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<FrictionJointConf>;
 
-    /// @brief Default constructor.
-    constexpr FrictionJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Initializing constructor.
-    /// @details Initialize the bodies, anchors, axis, and reference angle using the world
-    ///   anchor and world axis.
-    FrictionJointConf(BodyID bodyA, BodyID bodyB,
-                      Length2 laA = Length2{}, Length2 laB = Length2{}) noexcept;
-
-    /// @brief Uses the given maximum force value.
-    constexpr auto& UseMaxForce(NonNegative<Force> v) noexcept
+    namespace d2
     {
-        maxForce = v;
-        return *this;
-    }
 
-    /// @brief Uses the given maximum torque value.
-    constexpr auto& UseMaxTorque(NonNegative<Torque> v) noexcept
+        class World;
+        class BodyConstraint;
+
+        /// @brief Friction joint definition.
+        /// @details This is used for top-down friction. It provides 2-D translational friction
+        ///   and angular friction.
+        /// @see Joint, World::CreateJoint
+        /// @ingroup JointsGroup
+        struct FrictionJointConf : public JointBuilder<FrictionJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<FrictionJointConf>;
+
+            /// @brief Default constructor.
+            constexpr FrictionJointConf() = default;
+
+            /// @brief Initializing constructor.
+            /// @details Initialize the bodies, anchors, axis, and reference angle using the world
+            ///   anchor and world axis.
+            FrictionJointConf(BodyID bodyA, BodyID bodyB,
+                              Length2 laA = Length2{}, Length2 laB = Length2{}) noexcept;
+
+            /// @brief Uses the given maximum force value.
+            constexpr auto& UseMaxForce(NonNegative<Force> v) noexcept
+            {
+                maxForce = v;
+                return *this;
+            }
+
+            /// @brief Uses the given maximum torque value.
+            constexpr auto& UseMaxTorque(NonNegative<Torque> v) noexcept
+            {
+                maxTorque = v;
+                return *this;
+            }
+
+            /// @brief Local anchor point relative to body A's origin.
+            Length2 localAnchorA = Length2{};
+
+            /// @brief Local anchor point relative to body B's origin.
+            Length2 localAnchorB = Length2{};
+
+            /// @brief Maximum friction force.
+            NonNegative<Force> maxForce{};// 0_N
+
+            /// @brief Maximum friction torque.
+            NonNegative<Torque> maxTorque{};// 0_Nm
+
+            // Solver shared data - data saved & updated over multiple InitVelocityConstraints calls.
+            Momentum2 linearImpulse = Momentum2{};              ///< Linear impulse.
+            AngularMomentum angularImpulse = AngularMomentum{0};///< Angular impulse.
+
+            // Solver temp
+            Length2 rA = {};            ///< Relative A.
+            Length2 rB = {};            ///< Relative B.
+            Mass22 linearMass = {};     ///< 2-by-2 linear mass matrix in kilograms.
+            RotInertia angularMass = {};///< Angular mass.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        FrictionJointConf GetFrictionJointConf(const Joint& joint) noexcept;
+
+        /// @brief Gets the confguration for the given parameters.
+        /// @relatedalso World
+        FrictionJointConf GetFrictionJointConf(const World& world,
+                                               BodyID bodyA, BodyID bodyB, Length2 anchor);
+
+        /// @brief Gets the current linear reaction for the given configuration.
+        /// @relatedalso FrictionJointConf
+        constexpr Momentum2 GetLinearReaction(const FrictionJointConf& object) noexcept
+        {
+            return object.linearImpulse;
+        }
+
+        /// @brief Gets the current angular reaction for the given configuration.
+        /// @relatedalso FrictionJointConf
+        constexpr AngularMomentum GetAngularReaction(const FrictionJointConf& object) noexcept
+        {
+            return object.angularImpulse;
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso FrictionJointConf
+        constexpr bool ShiftOrigin(FrictionJointConf&, Length2) noexcept
+        {
+            return false;
+        }
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso FrictionJointConf
+        void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso FrictionJointConf
+        bool SolveVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso FrictionJointConf
+        bool SolvePosition(const FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for getting the max force value of the given configuration.
+        /// @relatedalso FrictionJointConf
+        constexpr auto GetMaxForce(const FrictionJointConf& object) noexcept
+        {
+            return object.maxForce;
+        }
+
+        /// @brief Free function for setting the max force value of the given configuration.
+        /// @relatedalso FrictionJointConf
+        constexpr void SetMaxForce(FrictionJointConf& object, NonNegative<Force> value) noexcept
+        {
+            object.UseMaxForce(value);
+        }
+
+        /// @brief Free function for getting the max torque value of the given configuration.
+        /// @relatedalso FrictionJointConf
+        constexpr auto GetMaxTorque(const FrictionJointConf& object) noexcept
+        {
+            return object.maxTorque;
+        }
+
+        /// @brief Free function for setting the max force value of the given configuration.
+        /// @relatedalso FrictionJointConf
+        constexpr auto SetMaxTorque(FrictionJointConf& object, NonNegative<Torque> value) noexcept
+        {
+            object.UseMaxTorque(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::FrictionJointConf</code>.
+    template<>
+    struct TypeInfo<d2::FrictionJointConf>
     {
-        maxTorque = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::FrictionJointConf";
+    };
 
-    /// @brief Local anchor point relative to body A's origin.
-    Length2 localAnchorA = Length2{};
+}// namespace playrho
 
-    /// @brief Local anchor point relative to body B's origin.
-    Length2 localAnchorB = Length2{};
-
-    /// @brief Maximum friction force.
-    NonNegative<Force> maxForce{}; // 0_N
-
-    /// @brief Maximum friction torque.
-    NonNegative<Torque> maxTorque{}; // 0_Nm
-
-    // Solver shared data - data saved & updated over multiple InitVelocityConstraints calls.
-    Momentum2 linearImpulse = Momentum2{}; ///< Linear impulse.
-    AngularMomentum angularImpulse = AngularMomentum{0}; ///< Angular impulse.
-
-    // Solver temp
-    Length2 rA = {}; ///< Relative A.
-    Length2 rB = {}; ///< Relative B.
-    Mass22 linearMass = {}; ///< 2-by-2 linear mass matrix in kilograms.
-    RotInertia angularMass = {}; ///< Angular mass.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-FrictionJointConf GetFrictionJointConf(const Joint& joint) noexcept;
-
-/// @brief Gets the confguration for the given parameters.
-/// @relatedalso World
-FrictionJointConf GetFrictionJointConf(const World& world,
-                                       BodyID bodyA, BodyID bodyB, Length2 anchor);
-
-/// @brief Gets the current linear reaction for the given configuration.
-/// @relatedalso FrictionJointConf
-constexpr Momentum2 GetLinearReaction(const FrictionJointConf& object) noexcept
-{
-    return object.linearImpulse;
-}
-
-/// @brief Gets the current angular reaction for the given configuration.
-/// @relatedalso FrictionJointConf
-constexpr AngularMomentum GetAngularReaction(const FrictionJointConf& object) noexcept
-{
-    return object.angularImpulse;
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso FrictionJointConf
-constexpr bool ShiftOrigin(FrictionJointConf&, Length2) noexcept
-{
-    return false;
-}
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso FrictionJointConf
-void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso FrictionJointConf
-bool SolveVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso FrictionJointConf
-bool SolvePosition(const FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for getting the max force value of the given configuration.
-/// @relatedalso FrictionJointConf
-constexpr auto GetMaxForce(const FrictionJointConf& object) noexcept
-{
-    return object.maxForce;
-}
-
-/// @brief Free function for setting the max force value of the given configuration.
-/// @relatedalso FrictionJointConf
-constexpr void SetMaxForce(FrictionJointConf& object, NonNegative<Force> value) noexcept
-{
-    object.UseMaxForce(value);
-}
-
-/// @brief Free function for getting the max torque value of the given configuration.
-/// @relatedalso FrictionJointConf
-constexpr auto GetMaxTorque(const FrictionJointConf& object) noexcept
-{
-    return object.maxTorque;
-}
-
-/// @brief Free function for setting the max force value of the given configuration.
-/// @relatedalso FrictionJointConf
-constexpr auto SetMaxTorque(FrictionJointConf& object, NonNegative<Torque> value) noexcept
-{
-    object.UseMaxTorque(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::FrictionJointConf</code>.
-template <>
-struct TypeInfo<d2::FrictionJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::FrictionJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/GearJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/GearJointConf.cpp
@@ -21,377 +21,371 @@
 
 #include <PlayRho/Dynamics/Joints/GearJointConf.hpp>
 
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
+#include <PlayRho/Dynamics/Joints/Joint.hpp>
+#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/WorldBody.hpp>
 #include <PlayRho/Dynamics/WorldJoint.hpp>
-#include <PlayRho/Dynamics/Joints/Joint.hpp>
-#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
-#include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<GearJointConf>::value,
-              "GearJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<GearJointConf>::value,
-              "GearJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<GearJointConf>::value,
-              "GearJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<GearJointConf>::value,
-              "GearJointConf should be move constructible!");
-static_assert(std::is_move_assignable<GearJointConf>::value,
-              "GearJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<GearJointConf>::value,
-              "GearJointConf should be nothrow destructible!");
-
-// Gear Joint:
-// C0 = (coordinate1 + ratio * coordinate2)_initial
-// C = (coordinate1 + ratio * coordinate2) - C0 = 0
-// J = [J1 ratio * J2]
-// K = J * invM * JT
-//   = J1 * invM1 * J1T + ratio * ratio * J2 * invM2 * J2T
-//
-// Revolute:
-// coordinate = rotation
-// Cdot = angularVelocity
-// J = [0 0 1]
-// K = J * invM * JT = invI
-//
-// Prismatic:
-// coordinate = dot(p - pg, ug)
-// Cdot = dot(v + cross(w, r), ug)
-// J = [ug cross(r, ug)]
-// K = J * invM * JT = invMass + invI * cross(r, ug)^2
-
-GearJointConf::GearJointConf(BodyID bA, BodyID bB, BodyID bC, BodyID bD) noexcept:
-    super{super{}.UseBodyA(bA).UseBodyB(bB)},
-    bodyC(bC), bodyD(bD)
+namespace playrho
 {
-    // Intentionally empty.
-}
-
-GearJointConf GetGearJointConf(const Joint& joint) noexcept
-{
-    return TypeCast<GearJointConf>(joint);
-}
-
-GearJointConf GetGearJointConf(const World& world, JointID id1, JointID id2, Real ratio)
-{
-    auto def = GearJointConf{
-        /*body-A*/ GetBodyB(world, id1), /*body-B*/ GetBodyB(world, id2),
-        /*body-C*/ GetBodyA(world, id1), /*body-D*/ GetBodyA(world, id2)
-    };
-
-    auto scalar1 = Real{0};
-    def.type1 = GetType(world, id1);
-    if (def.type1 == GetTypeID<RevoluteJointConf>()) {
-        def.referenceAngle1 = GetReferenceAngle(world, id1);
-        scalar1 = (GetAngle(world, def.bodyA) - GetAngle(world, def.bodyC) - def.referenceAngle1) / Radian;
-    } else if (def.type1 == GetTypeID<PrismaticJointConf>()) {
-        const auto xfA = GetTransformation(world, def.bodyA);
-        const auto xfC = GetTransformation(world, def.bodyC);
-        def.localAnchorC = GetLocalAnchorA(world, id1);
-        def.localAnchorA = GetLocalAnchorB(world, id1);
-        def.localAxis1 = GetLocalXAxisA(world, id1);
-        const auto pC = def.localAnchorC;
-        const auto pA = InverseRotate(Rotate(def.localAnchorA, xfA.q) + (xfA.p - xfC.p), xfC.q);
-        scalar1 = Dot(pA - pC, def.localAxis1) / Meter;
-    }
-    else {
-        throw InvalidArgument("GetGearJointConf not supported for joint 1 type");
-    }
-
-    auto scalar2 = Real{0};
-    def.type2 = GetType(world, id2);
-    if (def.type2 == GetTypeID<RevoluteJointConf>()) {
-        def.referenceAngle2 = GetReferenceAngle(world, id2);
-        scalar2 = (GetAngle(world, def.bodyB) - GetAngle(world, def.bodyD) - def.referenceAngle1) / Radian;
-    } else if (def.type2 == GetTypeID<PrismaticJointConf>()) {
-        const auto xfB = GetTransformation(world, def.bodyB);
-        const auto xfD = GetTransformation(world, def.bodyD);
-        def.localAnchorD = GetLocalAnchorA(world, id2);
-        def.localAnchorB = GetLocalAnchorB(world, id2);
-        def.localAxis2 = GetLocalXAxisA(world, id2);
-        const auto pD = def.localAnchorD;
-        const auto pB = InverseRotate(Rotate(def.localAnchorB, xfB.q) + (xfB.p - xfD.p), xfD.q);
-        scalar2 = Dot(pB - pD, def.localAxis2) / Meter;
-    }
-    else {
-        throw InvalidArgument("GetGearJointConf not supported for joint 2 type");
-    }
-
-    def.ratio = ratio;
-    def.constant = scalar1 + def.ratio * scalar2;
-    return def;
-}
-
-void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-    auto& bodyConstraintC = At(bodies, object.bodyC);
-    auto& bodyConstraintD = At(bodies, object.bodyD);
-
-    auto velA = bodyConstraintA.GetVelocity();
-    const auto aA = bodyConstraintA.GetPosition().angular;
-
-    auto velB = bodyConstraintB.GetVelocity();
-    const auto aB = bodyConstraintB.GetPosition().angular;
-
-    auto velC = bodyConstraintC.GetVelocity();
-    const auto aC = bodyConstraintC.GetPosition().angular;
-
-    auto velD = bodyConstraintD.GetVelocity();
-    const auto aD = bodyConstraintD.GetPosition().angular;
-
-    const auto qA = UnitVec::Get(aA);
-    const auto qB = UnitVec::Get(aB);
-    const auto qC = UnitVec::Get(aC);
-    const auto qD = UnitVec::Get(aD);
-
-    auto invMass = Real{0}; // Unitless to double for either linear mass or angular mass.
-
-    if (object.type1 == GetTypeID<RevoluteJointConf>())
+    namespace d2
     {
-        object.JvAC = Vec2{};
-        object.JwA = 1_m;
-        object.JwC = 1_m;
-        const auto invAngMass = bodyConstraintA.GetInvRotInertia() + bodyConstraintC.GetInvRotInertia();
-        invMass += StripUnit(invAngMass);
-    }
-    else
-    {
-        const auto u = Rotate(object.localAxis1, qC);
-        const auto rC = Length2{Rotate(object.localAnchorC - bodyConstraintC.GetLocalCenter(), qC)};
-        const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
-        object.JvAC = Real{1} * u;
-        object.JwC = Cross(rC, u);
-        object.JwA = Cross(rA, u);
-        const auto invRotMassC = InvMass{bodyConstraintC.GetInvRotInertia() * Square(object.JwC) / SquareRadian};
-        const auto invRotMassA = InvMass{bodyConstraintA.GetInvRotInertia() * Square(object.JwA) / SquareRadian};
-        const auto invLinMass = InvMass{bodyConstraintC.GetInvMass() + bodyConstraintA.GetInvMass() + invRotMassC + invRotMassA};
-        invMass += StripUnit(invLinMass);
-    }
 
-    if (object.type2 == GetTypeID<RevoluteJointConf>())
-    {
-        object.JvBD = Vec2{};
-        object.JwB = object.ratio * Meter;
-        object.JwD = object.ratio * Meter;
-        const auto invAngMass = InvRotInertia{Square(object.ratio) * (bodyConstraintB.GetInvRotInertia() + bodyConstraintD.GetInvRotInertia())};
-        invMass += StripUnit(invAngMass);
-    }
-    else
-    {
-        const auto u = Rotate(object.localAxis2, qD);
-        const auto rD = Rotate(object.localAnchorD - bodyConstraintD.GetLocalCenter(), qD);
-        const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-        object.JvBD = object.ratio * u;
-        object.JwD = object.ratio * Cross(rD, u);
-        object.JwB = object.ratio * Cross(rB, u);
-        const auto invRotMassD = InvMass{bodyConstraintD.GetInvRotInertia() * Square(object.JwD) / SquareRadian};
-        const auto invRotMassB = InvMass{bodyConstraintB.GetInvRotInertia() * Square(object.JwB) / SquareRadian};
-        const auto invLinMass = InvMass{
-            Square(object.ratio) * (bodyConstraintD.GetInvMass() + bodyConstraintB.GetInvMass()) +
-            invRotMassD + invRotMassB
-        };
-        invMass += StripUnit(invLinMass);
-    }
+        static_assert(std::is_default_constructible<GearJointConf>::value,
+                      "GearJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<GearJointConf>::value,
+                      "GearJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<GearJointConf>::value,
+                      "GearJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<GearJointConf>::value,
+                      "GearJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<GearJointConf>::value,
+                      "GearJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<GearJointConf>::value,
+                      "GearJointConf should be nothrow destructible!");
 
-    // Compute effective mass.
-    object.mass = (invMass > Real{0})? Real{1} / invMass: Real{0};
+        // Gear Joint:
+        // C0 = (coordinate1 + ratio * coordinate2)_initial
+        // C = (coordinate1 + ratio * coordinate2) - C0 = 0
+        // J = [J1 ratio * J2]
+        // K = J * invM * JT
+        //   = J1 * invM1 * J1T + ratio * ratio * J2 * invM2 * J2T
+        //
+        // Revolute:
+        // coordinate = rotation
+        // Cdot = angularVelocity
+        // J = [0 0 1]
+        // K = J * invM * JT = invI
+        //
+        // Prismatic:
+        // coordinate = dot(p - pg, ug)
+        // Cdot = dot(v + cross(w, r), ug)
+        // J = [ug cross(r, ug)]
+        // K = J * invM * JT = invMass + invI * cross(r, ug)^2
 
-    if (step.doWarmStart)
-    {
-        velA += Velocity{
-            (bodyConstraintA.GetInvMass() * object.impulse) * object.JvAC,
-            bodyConstraintA.GetInvRotInertia() * object.impulse * object.JwA / Radian
-        };
-        velB += Velocity{
-            (bodyConstraintB.GetInvMass() * object.impulse) * object.JvBD,
-            bodyConstraintB.GetInvRotInertia() * object.impulse * object.JwB / Radian
-        };
-        velC -= Velocity{
-            (bodyConstraintC.GetInvMass() * object.impulse) * object.JvAC,
-            bodyConstraintC.GetInvRotInertia() * object.impulse * object.JwC / Radian
-        };
-        velD -= Velocity{
-            (bodyConstraintD.GetInvMass() * object.impulse) * object.JvBD,
-            bodyConstraintD.GetInvRotInertia() * object.impulse * object.JwD / Radian
-        };
-    }
-    else
-    {
-        object.impulse = 0_Ns;
-    }
+        GearJointConf::GearJointConf(BodyID bA, BodyID bB, BodyID bC, BodyID bD) noexcept
+            : super{super{}.UseBodyA(bA).UseBodyB(bB)},
+              bodyC(bC), bodyD(bD)
+        {
+            // Intentionally empty.
+        }
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-    bodyConstraintC.SetVelocity(velC);
-    bodyConstraintD.SetVelocity(velD);
-}
+        GearJointConf GetGearJointConf(const Joint& joint) noexcept
+        {
+            return TypeCast<GearJointConf>(joint);
+        }
 
-bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-    auto& bodyConstraintC = At(bodies, object.bodyC);
-    auto& bodyConstraintD = At(bodies, object.bodyD);
+        GearJointConf GetGearJointConf(const World& world, JointID id1, JointID id2, Real ratio)
+        {
+            auto def = GearJointConf{
+                /*body-A*/ GetBodyB(world, id1), /*body-B*/ GetBodyB(world, id2),
+                /*body-C*/ GetBodyA(world, id1), /*body-D*/ GetBodyA(world, id2)};
 
-    auto velA = bodyConstraintA.GetVelocity();
-    auto velB = bodyConstraintB.GetVelocity();
-    auto velC = bodyConstraintC.GetVelocity();
-    auto velD = bodyConstraintD.GetVelocity();
+            auto scalar1 = Real{0};
+            def.type1 = GetType(world, id1);
+            if (def.type1 == GetTypeID<RevoluteJointConf>())
+            {
+                def.referenceAngle1 = GetReferenceAngle(world, id1);
+                scalar1 = (GetAngle(world, def.bodyA) - GetAngle(world, def.bodyC) - def.referenceAngle1) / Radian;
+            }
+            else if (def.type1 == GetTypeID<PrismaticJointConf>())
+            {
+                const auto xfA = GetTransformation(world, def.bodyA);
+                const auto xfC = GetTransformation(world, def.bodyC);
+                def.localAnchorC = GetLocalAnchorA(world, id1);
+                def.localAnchorA = GetLocalAnchorB(world, id1);
+                def.localAxis1 = GetLocalXAxisA(world, id1);
+                const auto pC = def.localAnchorC;
+                const auto pA = InverseRotate(Rotate(def.localAnchorA, xfA.q) + (xfA.p - xfC.p), xfC.q);
+                scalar1 = Dot(pA - pC, def.localAxis1) / Meter;
+            }
+            else
+            {
+                throw InvalidArgument("GetGearJointConf not supported for joint 1 type");
+            }
 
-    const auto acDot = LinearVelocity{Dot(object.JvAC, velA.linear - velC.linear)};
-    const auto bdDot = LinearVelocity{Dot(object.JvBD, velB.linear - velD.linear)};
-    const auto Cdot = acDot + bdDot
-    + (object.JwA * velA.angular - object.JwC * velC.angular) / Radian
-    + (object.JwB * velB.angular - object.JwD * velD.angular) / Radian;
+            auto scalar2 = Real{0};
+            def.type2 = GetType(world, id2);
+            if (def.type2 == GetTypeID<RevoluteJointConf>())
+            {
+                def.referenceAngle2 = GetReferenceAngle(world, id2);
+                scalar2 = (GetAngle(world, def.bodyB) - GetAngle(world, def.bodyD) - def.referenceAngle1) / Radian;
+            }
+            else if (def.type2 == GetTypeID<PrismaticJointConf>())
+            {
+                const auto xfB = GetTransformation(world, def.bodyB);
+                const auto xfD = GetTransformation(world, def.bodyD);
+                def.localAnchorD = GetLocalAnchorA(world, id2);
+                def.localAnchorB = GetLocalAnchorB(world, id2);
+                def.localAxis2 = GetLocalXAxisA(world, id2);
+                const auto pD = def.localAnchorD;
+                const auto pB = InverseRotate(Rotate(def.localAnchorB, xfB.q) + (xfB.p - xfD.p), xfD.q);
+                scalar2 = Dot(pB - pD, def.localAxis2) / Meter;
+            }
+            else
+            {
+                throw InvalidArgument("GetGearJointConf not supported for joint 2 type");
+            }
 
-    const auto impulse = Momentum{-object.mass * Kilogram * Cdot};
-    object.impulse += impulse;
+            def.ratio = ratio;
+            def.constant = scalar1 + def.ratio * scalar2;
+            return def;
+        }
 
-    velA += Velocity{
-        (bodyConstraintA.GetInvMass() * impulse) * object.JvAC,
-        bodyConstraintA.GetInvRotInertia() * impulse * object.JwA / Radian
-    };
-    velB += Velocity{
-        (bodyConstraintB.GetInvMass() * impulse) * object.JvBD,
-        bodyConstraintB.GetInvRotInertia() * impulse * object.JwB / Radian
-    };
-    velC -= Velocity{
-        (bodyConstraintC.GetInvMass() * impulse) * object.JvAC,
-        bodyConstraintC.GetInvRotInertia() * impulse * object.JwC / Radian
-    };
-    velD -= Velocity{
-        (bodyConstraintD.GetInvMass() * impulse) * object.JvBD,
-        bodyConstraintD.GetInvRotInertia() * impulse * object.JwD / Radian
-    };
+        void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+            auto& bodyConstraintC = At(bodies, object.bodyC);
+            auto& bodyConstraintD = At(bodies, object.bodyD);
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-    bodyConstraintC.SetVelocity(velC);
-    bodyConstraintD.SetVelocity(velD);
+            auto velA = bodyConstraintA.GetVelocity();
+            const auto aA = bodyConstraintA.GetPosition().angular;
 
-    return impulse == 0_Ns;
-}
+            auto velB = bodyConstraintB.GetVelocity();
+            const auto aB = bodyConstraintB.GetPosition().angular;
 
-bool SolvePosition(const GearJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-    auto& bodyConstraintC = At(bodies, object.bodyC);
-    auto& bodyConstraintD = At(bodies, object.bodyD);
+            auto velC = bodyConstraintC.GetVelocity();
+            const auto aC = bodyConstraintC.GetPosition().angular;
 
-    auto posA = bodyConstraintA.GetPosition();
-    auto posB = bodyConstraintB.GetPosition();
-    auto posC = bodyConstraintC.GetPosition();
-    auto posD = bodyConstraintD.GetPosition();
+            auto velD = bodyConstraintD.GetVelocity();
+            const auto aD = bodyConstraintD.GetPosition().angular;
 
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-    const auto qC = UnitVec::Get(posC.angular);
-    const auto qD = UnitVec::Get(posD.angular);
+            const auto qA = UnitVec::Get(aA);
+            const auto qB = UnitVec::Get(aB);
+            const auto qC = UnitVec::Get(aC);
+            const auto qD = UnitVec::Get(aD);
 
-    const auto linearError = 0_m;
+            auto invMass = Real{0};// Unitless to double for either linear mass or angular mass.
 
-    Vec2 JvAC, JvBD;
-    Real JwA, JwB, JwC, JwD;
+            if (object.type1 == GetTypeID<RevoluteJointConf>())
+            {
+                object.JvAC = Vec2{};
+                object.JwA = 1_m;
+                object.JwC = 1_m;
+                const auto invAngMass = bodyConstraintA.GetInvRotInertia() + bodyConstraintC.GetInvRotInertia();
+                invMass += StripUnit(invAngMass);
+            }
+            else
+            {
+                const auto u = Rotate(object.localAxis1, qC);
+                const auto rC = Length2{Rotate(object.localAnchorC - bodyConstraintC.GetLocalCenter(), qC)};
+                const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
+                object.JvAC = Real{1} * u;
+                object.JwC = Cross(rC, u);
+                object.JwA = Cross(rA, u);
+                const auto invRotMassC = InvMass{bodyConstraintC.GetInvRotInertia() * Square(object.JwC) / SquareRadian};
+                const auto invRotMassA = InvMass{bodyConstraintA.GetInvRotInertia() * Square(object.JwA) / SquareRadian};
+                const auto invLinMass = InvMass{bodyConstraintC.GetInvMass() + bodyConstraintA.GetInvMass() + invRotMassC + invRotMassA};
+                invMass += StripUnit(invLinMass);
+            }
 
-    auto coordinateA = Real{0}; // Angle or length.
-    auto coordinateB = Real{0};
-    auto invMass = Real{0}; // Inverse linear mass or inverse angular mass.
+            if (object.type2 == GetTypeID<RevoluteJointConf>())
+            {
+                object.JvBD = Vec2{};
+                object.JwB = object.ratio * Meter;
+                object.JwD = object.ratio * Meter;
+                const auto invAngMass = InvRotInertia{Square(object.ratio) * (bodyConstraintB.GetInvRotInertia() + bodyConstraintD.GetInvRotInertia())};
+                invMass += StripUnit(invAngMass);
+            }
+            else
+            {
+                const auto u = Rotate(object.localAxis2, qD);
+                const auto rD = Rotate(object.localAnchorD - bodyConstraintD.GetLocalCenter(), qD);
+                const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+                object.JvBD = object.ratio * u;
+                object.JwD = object.ratio * Cross(rD, u);
+                object.JwB = object.ratio * Cross(rB, u);
+                const auto invRotMassD = InvMass{bodyConstraintD.GetInvRotInertia() * Square(object.JwD) / SquareRadian};
+                const auto invRotMassB = InvMass{bodyConstraintB.GetInvRotInertia() * Square(object.JwB) / SquareRadian};
+                const auto invLinMass = InvMass{
+                    Square(object.ratio) * (bodyConstraintD.GetInvMass() + bodyConstraintB.GetInvMass()) + invRotMassD + invRotMassB};
+                invMass += StripUnit(invLinMass);
+            }
 
-    if (object.type1 == GetTypeID<RevoluteJointConf>())
-    {
-        JvAC = Vec2{};
-        JwA = 1;
-        JwC = 1;
-        const auto invAngMass = bodyConstraintA.GetInvRotInertia() + bodyConstraintC.GetInvRotInertia();
-        invMass += StripUnit(invAngMass);
-        coordinateA = (posA.angular - posC.angular - object.referenceAngle1) / Radian;
-    }
-    else
-    {
-        const auto u = Rotate(object.localAxis1, qC);
-        const auto rC = Rotate(object.localAnchorC - bodyConstraintC.GetLocalCenter(), qC);
-        const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-        JvAC = u * Real{1};
-        JwC = StripUnit(Length{Cross(rC, u)});
-        JwA = StripUnit(Length{Cross(rA, u)});
-        const auto invLinMass = InvMass{bodyConstraintC.GetInvMass() + bodyConstraintA.GetInvMass()};
-        const auto invRotMassC = InvMass{bodyConstraintC.GetInvRotInertia() * Square(JwC * Meter / Radian)};
-        const auto invRotMassA = InvMass{bodyConstraintA.GetInvRotInertia() * Square(JwA * Meter / Radian)};
-        invMass += StripUnit(invLinMass + invRotMassC + invRotMassA);
-        const auto pC = object.localAnchorC - bodyConstraintC.GetLocalCenter();
-        const auto pA = InverseRotate(rA + (posA.linear - posC.linear), qC);
-        coordinateA = Dot(pA - pC, object.localAxis1) / Meter;
-    }
+            // Compute effective mass.
+            object.mass = (invMass > Real{0}) ? Real{1} / invMass : Real{0};
 
-    if (object.type2 == GetTypeID<RevoluteJointConf>())
-    {
-        JvBD = Vec2{};
-        JwB = object.ratio;
-        JwD = object.ratio;
-        const auto invAngMass = InvRotInertia{
-            Square(object.ratio) * (bodyConstraintB.GetInvRotInertia() + bodyConstraintD.GetInvRotInertia())
-        };
-        invMass += StripUnit(invAngMass);
-        coordinateB = (posB.angular - posD.angular - object.referenceAngle2) / Radian;
-    }
-    else
-    {
-        const auto u = Rotate(object.localAxis2, qD);
-        const auto rD = Rotate(object.localAnchorD - bodyConstraintD.GetLocalCenter(), qD);
-        const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-        JvBD = object.ratio * u;
-        JwD = object.ratio * StripUnit(Length{Cross(rD, u)});
-        JwB = object.ratio * StripUnit(Length{Cross(rB, u)});
-        const auto invLinMass = InvMass{Square(object.ratio) * (bodyConstraintD.GetInvMass() + bodyConstraintB.GetInvMass())};
-        const auto invRotMassD = InvMass{bodyConstraintD.GetInvRotInertia() * Square(JwD * Meter / Radian)};
-        const auto invRotMassB = InvMass{bodyConstraintB.GetInvRotInertia() * Square(JwB * Meter / Radian)};
-        invMass += StripUnit(invLinMass + invRotMassD + invRotMassB);
-        const auto pD = object.localAnchorD - bodyConstraintD.GetLocalCenter();
-        const auto pB = InverseRotate(rB + (posB.linear - posD.linear), qD);
-        coordinateB = Dot(pB - pD, object.localAxis2) / Meter;
-    }
+            if (step.doWarmStart)
+            {
+                velA += Velocity{
+                    (bodyConstraintA.GetInvMass() * object.impulse) * object.JvAC,
+                    bodyConstraintA.GetInvRotInertia() * object.impulse * object.JwA / Radian};
+                velB += Velocity{
+                    (bodyConstraintB.GetInvMass() * object.impulse) * object.JvBD,
+                    bodyConstraintB.GetInvRotInertia() * object.impulse * object.JwB / Radian};
+                velC -= Velocity{
+                    (bodyConstraintC.GetInvMass() * object.impulse) * object.JvAC,
+                    bodyConstraintC.GetInvRotInertia() * object.impulse * object.JwC / Radian};
+                velD -= Velocity{
+                    (bodyConstraintD.GetInvMass() * object.impulse) * object.JvBD,
+                    bodyConstraintD.GetInvRotInertia() * object.impulse * object.JwD / Radian};
+            }
+            else
+            {
+                object.impulse = 0_Ns;
+            }
 
-    const auto C = ((coordinateA + object.ratio * coordinateB) - object.constant);
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+            bodyConstraintC.SetVelocity(velC);
+            bodyConstraintD.SetVelocity(velD);
+        }
 
-    const auto impulse = ((invMass > 0)? -C / invMass: 0) * Kilogram * Meter;
+        bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+            auto& bodyConstraintC = At(bodies, object.bodyC);
+            auto& bodyConstraintD = At(bodies, object.bodyD);
 
-    posA += Position{
-        bodyConstraintA.GetInvMass() * impulse * JvAC,
-        bodyConstraintA.GetInvRotInertia() * impulse * JwA * Meter / Radian
-    };
-    posB += Position{
-        bodyConstraintB.GetInvMass() * impulse * JvBD,
-        bodyConstraintB.GetInvRotInertia() * impulse * JwB * Meter / Radian
-    };
-    posC -= Position{
-        bodyConstraintC.GetInvMass() * impulse * JvAC,
-        bodyConstraintC.GetInvRotInertia() * impulse * JwC * Meter / Radian
-    };
-    posD -= Position{
-        bodyConstraintD.GetInvMass() * impulse * JvBD,
-        bodyConstraintD.GetInvRotInertia() * impulse * JwD * Meter / Radian
-    };
+            auto velA = bodyConstraintA.GetVelocity();
+            auto velB = bodyConstraintB.GetVelocity();
+            auto velC = bodyConstraintC.GetVelocity();
+            auto velD = bodyConstraintD.GetVelocity();
 
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
-    bodyConstraintC.SetPosition(posC);
-    bodyConstraintD.SetPosition(posD);
+            const auto acDot = LinearVelocity{Dot(object.JvAC, velA.linear - velC.linear)};
+            const auto bdDot = LinearVelocity{Dot(object.JvBD, velB.linear - velD.linear)};
+            const auto Cdot = acDot + bdDot
+                              + (object.JwA * velA.angular - object.JwC * velC.angular) / Radian
+                              + (object.JwB * velB.angular - object.JwD * velD.angular) / Radian;
 
-    // TODO_ERIN not implemented
-    return linearError < conf.linearSlop;
-}
+            const auto impulse = Momentum{-object.mass * Kilogram * Cdot};
+            object.impulse += impulse;
 
-} // namespace d2
-} // namespace playrho
+            velA += Velocity{
+                (bodyConstraintA.GetInvMass() * impulse) * object.JvAC,
+                bodyConstraintA.GetInvRotInertia() * impulse * object.JwA / Radian};
+            velB += Velocity{
+                (bodyConstraintB.GetInvMass() * impulse) * object.JvBD,
+                bodyConstraintB.GetInvRotInertia() * impulse * object.JwB / Radian};
+            velC -= Velocity{
+                (bodyConstraintC.GetInvMass() * impulse) * object.JvAC,
+                bodyConstraintC.GetInvRotInertia() * impulse * object.JwC / Radian};
+            velD -= Velocity{
+                (bodyConstraintD.GetInvMass() * impulse) * object.JvBD,
+                bodyConstraintD.GetInvRotInertia() * impulse * object.JwD / Radian};
+
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+            bodyConstraintC.SetVelocity(velC);
+            bodyConstraintD.SetVelocity(velD);
+
+            return impulse == 0_Ns;
+        }
+
+        bool SolvePosition(const GearJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+            auto& bodyConstraintC = At(bodies, object.bodyC);
+            auto& bodyConstraintD = At(bodies, object.bodyD);
+
+            auto posA = bodyConstraintA.GetPosition();
+            auto posB = bodyConstraintB.GetPosition();
+            auto posC = bodyConstraintC.GetPosition();
+            auto posD = bodyConstraintD.GetPosition();
+
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+            const auto qC = UnitVec::Get(posC.angular);
+            const auto qD = UnitVec::Get(posD.angular);
+
+            const auto linearError = 0_m;
+
+            Vec2 JvAC, JvBD;
+            Real JwA, JwB, JwC, JwD;
+
+            auto coordinateA = Real{0};// Angle or length.
+            auto coordinateB = Real{0};
+            auto invMass = Real{0};// Inverse linear mass or inverse angular mass.
+
+            if (object.type1 == GetTypeID<RevoluteJointConf>())
+            {
+                JvAC = Vec2{};
+                JwA = 1;
+                JwC = 1;
+                const auto invAngMass = bodyConstraintA.GetInvRotInertia() + bodyConstraintC.GetInvRotInertia();
+                invMass += StripUnit(invAngMass);
+                coordinateA = (posA.angular - posC.angular - object.referenceAngle1) / Radian;
+            }
+            else
+            {
+                const auto u = Rotate(object.localAxis1, qC);
+                const auto rC = Rotate(object.localAnchorC - bodyConstraintC.GetLocalCenter(), qC);
+                const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+                JvAC = u * Real{1};
+                JwC = StripUnit(Length{Cross(rC, u)});
+                JwA = StripUnit(Length{Cross(rA, u)});
+                const auto invLinMass = InvMass{bodyConstraintC.GetInvMass() + bodyConstraintA.GetInvMass()};
+                const auto invRotMassC = InvMass{bodyConstraintC.GetInvRotInertia() * Square(JwC * Meter / Radian)};
+                const auto invRotMassA = InvMass{bodyConstraintA.GetInvRotInertia() * Square(JwA * Meter / Radian)};
+                invMass += StripUnit(invLinMass + invRotMassC + invRotMassA);
+                const auto pC = object.localAnchorC - bodyConstraintC.GetLocalCenter();
+                const auto pA = InverseRotate(rA + (posA.linear - posC.linear), qC);
+                coordinateA = Dot(pA - pC, object.localAxis1) / Meter;
+            }
+
+            if (object.type2 == GetTypeID<RevoluteJointConf>())
+            {
+                JvBD = Vec2{};
+                JwB = object.ratio;
+                JwD = object.ratio;
+                const auto invAngMass = InvRotInertia{
+                    Square(object.ratio) * (bodyConstraintB.GetInvRotInertia() + bodyConstraintD.GetInvRotInertia())};
+                invMass += StripUnit(invAngMass);
+                coordinateB = (posB.angular - posD.angular - object.referenceAngle2) / Radian;
+            }
+            else
+            {
+                const auto u = Rotate(object.localAxis2, qD);
+                const auto rD = Rotate(object.localAnchorD - bodyConstraintD.GetLocalCenter(), qD);
+                const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+                JvBD = object.ratio * u;
+                JwD = object.ratio * StripUnit(Length{Cross(rD, u)});
+                JwB = object.ratio * StripUnit(Length{Cross(rB, u)});
+                const auto invLinMass = InvMass{Square(object.ratio) * (bodyConstraintD.GetInvMass() + bodyConstraintB.GetInvMass())};
+                const auto invRotMassD = InvMass{bodyConstraintD.GetInvRotInertia() * Square(JwD * Meter / Radian)};
+                const auto invRotMassB = InvMass{bodyConstraintB.GetInvRotInertia() * Square(JwB * Meter / Radian)};
+                invMass += StripUnit(invLinMass + invRotMassD + invRotMassB);
+                const auto pD = object.localAnchorD - bodyConstraintD.GetLocalCenter();
+                const auto pB = InverseRotate(rB + (posB.linear - posD.linear), qD);
+                coordinateB = Dot(pB - pD, object.localAxis2) / Meter;
+            }
+
+            const auto C = ((coordinateA + object.ratio * coordinateB) - object.constant);
+
+            const auto impulse = ((invMass > 0) ? -C / invMass : 0) * Kilogram * Meter;
+
+            posA += Position{
+                bodyConstraintA.GetInvMass() * impulse * JvAC,
+                bodyConstraintA.GetInvRotInertia() * impulse * JwA * Meter / Radian};
+            posB += Position{
+                bodyConstraintB.GetInvMass() * impulse * JvBD,
+                bodyConstraintB.GetInvRotInertia() * impulse * JwB * Meter / Radian};
+            posC -= Position{
+                bodyConstraintC.GetInvMass() * impulse * JvAC,
+                bodyConstraintC.GetInvRotInertia() * impulse * JwC * Meter / Radian};
+            posD -= Position{
+                bodyConstraintD.GetInvMass() * impulse * JvBD,
+                bodyConstraintD.GetInvRotInertia() * impulse * JwD * Meter / Radian};
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+            bodyConstraintC.SetPosition(posC);
+            bodyConstraintD.SetPosition(posD);
+
+            // TODO_ERIN not implemented
+            return linearError < conf.linearSlop;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/GearJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/GearJointConf.hpp
@@ -27,185 +27,187 @@
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class Joint;
-class World;
-class BodyConstraint;
-
-/// @brief Gear joint definition.
-/// @details A gear joint is used to connect two joints together. Either joint can be
-///   a revolute or prismatic joint. You specify a gear ratio to bind the motions together:
-///      <code>coordinate1 + ratio * coordinate2 = constant</code>.
-///   The ratio can be negative or positive. If one joint is a revolute joint and the other
-///   joint is a prismatic joint, then the ratio will have units of length or units of 1/length.
-/// @warning You have to manually destroy the gear joint if joint-1 or joint-2 is destroyed.
-/// @see Joint, World::CreateJoint
-/// @ingroup JointsGroup
-/// @image html gearJoint.gif
-struct GearJointConf : public JointBuilder<GearJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<GearJointConf>;
 
-    /// @brief Default constructor.
-    constexpr GearJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Initializing constructor.
-    GearJointConf(BodyID bA, BodyID bB, BodyID bC, BodyID bD) noexcept;
-
-    /// @brief Uses the given ratio value.
-    constexpr auto& UseRatio(Real v) noexcept
+    namespace d2
     {
-        ratio = v;
-        return *this;
-    }
 
-    /// @brief Identifier of body C.
-    BodyID bodyC = InvalidBodyID;
+        class Joint;
+        class World;
+        class BodyConstraint;
 
-    /// @brief Identifier of body D.
-    BodyID bodyD = InvalidBodyID;
+        /// @brief Gear joint definition.
+        /// @details A gear joint is used to connect two joints together. Either joint can be
+        ///   a revolute or prismatic joint. You specify a gear ratio to bind the motions together:
+        ///      <code>coordinate1 + ratio * coordinate2 = constant</code>.
+        ///   The ratio can be negative or positive. If one joint is a revolute joint and the other
+        ///   joint is a prismatic joint, then the ratio will have units of length or units of 1/length.
+        /// @warning You have to manually destroy the gear joint if joint-1 or joint-2 is destroyed.
+        /// @see Joint, World::CreateJoint
+        /// @ingroup JointsGroup
+        /// @image html gearJoint.gif
+        struct GearJointConf : public JointBuilder<GearJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<GearJointConf>;
 
-    /// @brief Type of the first joint.
-    JointType type1 = GetTypeID<void>();
+            /// @brief Default constructor.
+            constexpr GearJointConf() = default;
 
-    /// @brief Type of the second joint.
-    JointType type2 = GetTypeID<void>();
+            /// @brief Initializing constructor.
+            GearJointConf(BodyID bA, BodyID bB, BodyID bC, BodyID bD) noexcept;
 
-    // Used when not Revolute...
-    Length2 localAnchorA{}; ///< Local anchor A.
-    Length2 localAnchorB{}; ///< Local anchor B.
-    Length2 localAnchorC{}; ///< Local anchor C.
-    Length2 localAnchorD{}; ///< Local anchor D.
-    
-    UnitVec localAxis1; ///< Local axis 1. Used when type1 is not Revolute.
-    UnitVec localAxis2; ///< Local axis 2. Used when type2 is not Revolute.
+            /// @brief Uses the given ratio value.
+            constexpr auto& UseRatio(Real v) noexcept
+            {
+                ratio = v;
+                return *this;
+            }
 
-    Angle referenceAngle1 = 0_deg; ///< Reference angle of joint 1. Used when type1 is Revolute.
-    Angle referenceAngle2 = 0_deg; ///< Reference angle of joint 2. Used when type2 is Revolute.
+            /// @brief Identifier of body C.
+            BodyID bodyC = InvalidBodyID;
 
-    /// The gear ratio.
-    /// @see constant, GearJoint.
-    Real ratio = Real{1};
+            /// @brief Identifier of body D.
+            BodyID bodyD = InvalidBodyID;
 
-    /// @brief Constant applied with the ratio.
-    /// @see ratio.
-    Real constant = Real{0};
+            /// @brief Type of the first joint.
+            JointType type1 = GetTypeID<void>();
 
-    Momentum impulse = 0_Ns; ///< Impulse.
+            /// @brief Type of the second joint.
+            JointType type2 = GetTypeID<void>();
 
-    // Solver temp
-    Vec2 JvAC = Vec2{}; ///< <code>AC Jv</code> data.
-    Vec2 JvBD = {}; ///< <code>BD Jv</code> data.
-    Length JwA = 0_m; ///< A <code>Jw</code> data.
-    Length JwB = 0_m; ///< B <code>Jw</code> data.
-    Length JwC = 0_m; ///< C <code>Jw</code> data.
-    Length JwD = 0_m; ///< D <code>Jw</code> data.
-    Real mass = 0; ///< Either linear mass or angular mass.
-};
+            // Used when not Revolute...
+            Length2 localAnchorA{};///< Local anchor A.
+            Length2 localAnchorB{};///< Local anchor B.
+            Length2 localAnchorC{};///< Local anchor C.
+            Length2 localAnchorD{};///< Local anchor D.
 
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-GearJointConf GetGearJointConf(const Joint& joint) noexcept;
+            UnitVec localAxis1;///< Local axis 1. Used when type1 is not Revolute.
+            UnitVec localAxis2;///< Local axis 2. Used when type2 is not Revolute.
 
-/// @brief Gets the configuration for the given parameters.
-/// @relatedalso World
-GearJointConf GetGearJointConf(const World& world, JointID id1, JointID id2, Real ratio = Real{1});
+            Angle referenceAngle1 = 0_deg;///< Reference angle of joint 1. Used when type1 is Revolute.
+            Angle referenceAngle2 = 0_deg;///< Reference angle of joint 2. Used when type2 is Revolute.
 
-/// @brief Gets the current linear reaction for the given configuration.
-/// @relatedalso GearJointConf
-constexpr Momentum2 GetLinearReaction(const GearJointConf& object)
-{
-    return object.impulse * object.JvAC;
-}
+            /// The gear ratio.
+            /// @see constant, GearJoint.
+            Real ratio = Real{1};
 
-/// @brief Gets the current angular reaction for the given configuration.
-/// @relatedalso GearJointConf
-constexpr AngularMomentum GetAngularReaction(const GearJointConf& object)
-{
-    return object.impulse * object.JwA / Radian;
-}
+            /// @brief Constant applied with the ratio.
+            /// @see ratio.
+            Real constant = Real{0};
 
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso GearJointConf
-constexpr bool ShiftOrigin(GearJointConf&, Length2) noexcept
-{
-    return false;
-}
+            Momentum impulse = 0_Ns;///< Impulse.
 
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso GearJointConf
-void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
+            // Solver temp
+            Vec2 JvAC = Vec2{};///< <code>AC Jv</code> data.
+            Vec2 JvBD = {};    ///< <code>BD Jv</code> data.
+            Length JwA = 0_m;  ///< A <code>Jw</code> data.
+            Length JwB = 0_m;  ///< B <code>Jw</code> data.
+            Length JwC = 0_m;  ///< C <code>Jw</code> data.
+            Length JwD = 0_m;  ///< D <code>Jw</code> data.
+            Real mass = 0;     ///< Either linear mass or angular mass.
+        };
 
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso GearJointConf
-bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        GearJointConf GetGearJointConf(const Joint& joint) noexcept;
 
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso GearJointConf
-bool SolvePosition(const GearJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
+        /// @brief Gets the configuration for the given parameters.
+        /// @relatedalso World
+        GearJointConf GetGearJointConf(const World& world, JointID id1, JointID id2, Real ratio = Real{1});
 
-/// @brief Free function for getting the ratio value of the given configuration.
-/// @relatedalso GearJointConf
-constexpr auto GetRatio(const GearJointConf& object) noexcept
-{
-    return object.ratio;
-}
+        /// @brief Gets the current linear reaction for the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr Momentum2 GetLinearReaction(const GearJointConf& object)
+        {
+            return object.impulse * object.JvAC;
+        }
 
-/// @brief Free function for setting the ratio value of the given configuration.
-/// @relatedalso GearJointConf
-constexpr auto SetRatio(GearJointConf& object, Real value) noexcept
-{
-    object.UseRatio(value);
-}
+        /// @brief Gets the current angular reaction for the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr AngularMomentum GetAngularReaction(const GearJointConf& object)
+        {
+            return object.impulse * object.JwA / Radian;
+        }
 
-/// @brief Free function for getting the constant value of the given configuration.
-/// @relatedalso GearJointConf
-constexpr auto GetConstant(const GearJointConf& object) noexcept
-{
-    return object.constant;
-}
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr bool ShiftOrigin(GearJointConf&, Length2) noexcept
+        {
+            return false;
+        }
 
-/// @brief Free function for getting joint 1 type value of the given configuration.
-/// @relatedalso GearJointConf
-constexpr auto GetType1(const GearJointConf& object) noexcept
-{
-    return object.type1;
-}
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso GearJointConf
+        void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
 
-/// @brief Free function for getting joint 2 type value of the given configuration.
-/// @relatedalso GearJointConf
-constexpr auto GetType2(const GearJointConf& object) noexcept
-{
-    return object.type2;
-}
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso GearJointConf
+        bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
 
-} // namespace d2
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso GearJointConf
+        bool SolvePosition(const GearJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
 
-/// @brief Type info specialization for <code>d2::GearJointConf</code>.
-template <>
-struct TypeInfo<d2::GearJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::GearJointConf";
-};
+        /// @brief Free function for getting the ratio value of the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr auto GetRatio(const GearJointConf& object) noexcept
+        {
+            return object.ratio;
+        }
 
-} // namespace playrho
+        /// @brief Free function for setting the ratio value of the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr auto SetRatio(GearJointConf& object, Real value) noexcept
+        {
+            object.UseRatio(value);
+        }
 
-#endif // PLAYRHO_DYNAMICS_JOINTS_GEARJOINTCONF_HPP
+        /// @brief Free function for getting the constant value of the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr auto GetConstant(const GearJointConf& object) noexcept
+        {
+            return object.constant;
+        }
+
+        /// @brief Free function for getting joint 1 type value of the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr auto GetType1(const GearJointConf& object) noexcept
+        {
+            return object.type1;
+        }
+
+        /// @brief Free function for getting joint 2 type value of the given configuration.
+        /// @relatedalso GearJointConf
+        constexpr auto GetType2(const GearJointConf& object) noexcept
+        {
+            return object.type2;
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::GearJointConf</code>.
+    template<>
+    struct TypeInfo<d2::GearJointConf>
+    {
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::GearJointConf";
+    };
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_JOINTS_GEARJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/Joint.cpp
+++ b/PlayRho/Dynamics/Joints/Joint.cpp
@@ -41,648 +41,764 @@
 
 #include <algorithm>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_nothrow_default_constructible<Joint>::value,
-              "Joint must be nothrow default constructible!");
-static_assert(std::is_copy_constructible<Joint>::value,
-              "Joint must be copy constructible!");
-static_assert(std::is_nothrow_move_constructible<Joint>::value,
-              "Joint must be nothrow move constructible!");
-static_assert(std::is_copy_assignable<Joint>::value,
-              "Joint must be copy assignable!");
-static_assert(std::is_nothrow_move_assignable<Joint>::value,
-              "Joint must be nothrow move assignable!");
-static_assert(std::is_nothrow_destructible<Joint>::value,
-              "Joint must be nothrow destructible!");
-
-// Free functions...
-
-BodyConstraint& At(std::vector<BodyConstraint>& container, BodyID key)
+namespace playrho
 {
-    return container.at(UnderlyingValue(key));
-}
+    namespace d2
+    {
 
-Length2 GetLocalAnchorA(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        return GetLocalAnchorA(TypeCast<DistanceJointConf>(object));
-    }
-    if (type == GetTypeID<FrictionJointConf>()) {
-        return GetLocalAnchorA(TypeCast<FrictionJointConf>(object));
-    }
-    if (type == GetTypeID<GearJointConf>()) {
-        return GetLocalAnchorA(TypeCast<GearJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLocalAnchorA(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<PulleyJointConf>()) {
-        return GetLocalAnchorA(TypeCast<PulleyJointConf>(object));
-    }
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetLocalAnchorA(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<RopeJointConf>()) {
-        return GetLocalAnchorA(TypeCast<RopeJointConf>(object));
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        return GetLocalAnchorA(TypeCast<WeldJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetLocalAnchorA(TypeCast<WheelJointConf>(object));
-    }
-    // TODO: consider if throwing invalid_argument more appropriate.
-    return Length2{};
-}
+        static_assert(std::is_nothrow_default_constructible<Joint>::value,
+                      "Joint must be nothrow default constructible!");
+        static_assert(std::is_copy_constructible<Joint>::value,
+                      "Joint must be copy constructible!");
+        static_assert(std::is_nothrow_move_constructible<Joint>::value,
+                      "Joint must be nothrow move constructible!");
+        static_assert(std::is_copy_assignable<Joint>::value,
+                      "Joint must be copy assignable!");
+        static_assert(std::is_nothrow_move_assignable<Joint>::value,
+                      "Joint must be nothrow move assignable!");
+        static_assert(std::is_nothrow_destructible<Joint>::value,
+                      "Joint must be nothrow destructible!");
 
-Length2 GetLocalAnchorB(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        return GetLocalAnchorB(TypeCast<DistanceJointConf>(object));
-    }
-    if (type == GetTypeID<FrictionJointConf>()) {
-        return GetLocalAnchorB(TypeCast<FrictionJointConf>(object));
-    }
-    if (type == GetTypeID<GearJointConf>()) {
-        return GetLocalAnchorB(TypeCast<GearJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLocalAnchorB(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<PulleyJointConf>()) {
-        return GetLocalAnchorB(TypeCast<PulleyJointConf>(object));
-    }
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetLocalAnchorB(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<RopeJointConf>()) {
-        return GetLocalAnchorB(TypeCast<RopeJointConf>(object));
-    }
-    if (type == GetTypeID<TargetJointConf>()) {
-        return GetLocalAnchorB(TypeCast<TargetJointConf>(object));
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        return GetLocalAnchorB(TypeCast<WeldJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetLocalAnchorB(TypeCast<WheelJointConf>(object));
-    }
-    // TODO: consider if throwing invalid_argument more appropriate.
-    return Length2{};
-}
+        // Free functions...
 
-Momentum2 GetLinearReaction(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        return GetLinearReaction(TypeCast<DistanceJointConf>(object));
-    }
-    if (type == GetTypeID<FrictionJointConf>()) {
-        return GetLinearReaction(TypeCast<FrictionJointConf>(object));
-    }
-    if (type == GetTypeID<GearJointConf>()) {
-        return GetLinearReaction(TypeCast<GearJointConf>(object));
-    }
-    if (type == GetTypeID<MotorJointConf>()) {
-        return GetLinearReaction(TypeCast<MotorJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLinearReaction(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<PulleyJointConf>()) {
-        return GetLinearReaction(TypeCast<PulleyJointConf>(object));
-    }
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetLinearReaction(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<RopeJointConf>()) {
-        return GetLinearReaction(TypeCast<RopeJointConf>(object));
-    }
-    if (type == GetTypeID<TargetJointConf>()) {
-        return GetLinearReaction(TypeCast<TargetJointConf>(object));
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        return GetLinearReaction(TypeCast<WeldJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetLinearReaction(TypeCast<WheelJointConf>(object));
-    }
-    // TODO: consider if throwing invalid_argument more appropriate.
-    // throw std::invalid_argument("GetLinearReaction not supported by joint type");
-    return {};
-}
+        BodyConstraint& At(std::vector<BodyConstraint>& container, BodyID key)
+        {
+            return container.at(UnderlyingValue(key));
+        }
 
-AngularMomentum GetAngularReaction(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        return GetAngularReaction(TypeCast<DistanceJointConf>(object));
-    }
-    if (type == GetTypeID<FrictionJointConf>()) {
-        return GetAngularReaction(TypeCast<FrictionJointConf>(object));
-    }
-    if (type == GetTypeID<GearJointConf>()) {
-        return GetAngularReaction(TypeCast<GearJointConf>(object));
-    }
-    if (type == GetTypeID<MotorJointConf>()) {
-        return GetAngularReaction(TypeCast<MotorJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetAngularReaction(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<PulleyJointConf>()) {
-        return GetAngularReaction(TypeCast<PulleyJointConf>(object));
-    }
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetAngularReaction(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<RopeJointConf>()) {
-        return GetAngularReaction(TypeCast<RopeJointConf>(object));
-    }
-    if (type == GetTypeID<TargetJointConf>()) {
-        return GetAngularReaction(TypeCast<TargetJointConf>(object));
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        return GetAngularReaction(TypeCast<WeldJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetAngularReaction(TypeCast<WheelJointConf>(object));
-    }
-    // TODO: consider if throwing invalid_argument more appropriate.
-    // throw std::invalid_argument("GetAngularReaction not supported by joint type");
-    return {};
-}
+        Length2 GetLocalAnchorA(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<DistanceJointConf>(object));
+            }
+            if (type == GetTypeID<FrictionJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<FrictionJointConf>(object));
+            }
+            if (type == GetTypeID<GearJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<GearJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<PulleyJointConf>(object));
+            }
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<RopeJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<RopeJointConf>(object));
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<WeldJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetLocalAnchorA(TypeCast<WheelJointConf>(object));
+            }
+            // TODO: consider if throwing invalid_argument more appropriate.
+            return Length2{};
+        }
 
-Angle GetReferenceAngle(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetReferenceAngle(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetReferenceAngle(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        return GetReferenceAngle(TypeCast<WeldJointConf>(object));
-    }
-    throw std::invalid_argument("GetReferenceAngle not supported by joint type");
-}
+        Length2 GetLocalAnchorB(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<DistanceJointConf>(object));
+            }
+            if (type == GetTypeID<FrictionJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<FrictionJointConf>(object));
+            }
+            if (type == GetTypeID<GearJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<GearJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<PulleyJointConf>(object));
+            }
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<RopeJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<RopeJointConf>(object));
+            }
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<TargetJointConf>(object));
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<WeldJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetLocalAnchorB(TypeCast<WheelJointConf>(object));
+            }
+            // TODO: consider if throwing invalid_argument more appropriate.
+            return Length2{};
+        }
 
-UnitVec GetLocalXAxisA(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetLocalXAxisA(TypeCast<WheelJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLocalXAxisA(TypeCast<PrismaticJointConf>(object));
-    }
-    throw std::invalid_argument("GetLocalXAxisA not supported by joint type");
-}
+        Momentum2 GetLinearReaction(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                return GetLinearReaction(TypeCast<DistanceJointConf>(object));
+            }
+            if (type == GetTypeID<FrictionJointConf>())
+            {
+                return GetLinearReaction(TypeCast<FrictionJointConf>(object));
+            }
+            if (type == GetTypeID<GearJointConf>())
+            {
+                return GetLinearReaction(TypeCast<GearJointConf>(object));
+            }
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                return GetLinearReaction(TypeCast<MotorJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLinearReaction(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                return GetLinearReaction(TypeCast<PulleyJointConf>(object));
+            }
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetLinearReaction(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<RopeJointConf>())
+            {
+                return GetLinearReaction(TypeCast<RopeJointConf>(object));
+            }
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                return GetLinearReaction(TypeCast<TargetJointConf>(object));
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                return GetLinearReaction(TypeCast<WeldJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetLinearReaction(TypeCast<WheelJointConf>(object));
+            }
+            // TODO: consider if throwing invalid_argument more appropriate.
+            // throw std::invalid_argument("GetLinearReaction not supported by joint type");
+            return {};
+        }
 
-UnitVec GetLocalYAxisA(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetLocalYAxisA(TypeCast<WheelJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLocalYAxisA(TypeCast<PrismaticJointConf>(object));
-    }
-    throw std::invalid_argument("GetLocalYAxisA not supported by joint type");
-}
+        AngularMomentum GetAngularReaction(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                return GetAngularReaction(TypeCast<DistanceJointConf>(object));
+            }
+            if (type == GetTypeID<FrictionJointConf>())
+            {
+                return GetAngularReaction(TypeCast<FrictionJointConf>(object));
+            }
+            if (type == GetTypeID<GearJointConf>())
+            {
+                return GetAngularReaction(TypeCast<GearJointConf>(object));
+            }
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                return GetAngularReaction(TypeCast<MotorJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetAngularReaction(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                return GetAngularReaction(TypeCast<PulleyJointConf>(object));
+            }
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetAngularReaction(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<RopeJointConf>())
+            {
+                return GetAngularReaction(TypeCast<RopeJointConf>(object));
+            }
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                return GetAngularReaction(TypeCast<TargetJointConf>(object));
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                return GetAngularReaction(TypeCast<WeldJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetAngularReaction(TypeCast<WheelJointConf>(object));
+            }
+            // TODO: consider if throwing invalid_argument more appropriate.
+            // throw std::invalid_argument("GetAngularReaction not supported by joint type");
+            return {};
+        }
 
-AngularVelocity GetMotorSpeed(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetMotorSpeed(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetMotorSpeed(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetMotorSpeed(TypeCast<WheelJointConf>(object));
-    }
-    throw std::invalid_argument("GetMotorSpeed not supported by joint type");
-}
+        Angle GetReferenceAngle(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetReferenceAngle(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetReferenceAngle(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                return GetReferenceAngle(TypeCast<WeldJointConf>(object));
+            }
+            throw std::invalid_argument("GetReferenceAngle not supported by joint type");
+        }
 
-void SetMotorSpeed(Joint& object, AngularVelocity value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        object = TypeCast<RevoluteJointConf>(object).UseMotorSpeed(value);
-        return;
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        object = TypeCast<PrismaticJointConf>(object).UseMotorSpeed(value);
-        return;
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        object = TypeCast<WheelJointConf>(object).UseMotorSpeed(value);
-        return;
-    }
-    throw std::invalid_argument("SetMotorSpeed not supported by joint type!");
-}
+        UnitVec GetLocalXAxisA(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetLocalXAxisA(TypeCast<WheelJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLocalXAxisA(TypeCast<PrismaticJointConf>(object));
+            }
+            throw std::invalid_argument("GetLocalXAxisA not supported by joint type");
+        }
 
-RotInertia GetAngularMass(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<FrictionJointConf>()) {
-        return GetAngularMass(TypeCast<FrictionJointConf>(object));
-    }
-    if (type == GetTypeID<MotorJointConf>()) {
-        return GetAngularMass(TypeCast<MotorJointConf>(object));
-    }
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetAngularMass(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetAngularMass(TypeCast<WheelJointConf>(object));
-    }
-    throw std::invalid_argument("GetAngularMass not supported by joint type");
-}
+        UnitVec GetLocalYAxisA(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetLocalYAxisA(TypeCast<WheelJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLocalYAxisA(TypeCast<PrismaticJointConf>(object));
+            }
+            throw std::invalid_argument("GetLocalYAxisA not supported by joint type");
+        }
 
-Force GetMaxForce(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<FrictionJointConf>()) {
-        return TypeCast<FrictionJointConf>(object).maxForce;
-    }
-    if (type == GetTypeID<MotorJointConf>()) {
-        return TypeCast<MotorJointConf>(object).maxForce;
-    }
-    if (type == GetTypeID<TargetJointConf>()) {
-        return TypeCast<TargetJointConf>(object).maxForce;
-    }
-    throw std::invalid_argument("GetMaxForce not supported by joint type");
-}
+        AngularVelocity GetMotorSpeed(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetMotorSpeed(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetMotorSpeed(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetMotorSpeed(TypeCast<WheelJointConf>(object));
+            }
+            throw std::invalid_argument("GetMotorSpeed not supported by joint type");
+        }
 
-Torque GetMaxTorque(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<FrictionJointConf>()) {
-        return GetMaxTorque(TypeCast<FrictionJointConf>(object));
-    }
-    if (type == GetTypeID<MotorJointConf>()) {
-        return GetMaxTorque(TypeCast<MotorJointConf>(object));
-    }
-    throw std::invalid_argument("GetMaxTorque not supported by joint type");
-}
+        void SetMotorSpeed(Joint& object, AngularVelocity value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                object = TypeCast<RevoluteJointConf>(object).UseMotorSpeed(value);
+                return;
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                object = TypeCast<PrismaticJointConf>(object).UseMotorSpeed(value);
+                return;
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                object = TypeCast<WheelJointConf>(object).UseMotorSpeed(value);
+                return;
+            }
+            throw std::invalid_argument("SetMotorSpeed not supported by joint type!");
+        }
 
-Force GetMaxMotorForce(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetMaxMotorForce(TypeCast<PrismaticJointConf>(object));
-    }
-    throw std::invalid_argument("GetMaxMotorForce not supported by joint type");
-}
+        RotInertia GetAngularMass(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<FrictionJointConf>())
+            {
+                return GetAngularMass(TypeCast<FrictionJointConf>(object));
+            }
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                return GetAngularMass(TypeCast<MotorJointConf>(object));
+            }
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetAngularMass(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetAngularMass(TypeCast<WheelJointConf>(object));
+            }
+            throw std::invalid_argument("GetAngularMass not supported by joint type");
+        }
 
-void SetMaxMotorForce(Joint& object, Force value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        object = TypeCast<PrismaticJointConf>(object).UseMaxMotorForce(value);
-        return;
-    }
-    throw std::invalid_argument("SetMaxMotorForce not supported by joint type!");
-}
+        Force GetMaxForce(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<FrictionJointConf>())
+            {
+                return TypeCast<FrictionJointConf>(object).maxForce;
+            }
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                return TypeCast<MotorJointConf>(object).maxForce;
+            }
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                return TypeCast<TargetJointConf>(object).maxForce;
+            }
+            throw std::invalid_argument("GetMaxForce not supported by joint type");
+        }
 
-Torque GetMaxMotorTorque(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetMaxMotorTorque(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetMaxMotorTorque(TypeCast<WheelJointConf>(object));
-    }
-    throw std::invalid_argument("GetMaxMotorTorque not supported by joint type");
-}
+        Torque GetMaxTorque(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<FrictionJointConf>())
+            {
+                return GetMaxTorque(TypeCast<FrictionJointConf>(object));
+            }
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                return GetMaxTorque(TypeCast<MotorJointConf>(object));
+            }
+            throw std::invalid_argument("GetMaxTorque not supported by joint type");
+        }
 
-void SetMaxMotorTorque(Joint& object, Torque value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        object = TypeCast<RevoluteJointConf>(object).UseMaxMotorTorque(value);
-        return;
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        object = TypeCast<WheelJointConf>(object).UseMaxMotorTorque(value);
-        return;
-    }
-    throw std::invalid_argument("SetMaxMotorTorque not supported by joint type!");
-}
+        Force GetMaxMotorForce(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetMaxMotorForce(TypeCast<PrismaticJointConf>(object));
+            }
+            throw std::invalid_argument("GetMaxMotorForce not supported by joint type");
+        }
 
-Real GetRatio(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<GearJointConf>()) {
-        return GetRatio(TypeCast<GearJointConf>(object));
-    }
-    if (type == GetTypeID<PulleyJointConf>()) {
-        return GetRatio(TypeCast<PulleyJointConf>(object));
-    }
-    throw std::invalid_argument("GetRatio not supported by joint type!");
-}
+        void SetMaxMotorForce(Joint& object, Force value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                object = TypeCast<PrismaticJointConf>(object).UseMaxMotorForce(value);
+                return;
+            }
+            throw std::invalid_argument("SetMaxMotorForce not supported by joint type!");
+        }
 
-Real GetDampingRatio(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        return GetDampingRatio(TypeCast<DistanceJointConf>(object));
-    }
-    if (type == GetTypeID<TargetJointConf>()) {
-        return GetDampingRatio(TypeCast<TargetJointConf>(object));
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        return GetDampingRatio(TypeCast<WeldJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetDampingRatio(TypeCast<WheelJointConf>(object));
-    }
-    throw std::invalid_argument("GetRatio not supported by joint type!");
-}
+        Torque GetMaxMotorTorque(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetMaxMotorTorque(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetMaxMotorTorque(TypeCast<WheelJointConf>(object));
+            }
+            throw std::invalid_argument("GetMaxMotorTorque not supported by joint type");
+        }
 
-Frequency GetFrequency(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        return GetFrequency(TypeCast<DistanceJointConf>(object));
-    }
-    if (type == GetTypeID<TargetJointConf>()) {
-        return GetFrequency(TypeCast<TargetJointConf>(object));
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        return GetFrequency(TypeCast<WeldJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetFrequency(TypeCast<WheelJointConf>(object));
-    }
-    throw std::invalid_argument("GetFrequency not supported by joint type");
-}
+        void SetMaxMotorTorque(Joint& object, Torque value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                object = TypeCast<RevoluteJointConf>(object).UseMaxMotorTorque(value);
+                return;
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                object = TypeCast<WheelJointConf>(object).UseMaxMotorTorque(value);
+                return;
+            }
+            throw std::invalid_argument("SetMaxMotorTorque not supported by joint type!");
+        }
 
-void SetFrequency(Joint& object, Frequency value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        object = TypeCast<DistanceJointConf>(object).UseFrequency(value);
-        return;
-    }
-    if (type == GetTypeID<TargetJointConf>()) {
-        object = TypeCast<TargetJointConf>(object).UseFrequency(value);
-        return;
-    }
-    if (type == GetTypeID<WeldJointConf>()) {
-        object = TypeCast<WeldJointConf>(object).UseFrequency(value);
-        return;
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        object = TypeCast<WheelJointConf>(object).UseFrequency(value);
-        return;
-    }
-    throw std::invalid_argument("SetFrequency not supported by joint type!");
-}
+        Real GetRatio(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<GearJointConf>())
+            {
+                return GetRatio(TypeCast<GearJointConf>(object));
+            }
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                return GetRatio(TypeCast<PulleyJointConf>(object));
+            }
+            throw std::invalid_argument("GetRatio not supported by joint type!");
+        }
 
-AngularMomentum GetAngularMotorImpulse(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetAngularMotorImpulse(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return GetAngularReaction(TypeCast<WheelJointConf>(object));
-    }
-    throw std::invalid_argument("GetAngularMotorImpulse not supported by joint type");
-}
+        Real GetDampingRatio(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                return GetDampingRatio(TypeCast<DistanceJointConf>(object));
+            }
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                return GetDampingRatio(TypeCast<TargetJointConf>(object));
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                return GetDampingRatio(TypeCast<WeldJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetDampingRatio(TypeCast<WheelJointConf>(object));
+            }
+            throw std::invalid_argument("GetRatio not supported by joint type!");
+        }
 
-Length2 GetTarget(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<TargetJointConf>()) {
-        return GetTarget(TypeCast<TargetJointConf>(object));
-    }
-    throw std::invalid_argument("GetTarget not supported by joint type");
-}
+        Frequency GetFrequency(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                return GetFrequency(TypeCast<DistanceJointConf>(object));
+            }
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                return GetFrequency(TypeCast<TargetJointConf>(object));
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                return GetFrequency(TypeCast<WeldJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetFrequency(TypeCast<WheelJointConf>(object));
+            }
+            throw std::invalid_argument("GetFrequency not supported by joint type");
+        }
 
-void SetTarget(Joint& object, Length2 value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<TargetJointConf>()) {
-        object = TypeCast<TargetJointConf>(object).UseTarget(value);
-        return;
-    }
-    throw std::invalid_argument("SetTarget not supported by joint type");
-}
+        void SetFrequency(Joint& object, Frequency value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                object = TypeCast<DistanceJointConf>(object).UseFrequency(value);
+                return;
+            }
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                object = TypeCast<TargetJointConf>(object).UseFrequency(value);
+                return;
+            }
+            if (type == GetTypeID<WeldJointConf>())
+            {
+                object = TypeCast<WeldJointConf>(object).UseFrequency(value);
+                return;
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                object = TypeCast<WheelJointConf>(object).UseFrequency(value);
+                return;
+            }
+            throw std::invalid_argument("SetFrequency not supported by joint type!");
+        }
 
-Length GetLinearLowerLimit(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLinearLowerLimit(TypeCast<PrismaticJointConf>(object));
-    }
-    throw std::invalid_argument("GetLinearLowerLimit not supported by joint type!");
-}
+        AngularMomentum GetAngularMotorImpulse(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetAngularMotorImpulse(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return GetAngularReaction(TypeCast<WheelJointConf>(object));
+            }
+            throw std::invalid_argument("GetAngularMotorImpulse not supported by joint type");
+        }
 
-Length GetLinearUpperLimit(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLinearUpperLimit(TypeCast<PrismaticJointConf>(object));
-    }
-    throw std::invalid_argument("GetLinearUpperLimit not supported by joint type!");
-}
+        Length2 GetTarget(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                return GetTarget(TypeCast<TargetJointConf>(object));
+            }
+            throw std::invalid_argument("GetTarget not supported by joint type");
+        }
 
-void SetLinearLimits(Joint& object, Length lower, Length upper)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        object = TypeCast<PrismaticJointConf>(object).UseLowerLength(lower).UseUpperLength(upper);
-        return;
-    }
-    throw std::invalid_argument("SetLinearLimits not supported by joint type!");
-}
+        void SetTarget(Joint& object, Length2 value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<TargetJointConf>())
+            {
+                object = TypeCast<TargetJointConf>(object).UseTarget(value);
+                return;
+            }
+            throw std::invalid_argument("SetTarget not supported by joint type");
+        }
 
-Angle GetAngularLowerLimit(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetAngularLowerLimit(TypeCast<RevoluteJointConf>(object));
-    }
-    throw std::invalid_argument("GetAngularLowerLimit not supported by joint type!");
-}
+        Length GetLinearLowerLimit(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLinearLowerLimit(TypeCast<PrismaticJointConf>(object));
+            }
+            throw std::invalid_argument("GetLinearLowerLimit not supported by joint type!");
+        }
 
-Angle GetAngularUpperLimit(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetAngularUpperLimit(TypeCast<RevoluteJointConf>(object));
-    }
-    throw std::invalid_argument("GetAngularUpperLimit not supported by joint type!");
-}
+        Length GetLinearUpperLimit(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLinearUpperLimit(TypeCast<PrismaticJointConf>(object));
+            }
+            throw std::invalid_argument("GetLinearUpperLimit not supported by joint type!");
+        }
 
-void SetAngularLimits(Joint& object, Angle lower, Angle upper)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        object = TypeCast<RevoluteJointConf>(object).UseLowerAngle(lower).UseUpperAngle(upper);
-        return;
-    }
-    throw std::invalid_argument("SetAngularLimits not supported by joint type!");
-}
+        void SetLinearLimits(Joint& object, Length lower, Length upper)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                object = TypeCast<PrismaticJointConf>(object).UseLowerLength(lower).UseUpperLength(upper);
+                return;
+            }
+            throw std::invalid_argument("SetLinearLimits not supported by joint type!");
+        }
 
-bool IsLimitEnabled(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return IsLimitEnabled(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return IsLimitEnabled(TypeCast<PrismaticJointConf>(object));
-    }
-    throw std::invalid_argument("IsLimitEnabled not supported by joint type!");
-}
+        Angle GetAngularLowerLimit(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetAngularLowerLimit(TypeCast<RevoluteJointConf>(object));
+            }
+            throw std::invalid_argument("GetAngularLowerLimit not supported by joint type!");
+        }
 
-void EnableLimit(Joint& object, bool value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        object = TypeCast<RevoluteJointConf>(object).UseEnableLimit(value);
-        return;
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        object = TypeCast<PrismaticJointConf>(object).UseEnableLimit(value);
-        return;
-    }
-    throw std::invalid_argument("EnableLimit not supported by joint type!");
-}
+        Angle GetAngularUpperLimit(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetAngularUpperLimit(TypeCast<RevoluteJointConf>(object));
+            }
+            throw std::invalid_argument("GetAngularUpperLimit not supported by joint type!");
+        }
 
-bool IsMotorEnabled(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return IsMotorEnabled(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return IsMotorEnabled(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        return IsMotorEnabled(TypeCast<WheelJointConf>(object));
-    }
-    throw std::invalid_argument("IsMotorEnabled not supported by joint type!");
-}
+        void SetAngularLimits(Joint& object, Angle lower, Angle upper)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                object = TypeCast<RevoluteJointConf>(object).UseLowerAngle(lower).UseUpperAngle(upper);
+                return;
+            }
+            throw std::invalid_argument("SetAngularLimits not supported by joint type!");
+        }
 
-void EnableMotor(Joint& object, bool value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        object = TypeCast<RevoluteJointConf>(object).UseEnableMotor(value);
-        return;
-    }
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        object = TypeCast<PrismaticJointConf>(object).UseEnableMotor(value);
-        return;
-    }
-    if (type == GetTypeID<WheelJointConf>()) {
-        object = TypeCast<WheelJointConf>(object).UseEnableMotor(value);
-        return;
-    }
-    throw std::invalid_argument("EnableMotor not supported by joint type!");
-}
+        bool IsLimitEnabled(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return IsLimitEnabled(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return IsLimitEnabled(TypeCast<PrismaticJointConf>(object));
+            }
+            throw std::invalid_argument("IsLimitEnabled not supported by joint type!");
+        }
 
-Length2 GetLinearOffset(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<MotorJointConf>()) {
-        return GetLinearOffset(TypeCast<MotorJointConf>(object));
-    }
-    throw std::invalid_argument("GetLinearOffset not supported by joint type!");
-}
+        void EnableLimit(Joint& object, bool value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                object = TypeCast<RevoluteJointConf>(object).UseEnableLimit(value);
+                return;
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                object = TypeCast<PrismaticJointConf>(object).UseEnableLimit(value);
+                return;
+            }
+            throw std::invalid_argument("EnableLimit not supported by joint type!");
+        }
 
-void SetLinearOffset(Joint& object, Length2 value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<MotorJointConf>()) {
-        object = TypeCast<MotorJointConf>(object).UseLinearOffset(value);
-        return;
-    }
-    throw std::invalid_argument("SetLinearOffset not supported by joint type!");
-}
+        bool IsMotorEnabled(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return IsMotorEnabled(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return IsMotorEnabled(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                return IsMotorEnabled(TypeCast<WheelJointConf>(object));
+            }
+            throw std::invalid_argument("IsMotorEnabled not supported by joint type!");
+        }
 
-Angle GetAngularOffset(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<MotorJointConf>()) {
-        return GetAngularOffset(TypeCast<MotorJointConf>(object));
-    }
-    throw std::invalid_argument("GetAngularOffset not supported by joint type!");
-}
+        void EnableMotor(Joint& object, bool value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                object = TypeCast<RevoluteJointConf>(object).UseEnableMotor(value);
+                return;
+            }
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                object = TypeCast<PrismaticJointConf>(object).UseEnableMotor(value);
+                return;
+            }
+            if (type == GetTypeID<WheelJointConf>())
+            {
+                object = TypeCast<WheelJointConf>(object).UseEnableMotor(value);
+                return;
+            }
+            throw std::invalid_argument("EnableMotor not supported by joint type!");
+        }
 
-void SetAngularOffset(Joint& object, Angle value)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<MotorJointConf>()) {
-        object = TypeCast<MotorJointConf>(object).UseAngularOffset(value);
-        return;
-    }
-    throw std::invalid_argument("SetAngularOffset not supported by joint type!");
-}
+        Length2 GetLinearOffset(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                return GetLinearOffset(TypeCast<MotorJointConf>(object));
+            }
+            throw std::invalid_argument("GetLinearOffset not supported by joint type!");
+        }
 
-LimitState GetLimitState(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLimitState(TypeCast<PrismaticJointConf>(object));
-    }
-    if (type == GetTypeID<RevoluteJointConf>()) {
-        return GetLimitState(TypeCast<RevoluteJointConf>(object));
-    }
-    if (type == GetTypeID<RopeJointConf>()) {
-        return GetLimitState(TypeCast<RopeJointConf>(object));
-    }
-    throw std::invalid_argument("GetLimitState not supported by joint type!");
-}
+        void SetLinearOffset(Joint& object, Length2 value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                object = TypeCast<MotorJointConf>(object).UseLinearOffset(value);
+                return;
+            }
+            throw std::invalid_argument("SetLinearOffset not supported by joint type!");
+        }
 
-Length2 GetGroundAnchorA(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PulleyJointConf>()) {
-        return GetGroundAnchorA(TypeCast<PulleyJointConf>(object));
-    }
-    throw std::invalid_argument("GetGroundAnchorA not supported by joint type!");
-}
+        Angle GetAngularOffset(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                return GetAngularOffset(TypeCast<MotorJointConf>(object));
+            }
+            throw std::invalid_argument("GetAngularOffset not supported by joint type!");
+        }
 
-Length2 GetGroundAnchorB(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PulleyJointConf>()) {
-        return GetGroundAnchorB(TypeCast<PulleyJointConf>(object));
-    }
-    throw std::invalid_argument("GetGroundAnchorB not supported by joint type!");
-}
+        void SetAngularOffset(Joint& object, Angle value)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<MotorJointConf>())
+            {
+                object = TypeCast<MotorJointConf>(object).UseAngularOffset(value);
+                return;
+            }
+            throw std::invalid_argument("SetAngularOffset not supported by joint type!");
+        }
 
-Momentum GetLinearMotorImpulse(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<PrismaticJointConf>()) {
-        return GetLinearMotorImpulse(TypeCast<PrismaticJointConf>(object));
-    }
-    throw std::invalid_argument("GetLinearMotorImpulse not supported by joint type!");
-}
+        LimitState GetLimitState(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLimitState(TypeCast<PrismaticJointConf>(object));
+            }
+            if (type == GetTypeID<RevoluteJointConf>())
+            {
+                return GetLimitState(TypeCast<RevoluteJointConf>(object));
+            }
+            if (type == GetTypeID<RopeJointConf>())
+            {
+                return GetLimitState(TypeCast<RopeJointConf>(object));
+            }
+            throw std::invalid_argument("GetLimitState not supported by joint type!");
+        }
 
-Length GetLength(const Joint& object)
-{
-    const auto type = GetType(object);
-    if (type == GetTypeID<DistanceJointConf>()) {
-        return GetLength(TypeCast<DistanceJointConf>(object));
-    }
-    throw std::invalid_argument("GetLength not supported by joint type!");
-}
+        Length2 GetGroundAnchorA(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                return GetGroundAnchorA(TypeCast<PulleyJointConf>(object));
+            }
+            throw std::invalid_argument("GetGroundAnchorA not supported by joint type!");
+        }
 
-} // namespace d2
-} // namespace playrho
+        Length2 GetGroundAnchorB(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PulleyJointConf>())
+            {
+                return GetGroundAnchorB(TypeCast<PulleyJointConf>(object));
+            }
+            throw std::invalid_argument("GetGroundAnchorB not supported by joint type!");
+        }
+
+        Momentum GetLinearMotorImpulse(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<PrismaticJointConf>())
+            {
+                return GetLinearMotorImpulse(TypeCast<PrismaticJointConf>(object));
+            }
+            throw std::invalid_argument("GetLinearMotorImpulse not supported by joint type!");
+        }
+
+        Length GetLength(const Joint& object)
+        {
+            const auto type = GetType(object);
+            if (type == GetTypeID<DistanceJointConf>())
+            {
+                return GetLength(TypeCast<DistanceJointConf>(object));
+            }
+            throw std::invalid_argument("GetLength not supported by joint type!");
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -24,548 +24,555 @@
 
 #include <PlayRho/Common/Math.hpp>
 
+#include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/Joints/JointType.hpp>
 #include <PlayRho/Dynamics/Joints/LimitState.hpp>
-#include <PlayRho/Dynamics/BodyID.hpp>
 
-#include <memory> // for std::unique_ptr
-#include <vector>
+#include <memory>   // for std::unique_ptr
+#include <stdexcept>// for std::bad_cast
 #include <utility>
-#include <stdexcept> // for std::bad_cast
+#include <vector>
 
-namespace playrho {
-
-struct StepConf;
-struct ConstraintSolverConf;
-
-namespace d2 {
-
-class Joint;
-class BodyConstraint;
-
-/// @brief Gets the identifier of the type of data this can be casted to.
-JointType GetType(const Joint& object) noexcept;
-
-/// @brief Gets the first body attached to this joint.
-BodyID GetBodyA(const Joint& object) noexcept;
-
-/// @brief Gets the second body attached to this joint.
-BodyID GetBodyB(const Joint& object) noexcept;
-
-/// @brief Gets collide connected.
-/// @note Modifying the collide connect flag won't work correctly because
-///   the flag is only checked when fixture AABBs begin to overlap.
-bool GetCollideConnected(const Joint& object) noexcept;
-
-/// @brief Shifts the origin for any points stored in world coordinates.
-/// @return <code>true</code> if shift done, <code>false</code> otherwise.
-bool ShiftOrigin(Joint& object, Length2 value) noexcept;
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-void InitVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-bool SolveVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-bool SolvePosition(const Joint& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @defgroup JointsGroup Joint Classes
-/// @brief The user creatable classes that specify constraints on one or more body instances.
-/// @ingroup ConstraintsGroup
-
-/// @brief Joint class.
-/// @details Joints are constraints that are used to constrain one or more bodies in various
-///   fashions. Some joints also feature limits and motors.
-/// @ingroup JointsGroup
-/// @ingroup PhysicalEntities
-class Joint
+namespace playrho
 {
-public:
-    /// @brief Body constraints map type alias.
-    using BodyConstraintsMap = std::vector<BodyConstraint>;
 
-    /// @brief Default constructor.
-    Joint() noexcept = default;
+    struct StepConf;
+    struct ConstraintSolverConf;
 
-    /// @brief Initializing constructor.
-    template <typename T>
-    Joint(T arg): m_self{std::make_unique<Model<T>>(std::move(arg))}
+    namespace d2
     {
-        // Intentionally empty.
-    }
 
-    /// @brief Copy constructor.
-    Joint(const Joint& other): m_self{other.m_self? other.m_self->Clone_(): nullptr}
-    {
-        // Intentionally empty.
-    }
+        class Joint;
+        class BodyConstraint;
 
-    /// @brief Move constructor.
-    Joint(Joint&& other) noexcept: m_self{std::move(other.m_self)}
-    {
-        // Intentionally empty.
-    }
+        /// @brief Gets the identifier of the type of data this can be casted to.
+        JointType GetType(const Joint& object) noexcept;
 
-    /// @brief Copy assignment.
-    Joint& operator= (const Joint& other)
-    {
-        m_self = other.m_self? other.m_self->Clone_(): nullptr;
-        return *this;
-    }
+        /// @brief Gets the first body attached to this joint.
+        BodyID GetBodyA(const Joint& object) noexcept;
 
-    /// @brief Move assignment.
-    Joint& operator= (Joint&& other) noexcept
-    {
-        m_self = std::move(other.m_self);
-        return *this;
-    }
+        /// @brief Gets the second body attached to this joint.
+        BodyID GetBodyB(const Joint& object) noexcept;
 
-    /// @brief Move assignment support for any valid underlying configuration.
-    template <typename T, typename Tp = std::decay_t<T>,
-        typename = std::enable_if_t<
-            !std::is_same<Tp, Joint>::value && std::is_copy_constructible<Tp>::value
-        >
-    >
-    Joint& operator= (T&& other) noexcept
-    {
-        Joint(std::forward<T>(other)).swap(*this);
-        return *this;
-    }
+        /// @brief Gets collide connected.
+        /// @note Modifying the collide connect flag won't work correctly because
+        ///   the flag is only checked when fixture AABBs begin to overlap.
+        bool GetCollideConnected(const Joint& object) noexcept;
 
-    /// @brief Swap function.
-    void swap(Joint& other) noexcept
-    {
-        std::swap(m_self, other.m_self);
-    }
+        /// @brief Shifts the origin for any points stored in world coordinates.
+        /// @return <code>true</code> if shift done, <code>false</code> otherwise.
+        bool ShiftOrigin(Joint& object, Length2 value) noexcept;
 
-    friend JointType GetType(const Joint& object) noexcept
-    {
-        return object.m_self? object.m_self->GetType_(): GetTypeID<void>();
-    }
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        void InitVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
 
-    /// @brief Converts the given joint into its current configuration value.
-    /// @note The design for this was based off the design of the C++17 <code>std::any</code>
-    ///   class and its associated <code>std::any_cast</code> function.
-    template <typename T>
-    friend auto TypeCast(const Joint* value) noexcept
-    {
-        if (!value || (GetType(*value) != GetTypeID<std::remove_pointer_t<T>>())) {
-            return static_cast<T>(nullptr);
-        }
-        return static_cast<T>(value->m_self->GetData_());
-    }
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        bool SolveVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
 
-    friend BodyID GetBodyA(const Joint& object) noexcept
-    {
-        return object.m_self? object.m_self->GetBodyA_(): InvalidBodyID;
-    }
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        bool SolvePosition(const Joint& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
 
-    friend BodyID GetBodyB(const Joint& object) noexcept
-    {
-        return object.m_self? object.m_self->GetBodyB_(): InvalidBodyID;
-    }
+        /// @defgroup JointsGroup Joint Classes
+        /// @brief The user creatable classes that specify constraints on one or more body instances.
+        /// @ingroup ConstraintsGroup
 
-    friend bool GetCollideConnected(const Joint& object) noexcept
-    {
-        return object.m_self? object.m_self->GetCollideConnected_(): false;
-    }
+        /// @brief Joint class.
+        /// @details Joints are constraints that are used to constrain one or more bodies in various
+        ///   fashions. Some joints also feature limits and motors.
+        /// @ingroup JointsGroup
+        /// @ingroup PhysicalEntities
+        class Joint
+        {
+         public:
+            /// @brief Body constraints map type alias.
+            using BodyConstraintsMap = std::vector<BodyConstraint>;
 
-    friend bool ShiftOrigin(Joint& object, Length2 value) noexcept
-    {
-        return object.m_self? object.m_self->ShiftOrigin_(value): false;
-    }
+            /// @brief Default constructor.
+            Joint() noexcept = default;
 
-    friend void InitVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
-                             const playrho::StepConf& step,
-                             const ConstraintSolverConf& conf)
-    {
-        if (object.m_self) object.m_self->InitVelocity_(bodies, step, conf);
-    }
+            /// @brief Initializing constructor.
+            template<typename T>
+            Joint(T arg)
+                : m_self{std::make_unique<Model<T>>(std::move(arg))}
+            {
+                // Intentionally empty.
+            }
 
-    friend bool SolveVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
-                              const playrho::StepConf& step)
-    {
-        return object.m_self? object.m_self->SolveVelocity_(bodies, step): false;
-    }
+            /// @brief Copy constructor.
+            Joint(const Joint& other)
+                : m_self{other.m_self ? other.m_self->Clone_() : nullptr}
+            {
+                // Intentionally empty.
+            }
 
-    friend bool SolvePosition(const Joint& object, std::vector<BodyConstraint>& bodies,
-                              const ConstraintSolverConf& conf)
-    {
-        return object.m_self? object.m_self->SolvePosition_(bodies, conf): false;
-    }
+            /// @brief Move constructor.
+            Joint(Joint&& other) noexcept
+                : m_self{std::move(other.m_self)}
+            {
+                // Intentionally empty.
+            }
 
-private:
-    /// @brief Internal configuration concept.
-    /// @note Provides the interface for runtime value polymorphism.
-    struct Concept
-    {
-        /// @brief Explicitly declared virtual destructor.
-        virtual ~Concept() = default;
+            /// @brief Copy assignment.
+            Joint& operator=(const Joint& other)
+            {
+                m_self = other.m_self ? other.m_self->Clone_() : nullptr;
+                return *this;
+            }
 
-        /// @brief Clones this concept and returns a pointer to a mutable copy.
-        /// @note This may throw <code>std::bad_alloc</code> or any exception that's thrown
-        ///   by the constructor for the model's underlying data type.
-        /// @throws std::bad_alloc if there's a failure allocating storage.
-        virtual std::unique_ptr<Concept> Clone_() const = 0;
+            /// @brief Move assignment.
+            Joint& operator=(Joint&& other) noexcept
+            {
+                m_self = std::move(other.m_self);
+                return *this;
+            }
 
-        /// @brief Gets the use type information.
-        /// @return Type info of the underlying value's type.
-        virtual TypeID GetType_() const noexcept = 0;
+            /// @brief Move assignment support for any valid underlying configuration.
+            template<typename T, typename Tp = std::decay_t<T>,
+                     typename = std::enable_if_t<
+                         !std::is_same<Tp, Joint>::value && std::is_copy_constructible<Tp>::value>>
+            Joint& operator=(T&& other) noexcept
+            {
+                Joint(std::forward<T>(other)).swap(*this);
+                return *this;
+            }
 
-        /// @brief Gets the data for the underlying configuration.
-        virtual const void* GetData_() const noexcept = 0;
+            /// @brief Swap function.
+            void swap(Joint& other) noexcept
+            {
+                std::swap(m_self, other.m_self);
+            }
 
-        /// @brief Gets the ID of body-A.
-        virtual BodyID GetBodyA_() const noexcept = 0;
+            friend JointType GetType(const Joint& object) noexcept
+            {
+                return object.m_self ? object.m_self->GetType_() : GetTypeID<void>();
+            }
 
-        /// @brief Gets the ID of body-B.
-        virtual BodyID GetBodyB_() const noexcept = 0;
+            /// @brief Converts the given joint into its current configuration value.
+            /// @note The design for this was based off the design of the C++17 <code>std::any</code>
+            ///   class and its associated <code>std::any_cast</code> function.
+            template<typename T>
+            friend auto TypeCast(const Joint* value) noexcept
+            {
+                if (!value || (GetType(*value) != GetTypeID<std::remove_pointer_t<T>>()))
+                {
+                    return static_cast<T>(nullptr);
+                }
+                return static_cast<T>(value->m_self->GetData_());
+            }
 
-        /// @brief Gets whether collision handling should be done for connected bodies.
-        virtual bool GetCollideConnected_() const noexcept = 0;
+            friend BodyID GetBodyA(const Joint& object) noexcept
+            {
+                return object.m_self ? object.m_self->GetBodyA_() : InvalidBodyID;
+            }
 
-        /// @brief Call to notify joint of a shift in the world origin.
-        virtual bool ShiftOrigin_(Length2 value) noexcept = 0;
+            friend BodyID GetBodyB(const Joint& object) noexcept
+            {
+                return object.m_self ? object.m_self->GetBodyB_() : InvalidBodyID;
+            }
 
-        /// @brief Initializes the velocities for this joint.
-        virtual void InitVelocity_(BodyConstraintsMap& bodies,
+            friend bool GetCollideConnected(const Joint& object) noexcept
+            {
+                return object.m_self ? object.m_self->GetCollideConnected_() : false;
+            }
+
+            friend bool ShiftOrigin(Joint& object, Length2 value) noexcept
+            {
+                return object.m_self ? object.m_self->ShiftOrigin_(value) : false;
+            }
+
+            friend void InitVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
+                                     const playrho::StepConf& step,
+                                     const ConstraintSolverConf& conf)
+            {
+                if (object.m_self) object.m_self->InitVelocity_(bodies, step, conf);
+            }
+
+            friend bool SolveVelocity(Joint& object, std::vector<BodyConstraint>& bodies,
+                                      const playrho::StepConf& step)
+            {
+                return object.m_self ? object.m_self->SolveVelocity_(bodies, step) : false;
+            }
+
+            friend bool SolvePosition(const Joint& object, std::vector<BodyConstraint>& bodies,
+                                      const ConstraintSolverConf& conf)
+            {
+                return object.m_self ? object.m_self->SolvePosition_(bodies, conf) : false;
+            }
+
+         private:
+            /// @brief Internal configuration concept.
+            /// @note Provides the interface for runtime value polymorphism.
+            struct Concept
+            {
+                /// @brief Explicitly declared virtual destructor.
+                virtual ~Concept() = default;
+
+                /// @brief Clones this concept and returns a pointer to a mutable copy.
+                /// @note This may throw <code>std::bad_alloc</code> or any exception that's thrown
+                ///   by the constructor for the model's underlying data type.
+                /// @throws std::bad_alloc if there's a failure allocating storage.
+                virtual std::unique_ptr<Concept> Clone_() const = 0;
+
+                /// @brief Gets the use type information.
+                /// @return Type info of the underlying value's type.
+                virtual TypeID GetType_() const noexcept = 0;
+
+                /// @brief Gets the data for the underlying configuration.
+                virtual const void* GetData_() const noexcept = 0;
+
+                /// @brief Gets the ID of body-A.
+                virtual BodyID GetBodyA_() const noexcept = 0;
+
+                /// @brief Gets the ID of body-B.
+                virtual BodyID GetBodyB_() const noexcept = 0;
+
+                /// @brief Gets whether collision handling should be done for connected bodies.
+                virtual bool GetCollideConnected_() const noexcept = 0;
+
+                /// @brief Call to notify joint of a shift in the world origin.
+                virtual bool ShiftOrigin_(Length2 value) noexcept = 0;
+
+                /// @brief Initializes the velocities for this joint.
+                virtual void InitVelocity_(BodyConstraintsMap& bodies,
+                                           const playrho::StepConf& step,
+                                           const ConstraintSolverConf& conf) = 0;
+
+                /// @brief Solves the velocities for this joint.
+                virtual bool SolveVelocity_(BodyConstraintsMap& bodies,
+                                            const playrho::StepConf& step) = 0;
+
+                /// @brief Solves the positions for this joint.
+                virtual bool SolvePosition_(BodyConstraintsMap& bodies,
+                                            const ConstraintSolverConf& conf) const = 0;
+            };
+
+            /// @brief Internal model configuration concept.
+            /// @note Provides the implementation for runtime value polymorphism.
+            template<typename T>
+            struct Model final : Concept
+            {
+                /// @brief Type alias for the type of the data held.
+                using data_type = T;
+
+                /// @brief Initializing constructor.
+                Model(T arg)
+                    : data{std::move(arg)}
+                {
+                }
+
+                /// @copydoc Concept::Clone_
+                std::unique_ptr<Concept> Clone_() const override
+                {
+                    return std::make_unique<Model>(data);
+                }
+
+                /// @copydoc Concept::GetType_
+                TypeID GetType_() const noexcept override
+                {
+                    return GetTypeID<data_type>();
+                }
+
+                /// @copydoc Concept::GetData_
+                const void* GetData_() const noexcept override
+                {
+                    // Note address of "data" not necessarily same as address of "this" since
+                    // base class is virtual.
+                    return &data;
+                }
+
+                /// @copydoc Concept::GetBodyA_
+                BodyID GetBodyA_() const noexcept override
+                {
+                    return GetBodyA(data);
+                }
+
+                /// @copydoc Concept::GetBodyB_
+                BodyID GetBodyB_() const noexcept override
+                {
+                    return GetBodyB(data);
+                }
+
+                /// @copydoc Concept::GetCollideConnected_
+                bool GetCollideConnected_() const noexcept override
+                {
+                    return GetCollideConnected(data);
+                }
+
+                /// @copydoc Concept::ShiftOrigin_
+                bool ShiftOrigin_(Length2 value) noexcept override
+                {
+                    return ShiftOrigin(data, value);
+                }
+
+                /// @copydoc Concept::InitVelocity_
+                void InitVelocity_(BodyConstraintsMap& bodies,
                                    const playrho::StepConf& step,
-                                   const ConstraintSolverConf& conf) = 0;
+                                   const ConstraintSolverConf& conf) override
+                {
+                    InitVelocity(data, bodies, step, conf);
+                }
 
-        /// @brief Solves the velocities for this joint.
-        virtual bool SolveVelocity_(BodyConstraintsMap& bodies,
-                                    const playrho::StepConf& step) = 0;
+                /// @copydoc Concept::SolveVelocity_
+                bool SolveVelocity_(BodyConstraintsMap& bodies,
+                                    const playrho::StepConf& step) override
+                {
+                    return SolveVelocity(data, bodies, step);
+                }
 
-        /// @brief Solves the positions for this joint.
-        virtual bool SolvePosition_(BodyConstraintsMap& bodies,
-                                    const ConstraintSolverConf& conf) const = 0;
-    };
+                /// @copydoc Concept::SolvePosition_
+                bool SolvePosition_(BodyConstraintsMap& bodies,
+                                    const ConstraintSolverConf& conf) const override
+                {
+                    return SolvePosition(data, bodies, conf);
+                }
 
-    /// @brief Internal model configuration concept.
-    /// @note Provides the implementation for runtime value polymorphism.
-    template <typename T>
-    struct Model final: Concept
-    {
-        /// @brief Type alias for the type of the data held.
-        using data_type = T;
+                data_type data;///< Data.
+            };
 
-        /// @brief Initializing constructor.
-        Model(T arg): data{std::move(arg)} {}
+            std::unique_ptr<Concept> m_self;///< Self pointer.
+        };
 
-        /// @copydoc Concept::Clone_
-        std::unique_ptr<Concept> Clone_() const override
+        // Free functions...
+
+        /// @brief Provides referenced access to the identified element of the given container.
+        BodyConstraint& At(std::vector<BodyConstraint>& container, BodyID key);
+
+        /// @brief Converts the given joint into its current configuration value.
+        /// @note The design for this was based off the design of the C++17 <code>std::any</code>
+        ///   type and its associated <code>std::any_cast</code> function.
+        /// @throws std::bad_cast If the given template parameter type isn't the type of this
+        ///   joint's configuration value.
+        /// @relatedalso Joint
+        template<typename T>
+        inline auto TypeCast(const Joint& value)
         {
-            return std::make_unique<Model>(data);
+            auto tmp = TypeCast<std::add_pointer_t<std::add_const_t<T>>>(&value);
+            if (tmp == nullptr)
+                throw std::bad_cast();
+            return *tmp;
         }
 
-        /// @copydoc Concept::GetType_
-        TypeID GetType_() const noexcept override
+        /// Get the anchor point on body-A in local coordinates.
+        /// @relatedalso Joint
+        Length2 GetLocalAnchorA(const Joint& object);
+
+        /// Get the anchor point on body-B in local coordinates.
+        /// @relatedalso Joint
+        Length2 GetLocalAnchorB(const Joint& object);
+
+        /// Get the linear reaction on body-B at the joint anchor.
+        /// @relatedalso Joint
+        Momentum2 GetLinearReaction(const Joint& object);
+
+        /// Get the angular reaction on body-B.
+        /// @relatedalso Joint
+        AngularMomentum GetAngularReaction(const Joint& object);
+
+        /// @brief Gets the reference angle of the joint if it has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Angle GetReferenceAngle(const Joint& object);
+
+        /// @brief Gets the given joint's local X axis A if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        UnitVec GetLocalXAxisA(const Joint& object);
+
+        /// @brief Gets the given joint's local Y axis A if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        UnitVec GetLocalYAxisA(const Joint& object);
+
+        /// @brief Gets the given joint's motor speed if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        AngularVelocity GetMotorSpeed(const Joint& object);
+
+        /// @brief Sets the given joint's motor speed if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetMotorSpeed(Joint& object, AngularVelocity value);
+
+        /// @brief Gets the given joint's max force if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Force GetMaxForce(const Joint& object);
+
+        /// @brief Gets the given joint's max torque if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Torque GetMaxTorque(const Joint& object);
+
+        /// @brief Gets the given joint's max motor force if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Force GetMaxMotorForce(const Joint& object);
+
+        /// @brief Sets the given joint's max motor force if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetMaxMotorForce(Joint& object, Force value);
+
+        /// @brief Gets the given joint's max motor torque if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Torque GetMaxMotorTorque(const Joint& object);
+
+        /// @brief Sets the given joint's max motor torque if its type supports that.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetMaxMotorTorque(Joint& object, Torque value);
+
+        /// @brief Gets the given joint's angular mass.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        RotInertia GetAngularMass(const Joint& object);
+
+        /// @brief Gets the given joint's ratio property if it has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Real GetRatio(const Joint& object);
+
+        /// @brief Gets the given joint's damping ratio property if it has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Real GetDampingRatio(const Joint& object);
+
+        /// @brief Gets the frequency of the joint if it has this property.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Frequency GetFrequency(const Joint& object);
+
+        /// @brief Sets the frequency of the joint if it has this property.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetFrequency(Joint& object, Frequency value);
+
+        /// @brief Gets the angular motor impulse of the joint if it has this property.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        AngularMomentum GetAngularMotorImpulse(const Joint& object);
+
+        /// @brief Gets the given joint's target property if it has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Length2 GetTarget(const Joint& object);
+
+        /// @brief Sets the given joint's target property if it has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetTarget(Joint& object, Length2 value);
+
+        /// Gets the lower linear joint limit.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Length GetLinearLowerLimit(const Joint& object);
+
+        /// Gets the upper linear joint limit.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Length GetLinearUpperLimit(const Joint& object);
+
+        /// Sets the joint limits.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetLinearLimits(Joint& object, Length lower, Length upper);
+
+        /// Gets the lower joint limit.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Angle GetAngularLowerLimit(const Joint& object);
+
+        /// @brief Gets the upper joint limit.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Angle GetAngularUpperLimit(const Joint& object);
+
+        /// @brief Sets the joint limits.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetAngularLimits(Joint& object, Angle lower, Angle upper);
+
+        /// @brief Gets the specified joint's limit property if it supports one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        bool IsLimitEnabled(const Joint& object);
+
+        /// @brief Enables the specified joint's limit property if it supports one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void EnableLimit(Joint& object, bool value);
+
+        /// @brief Gets the specified joint's motor property value if it supports one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        bool IsMotorEnabled(const Joint& object);
+
+        /// @brief Enables the specified joint's motor property if it supports one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void EnableMotor(Joint& object, bool value);
+
+        /// @brief Gets the linear offset property of the specified joint if its type has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Length2 GetLinearOffset(const Joint& object);
+
+        /// @brief Sets the linear offset property of the specified joint if its type has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetLinearOffset(Joint& object, Length2 value);
+
+        /// @brief Gets the angular offset property of the specified joint if its type has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Angle GetAngularOffset(const Joint& object);
+
+        /// @brief Sets the angular offset property of the specified joint if its type has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        void SetAngularOffset(Joint& object, Angle value);
+
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        LimitState GetLimitState(const Joint& object);
+
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Length2 GetGroundAnchorA(const Joint& object);
+
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Length2 GetGroundAnchorB(const Joint& object);
+
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Momentum GetLinearMotorImpulse(const Joint& object);
+
+        /// @brief Gets the length property of the specified joint if its type has one.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        Length GetLength(const Joint& object);
+
+        /// @brief Gets the current motor torque for the given joint given the inverse time step.
+        /// @throws std::invalid_argument If not supported for the given joint's type.
+        /// @relatedalso Joint
+        inline Torque GetMotorTorque(const Joint& joint, Frequency inv_dt)
         {
-            return GetTypeID<data_type>();
+            return GetAngularMotorImpulse(joint) * inv_dt;
         }
 
-        /// @copydoc Concept::GetData_
-        const void* GetData_() const noexcept override
-        {
-            // Note address of "data" not necessarily same as address of "this" since
-            // base class is virtual.
-            return &data;
-        }
+    }// namespace d2
+}// namespace playrho
 
-        /// @copydoc Concept::GetBodyA_
-        BodyID GetBodyA_() const noexcept override
-        {
-            return GetBodyA(data);
-        }
-
-        /// @copydoc Concept::GetBodyB_
-        BodyID GetBodyB_() const noexcept override
-        {
-            return GetBodyB(data);
-        }
-
-        /// @copydoc Concept::GetCollideConnected_
-        bool GetCollideConnected_() const noexcept override
-        {
-            return GetCollideConnected(data);
-        }
-
-        /// @copydoc Concept::ShiftOrigin_
-        bool ShiftOrigin_(Length2 value) noexcept override
-        {
-            return ShiftOrigin(data, value);
-        }
-
-        /// @copydoc Concept::InitVelocity_
-        void InitVelocity_(BodyConstraintsMap& bodies,
-                           const playrho::StepConf& step,
-                           const ConstraintSolverConf& conf) override
-        {
-            InitVelocity(data, bodies, step, conf);
-        }
-
-        /// @copydoc Concept::SolveVelocity_
-        bool SolveVelocity_(BodyConstraintsMap& bodies,
-                            const playrho::StepConf& step) override
-        {
-            return SolveVelocity(data, bodies, step);
-        }
-
-        /// @copydoc Concept::SolvePosition_
-        bool SolvePosition_(BodyConstraintsMap& bodies,
-                            const ConstraintSolverConf& conf) const override
-        {
-            return SolvePosition(data, bodies, conf);
-        }
-
-        data_type data; ///< Data.
-    };
-
-    std::unique_ptr<Concept> m_self; ///< Self pointer.
-};
-
-// Free functions...
-
-/// @brief Provides referenced access to the identified element of the given container.
-BodyConstraint& At(std::vector<BodyConstraint>& container, BodyID key);
-
-/// @brief Converts the given joint into its current configuration value.
-/// @note The design for this was based off the design of the C++17 <code>std::any</code>
-///   type and its associated <code>std::any_cast</code> function.
-/// @throws std::bad_cast If the given template parameter type isn't the type of this
-///   joint's configuration value.
-/// @relatedalso Joint
-template <typename T>
-inline auto TypeCast(const Joint& value)
-{
-    auto tmp = TypeCast<std::add_pointer_t<std::add_const_t<T>>>(&value);
-    if (tmp == nullptr)
-        throw std::bad_cast();
-    return *tmp;
-}
-
-/// Get the anchor point on body-A in local coordinates.
-/// @relatedalso Joint
-Length2 GetLocalAnchorA(const Joint& object);
-
-/// Get the anchor point on body-B in local coordinates.
-/// @relatedalso Joint
-Length2 GetLocalAnchorB(const Joint& object);
-
-/// Get the linear reaction on body-B at the joint anchor.
-/// @relatedalso Joint
-Momentum2 GetLinearReaction(const Joint& object);
-
-/// Get the angular reaction on body-B.
-/// @relatedalso Joint
-AngularMomentum GetAngularReaction(const Joint& object);
-
-/// @brief Gets the reference angle of the joint if it has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Angle GetReferenceAngle(const Joint& object);
-
-/// @brief Gets the given joint's local X axis A if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-UnitVec GetLocalXAxisA(const Joint& object);
-
-/// @brief Gets the given joint's local Y axis A if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-UnitVec GetLocalYAxisA(const Joint& object);
-
-/// @brief Gets the given joint's motor speed if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-AngularVelocity GetMotorSpeed(const Joint& object);
-
-/// @brief Sets the given joint's motor speed if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetMotorSpeed(Joint& object, AngularVelocity value);
-
-/// @brief Gets the given joint's max force if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Force GetMaxForce(const Joint& object);
-
-/// @brief Gets the given joint's max torque if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Torque GetMaxTorque(const Joint& object);
-
-/// @brief Gets the given joint's max motor force if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Force GetMaxMotorForce(const Joint& object);
-
-/// @brief Sets the given joint's max motor force if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetMaxMotorForce(Joint& object, Force value);
-
-/// @brief Gets the given joint's max motor torque if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Torque GetMaxMotorTorque(const Joint& object);
-
-/// @brief Sets the given joint's max motor torque if its type supports that.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetMaxMotorTorque(Joint& object, Torque value);
-
-/// @brief Gets the given joint's angular mass.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-RotInertia GetAngularMass(const Joint& object);
-
-/// @brief Gets the given joint's ratio property if it has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Real GetRatio(const Joint& object);
-
-/// @brief Gets the given joint's damping ratio property if it has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Real GetDampingRatio(const Joint& object);
-
-/// @brief Gets the frequency of the joint if it has this property.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Frequency GetFrequency(const Joint& object);
-
-/// @brief Sets the frequency of the joint if it has this property.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetFrequency(Joint& object, Frequency value);
-
-/// @brief Gets the angular motor impulse of the joint if it has this property.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-AngularMomentum GetAngularMotorImpulse(const Joint& object);
-
-/// @brief Gets the given joint's target property if it has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Length2 GetTarget(const Joint& object);
-
-/// @brief Sets the given joint's target property if it has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetTarget(Joint& object, Length2 value);
-
-/// Gets the lower linear joint limit.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Length GetLinearLowerLimit(const Joint& object);
-
-/// Gets the upper linear joint limit.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Length GetLinearUpperLimit(const Joint& object);
-
-/// Sets the joint limits.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetLinearLimits(Joint& object, Length lower, Length upper);
-
-/// Gets the lower joint limit.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Angle GetAngularLowerLimit(const Joint& object);
-
-/// @brief Gets the upper joint limit.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Angle GetAngularUpperLimit(const Joint& object);
-
-/// @brief Sets the joint limits.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetAngularLimits(Joint& object, Angle lower, Angle upper);
-
-/// @brief Gets the specified joint's limit property if it supports one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-bool IsLimitEnabled(const Joint& object);
-
-/// @brief Enables the specified joint's limit property if it supports one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void EnableLimit(Joint& object, bool value);
-
-/// @brief Gets the specified joint's motor property value if it supports one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-bool IsMotorEnabled(const Joint& object);
-
-/// @brief Enables the specified joint's motor property if it supports one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void EnableMotor(Joint& object, bool value);
-
-/// @brief Gets the linear offset property of the specified joint if its type has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Length2 GetLinearOffset(const Joint& object);
-
-/// @brief Sets the linear offset property of the specified joint if its type has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetLinearOffset(Joint& object, Length2 value);
-
-/// @brief Gets the angular offset property of the specified joint if its type has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Angle GetAngularOffset(const Joint& object);
-
-/// @brief Sets the angular offset property of the specified joint if its type has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-void SetAngularOffset(Joint& object, Angle value);
-
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-LimitState GetLimitState(const Joint& object);
-
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Length2 GetGroundAnchorA(const Joint& object);
-
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Length2 GetGroundAnchorB(const Joint& object);
-
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Momentum GetLinearMotorImpulse(const Joint& object);
-
-/// @brief Gets the length property of the specified joint if its type has one.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-Length GetLength(const Joint& object);
-
-/// @brief Gets the current motor torque for the given joint given the inverse time step.
-/// @throws std::invalid_argument If not supported for the given joint's type.
-/// @relatedalso Joint
-inline Torque GetMotorTorque(const Joint& joint, Frequency inv_dt)
-{
-    return GetAngularMotorImpulse(joint) * inv_dt;
-}
-
-} // namespace d2
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_JOINT_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_JOINT_HPP

--- a/PlayRho/Dynamics/Joints/JointConf.cpp
+++ b/PlayRho/Dynamics/Joints/JointConf.cpp
@@ -19,31 +19,33 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/Joints/JointConf.hpp>
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
+#include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<JointConf>::value,
-              "JointConf should be default constructible!");
-static_assert(std::is_copy_constructible<JointConf>::value,
-              "JointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<JointConf>::value,
-              "JointConf should be copy assignable!");
-static_assert(std::is_nothrow_move_constructible<JointConf>::value,
-              "JointConf should be nothrow move constructible!");
-static_assert(std::is_nothrow_move_assignable<JointConf>::value,
-              "JointConf should be nothrow move assignable!");
-static_assert(std::is_nothrow_destructible<JointConf>::value,
-              "JointConf should be nothrow destructible!");
-
-void Set(JointConf& def, const Joint& joint) noexcept
+namespace playrho
 {
-    def.bodyA = GetBodyA(joint);
-    def.bodyB = GetBodyB(joint);
-    def.collideConnected = GetCollideConnected(joint);
-}
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        static_assert(std::is_default_constructible<JointConf>::value,
+                      "JointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<JointConf>::value,
+                      "JointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<JointConf>::value,
+                      "JointConf should be copy assignable!");
+        static_assert(std::is_nothrow_move_constructible<JointConf>::value,
+                      "JointConf should be nothrow move constructible!");
+        static_assert(std::is_nothrow_move_assignable<JointConf>::value,
+                      "JointConf should be nothrow move assignable!");
+        static_assert(std::is_nothrow_destructible<JointConf>::value,
+                      "JointConf should be nothrow destructible!");
+
+        void Set(JointConf& def, const Joint& joint) noexcept
+        {
+            def.bodyA = GetBodyA(joint);
+            def.bodyB = GetBodyB(joint);
+            def.collideConnected = GetCollideConnected(joint);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/JointConf.hpp
+++ b/PlayRho/Dynamics/Joints/JointConf.hpp
@@ -22,271 +22,269 @@
 #ifndef PLAYRHO_DYNAMICS_JOINTS_JOINTCONF_HPP
 #define PLAYRHO_DYNAMICS_JOINTS_JOINTCONF_HPP
 
-#include <PlayRho/Dynamics/Joints/JointType.hpp>
 #include <PlayRho/Dynamics/BodyID.hpp>
+#include <PlayRho/Dynamics/Joints/JointType.hpp>
 
 #include <cstdint>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Abstract base joint definition class.
-/// @details Joint definitions are used to construct joints.
-/// @note This class is not meant to be directly instantiated; it is meant
-///   to be inherited from.
-struct JointConf
+namespace playrho
 {
-    /// @brief 1st attached body.
-    BodyID bodyA = InvalidBodyID;
-    
-    /// @brief 2nd attached body.
-    BodyID bodyB = InvalidBodyID;
-    
-    /// @brief Collide connected.
-    /// @details Set this flag to true if the attached bodies should collide.
-    bool collideConnected = false;
-};
-
-/// @brief Gets the first body attached to this joint.
-constexpr BodyID GetBodyA(const JointConf& object) noexcept
-{
-    return object.bodyA;
-}
-
-/// @brief Gets the second body attached to this joint.
-constexpr BodyID GetBodyB(const JointConf& object) noexcept
-{
-    return object.bodyB;
-}
-
-constexpr bool GetCollideConnected(const JointConf& object) noexcept
-{
-    return object.collideConnected;
-}
-
-/// @brief Joint builder definition structure.
-/// @details This is a builder structure of chainable methods for building a shape
-///   configuration.
-/// @note This is a templated nested value class for initializing joints that
-///   uses the Curiously Recurring Template Pattern (CRTP) to provide method chaining
-///   via static polymorphism.
-/// @see https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
-template <class T>
-struct JointBuilder : JointConf
-{
-    /// @brief Value type.
-    using value_type = T;
-
-    /// @brief Reference type.
-    using reference = value_type&;
-
-    /// @brief Use value for body A setting.
-    constexpr reference UseBodyA(BodyID b) noexcept
+    namespace d2
     {
-        bodyA = b;
-        return static_cast<reference>(*this);
-    }
-    
-    /// @brief Use value for body B setting.
-    constexpr reference UseBodyB(BodyID b) noexcept
-    {
-        bodyB = b;
-        return static_cast<reference>(*this);
-    }
 
-    /// @brief Use value for collide connected setting.
-    constexpr reference UseCollideConnected(bool v) noexcept
-    {
-        collideConnected = v;
-        return static_cast<reference>(*this);
-    }
-};
+        /// @brief Abstract base joint definition class.
+        /// @details Joint definitions are used to construct joints.
+        /// @note This class is not meant to be directly instantiated; it is meant
+        ///   to be inherited from.
+        struct JointConf
+        {
+            /// @brief 1st attached body.
+            BodyID bodyA = InvalidBodyID;
 
-class Joint;
+            /// @brief 2nd attached body.
+            BodyID bodyB = InvalidBodyID;
 
-/// @brief Sets the joint definition data for the given joint.
-/// @relatedalso JointConf
-void Set(JointConf& def, const Joint& joint) noexcept;
+            /// @brief Collide connected.
+            /// @details Set this flag to true if the attached bodies should collide.
+            bool collideConnected = false;
+        };
 
-template <typename T>
-constexpr auto IsLimitEnabled(const T& conf) noexcept -> decltype(std::declval<T>().enableLimit)
-{
-    return conf.enableLimit;
-}
+        /// @brief Gets the first body attached to this joint.
+        constexpr BodyID GetBodyA(const JointConf& object) noexcept
+        {
+            return object.bodyA;
+        }
 
-template <typename T>
-constexpr auto EnableLimit(T& conf, bool v) noexcept ->
-    decltype(std::declval<T>().UseEnableLimit(bool{}))
-{
-    return conf.UseEnableLimit(v);
-}
+        /// @brief Gets the second body attached to this joint.
+        constexpr BodyID GetBodyB(const JointConf& object) noexcept
+        {
+            return object.bodyB;
+        }
 
-template <typename T>
-constexpr auto GetLength(const T& conf) noexcept -> decltype(std::declval<T>().length)
-{
-    return conf.length;
-}
+        constexpr bool GetCollideConnected(const JointConf& object) noexcept
+        {
+            return object.collideConnected;
+        }
 
-template <typename T>
-constexpr auto GetMaxForce(const T& conf) noexcept -> decltype(std::declval<T>().maxForce)
-{
-    return conf.maxForce;
-}
+        /// @brief Joint builder definition structure.
+        /// @details This is a builder structure of chainable methods for building a shape
+        ///   configuration.
+        /// @note This is a templated nested value class for initializing joints that
+        ///   uses the Curiously Recurring Template Pattern (CRTP) to provide method chaining
+        ///   via static polymorphism.
+        /// @see https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
+        template<class T>
+        struct JointBuilder : JointConf
+        {
+            /// @brief Value type.
+            using value_type = T;
 
-template <typename T>
-constexpr auto GetMaxTorque(const T& conf) noexcept -> decltype(std::declval<T>().maxTorque)
-{
-    return conf.maxTorque;
-}
+            /// @brief Reference type.
+            using reference = value_type&;
 
-template <typename T>
-constexpr auto GetRatio(const T& conf) noexcept -> decltype(std::declval<T>().ratio)
-{
-    return conf.ratio;
-}
+            /// @brief Use value for body A setting.
+            constexpr reference UseBodyA(BodyID b) noexcept
+            {
+                bodyA = b;
+                return static_cast<reference>(*this);
+            }
 
-template <typename T>
-constexpr auto GetDampingRatio(const T& conf) noexcept -> decltype(std::declval<T>().dampingRatio)
-{
-    return conf.dampingRatio;
-}
+            /// @brief Use value for body B setting.
+            constexpr reference UseBodyB(BodyID b) noexcept
+            {
+                bodyB = b;
+                return static_cast<reference>(*this);
+            }
 
-template <typename T>
-constexpr auto GetReferenceAngle(const T& conf) noexcept -> decltype(std::declval<T>().referenceAngle)
-{
-    return conf.referenceAngle;
-}
+            /// @brief Use value for collide connected setting.
+            constexpr reference UseCollideConnected(bool v) noexcept
+            {
+                collideConnected = v;
+                return static_cast<reference>(*this);
+            }
+        };
 
-template <typename T>
-constexpr auto GetLinearReaction(const T& conf) noexcept -> decltype(std::declval<T>().linearImpulse)
-{
-    return conf.linearImpulse;
-}
+        class Joint;
 
-template <typename T>
-constexpr auto GetLinearOffset(const T& conf) noexcept -> decltype(std::declval<T>().linearOffset)
-{
-    return conf.linearOffset;
-}
+        /// @brief Sets the joint definition data for the given joint.
+        /// @relatedalso JointConf
+        void Set(JointConf& def, const Joint& joint) noexcept;
 
-template <typename T>
-constexpr auto GetLimitState(const T& conf) noexcept -> decltype(std::declval<T>().limitState)
-{
-    return conf.limitState;
-}
+        template<typename T>
+        constexpr auto IsLimitEnabled(const T& conf) noexcept -> decltype(std::declval<T>().enableLimit)
+        {
+            return conf.enableLimit;
+        }
 
-template <typename T>
-constexpr auto GetGroundAnchorA(const T& conf) noexcept -> decltype(std::declval<T>().groundAnchorA)
-{
-    return conf.groundAnchorA;
-}
+        template<typename T>
+        constexpr auto EnableLimit(T& conf, bool v) noexcept -> decltype(std::declval<T>().UseEnableLimit(bool{}))
+        {
+            return conf.UseEnableLimit(v);
+        }
 
-template <typename T>
-constexpr auto GetGroundAnchorB(const T& conf) noexcept -> decltype(std::declval<T>().groundAnchorB)
-{
-    return conf.groundAnchorB;
-}
+        template<typename T>
+        constexpr auto GetLength(const T& conf) noexcept -> decltype(std::declval<T>().length)
+        {
+            return conf.length;
+        }
 
-template <typename T>
-constexpr auto GetLocalAnchorA(const T& conf) noexcept -> decltype(std::declval<T>().localAnchorA)
-{
-    return conf.localAnchorA;
-}
+        template<typename T>
+        constexpr auto GetMaxForce(const T& conf) noexcept -> decltype(std::declval<T>().maxForce)
+        {
+            return conf.maxForce;
+        }
 
-template <typename T>
-constexpr auto GetLocalAnchorB(const T& conf) noexcept -> decltype(std::declval<T>().localAnchorB)
-{
-    return conf.localAnchorB;
-}
+        template<typename T>
+        constexpr auto GetMaxTorque(const T& conf) noexcept -> decltype(std::declval<T>().maxTorque)
+        {
+            return conf.maxTorque;
+        }
 
-template <typename T>
-constexpr auto GetLocalXAxisA(const T& conf) noexcept -> decltype(std::declval<T>().localXAxisA)
-{
-    return conf.localXAxisA;
-}
+        template<typename T>
+        constexpr auto GetRatio(const T& conf) noexcept -> decltype(std::declval<T>().ratio)
+        {
+            return conf.ratio;
+        }
 
-template <typename T>
-constexpr auto GetLocalYAxisA(const T& conf) noexcept -> decltype(std::declval<T>().localYAxisA)
-{
-    return conf.localYAxisA;
-}
+        template<typename T>
+        constexpr auto GetDampingRatio(const T& conf) noexcept -> decltype(std::declval<T>().dampingRatio)
+        {
+            return conf.dampingRatio;
+        }
 
-template <typename T>
-constexpr auto GetFrequency(const T& conf) noexcept -> decltype(std::declval<T>().frequency)
-{
-    return conf.frequency;
-}
+        template<typename T>
+        constexpr auto GetReferenceAngle(const T& conf) noexcept -> decltype(std::declval<T>().referenceAngle)
+        {
+            return conf.referenceAngle;
+        }
 
-template <typename T>
-constexpr auto IsMotorEnabled(const T& conf) noexcept -> decltype(std::declval<T>().enableMotor)
-{
-    return conf.enableMotor;
-}
+        template<typename T>
+        constexpr auto GetLinearReaction(const T& conf) noexcept -> decltype(std::declval<T>().linearImpulse)
+        {
+            return conf.linearImpulse;
+        }
 
-template <typename T>
-constexpr auto EnableMotor(T& conf, bool v) noexcept ->
-decltype(std::declval<T>().UseEnableMotor(bool{}))
-{
-    return conf.UseEnableMotor(v);
-}
+        template<typename T>
+        constexpr auto GetLinearOffset(const T& conf) noexcept -> decltype(std::declval<T>().linearOffset)
+        {
+            return conf.linearOffset;
+        }
 
-template <typename T>
-constexpr auto GetMotorSpeed(const T& conf) noexcept -> decltype(std::declval<T>().motorSpeed)
-{
-    return conf.motorSpeed;
-}
+        template<typename T>
+        constexpr auto GetLimitState(const T& conf) noexcept -> decltype(std::declval<T>().limitState)
+        {
+            return conf.limitState;
+        }
 
-template <typename T>
-constexpr auto SetMotorSpeed(T& conf, AngularVelocity v) noexcept ->
-decltype(std::declval<T>().UseMotorSpeed(AngularVelocity{}))
-{
-    return conf.UseMotorSpeed(v);
-}
+        template<typename T>
+        constexpr auto GetGroundAnchorA(const T& conf) noexcept -> decltype(std::declval<T>().groundAnchorA)
+        {
+            return conf.groundAnchorA;
+        }
 
-template <typename T>
-constexpr auto GetLinearMotorImpulse(const T& conf) noexcept -> decltype(std::declval<T>().motorImpulse)
-{
-    return conf.motorImpulse;
-}
+        template<typename T>
+        constexpr auto GetGroundAnchorB(const T& conf) noexcept -> decltype(std::declval<T>().groundAnchorB)
+        {
+            return conf.groundAnchorB;
+        }
 
-template <typename T>
-constexpr auto GetMaxMotorForce(const T& conf) noexcept -> decltype(std::declval<T>().maxMotorForce)
-{
-    return conf.maxMotorForce;
-}
+        template<typename T>
+        constexpr auto GetLocalAnchorA(const T& conf) noexcept -> decltype(std::declval<T>().localAnchorA)
+        {
+            return conf.localAnchorA;
+        }
 
-template <typename T>
-constexpr auto GetMaxMotorTorque(const T& conf) noexcept -> decltype(std::declval<T>().maxMotorTorque)
-{
-    return conf.maxMotorTorque;
-}
+        template<typename T>
+        constexpr auto GetLocalAnchorB(const T& conf) noexcept -> decltype(std::declval<T>().localAnchorB)
+        {
+            return conf.localAnchorB;
+        }
 
-template <typename T>
-constexpr auto GetAngularOffset(const T& conf) noexcept -> decltype(std::declval<T>().angularOffset)
-{
-    return conf.angularOffset;
-}
+        template<typename T>
+        constexpr auto GetLocalXAxisA(const T& conf) noexcept -> decltype(std::declval<T>().localXAxisA)
+        {
+            return conf.localXAxisA;
+        }
 
-template <typename T>
-constexpr auto GetAngularReaction(const T& conf) noexcept -> decltype(std::declval<T>().angularImpulse)
-{
-    return conf.angularImpulse;
-}
+        template<typename T>
+        constexpr auto GetLocalYAxisA(const T& conf) noexcept -> decltype(std::declval<T>().localYAxisA)
+        {
+            return conf.localYAxisA;
+        }
 
-template <typename T>
-constexpr auto GetAngularMass(const T& conf) noexcept -> decltype(std::declval<T>().angularMass)
-{
-    return conf.angularMass;
-}
+        template<typename T>
+        constexpr auto GetFrequency(const T& conf) noexcept -> decltype(std::declval<T>().frequency)
+        {
+            return conf.frequency;
+        }
 
-template <typename T>
-constexpr auto GetAngularMotorImpulse(const T& conf) noexcept ->
-    decltype(std::declval<T>().angularMotorImpulse)
-{
-    return conf.angularMotorImpulse;
-}
+        template<typename T>
+        constexpr auto IsMotorEnabled(const T& conf) noexcept -> decltype(std::declval<T>().enableMotor)
+        {
+            return conf.enableMotor;
+        }
 
-} // namespace d2
-} // namespace playrho
+        template<typename T>
+        constexpr auto EnableMotor(T& conf, bool v) noexcept -> decltype(std::declval<T>().UseEnableMotor(bool{}))
+        {
+            return conf.UseEnableMotor(v);
+        }
 
-#endif // PLAYRHO_DYNAMICS_JOINTS_JOINTCONF_HPP
+        template<typename T>
+        constexpr auto GetMotorSpeed(const T& conf) noexcept -> decltype(std::declval<T>().motorSpeed)
+        {
+            return conf.motorSpeed;
+        }
+
+        template<typename T>
+        constexpr auto SetMotorSpeed(T& conf, AngularVelocity v) noexcept -> decltype(std::declval<T>().UseMotorSpeed(AngularVelocity{}))
+        {
+            return conf.UseMotorSpeed(v);
+        }
+
+        template<typename T>
+        constexpr auto GetLinearMotorImpulse(const T& conf) noexcept -> decltype(std::declval<T>().motorImpulse)
+        {
+            return conf.motorImpulse;
+        }
+
+        template<typename T>
+        constexpr auto GetMaxMotorForce(const T& conf) noexcept -> decltype(std::declval<T>().maxMotorForce)
+        {
+            return conf.maxMotorForce;
+        }
+
+        template<typename T>
+        constexpr auto GetMaxMotorTorque(const T& conf) noexcept -> decltype(std::declval<T>().maxMotorTorque)
+        {
+            return conf.maxMotorTorque;
+        }
+
+        template<typename T>
+        constexpr auto GetAngularOffset(const T& conf) noexcept -> decltype(std::declval<T>().angularOffset)
+        {
+            return conf.angularOffset;
+        }
+
+        template<typename T>
+        constexpr auto GetAngularReaction(const T& conf) noexcept -> decltype(std::declval<T>().angularImpulse)
+        {
+            return conf.angularImpulse;
+        }
+
+        template<typename T>
+        constexpr auto GetAngularMass(const T& conf) noexcept -> decltype(std::declval<T>().angularMass)
+        {
+            return conf.angularMass;
+        }
+
+        template<typename T>
+        constexpr auto GetAngularMotorImpulse(const T& conf) noexcept -> decltype(std::declval<T>().angularMotorImpulse)
+        {
+            return conf.angularMotorImpulse;
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_JOINTS_JOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/JointID.hpp
+++ b/PlayRho/Dynamics/Joints/JointID.hpp
@@ -21,31 +21,32 @@
 #ifndef PLAYRHO_DYNAMICS_JOINTS_JOINTID_HPP
 #define PLAYRHO_DYNAMICS_JOINTS_JOINTID_HPP
 
-#include <PlayRho/Common/StrongType.hpp>
 #include <PlayRho/Common/Settings.hpp>
+#include <PlayRho/Common/StrongType.hpp>
 
-namespace playrho {
-
-/// @brief Joint identifier.
-using JointID = strongtype::IndexingNamedType<JointCounter, struct JointIdentifier>;
-
-/// @brief Invalid joint ID value.
-constexpr auto InvalidJointID = static_cast<JointID>(static_cast<JointID::underlying_type>(-1));
-
-/// @brief Gets an invalid value for the JointID type.
-template <>
-constexpr JointID GetInvalid() noexcept
+namespace playrho
 {
-    return InvalidJointID;
-}
 
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const JointID& value) noexcept
-{
-    return value != GetInvalid<JointID>();
-}
+    /// @brief Joint identifier.
+    using JointID = strongtype::IndexingNamedType<JointCounter, struct JointIdentifier>;
 
-} // namespace playrho
+    /// @brief Invalid joint ID value.
+    constexpr auto InvalidJointID = static_cast<JointID>(static_cast<JointID::underlying_type>(-1));
 
-#endif // PLAYRHO_DYNAMICS_JOINTS_JOINTID_HPP
+    /// @brief Gets an invalid value for the JointID type.
+    template<>
+    constexpr JointID GetInvalid() noexcept
+    {
+        return InvalidJointID;
+    }
+
+    /// @brief Determines if the given value is valid.
+    template<>
+    constexpr bool IsValid(const JointID& value) noexcept
+    {
+        return value != GetInvalid<JointID>();
+    }
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_JOINTS_JOINTID_HPP

--- a/PlayRho/Dynamics/Joints/JointKey.cpp
+++ b/PlayRho/Dynamics/Joints/JointKey.cpp
@@ -18,16 +18,18 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/Joints/JointKey.hpp>
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
+#include <PlayRho/Dynamics/Joints/JointKey.hpp>
 
-namespace playrho {
-namespace d2 {
-
-JointKey GetJointKey(const Joint& joint) noexcept
+namespace playrho
 {
-    return JointKey::Get(GetBodyA(joint), GetBodyB(joint));
-}
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        JointKey GetJointKey(const Joint& joint) noexcept
+        {
+            return JointKey::Get(GetBodyA(joint), GetBodyB(joint));
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/JointKey.hpp
+++ b/PlayRho/Dynamics/Joints/JointKey.hpp
@@ -29,115 +29,115 @@
 #include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 
-#include <utility>
 #include <functional>
+#include <utility>
 
-namespace playrho {
-namespace d2 {
-
-class Joint;
-
-/// @brief Joint key.
-class JointKey
+namespace playrho
 {
-public:
-    /// @brief Gets the <code>JointKey</code> for the given bodies.
-    static constexpr JointKey Get(BodyID bodyA, BodyID bodyB) noexcept
+    namespace d2
     {
-        return (bodyA < bodyB)? JointKey{bodyA, bodyB}: JointKey{bodyB, bodyA};
-    }
-    
-    /// @brief Gets body 1.
-    constexpr BodyID GetBody1() const noexcept
-    {
-        return m_body1;
-    }
-    
-    /// @brief Gets body 2.
-    constexpr BodyID GetBody2() const
-    {
-        return m_body2;
-    }
 
-private:
-    /// @brief Initializing constructor.
-    constexpr JointKey(BodyID body1, BodyID body2):
-        m_body1(body1), m_body2(body2)
-    {
-        // Intentionally empty.
-    }
+        class Joint;
 
-    /// @brief Body 1.
-    /// @details This is the body with the lower-than or equal-to address.
-    BodyID m_body1;
+        /// @brief Joint key.
+        class JointKey
+        {
+         public:
+            /// @brief Gets the <code>JointKey</code> for the given bodies.
+            static constexpr JointKey Get(BodyID bodyA, BodyID bodyB) noexcept
+            {
+                return (bodyA < bodyB) ? JointKey{bodyA, bodyB} : JointKey{bodyB, bodyA};
+            }
 
-    /// @brief Body 2.
-    /// @details This is the body with the higher-than or equal-to address.
-    BodyID m_body2;
-};
+            /// @brief Gets body 1.
+            constexpr BodyID GetBody1() const noexcept
+            {
+                return m_body1;
+            }
 
-/// @brief Gets the <code>JointKey</code> for the given joint.
-JointKey GetJointKey(const Joint& joint) noexcept;
+            /// @brief Gets body 2.
+            constexpr BodyID GetBody2() const
+            {
+                return m_body2;
+            }
 
-/// @brief Compares the given joint keys.
-constexpr int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
-{
-    if (lhs.GetBody1() < rhs.GetBody1())
-    {
-        return -1;
-    }
-    if (lhs.GetBody1() > rhs.GetBody1())
-    {
-        return +1;
-    }
-    if (lhs.GetBody2() < rhs.GetBody2())
-    {
-        return -1;
-    }
-    if (lhs.GetBody2() > rhs.GetBody2())
-    {
-        return +1;
-    }
-    return 0;
-}
+         private:
+            /// @brief Initializing constructor.
+            constexpr JointKey(BodyID body1, BodyID body2)
+                : m_body1(body1), m_body2(body2)
+            {
+                // Intentionally empty.
+            }
 
-/// @brief Determines whether the given key is for the given body.
-/// @relatedalso JointKey
-constexpr bool IsFor(const JointKey key, BodyID body) noexcept
-{
-    return body == key.GetBody1() || body == key.GetBody2();
-}
+            /// @brief Body 1.
+            /// @details This is the body with the lower-than or equal-to address.
+            BodyID m_body1;
 
-} // namespace d2
-} // namespace playrho
+            /// @brief Body 2.
+            /// @details This is the body with the higher-than or equal-to address.
+            BodyID m_body2;
+        };
+
+        /// @brief Gets the <code>JointKey</code> for the given joint.
+        JointKey GetJointKey(const Joint& joint) noexcept;
+
+        /// @brief Compares the given joint keys.
+        constexpr int Compare(const JointKey& lhs, const JointKey& rhs) noexcept
+        {
+            if (lhs.GetBody1() < rhs.GetBody1())
+            {
+                return -1;
+            }
+            if (lhs.GetBody1() > rhs.GetBody1())
+            {
+                return +1;
+            }
+            if (lhs.GetBody2() < rhs.GetBody2())
+            {
+                return -1;
+            }
+            if (lhs.GetBody2() > rhs.GetBody2())
+            {
+                return +1;
+            }
+            return 0;
+        }
+
+        /// @brief Determines whether the given key is for the given body.
+        /// @relatedalso JointKey
+        constexpr bool IsFor(const JointKey key, BodyID body) noexcept
+        {
+            return body == key.GetBody1() || body == key.GetBody2();
+        }
+
+    }// namespace d2
+}// namespace playrho
 
 namespace std
 {
     /// @brief Function object for performing less-than comparisons between two joint keys.
-    template <>
+    template<>
     struct less<playrho::d2::JointKey>
     {
         /// @brief Function object operator.
-        constexpr
-        bool operator()(const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs) const
+        constexpr bool operator()(const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs) const
         {
             return playrho::d2::Compare(lhs, rhs) < 0;
         }
     };
-    
+
     /// @brief Function object for performing equal-to comparisons between two joint keys.
-    template <>
+    template<>
     struct equal_to<playrho::d2::JointKey>
     {
-        
+
         /// @brief Function object operator.
-        constexpr
-        bool operator()( const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs ) const
+        constexpr bool operator()(const playrho::d2::JointKey& lhs, const playrho::d2::JointKey& rhs) const
         {
             return playrho::d2::Compare(lhs, rhs) == 0;
         }
     };
 
-} // namespace std
+}// namespace std
 
-#endif // PLAYRHO_DYNAMICS_JOINTS_JOINTKEY_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_JOINTKEY_HPP

--- a/PlayRho/Dynamics/Joints/JointType.cpp
+++ b/PlayRho/Dynamics/Joints/JointType.cpp
@@ -21,13 +21,15 @@
 
 #include <PlayRho/Dynamics/Joints/JointType.hpp>
 
-namespace playrho {
-namespace d2 {
-
-const char* ToString(JointType type) noexcept
+namespace playrho
 {
-    return GetName(type);
-}
+    namespace d2
+    {
 
-} // namespace d2
-} // namespace playrho
+        const char* ToString(JointType type) noexcept
+        {
+            return GetName(type);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/JointType.hpp
+++ b/PlayRho/Dynamics/Joints/JointType.hpp
@@ -22,23 +22,25 @@
 #ifndef PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP
 #define PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP
 
-#include <PlayRho/Common/TypeInfo.hpp> // for TypeID
+#include <PlayRho/Common/TypeInfo.hpp>// for TypeID
 
 #include <cstdint>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-/// @brief Joint type alias.
-/// @note It's unclear whether it'd be better for this to be its own strong type so for
-///   now it's an alias recognizing it as different without the compiler enforcing it.
-using JointType = TypeID;
+        /// @brief Joint type alias.
+        /// @note It's unclear whether it'd be better for this to be its own strong type so for
+        ///   now it's an alias recognizing it as different without the compiler enforcing it.
+        using JointType = TypeID;
 
-/// @brief Provides a C-style (null-terminated) string name for given joint type.
-/// @return C-style English-language human-readable string uniquely identifying the joint type.
-const char* ToString(JointType type) noexcept;
+        /// @brief Provides a C-style (null-terminated) string name for given joint type.
+        /// @return C-style English-language human-readable string uniquely identifying the joint type.
+        const char* ToString(JointType type) noexcept;
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_JOINTTYPE_HPP

--- a/PlayRho/Dynamics/Joints/LimitState.cpp
+++ b/PlayRho/Dynamics/Joints/LimitState.cpp
@@ -23,21 +23,27 @@
 
 #include <cassert>
 
-namespace playrho {
-namespace d2 {
-
-const char* ToString(LimitState val) noexcept
+namespace playrho
 {
-    switch (val)
+    namespace d2
     {
-        case LimitState::e_atLowerLimit: return "at lower";
-        case LimitState::e_atUpperLimit: return "at upper";
-        case LimitState::e_equalLimits: return "equal";
-        case LimitState::e_inactiveLimit: break;
-    }
-    assert(val == LimitState::e_inactiveLimit);
-    return "inactive";
-}
 
-} // namespace d2
-} // namespace playrho
+        const char* ToString(LimitState val) noexcept
+        {
+            switch (val)
+            {
+            case LimitState::e_atLowerLimit:
+                return "at lower";
+            case LimitState::e_atUpperLimit:
+                return "at upper";
+            case LimitState::e_equalLimits:
+                return "equal";
+            case LimitState::e_inactiveLimit:
+                break;
+            }
+            assert(val == LimitState::e_inactiveLimit);
+            return "inactive";
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/LimitState.hpp
+++ b/PlayRho/Dynamics/Joints/LimitState.hpp
@@ -22,32 +22,34 @@
 #ifndef PLAYRHO_DYNAMICS_JOINTS_LIMITSTATE_HPP
 #define PLAYRHO_DYNAMICS_JOINTS_LIMITSTATE_HPP
 
-namespace playrho {
-namespace d2 {
-
-/// @brief Limit state.
-/// @note Only used by joints that implement some notion of a limited range.
-enum class LimitState
+namespace playrho
 {
-    /// @brief Inactive limit.
-    e_inactiveLimit,
+    namespace d2
+    {
 
-    /// @brief At-lower limit.
-    e_atLowerLimit,
+        /// @brief Limit state.
+        /// @note Only used by joints that implement some notion of a limited range.
+        enum class LimitState
+        {
+            /// @brief Inactive limit.
+            e_inactiveLimit,
 
-    /// @brief At-upper limit.
-    e_atUpperLimit,
+            /// @brief At-lower limit.
+            e_atLowerLimit,
 
-    /// @brief Equal limit.
-    /// @details Equal limit is used to indicate that a joint's upper and lower limits
-    ///   are approximately the same.
-    e_equalLimits
-};
+            /// @brief At-upper limit.
+            e_atUpperLimit,
 
-/// @brief Provides a human readable C-style string uniquely identifying the given limit state.
-const char* ToString(LimitState val) noexcept;
+            /// @brief Equal limit.
+            /// @details Equal limit is used to indicate that a joint's upper and lower limits
+            ///   are approximately the same.
+            e_equalLimits
+        };
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Provides a human readable C-style string uniquely identifying the given limit state.
+        const char* ToString(LimitState val) noexcept;
 
-#endif // PLAYRHO_DYNAMICS_JOINTS_LIMITSTATE_HPP
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_JOINTS_LIMITSTATE_HPP

--- a/PlayRho/Dynamics/Joints/MotorJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.cpp
@@ -21,228 +21,221 @@
 
 #include <PlayRho/Dynamics/Joints/MotorJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<MotorJointConf>::value,
-              "MotorJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<MotorJointConf>::value,
-              "MotorJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<MotorJointConf>::value,
-              "MotorJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<MotorJointConf>::value,
-              "MotorJointConf should be move constructible!");
-static_assert(std::is_move_assignable<MotorJointConf>::value,
-              "MotorJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<MotorJointConf>::value,
-              "MotorJointConf should be nothrow destructible!");
-
-// Point-to-point constraint
-// Cdot = v2 - v1
-//      = v2 + cross(w2, r2) - v1 - cross(w1, r1)
-// J = [-I -r1_skew I r2_skew ]
-// Identity used:
-// w k % (rx i + ry j) = w * (-ry i + rx j)
-//
-// r1 = offset - c1
-// r2 = -c2
-
-// Angle constraint
-// Cdot = w2 - w1
-// J = [0 0 -1 0 0 1]
-// K = invI1 + invI2
-
-MotorJointConf::MotorJointConf(BodyID bA, BodyID bB, Length2 lo, Angle ao) noexcept:
-    super{super{}.UseBodyA(bA).UseBodyB(bB)},
-    linearOffset{lo}, angularOffset{ao}
+namespace playrho
 {
-    // Intentionally empty.
-}
-
-MotorJointConf GetMotorJointConf(const Joint& joint) noexcept
-{
-    return TypeCast<MotorJointConf>(joint);
-}
-
-MotorJointConf GetMotorJointConf(const World& world, BodyID bA, BodyID bB)
-{
-    return MotorJointConf{
-        bA, bB,
-        GetLocalPoint(world, bA, GetLocation(world, bB)),
-        GetAngle(world, bB) - GetAngle(world, bA)
-    };
-}
-
-void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto posA = bodyConstraintA.GetPosition();
-    auto velA = bodyConstraintA.GetVelocity();
-
-    const auto posB = bodyConstraintB.GetPosition();
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    // Compute the effective mass matrix.
-    object.rA = Rotate(object.linearOffset - bodyConstraintA.GetLocalCenter(), qA);
-    object.rB = Rotate(-bodyConstraintB.GetLocalCenter(), qB);
-
-    // J = [-I -r1_skew I r2_skew]
-    // r_skew = [-ry; rx]
-
-    // Matlab
-    // K = [ mA+r1y^2*iA+mB+r2y^2*iB,  -r1y*iA*r1x-r2y*iB*r2x,          -r1y*iA-r2y*iB]
-    //     [  -r1y*iA*r1x-r2y*iB*r2x, mA+r1x^2*iA+mB+r2x^2*iB,           r1x*iA+r2x*iB]
-    //     [          -r1y*iA-r2y*iB,           r1x*iA+r2x*iB,                   iA+iB]
-
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
+    namespace d2
     {
-        const auto exx = InvMass{
-            invMassA + invMassB +
-            invRotInertiaA * Square(GetY(object.rA)) / SquareRadian +
-            invRotInertiaB * Square(GetY(object.rB)) / SquareRadian
-        };
-        const auto exy = InvMass{
-            -invRotInertiaA * GetX(object.rA) * GetY(object.rA) / SquareRadian +
-            -invRotInertiaB * GetX(object.rB) * GetY(object.rB) / SquareRadian
-        };
-        const auto eyy = InvMass{
-            invMassA + invMassB +
-            invRotInertiaA * Square(GetX(object.rA)) / SquareRadian +
-            invRotInertiaB * Square(GetX(object.rB)) / SquareRadian
-        };
-        // Upper 2 by 2 of K above for point to point
-        const auto k22 = InvMass22{Vector<InvMass, 2>{exx, exy}, Vector<InvMass, 2>{exy, eyy}};
-        object.linearMass = Invert(k22);
-    }
 
-    const auto invRotInertia = invRotInertiaA + invRotInertiaB;
-    object.angularMass = (invRotInertia > InvRotInertia{0})? RotInertia{Real{1} / invRotInertia}: RotInertia{0};
+        static_assert(std::is_default_constructible<MotorJointConf>::value,
+                      "MotorJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<MotorJointConf>::value,
+                      "MotorJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<MotorJointConf>::value,
+                      "MotorJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<MotorJointConf>::value,
+                      "MotorJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<MotorJointConf>::value,
+                      "MotorJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<MotorJointConf>::value,
+                      "MotorJointConf should be nothrow destructible!");
 
-    object.linearError = (posB.linear + object.rB) - (posA.linear + object.rA);
-    object.angularError = (posB.angular - posA.angular) - object.angularOffset;
+        // Point-to-point constraint
+        // Cdot = v2 - v1
+        //      = v2 + cross(w2, r2) - v1 - cross(w1, r1)
+        // J = [-I -r1_skew I r2_skew ]
+        // Identity used:
+        // w k % (rx i + ry j) = w * (-ry i + rx j)
+        //
+        // r1 = offset - c1
+        // r2 = -c2
 
-    if (step.doWarmStart)
-    {
-        // Scale impulses to support a variable time step.
-        object.linearImpulse *= step.dtRatio;
-        object.angularImpulse *= step.dtRatio;
+        // Angle constraint
+        // Cdot = w2 - w1
+        // J = [0 0 -1 0 0 1]
+        // K = invI1 + invI2
 
-        const auto P = object.linearImpulse;
-        // L * M * L T^-1 / QP is: L^2 M T^-1 QP^-1 which is: AngularMomentum.
-        const auto crossAP = AngularMomentum{Cross(object.rA, P) / Radian};
-        const auto crossBP = AngularMomentum{Cross(object.rB, P) / Radian}; // L * M * L T^-1 is: L^2 M T^-1
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * (crossAP + object.angularImpulse)};
-        velB += Velocity{invMassB * P, invRotInertiaB * (crossBP + object.angularImpulse)};
-    }
-    else
-    {
-        object.linearImpulse = Momentum2{};
-        object.angularImpulse = AngularMomentum{0};
-    }
-
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
-
-bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    auto velA = bodyConstraintA.GetVelocity();
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    const auto h = step.deltaTime;
-    const auto inv_h = (h != 0_s)? Real(1) / h: 0_Hz;
-
-    auto solved = true;
-
-    // Solve angular friction
-    {
-        const auto Cdot = AngularVelocity{(velB.angular - velA.angular)
-            + inv_h * object.correctionFactor * object.angularError};
-        const auto angularImpulse = AngularMomentum{-object.angularMass * Cdot};
-
-        const auto oldAngularImpulse = object.angularImpulse;
-        const auto maxAngularImpulse = h * object.maxTorque;
-        const auto newAngularImpulse = std::clamp(oldAngularImpulse + angularImpulse,
-                                                  -maxAngularImpulse, maxAngularImpulse);
-        object.angularImpulse = newAngularImpulse;
-        const auto incAngularImpulse = newAngularImpulse - oldAngularImpulse;
-
-        if (incAngularImpulse != AngularMomentum{0})
+        MotorJointConf::MotorJointConf(BodyID bA, BodyID bB, Length2 lo, Angle ao) noexcept
+            : super{super{}.UseBodyA(bA).UseBodyB(bB)},
+              linearOffset{lo}, angularOffset{ao}
         {
-            solved = false;
-        }
-        velA.angular -= invRotInertiaA * incAngularImpulse;
-        velB.angular += invRotInertiaB * incAngularImpulse;
-    }
-
-    // Solve linear friction
-    {
-        const auto vb = LinearVelocity2{velB.linear + (GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
-        const auto va = LinearVelocity2{velA.linear + (GetRevPerpendicular(object.rA) * (velA.angular / Radian))};
-        const auto Cdot = LinearVelocity2{(vb - va) + inv_h * object.correctionFactor * object.linearError};
-
-        const auto impulse = -Transform(Cdot, object.linearMass);
-        const auto oldImpulse = object.linearImpulse;
-        object.linearImpulse += impulse;
-
-        const auto maxImpulse = h * object.maxForce;
-
-        if (GetMagnitudeSquared(object.linearImpulse) > Square(maxImpulse))
-        {
-            object.linearImpulse = GetUnitVector(object.linearImpulse, UnitVec::GetZero()) * maxImpulse;
+            // Intentionally empty.
         }
 
-        const auto incImpulse = object.linearImpulse - oldImpulse;
-        const auto angImpulseA = AngularMomentum{Cross(object.rA, incImpulse) / Radian};
-        const auto angImpulseB = AngularMomentum{Cross(object.rB, incImpulse) / Radian};
-
-        if (incImpulse != Momentum2{})
+        MotorJointConf GetMotorJointConf(const Joint& joint) noexcept
         {
-            solved = false;
+            return TypeCast<MotorJointConf>(joint);
         }
 
-        velA -= Velocity{invMassA * incImpulse, invRotInertiaA * angImpulseA};
-        velB += Velocity{invMassB * incImpulse, invRotInertiaB * angImpulseB};
-    }
+        MotorJointConf GetMotorJointConf(const World& world, BodyID bA, BodyID bB)
+        {
+            return MotorJointConf{
+                bA, bB,
+                GetLocalPoint(world, bA, GetLocation(world, bB)),
+                GetAngle(world, bB) - GetAngle(world, bA)};
+        }
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
+        void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    return solved;
-}
+            const auto posA = bodyConstraintA.GetPosition();
+            auto velA = bodyConstraintA.GetVelocity();
 
-bool SolvePosition(const MotorJointConf&, std::vector<BodyConstraint>&,
-                   const ConstraintSolverConf&)
-{
-    return true;
-}
+            const auto posB = bodyConstraintB.GetPosition();
+            auto velB = bodyConstraintB.GetVelocity();
 
-} // namespace d2
-} // namespace playrho
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            // Compute the effective mass matrix.
+            object.rA = Rotate(object.linearOffset - bodyConstraintA.GetLocalCenter(), qA);
+            object.rB = Rotate(-bodyConstraintB.GetLocalCenter(), qB);
+
+            // J = [-I -r1_skew I r2_skew]
+            // r_skew = [-ry; rx]
+
+            // Matlab
+            // K = [ mA+r1y^2*iA+mB+r2y^2*iB,  -r1y*iA*r1x-r2y*iB*r2x,          -r1y*iA-r2y*iB]
+            //     [  -r1y*iA*r1x-r2y*iB*r2x, mA+r1x^2*iA+mB+r2x^2*iB,           r1x*iA+r2x*iB]
+            //     [          -r1y*iA-r2y*iB,           r1x*iA+r2x*iB,                   iA+iB]
+
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            {
+                const auto exx = InvMass{
+                    invMassA + invMassB + invRotInertiaA * Square(GetY(object.rA)) / SquareRadian + invRotInertiaB * Square(GetY(object.rB)) / SquareRadian};
+                const auto exy = InvMass{
+                    -invRotInertiaA * GetX(object.rA) * GetY(object.rA) / SquareRadian + -invRotInertiaB * GetX(object.rB) * GetY(object.rB) / SquareRadian};
+                const auto eyy = InvMass{
+                    invMassA + invMassB + invRotInertiaA * Square(GetX(object.rA)) / SquareRadian + invRotInertiaB * Square(GetX(object.rB)) / SquareRadian};
+                // Upper 2 by 2 of K above for point to point
+                const auto k22 = InvMass22{Vector<InvMass, 2>{exx, exy}, Vector<InvMass, 2>{exy, eyy}};
+                object.linearMass = Invert(k22);
+            }
+
+            const auto invRotInertia = invRotInertiaA + invRotInertiaB;
+            object.angularMass = (invRotInertia > InvRotInertia{0}) ? RotInertia{Real{1} / invRotInertia} : RotInertia{0};
+
+            object.linearError = (posB.linear + object.rB) - (posA.linear + object.rA);
+            object.angularError = (posB.angular - posA.angular) - object.angularOffset;
+
+            if (step.doWarmStart)
+            {
+                // Scale impulses to support a variable time step.
+                object.linearImpulse *= step.dtRatio;
+                object.angularImpulse *= step.dtRatio;
+
+                const auto P = object.linearImpulse;
+                // L * M * L T^-1 / QP is: L^2 M T^-1 QP^-1 which is: AngularMomentum.
+                const auto crossAP = AngularMomentum{Cross(object.rA, P) / Radian};
+                const auto crossBP = AngularMomentum{Cross(object.rB, P) / Radian};// L * M * L T^-1 is: L^2 M T^-1
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * (crossAP + object.angularImpulse)};
+                velB += Velocity{invMassB * P, invRotInertiaB * (crossBP + object.angularImpulse)};
+            }
+            else
+            {
+                object.linearImpulse = Momentum2{};
+                object.angularImpulse = AngularMomentum{0};
+            }
+
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
+
+        bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            auto velA = bodyConstraintA.GetVelocity();
+            auto velB = bodyConstraintB.GetVelocity();
+
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            const auto h = step.deltaTime;
+            const auto inv_h = (h != 0_s) ? Real(1) / h : 0_Hz;
+
+            auto solved = true;
+
+            // Solve angular friction
+            {
+                const auto Cdot = AngularVelocity{(velB.angular - velA.angular)
+                                                  + inv_h * object.correctionFactor * object.angularError};
+                const auto angularImpulse = AngularMomentum{-object.angularMass * Cdot};
+
+                const auto oldAngularImpulse = object.angularImpulse;
+                const auto maxAngularImpulse = h * object.maxTorque;
+                const auto newAngularImpulse = std::clamp(oldAngularImpulse + angularImpulse,
+                                                          -maxAngularImpulse, maxAngularImpulse);
+                object.angularImpulse = newAngularImpulse;
+                const auto incAngularImpulse = newAngularImpulse - oldAngularImpulse;
+
+                if (incAngularImpulse != AngularMomentum{0})
+                {
+                    solved = false;
+                }
+                velA.angular -= invRotInertiaA * incAngularImpulse;
+                velB.angular += invRotInertiaB * incAngularImpulse;
+            }
+
+            // Solve linear friction
+            {
+                const auto vb = LinearVelocity2{velB.linear + (GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
+                const auto va = LinearVelocity2{velA.linear + (GetRevPerpendicular(object.rA) * (velA.angular / Radian))};
+                const auto Cdot = LinearVelocity2{(vb - va) + inv_h * object.correctionFactor * object.linearError};
+
+                const auto impulse = -Transform(Cdot, object.linearMass);
+                const auto oldImpulse = object.linearImpulse;
+                object.linearImpulse += impulse;
+
+                const auto maxImpulse = h * object.maxForce;
+
+                if (GetMagnitudeSquared(object.linearImpulse) > Square(maxImpulse))
+                {
+                    object.linearImpulse = GetUnitVector(object.linearImpulse, UnitVec::GetZero()) * maxImpulse;
+                }
+
+                const auto incImpulse = object.linearImpulse - oldImpulse;
+                const auto angImpulseA = AngularMomentum{Cross(object.rA, incImpulse) / Radian};
+                const auto angImpulseB = AngularMomentum{Cross(object.rB, incImpulse) / Radian};
+
+                if (incImpulse != Momentum2{})
+                {
+                    solved = false;
+                }
+
+                velA -= Velocity{invMassA * incImpulse, invRotInertiaA * angImpulseA};
+                velB += Velocity{invMassB * incImpulse, invRotInertiaB * angImpulseB};
+            }
+
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+
+            return solved;
+        }
+
+        bool SolvePosition(const MotorJointConf&, std::vector<BodyConstraint>&,
+                           const ConstraintSolverConf&)
+        {
+            return true;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/MotorJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.hpp
@@ -24,243 +24,245 @@
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
-#include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/NonNegative.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class World;
-class BodyConstraint;
-
-/// @brief Motor joint definition.
-/// @details A motor joint is used to control the relative motion between two bodies. A
-///   typical usage is to control the movement of a dynamic body with respect to the ground.
-/// @see Joint, World::CreateJoint
-/// @ingroup JointsGroup
-struct MotorJointConf : public JointBuilder<MotorJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<MotorJointConf>;
 
-    /// @brief Default constructor.
-    constexpr MotorJointConf() = default;
-    
-    /// @brief Initialize the bodies and offsets using the current transforms.
-    MotorJointConf(BodyID bA, BodyID bB,
-                   Length2 lo = Length2{}, Angle ao = 0_deg) noexcept;
-    
-    /// @brief Uses the given linear offset value.
-    constexpr auto& UseLinearOffset(Length2 v) noexcept
+    struct ConstraintSolverConf;
+    struct StepConf;
+
+    namespace d2
     {
-        linearOffset = v;
-        return *this;
-    }
 
-    /// @brief Uses the given angular offset value.
-    constexpr auto& UseAngularOffset(Angle v) noexcept
+        class World;
+        class BodyConstraint;
+
+        /// @brief Motor joint definition.
+        /// @details A motor joint is used to control the relative motion between two bodies. A
+        ///   typical usage is to control the movement of a dynamic body with respect to the ground.
+        /// @see Joint, World::CreateJoint
+        /// @ingroup JointsGroup
+        struct MotorJointConf : public JointBuilder<MotorJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<MotorJointConf>;
+
+            /// @brief Default constructor.
+            constexpr MotorJointConf() = default;
+
+            /// @brief Initialize the bodies and offsets using the current transforms.
+            MotorJointConf(BodyID bA, BodyID bB,
+                           Length2 lo = Length2{}, Angle ao = 0_deg) noexcept;
+
+            /// @brief Uses the given linear offset value.
+            constexpr auto& UseLinearOffset(Length2 v) noexcept
+            {
+                linearOffset = v;
+                return *this;
+            }
+
+            /// @brief Uses the given angular offset value.
+            constexpr auto& UseAngularOffset(Angle v) noexcept
+            {
+                angularOffset = v;
+                return *this;
+            }
+
+            /// @brief Uses the given maximum force value.
+            constexpr auto& UseMaxForce(NonNegative<Force> v) noexcept
+            {
+                maxForce = v;
+                return *this;
+            }
+
+            /// @brief Uses the given max torque value.
+            constexpr auto& UseMaxTorque(NonNegative<Torque> v) noexcept
+            {
+                maxTorque = v;
+                return *this;
+            }
+
+            /// @brief Uses the given correction factor.
+            constexpr auto& UseCorrectionFactor(Real v) noexcept
+            {
+                correctionFactor = v;
+                return *this;
+            }
+
+            /// @brief Position of body-B minus the position of body-A, in body-A's frame.
+            Length2 linearOffset = Length2{};
+
+            /// @brief Angle of body-B minus angle of body-A.
+            Angle angularOffset = 0_deg;
+
+            Momentum2 linearImpulse{};       ///< Linear impulse.
+            AngularMomentum angularImpulse{};///< Angular impulse.
+
+            /// @brief Maximum motor force.
+            NonNegative<Force> maxForce = NonNegative<Force>(1_N);
+
+            /// @brief Maximum motor torque.
+            NonNegative<Torque> maxTorque = NonNegative<Torque>(1_Nm);
+
+            /// @brief Position correction factor in the range [0,1].
+            Real correctionFactor = Real(0.3);
+
+            // Solver temp
+            Length2 rA = {};            ///< Relative A.
+            Length2 rB = {};            ///< Relative B.
+            Length2 linearError{};      ///< Linear error.
+            Angle angularError = 0_deg; ///< Angular error.
+            Mass22 linearMass = {};     ///< 2-by-2 linear mass matrix in kilograms.
+            RotInertia angularMass = {};///< Angular mass.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        MotorJointConf GetMotorJointConf(const Joint& joint) noexcept;
+
+        /// @brief Gets the confguration for the given parameters.
+        /// @relatedalso World
+        MotorJointConf GetMotorJointConf(const World& world, BodyID bA, BodyID bB);
+
+        /// @brief Gets the local anchor A.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetLocalAnchorA(const MotorJointConf&) noexcept
+        {
+            return Length2{};
+        }
+
+        /// @brief Gets the local anchor B.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetLocalAnchorB(const MotorJointConf&) noexcept
+        {
+            return Length2{};
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto ShiftOrigin(MotorJointConf&, Length2) noexcept
+        {
+            return false;
+        }
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso MotorJointConf
+        void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso MotorJointConf
+        bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso MotorJointConf
+        bool SolvePosition(const MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for getting the maximum force value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetMaxForce(const MotorJointConf& object) noexcept
+        {
+            return object.maxForce;
+        }
+
+        /// @brief Free function for setting the maximum force value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto SetMaxForce(MotorJointConf& object, NonNegative<Force> value) noexcept
+        {
+            object.UseMaxForce(value);
+        }
+
+        /// @brief Free function for getting the maximum torque value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetMaxTorque(const MotorJointConf& object) noexcept
+        {
+            return object.maxTorque;
+        }
+
+        /// @brief Free function for setting the maximum torque value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto SetMaxTorque(MotorJointConf& object, NonNegative<Torque> value) noexcept
+        {
+            object.UseMaxTorque(value);
+        }
+
+        /// @brief Free function for getting the linear error value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetLinearError(const MotorJointConf& object) noexcept
+        {
+            return object.linearError;
+        }
+
+        /// @brief Free function for getting the angular error value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetAngularError(const MotorJointConf& object) noexcept
+        {
+            return object.angularError;
+        }
+
+        /// @brief Free function for getting the linear offset value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetLinearOffset(const MotorJointConf& object) noexcept
+        {
+            return object.linearOffset;
+        }
+
+        /// @brief Free function for setting the linear offset value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto SetLinearOffset(MotorJointConf& object, Length2 value) noexcept
+        {
+            object.UseLinearOffset(value);
+        }
+
+        /// @brief Free function for getting the angular offset value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetAngularOffset(const MotorJointConf& object) noexcept
+        {
+            return object.angularOffset;
+        }
+
+        /// @brief Free function for setting the angular offset value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto SetAngularOffset(MotorJointConf& object, Angle value) noexcept
+        {
+            object.UseAngularOffset(value);
+        }
+
+        /// @brief Free function for getting the correction factor value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto GetCorrectionFactor(const MotorJointConf& object) noexcept
+        {
+            return object.correctionFactor;
+        }
+
+        /// @brief Free function for setting the correction factor value of the given configuration.
+        /// @relatedalso MotorJointConf
+        constexpr auto SetCorrectionFactor(MotorJointConf& object, Real value) noexcept
+        {
+            object.UseCorrectionFactor(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::MotorJointConf</code>.
+    template<>
+    struct TypeInfo<d2::MotorJointConf>
     {
-        angularOffset = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::MotorJointConf";
+    };
 
-    /// @brief Uses the given maximum force value.
-    constexpr auto& UseMaxForce(NonNegative<Force> v) noexcept
-    {
-        maxForce = v;
-        return *this;
-    }
+}// namespace playrho
 
-    /// @brief Uses the given max torque value.
-    constexpr auto& UseMaxTorque(NonNegative<Torque> v) noexcept
-    {
-        maxTorque = v;
-        return *this;
-    }
-
-    /// @brief Uses the given correction factor.
-    constexpr auto& UseCorrectionFactor(Real v) noexcept
-    {
-        correctionFactor = v;
-        return *this;
-    }
-
-    /// @brief Position of body-B minus the position of body-A, in body-A's frame.
-    Length2 linearOffset = Length2{};
-
-    /// @brief Angle of body-B minus angle of body-A.
-    Angle angularOffset = 0_deg;
-
-    Momentum2 linearImpulse{}; ///< Linear impulse.
-    AngularMomentum angularImpulse{}; ///< Angular impulse.
-
-    /// @brief Maximum motor force.
-    NonNegative<Force> maxForce = NonNegative<Force>(1_N);
-    
-    /// @brief Maximum motor torque.
-    NonNegative<Torque> maxTorque = NonNegative<Torque>(1_Nm);
-    
-    /// @brief Position correction factor in the range [0,1].
-    Real correctionFactor = Real(0.3);
-
-    // Solver temp
-    Length2 rA = {}; ///< Relative A.
-    Length2 rB = {}; ///< Relative B.
-    Length2 linearError{}; ///< Linear error.
-    Angle angularError = 0_deg; ///< Angular error.
-    Mass22 linearMass = {}; ///< 2-by-2 linear mass matrix in kilograms.
-    RotInertia angularMass = {}; ///< Angular mass.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-MotorJointConf GetMotorJointConf(const Joint& joint) noexcept;
-
-/// @brief Gets the confguration for the given parameters.
-/// @relatedalso World
-MotorJointConf GetMotorJointConf(const World& world, BodyID bA, BodyID bB);
-
-/// @brief Gets the local anchor A.
-/// @relatedalso MotorJointConf
-constexpr auto GetLocalAnchorA(const MotorJointConf&) noexcept
-{
-    return Length2{};
-}
-
-/// @brief Gets the local anchor B.
-/// @relatedalso MotorJointConf
-constexpr auto GetLocalAnchorB(const MotorJointConf&) noexcept
-{
-    return Length2{};
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto ShiftOrigin(MotorJointConf&, Length2) noexcept
-{
-    return false;
-}
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso MotorJointConf
-void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso MotorJointConf
-bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso MotorJointConf
-bool SolvePosition(const MotorJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for getting the maximum force value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto GetMaxForce(const MotorJointConf& object) noexcept
-{
-    return object.maxForce;
-}
-
-/// @brief Free function for setting the maximum force value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto SetMaxForce(MotorJointConf& object, NonNegative<Force> value) noexcept
-{
-    object.UseMaxForce(value);
-}
-
-/// @brief Free function for getting the maximum torque value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto GetMaxTorque(const MotorJointConf& object) noexcept
-{
-    return object.maxTorque;
-}
-
-/// @brief Free function for setting the maximum torque value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto SetMaxTorque(MotorJointConf& object, NonNegative<Torque> value) noexcept
-{
-    object.UseMaxTorque(value);
-}
-
-/// @brief Free function for getting the linear error value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto GetLinearError(const MotorJointConf& object) noexcept
-{
-    return object.linearError;
-}
-
-/// @brief Free function for getting the angular error value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto GetAngularError(const MotorJointConf& object) noexcept
-{
-    return object.angularError;
-}
-
-/// @brief Free function for getting the linear offset value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto GetLinearOffset(const MotorJointConf& object) noexcept
-{
-    return object.linearOffset;
-}
-
-/// @brief Free function for setting the linear offset value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto SetLinearOffset(MotorJointConf& object, Length2 value) noexcept
-{
-    object.UseLinearOffset(value);
-}
-
-/// @brief Free function for getting the angular offset value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto GetAngularOffset(const MotorJointConf& object) noexcept
-{
-    return object.angularOffset;
-}
-
-/// @brief Free function for setting the angular offset value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto SetAngularOffset(MotorJointConf& object, Angle value) noexcept
-{
-    object.UseAngularOffset(value);
-}
-
-/// @brief Free function for getting the correction factor value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto GetCorrectionFactor(const MotorJointConf& object) noexcept
-{
-    return object.correctionFactor;
-}
-
-/// @brief Free function for setting the correction factor value of the given configuration.
-/// @relatedalso MotorJointConf
-constexpr auto SetCorrectionFactor(MotorJointConf& object, Real value) noexcept
-{
-    object.UseCorrectionFactor(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::MotorJointConf</code>.
-template <>
-struct TypeInfo<d2::MotorJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::MotorJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_MOTORJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_MOTORJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.cpp
@@ -21,555 +21,534 @@
 
 #include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<PrismaticJointConf>::value,
-              "PrismaticJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<PrismaticJointConf>::value,
-              "PrismaticJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<PrismaticJointConf>::value,
-              "PrismaticJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<PrismaticJointConf>::value,
-              "PrismaticJointConf should be move constructible!");
-static_assert(std::is_move_assignable<PrismaticJointConf>::value,
-              "PrismaticJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<PrismaticJointConf>::value,
-              "PrismaticJointConf should be nothrow destructible!");
-
-// Linear constraint (point-to-line)
-// d = p2 - p1 = x2 + r2 - x1 - r1
-// C = dot(perp, d)
-// Cdot = dot(d, cross(w1, perp)) + dot(perp, v2 + cross(w2, r2) - v1 - cross(w1, r1))
-//      = -dot(perp, v1) - dot(cross(d + r1, perp), w1) + dot(perp, v2) + dot(cross(r2, perp), v2)
-// J = [-perp, -cross(d + r1, perp), perp, cross(r2,perp)]
-//
-// Angular constraint
-// C = a2 - a1 + a_initial
-// Cdot = w2 - w1
-// J = [0 0 -1 0 0 1]
-//
-// K = J * invM * JT
-//
-// J = [-a -s1 a s2]
-//     [0  -1  0  1]
-// a = perp
-// s1 = cross(d + r1, a) = cross(p2 - x1, a)
-// s2 = cross(r2, a) = cross(p2 - x2, a)
-
-
-// Motor/Limit linear constraint
-// C = dot(ax1, d)
-// Cdot = = -dot(ax1, v1) - dot(cross(d + r1, ax1), w1) + dot(ax1, v2) + dot(cross(r2, ax1), v2)
-// J = [-ax1 -cross(d+r1,ax1) ax1 cross(r2,ax1)]
-
-// Block Solver
-// We develop a block solver that includes the joint limit. This makes the limit stiff (inelastic) even
-// when the mass has poor distribution (leading to large torques about the joint anchor points).
-//
-// The Jacobian has 3 rows:
-// J = [-uT -s1 uT s2] // linear
-//     [0   -1   0  1] // angular
-//     [-vT -a1 vT a2] // limit
-//
-// u = perp
-// v = axis
-// s1 = cross(d + r1, u), s2 = cross(r2, u)
-// a1 = cross(d + r1, v), a2 = cross(r2, v)
-
-// M * (v2 - v1) = JT * df
-// J * v2 = bias
-//
-// v2 = v1 + invM * JT * df
-// J * (v1 + invM * JT * df) = bias
-// K * df = bias - J * v1 = -Cdot
-// K = J * invM * JT
-// Cdot = J * v1 - bias
-//
-// Now solve for f2.
-// df = f2 - f1
-// K * (f2 - f1) = -Cdot
-// f2 = invK * (-Cdot) + f1
-//
-// Clamp accumulated limit impulse.
-// lower: f2(3) = max(f2(3), 0)
-// upper: f2(3) = min(f2(3), 0)
-//
-// Solve for correct f2(1:2)
-// K(1:2, 1:2) * f2(1:2) = -Cdot(1:2) - K(1:2,3) * f2(3) + K(1:2,1:3) * f1
-//                       = -Cdot(1:2) - K(1:2,3) * f2(3) + K(1:2,1:2) * f1(1:2) + K(1:2,3) * f1(3)
-// K(1:2, 1:2) * f2(1:2) = -Cdot(1:2) - K(1:2,3) * (f2(3) - f1(3)) + K(1:2,1:2) * f1(1:2)
-// f2(1:2) = invK(1:2,1:2) * (-Cdot(1:2) - K(1:2,3) * (f2(3) - f1(3))) + f1(1:2)
-//
-// Now compute impulse to be applied:
-// df = f2 - f1
-
-PrismaticJointConf::PrismaticJointConf(BodyID bA, BodyID bB,
-                                       Length2 laA, Length2 laB,
-                                       UnitVec axisA, Angle angle) noexcept:
-    super{super{}.UseBodyA(bA).UseBodyB(bB)},
-    localAnchorA{laA}, localAnchorB{laB},
-    localXAxisA{axisA}, localYAxisA{GetRevPerpendicular(axisA)},
-    referenceAngle{angle}
+namespace playrho
 {
-    // Intentionally empty.
-}
-
-PrismaticJointConf GetPrismaticJointConf(const Joint& joint)
-{
-    return TypeCast<PrismaticJointConf>(joint);
-}
-
-PrismaticJointConf GetPrismaticJointConf(const World& world,
-                                         BodyID bA, BodyID bB,
-                                         const Length2 anchor,
-                                         const UnitVec axis)
-{
-    return PrismaticJointConf{
-        bA, bB,
-        GetLocalPoint(world, bA, anchor), GetLocalPoint(world, bB, anchor),
-        GetLocalVector(world, bA, axis),
-        GetAngle(world, bB) - GetAngle(world, bA)
-    };
-}
-
-Momentum2 GetLinearReaction(const PrismaticJointConf& conf)
-{
-    const auto ulImpulse = GetX(conf.impulse) * conf.perp;
-    const auto impulse = Momentum2{GetX(ulImpulse) * NewtonSecond, GetY(ulImpulse) * NewtonSecond};
-    return Momentum2{impulse + (conf.motorImpulse + GetZ(conf.impulse) * NewtonSecond) * conf.axis};
-}
-
-AngularMomentum GetAngularReaction(const PrismaticJointConf& conf)
-{
-    return GetY(conf.impulse) * SquareMeter * Kilogram / (Second * Radian);
-}
-
-void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto posA = bodyConstraintA.GetPosition();
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    auto velA = bodyConstraintA.GetVelocity();
-
-    const auto posB = bodyConstraintB.GetPosition();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    // Compute the effective masses.
-    const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA); // Length2
-    const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB); // Length2
-    const auto d = (posB.linear - posA.linear) + rB - rA; // Length2
-
-    // Compute motor Jacobian and effective mass.
-    object.axis = Rotate(object.localXAxisA, qA);
-    object.a1 = Cross(d + rA, object.axis); // Length
-    object.a2 = Cross(rB, object.axis); // Length
-
-    const auto invRotMassA = InvMass{invRotInertiaA * object.a1 * object.a1 / SquareRadian};
-    const auto invRotMassB = InvMass{invRotInertiaB * object.a2 * object.a2 / SquareRadian};
-    const auto totalInvMass = invMassA + invMassB + invRotMassA + invRotMassB;
-    object.motorMass = (totalInvMass > InvMass{0})? Real{1} / totalInvMass: 0_kg;
-
-    // Prismatic constraint.
+    namespace d2
     {
-        object.perp = Rotate(object.localYAxisA, qA);
 
-        object.s1 = Cross(d + rA, object.perp);
-        object.s2 = Cross(rB, object.perp);
+        static_assert(std::is_default_constructible<PrismaticJointConf>::value,
+                      "PrismaticJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<PrismaticJointConf>::value,
+                      "PrismaticJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<PrismaticJointConf>::value,
+                      "PrismaticJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<PrismaticJointConf>::value,
+                      "PrismaticJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<PrismaticJointConf>::value,
+                      "PrismaticJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<PrismaticJointConf>::value,
+                      "PrismaticJointConf should be nothrow destructible!");
 
-        const auto invRotMassA2 = InvMass{invRotInertiaA * object.s1 * object.s1 / SquareRadian};
-        const auto invRotMassB2 = InvMass{invRotInertiaB * object.s2 * object.s2 / SquareRadian};
-        const auto k11 = StripUnit(invMassA + invMassB + invRotMassA2 + invRotMassB2);
+        // Linear constraint (point-to-line)
+        // d = p2 - p1 = x2 + r2 - x1 - r1
+        // C = dot(perp, d)
+        // Cdot = dot(d, cross(w1, perp)) + dot(perp, v2 + cross(w2, r2) - v1 - cross(w1, r1))
+        //      = -dot(perp, v1) - dot(cross(d + r1, perp), w1) + dot(perp, v2) + dot(cross(r2, perp), v2)
+        // J = [-perp, -cross(d + r1, perp), perp, cross(r2,perp)]
+        //
+        // Angular constraint
+        // C = a2 - a1 + a_initial
+        // Cdot = w2 - w1
+        // J = [0 0 -1 0 0 1]
+        //
+        // K = J * invM * JT
+        //
+        // J = [-a -s1 a s2]
+        //     [0  -1  0  1]
+        // a = perp
+        // s1 = cross(d + r1, a) = cross(p2 - x1, a)
+        // s2 = cross(r2, a) = cross(p2 - x2, a)
 
-        // L^-2 M^-1 QP^2 * L is: L^-1 M^-1 QP^2.
-        const auto k12 = (invRotInertiaA * object.s1 + invRotInertiaB * object.s2) * Meter * Kilogram / SquareRadian;
-        const auto k13 = StripUnit(InvMass{(invRotInertiaA * object.s1 * object.a1 + invRotInertiaB * object.s2 * object.a2) / SquareRadian});
-        const auto totalInvRotInertia = invRotInertiaA + invRotInertiaB;
+        // Motor/Limit linear constraint
+        // C = dot(ax1, d)
+        // Cdot = = -dot(ax1, v1) - dot(cross(d + r1, ax1), w1) + dot(ax1, v2) + dot(cross(r2, ax1), v2)
+        // J = [-ax1 -cross(d+r1,ax1) ax1 cross(r2,ax1)]
 
-        const auto k22 = (totalInvRotInertia == InvRotInertia{0})? Real{1}: StripUnit(totalInvRotInertia);
-        const auto k23 = (invRotInertiaA * object.a1 + invRotInertiaB * object.a2) * Meter * Kilogram / SquareRadian;
-        const auto k33 = StripUnit(totalInvMass);
+        // Block Solver
+        // We develop a block solver that includes the joint limit. This makes the limit stiff (inelastic) even
+        // when the mass has poor distribution (leading to large torques about the joint anchor points).
+        //
+        // The Jacobian has 3 rows:
+        // J = [-uT -s1 uT s2] // linear
+        //     [0   -1   0  1] // angular
+        //     [-vT -a1 vT a2] // limit
+        //
+        // u = perp
+        // v = axis
+        // s1 = cross(d + r1, u), s2 = cross(r2, u)
+        // a1 = cross(d + r1, v), a2 = cross(r2, v)
 
-        GetX(object.K) = Vec3{k11, k12, k13};
-        GetY(object.K) = Vec3{k12, k22, k23};
-        GetZ(object.K) = Vec3{k13, k23, k33};
-    }
-
-    // Compute motor and limit terms.
-    if (object.enableLimit)
-    {
-        const auto jointTranslation = Length{Dot(object.axis, d)};
-        if (abs(object.upperTranslation - object.lowerTranslation) < (conf.linearSlop * Real{2}))
-        {
-            object.limitState = LimitState::e_equalLimits;
-        }
-        else if (jointTranslation <= object.lowerTranslation)
-        {
-            if (object.limitState != LimitState::e_atLowerLimit)
-            {
-                object.limitState = LimitState::e_atLowerLimit;
-                GetZ(object.impulse) = 0;
-            }
-        }
-        else if (jointTranslation >= object.upperTranslation)
-        {
-            if (object.limitState != LimitState::e_atUpperLimit)
-            {
-                object.limitState = LimitState::e_atUpperLimit;
-                GetZ(object.impulse) = 0;
-            }
-        }
-        else
-        {
-            object.limitState = LimitState::e_inactiveLimit;
-            GetZ(object.impulse) = 0;
-        }
-    }
-    else
-    {
-        object.limitState = LimitState::e_inactiveLimit;
-        GetZ(object.impulse) = 0;
-    }
-
-    if (!object.enableMotor)
-    {
-        object.motorImpulse = 0;
-    }
-
-    if (step.doWarmStart)
-    {
-        // Account for variable time step.
-        object.impulse *= step.dtRatio;
-        object.motorImpulse *= step.dtRatio;
-
-        const auto ulImpulseX = GetX(object.impulse) * object.perp;
-        const auto Px = Momentum2{GetX(ulImpulseX) * NewtonSecond, GetY(ulImpulseX) * NewtonSecond};
-        const auto Pxs1 = Momentum{GetX(object.impulse) * object.s1 * Kilogram / Second};
-        const auto Pxs2 = Momentum{GetX(object.impulse) * object.s2 * Kilogram / Second};
-        const auto PzLength = Momentum{object.motorImpulse + GetZ(object.impulse) * NewtonSecond};
-        const auto Pz = Momentum2{PzLength * object.axis};
-        const auto P = Px + Pz;
-
-        // AngularMomentum is L^2 M T^-1 QP^-1.
-        const auto L = AngularMomentum{GetY(object.impulse) * SquareMeter * Kilogram / (Second * Radian)};
-        const auto LA = L + (Pxs1 * Meter + PzLength * object.a1) / Radian;
-        const auto LB = L + (Pxs2 * Meter + PzLength * object.a2) / Radian;
-
-        // InvRotInertia is L^-2 M^-1 QP^2
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        object.impulse = Vec3{};
-        object.motorImpulse = 0;
-    }
-
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
-
-bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto oldVelA = bodyConstraintA.GetVelocity();
-    auto velA = oldVelA;
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-
-    const auto oldVelB = bodyConstraintB.GetVelocity();
-    auto velB = oldVelB;
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    // Solve linear motor constraint.
-    if (object.enableMotor && object.limitState != LimitState::e_equalLimits)
-    {
-        const auto vDot = LinearVelocity{Dot(object.axis, velB.linear - velA.linear)};
-        const auto Cdot = vDot + (object.a2 * velB.angular - object.a1 * velA.angular) / Radian;
-        auto impulse = Momentum{object.motorMass * (object.motorSpeed * Meter / Radian - Cdot)};
-        const auto oldImpulse = object.motorImpulse;
-        const auto maxImpulse = step.deltaTime * object.maxMotorForce;
-        object.motorImpulse = std::clamp(object.motorImpulse + impulse, -maxImpulse, maxImpulse);
-        impulse = object.motorImpulse - oldImpulse;
-
-        const auto P = Momentum2{impulse * object.axis};
-
-        // Momentum is L^2 M T^-1. AngularMomentum is L^2 M T^-1 QP^-1.
-        const auto LA = impulse * object.a1 / Radian;
-        const auto LB = impulse * object.a2 / Radian;
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-
-    const auto velDelta = velB.linear - velA.linear;
-    const auto sRotSpeed = LinearVelocity{(object.s2 * velB.angular - object.s1 * velA.angular) / Radian};
-    const auto Cdot1 = Vec2{
-        StripUnit(Dot(object.perp, velDelta) + sRotSpeed),
-        StripUnit(velB.angular - velA.angular)
-    };
-
-    if (object.enableLimit && (object.limitState != LimitState::e_inactiveLimit))
-    {
-        // Solve prismatic and limit constraint in block form.
-        const auto deltaDot = LinearVelocity{Dot(object.axis, velDelta)};
-        const auto aRotSpeed = LinearVelocity{(object.a2 * velB.angular - object.a1 * velA.angular) / Radian};
-        const auto Cdot2 = StripUnit(deltaDot + aRotSpeed);
-        const auto Cdot = Vec3{GetX(Cdot1), GetY(Cdot1), Cdot2};
-
-        const auto f1 = object.impulse;
-        object.impulse += Solve33(object.K, -Cdot);
-
-        if (object.limitState == LimitState::e_atLowerLimit)
-        {
-            GetZ(object.impulse) = std::max(GetZ(object.impulse), Real{0});
-        }
-        else if (object.limitState == LimitState::e_atUpperLimit)
-        {
-            GetZ(object.impulse) = std::min(GetZ(object.impulse), Real{0});
-        }
-
+        // M * (v2 - v1) = JT * df
+        // J * v2 = bias
+        //
+        // v2 = v1 + invM * JT * df
+        // J * (v1 + invM * JT * df) = bias
+        // K * df = bias - J * v1 = -Cdot
+        // K = J * invM * JT
+        // Cdot = J * v1 - bias
+        //
+        // Now solve for f2.
+        // df = f2 - f1
+        // K * (f2 - f1) = -Cdot
+        // f2 = invK * (-Cdot) + f1
+        //
+        // Clamp accumulated limit impulse.
+        // lower: f2(3) = max(f2(3), 0)
+        // upper: f2(3) = min(f2(3), 0)
+        //
+        // Solve for correct f2(1:2)
+        // K(1:2, 1:2) * f2(1:2) = -Cdot(1:2) - K(1:2,3) * f2(3) + K(1:2,1:3) * f1
+        //                       = -Cdot(1:2) - K(1:2,3) * f2(3) + K(1:2,1:2) * f1(1:2) + K(1:2,3) * f1(3)
+        // K(1:2, 1:2) * f2(1:2) = -Cdot(1:2) - K(1:2,3) * (f2(3) - f1(3)) + K(1:2,1:2) * f1(1:2)
         // f2(1:2) = invK(1:2,1:2) * (-Cdot(1:2) - K(1:2,3) * (f2(3) - f1(3))) + f1(1:2)
-        const auto b = -Cdot1 - (GetZ(object.impulse) - GetZ(f1)) * Vec2{GetX(GetZ(object.K)), GetY(GetZ(object.K))};
-        const auto f2r = Solve22(object.K, b) + Vec2{GetX(f1), GetY(f1)};
-        GetX(object.impulse) = GetX(f2r);
-        GetY(object.impulse) = GetY(f2r);
+        //
+        // Now compute impulse to be applied:
+        // df = f2 - f1
 
-        const auto df = object.impulse - f1;
-
-        const auto ulP = GetX(df) * object.perp + GetZ(df) * object.axis;
-        const auto P = Momentum2{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
-        const auto LA = AngularMomentum{
-            (GetX(df) * object.s1 + GetY(df) * Meter + GetZ(df) * object.a1) * NewtonSecond / Radian
-        };
-        const auto LB = AngularMomentum{
-            (GetX(df) * object.s2 + GetY(df) * Meter + GetZ(df) * object.a2) * NewtonSecond / Radian
-        };
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        // Limit is inactive, just solve the prismatic constraint in block form.
-        const auto df = Solve22(object.K, -Cdot1);
-
-        // object.impulse is a Vec3 while df is a Vec2; so can't just object.impulse += df
-        GetX(object.impulse) += GetX(df);
-        GetY(object.impulse) += GetY(df);
-
-        const auto ulP = GetX(df) * object.perp;
-        const auto P = Momentum2{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
-        const auto LA = AngularMomentum{
-            (GetX(df) * object.s1 + GetY(df) * Meter) * NewtonSecond / Radian
-        };
-        const auto LB = AngularMomentum{
-            (GetX(df) * object.s2 + GetY(df) * Meter) * NewtonSecond / Radian
-        };
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-
-    if ((velA != oldVelA) || (velB != oldVelB))
-    {
-        bodyConstraintA.SetVelocity(velA);
-        bodyConstraintB.SetVelocity(velB);
-        return false;
-    }
-    return true;
-}
-
-// A velocity based solver computes reaction forces(impulses) using the velocity constraint solver.
-// Under this context, the position solver is not there to resolve forces. It is only there to cope
-// with integration error.
-//
-// Therefore, the pseudo impulses in the position solver do not have any physical meaning. Thus it
-// is okay if they suck.
-//
-// We could take the active state from the velocity solver. However, the joint might push past the
-// limit when the velocity solver indicates the limit is inactive.
-//
-bool SolvePosition(const PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    auto posA = bodyConstraintA.GetPosition();
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-
-    auto posB = bodyConstraintB.GetPosition();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    // Compute fresh Jacobians
-    const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-    const auto d = Length2{(posB.linear + rB) - (posA.linear + rA)};
-
-    const auto axis = Rotate(object.localXAxisA, qA);
-    const auto a1 = Length{Cross(d + rA, axis)};
-    const auto a2 = Length{Cross(rB, axis)};
-    const auto perp = Rotate(object.localYAxisA, qA);
-
-    const auto s1 = Length{Cross(d + rA, perp)};
-    const auto s2 = Length{Cross(rB, perp)};
-
-    const auto C1 = Vec2{
-        Dot(perp, d) / Meter,
-        (posB.angular - posA.angular - object.referenceAngle) / Radian
-    };
-
-    auto linearError = Length{abs(GetX(C1)) * Meter};
-    const auto angularError = Angle{abs(GetY(C1)) * Radian};
-
-    auto active = false;
-    auto C2 = Real{0};
-    if (object.enableLimit)
-    {
-        const auto translation = Length{Dot(axis, d)};
-        if (abs(object.upperTranslation - object.lowerTranslation) < (Real{2} * conf.linearSlop))
+        PrismaticJointConf::PrismaticJointConf(BodyID bA, BodyID bB,
+                                               Length2 laA, Length2 laB,
+                                               UnitVec axisA, Angle angle) noexcept
+            : super{super{}.UseBodyA(bA).UseBodyB(bB)},
+              localAnchorA{laA}, localAnchorB{laB},
+              localXAxisA{axisA}, localYAxisA{GetRevPerpendicular(axisA)},
+              referenceAngle{angle}
         {
-            // Prevent large angular corrections
-            C2 = StripUnit(std::clamp(translation, -conf.maxLinearCorrection, conf.maxLinearCorrection));
-            linearError = std::max(linearError, abs(translation));
-            active = true;
-        }
-        else if (translation <= object.lowerTranslation)
-        {
-            // Prevent large linear corrections and allow some slop.
-            C2 = StripUnit(std::clamp(translation - object.lowerTranslation + conf.linearSlop, -conf.maxLinearCorrection, 0_m));
-            linearError = std::max(linearError, object.lowerTranslation - translation);
-            active = true;
-        }
-        else if (translation >= object.upperTranslation)
-        {
-            // Prevent large linear corrections and allow some slop.
-            C2 = StripUnit(std::clamp(translation - object.upperTranslation - conf.linearSlop, 0_m, conf.maxLinearCorrection));
-            linearError = std::max(linearError, translation - object.upperTranslation);
-            active = true;
-        }
-    }
-
-    Vec3 impulse;
-    if (active)
-    {
-        const auto k11 = StripUnit(InvMass{
-            invMassA + invRotInertiaA * s1 * s1 / SquareRadian +
-            invMassB + invRotInertiaB * s2 * s2 / SquareRadian
-        });
-        const auto k12 = StripUnit(InvMass{
-            invRotInertiaA * s1 * Meter / SquareRadian +
-            invRotInertiaB * s2 * Meter / SquareRadian
-        });
-        const auto k13 = StripUnit(InvMass{
-            invRotInertiaA * s1 * a1 / SquareRadian +
-            invRotInertiaB * s2 * a2 / SquareRadian
-        });
-
-        // InvRotInertia is L^-2 M^-1 QP^2
-        auto k22 = StripUnit(invRotInertiaA + invRotInertiaB);
-        if (k22 == Real{0})
-        {
-            // For fixed rotation
-            k22 = StripUnit(Real{1} * SquareRadian / (Kilogram * SquareMeter));
-        }
-        const auto k23 = StripUnit(InvMass{
-            invRotInertiaA * a1 * Meter / SquareRadian +
-            invRotInertiaB * a2 * Meter / SquareRadian
-        });
-        const auto k33 = StripUnit(InvMass{
-            invMassA + invRotInertiaA * Square(a1) / SquareRadian +
-            invMassB + invRotInertiaB * Square(a2) / SquareRadian
-        });
-
-        const auto K = Mat33{Vec3{k11, k12, k13}, Vec3{k12, k22, k23}, Vec3{k13, k23, k33}};
-        const auto C = Vec3{GetX(C1), GetY(C1), C2};
-
-        impulse = Solve33(K, -C);
-    }
-    else
-    {
-        const auto k11 = StripUnit(InvMass{
-            invMassA + invRotInertiaA * s1 * s1 / SquareRadian +
-            invMassB + invRotInertiaB * s2 * s2 / SquareRadian
-        });
-        const auto k12 = StripUnit(InvMass{
-            invRotInertiaA * s1 * Meter / SquareRadian +
-            invRotInertiaB * s2 * Meter / SquareRadian
-        });
-        auto k22 = StripUnit(invRotInertiaA + invRotInertiaB);
-        if (k22 == 0)
-        {
-            k22 = 1;
+            // Intentionally empty.
         }
 
-        const auto K = Mat22{Vec2{k11, k12}, Vec2{k12, k22}};
+        PrismaticJointConf GetPrismaticJointConf(const Joint& joint)
+        {
+            return TypeCast<PrismaticJointConf>(joint);
+        }
 
-        const auto impulse1 = Solve(K, -C1);
-        GetX(impulse) = GetX(impulse1);
-        GetY(impulse) = GetY(impulse1);
-        GetZ(impulse) = 0;
-    }
+        PrismaticJointConf GetPrismaticJointConf(const World& world,
+                                                 BodyID bA, BodyID bB,
+                                                 const Length2 anchor,
+                                                 const UnitVec axis)
+        {
+            return PrismaticJointConf{
+                bA, bB,
+                GetLocalPoint(world, bA, anchor), GetLocalPoint(world, bB, anchor),
+                GetLocalVector(world, bA, axis),
+                GetAngle(world, bB) - GetAngle(world, bA)};
+        }
 
-    const auto P = (GetX(impulse) * perp + GetZ(impulse) * axis) * Kilogram * Meter;
-    const auto LA = (GetX(impulse) * s1 + GetY(impulse) * Meter + GetZ(impulse) * a1) * Kilogram * Meter / Radian;
-    const auto LB = (GetX(impulse) * s2 + GetY(impulse) * Meter + GetZ(impulse) * a2) * Kilogram * Meter / Radian;
+        Momentum2 GetLinearReaction(const PrismaticJointConf& conf)
+        {
+            const auto ulImpulse = GetX(conf.impulse) * conf.perp;
+            const auto impulse = Momentum2{GetX(ulImpulse) * NewtonSecond, GetY(ulImpulse) * NewtonSecond};
+            return Momentum2{impulse + (conf.motorImpulse + GetZ(conf.impulse) * NewtonSecond) * conf.axis};
+        }
 
-    posA -= Position{Length2{invMassA * P}, invRotInertiaA * LA};
-    posB += Position{invMassB * P, invRotInertiaB * LB};
+        AngularMomentum GetAngularReaction(const PrismaticJointConf& conf)
+        {
+            return GetY(conf.impulse) * SquareMeter * Kilogram / (Second * Radian);
+        }
 
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
+        void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    return (linearError <= conf.linearSlop) && (angularError <= conf.angularSlop);
-}
+            const auto posA = bodyConstraintA.GetPosition();
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            auto velA = bodyConstraintA.GetVelocity();
 
-LinearVelocity GetLinearVelocity(const World& world, const PrismaticJointConf& joint) noexcept
-{
-    const auto bA = GetBodyA(joint);
-    const auto bB = GetBodyB(joint);
-    const auto rA = Rotate(GetLocalAnchorA(joint) - GetLocalCenter(world, bA),
-                           GetTransformation(world, bA).q);
-    const auto rB = Rotate(GetLocalAnchorB(joint) - GetLocalCenter(world, bB),
-                           GetTransformation(world, bB).q);
-    const auto p1 = GetWorldCenter(world, bA) + rA;
-    const auto p2 = GetWorldCenter(world, bB) + rB;
-    const auto d = p2 - p1;
-    const auto axis = Rotate(GetLocalXAxisA(joint), GetTransformation(world, bA).q);
-    const auto vA = GetVelocity(world, bA).linear;
-    const auto vB = GetVelocity(world, bB).linear;
-    const auto wA = GetVelocity(world, bA).angular;
-    const auto wB = GetVelocity(world, bB).angular;
-    const auto vel = (vB + (GetRevPerpendicular(rB) * (wB / Radian))) -
-    (vA + (GetRevPerpendicular(rA) * (wA / Radian)));
-    return Dot(d, (GetRevPerpendicular(axis) * (wA / Radian))) + Dot(axis, vel);
-}
+            const auto posB = bodyConstraintB.GetPosition();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+            auto velB = bodyConstraintB.GetVelocity();
 
-} // namespace d2
-} // namespace playrho
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            // Compute the effective masses.
+            const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);// Length2
+            const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);// Length2
+            const auto d = (posB.linear - posA.linear) + rB - rA;                              // Length2
+
+            // Compute motor Jacobian and effective mass.
+            object.axis = Rotate(object.localXAxisA, qA);
+            object.a1 = Cross(d + rA, object.axis);// Length
+            object.a2 = Cross(rB, object.axis);    // Length
+
+            const auto invRotMassA = InvMass{invRotInertiaA * object.a1 * object.a1 / SquareRadian};
+            const auto invRotMassB = InvMass{invRotInertiaB * object.a2 * object.a2 / SquareRadian};
+            const auto totalInvMass = invMassA + invMassB + invRotMassA + invRotMassB;
+            object.motorMass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
+
+            // Prismatic constraint.
+            {
+                object.perp = Rotate(object.localYAxisA, qA);
+
+                object.s1 = Cross(d + rA, object.perp);
+                object.s2 = Cross(rB, object.perp);
+
+                const auto invRotMassA2 = InvMass{invRotInertiaA * object.s1 * object.s1 / SquareRadian};
+                const auto invRotMassB2 = InvMass{invRotInertiaB * object.s2 * object.s2 / SquareRadian};
+                const auto k11 = StripUnit(invMassA + invMassB + invRotMassA2 + invRotMassB2);
+
+                // L^-2 M^-1 QP^2 * L is: L^-1 M^-1 QP^2.
+                const auto k12 = (invRotInertiaA * object.s1 + invRotInertiaB * object.s2) * Meter * Kilogram / SquareRadian;
+                const auto k13 = StripUnit(InvMass{(invRotInertiaA * object.s1 * object.a1 + invRotInertiaB * object.s2 * object.a2) / SquareRadian});
+                const auto totalInvRotInertia = invRotInertiaA + invRotInertiaB;
+
+                const auto k22 = (totalInvRotInertia == InvRotInertia{0}) ? Real{1} : StripUnit(totalInvRotInertia);
+                const auto k23 = (invRotInertiaA * object.a1 + invRotInertiaB * object.a2) * Meter * Kilogram / SquareRadian;
+                const auto k33 = StripUnit(totalInvMass);
+
+                GetX(object.K) = Vec3{k11, k12, k13};
+                GetY(object.K) = Vec3{k12, k22, k23};
+                GetZ(object.K) = Vec3{k13, k23, k33};
+            }
+
+            // Compute motor and limit terms.
+            if (object.enableLimit)
+            {
+                const auto jointTranslation = Length{Dot(object.axis, d)};
+                if (abs(object.upperTranslation - object.lowerTranslation) < (conf.linearSlop * Real{2}))
+                {
+                    object.limitState = LimitState::e_equalLimits;
+                }
+                else if (jointTranslation <= object.lowerTranslation)
+                {
+                    if (object.limitState != LimitState::e_atLowerLimit)
+                    {
+                        object.limitState = LimitState::e_atLowerLimit;
+                        GetZ(object.impulse) = 0;
+                    }
+                }
+                else if (jointTranslation >= object.upperTranslation)
+                {
+                    if (object.limitState != LimitState::e_atUpperLimit)
+                    {
+                        object.limitState = LimitState::e_atUpperLimit;
+                        GetZ(object.impulse) = 0;
+                    }
+                }
+                else
+                {
+                    object.limitState = LimitState::e_inactiveLimit;
+                    GetZ(object.impulse) = 0;
+                }
+            }
+            else
+            {
+                object.limitState = LimitState::e_inactiveLimit;
+                GetZ(object.impulse) = 0;
+            }
+
+            if (!object.enableMotor)
+            {
+                object.motorImpulse = 0;
+            }
+
+            if (step.doWarmStart)
+            {
+                // Account for variable time step.
+                object.impulse *= step.dtRatio;
+                object.motorImpulse *= step.dtRatio;
+
+                const auto ulImpulseX = GetX(object.impulse) * object.perp;
+                const auto Px = Momentum2{GetX(ulImpulseX) * NewtonSecond, GetY(ulImpulseX) * NewtonSecond};
+                const auto Pxs1 = Momentum{GetX(object.impulse) * object.s1 * Kilogram / Second};
+                const auto Pxs2 = Momentum{GetX(object.impulse) * object.s2 * Kilogram / Second};
+                const auto PzLength = Momentum{object.motorImpulse + GetZ(object.impulse) * NewtonSecond};
+                const auto Pz = Momentum2{PzLength * object.axis};
+                const auto P = Px + Pz;
+
+                // AngularMomentum is L^2 M T^-1 QP^-1.
+                const auto L = AngularMomentum{GetY(object.impulse) * SquareMeter * Kilogram / (Second * Radian)};
+                const auto LA = L + (Pxs1 * Meter + PzLength * object.a1) / Radian;
+                const auto LB = L + (Pxs2 * Meter + PzLength * object.a2) / Radian;
+
+                // InvRotInertia is L^-2 M^-1 QP^2
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                object.impulse = Vec3{};
+                object.motorImpulse = 0;
+            }
+
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
+
+        bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            const auto oldVelA = bodyConstraintA.GetVelocity();
+            auto velA = oldVelA;
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+
+            const auto oldVelB = bodyConstraintB.GetVelocity();
+            auto velB = oldVelB;
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            // Solve linear motor constraint.
+            if (object.enableMotor && object.limitState != LimitState::e_equalLimits)
+            {
+                const auto vDot = LinearVelocity{Dot(object.axis, velB.linear - velA.linear)};
+                const auto Cdot = vDot + (object.a2 * velB.angular - object.a1 * velA.angular) / Radian;
+                auto impulse = Momentum{object.motorMass * (object.motorSpeed * Meter / Radian - Cdot)};
+                const auto oldImpulse = object.motorImpulse;
+                const auto maxImpulse = step.deltaTime * object.maxMotorForce;
+                object.motorImpulse = std::clamp(object.motorImpulse + impulse, -maxImpulse, maxImpulse);
+                impulse = object.motorImpulse - oldImpulse;
+
+                const auto P = Momentum2{impulse * object.axis};
+
+                // Momentum is L^2 M T^-1. AngularMomentum is L^2 M T^-1 QP^-1.
+                const auto LA = impulse * object.a1 / Radian;
+                const auto LB = impulse * object.a2 / Radian;
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+
+            const auto velDelta = velB.linear - velA.linear;
+            const auto sRotSpeed = LinearVelocity{(object.s2 * velB.angular - object.s1 * velA.angular) / Radian};
+            const auto Cdot1 = Vec2{
+                StripUnit(Dot(object.perp, velDelta) + sRotSpeed),
+                StripUnit(velB.angular - velA.angular)};
+
+            if (object.enableLimit && (object.limitState != LimitState::e_inactiveLimit))
+            {
+                // Solve prismatic and limit constraint in block form.
+                const auto deltaDot = LinearVelocity{Dot(object.axis, velDelta)};
+                const auto aRotSpeed = LinearVelocity{(object.a2 * velB.angular - object.a1 * velA.angular) / Radian};
+                const auto Cdot2 = StripUnit(deltaDot + aRotSpeed);
+                const auto Cdot = Vec3{GetX(Cdot1), GetY(Cdot1), Cdot2};
+
+                const auto f1 = object.impulse;
+                object.impulse += Solve33(object.K, -Cdot);
+
+                if (object.limitState == LimitState::e_atLowerLimit)
+                {
+                    GetZ(object.impulse) = std::max(GetZ(object.impulse), Real{0});
+                }
+                else if (object.limitState == LimitState::e_atUpperLimit)
+                {
+                    GetZ(object.impulse) = std::min(GetZ(object.impulse), Real{0});
+                }
+
+                // f2(1:2) = invK(1:2,1:2) * (-Cdot(1:2) - K(1:2,3) * (f2(3) - f1(3))) + f1(1:2)
+                const auto b = -Cdot1 - (GetZ(object.impulse) - GetZ(f1)) * Vec2{GetX(GetZ(object.K)), GetY(GetZ(object.K))};
+                const auto f2r = Solve22(object.K, b) + Vec2{GetX(f1), GetY(f1)};
+                GetX(object.impulse) = GetX(f2r);
+                GetY(object.impulse) = GetY(f2r);
+
+                const auto df = object.impulse - f1;
+
+                const auto ulP = GetX(df) * object.perp + GetZ(df) * object.axis;
+                const auto P = Momentum2{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
+                const auto LA = AngularMomentum{
+                    (GetX(df) * object.s1 + GetY(df) * Meter + GetZ(df) * object.a1) * NewtonSecond / Radian};
+                const auto LB = AngularMomentum{
+                    (GetX(df) * object.s2 + GetY(df) * Meter + GetZ(df) * object.a2) * NewtonSecond / Radian};
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                // Limit is inactive, just solve the prismatic constraint in block form.
+                const auto df = Solve22(object.K, -Cdot1);
+
+                // object.impulse is a Vec3 while df is a Vec2; so can't just object.impulse += df
+                GetX(object.impulse) += GetX(df);
+                GetY(object.impulse) += GetY(df);
+
+                const auto ulP = GetX(df) * object.perp;
+                const auto P = Momentum2{GetX(ulP) * NewtonSecond, GetY(ulP) * NewtonSecond};
+                const auto LA = AngularMomentum{
+                    (GetX(df) * object.s1 + GetY(df) * Meter) * NewtonSecond / Radian};
+                const auto LB = AngularMomentum{
+                    (GetX(df) * object.s2 + GetY(df) * Meter) * NewtonSecond / Radian};
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+
+            if ((velA != oldVelA) || (velB != oldVelB))
+            {
+                bodyConstraintA.SetVelocity(velA);
+                bodyConstraintB.SetVelocity(velB);
+                return false;
+            }
+            return true;
+        }
+
+        // A velocity based solver computes reaction forces(impulses) using the velocity constraint solver.
+        // Under this context, the position solver is not there to resolve forces. It is only there to cope
+        // with integration error.
+        //
+        // Therefore, the pseudo impulses in the position solver do not have any physical meaning. Thus it
+        // is okay if they suck.
+        //
+        // We could take the active state from the velocity solver. However, the joint might push past the
+        // limit when the velocity solver indicates the limit is inactive.
+        //
+        bool SolvePosition(const PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            auto posA = bodyConstraintA.GetPosition();
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+
+            auto posB = bodyConstraintB.GetPosition();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            // Compute fresh Jacobians
+            const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+            const auto d = Length2{(posB.linear + rB) - (posA.linear + rA)};
+
+            const auto axis = Rotate(object.localXAxisA, qA);
+            const auto a1 = Length{Cross(d + rA, axis)};
+            const auto a2 = Length{Cross(rB, axis)};
+            const auto perp = Rotate(object.localYAxisA, qA);
+
+            const auto s1 = Length{Cross(d + rA, perp)};
+            const auto s2 = Length{Cross(rB, perp)};
+
+            const auto C1 = Vec2{
+                Dot(perp, d) / Meter,
+                (posB.angular - posA.angular - object.referenceAngle) / Radian};
+
+            auto linearError = Length{abs(GetX(C1)) * Meter};
+            const auto angularError = Angle{abs(GetY(C1)) * Radian};
+
+            auto active = false;
+            auto C2 = Real{0};
+            if (object.enableLimit)
+            {
+                const auto translation = Length{Dot(axis, d)};
+                if (abs(object.upperTranslation - object.lowerTranslation) < (Real{2} * conf.linearSlop))
+                {
+                    // Prevent large angular corrections
+                    C2 = StripUnit(std::clamp(translation, -conf.maxLinearCorrection, conf.maxLinearCorrection));
+                    linearError = std::max(linearError, abs(translation));
+                    active = true;
+                }
+                else if (translation <= object.lowerTranslation)
+                {
+                    // Prevent large linear corrections and allow some slop.
+                    C2 = StripUnit(std::clamp(translation - object.lowerTranslation + conf.linearSlop, -conf.maxLinearCorrection, 0_m));
+                    linearError = std::max(linearError, object.lowerTranslation - translation);
+                    active = true;
+                }
+                else if (translation >= object.upperTranslation)
+                {
+                    // Prevent large linear corrections and allow some slop.
+                    C2 = StripUnit(std::clamp(translation - object.upperTranslation - conf.linearSlop, 0_m, conf.maxLinearCorrection));
+                    linearError = std::max(linearError, translation - object.upperTranslation);
+                    active = true;
+                }
+            }
+
+            Vec3 impulse;
+            if (active)
+            {
+                const auto k11 = StripUnit(InvMass{
+                    invMassA + invRotInertiaA * s1 * s1 / SquareRadian + invMassB + invRotInertiaB * s2 * s2 / SquareRadian});
+                const auto k12 = StripUnit(InvMass{
+                    invRotInertiaA * s1 * Meter / SquareRadian + invRotInertiaB * s2 * Meter / SquareRadian});
+                const auto k13 = StripUnit(InvMass{
+                    invRotInertiaA * s1 * a1 / SquareRadian + invRotInertiaB * s2 * a2 / SquareRadian});
+
+                // InvRotInertia is L^-2 M^-1 QP^2
+                auto k22 = StripUnit(invRotInertiaA + invRotInertiaB);
+                if (k22 == Real{0})
+                {
+                    // For fixed rotation
+                    k22 = StripUnit(Real{1} * SquareRadian / (Kilogram * SquareMeter));
+                }
+                const auto k23 = StripUnit(InvMass{
+                    invRotInertiaA * a1 * Meter / SquareRadian + invRotInertiaB * a2 * Meter / SquareRadian});
+                const auto k33 = StripUnit(InvMass{
+                    invMassA + invRotInertiaA * Square(a1) / SquareRadian + invMassB + invRotInertiaB * Square(a2) / SquareRadian});
+
+                const auto K = Mat33{Vec3{k11, k12, k13}, Vec3{k12, k22, k23}, Vec3{k13, k23, k33}};
+                const auto C = Vec3{GetX(C1), GetY(C1), C2};
+
+                impulse = Solve33(K, -C);
+            }
+            else
+            {
+                const auto k11 = StripUnit(InvMass{
+                    invMassA + invRotInertiaA * s1 * s1 / SquareRadian + invMassB + invRotInertiaB * s2 * s2 / SquareRadian});
+                const auto k12 = StripUnit(InvMass{
+                    invRotInertiaA * s1 * Meter / SquareRadian + invRotInertiaB * s2 * Meter / SquareRadian});
+                auto k22 = StripUnit(invRotInertiaA + invRotInertiaB);
+                if (k22 == 0)
+                {
+                    k22 = 1;
+                }
+
+                const auto K = Mat22{Vec2{k11, k12}, Vec2{k12, k22}};
+
+                const auto impulse1 = Solve(K, -C1);
+                GetX(impulse) = GetX(impulse1);
+                GetY(impulse) = GetY(impulse1);
+                GetZ(impulse) = 0;
+            }
+
+            const auto P = (GetX(impulse) * perp + GetZ(impulse) * axis) * Kilogram * Meter;
+            const auto LA = (GetX(impulse) * s1 + GetY(impulse) * Meter + GetZ(impulse) * a1) * Kilogram * Meter / Radian;
+            const auto LB = (GetX(impulse) * s2 + GetY(impulse) * Meter + GetZ(impulse) * a2) * Kilogram * Meter / Radian;
+
+            posA -= Position{Length2{invMassA * P}, invRotInertiaA * LA};
+            posB += Position{invMassB * P, invRotInertiaB * LB};
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+
+            return (linearError <= conf.linearSlop) && (angularError <= conf.angularSlop);
+        }
+
+        LinearVelocity GetLinearVelocity(const World& world, const PrismaticJointConf& joint) noexcept
+        {
+            const auto bA = GetBodyA(joint);
+            const auto bB = GetBodyB(joint);
+            const auto rA = Rotate(GetLocalAnchorA(joint) - GetLocalCenter(world, bA),
+                                   GetTransformation(world, bA).q);
+            const auto rB = Rotate(GetLocalAnchorB(joint) - GetLocalCenter(world, bB),
+                                   GetTransformation(world, bB).q);
+            const auto p1 = GetWorldCenter(world, bA) + rA;
+            const auto p2 = GetWorldCenter(world, bB) + rB;
+            const auto d = p2 - p1;
+            const auto axis = Rotate(GetLocalXAxisA(joint), GetTransformation(world, bA).q);
+            const auto vA = GetVelocity(world, bA).linear;
+            const auto vB = GetVelocity(world, bB).linear;
+            const auto wA = GetVelocity(world, bA).angular;
+            const auto wB = GetVelocity(world, bB).angular;
+            const auto vel = (vB + (GetRevPerpendicular(rB) * (wB / Radian))) - (vA + (GetRevPerpendicular(rA) * (wA / Radian)));
+            return Dot(d, (GetRevPerpendicular(axis) * (wA / Radian))) + Dot(axis, vel);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
@@ -24,231 +24,233 @@
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
-#include <PlayRho/Dynamics/Joints/LimitState.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Dynamics/Joints/LimitState.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class World;
-class BodyConstraint;
-
-/// @brief Prismatic joint definition.
-/// @details This joint provides one degree of freedom: translation along an axis fixed in
-///   body-A. Relative rotation is prevented. This requires defining a line of motion using
-///   an axis and an anchor point. The definition uses local anchor points and a local axis
-///   so that the initial configuration can violate the constraint slightly. The joint
-///   translation is zero when the local anchor points coincide in world space. Using local
-///   anchors and a local axis helps when saving and loading a game.
-/// @note You can use a joint limit to restrict the range of motion and a joint motor
-///   to drive the motion or to model joint friction.
-/// @ingroup JointsGroup
-/// @image html prismaticJoint.gif
-/// @see https://en.wikipedia.org/wiki/Prismatic_joint
-/// @see Joint, World::CreateJoint
-struct PrismaticJointConf : public JointBuilder<PrismaticJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<PrismaticJointConf>;
 
-    /// @brief Default constructor.
-    constexpr PrismaticJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Copy constructor.
-    PrismaticJointConf(const PrismaticJointConf& copy) = default;
-
-    /// @brief Initializing constructor.
-    /// @details Initializes the bodies, anchors, axis, and reference angle using the world
-    ///   anchor and unit world axis.
-    PrismaticJointConf(BodyID bA, BodyID bB,
-                       Length2 laA = Length2{}, Length2 laB = Length2{},
-                       UnitVec axisA = UnitVec::GetRight(), Angle angle = 0_deg) noexcept;
-
-    /// @brief Uses the given enable limit state value.
-    constexpr auto& UseEnableLimit(bool v) noexcept
+    namespace d2
     {
-        enableLimit = v;
-        return *this;
-    }
 
-    /// @brief Uses the given lower translation value.
-    constexpr auto& UseLowerLength(Length v) noexcept
+        class World;
+        class BodyConstraint;
+
+        /// @brief Prismatic joint definition.
+        /// @details This joint provides one degree of freedom: translation along an axis fixed in
+        ///   body-A. Relative rotation is prevented. This requires defining a line of motion using
+        ///   an axis and an anchor point. The definition uses local anchor points and a local axis
+        ///   so that the initial configuration can violate the constraint slightly. The joint
+        ///   translation is zero when the local anchor points coincide in world space. Using local
+        ///   anchors and a local axis helps when saving and loading a game.
+        /// @note You can use a joint limit to restrict the range of motion and a joint motor
+        ///   to drive the motion or to model joint friction.
+        /// @ingroup JointsGroup
+        /// @image html prismaticJoint.gif
+        /// @see https://en.wikipedia.org/wiki/Prismatic_joint
+        /// @see Joint, World::CreateJoint
+        struct PrismaticJointConf : public JointBuilder<PrismaticJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<PrismaticJointConf>;
+
+            /// @brief Default constructor.
+            constexpr PrismaticJointConf() = default;
+
+            /// @brief Copy constructor.
+            PrismaticJointConf(const PrismaticJointConf& copy) = default;
+
+            /// @brief Initializing constructor.
+            /// @details Initializes the bodies, anchors, axis, and reference angle using the world
+            ///   anchor and unit world axis.
+            PrismaticJointConf(BodyID bA, BodyID bB,
+                               Length2 laA = Length2{}, Length2 laB = Length2{},
+                               UnitVec axisA = UnitVec::GetRight(), Angle angle = 0_deg) noexcept;
+
+            /// @brief Uses the given enable limit state value.
+            constexpr auto& UseEnableLimit(bool v) noexcept
+            {
+                enableLimit = v;
+                return *this;
+            }
+
+            /// @brief Uses the given lower translation value.
+            constexpr auto& UseLowerLength(Length v) noexcept
+            {
+                lowerTranslation = v;
+                return *this;
+            }
+
+            /// @brief Uses the given upper translation value.
+            constexpr auto& UseUpperLength(Length v) noexcept
+            {
+                upperTranslation = v;
+                return *this;
+            }
+
+            /// @brief Uses the given enable motor state value.
+            constexpr auto& UseEnableMotor(bool v) noexcept
+            {
+                enableMotor = v;
+                return *this;
+            }
+
+            /// @brief Uses the given motor speed value.
+            constexpr auto& UseMotorSpeed(AngularVelocity v) noexcept
+            {
+                motorSpeed = v;
+                return *this;
+            }
+
+            /// @brief Uses the given max motor force value.
+            constexpr auto& UseMaxMotorForce(Force v) noexcept
+            {
+                maxMotorForce = v;
+                return *this;
+            }
+
+            /// The local anchor point relative to body A's origin.
+            Length2 localAnchorA = Length2{};
+
+            /// The local anchor point relative to body B's origin.
+            Length2 localAnchorB = Length2{};
+
+            /// The local translation unit axis in body A.
+            UnitVec localXAxisA = UnitVec::GetRight();
+
+            UnitVec localYAxisA = GetRevPerpendicular(UnitVec::GetRight());
+
+            /// The constrained angle between the bodies: body B's angle minus body A's angle.
+            Angle referenceAngle = 0_deg;
+
+            Vec3 impulse = Vec3{};///< Impulse.
+
+            Momentum motorImpulse = 0;///< Motor impulse.
+
+            /// Enable/disable the joint limit.
+            bool enableLimit = false;
+
+            /// The lower translation limit.
+            Length lowerTranslation = 0_m;
+
+            /// The upper translation limit.
+            Length upperTranslation = 0_m;
+
+            /// Enable/disable the joint motor.
+            bool enableMotor = false;
+
+            /// The maximum motor force.
+            Force maxMotorForce = 0_N;
+
+            /// The desired angular motor speed.
+            AngularVelocity motorSpeed = 0_rpm;
+
+            LimitState limitState = LimitState::e_inactiveLimit;///< Limit state.
+
+            // Solver temp
+            UnitVec axis = UnitVec::GetZero();///< Axis.
+            UnitVec perp = UnitVec::GetZero();///< Perpendicular.
+            Length s1 = 0_m;                  ///< Location S-1.
+            Length s2 = 0_m;                  ///< Location S-2.
+            Length a1 = 0_m;                  ///< Location A-1.
+            Length a2 = 0_m;                  ///< Location A-2.
+            Mat33 K = {};                     ///< K matrix.
+            Mass motorMass = 0_kg;            ///< Motor mass.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        PrismaticJointConf GetPrismaticJointConf(const Joint& joint);
+
+        /// @brief Gets the configuration for the given parameters.
+        /// @relatedalso World
+        PrismaticJointConf GetPrismaticJointConf(const World& world,
+                                                 BodyID bA, BodyID bB,
+                                                 const Length2 anchor,
+                                                 const UnitVec axis);
+
+        /// @brief Gets the current linear velocity of the given configuration.
+        /// @relatedalso World
+        LinearVelocity GetLinearVelocity(const World& world, const PrismaticJointConf& joint) noexcept;
+
+        /// @brief Free function for getting the linear lower limit value of the given configuration.
+        /// @relatedalso PrismaticJointConf
+        constexpr auto GetLinearLowerLimit(const PrismaticJointConf& conf) noexcept
+        {
+            return conf.lowerTranslation;
+        }
+
+        /// @brief Free function for getting the linear upper limit value of the given configuration.
+        /// @relatedalso PrismaticJointConf
+        constexpr auto GetLinearUpperLimit(const PrismaticJointConf& conf) noexcept
+        {
+            return conf.upperTranslation;
+        }
+
+        /// @brief Free function for setting the linear limits of the given configuration.
+        /// @relatedalso PrismaticJointConf
+        constexpr void SetLinearLimits(PrismaticJointConf& conf, Length lower, Length upper) noexcept
+        {
+            conf.UseLowerLength(lower).UseUpperLength(upper);
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso PrismaticJointConf
+        constexpr auto ShiftOrigin(PrismaticJointConf&, Length2) noexcept
+        {
+            return false;
+        }
+
+        /// @brief Gets the current linear reaction of the given configuration.
+        /// @relatedalso PrismaticJointConf
+        Momentum2 GetLinearReaction(const PrismaticJointConf& conf);
+
+        /// @brief Gets the current angular reaction of the given configuration.
+        /// @relatedalso PrismaticJointConf
+        AngularMomentum GetAngularReaction(const PrismaticJointConf& conf);
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocityConstraints.
+        /// @relatedalso PrismaticJointConf
+        void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso PrismaticJointConf
+        bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso PrismaticJointConf
+        bool SolvePosition(const PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for setting the maximum motor torque value of the given configuration.
+        /// @relatedalso PrismaticJointConf
+        constexpr void SetMaxMotorForce(PrismaticJointConf& object, Force value)
+        {
+            object.UseMaxMotorForce(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::PrismaticJointConf</code>.
+    template<>
+    struct TypeInfo<d2::PrismaticJointConf>
     {
-        lowerTranslation = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::PrismaticJointConf";
+    };
 
-    /// @brief Uses the given upper translation value.
-    constexpr auto& UseUpperLength(Length v) noexcept
-    {
-        upperTranslation = v;
-        return *this;
-    }
+}// namespace playrho
 
-    /// @brief Uses the given enable motor state value.
-    constexpr auto& UseEnableMotor(bool v) noexcept
-    {
-        enableMotor = v;
-        return *this;
-    }
-
-    /// @brief Uses the given motor speed value.
-    constexpr auto& UseMotorSpeed(AngularVelocity v) noexcept
-    {
-        motorSpeed = v;
-        return *this;
-    }
-
-    /// @brief Uses the given max motor force value.
-    constexpr auto& UseMaxMotorForce(Force v) noexcept
-    {
-        maxMotorForce = v;
-        return *this;
-    }
-
-    /// The local anchor point relative to body A's origin.
-    Length2 localAnchorA = Length2{};
-
-    /// The local anchor point relative to body B's origin.
-    Length2 localAnchorB = Length2{};
-
-    /// The local translation unit axis in body A.
-    UnitVec localXAxisA = UnitVec::GetRight();
-
-    UnitVec localYAxisA = GetRevPerpendicular(UnitVec::GetRight());
-
-    /// The constrained angle between the bodies: body B's angle minus body A's angle.
-    Angle referenceAngle = 0_deg;
-
-    Vec3 impulse = Vec3{}; ///< Impulse.
-
-    Momentum motorImpulse = 0; ///< Motor impulse.
-
-    /// Enable/disable the joint limit.
-    bool enableLimit = false;
-
-    /// The lower translation limit.
-    Length lowerTranslation = 0_m;
-
-    /// The upper translation limit.
-    Length upperTranslation = 0_m;
-
-    /// Enable/disable the joint motor.
-    bool enableMotor = false;
-
-    /// The maximum motor force.
-    Force maxMotorForce = 0_N;
-
-    /// The desired angular motor speed.
-    AngularVelocity motorSpeed = 0_rpm;
-
-    LimitState limitState = LimitState::e_inactiveLimit; ///< Limit state.
-
-    // Solver temp
-    UnitVec axis = UnitVec::GetZero(); ///< Axis.
-    UnitVec perp = UnitVec::GetZero(); ///< Perpendicular.
-    Length s1 = 0_m; ///< Location S-1.
-    Length s2 = 0_m; ///< Location S-2.
-    Length a1 = 0_m; ///< Location A-1.
-    Length a2 = 0_m; ///< Location A-2.
-    Mat33 K = {}; ///< K matrix.
-    Mass motorMass = 0_kg; ///< Motor mass.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-PrismaticJointConf GetPrismaticJointConf(const Joint& joint);
-
-/// @brief Gets the configuration for the given parameters.
-/// @relatedalso World
-PrismaticJointConf GetPrismaticJointConf(const World& world,
-                                         BodyID bA, BodyID bB,
-                                         const Length2 anchor,
-                                         const UnitVec axis);
-
-/// @brief Gets the current linear velocity of the given configuration.
-/// @relatedalso World
-LinearVelocity GetLinearVelocity(const World& world, const PrismaticJointConf& joint) noexcept;
-
-/// @brief Free function for getting the linear lower limit value of the given configuration.
-/// @relatedalso PrismaticJointConf
-constexpr auto GetLinearLowerLimit(const PrismaticJointConf& conf) noexcept
-{
-    return conf.lowerTranslation;
-}
-
-/// @brief Free function for getting the linear upper limit value of the given configuration.
-/// @relatedalso PrismaticJointConf
-constexpr auto GetLinearUpperLimit(const PrismaticJointConf& conf) noexcept
-{
-    return conf.upperTranslation;
-}
-
-/// @brief Free function for setting the linear limits of the given configuration.
-/// @relatedalso PrismaticJointConf
-constexpr void SetLinearLimits(PrismaticJointConf& conf, Length lower, Length upper) noexcept
-{
-    conf.UseLowerLength(lower).UseUpperLength(upper);
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso PrismaticJointConf
-constexpr auto ShiftOrigin(PrismaticJointConf&, Length2) noexcept
-{
-    return false;
-}
-
-/// @brief Gets the current linear reaction of the given configuration.
-/// @relatedalso PrismaticJointConf
-Momentum2 GetLinearReaction(const PrismaticJointConf& conf);
-
-/// @brief Gets the current angular reaction of the given configuration.
-/// @relatedalso PrismaticJointConf
-AngularMomentum GetAngularReaction(const PrismaticJointConf& conf);
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocityConstraints.
-/// @relatedalso PrismaticJointConf
-void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso PrismaticJointConf
-bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso PrismaticJointConf
-bool SolvePosition(const PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for setting the maximum motor torque value of the given configuration.
-/// @relatedalso PrismaticJointConf
-constexpr void SetMaxMotorForce(PrismaticJointConf& object, Force value)
-{
-    object.UseMaxMotorForce(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::PrismaticJointConf</code>.
-template <>
-struct TypeInfo<d2::PrismaticJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::PrismaticJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
@@ -21,227 +21,228 @@
 
 #include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<PulleyJointConf>::value,
-              "PulleyJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<PulleyJointConf>::value,
-              "PulleyJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<PulleyJointConf>::value,
-              "PulleyJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<PulleyJointConf>::value,
-              "PulleyJointConf should be move constructible!");
-static_assert(std::is_move_assignable<PulleyJointConf>::value,
-              "PulleyJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<PulleyJointConf>::value,
-              "PulleyJointConf should be nothrow destructible!");
-
-// Pulley:
-// length1 = norm(p1 - s1)
-// length2 = norm(p2 - s2)
-// C0 = (length1 + ratio * length2)_initial
-// C = C0 - (length1 + ratio * length2)
-// u1 = (p1 - s1) / norm(p1 - s1)
-// u2 = (p2 - s2) / norm(p2 - s2)
-// Cdot = -dot(u1, v1 + cross(w1, r1)) - ratio * dot(u2, v2 + cross(w2, r2))
-// J = -[u1 cross(r1, u1) ratio * u2  ratio * cross(r2, u2)]
-// K = J * invM * JT
-//   = invMass1 + invI1 * cross(r1, u1)^2 + ratio^2 * (invMass2 + invI2 * cross(r2, u2)^2)
-
-PulleyJointConf::PulleyJointConf(BodyID bA, BodyID bB,
-                                 Length2 groundA, Length2 groundB,
-                                 Length2 anchorA, Length2 anchorB,
-                                 Length lA, Length lB):
-    super{super{}.UseBodyA(bA).UseBodyB(bB).UseCollideConnected(true)},
-    groundAnchorA{groundA}, groundAnchorB{groundB},
-    localAnchorA{anchorA}, localAnchorB{anchorB},
-    lengthA{lA}, lengthB{lB}
+namespace playrho
 {
-    // Intentionally empty.
-}
-
-PulleyJointConf GetPulleyJointConf(const Joint& joint)
-{
-    return TypeCast<PulleyJointConf>(joint);
-}
-
-PulleyJointConf GetPulleyJointConf(const World& world,
-                                   BodyID bA, BodyID bB,
-                                   Length2 groundA, Length2 groundB,
-                                   Length2 anchorA, Length2 anchorB)
-{
-    return PulleyJointConf{
-        bA, bB, groundA, groundB,
-        GetLocalPoint(world, bA, anchorA), GetLocalPoint(world, bB, anchorB),
-        GetMagnitude(anchorA - groundA), GetMagnitude(anchorB - groundB)
-    };
-}
-
-void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto posA = bodyConstraintA.GetPosition();
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    auto velA = bodyConstraintA.GetVelocity();
-
-    const auto posB = bodyConstraintB.GetPosition();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-
-    // Get the pulley axes.
-    const auto pulleyAxisA = Length2{posA.linear + object.rA - object.groundAnchorA};
-    const auto pulleyAxisB = Length2{posB.linear + object.rB - object.groundAnchorB};
-
-    object.uA = GetUnitVector(pulleyAxisA, UnitVec::GetZero());
-    object.uB = GetUnitVector(pulleyAxisB, UnitVec::GetZero());
-
-    // Compute effective mass.
-    const auto ruA = Cross(object.rA, object.uA);
-    const auto ruB = Cross(object.rB, object.uB);
-
-    const auto totInvMassA = invMassA + (invRotInertiaA * Square(ruA)) / SquareRadian;
-    const auto totInvMassB = invMassB + (invRotInertiaB * Square(ruB)) / SquareRadian;
-
-    const auto totalInvMass = totInvMassA + object.ratio * object.ratio * totInvMassB;
-
-    object.mass = (totalInvMass > InvMass{0})? Real{1} / totalInvMass: 0_kg;
-
-    if (step.doWarmStart)
+    namespace d2
     {
-        // Scale impulses to support variable time steps.
-        object.impulse *= step.dtRatio;
 
-        // Warm starting.
-        const auto PA = -(object.impulse) * object.uA;
-        const auto PB = (-object.ratio * object.impulse) * object.uB;
+        static_assert(std::is_default_constructible<PulleyJointConf>::value,
+                      "PulleyJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<PulleyJointConf>::value,
+                      "PulleyJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<PulleyJointConf>::value,
+                      "PulleyJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<PulleyJointConf>::value,
+                      "PulleyJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<PulleyJointConf>::value,
+                      "PulleyJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<PulleyJointConf>::value,
+                      "PulleyJointConf should be nothrow destructible!");
 
-        velA += Velocity{invMassA * PA, invRotInertiaA * Cross(object.rA, PA) / Radian};
-        velB += Velocity{invMassB * PB, invRotInertiaB * Cross(object.rB, PB) / Radian};
-    }
-    else
-    {
-        object.impulse = 0_Ns;
-    }
+        // Pulley:
+        // length1 = norm(p1 - s1)
+        // length2 = norm(p2 - s2)
+        // C0 = (length1 + ratio * length2)_initial
+        // C = C0 - (length1 + ratio * length2)
+        // u1 = (p1 - s1) / norm(p1 - s1)
+        // u2 = (p2 - s2) / norm(p2 - s2)
+        // Cdot = -dot(u1, v1 + cross(w1, r1)) - ratio * dot(u2, v2 + cross(w2, r2))
+        // J = -[u1 cross(r1, u1) ratio * u2  ratio * cross(r2, u2)]
+        // K = J * invM * JT
+        //   = invMass1 + invI1 * cross(r1, u1)^2 + ratio^2 * (invMass2 + invI2 * cross(r2, u2)^2)
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
+        PulleyJointConf::PulleyJointConf(BodyID bA, BodyID bB,
+                                         Length2 groundA, Length2 groundB,
+                                         Length2 anchorA, Length2 anchorB,
+                                         Length lA, Length lB)
+            : super{super{}.UseBodyA(bA).UseBodyB(bB).UseCollideConnected(true)},
+              groundAnchorA{groundA}, groundAnchorB{groundB},
+              localAnchorA{anchorA}, localAnchorB{anchorB},
+              lengthA{lA}, lengthB{lB}
+        {
+            // Intentionally empty.
+        }
 
-bool SolveVelocity(PulleyJointConf& object,
-                   std::vector<BodyConstraint>& bodies, const StepConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+        PulleyJointConf GetPulleyJointConf(const Joint& joint)
+        {
+            return TypeCast<PulleyJointConf>(joint);
+        }
 
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    auto velA = bodyConstraintA.GetVelocity();
+        PulleyJointConf GetPulleyJointConf(const World& world,
+                                           BodyID bA, BodyID bB,
+                                           Length2 groundA, Length2 groundB,
+                                           Length2 anchorA, Length2 anchorB)
+        {
+            return PulleyJointConf{
+                bA, bB, groundA, groundB,
+                GetLocalPoint(world, bA, anchorA), GetLocalPoint(world, bB, anchorB),
+                GetMagnitude(anchorA - groundA), GetMagnitude(anchorB - groundB)};
+        }
 
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-    auto velB = bodyConstraintB.GetVelocity();
+        void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    const auto vpA = LinearVelocity2{velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian)};
-    const auto vpB = LinearVelocity2{velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian)};
+            const auto posA = bodyConstraintA.GetPosition();
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            auto velA = bodyConstraintA.GetVelocity();
 
-    const auto Cdot = LinearVelocity{-Dot(object.uA, vpA) - object.ratio * Dot(object.uB, vpB)};
-    const auto impulse = -object.mass * Cdot;
-    object.impulse += impulse;
+            const auto posB = bodyConstraintB.GetPosition();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+            auto velB = bodyConstraintB.GetVelocity();
 
-    const auto PA = -impulse * object.uA;
-    const auto PB = -object.ratio * impulse * object.uB;
-    velA += Velocity{invMassA * PA, invRotInertiaA * Cross(object.rA, PA) / Radian};
-    velB += Velocity{invMassB * PB, invRotInertiaB * Cross(object.rB, PB) / Radian};
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
+            object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
 
-    return impulse == 0_Ns;
-}
+            // Get the pulley axes.
+            const auto pulleyAxisA = Length2{posA.linear + object.rA - object.groundAnchorA};
+            const auto pulleyAxisB = Length2{posB.linear + object.rB - object.groundAnchorB};
 
-bool SolvePosition(const PulleyJointConf& object,
-                   std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+            object.uA = GetUnitVector(pulleyAxisA, UnitVec::GetZero());
+            object.uB = GetUnitVector(pulleyAxisB, UnitVec::GetZero());
 
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    auto posA = bodyConstraintA.GetPosition();
+            // Compute effective mass.
+            const auto ruA = Cross(object.rA, object.uA);
+            const auto ruB = Cross(object.rB, object.uB);
 
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-    auto posB = bodyConstraintB.GetPosition();
+            const auto totInvMassA = invMassA + (invRotInertiaA * Square(ruA)) / SquareRadian;
+            const auto totInvMassB = invMassB + (invRotInertiaB * Square(ruB)) / SquareRadian;
 
-    const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(),
-                           UnitVec::Get(posA.angular));
-    const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(),
-                           UnitVec::Get(posB.angular));
+            const auto totalInvMass = totInvMassA + object.ratio * object.ratio * totInvMassB;
 
-    // Get the pulley axes.
-    const auto pA = Length2{posA.linear + rA - object.groundAnchorA};
-    const auto uvresultA = UnitVec::Get(pA[0], pA[1]);
-    const auto uA = std::get<UnitVec>(uvresultA);
-    const auto lengthA = std::get<Length>(uvresultA);
+            object.mass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
 
-    const auto pB = Length2{posB.linear + rB - object.groundAnchorB};
-    const auto uvresultB = UnitVec::Get(pB[0], pB[1]);
-    const auto uB = std::get<UnitVec>(uvresultB);
-    const auto lengthB = std::get<Length>(uvresultB);
+            if (step.doWarmStart)
+            {
+                // Scale impulses to support variable time steps.
+                object.impulse *= step.dtRatio;
 
-    // Compute effective mass.
-    const auto ruA = Length{Cross(rA, uA)};
-    const auto ruB = Length{Cross(rB, uB)};
+                // Warm starting.
+                const auto PA = -(object.impulse) * object.uA;
+                const auto PB = (-object.ratio * object.impulse) * object.uB;
 
-    const auto totalInvMassA = invMassA + invRotInertiaA * ruA * ruA / SquareRadian;
-    const auto totalInvMassB = invMassB + invRotInertiaB * ruB * ruB / SquareRadian;
+                velA += Velocity{invMassA * PA, invRotInertiaA * Cross(object.rA, PA) / Radian};
+                velB += Velocity{invMassB * PB, invRotInertiaB * Cross(object.rB, PB) / Radian};
+            }
+            else
+            {
+                object.impulse = 0_Ns;
+            }
 
-    const auto totalInvMass = totalInvMassA + object.ratio * object.ratio * totalInvMassB;
-    const auto mass = (totalInvMass > InvMass{0})? Real{1} / totalInvMass: 0_kg;
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
 
-    const auto C = Length{object.constant - lengthA - (object.ratio * lengthB)};
-    const auto linearError = abs(C);
+        bool SolveVelocity(PulleyJointConf& object,
+                           std::vector<BodyConstraint>& bodies, const StepConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    const auto impulse = -mass * C;
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            auto velA = bodyConstraintA.GetVelocity();
 
-    const auto PA = -impulse * uA;
-    const auto PB = -object.ratio * impulse * uB;
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+            auto velB = bodyConstraintB.GetVelocity();
 
-    posA += Position{invMassA * PA, invRotInertiaA * Cross(rA, PA) / Radian};
-    posB += Position{invMassB * PB, invRotInertiaB * Cross(rB, PB) / Radian};
+            const auto vpA = LinearVelocity2{velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian)};
+            const auto vpB = LinearVelocity2{velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian)};
 
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
+            const auto Cdot = LinearVelocity{-Dot(object.uA, vpA) - object.ratio * Dot(object.uB, vpB)};
+            const auto impulse = -object.mass * Cdot;
+            object.impulse += impulse;
 
-    return linearError < conf.linearSlop;
-}
+            const auto PA = -impulse * object.uA;
+            const auto PB = -object.ratio * impulse * object.uB;
+            velA += Velocity{invMassA * PA, invRotInertiaA * Cross(object.rA, PA) / Radian};
+            velB += Velocity{invMassB * PB, invRotInertiaB * Cross(object.rB, PB) / Radian};
 
-bool ShiftOrigin(PulleyJointConf& object, Length2 newOrigin) noexcept
-{
-    object.groundAnchorA -= newOrigin;
-    object.groundAnchorB -= newOrigin;
-    return true;
-}
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
 
-} // namespace d2
-} // namespace playrho
+            return impulse == 0_Ns;
+        }
+
+        bool SolvePosition(const PulleyJointConf& object,
+                           std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            auto posA = bodyConstraintA.GetPosition();
+
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+            auto posB = bodyConstraintB.GetPosition();
+
+            const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(),
+                                   UnitVec::Get(posA.angular));
+            const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(),
+                                   UnitVec::Get(posB.angular));
+
+            // Get the pulley axes.
+            const auto pA = Length2{posA.linear + rA - object.groundAnchorA};
+            const auto uvresultA = UnitVec::Get(pA[0], pA[1]);
+            const auto uA = std::get<UnitVec>(uvresultA);
+            const auto lengthA = std::get<Length>(uvresultA);
+
+            const auto pB = Length2{posB.linear + rB - object.groundAnchorB};
+            const auto uvresultB = UnitVec::Get(pB[0], pB[1]);
+            const auto uB = std::get<UnitVec>(uvresultB);
+            const auto lengthB = std::get<Length>(uvresultB);
+
+            // Compute effective mass.
+            const auto ruA = Length{Cross(rA, uA)};
+            const auto ruB = Length{Cross(rB, uB)};
+
+            const auto totalInvMassA = invMassA + invRotInertiaA * ruA * ruA / SquareRadian;
+            const auto totalInvMassB = invMassB + invRotInertiaB * ruB * ruB / SquareRadian;
+
+            const auto totalInvMass = totalInvMassA + object.ratio * object.ratio * totalInvMassB;
+            const auto mass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
+
+            const auto C = Length{object.constant - lengthA - (object.ratio * lengthB)};
+            const auto linearError = abs(C);
+
+            const auto impulse = -mass * C;
+
+            const auto PA = -impulse * uA;
+            const auto PB = -object.ratio * impulse * uB;
+
+            posA += Position{invMassA * PA, invRotInertiaA * Cross(rA, PA) / Radian};
+            posB += Position{invMassB * PB, invRotInertiaB * Cross(rB, PB) / Radian};
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+
+            return linearError < conf.linearSlop;
+        }
+
+        bool ShiftOrigin(PulleyJointConf& object, Length2 newOrigin) noexcept
+        {
+            object.groundAnchorA -= newOrigin;
+            object.groundAnchorB -= newOrigin;
+            return true;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
@@ -26,172 +26,177 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class Joint;
-class World;
-class BodyConstraint;
-
-/// @brief Pulley joint definition.
-/// @details The pulley joint is connected to two bodies and two fixed ground points.
-///   The pulley supports a ratio such that: <code>length1 + ratio * length2 <= constant</code>.
-/// @note The force transmitted is scaled by the ratio.
-/// @warning the pulley joint can get a bit squirrelly by itself. They often
-///   work better when combined with prismatic joints. You should also cover the
-///   the anchor points with static shapes to prevent one side from going to
-///   zero length.
-/// @ingroup JointsGroup
-/// @image html pulleyJoint.gif
-/// @see Joint, World::CreateJoint
-struct PulleyJointConf : public JointBuilder<PulleyJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<PulleyJointConf>;
 
-    /// @brief Default ground anchor A.
-    static constexpr Length2 DefaultGroundAnchorA = Length2{-1_m, +1_m};
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Default ground anchor B.
-    static constexpr Length2 DefaultGroundAnchorB = Length2{+1_m, +1_m};
-
-    /// @brief Default local anchor A.
-    static constexpr Length2 DefaultLocalAnchorA = Length2{-1_m, 0_m};
-
-    /// @brief Default local anchor B.
-    static constexpr Length2 DefaultLocalAnchorB = Length2{+1_m, 0_m};
-
-    /// @brief Default constructor.
-    PulleyJointConf() noexcept: super{super{}.UseCollideConnected(true)} {}
-
-    /// Initialize the bodies, anchors, lengths, max lengths, and ratio using the world anchors.
-    PulleyJointConf(BodyID bodyA, BodyID bodyB,
-                    Length2 groundAnchorA = DefaultGroundAnchorA,
-                    Length2 groundAnchorB = DefaultGroundAnchorB,
-                    Length2 anchorA = DefaultLocalAnchorA,
-                    Length2 anchorB = DefaultLocalAnchorB,
-                    Length lA = 0_m, Length lB = 0_m);
-
-    /// @brief Uses the given ratio value.
-    constexpr auto& UseRatio(Real v) noexcept
+    namespace d2
     {
-        ratio = v;
-        return *this;
-    }
 
-    /// The first ground anchor in world coordinates. This point never moves.
-    Length2 groundAnchorA = DefaultGroundAnchorA;
+        class Joint;
+        class World;
+        class BodyConstraint;
 
-    /// The second ground anchor in world coordinates. This point never moves.
-    Length2 groundAnchorB = DefaultGroundAnchorB;
+        /// @brief Pulley joint definition.
+        /// @details The pulley joint is connected to two bodies and two fixed ground points.
+        ///   The pulley supports a ratio such that: <code>length1 + ratio * length2 <= constant</code>.
+        /// @note The force transmitted is scaled by the ratio.
+        /// @warning the pulley joint can get a bit squirrelly by itself. They often
+        ///   work better when combined with prismatic joints. You should also cover the
+        ///   the anchor points with static shapes to prevent one side from going to
+        ///   zero length.
+        /// @ingroup JointsGroup
+        /// @image html pulleyJoint.gif
+        /// @see Joint, World::CreateJoint
+        struct PulleyJointConf : public JointBuilder<PulleyJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<PulleyJointConf>;
 
-    /// The local anchor point relative to body A's origin.
-    Length2 localAnchorA = DefaultLocalAnchorA;
+            /// @brief Default ground anchor A.
+            static constexpr Length2 DefaultGroundAnchorA = Length2{-1_m, +1_m};
 
-    /// The local anchor point relative to body B's origin.
-    Length2 localAnchorB = DefaultLocalAnchorB;
+            /// @brief Default ground anchor B.
+            static constexpr Length2 DefaultGroundAnchorB = Length2{+1_m, +1_m};
 
-    /// The a reference length for the segment attached to body-A.
-    Length lengthA = 0_m;
+            /// @brief Default local anchor A.
+            static constexpr Length2 DefaultLocalAnchorA = Length2{-1_m, 0_m};
 
-    /// The a reference length for the segment attached to body-B.
-    Length lengthB = 0_m;
+            /// @brief Default local anchor B.
+            static constexpr Length2 DefaultLocalAnchorB = Length2{+1_m, 0_m};
 
-    /// The pulley ratio, used to simulate a block-and-tackle.
-    Real ratio = 1;
+            /// @brief Default constructor.
+            PulleyJointConf() noexcept
+                : super{super{}.UseCollideConnected(true)}
+            {
+            }
 
-    Length constant = 0_m; ///< Constant.
+            /// Initialize the bodies, anchors, lengths, max lengths, and ratio using the world anchors.
+            PulleyJointConf(BodyID bodyA, BodyID bodyB,
+                            Length2 groundAnchorA = DefaultGroundAnchorA,
+                            Length2 groundAnchorB = DefaultGroundAnchorB,
+                            Length2 anchorA = DefaultLocalAnchorA,
+                            Length2 anchorB = DefaultLocalAnchorB,
+                            Length lA = 0_m, Length lB = 0_m);
 
-    // Solver shared (between calls to InitVelocityConstraints).
-    Momentum impulse = 0_Ns; ///< Impulse.
+            /// @brief Uses the given ratio value.
+            constexpr auto& UseRatio(Real v) noexcept
+            {
+                ratio = v;
+                return *this;
+            }
 
-    // Solver temp (recalculated every call to InitVelocityConstraints).
-    UnitVec uA; ///< Unit vector A.
-    UnitVec uB; ///< Unit vector B.
-    Length2 rA{}; ///< Relative A.
-    Length2 rB{}; ///< Relative B.
-    Mass mass = 0_kg; ///< Mass.
-};
+            /// The first ground anchor in world coordinates. This point never moves.
+            Length2 groundAnchorA = DefaultGroundAnchorA;
 
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-PulleyJointConf GetPulleyJointConf(const Joint& joint);
+            /// The second ground anchor in world coordinates. This point never moves.
+            Length2 groundAnchorB = DefaultGroundAnchorB;
 
-/// @brief Gets the configuration for the given parameters.
-/// @relatedalso World
-PulleyJointConf GetPulleyJointConf(const World& world,
-                                   BodyID bA, BodyID bB,
-                                   Length2 groundA, Length2 groundB,
-                                   Length2 anchorA, Length2 anchorB);
+            /// The local anchor point relative to body A's origin.
+            Length2 localAnchorA = DefaultLocalAnchorA;
 
-/// @brief Gets the current linear reaction of the given configuration.
-/// @relatedalso PulleyJointConf
-constexpr Momentum2 GetLinearReaction(const PulleyJointConf& object) noexcept
-{
-    return object.impulse * object.uB;
-}
+            /// The local anchor point relative to body B's origin.
+            Length2 localAnchorB = DefaultLocalAnchorB;
 
-/// @brief Gets the current angular reaction of the given configuration.
-/// @relatedalso PulleyJointConf
-constexpr AngularMomentum GetAngularReaction(const PulleyJointConf&) noexcept
-{
-    return AngularMomentum{0};
-}
+            /// The a reference length for the segment attached to body-A.
+            Length lengthA = 0_m;
 
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso PulleyJointConf
-bool ShiftOrigin(PulleyJointConf& object, Length2 newOrigin) noexcept;
+            /// The a reference length for the segment attached to body-B.
+            Length lengthB = 0_m;
 
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso PulleyJointConf
-void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
+            /// The pulley ratio, used to simulate a block-and-tackle.
+            Real ratio = 1;
 
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso PulleyJointConf
-bool SolveVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
+            Length constant = 0_m;///< Constant.
 
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso PulleyJointConf
-bool SolvePosition(const PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
+            // Solver shared (between calls to InitVelocityConstraints).
+            Momentum impulse = 0_Ns;///< Impulse.
 
-/// @brief Free function for getting the length A value of the given configuration.
-/// @relatedalso PulleyJointConf
-constexpr auto GetLengthA(const PulleyJointConf& object) noexcept
-{
-    return object.lengthA;
-}
+            // Solver temp (recalculated every call to InitVelocityConstraints).
+            UnitVec uA;      ///< Unit vector A.
+            UnitVec uB;      ///< Unit vector B.
+            Length2 rA{};    ///< Relative A.
+            Length2 rB{};    ///< Relative B.
+            Mass mass = 0_kg;///< Mass.
+        };
 
-/// @brief Free function for getting the length B value of the given configuration.
-/// @relatedalso PulleyJointConf
-constexpr auto GetLengthB(const PulleyJointConf& object) noexcept
-{
-    return object.lengthB;
-}
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        PulleyJointConf GetPulleyJointConf(const Joint& joint);
 
-} // namespace d2
+        /// @brief Gets the configuration for the given parameters.
+        /// @relatedalso World
+        PulleyJointConf GetPulleyJointConf(const World& world,
+                                           BodyID bA, BodyID bB,
+                                           Length2 groundA, Length2 groundB,
+                                           Length2 anchorA, Length2 anchorB);
 
-/// @brief Type info specialization for <code>d2::PulleyJointConf</code>.
-template <>
-struct TypeInfo<d2::PulleyJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::PulleyJointConf";
-};
+        /// @brief Gets the current linear reaction of the given configuration.
+        /// @relatedalso PulleyJointConf
+        constexpr Momentum2 GetLinearReaction(const PulleyJointConf& object) noexcept
+        {
+            return object.impulse * object.uB;
+        }
 
-} // namespace playrho
+        /// @brief Gets the current angular reaction of the given configuration.
+        /// @relatedalso PulleyJointConf
+        constexpr AngularMomentum GetAngularReaction(const PulleyJointConf&) noexcept
+        {
+            return AngularMomentum{0};
+        }
 
-#endif // PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINTCONF_HPP
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso PulleyJointConf
+        bool ShiftOrigin(PulleyJointConf& object, Length2 newOrigin) noexcept;
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso PulleyJointConf
+        void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso PulleyJointConf
+        bool SolveVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso PulleyJointConf
+        bool SolvePosition(const PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for getting the length A value of the given configuration.
+        /// @relatedalso PulleyJointConf
+        constexpr auto GetLengthA(const PulleyJointConf& object) noexcept
+        {
+            return object.lengthA;
+        }
+
+        /// @brief Free function for getting the length B value of the given configuration.
+        /// @relatedalso PulleyJointConf
+        constexpr auto GetLengthB(const PulleyJointConf& object) noexcept
+        {
+            return object.lengthB;
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::PulleyJointConf</code>.
+    template<>
+    struct TypeInfo<d2::PulleyJointConf>
+    {
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::PulleyJointConf";
+    };
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.cpp
@@ -21,465 +21,443 @@
 
 #include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-namespace {
-
-Mat33 GetMat33(InvMass invMassA, Length2 rA, InvRotInertia invRotInertiaA,
-               InvMass invMassB, Length2 rB, InvRotInertia invRotInertiaB)
+namespace playrho
 {
-    const auto totInvI = invRotInertiaA + invRotInertiaB;
-
-    const auto exx = InvMass{
-        invMassA + (Square(GetY(rA)) * invRotInertiaA / SquareRadian) +
-        invMassB + (Square(GetY(rB)) * invRotInertiaB / SquareRadian)
-    };
-    const auto eyx = InvMass{
-        (-GetY(rA) * GetX(rA) * invRotInertiaA / SquareRadian) +
-        (-GetY(rB) * GetX(rB) * invRotInertiaB / SquareRadian)
-    };
-    const auto ezx = InvMass{
-        (-GetY(rA) * invRotInertiaA * Meter / SquareRadian) +
-        (-GetY(rB) * invRotInertiaB * Meter / SquareRadian)
-    };
-    const auto eyy = InvMass{
-        invMassA + (Square(GetX(rA)) * invRotInertiaA / SquareRadian) +
-        invMassB + (Square(GetX(rB)) * invRotInertiaB / SquareRadian)
-    };
-    const auto ezy = InvMass{
-        (GetX(rA) * invRotInertiaA * Meter / SquareRadian) +
-        (GetX(rB) * invRotInertiaB * Meter / SquareRadian)
-    };
-
-    auto mass = Mat33{};
-    GetX(GetX(mass)) = StripUnit(exx);
-    GetX(GetY(mass)) = StripUnit(eyx);
-    GetX(GetZ(mass)) = StripUnit(ezx);
-    GetY(GetX(mass)) = GetX(GetY(mass));
-    GetY(GetY(mass)) = StripUnit(eyy);
-    GetY(GetZ(mass)) = StripUnit(ezy);
-    GetZ(GetX(mass)) = GetX(GetZ(mass));
-    GetZ(GetY(mass)) = GetY(GetZ(mass));
-    GetZ(GetZ(mass)) = StripUnit(totInvI);
-    return mass;
-}
-
-} // unnamed namespace
-
-static_assert(std::is_default_constructible<RevoluteJointConf>::value,
-              "RevoluteJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<RevoluteJointConf>::value,
-              "RevoluteJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<RevoluteJointConf>::value,
-              "RevoluteJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<RevoluteJointConf>::value,
-              "RevoluteJointConf should be move constructible!");
-static_assert(std::is_move_assignable<RevoluteJointConf>::value,
-              "RevoluteJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<RevoluteJointConf>::value,
-              "RevoluteJointConf should be nothrow destructible!");
-
-// Point-to-point constraint
-// C = p2 - p1
-// Cdot = v2 - v1
-//      = v2 + cross(w2, r2) - v1 - cross(w1, r1)
-// J = [-I -r1_skew I r2_skew ]
-// Identity used:
-// w k % (rx i + ry j) = w * (-ry i + rx j)
-
-// Motor constraint
-// Cdot = w2 - w1
-// J = [0 0 -1 0 0 1]
-// K = invI1 + invI2
-
-RevoluteJointConf::RevoluteJointConf(BodyID bA, BodyID bB,
-                                     Length2 laA, Length2 laB,
-                                     Angle ra) noexcept:
-    super{super{}.UseBodyA(bA).UseBodyB(bB)},
-    localAnchorA{laA}, localAnchorB{laB}, referenceAngle{ra}
-{
-    // Intentionally empty.
-}
-
-RevoluteJointConf GetRevoluteJointConf(const Joint& joint)
-{
-    return TypeCast<RevoluteJointConf>(joint);
-}
-
-RevoluteJointConf GetRevoluteJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchor)
-{
-    return RevoluteJointConf{
-        bodyA, bodyB,
-        GetLocalPoint(world, bodyA, anchor),
-        GetLocalPoint(world, bodyB, anchor),
-        GetAngle(world, bodyB) - GetAngle(world, bodyA)
-    };
-}
-
-Angle GetAngle(const World& world, const RevoluteJointConf& conf)
-{
-    return GetAngle(world, GetBodyB(conf)) - GetAngle(world, GetBodyA(conf))
-         - GetReferenceAngle(conf);
-}
-
-AngularVelocity GetAngularVelocity(const World& world, const RevoluteJointConf& conf)
-{
-    return GetVelocity(world, GetBodyB(conf)).angular
-         - GetVelocity(world, GetBodyA(conf)).angular;
-}
-
-void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    const auto aA = bodyConstraintA.GetPosition().angular;
-    auto velA = bodyConstraintA.GetVelocity();
-
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-    const auto aB = bodyConstraintB.GetPosition().angular;
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto qA = UnitVec::Get(aA);
-    const auto qB = UnitVec::Get(aB);
-
-    object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-
-    // J = [-I -r1_skew I r2_skew]
-    //     [ 0       -1 0       1]
-    // r_skew = [-ry; rx]
-
-    // Matlab
-    // K = [ mA+r1y^2*iA+mB+r2y^2*iB,  -r1y*iA*r1x-r2y*iB*r2x,          -r1y*iA-r2y*iB]
-    //     [  -r1y*iA*r1x-r2y*iB*r2x, mA+r1x^2*iA+mB+r2x^2*iB,           r1x*iA+r2x*iB]
-    //     [          -r1y*iA-r2y*iB,           r1x*iA+r2x*iB,                   iA+iB]
-
-    const auto totInvI = invRotInertiaA + invRotInertiaB;
-    const auto fixedRotation = (totInvI == InvRotInertia{0});
-
-    object.mass = GetMat33(invMassA, object.rA, invRotInertiaA,
-                           invMassB, object.rB, invRotInertiaB);
-    object.angularMass = (totInvI > InvRotInertia{0})? RotInertia{Real{1} / totInvI}: RotInertia{0};
-
-    if (!object.enableMotor || fixedRotation)
+    namespace d2
     {
-        object.angularMotorImpulse = 0;
-    }
 
-    if (object.enableLimit && !fixedRotation)
-    {
-        const auto jointAngle = aB - aA - GetReferenceAngle(object);
-        if (abs(object.upperAngle - object.lowerAngle) < (conf.angularSlop * 2))
+        namespace
         {
-            object.limitState = LimitState::e_equalLimits;
-        }
-        else if (jointAngle <= object.lowerAngle)
-        {
-            if (object.limitState != LimitState::e_atLowerLimit)
+
+            Mat33 GetMat33(InvMass invMassA, Length2 rA, InvRotInertia invRotInertiaA,
+                           InvMass invMassB, Length2 rB, InvRotInertia invRotInertiaB)
             {
-                object.limitState = LimitState::e_atLowerLimit;
-                GetZ(object.impulse) = 0;
+                const auto totInvI = invRotInertiaA + invRotInertiaB;
+
+                const auto exx = InvMass{
+                    invMassA + (Square(GetY(rA)) * invRotInertiaA / SquareRadian) + invMassB + (Square(GetY(rB)) * invRotInertiaB / SquareRadian)};
+                const auto eyx = InvMass{
+                    (-GetY(rA) * GetX(rA) * invRotInertiaA / SquareRadian) + (-GetY(rB) * GetX(rB) * invRotInertiaB / SquareRadian)};
+                const auto ezx = InvMass{
+                    (-GetY(rA) * invRotInertiaA * Meter / SquareRadian) + (-GetY(rB) * invRotInertiaB * Meter / SquareRadian)};
+                const auto eyy = InvMass{
+                    invMassA + (Square(GetX(rA)) * invRotInertiaA / SquareRadian) + invMassB + (Square(GetX(rB)) * invRotInertiaB / SquareRadian)};
+                const auto ezy = InvMass{
+                    (GetX(rA) * invRotInertiaA * Meter / SquareRadian) + (GetX(rB) * invRotInertiaB * Meter / SquareRadian)};
+
+                auto mass = Mat33{};
+                GetX(GetX(mass)) = StripUnit(exx);
+                GetX(GetY(mass)) = StripUnit(eyx);
+                GetX(GetZ(mass)) = StripUnit(ezx);
+                GetY(GetX(mass)) = GetX(GetY(mass));
+                GetY(GetY(mass)) = StripUnit(eyy);
+                GetY(GetZ(mass)) = StripUnit(ezy);
+                GetZ(GetX(mass)) = GetX(GetZ(mass));
+                GetZ(GetY(mass)) = GetY(GetZ(mass));
+                GetZ(GetZ(mass)) = StripUnit(totInvI);
+                return mass;
             }
-        }
-        else if (jointAngle >= object.upperAngle)
+
+        }// unnamed namespace
+
+        static_assert(std::is_default_constructible<RevoluteJointConf>::value,
+                      "RevoluteJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<RevoluteJointConf>::value,
+                      "RevoluteJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<RevoluteJointConf>::value,
+                      "RevoluteJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<RevoluteJointConf>::value,
+                      "RevoluteJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<RevoluteJointConf>::value,
+                      "RevoluteJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<RevoluteJointConf>::value,
+                      "RevoluteJointConf should be nothrow destructible!");
+
+        // Point-to-point constraint
+        // C = p2 - p1
+        // Cdot = v2 - v1
+        //      = v2 + cross(w2, r2) - v1 - cross(w1, r1)
+        // J = [-I -r1_skew I r2_skew ]
+        // Identity used:
+        // w k % (rx i + ry j) = w * (-ry i + rx j)
+
+        // Motor constraint
+        // Cdot = w2 - w1
+        // J = [0 0 -1 0 0 1]
+        // K = invI1 + invI2
+
+        RevoluteJointConf::RevoluteJointConf(BodyID bA, BodyID bB,
+                                             Length2 laA, Length2 laB,
+                                             Angle ra) noexcept
+            : super{super{}.UseBodyA(bA).UseBodyB(bB)},
+              localAnchorA{laA}, localAnchorB{laB}, referenceAngle{ra}
         {
-            if (object.limitState != LimitState::e_atUpperLimit)
+            // Intentionally empty.
+        }
+
+        RevoluteJointConf GetRevoluteJointConf(const Joint& joint)
+        {
+            return TypeCast<RevoluteJointConf>(joint);
+        }
+
+        RevoluteJointConf GetRevoluteJointConf(const World& world, BodyID bodyA, BodyID bodyB,
+                                               Length2 anchor)
+        {
+            return RevoluteJointConf{
+                bodyA, bodyB,
+                GetLocalPoint(world, bodyA, anchor),
+                GetLocalPoint(world, bodyB, anchor),
+                GetAngle(world, bodyB) - GetAngle(world, bodyA)};
+        }
+
+        Angle GetAngle(const World& world, const RevoluteJointConf& conf)
+        {
+            return GetAngle(world, GetBodyB(conf)) - GetAngle(world, GetBodyA(conf))
+                   - GetReferenceAngle(conf);
+        }
+
+        AngularVelocity GetAngularVelocity(const World& world, const RevoluteJointConf& conf)
+        {
+            return GetVelocity(world, GetBodyB(conf)).angular
+                   - GetVelocity(world, GetBodyA(conf)).angular;
+        }
+
+        void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            const auto aA = bodyConstraintA.GetPosition().angular;
+            auto velA = bodyConstraintA.GetVelocity();
+
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+            const auto aB = bodyConstraintB.GetPosition().angular;
+            auto velB = bodyConstraintB.GetVelocity();
+
+            const auto qA = UnitVec::Get(aA);
+            const auto qB = UnitVec::Get(aB);
+
+            object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+
+            // J = [-I -r1_skew I r2_skew]
+            //     [ 0       -1 0       1]
+            // r_skew = [-ry; rx]
+
+            // Matlab
+            // K = [ mA+r1y^2*iA+mB+r2y^2*iB,  -r1y*iA*r1x-r2y*iB*r2x,          -r1y*iA-r2y*iB]
+            //     [  -r1y*iA*r1x-r2y*iB*r2x, mA+r1x^2*iA+mB+r2x^2*iB,           r1x*iA+r2x*iB]
+            //     [          -r1y*iA-r2y*iB,           r1x*iA+r2x*iB,                   iA+iB]
+
+            const auto totInvI = invRotInertiaA + invRotInertiaB;
+            const auto fixedRotation = (totInvI == InvRotInertia{0});
+
+            object.mass = GetMat33(invMassA, object.rA, invRotInertiaA,
+                                   invMassB, object.rB, invRotInertiaB);
+            object.angularMass = (totInvI > InvRotInertia{0}) ? RotInertia{Real{1} / totInvI} : RotInertia{0};
+
+            if (!object.enableMotor || fixedRotation)
             {
-                object.limitState = LimitState::e_atUpperLimit;
-                GetZ(object.impulse) = 0;
+                object.angularMotorImpulse = 0;
             }
-        }
-        else // jointAngle > object.lowerAngle && jointAngle < object.upperAngle
-        {
-            object.limitState = LimitState::e_inactiveLimit;
-            GetZ(object.impulse) = 0;
-        }
-    }
-    else
-    {
-        object.limitState = LimitState::e_inactiveLimit;
-    }
 
-    if (step.doWarmStart)
-    {
-        // Scale impulses to support a variable time step.
-        object.impulse *= step.dtRatio;
-        object.angularMotorImpulse *= step.dtRatio;
-
-        const auto P = Momentum2{GetX(object.impulse) * NewtonSecond, GetY(object.impulse) * NewtonSecond};
-
-        // AngularMomentum is L^2 M T^-1 QP^-1.
-        const auto L = AngularMomentum{
-            object.angularMotorImpulse + (GetZ(object.impulse) * SquareMeter * Kilogram / (Second * Radian))
-        };
-        const auto LA = AngularMomentum{Cross(object.rA, P) / Radian} + L;
-        const auto LB = AngularMomentum{Cross(object.rB, P) / Radian} + L;
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        object.impulse = Vec3{};
-        object.angularMotorImpulse = 0;
-    }
-
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
-
-bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto oldVelA = bodyConstraintA.GetVelocity();
-    auto velA = oldVelA;
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-
-    const auto oldVelB = bodyConstraintB.GetVelocity();
-    auto velB = oldVelB;
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    const auto fixedRotation = (invRotInertiaA + invRotInertiaB == InvRotInertia{0});
-
-    // Solve motor constraint.
-    if (object.enableMotor && (object.limitState != LimitState::e_equalLimits)
-        && !fixedRotation)
-    {
-        const auto impulse = AngularMomentum{-object.angularMass * (velB.angular - velA.angular - object.motorSpeed)};
-        const auto oldImpulse = object.angularMotorImpulse;
-        const auto maxImpulse = step.deltaTime * object.maxMotorTorque;
-        object.angularMotorImpulse = std::clamp(object.angularMotorImpulse + impulse,
-                                                -maxImpulse, maxImpulse);
-        const auto incImpulse = object.angularMotorImpulse - oldImpulse;
-
-        velA.angular -= invRotInertiaA * incImpulse;
-        velB.angular += invRotInertiaB * incImpulse;
-    }
-
-    const auto vb = velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian);
-    const auto va = velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian);
-    const auto vDelta = vb - va;
-
-    // Solve limit constraint.
-    if (object.enableLimit && (object.limitState != LimitState::e_inactiveLimit)
-        && !fixedRotation)
-    {
-        const auto Cdot = Vec3{
-            GetX(vDelta) / MeterPerSecond,
-            GetY(vDelta) / MeterPerSecond,
-            (velB.angular - velA.angular) / RadianPerSecond
-        };
-        auto impulse = -Solve33(object.mass, Cdot);
-
-        auto UpdateImpulseProc = [&]() {
-            const auto rhs = -Vec2{
-                GetX(vDelta) / MeterPerSecond,
-                GetY(vDelta) / MeterPerSecond
-            } + GetZ(object.impulse) * Vec2{GetX(GetZ(object.mass)), GetY(GetZ(object.mass))};
-            const auto reduced = Solve22(object.mass, rhs);
-            GetX(impulse) = GetX(reduced);
-            GetY(impulse) = GetY(reduced);
-            GetZ(impulse) = -GetZ(object.impulse);
-            GetX(object.impulse) += GetX(reduced);
-            GetY(object.impulse) += GetY(reduced);
-            GetZ(object.impulse) = 0;
-        };
-
-        switch (object.limitState)
-        {
-            case LimitState::e_atLowerLimit:
+            if (object.enableLimit && !fixedRotation)
             {
-                const auto newImpulse = GetZ(object.impulse) + GetZ(impulse);
-                if (newImpulse < 0)
+                const auto jointAngle = aB - aA - GetReferenceAngle(object);
+                if (abs(object.upperAngle - object.lowerAngle) < (conf.angularSlop * 2))
                 {
-                    UpdateImpulseProc();
+                    object.limitState = LimitState::e_equalLimits;
                 }
-                else
+                else if (jointAngle <= object.lowerAngle)
                 {
+                    if (object.limitState != LimitState::e_atLowerLimit)
+                    {
+                        object.limitState = LimitState::e_atLowerLimit;
+                        GetZ(object.impulse) = 0;
+                    }
+                }
+                else if (jointAngle >= object.upperAngle)
+                {
+                    if (object.limitState != LimitState::e_atUpperLimit)
+                    {
+                        object.limitState = LimitState::e_atUpperLimit;
+                        GetZ(object.impulse) = 0;
+                    }
+                }
+                else// jointAngle > object.lowerAngle && jointAngle < object.upperAngle
+                {
+                    object.limitState = LimitState::e_inactiveLimit;
+                    GetZ(object.impulse) = 0;
+                }
+            }
+            else
+            {
+                object.limitState = LimitState::e_inactiveLimit;
+            }
+
+            if (step.doWarmStart)
+            {
+                // Scale impulses to support a variable time step.
+                object.impulse *= step.dtRatio;
+                object.angularMotorImpulse *= step.dtRatio;
+
+                const auto P = Momentum2{GetX(object.impulse) * NewtonSecond, GetY(object.impulse) * NewtonSecond};
+
+                // AngularMomentum is L^2 M T^-1 QP^-1.
+                const auto L = AngularMomentum{
+                    object.angularMotorImpulse + (GetZ(object.impulse) * SquareMeter * Kilogram / (Second * Radian))};
+                const auto LA = AngularMomentum{Cross(object.rA, P) / Radian} + L;
+                const auto LB = AngularMomentum{Cross(object.rB, P) / Radian} + L;
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                object.impulse = Vec3{};
+                object.angularMotorImpulse = 0;
+            }
+
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
+
+        bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            const auto oldVelA = bodyConstraintA.GetVelocity();
+            auto velA = oldVelA;
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+
+            const auto oldVelB = bodyConstraintB.GetVelocity();
+            auto velB = oldVelB;
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            const auto fixedRotation = (invRotInertiaA + invRotInertiaB == InvRotInertia{0});
+
+            // Solve motor constraint.
+            if (object.enableMotor && (object.limitState != LimitState::e_equalLimits)
+                && !fixedRotation)
+            {
+                const auto impulse = AngularMomentum{-object.angularMass * (velB.angular - velA.angular - object.motorSpeed)};
+                const auto oldImpulse = object.angularMotorImpulse;
+                const auto maxImpulse = step.deltaTime * object.maxMotorTorque;
+                object.angularMotorImpulse = std::clamp(object.angularMotorImpulse + impulse,
+                                                        -maxImpulse, maxImpulse);
+                const auto incImpulse = object.angularMotorImpulse - oldImpulse;
+
+                velA.angular -= invRotInertiaA * incImpulse;
+                velB.angular += invRotInertiaB * incImpulse;
+            }
+
+            const auto vb = velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian);
+            const auto va = velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian);
+            const auto vDelta = vb - va;
+
+            // Solve limit constraint.
+            if (object.enableLimit && (object.limitState != LimitState::e_inactiveLimit)
+                && !fixedRotation)
+            {
+                const auto Cdot = Vec3{
+                    GetX(vDelta) / MeterPerSecond,
+                    GetY(vDelta) / MeterPerSecond,
+                    (velB.angular - velA.angular) / RadianPerSecond};
+                auto impulse = -Solve33(object.mass, Cdot);
+
+                auto UpdateImpulseProc = [&]() {
+                    const auto rhs = -Vec2{
+                                         GetX(vDelta) / MeterPerSecond,
+                                         GetY(vDelta) / MeterPerSecond}
+                                     + GetZ(object.impulse) * Vec2{GetX(GetZ(object.mass)), GetY(GetZ(object.mass))};
+                    const auto reduced = Solve22(object.mass, rhs);
+                    GetX(impulse) = GetX(reduced);
+                    GetY(impulse) = GetY(reduced);
+                    GetZ(impulse) = -GetZ(object.impulse);
+                    GetX(object.impulse) += GetX(reduced);
+                    GetY(object.impulse) += GetY(reduced);
+                    GetZ(object.impulse) = 0;
+                };
+
+                switch (object.limitState)
+                {
+                case LimitState::e_atLowerLimit: {
+                    const auto newImpulse = GetZ(object.impulse) + GetZ(impulse);
+                    if (newImpulse < 0)
+                    {
+                        UpdateImpulseProc();
+                    }
+                    else
+                    {
+                        object.impulse += impulse;
+                    }
+                    break;
+                }
+                case LimitState::e_atUpperLimit: {
+                    const auto newImpulse = GetZ(object.impulse) + GetZ(impulse);
+                    if (newImpulse > 0)
+                    {
+                        UpdateImpulseProc();
+                    }
+                    else
+                    {
+                        object.impulse += impulse;
+                    }
+                    break;
+                }
+                default:
+                    assert(object.limitState == LimitState::e_equalLimits);
                     object.impulse += impulse;
+                    break;
                 }
-                break;
+
+                const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
+                const auto L = AngularMomentum{GetZ(impulse) * SquareMeter * Kilogram / (Second * Radian)};
+                const auto LA = AngularMomentum{Cross(object.rA, P) / Radian} + L;
+                const auto LB = AngularMomentum{Cross(object.rB, P) / Radian} + L;
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
             }
-            case LimitState::e_atUpperLimit:
+            else
             {
-                const auto newImpulse = GetZ(object.impulse) + GetZ(impulse);
-                if (newImpulse > 0)
-                {
-                    UpdateImpulseProc();
-                }
-                else
-                {
-                    object.impulse += impulse;
-                }
-                break;
+                // Solve point-to-point constraint
+                const auto impulse = Solve22(object.mass, -Vec2{
+                                                              get<0>(vDelta) / MeterPerSecond, get<1>(vDelta) / MeterPerSecond});
+
+                GetX(object.impulse) += GetX(impulse);
+                GetY(object.impulse) += GetY(impulse);
+
+                const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
+                const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
+                const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
             }
-            default:
-                assert(object.limitState == LimitState::e_equalLimits);
-                object.impulse += impulse;
-                break;
+
+            if ((velA != oldVelA) || (velB != oldVelB))
+            {
+                bodyConstraintA.SetVelocity(velA);
+                bodyConstraintB.SetVelocity(velB);
+                return false;
+            }
+            return true;
         }
 
-        const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
-        const auto L = AngularMomentum{GetZ(impulse) * SquareMeter * Kilogram / (Second * Radian)};
-        const auto LA = AngularMomentum{Cross(object.rA, P) / Radian} + L;
-        const auto LB = AngularMomentum{Cross(object.rB, P) / Radian} + L;
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        // Solve point-to-point constraint
-        const auto impulse = Solve22(object.mass, -Vec2{
-            get<0>(vDelta) / MeterPerSecond, get<1>(vDelta) / MeterPerSecond
-        });
-
-        GetX(object.impulse) += GetX(impulse);
-        GetY(object.impulse) += GetY(impulse);
-
-        const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
-        const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
-        const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-
-    if ((velA != oldVelA) || (velB != oldVelB))
-    {
-        bodyConstraintA.SetVelocity(velA);
-        bodyConstraintB.SetVelocity(velB);
-        return false;
-    }
-    return true;
-}
-
-bool SolvePosition(const RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    auto posA = bodyConstraintA.GetPosition();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-
-    auto posB = bodyConstraintB.GetPosition();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    const auto fixedRotation = ((invRotInertiaA + invRotInertiaB) == InvRotInertia{0});
-
-    // Solve angular limit constraint.
-    auto angularError = 0_rad;
-    if (object.enableLimit && (object.limitState != LimitState::e_inactiveLimit)
-        && !fixedRotation)
-    {
-        const auto angle = posB.angular - posA.angular - GetReferenceAngle(object);
-
-        // RotInertia is L^2 M QP^-2, Angle is QP, so RotInertia * Angle is L^2 M QP^-1.
-        auto limitImpulse = Real{0} * SquareMeter * Kilogram / Radian;
-
-        switch (object.limitState)
+        bool SolvePosition(const RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
         {
-            case LimitState::e_atLowerLimit:
-            {
-                auto C = angle - object.lowerAngle;
-                angularError = -C;
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-                // Prevent large angular corrections and allow some slop.
-                C = std::clamp(C + conf.angularSlop, -conf.maxAngularCorrection, 0_rad);
-                limitImpulse = -object.angularMass * C;
-                break;
-            }
-            case LimitState::e_atUpperLimit:
-            {
-                auto C = angle - object.upperAngle;
-                angularError = C;
+            auto posA = bodyConstraintA.GetPosition();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
 
-                // Prevent large angular corrections and allow some slop.
-                C = std::clamp(C - conf.angularSlop, 0_rad, conf.maxAngularCorrection);
-                limitImpulse = -object.angularMass * C;
-                break;
-            }
-            default:
+            auto posB = bodyConstraintB.GetPosition();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            const auto fixedRotation = ((invRotInertiaA + invRotInertiaB) == InvRotInertia{0});
+
+            // Solve angular limit constraint.
+            auto angularError = 0_rad;
+            if (object.enableLimit && (object.limitState != LimitState::e_inactiveLimit)
+                && !fixedRotation)
             {
-                assert(object.limitState == LimitState::e_equalLimits);
-                // Prevent large angular corrections
-                const auto C = std::clamp(angle - object.lowerAngle,
-                                          -conf.maxAngularCorrection, conf.maxAngularCorrection);
-                limitImpulse = -object.angularMass * C;
-                angularError = abs(C);
-                break;
+                const auto angle = posB.angular - posA.angular - GetReferenceAngle(object);
+
+                // RotInertia is L^2 M QP^-2, Angle is QP, so RotInertia * Angle is L^2 M QP^-1.
+                auto limitImpulse = Real{0} * SquareMeter * Kilogram / Radian;
+
+                switch (object.limitState)
+                {
+                case LimitState::e_atLowerLimit: {
+                    auto C = angle - object.lowerAngle;
+                    angularError = -C;
+
+                    // Prevent large angular corrections and allow some slop.
+                    C = std::clamp(C + conf.angularSlop, -conf.maxAngularCorrection, 0_rad);
+                    limitImpulse = -object.angularMass * C;
+                    break;
+                }
+                case LimitState::e_atUpperLimit: {
+                    auto C = angle - object.upperAngle;
+                    angularError = C;
+
+                    // Prevent large angular corrections and allow some slop.
+                    C = std::clamp(C - conf.angularSlop, 0_rad, conf.maxAngularCorrection);
+                    limitImpulse = -object.angularMass * C;
+                    break;
+                }
+                default: {
+                    assert(object.limitState == LimitState::e_equalLimits);
+                    // Prevent large angular corrections
+                    const auto C = std::clamp(angle - object.lowerAngle,
+                                              -conf.maxAngularCorrection, conf.maxAngularCorrection);
+                    limitImpulse = -object.angularMass * C;
+                    angularError = abs(C);
+                    break;
+                }
+                }
+
+                // InvRotInertia is L^-2 M^-1 QP^2, limitImpulse is L^2 M QP^-1, so product is QP.
+                posA.angular -= invRotInertiaA * limitImpulse;
+                posB.angular += invRotInertiaB * limitImpulse;
             }
+
+            // Solve point-to-point constraint.
+            auto positionError = 0_m2;
+            {
+                const auto qA = UnitVec::Get(posA.angular);
+                const auto qB = UnitVec::Get(posB.angular);
+
+                const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
+                const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
+
+                const auto C = (posB.linear + rB) - (posA.linear + rA);
+                positionError = GetMagnitudeSquared(C);
+
+                const auto invMassA = bodyConstraintA.GetInvMass();
+                const auto invMassB = bodyConstraintB.GetInvMass();
+
+                const auto exx = InvMass{
+                    invMassA + (invRotInertiaA * Square(GetY(rA)) / SquareRadian) + invMassB + (invRotInertiaB * Square(GetY(rB)) / SquareRadian)};
+                const auto exy = InvMass{
+                    (-invRotInertiaA * GetX(rA) * GetY(rA) / SquareRadian) + (-invRotInertiaB * GetX(rB) * GetY(rB) / SquareRadian)};
+                const auto eyy = InvMass{
+                    invMassA + (invRotInertiaA * Square(GetX(rA)) / SquareRadian) + invMassB + (invRotInertiaB * Square(GetX(rB)) / SquareRadian)};
+
+                InvMass22 K;
+                GetX(GetX(K)) = exx;
+                GetY(GetX(K)) = exy;
+                GetX(GetY(K)) = exy;
+                GetY(GetY(K)) = eyy;
+                const auto P = -Solve(K, C);
+
+                posA -= Position{invMassA * P, invRotInertiaA * Cross(rA, P) / Radian};
+                posB += Position{invMassB * P, invRotInertiaB * Cross(rB, P) / Radian};
+            }
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+
+            return (positionError <= Square(conf.linearSlop)) && (angularError <= conf.angularSlop);
         }
 
-        // InvRotInertia is L^-2 M^-1 QP^2, limitImpulse is L^2 M QP^-1, so product is QP.
-        posA.angular -= invRotInertiaA * limitImpulse;
-        posB.angular += invRotInertiaB * limitImpulse;
-    }
-
-    // Solve point-to-point constraint.
-    auto positionError = 0_m2;
-    {
-        const auto qA = UnitVec::Get(posA.angular);
-        const auto qB = UnitVec::Get(posB.angular);
-
-        const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
-        const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
-
-        const auto C = (posB.linear + rB) - (posA.linear + rA);
-        positionError = GetMagnitudeSquared(C);
-
-        const auto invMassA = bodyConstraintA.GetInvMass();
-        const auto invMassB = bodyConstraintB.GetInvMass();
-
-        const auto exx = InvMass{
-            invMassA + (invRotInertiaA * Square(GetY(rA)) / SquareRadian) +
-            invMassB + (invRotInertiaB * Square(GetY(rB)) / SquareRadian)
-        };
-        const auto exy = InvMass{
-            (-invRotInertiaA * GetX(rA) * GetY(rA) / SquareRadian) +
-            (-invRotInertiaB * GetX(rB) * GetY(rB) / SquareRadian)
-        };
-        const auto eyy = InvMass{
-            invMassA + (invRotInertiaA * Square(GetX(rA)) / SquareRadian) +
-            invMassB + (invRotInertiaB * Square(GetX(rB)) / SquareRadian)
-        };
-
-        InvMass22 K;
-        GetX(GetX(K)) = exx;
-        GetY(GetX(K)) = exy;
-        GetX(GetY(K)) = exy;
-        GetY(GetY(K)) = eyy;
-        const auto P = -Solve(K, C);
-
-        posA -= Position{invMassA * P, invRotInertiaA * Cross(rA, P) / Radian};
-        posB += Position{invMassB * P, invRotInertiaB * Cross(rB, P) / Radian};
-    }
-
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
-
-    return (positionError <= Square(conf.linearSlop)) && (angularError <= conf.angularSlop);
-}
-
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
@@ -27,233 +27,235 @@
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Dynamics/Joints/LimitState.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class World;
-class BodyConstraint;
-
-/// @brief Revolute joint definition.
-/// @details A revolute joint constrains two bodies to share a common point while they
-///   are free to rotate about the point. The relative rotation about the shared point
-///   is the joint angle. This requires defining an anchor point where the bodies are
-///   joined. The definition uses local anchor points so that the initial configuration
-///   can violate the constraint slightly. You also need to specify the initial relative
-///   angle for joint limits. This helps when saving and loading a game.
-/// @note The local anchor points are measured from the body's origin
-///   rather than the center of mass because:
-///    1. you might not know where the center of mass will be;
-///    2. if you add/remove shapes from a body and recompute the mass,
-///       the joints will be broken.
-/// @note You can limit the relative rotation with a joint limit that specifies a
-///   lower and upper angle. You can use a motor to drive the relative rotation about
-///   the shared point. A maximum motor torque is provided so that infinite forces are
-///   not generated.
-/// @ingroup JointsGroup
-/// @image html revoluteJoint.gif
-/// @see https://en.wikipedia.org/wiki/Revolute_joint
-/// @see Joint, World::CreateJoint
-struct RevoluteJointConf : public JointBuilder<RevoluteJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<RevoluteJointConf>;
 
-    /// @brief Default constructor.
-    constexpr RevoluteJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
-    RevoluteJointConf(BodyID bA, BodyID bB,
-                      Length2 laA = Length2{}, Length2 laB = Length2{},
-                      Angle ra = 0_deg) noexcept;
-
-    /// @brief Uses the given enable limit state value.
-    constexpr auto& UseEnableLimit(bool v) noexcept
+    namespace d2
     {
-        enableLimit = v;
-        return *this;
-    }
 
-    /// @brief Uses the given lower angle value.
-    constexpr auto& UseLowerAngle(Angle v) noexcept
+        class World;
+        class BodyConstraint;
+
+        /// @brief Revolute joint definition.
+        /// @details A revolute joint constrains two bodies to share a common point while they
+        ///   are free to rotate about the point. The relative rotation about the shared point
+        ///   is the joint angle. This requires defining an anchor point where the bodies are
+        ///   joined. The definition uses local anchor points so that the initial configuration
+        ///   can violate the constraint slightly. You also need to specify the initial relative
+        ///   angle for joint limits. This helps when saving and loading a game.
+        /// @note The local anchor points are measured from the body's origin
+        ///   rather than the center of mass because:
+        ///    1. you might not know where the center of mass will be;
+        ///    2. if you add/remove shapes from a body and recompute the mass,
+        ///       the joints will be broken.
+        /// @note You can limit the relative rotation with a joint limit that specifies a
+        ///   lower and upper angle. You can use a motor to drive the relative rotation about
+        ///   the shared point. A maximum motor torque is provided so that infinite forces are
+        ///   not generated.
+        /// @ingroup JointsGroup
+        /// @image html revoluteJoint.gif
+        /// @see https://en.wikipedia.org/wiki/Revolute_joint
+        /// @see Joint, World::CreateJoint
+        struct RevoluteJointConf : public JointBuilder<RevoluteJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<RevoluteJointConf>;
+
+            /// @brief Default constructor.
+            constexpr RevoluteJointConf() = default;
+
+            /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
+            RevoluteJointConf(BodyID bA, BodyID bB,
+                              Length2 laA = Length2{}, Length2 laB = Length2{},
+                              Angle ra = 0_deg) noexcept;
+
+            /// @brief Uses the given enable limit state value.
+            constexpr auto& UseEnableLimit(bool v) noexcept
+            {
+                enableLimit = v;
+                return *this;
+            }
+
+            /// @brief Uses the given lower angle value.
+            constexpr auto& UseLowerAngle(Angle v) noexcept
+            {
+                lowerAngle = v;
+                return *this;
+            }
+
+            /// @brief Uses the given upper angle value.
+            constexpr auto& UseUpperAngle(Angle v) noexcept
+            {
+                upperAngle = v;
+                return *this;
+            }
+
+            /// @brief Uses the given enable motor state value.
+            constexpr auto& UseEnableMotor(bool v) noexcept
+            {
+                enableMotor = v;
+                return *this;
+            }
+
+            /// @brief Uses the given motor speed value.
+            constexpr auto& UseMotorSpeed(AngularVelocity v) noexcept
+            {
+                motorSpeed = v;
+                return *this;
+            }
+
+            /// @brief Uses the given max motor torque value.
+            constexpr auto& UseMaxMotorTorque(Torque v) noexcept
+            {
+                maxMotorTorque = v;
+                return *this;
+            }
+
+            /// @brief Local anchor point relative to body A's origin.
+            Length2 localAnchorA = Length2{};
+
+            /// @brief Local anchor point relative to body B's origin.
+            Length2 localAnchorB = Length2{};
+
+            /// @brief Impulse.
+            /// @note Modified by: <code>InitVelocity</code>,
+            ///   <code>SolveVelocityConstraints</code>.
+            Vec3 impulse = Vec3{};
+
+            /// @brief Motor impulse.
+            /// @note Modified by: <code>InitVelocity</code>, <code>SolveVelocity</code>.
+            AngularMomentum angularMotorImpulse = {};
+
+            /// @brief Reference angle.
+            /// @details This is the body-B angle minus body-A angle in the reference state (radians).
+            Angle referenceAngle = 0_deg;
+
+            /// @brief Flag to enable joint limits.
+            bool enableLimit = false;
+
+            /// @brief Lower angle for the joint limit.
+            Angle lowerAngle = 0_deg;
+
+            /// @brief Upper angle for the joint limit.
+            Angle upperAngle = 0_deg;
+
+            /// @brief Flag to enable the joint motor.
+            bool enableMotor = false;
+
+            /// @brief Desired motor speed.
+            AngularVelocity motorSpeed = 0_rpm;
+
+            /// @brief Maximum motor torque used to achieve the desired motor speed.
+            Torque maxMotorTorque = 0;
+
+            Length2 rA = {};                                    ///< Rotated delta of body A's local center from local anchor A.
+            Length2 rB = {};                                    ///< Rotated delta of body B's local center from local anchor B.
+            Mat33 mass = {};                                    ///< Effective mass for point-to-point constraint.
+            RotInertia angularMass = {};                        ///< Effective mass for motor/limit angular constraint.
+            LimitState limitState = LimitState::e_inactiveLimit;///< Limit state.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        RevoluteJointConf GetRevoluteJointConf(const Joint& joint);
+
+        /// @brief Gets the configuration for the given parameters.
+        /// @relatedalso World
+        RevoluteJointConf GetRevoluteJointConf(const World& world, BodyID bodyA, BodyID bodyB, Length2 anchor);
+
+        /// @brief Gets the current angle of the given configuration in the given world.
+        /// @relatedalso World
+        Angle GetAngle(const World& world, const RevoluteJointConf& conf);
+
+        /// @brief Gets the current angular velocity of the given configuration.
+        /// @relatedalso World
+        AngularVelocity GetAngularVelocity(const World& world, const RevoluteJointConf& conf);
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso RevoluteJointConf
+        constexpr auto ShiftOrigin(RevoluteJointConf&, Length2) noexcept
+        {
+            return false;
+        }
+
+        /// @brief Free function for getting the angular lower limit value of the given configuration.
+        /// @relatedalso RevoluteJointConf
+        constexpr Angle GetAngularLowerLimit(const RevoluteJointConf& conf) noexcept
+        {
+            return conf.lowerAngle;
+        }
+
+        /// @brief Free function for getting the angular upper limit value of the given configuration.
+        /// @relatedalso RevoluteJointConf
+        constexpr Angle GetAngularUpperLimit(const RevoluteJointConf& conf) noexcept
+        {
+            return conf.upperAngle;
+        }
+
+        /// @brief Gets the current linear reaction of the given configuration.
+        /// @relatedalso RevoluteJointConf
+        constexpr Momentum2 GetLinearReaction(const RevoluteJointConf& conf) noexcept
+        {
+            return Momentum2{GetX(conf.impulse) * NewtonSecond, GetY(conf.impulse) * NewtonSecond};
+        }
+
+        /// @brief Gets the current angular reaction of the given configuration.
+        /// @relatedalso RevoluteJointConf
+        constexpr AngularMomentum GetAngularReaction(const RevoluteJointConf& conf) noexcept
+        {
+            // AngularMomentum is L^2 M T^-1 QP^-1.
+            return GetZ(conf.impulse) * SquareMeter * Kilogram / (Second * Radian);
+        }
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocityConstraints.
+        /// @relatedalso RevoluteJointConf
+        void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso RevoluteJointConf
+        bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso RevoluteJointConf
+        bool SolvePosition(const RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for setting the angular limits of the given configuration.
+        /// @relatedalso RevoluteJointConf
+        constexpr void SetAngularLimits(RevoluteJointConf& object, Angle lower, Angle upper) noexcept
+        {
+            object.UseLowerAngle(lower).UseUpperAngle(upper);
+        }
+
+        /// @brief Free function for setting the max motor torque of the given configuration.
+        /// @relatedalso RevoluteJointConf
+        constexpr void SetMaxMotorTorque(RevoluteJointConf& object, Torque value)
+        {
+            object.UseMaxMotorTorque(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::RevoluteJointConf</code>.
+    template<>
+    struct TypeInfo<d2::RevoluteJointConf>
     {
-        lowerAngle = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::RevoluteJointConf";
+    };
 
-    /// @brief Uses the given upper angle value.
-    constexpr auto& UseUpperAngle(Angle v) noexcept
-    {
-        upperAngle = v;
-        return *this;
-    }
+}// namespace playrho
 
-    /// @brief Uses the given enable motor state value.
-    constexpr auto& UseEnableMotor(bool v) noexcept
-    {
-        enableMotor = v;
-        return *this;
-    }
-
-    /// @brief Uses the given motor speed value.
-    constexpr auto& UseMotorSpeed(AngularVelocity v) noexcept
-    {
-        motorSpeed = v;
-        return *this;
-    }
-
-    /// @brief Uses the given max motor torque value.
-    constexpr auto& UseMaxMotorTorque(Torque v) noexcept
-    {
-        maxMotorTorque = v;
-        return *this;
-    }
-
-    /// @brief Local anchor point relative to body A's origin.
-    Length2 localAnchorA = Length2{};
-
-    /// @brief Local anchor point relative to body B's origin.
-    Length2 localAnchorB = Length2{};
-
-    /// @brief Impulse.
-    /// @note Modified by: <code>InitVelocity</code>,
-    ///   <code>SolveVelocityConstraints</code>.
-    Vec3 impulse = Vec3{};
-
-    /// @brief Motor impulse.
-    /// @note Modified by: <code>InitVelocity</code>, <code>SolveVelocity</code>.
-    AngularMomentum angularMotorImpulse = {};
-
-    /// @brief Reference angle.
-    /// @details This is the body-B angle minus body-A angle in the reference state (radians).
-    Angle referenceAngle = 0_deg;
-
-    /// @brief Flag to enable joint limits.
-    bool enableLimit = false;
-
-    /// @brief Lower angle for the joint limit.
-    Angle lowerAngle = 0_deg;
-
-    /// @brief Upper angle for the joint limit.
-    Angle upperAngle = 0_deg;
-
-    /// @brief Flag to enable the joint motor.
-    bool enableMotor = false;
-
-    /// @brief Desired motor speed.
-    AngularVelocity motorSpeed = 0_rpm;
-
-    /// @brief Maximum motor torque used to achieve the desired motor speed.
-    Torque maxMotorTorque = 0;
-
-    Length2 rA = {}; ///< Rotated delta of body A's local center from local anchor A.
-    Length2 rB = {}; ///< Rotated delta of body B's local center from local anchor B.
-    Mat33 mass = {}; ///< Effective mass for point-to-point constraint.
-    RotInertia angularMass = {}; ///< Effective mass for motor/limit angular constraint.
-    LimitState limitState = LimitState::e_inactiveLimit; ///< Limit state.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-RevoluteJointConf GetRevoluteJointConf(const Joint& joint);
-
-/// @brief Gets the configuration for the given parameters.
-/// @relatedalso World
-RevoluteJointConf GetRevoluteJointConf(const World& world, BodyID bodyA, BodyID bodyB, Length2 anchor);
-
-/// @brief Gets the current angle of the given configuration in the given world.
-/// @relatedalso World
-Angle GetAngle(const World& world, const RevoluteJointConf& conf);
-
-/// @brief Gets the current angular velocity of the given configuration.
-/// @relatedalso World
-AngularVelocity GetAngularVelocity(const World& world, const RevoluteJointConf& conf);
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso RevoluteJointConf
-constexpr auto ShiftOrigin(RevoluteJointConf&, Length2) noexcept
-{
-    return false;
-}
-
-/// @brief Free function for getting the angular lower limit value of the given configuration.
-/// @relatedalso RevoluteJointConf
-constexpr Angle GetAngularLowerLimit(const RevoluteJointConf& conf) noexcept
-{
-    return conf.lowerAngle;
-}
-
-/// @brief Free function for getting the angular upper limit value of the given configuration.
-/// @relatedalso RevoluteJointConf
-constexpr Angle GetAngularUpperLimit(const RevoluteJointConf& conf) noexcept
-{
-    return conf.upperAngle;
-}
-
-/// @brief Gets the current linear reaction of the given configuration.
-/// @relatedalso RevoluteJointConf
-constexpr Momentum2 GetLinearReaction(const RevoluteJointConf& conf) noexcept
-{
-    return Momentum2{GetX(conf.impulse) * NewtonSecond, GetY(conf.impulse) * NewtonSecond};
-}
-
-/// @brief Gets the current angular reaction of the given configuration.
-/// @relatedalso RevoluteJointConf
-constexpr AngularMomentum GetAngularReaction(const RevoluteJointConf& conf) noexcept
-{
-    // AngularMomentum is L^2 M T^-1 QP^-1.
-    return GetZ(conf.impulse) * SquareMeter * Kilogram / (Second * Radian);
-}
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocityConstraints.
-/// @relatedalso RevoluteJointConf
-void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso RevoluteJointConf
-bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso RevoluteJointConf
-bool SolvePosition(const RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for setting the angular limits of the given configuration.
-/// @relatedalso RevoluteJointConf
-constexpr void SetAngularLimits(RevoluteJointConf& object, Angle lower, Angle upper) noexcept
-{
-    object.UseLowerAngle(lower).UseUpperAngle(upper);
-}
-
-/// @brief Free function for setting the max motor torque of the given configuration.
-/// @relatedalso RevoluteJointConf
-constexpr void SetMaxMotorTorque(RevoluteJointConf& object, Torque value)
-{
-    object.UseMaxMotorTorque(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::RevoluteJointConf</code>.
-template <>
-struct TypeInfo<d2::RevoluteJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::RevoluteJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/RopeJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.cpp
@@ -21,190 +21,192 @@
 
 #include <PlayRho/Dynamics/Joints/RopeJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<RopeJointConf>::value,
-              "RopeJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<RopeJointConf>::value,
-              "RopeJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<RopeJointConf>::value,
-              "RopeJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<RopeJointConf>::value,
-              "RopeJointConf should be move constructible!");
-static_assert(std::is_move_assignable<RopeJointConf>::value,
-              "RopeJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<RopeJointConf>::value,
-              "RopeJointConf should be nothrow destructible!");
-
-RopeJointConf GetRopeJointConf(const Joint& joint) noexcept
+namespace playrho
 {
-    return TypeCast<RopeJointConf>(joint);
-}
-
-// Limit:
-// C = norm(pB - pA) - L
-// u = (pB - pA) / norm(pB - pA)
-// Cdot = dot(u, vB + cross(wB, rB) - vA - cross(wA, rA))
-// J = [-u -cross(rA, u) u cross(rB, u)]
-// K = J * invM * JT
-//   = invMassA + invIA * cross(rA, u)^2 + invMassB + invIB * cross(rB, u)^2
-
-void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    const auto posA = bodyConstraintA.GetPosition();
-    auto velA = bodyConstraintA.GetVelocity();
-
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-    const auto posB = bodyConstraintB.GetPosition();
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-    const auto posDelta = Length2{(posB.linear + object.rB) - (posA.linear + object.rA)};
-
-    const auto uvresult = UnitVec::Get(posDelta[0], posDelta[1]);
-    const auto uv = std::get<UnitVec>(uvresult);
-    object.length = std::get<Length>(uvresult);
-
-    const auto C = object.length - object.maxLength;
-    object.limitState = (C > 0_m)? LimitState::e_atUpperLimit: LimitState::e_inactiveLimit;
-
-    if (object.length > conf.linearSlop)
+    namespace d2
     {
-        object.u = uv;
-    }
-    else
-    {
-        object.u = UnitVec::GetZero();
-        object.mass = 0_kg;
-        object.impulse = 0;
-        return;
-    }
 
-    // Compute effective mass.
-    const auto crA = Length{Cross(object.rA, object.u)} / Radian;
-    const auto crB = Length{Cross(object.rB, object.u)} / Radian;
-    const auto invRotMassA = InvMass{invRotInertiaA * Square(crA)};
-    const auto invRotMassB = InvMass{invRotInertiaB * Square(crB)};
-    const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
+        static_assert(std::is_default_constructible<RopeJointConf>::value,
+                      "RopeJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<RopeJointConf>::value,
+                      "RopeJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<RopeJointConf>::value,
+                      "RopeJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<RopeJointConf>::value,
+                      "RopeJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<RopeJointConf>::value,
+                      "RopeJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<RopeJointConf>::value,
+                      "RopeJointConf should be nothrow destructible!");
 
-    object.mass = (invMass != InvMass{0}) ? Real{1} / invMass : 0_kg;
+        RopeJointConf GetRopeJointConf(const Joint& joint) noexcept
+        {
+            return TypeCast<RopeJointConf>(joint);
+        }
 
-    if (step.doWarmStart)
-    {
-        // Scale the impulse to support a variable time step.
-        object.impulse *= step.dtRatio;
+        // Limit:
+        // C = norm(pB - pA) - L
+        // u = (pB - pA) / norm(pB - pA)
+        // Cdot = dot(u, vB + cross(wB, rB) - vA - cross(wA, rA))
+        // J = [-u -cross(rA, u) u cross(rB, u)]
+        // K = J * invM * JT
+        //   = invMassA + invIA * cross(rA, u)^2 + invMassB + invIB * cross(rB, u)^2
 
-        const auto P = object.impulse * object.u;
+        void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-        // L * M * L T^-1 / QP is: L^2 M T^-1 QP^-1 which is: AngularMomentum.
-        // L * M * L T^-1 is: L^2 M T^-1
-        const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
-        const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        object.impulse = 0;
-    }
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            const auto posA = bodyConstraintA.GetPosition();
+            auto velA = bodyConstraintA.GetVelocity();
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+            const auto posB = bodyConstraintB.GetPosition();
+            auto velB = bodyConstraintB.GetVelocity();
 
-bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
 
-    auto velA = bodyConstraintA.GetVelocity();
-    auto velB = bodyConstraintB.GetVelocity();
+            object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+            const auto posDelta = Length2{(posB.linear + object.rB) - (posA.linear + object.rA)};
 
-    // Cdot = dot(u, v + cross(w, r))
-    const auto vpA = velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian);
-    const auto vpB = velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian);
-    const auto C = object.length - object.maxLength;
+            const auto uvresult = UnitVec::Get(posDelta[0], posDelta[1]);
+            const auto uv = std::get<UnitVec>(uvresult);
+            object.length = std::get<Length>(uvresult);
 
-    // Predictive constraint.
-    const auto inv_h = (step.deltaTime != 0_s)? Real(1) / step.deltaTime: 0_Hz;
-    const auto Cdot = LinearVelocity{Dot(object.u, vpB - vpA) + ((C < 0_m)? inv_h * C: 0_mps)};
+            const auto C = object.length - object.maxLength;
+            object.limitState = (C > 0_m) ? LimitState::e_atUpperLimit : LimitState::e_inactiveLimit;
 
-    auto localImpulse = -object.mass * Cdot;
-    const auto oldImpulse = object.impulse;
-    object.impulse = std::min(0_Ns, object.impulse + localImpulse);
-    localImpulse = object.impulse - oldImpulse;
+            if (object.length > conf.linearSlop)
+            {
+                object.u = uv;
+            }
+            else
+            {
+                object.u = UnitVec::GetZero();
+                object.mass = 0_kg;
+                object.impulse = 0;
+                return;
+            }
 
-    // L * M * L T^-1 / QP is: L^2 M T^-1 QP^-1 which is: AngularMomentum.
-    // L * M * L T^-1 is: L^2 M T^-1
-    const auto P = localImpulse * object.u;
-    const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
-    const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
+            // Compute effective mass.
+            const auto crA = Length{Cross(object.rA, object.u)} / Radian;
+            const auto crB = Length{Cross(object.rB, object.u)} / Radian;
+            const auto invRotMassA = InvMass{invRotInertiaA * Square(crA)};
+            const auto invRotMassB = InvMass{invRotInertiaB * Square(crB)};
+            const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
 
-    velA -= Velocity{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
-    velB += Velocity{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
+            object.mass = (invMass != InvMass{0}) ? Real{1} / invMass : 0_kg;
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
+            if (step.doWarmStart)
+            {
+                // Scale the impulse to support a variable time step.
+                object.impulse *= step.dtRatio;
 
-    return localImpulse == 0_Ns;
-}
+                const auto P = object.impulse * object.u;
 
-bool SolvePosition(const RopeJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+                // L * M * L T^-1 / QP is: L^2 M T^-1 QP^-1 which is: AngularMomentum.
+                // L * M * L T^-1 is: L^2 M T^-1
+                const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
+                const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                object.impulse = 0;
+            }
 
-    auto posA = bodyConstraintA.GetPosition();
-    auto posB = bodyConstraintB.GetPosition();
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
 
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
+        bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
-    const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
-    const auto posDelta = (posB.linear + rB) - (posA.linear + rA);
+            auto velA = bodyConstraintA.GetVelocity();
+            auto velB = bodyConstraintB.GetVelocity();
 
-    const auto uvresult = UnitVec::Get(posDelta[0], posDelta[1]);
-    const auto uv = std::get<UnitVec>(uvresult);
-    const auto length = std::get<Length>(uvresult);
+            // Cdot = dot(u, v + cross(w, r))
+            const auto vpA = velA.linear + GetRevPerpendicular(object.rA) * (velA.angular / Radian);
+            const auto vpB = velB.linear + GetRevPerpendicular(object.rB) * (velB.angular / Radian);
+            const auto C = object.length - object.maxLength;
 
-    const auto C = std::clamp(length - object.maxLength, 0_m, conf.maxLinearCorrection);
+            // Predictive constraint.
+            const auto inv_h = (step.deltaTime != 0_s) ? Real(1) / step.deltaTime : 0_Hz;
+            const auto Cdot = LinearVelocity{Dot(object.u, vpB - vpA) + ((C < 0_m) ? inv_h * C : 0_mps)};
 
-    const auto localImpulse = -object.mass * C;
+            auto localImpulse = -object.mass * Cdot;
+            const auto oldImpulse = object.impulse;
+            object.impulse = std::min(0_Ns, object.impulse + localImpulse);
+            localImpulse = object.impulse - oldImpulse;
 
-    const auto P = localImpulse * uv;
-    const auto LA = Cross(rA, P) / Radian;
-    const auto LB = Cross(rB, P) / Radian;
+            // L * M * L T^-1 / QP is: L^2 M T^-1 QP^-1 which is: AngularMomentum.
+            // L * M * L T^-1 is: L^2 M T^-1
+            const auto P = localImpulse * object.u;
+            const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
+            const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
 
-    posA -= Position{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
-    posB += Position{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
+            velA -= Velocity{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
+            velB += Velocity{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
 
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
 
-    return (length - object.maxLength) < conf.linearSlop;
-}
+            return localImpulse == 0_Ns;
+        }
 
-} // namespace d2
-} // namespace playrho
+        bool SolvePosition(const RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            auto posA = bodyConstraintA.GetPosition();
+            auto posB = bodyConstraintB.GetPosition();
+
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
+            const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
+            const auto posDelta = (posB.linear + rB) - (posA.linear + rA);
+
+            const auto uvresult = UnitVec::Get(posDelta[0], posDelta[1]);
+            const auto uv = std::get<UnitVec>(uvresult);
+            const auto length = std::get<Length>(uvresult);
+
+            const auto C = std::clamp(length - object.maxLength, 0_m, conf.maxLinearCorrection);
+
+            const auto localImpulse = -object.mass * C;
+
+            const auto P = localImpulse * uv;
+            const auto LA = Cross(rA, P) / Radian;
+            const auto LB = Cross(rB, P) / Radian;
+
+            posA -= Position{bodyConstraintA.GetInvMass() * P, bodyConstraintA.GetInvRotInertia() * LA};
+            posB += Position{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * LB};
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+
+            return (length - object.maxLength) < conf.linearSlop;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/RopeJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.hpp
@@ -27,142 +27,144 @@
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Dynamics/Joints/LimitState.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class Joint;
-class World;
-class BodyConstraint;
-
-/// @brief Rope joint definition.
-/// @details A rope joint enforces a maximum distance between two points on two bodies.
-///   It has no other effect. This requires two body anchor points and a maximum lengths.
-/// @note By default the connected objects will not collide.
-/// @warning If you attempt to change the maximum length during the simulation
-///   you will get some non-physical behavior. A model that would allow you to
-///   dynamically modify the length would have some sponginess, so it was decided
-///   not to implement it that way. See <code>DistanceJoint</code> if you want to dynamically
-///   control length.
-/// @ingroup JointsGroup
-/// @see collideConnected in JointConf.
-/// @see Joint, World::CreateJoint
-struct RopeJointConf : public JointBuilder<RopeJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<RopeJointConf>;
 
-    /// @brief Default constructor.
-    constexpr RopeJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Initializing constructor.
-    constexpr RopeJointConf(BodyID bodyA, BodyID bodyB) noexcept:
-        super{super{}.UseBodyA(bodyA).UseBodyB(bodyB)}
+    namespace d2
     {
-        // Intentionally empty.
-    }
 
-    /// @brief Uses the given max length value.
-    constexpr auto& UseMaxLength(Length v) noexcept
+        class Joint;
+        class World;
+        class BodyConstraint;
+
+        /// @brief Rope joint definition.
+        /// @details A rope joint enforces a maximum distance between two points on two bodies.
+        ///   It has no other effect. This requires two body anchor points and a maximum lengths.
+        /// @note By default the connected objects will not collide.
+        /// @warning If you attempt to change the maximum length during the simulation
+        ///   you will get some non-physical behavior. A model that would allow you to
+        ///   dynamically modify the length would have some sponginess, so it was decided
+        ///   not to implement it that way. See <code>DistanceJoint</code> if you want to dynamically
+        ///   control length.
+        /// @ingroup JointsGroup
+        /// @see collideConnected in JointConf.
+        /// @see Joint, World::CreateJoint
+        struct RopeJointConf : public JointBuilder<RopeJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<RopeJointConf>;
+
+            /// @brief Default constructor.
+            constexpr RopeJointConf() = default;
+
+            /// @brief Initializing constructor.
+            constexpr RopeJointConf(BodyID bodyA, BodyID bodyB) noexcept
+                : super{super{}.UseBodyA(bodyA).UseBodyB(bodyB)}
+            {
+                // Intentionally empty.
+            }
+
+            /// @brief Uses the given max length value.
+            constexpr auto& UseMaxLength(Length v) noexcept
+            {
+                maxLength = v;
+                return *this;
+            }
+
+            /// The local anchor point relative to body A's origin.
+            Length2 localAnchorA = Length2{-1_m, 0_m};
+
+            /// The local anchor point relative to body B's origin.
+            Length2 localAnchorB = Length2{+1_m, 0_m};
+
+            /// The maximum length of the rope.
+            Length maxLength = 0_m;
+
+            Length length = 0;      ///< Length.
+            Momentum impulse = 0_Ns;///< Impulse.
+
+            // Solver temp
+            UnitVec u;                                          ///< U direction.
+            Length2 rA = {};                                    ///< Relative A.
+            Length2 rB = {};                                    ///< Relative B.
+            Mass mass = 0_kg;                                   ///< Mass.
+            LimitState limitState = LimitState::e_inactiveLimit;///< Limit state.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        RopeJointConf GetRopeJointConf(const Joint& joint) noexcept;
+
+        /// @brief Gets the current linear reaction of the given configuration.
+        /// @relatedalso RopeJointConf
+        constexpr Momentum2 GetLinearReaction(const RopeJointConf& object) noexcept
+        {
+            return object.impulse * object.u;
+        }
+
+        /// @brief Gets the current angular reaction of the given configuration.
+        /// @relatedalso RopeJointConf
+        constexpr AngularMomentum GetAngularReaction(const RopeJointConf&) noexcept
+        {
+            return AngularMomentum{0};
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso RopeJointConf
+        constexpr auto ShiftOrigin(RopeJointConf&, Length2) noexcept
+        {
+            return false;
+        }
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso RopeJointConf
+        void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso RopeJointConf
+        bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso RopeJointConf
+        bool SolvePosition(const RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for getting the maximum length value of the given configuration.
+        /// @relatedalso RopeJointConf
+        constexpr auto GetMaxLength(const RopeJointConf& object) noexcept
+        {
+            return object.maxLength;
+        }
+
+        /// @brief Free function for setting the maximum length value of the given configuration.
+        /// @relatedalso RopeJointConf
+        constexpr auto SetMaxLength(RopeJointConf& object, Length value) noexcept
+        {
+            object.UseMaxLength(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::RopeJointConf</code>.
+    template<>
+    struct TypeInfo<d2::RopeJointConf>
     {
-        maxLength = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::RopeJointConf";
+    };
 
-    /// The local anchor point relative to body A's origin.
-    Length2 localAnchorA = Length2{-1_m, 0_m};
-    
-    /// The local anchor point relative to body B's origin.
-    Length2 localAnchorB = Length2{+1_m, 0_m};
-    
-    /// The maximum length of the rope.
-    Length maxLength = 0_m;
+}// namespace playrho
 
-    Length length = 0; ///< Length.
-    Momentum impulse = 0_Ns; ///< Impulse.
-
-    // Solver temp
-    UnitVec u; ///< U direction.
-    Length2 rA = {}; ///< Relative A.
-    Length2 rB = {}; ///< Relative B.
-    Mass mass = 0_kg; ///< Mass.
-    LimitState limitState = LimitState::e_inactiveLimit; ///< Limit state.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-RopeJointConf GetRopeJointConf(const Joint& joint) noexcept;
-
-/// @brief Gets the current linear reaction of the given configuration.
-/// @relatedalso RopeJointConf
-constexpr Momentum2 GetLinearReaction(const RopeJointConf& object) noexcept
-{
-    return object.impulse * object.u;
-}
-
-/// @brief Gets the current angular reaction of the given configuration.
-/// @relatedalso RopeJointConf
-constexpr AngularMomentum GetAngularReaction(const RopeJointConf&) noexcept
-{
-    return AngularMomentum{0};
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso RopeJointConf
-constexpr auto ShiftOrigin(RopeJointConf&, Length2) noexcept
-{
-    return false;
-}
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso RopeJointConf
-void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso RopeJointConf
-bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso RopeJointConf
-bool SolvePosition(const RopeJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for getting the maximum length value of the given configuration.
-/// @relatedalso RopeJointConf
-constexpr auto GetMaxLength(const RopeJointConf& object) noexcept
-{
-    return object.maxLength;
-}
-
-/// @brief Free function for setting the maximum length value of the given configuration.
-/// @relatedalso RopeJointConf
-constexpr auto SetMaxLength(RopeJointConf& object, Length value) noexcept
-{
-    object.UseMaxLength(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::RopeJointConf</code>.
-template <>
-struct TypeInfo<d2::RopeJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::RopeJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_ROPEJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_ROPEJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/TargetJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.cpp
@@ -21,158 +21,160 @@
 
 #include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<TargetJointConf>::value,
-              "TargetJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<TargetJointConf>::value,
-              "TargetJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<TargetJointConf>::value,
-              "TargetJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<TargetJointConf>::value,
-              "TargetJointConf should be move constructible!");
-static_assert(std::is_move_assignable<TargetJointConf>::value,
-              "TargetJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<TargetJointConf>::value,
-              "TargetJointConf should be nothrow destructible!");
-
-TargetJointConf GetTargetJointConf(const Joint& joint)
+namespace playrho
 {
-    return TypeCast<TargetJointConf>(joint);
-}
-
-Mass22 GetEffectiveMassMatrix(const TargetJointConf& object, const BodyConstraint& body) noexcept
-{
-    // K    = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
-    //      = [1/m1+1/m2     0    ] + invI1 * [r1.y*r1.y -r1.x*r1.y] + invI2 * [r1.y*r1.y -r1.x*r1.y]
-    //        [    0     1/m1+1/m2]           [-r1.x*r1.y r1.x*r1.x]           [-r1.x*r1.y r1.x*r1.x]
-
-    const auto invMass = body.GetInvMass();
-    const auto invRotInertia = body.GetInvRotInertia();
-
-    const auto exx = InvMass{invMass + (invRotInertia * Square(GetY(object.rB)) / SquareRadian) + object.gamma};
-    const auto exy = InvMass{-invRotInertia * GetX(object.rB) * GetY(object.rB) / SquareRadian};
-    const auto eyy = InvMass{invMass + (invRotInertia * Square(GetX(object.rB)) / SquareRadian) + object.gamma};
-
-    InvMass22 K;
-    GetX(GetX(K)) = exx;
-    GetY(GetX(K)) = exy;
-    GetX(GetY(K)) = exy;
-    GetY(GetY(K)) = eyy;
-    return Invert(K);
-}
-
-// p = attached point, m = mouse point
-// C = p - m
-// Cdot = v
-//      = v + cross(w, r)
-// J = [I r_skew]
-// Identity used:
-// w k % (rx i + ry j) = w * (-ry i + rx j)
-
-void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step, const ConstraintSolverConf&)
-{
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto posB = bodyConstraintB.GetPosition();
-    auto velB = bodyConstraintB.GetVelocity();
-
-    const auto qB = UnitVec::Get(posB.angular);
-
-    const auto mass = (bodyConstraintB.GetInvMass() != InvMass{})
-        ? (Real{1} / bodyConstraintB.GetInvMass()): 0_kg;
-
-    // Frequency
-    const auto omega = Real{2} * Pi * object.frequency; // T^-1
-
-    // Damping coefficient
-    const auto d = Real{2} * mass * object.dampingRatio * omega; // M T^-1
-
-    // Spring stiffness
-    const auto k = mass * Square(omega); // M T^-2
-
-    // magic formulas
-    // gamma has units of inverse mass.
-    // beta has units of inverse time.
-    const auto h = step.deltaTime;
-    const auto tmp = d + h * k; // M T^-1
-    assert(IsValid(Real{tmp * Second / Kilogram}));
-    const auto invGamma = Mass{h * tmp}; // M T^-1 * T is simply M.
-    object.gamma = (invGamma != 0_kg)? Real{1} / invGamma: InvMass{0};
-    const auto beta = Frequency{h * k * object.gamma}; // T * M T^-2 * M^-1 is T^-1
-
-    // Compute the effective mass matrix.
-    object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-
-    object.mass = GetEffectiveMassMatrix(object, bodyConstraintB);
-
-    object.C = LinearVelocity2{((posB.linear + object.rB) - object.target) * beta};
-    assert(IsValid(object.C));
-
-    // Cheat with some damping
-    velB.angular *= 0.98f;
-
-    if (step.doWarmStart)
+    namespace d2
     {
-        object.impulse *= step.dtRatio;
-        const auto P = object.impulse;
-        const auto crossBP = AngularMomentum{Cross(object.rB, P) / Radian}; // L * M * L T^-1 is: L^2 M T^-1
-        velB += Velocity{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * crossBP};
-    }
-    else
-    {
-        object.impulse = Momentum2{};
-    }
 
-    bodyConstraintB.SetVelocity(velB);
-}
+        static_assert(std::is_default_constructible<TargetJointConf>::value,
+                      "TargetJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<TargetJointConf>::value,
+                      "TargetJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<TargetJointConf>::value,
+                      "TargetJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<TargetJointConf>::value,
+                      "TargetJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<TargetJointConf>::value,
+                      "TargetJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<TargetJointConf>::value,
+                      "TargetJointConf should be nothrow destructible!");
 
-bool SolveVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step)
-{
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+        TargetJointConf GetTargetJointConf(const Joint& joint)
+        {
+            return TypeCast<TargetJointConf>(joint);
+        }
 
-    auto velB = bodyConstraintB.GetVelocity();
-    assert(IsValid(velB));
+        Mass22 GetEffectiveMassMatrix(const TargetJointConf& object, const BodyConstraint& body) noexcept
+        {
+            // K    = [(1/m1 + 1/m2) * eye(2) - skew(r1) * invI1 * skew(r1) - skew(r2) * invI2 * skew(r2)]
+            //      = [1/m1+1/m2     0    ] + invI1 * [r1.y*r1.y -r1.x*r1.y] + invI2 * [r1.y*r1.y -r1.x*r1.y]
+            //        [    0     1/m1+1/m2]           [-r1.x*r1.y r1.x*r1.x]           [-r1.x*r1.y r1.x*r1.x]
 
-    const auto Cdot = LinearVelocity2{velB.linear + (GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
-    const auto ev = Cdot + LinearVelocity2{object.C + (object.gamma * object.impulse)};
-    const auto oldImpulse = object.impulse;
-    const auto addImpulse = Transform(-ev, object.mass);
-    assert(IsValid(addImpulse));
-    object.impulse += addImpulse;
-    const auto maxImpulse = step.deltaTime * Force{object.maxForce};
-    if (GetMagnitudeSquared(object.impulse) > Square(maxImpulse))
-    {
-        object.impulse = GetUnitVector(object.impulse, UnitVec::GetZero()) * maxImpulse;
-    }
+            const auto invMass = body.GetInvMass();
+            const auto invRotInertia = body.GetInvRotInertia();
 
-    const auto incImpulse = (object.impulse - oldImpulse);
-    const auto angImpulseB = AngularMomentum{Cross(object.rB, incImpulse) / Radian};
+            const auto exx = InvMass{invMass + (invRotInertia * Square(GetY(object.rB)) / SquareRadian) + object.gamma};
+            const auto exy = InvMass{-invRotInertia * GetX(object.rB) * GetY(object.rB) / SquareRadian};
+            const auto eyy = InvMass{invMass + (invRotInertia * Square(GetX(object.rB)) / SquareRadian) + object.gamma};
 
-    velB += Velocity{
-        bodyConstraintB.GetInvMass() * incImpulse,
-        bodyConstraintB.GetInvRotInertia() * angImpulseB
-    };
+            InvMass22 K;
+            GetX(GetX(K)) = exx;
+            GetY(GetX(K)) = exy;
+            GetX(GetY(K)) = exy;
+            GetY(GetY(K)) = eyy;
+            return Invert(K);
+        }
 
-    bodyConstraintB.SetVelocity(velB);
+        // p = attached point, m = mouse point
+        // C = p - m
+        // Cdot = v
+        //      = v + cross(w, r)
+        // J = [I r_skew]
+        // Identity used:
+        // w k % (rx i + ry j) = w * (-ry i + rx j)
 
-    return incImpulse == Momentum2{};
-}
+        void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step, const ConstraintSolverConf&)
+        {
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-bool SolvePosition(const TargetJointConf&, std::vector<BodyConstraint>&,
-                   const ConstraintSolverConf&)
-{
-    return true;
-}
+            const auto posB = bodyConstraintB.GetPosition();
+            auto velB = bodyConstraintB.GetVelocity();
 
-} // namespace d2
-} // namespace playrho
+            const auto qB = UnitVec::Get(posB.angular);
+
+            const auto mass = (bodyConstraintB.GetInvMass() != InvMass{})
+                                  ? (Real{1} / bodyConstraintB.GetInvMass())
+                                  : 0_kg;
+
+            // Frequency
+            const auto omega = Real{2} * Pi * object.frequency;// T^-1
+
+            // Damping coefficient
+            const auto d = Real{2} * mass * object.dampingRatio * omega;// M T^-1
+
+            // Spring stiffness
+            const auto k = mass * Square(omega);// M T^-2
+
+            // magic formulas
+            // gamma has units of inverse mass.
+            // beta has units of inverse time.
+            const auto h = step.deltaTime;
+            const auto tmp = d + h * k;// M T^-1
+            assert(IsValid(Real{tmp * Second / Kilogram}));
+            const auto invGamma = Mass{h * tmp};// M T^-1 * T is simply M.
+            object.gamma = (invGamma != 0_kg) ? Real{1} / invGamma : InvMass{0};
+            const auto beta = Frequency{h * k * object.gamma};// T * M T^-2 * M^-1 is T^-1
+
+            // Compute the effective mass matrix.
+            object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+
+            object.mass = GetEffectiveMassMatrix(object, bodyConstraintB);
+
+            object.C = LinearVelocity2{((posB.linear + object.rB) - object.target) * beta};
+            assert(IsValid(object.C));
+
+            // Cheat with some damping
+            velB.angular *= 0.98f;
+
+            if (step.doWarmStart)
+            {
+                object.impulse *= step.dtRatio;
+                const auto P = object.impulse;
+                const auto crossBP = AngularMomentum{Cross(object.rB, P) / Radian};// L * M * L T^-1 is: L^2 M T^-1
+                velB += Velocity{bodyConstraintB.GetInvMass() * P, bodyConstraintB.GetInvRotInertia() * crossBP};
+            }
+            else
+            {
+                object.impulse = Momentum2{};
+            }
+
+            bodyConstraintB.SetVelocity(velB);
+        }
+
+        bool SolveVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step)
+        {
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            auto velB = bodyConstraintB.GetVelocity();
+            assert(IsValid(velB));
+
+            const auto Cdot = LinearVelocity2{velB.linear + (GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
+            const auto ev = Cdot + LinearVelocity2{object.C + (object.gamma * object.impulse)};
+            const auto oldImpulse = object.impulse;
+            const auto addImpulse = Transform(-ev, object.mass);
+            assert(IsValid(addImpulse));
+            object.impulse += addImpulse;
+            const auto maxImpulse = step.deltaTime * Force{object.maxForce};
+            if (GetMagnitudeSquared(object.impulse) > Square(maxImpulse))
+            {
+                object.impulse = GetUnitVector(object.impulse, UnitVec::GetZero()) * maxImpulse;
+            }
+
+            const auto incImpulse = (object.impulse - oldImpulse);
+            const auto angImpulseB = AngularMomentum{Cross(object.rB, incImpulse) / Radian};
+
+            velB += Velocity{
+                bodyConstraintB.GetInvMass() * incImpulse,
+                bodyConstraintB.GetInvRotInertia() * angImpulseB};
+
+            bodyConstraintB.SetVelocity(velB);
+
+            return incImpulse == Momentum2{};
+        }
+
+        bool SolvePosition(const TargetJointConf&, std::vector<BodyConstraint>&,
+                           const ConstraintSolverConf&)
+        {
+            return true;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/TargetJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.hpp
@@ -26,219 +26,221 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class BodyConstraint;
-
-/// @brief Target joint definition.
-/// @details A target joint is used to make a point on a body track a specified world point.
-///   This a soft constraint with a maximum force. This allows the constraint to stretch and
-///   without applying huge forces.
-/// @ingroup JointsGroup
-/// @see Joint, World::CreateJoint
-struct TargetJointConf : public JointBuilder<TargetJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<TargetJointConf>;
 
-    /// @brief Default constructor.
-    constexpr TargetJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Initializing constructor.
-    constexpr TargetJointConf(BodyID b) noexcept:
-        super{super{}.UseBodyB(b)}
+    namespace d2
     {
-        // Intentionally empty.
-    }
 
-    /// @brief Use value for target.
-    constexpr auto& UseTarget(Length2 v) noexcept
+        class BodyConstraint;
+
+        /// @brief Target joint definition.
+        /// @details A target joint is used to make a point on a body track a specified world point.
+        ///   This a soft constraint with a maximum force. This allows the constraint to stretch and
+        ///   without applying huge forces.
+        /// @ingroup JointsGroup
+        /// @see Joint, World::CreateJoint
+        struct TargetJointConf : public JointBuilder<TargetJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<TargetJointConf>;
+
+            /// @brief Default constructor.
+            constexpr TargetJointConf() = default;
+
+            /// @brief Initializing constructor.
+            constexpr TargetJointConf(BodyID b) noexcept
+                : super{super{}.UseBodyB(b)}
+            {
+                // Intentionally empty.
+            }
+
+            /// @brief Use value for target.
+            constexpr auto& UseTarget(Length2 v) noexcept
+            {
+                target = v;
+                return *this;
+            }
+
+            /// @brief Use value for the "anchor" (in coordinates local to "body B").
+            /// @note Typically this would be the value of:
+            ///   <code>bodyB
+            ///     ? InverseTransform(target, bodyB->GetTransformation())
+            ///     : GetInvalid<Length2>()</code>.
+            constexpr auto& UseAnchor(Length2 v) noexcept
+            {
+                localAnchorB = v;
+                return *this;
+            }
+
+            /// @brief Use value for max force.
+            constexpr auto& UseMaxForce(NonNegative<Force> v) noexcept
+            {
+                maxForce = v;
+                return *this;
+            }
+
+            /// @brief Use value for frequency.
+            constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
+            {
+                frequency = v;
+                return *this;
+            }
+
+            /// @brief Use value for damping ratio.
+            constexpr auto& UseDampingRatio(NonNegative<Real> v) noexcept
+            {
+                dampingRatio = v;
+                return *this;
+            }
+
+            /// The initial world target point. This is assumed
+            /// to coincide with the body anchor initially.
+            Length2 target = Length2{};
+
+            /// Anchor point.
+            Length2 localAnchorB = Length2{};
+
+            /// Max force.
+            /// @details
+            /// The maximum constraint force that can be exerted
+            /// to move the candidate body. Usually you will express
+            /// as some multiple of the weight (multiplier * mass * gravity).
+            /// @note This may not be negative.
+            NonNegative<Force> maxForce{};// 0_N
+
+            /// Frequency.
+            /// @details The has to do with the response speed.
+            /// @note This value may not be negative.
+            NonNegative<Frequency> frequency = NonNegative<Frequency>(5_Hz);
+
+            /// The damping ratio. 0 = no damping, 1 = critical damping.
+            NonNegative<Real> dampingRatio = NonNegative<Real>(0.7f);
+
+            InvMass gamma = InvMass{0};///< Gamma.
+
+            Momentum2 impulse = Momentum2{};///< Impulse.
+
+            // Solver variables. These are only valid after InitVelocityConstraints called.
+            Length2 rB = {};       ///< Relative B.
+            Mass22 mass = {};      ///< 2-by-2 mass matrix in kilograms.
+            LinearVelocity2 C = {};///< Velocity constant.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        TargetJointConf GetTargetJointConf(const Joint& joint);
+
+        /// @brief Gets the local anchar A for the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr auto GetLocalAnchorA(const TargetJointConf&) noexcept
+        {
+            return Length2{};
+        }
+
+        /// @brief Gets the current linear reaction of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr Momentum2 GetLinearReaction(const TargetJointConf& object)
+        {
+            return object.impulse;
+        }
+
+        /// @brief Gets the current angular reaction of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr AngularMomentum GetAngularReaction(const TargetJointConf&)
+        {
+            return AngularMomentum{0};
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr bool ShiftOrigin(TargetJointConf& object, Length2 newOrigin)
+        {
+            object.target -= newOrigin;
+            return true;
+        }
+
+        /// @brief Free function for getting the target value of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr auto GetTarget(const TargetJointConf& object) noexcept
+        {
+            return object.target;
+        }
+
+        /// @brief Gets the effective mass matrix for the given configuration and body information.
+        /// @relatedalso TargetJointConf
+        Mass22 GetEffectiveMassMatrix(const TargetJointConf& object, const BodyConstraint& body) noexcept;
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso TargetJointConf
+        void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso TargetJointConf
+        bool SolveVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso TargetJointConf
+        bool SolvePosition(const TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for setting the target value of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr void SetTarget(TargetJointConf& object, Length2 value) noexcept
+        {
+            object.UseTarget(value);
+        }
+
+        /// @brief Free function for getting the maximum force value of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr auto GetMaxForce(const TargetJointConf& object) noexcept
+        {
+            return object.maxForce;
+        }
+
+        /// @brief Free function for setting the maximum force value of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr auto SetMaxForce(TargetJointConf& object, NonNegative<Force> value) noexcept
+        {
+            object.UseMaxForce(value);
+        }
+
+        /// @brief Free function for setting the frequency value of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr void SetFrequency(TargetJointConf& object, NonNegative<Frequency> value) noexcept
+        {
+            object.UseFrequency(value);
+        }
+
+        /// @brief Free function for setting the damping ratio value of the given configuration.
+        /// @relatedalso TargetJointConf
+        constexpr void SetDampingRatio(TargetJointConf& object, Real value) noexcept
+        {
+            object.UseDampingRatio(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::TargetJointConf</code>.
+    template<>
+    struct TypeInfo<d2::TargetJointConf>
     {
-        target = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::TargetJointConf";
+    };
 
-    /// @brief Use value for the "anchor" (in coordinates local to "body B").
-    /// @note Typically this would be the value of:
-    ///   <code>bodyB
-    ///     ? InverseTransform(target, bodyB->GetTransformation())
-    ///     : GetInvalid<Length2>()</code>.
-    constexpr auto& UseAnchor(Length2 v) noexcept
-    {
-        localAnchorB = v;
-        return *this;
-    }
+}// namespace playrho
 
-    /// @brief Use value for max force.
-    constexpr auto& UseMaxForce(NonNegative<Force> v) noexcept
-    {
-        maxForce = v;
-        return *this;
-    }
-
-    /// @brief Use value for frequency.
-    constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
-    {
-        frequency = v;
-        return *this;
-    }
-
-    /// @brief Use value for damping ratio.
-    constexpr auto& UseDampingRatio(NonNegative<Real> v) noexcept
-    {
-        dampingRatio = v;
-        return *this;
-    }
-
-    /// The initial world target point. This is assumed
-    /// to coincide with the body anchor initially.
-    Length2 target = Length2{};
-
-    /// Anchor point.
-    Length2 localAnchorB = Length2{};
-
-    /// Max force.
-    /// @details
-    /// The maximum constraint force that can be exerted
-    /// to move the candidate body. Usually you will express
-    /// as some multiple of the weight (multiplier * mass * gravity).
-    /// @note This may not be negative.
-    NonNegative<Force> maxForce{}; // 0_N
-    
-    /// Frequency.
-    /// @details The has to do with the response speed.
-    /// @note This value may not be negative.
-    NonNegative<Frequency> frequency = NonNegative<Frequency>(5_Hz);
-    
-    /// The damping ratio. 0 = no damping, 1 = critical damping.
-    NonNegative<Real> dampingRatio = NonNegative<Real>(0.7f);
-
-    InvMass gamma = InvMass{0}; ///< Gamma.
-
-    Momentum2 impulse = Momentum2{}; ///< Impulse.
-
-    // Solver variables. These are only valid after InitVelocityConstraints called.
-    Length2 rB = {}; ///< Relative B.
-    Mass22 mass = {}; ///< 2-by-2 mass matrix in kilograms.
-    LinearVelocity2 C = {}; ///< Velocity constant.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-TargetJointConf GetTargetJointConf(const Joint& joint);
-
-/// @brief Gets the local anchar A for the given configuration.
-/// @relatedalso TargetJointConf
-constexpr auto GetLocalAnchorA(const TargetJointConf&) noexcept
-{
-    return Length2{};
-}
-
-/// @brief Gets the current linear reaction of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr Momentum2 GetLinearReaction(const TargetJointConf& object)
-{
-    return object.impulse;
-}
-
-/// @brief Gets the current angular reaction of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr AngularMomentum GetAngularReaction(const TargetJointConf&)
-{
-    return AngularMomentum{0};
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr bool ShiftOrigin(TargetJointConf& object, Length2 newOrigin)
-{
-    object.target -= newOrigin;
-    return true;
-}
-
-/// @brief Free function for getting the target value of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr auto GetTarget(const TargetJointConf& object) noexcept
-{
-    return object.target;
-}
-
-/// @brief Gets the effective mass matrix for the given configuration and body information.
-/// @relatedalso TargetJointConf
-Mass22 GetEffectiveMassMatrix(const TargetJointConf& object, const BodyConstraint& body) noexcept;
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso TargetJointConf
-void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso TargetJointConf
-bool SolveVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso TargetJointConf
-bool SolvePosition(const TargetJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for setting the target value of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr void SetTarget(TargetJointConf& object, Length2 value) noexcept
-{
-    object.UseTarget(value);
-}
-
-/// @brief Free function for getting the maximum force value of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr auto GetMaxForce(const TargetJointConf& object) noexcept
-{
-    return object.maxForce;
-}
-
-/// @brief Free function for setting the maximum force value of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr auto SetMaxForce(TargetJointConf& object, NonNegative<Force> value) noexcept
-{
-    object.UseMaxForce(value);
-}
-
-/// @brief Free function for setting the frequency value of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr void SetFrequency(TargetJointConf& object, NonNegative<Frequency> value) noexcept
-{
-    object.UseFrequency(value);
-}
-
-/// @brief Free function for setting the damping ratio value of the given configuration.
-/// @relatedalso TargetJointConf
-constexpr void SetDampingRatio(TargetJointConf& object, Real value) noexcept
-{
-    object.UseDampingRatio(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::TargetJointConf</code>.
-template <>
-struct TypeInfo<d2::TargetJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::TargetJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_MOUSEJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/WeldJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.cpp
@@ -21,361 +21,352 @@
 
 #include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
 
-#include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
-#include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-namespace {
-
-Mat33 GetMat33(InvMass invMassA, Length2 rA, InvRotInertia invRotInertiaA,
-               InvMass invMassB, Length2 rB, InvRotInertia invRotInertiaB)
+namespace playrho
 {
-    const auto exx = InvMass{
-        invMassA + Square(GetY(rA)) * invRotInertiaA / SquareRadian +
-        invMassB + Square(GetY(rB)) * invRotInertiaB / SquareRadian
-    };
-    const auto eyx = InvMass{
-        -GetY(rA) * GetX(rA) * invRotInertiaA / SquareRadian +
-        -GetY(rB) * GetX(rB) * invRotInertiaB / SquareRadian
-    };
-    const auto ezx = InvMass{
-        -GetY(rA) * invRotInertiaA * Meter / SquareRadian +
-        -GetY(rB) * invRotInertiaB * Meter / SquareRadian
-    };
-    const auto eyy = InvMass{
-        invMassA + Square(GetX(rA)) * invRotInertiaA / SquareRadian +
-        invMassB + Square(GetX(rB)) * invRotInertiaB / SquareRadian
-    };
-    const auto ezy = InvMass{
-        GetX(rA) * invRotInertiaA * Meter / SquareRadian +
-        GetX(rB) * invRotInertiaB * Meter / SquareRadian
-    };
-    const auto ezz = InvMass{(invRotInertiaA + invRotInertiaB) * SquareMeter / SquareRadian};
-
-    Mat33 K;
-    GetX(GetX(K)) = StripUnit(exx);
-    GetX(GetY(K)) = StripUnit(eyx);
-    GetX(GetZ(K)) = StripUnit(ezx);
-    GetY(GetX(K)) = GetX(GetY(K));
-    GetY(GetY(K)) = StripUnit(eyy);
-    GetY(GetZ(K)) = StripUnit(ezy);
-    GetZ(GetX(K)) = GetX(GetZ(K));
-    GetZ(GetY(K)) = GetY(GetZ(K));
-    GetZ(GetZ(K)) = StripUnit(ezz);
-    return K;
-}
-
-} // unnamed namespace
-
-static_assert(std::is_default_constructible<WeldJointConf>::value,
-              "WeldJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<WeldJointConf>::value,
-              "WeldJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<WeldJointConf>::value,
-              "WeldJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<WeldJointConf>::value,
-              "WeldJointConf should be move constructible!");
-static_assert(std::is_move_assignable<WeldJointConf>::value,
-              "WeldJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<WeldJointConf>::value,
-              "WeldJointConf should be nothrow destructible!");
-
-// Point-to-point constraint
-// C = p2 - p1
-// Cdot = v2 - v1
-//      = v2 + cross(w2, r2) - v1 - cross(w1, r1)
-// J = [-I -r1_skew I r2_skew ]
-// Identity used:
-// w k % (rx i + ry j) = w * (-ry i + rx j)
-
-// Angle constraint
-// C = angle2 - angle1 - referenceAngle
-// Cdot = w2 - w1
-// J = [0 0 -1 0 0 1]
-// K = invI1 + invI2
-
-WeldJointConf::WeldJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB, Angle ra) noexcept:
-    super{super{}.UseBodyA(bA).UseBodyB(bB)},
-    localAnchorA{laA}, localAnchorB{laB}, referenceAngle{ra}
-{
-    // Intentionally empty.
-}
-
-WeldJointConf GetWeldJointConf(const Joint& joint)
-{
-    return TypeCast<WeldJointConf>(joint);
-}
-
-WeldJointConf GetWeldJointConf(const World& world, BodyID bodyA, BodyID bodyB, const Length2 anchor)
-{
-    return WeldJointConf{
-        bodyA, bodyB,
-        GetLocalPoint(world, bodyA, anchor), GetLocalPoint(world, bodyB, anchor),
-        GetAngle(world, bodyB) - GetAngle(world, bodyA)
-    };
-}
-
-void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    auto velA = bodyConstraintA.GetVelocity();
-    const auto posA = bodyConstraintA.GetPosition();
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-
-    auto velB = bodyConstraintB.GetVelocity();
-    const auto posB = bodyConstraintB.GetPosition();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-
-    // J = [-I -r1_skew I r2_skew]
-    //     [ 0       -1 0       1]
-    // r_skew = [-ry; rx]
-
-    // Matlab
-    // K = [ invMassA+r1y^2*invRotInertiaA+invMassB+r2y^2*invRotInertiaB,  -r1y*invRotInertiaA*r1x-r2y*invRotInertiaB*r2x,          -r1y*invRotInertiaA-r2y*invRotInertiaB]
-    //     [  -r1y*invRotInertiaA*r1x-r2y*invRotInertiaB*r2x, invMassA+r1x^2*invRotInertiaA+invMassB+r2x^2*invRotInertiaB,           r1x*invRotInertiaA+r2x*invRotInertiaB]
-    //     [          -r1y*invRotInertiaA-r2y*invRotInertiaB,           r1x*invRotInertiaA+r2x*invRotInertiaB,                   invRotInertiaA+invRotInertiaB]
-
-    const auto K = GetMat33(invMassA, object.rA, invRotInertiaA,
-                            invMassB, object.rB, invRotInertiaB);
-    if (object.frequency > 0_Hz)
+    namespace d2
     {
-        object.mass = GetInverse22(K);
 
-        // InvRotInertia is L^-2 M^-1 QP^2
-        //    RotInertia is L^2  M    QP^-2
-        auto invRotInertia = InvRotInertia{invRotInertiaA + invRotInertiaB};
-        const auto rotInertia = (invRotInertia > InvRotInertia{0})? Real{1} / invRotInertia: RotInertia{0};
-
-        const auto C = Angle{posB.angular - posA.angular - object.referenceAngle};
-        const auto omega = Real(2) * Pi * object.frequency; // T^-1
-        const auto d = Real(2) * rotInertia * object.dampingRatio * omega;
-
-        // Spring stiffness: L^2 M QP^-2 T^-2
-        const auto k = rotInertia * omega * omega;
-
-        // magic formulas
-        const auto h = step.deltaTime;
-        const auto invGamma = RotInertia{h * (d + h * k)};
-        object.gamma = (invGamma != RotInertia{0})? Real{1} / invGamma: InvRotInertia{0};
-        // QP * T * L^2 M QP^-2 T^-2 * L^-2 M^-1 QP^2 is: QP T^-1
-        object.bias = AngularVelocity{C * h * k * object.gamma};
-
-        invRotInertia += object.gamma;
-        GetZ(GetZ(object.mass)) = StripUnit((invRotInertia != InvRotInertia{0}) ?
-                                       Real{1} / invRotInertia : RotInertia{0});
-    }
-    else if (GetZ(GetZ(K)) == 0)
-    {
-        object.mass = GetInverse22(K);
-        object.gamma = InvRotInertia{0};
-        object.bias = 0_rpm;
-    }
-    else
-    {
-        object.mass = GetSymInverse33(K);
-        object.gamma = InvRotInertia{0};
-        object.bias = 0_rpm;
-    }
-
-    if (step.doWarmStart)
-    {
-        // Scale impulses to support a variable time step.
-        object.impulse *= step.dtRatio;
-
-        const auto P = Momentum2{GetX(object.impulse) * NewtonSecond, GetY(object.impulse) * NewtonSecond};
-
-        // AngularMomentum is L^2 M T^-1 QP^-1.
-        const auto L = AngularMomentum{GetZ(object.impulse) * SquareMeter * Kilogram / (Second * Radian)};
-        const auto LA = L + AngularMomentum{Cross(object.rA, P) / Radian};
-        const auto LB = L + AngularMomentum{Cross(object.rB, P) / Radian};
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        object.impulse = Vec3{};
-    }
-
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto oldVelA = bodyConstraintA.GetVelocity();
-    auto velA = oldVelA;
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-
-    const auto oldVelB = bodyConstraintB.GetVelocity();
-    auto velB = oldVelB;
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    if (object.frequency > 0_Hz)
-    {
-        const auto Cdot2 = velB.angular - velA.angular;
-
-        // InvRotInertia is L^-2 M^-1 QP^2. Angular velocity is QP T^-1
-        const auto gamma = AngularVelocity{object.gamma * GetZ(object.impulse) * SquareMeter * Kilogram / (Radian * Second)};
-
-        // AngularMomentum is L^2 M T^-1 QP^-1.
-        const auto impulse2 = -GetZ(GetZ(object.mass)) * StripUnit(Cdot2 + object.bias + gamma);
-        GetZ(object.impulse) += impulse2;
-
-        velA.angular -= AngularVelocity{invRotInertiaA * impulse2 * SquareMeter * Kilogram / (Second * Radian)};
-        velB.angular += AngularVelocity{invRotInertiaB * impulse2 * SquareMeter * Kilogram / (Second * Radian)};
-
-        const auto vb = velB.linear + LinearVelocity2{(GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
-        const auto va = velA.linear + LinearVelocity2{(GetRevPerpendicular(object.rA) * (velA.angular / Radian))};
-
-        const auto Cdot1 = vb - va;
-
-        const auto impulse1 = -Transform(Vec2{GetX(Cdot1) / MeterPerSecond, GetY(Cdot1) / MeterPerSecond}, object.mass);
-        GetX(object.impulse) += GetX(impulse1);
-        GetY(object.impulse) += GetY(impulse1);
-
-        const auto P = Momentum2{GetX(impulse1) * NewtonSecond, GetY(impulse1) * NewtonSecond};
-        const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
-        const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        const auto vb = velB.linear + LinearVelocity2{(GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
-        const auto va = velA.linear + LinearVelocity2{(GetRevPerpendicular(object.rA) * (velA.angular / Radian))};
-
-        const auto Cdot1 = vb - va;
-        const auto Cdot2 = Real{(velB.angular - velA.angular) / RadianPerSecond};
-        const auto Cdot = Vec3{GetX(Cdot1) / MeterPerSecond, GetY(Cdot1) / MeterPerSecond, Cdot2};
-
-        const auto impulse = -Transform(Cdot, object.mass);
-        object.impulse += impulse;
-
-        const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
-
-        // AngularMomentum is L^2 M T^-1 QP^-1.
-        const auto L = AngularMomentum{GetZ(impulse) * SquareMeter * Kilogram / (Second * Radian)};
-        const auto LA = L + AngularMomentum{Cross(object.rA, P) / Radian};
-        const auto LB = L + AngularMomentum{Cross(object.rB, P) / Radian};
-
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-
-    if ((velA != oldVelA) || (velB != oldVelB))
-    {
-        bodyConstraintA.SetVelocity(velA);
-        bodyConstraintB.SetVelocity(velB);
-        return false;
-    }
-    return true;
-}
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-bool SolvePosition(const WeldJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    auto posA = bodyConstraintA.GetPosition();
-    auto posB = bodyConstraintB.GetPosition();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-
-    auto positionError = 0_m;
-    auto angularError = 0_deg;
-
-    const auto K = GetMat33(invMassA, rA, invRotInertiaA,
-                            invMassB, rB, invRotInertiaB);
-    if (object.frequency > 0_Hz)
-    {
-        const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
-
-        positionError = GetMagnitude(C1);
-        angularError = 0_deg;
-
-        const auto P = -Solve22(K, C1) * Kilogram;
-        const auto LA = Cross(rA, P) / Radian;
-        const auto LB = Cross(rB, P) / Radian;
-
-        posA -= Position{invMassA * P, invRotInertiaA * LA};
-        posB += Position{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
-        const auto C2 = Angle{posB.angular - posA.angular - object.referenceAngle};
-
-        positionError = GetMagnitude(C1);
-        angularError = abs(C2);
-
-        const auto C = Vec3{StripUnit(GetX(C1)), StripUnit(GetY(C1)), StripUnit(C2)};
-
-        Vec3 impulse;
-        if (GetZ(GetZ(K)) > 0)
+        namespace
         {
-            impulse = -Solve33(K, C);
-        }
-        else
+
+            Mat33 GetMat33(InvMass invMassA, Length2 rA, InvRotInertia invRotInertiaA,
+                           InvMass invMassB, Length2 rB, InvRotInertia invRotInertiaB)
+            {
+                const auto exx = InvMass{
+                    invMassA + Square(GetY(rA)) * invRotInertiaA / SquareRadian + invMassB + Square(GetY(rB)) * invRotInertiaB / SquareRadian};
+                const auto eyx = InvMass{
+                    -GetY(rA) * GetX(rA) * invRotInertiaA / SquareRadian + -GetY(rB) * GetX(rB) * invRotInertiaB / SquareRadian};
+                const auto ezx = InvMass{
+                    -GetY(rA) * invRotInertiaA * Meter / SquareRadian + -GetY(rB) * invRotInertiaB * Meter / SquareRadian};
+                const auto eyy = InvMass{
+                    invMassA + Square(GetX(rA)) * invRotInertiaA / SquareRadian + invMassB + Square(GetX(rB)) * invRotInertiaB / SquareRadian};
+                const auto ezy = InvMass{
+                    GetX(rA) * invRotInertiaA * Meter / SquareRadian + GetX(rB) * invRotInertiaB * Meter / SquareRadian};
+                const auto ezz = InvMass{(invRotInertiaA + invRotInertiaB) * SquareMeter / SquareRadian};
+
+                Mat33 K;
+                GetX(GetX(K)) = StripUnit(exx);
+                GetX(GetY(K)) = StripUnit(eyx);
+                GetX(GetZ(K)) = StripUnit(ezx);
+                GetY(GetX(K)) = GetX(GetY(K));
+                GetY(GetY(K)) = StripUnit(eyy);
+                GetY(GetZ(K)) = StripUnit(ezy);
+                GetZ(GetX(K)) = GetX(GetZ(K));
+                GetZ(GetY(K)) = GetY(GetZ(K));
+                GetZ(GetZ(K)) = StripUnit(ezz);
+                return K;
+            }
+
+        }// unnamed namespace
+
+        static_assert(std::is_default_constructible<WeldJointConf>::value,
+                      "WeldJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<WeldJointConf>::value,
+                      "WeldJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<WeldJointConf>::value,
+                      "WeldJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<WeldJointConf>::value,
+                      "WeldJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<WeldJointConf>::value,
+                      "WeldJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<WeldJointConf>::value,
+                      "WeldJointConf should be nothrow destructible!");
+
+        // Point-to-point constraint
+        // C = p2 - p1
+        // Cdot = v2 - v1
+        //      = v2 + cross(w2, r2) - v1 - cross(w1, r1)
+        // J = [-I -r1_skew I r2_skew ]
+        // Identity used:
+        // w k % (rx i + ry j) = w * (-ry i + rx j)
+
+        // Angle constraint
+        // C = angle2 - angle1 - referenceAngle
+        // Cdot = w2 - w1
+        // J = [0 0 -1 0 0 1]
+        // K = invI1 + invI2
+
+        WeldJointConf::WeldJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB, Angle ra) noexcept
+            : super{super{}.UseBodyA(bA).UseBodyB(bB)},
+              localAnchorA{laA}, localAnchorB{laB}, referenceAngle{ra}
         {
-            const auto impulse2 = -Solve22(K, GetVec2(C1));
-            impulse = Vec3{GetX(impulse2), GetY(impulse2), 0};
+            // Intentionally empty.
         }
 
-        const auto P = Length2{GetX(impulse) * Meter, GetY(impulse) * Meter} * Kilogram;
-        const auto L = GetZ(impulse) * Kilogram * SquareMeter / Radian;
-        const auto LA = L + Cross(rA, P) / Radian;
-        const auto LB = L + Cross(rB, P) / Radian;
+        WeldJointConf GetWeldJointConf(const Joint& joint)
+        {
+            return TypeCast<WeldJointConf>(joint);
+        }
 
-        posA -= Position{invMassA * P, invRotInertiaA * LA};
-        posB += Position{invMassB * P, invRotInertiaB * LB};
-    }
+        WeldJointConf GetWeldJointConf(const World& world, BodyID bodyA, BodyID bodyB, const Length2 anchor)
+        {
+            return WeldJointConf{
+                bodyA, bodyB,
+                GetLocalPoint(world, bodyA, anchor), GetLocalPoint(world, bodyB, anchor),
+                GetAngle(world, bodyB) - GetAngle(world, bodyA)};
+        }
 
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
+        void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    return (positionError <= conf.linearSlop) && (angularError <= conf.angularSlop);
-}
+            auto velA = bodyConstraintA.GetVelocity();
+            const auto posA = bodyConstraintA.GetPosition();
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
 
-} // namespace d2
-} // namespace playrho
+            auto velB = bodyConstraintB.GetVelocity();
+            const auto posB = bodyConstraintB.GetPosition();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            object.rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            object.rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+
+            // J = [-I -r1_skew I r2_skew]
+            //     [ 0       -1 0       1]
+            // r_skew = [-ry; rx]
+
+            // Matlab
+            // K = [ invMassA+r1y^2*invRotInertiaA+invMassB+r2y^2*invRotInertiaB,  -r1y*invRotInertiaA*r1x-r2y*invRotInertiaB*r2x,          -r1y*invRotInertiaA-r2y*invRotInertiaB]
+            //     [  -r1y*invRotInertiaA*r1x-r2y*invRotInertiaB*r2x, invMassA+r1x^2*invRotInertiaA+invMassB+r2x^2*invRotInertiaB,           r1x*invRotInertiaA+r2x*invRotInertiaB]
+            //     [          -r1y*invRotInertiaA-r2y*invRotInertiaB,           r1x*invRotInertiaA+r2x*invRotInertiaB,                   invRotInertiaA+invRotInertiaB]
+
+            const auto K = GetMat33(invMassA, object.rA, invRotInertiaA,
+                                    invMassB, object.rB, invRotInertiaB);
+            if (object.frequency > 0_Hz)
+            {
+                object.mass = GetInverse22(K);
+
+                // InvRotInertia is L^-2 M^-1 QP^2
+                //    RotInertia is L^2  M    QP^-2
+                auto invRotInertia = InvRotInertia{invRotInertiaA + invRotInertiaB};
+                const auto rotInertia = (invRotInertia > InvRotInertia{0}) ? Real{1} / invRotInertia : RotInertia{0};
+
+                const auto C = Angle{posB.angular - posA.angular - object.referenceAngle};
+                const auto omega = Real(2) * Pi * object.frequency;// T^-1
+                const auto d = Real(2) * rotInertia * object.dampingRatio * omega;
+
+                // Spring stiffness: L^2 M QP^-2 T^-2
+                const auto k = rotInertia * omega * omega;
+
+                // magic formulas
+                const auto h = step.deltaTime;
+                const auto invGamma = RotInertia{h * (d + h * k)};
+                object.gamma = (invGamma != RotInertia{0}) ? Real{1} / invGamma : InvRotInertia{0};
+                // QP * T * L^2 M QP^-2 T^-2 * L^-2 M^-1 QP^2 is: QP T^-1
+                object.bias = AngularVelocity{C * h * k * object.gamma};
+
+                invRotInertia += object.gamma;
+                GetZ(GetZ(object.mass)) = StripUnit((invRotInertia != InvRotInertia{0}) ? Real{1} / invRotInertia : RotInertia{0});
+            }
+            else if (GetZ(GetZ(K)) == 0)
+            {
+                object.mass = GetInverse22(K);
+                object.gamma = InvRotInertia{0};
+                object.bias = 0_rpm;
+            }
+            else
+            {
+                object.mass = GetSymInverse33(K);
+                object.gamma = InvRotInertia{0};
+                object.bias = 0_rpm;
+            }
+
+            if (step.doWarmStart)
+            {
+                // Scale impulses to support a variable time step.
+                object.impulse *= step.dtRatio;
+
+                const auto P = Momentum2{GetX(object.impulse) * NewtonSecond, GetY(object.impulse) * NewtonSecond};
+
+                // AngularMomentum is L^2 M T^-1 QP^-1.
+                const auto L = AngularMomentum{GetZ(object.impulse) * SquareMeter * Kilogram / (Second * Radian)};
+                const auto LA = L + AngularMomentum{Cross(object.rA, P) / Radian};
+                const auto LB = L + AngularMomentum{Cross(object.rB, P) / Radian};
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                object.impulse = Vec3{};
+            }
+
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            const auto oldVelA = bodyConstraintA.GetVelocity();
+            auto velA = oldVelA;
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+
+            const auto oldVelB = bodyConstraintB.GetVelocity();
+            auto velB = oldVelB;
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            if (object.frequency > 0_Hz)
+            {
+                const auto Cdot2 = velB.angular - velA.angular;
+
+                // InvRotInertia is L^-2 M^-1 QP^2. Angular velocity is QP T^-1
+                const auto gamma = AngularVelocity{object.gamma * GetZ(object.impulse) * SquareMeter * Kilogram / (Radian * Second)};
+
+                // AngularMomentum is L^2 M T^-1 QP^-1.
+                const auto impulse2 = -GetZ(GetZ(object.mass)) * StripUnit(Cdot2 + object.bias + gamma);
+                GetZ(object.impulse) += impulse2;
+
+                velA.angular -= AngularVelocity{invRotInertiaA * impulse2 * SquareMeter * Kilogram / (Second * Radian)};
+                velB.angular += AngularVelocity{invRotInertiaB * impulse2 * SquareMeter * Kilogram / (Second * Radian)};
+
+                const auto vb = velB.linear + LinearVelocity2{(GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
+                const auto va = velA.linear + LinearVelocity2{(GetRevPerpendicular(object.rA) * (velA.angular / Radian))};
+
+                const auto Cdot1 = vb - va;
+
+                const auto impulse1 = -Transform(Vec2{GetX(Cdot1) / MeterPerSecond, GetY(Cdot1) / MeterPerSecond}, object.mass);
+                GetX(object.impulse) += GetX(impulse1);
+                GetY(object.impulse) += GetY(impulse1);
+
+                const auto P = Momentum2{GetX(impulse1) * NewtonSecond, GetY(impulse1) * NewtonSecond};
+                const auto LA = AngularMomentum{Cross(object.rA, P) / Radian};
+                const auto LB = AngularMomentum{Cross(object.rB, P) / Radian};
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                const auto vb = velB.linear + LinearVelocity2{(GetRevPerpendicular(object.rB) * (velB.angular / Radian))};
+                const auto va = velA.linear + LinearVelocity2{(GetRevPerpendicular(object.rA) * (velA.angular / Radian))};
+
+                const auto Cdot1 = vb - va;
+                const auto Cdot2 = Real{(velB.angular - velA.angular) / RadianPerSecond};
+                const auto Cdot = Vec3{GetX(Cdot1) / MeterPerSecond, GetY(Cdot1) / MeterPerSecond, Cdot2};
+
+                const auto impulse = -Transform(Cdot, object.mass);
+                object.impulse += impulse;
+
+                const auto P = Momentum2{GetX(impulse) * NewtonSecond, GetY(impulse) * NewtonSecond};
+
+                // AngularMomentum is L^2 M T^-1 QP^-1.
+                const auto L = AngularMomentum{GetZ(impulse) * SquareMeter * Kilogram / (Second * Radian)};
+                const auto LA = L + AngularMomentum{Cross(object.rA, P) / Radian};
+                const auto LB = L + AngularMomentum{Cross(object.rB, P) / Radian};
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+
+            if ((velA != oldVelA) || (velB != oldVelB))
+            {
+                bodyConstraintA.SetVelocity(velA);
+                bodyConstraintB.SetVelocity(velB);
+                return false;
+            }
+            return true;
+        }
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        bool SolvePosition(const WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            auto posA = bodyConstraintA.GetPosition();
+            auto posB = bodyConstraintB.GetPosition();
+
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+
+            auto positionError = 0_m;
+            auto angularError = 0_deg;
+
+            const auto K = GetMat33(invMassA, rA, invRotInertiaA,
+                                    invMassB, rB, invRotInertiaB);
+            if (object.frequency > 0_Hz)
+            {
+                const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
+
+                positionError = GetMagnitude(C1);
+                angularError = 0_deg;
+
+                const auto P = -Solve22(K, C1) * Kilogram;
+                const auto LA = Cross(rA, P) / Radian;
+                const auto LB = Cross(rB, P) / Radian;
+
+                posA -= Position{invMassA * P, invRotInertiaA * LA};
+                posB += Position{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                const auto C1 = Length2{(posB.linear + rB) - (posA.linear + rA)};
+                const auto C2 = Angle{posB.angular - posA.angular - object.referenceAngle};
+
+                positionError = GetMagnitude(C1);
+                angularError = abs(C2);
+
+                const auto C = Vec3{StripUnit(GetX(C1)), StripUnit(GetY(C1)), StripUnit(C2)};
+
+                Vec3 impulse;
+                if (GetZ(GetZ(K)) > 0)
+                {
+                    impulse = -Solve33(K, C);
+                }
+                else
+                {
+                    const auto impulse2 = -Solve22(K, GetVec2(C1));
+                    impulse = Vec3{GetX(impulse2), GetY(impulse2), 0};
+                }
+
+                const auto P = Length2{GetX(impulse) * Meter, GetY(impulse) * Meter} * Kilogram;
+                const auto L = GetZ(impulse) * Kilogram * SquareMeter / Radian;
+                const auto LA = L + Cross(rA, P) / Radian;
+                const auto LB = L + Cross(rB, P) / Radian;
+
+                posA -= Position{invMassA * P, invRotInertiaA * LA};
+                posB += Position{invMassB * P, invRotInertiaB * LB};
+            }
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+
+            return (positionError <= conf.linearSlop) && (angularError <= conf.angularSlop);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/WeldJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.hpp
@@ -26,161 +26,163 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class World;
-class BodyConstraint;
-
-/// @brief Weld joint definition.
-/// @note A weld joint essentially glues two bodies together. A weld joint may
-///   distort somewhat because the island constraint solver is approximate.
-/// @note You need to specify local anchor points where they are attached and the
-///   relative body angle.
-/// @note The position of the anchor points is important for computing the reaction torque.
-/// @ingroup JointsGroup
-/// @see Joint, World::CreateJoint
-struct WeldJointConf : public JointBuilder<WeldJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<WeldJointConf>;
 
-    /// @brief Default constructor.
-    constexpr WeldJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// @brief Initializing constructor.
-    /// @details Initializes the bodies, anchors, and reference angle using a world
-    ///   anchor point.
-    /// @param bodyA Body A.
-    /// @param laA Local anchor A location in world coordinates.
-    /// @param bodyB Body B.
-    /// @param laB Local anchor B location in world coordinates.
-    WeldJointConf(BodyID bodyA, BodyID bodyB,
-                  Length2 laA = Length2{}, Length2 laB = Length2{}, Angle ra = 0_deg) noexcept;
-
-    /// @brief Uses the given frequency value.
-    constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
+    namespace d2
     {
-        frequency = v;
-        return *this;
-    }
 
-    /// @brief Uses the given damping ratio.
-    constexpr auto& UseDampingRatio(Real v) noexcept
+        class World;
+        class BodyConstraint;
+
+        /// @brief Weld joint definition.
+        /// @note A weld joint essentially glues two bodies together. A weld joint may
+        ///   distort somewhat because the island constraint solver is approximate.
+        /// @note You need to specify local anchor points where they are attached and the
+        ///   relative body angle.
+        /// @note The position of the anchor points is important for computing the reaction torque.
+        /// @ingroup JointsGroup
+        /// @see Joint, World::CreateJoint
+        struct WeldJointConf : public JointBuilder<WeldJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<WeldJointConf>;
+
+            /// @brief Default constructor.
+            constexpr WeldJointConf() = default;
+
+            /// @brief Initializing constructor.
+            /// @details Initializes the bodies, anchors, and reference angle using a world
+            ///   anchor point.
+            /// @param bodyA Body A.
+            /// @param laA Local anchor A location in world coordinates.
+            /// @param bodyB Body B.
+            /// @param laB Local anchor B location in world coordinates.
+            WeldJointConf(BodyID bodyA, BodyID bodyB,
+                          Length2 laA = Length2{}, Length2 laB = Length2{}, Angle ra = 0_deg) noexcept;
+
+            /// @brief Uses the given frequency value.
+            constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
+            {
+                frequency = v;
+                return *this;
+            }
+
+            /// @brief Uses the given damping ratio.
+            constexpr auto& UseDampingRatio(Real v) noexcept
+            {
+                dampingRatio = v;
+                return *this;
+            }
+
+            /// The local anchor point relative to body A's origin.
+            Length2 localAnchorA = Length2{};
+
+            /// The local anchor point relative to body B's origin.
+            Length2 localAnchorB = Length2{};
+
+            /// The body-B angle minus body-A angle in the reference state (radians).
+            Angle referenceAngle = 0_deg;
+
+            /// @brief Mass-spring-damper frequency.
+            /// @note Rotation only.
+            /// @note Disable softness with a value of 0.
+            NonNegative<Frequency> frequency{};// 0_Hz
+
+            /// @brief Damping ratio.
+            /// @note 0 = no damping, 1 = critical damping.
+            Real dampingRatio = 0;
+
+            // Solver shared
+            Vec3 impulse = Vec3{};///< Impulse.
+
+            // Solver temp
+            InvRotInertia gamma = {}; ///< Gamma.
+            AngularVelocity bias = {};///< Bias.
+            Length2 rA = {};          ///< Relative A.
+            Length2 rB = {};          ///< Relative B.
+            Mat33 mass = {};          ///< Mass.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        WeldJointConf GetWeldJointConf(const Joint& joint);
+
+        /// @brief Gets the configuration for the given parameters.
+        /// @relatedalso World
+        WeldJointConf GetWeldJointConf(const World& world, BodyID bodyA, BodyID bodyB,
+                                       const Length2 anchor = Length2{});
+
+        /// @brief Gets the current linear reaction of the given configuration.
+        /// @relatedalso WeldJointConf
+        constexpr Momentum2 GetLinearReaction(const WeldJointConf& object) noexcept
+        {
+            return Momentum2{GetX(object.impulse) * NewtonSecond, GetY(object.impulse) * NewtonSecond};
+        }
+
+        /// @brief Gets the current angular reaction of the given configuration.
+        /// @relatedalso WeldJointConf
+        constexpr AngularMomentum GetAngularReaction(const WeldJointConf& object) noexcept
+        {
+            // AngularMomentum is L^2 M T^-1 QP^-1
+            return AngularMomentum{GetZ(object.impulse) * SquareMeter * Kilogram / (Second * Radian)};
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso WeldJointConf
+        constexpr auto ShiftOrigin(WeldJointConf&, Length2) noexcept
+        {
+            return false;
+        }
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso WeldJointConf
+        void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso WeldJointConf
+        bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso WeldJointConf
+        bool SolvePosition(const WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Free function for setting the frequency of the given configuration.
+        /// @relatedalso WeldJointConf
+        constexpr void SetFrequency(WeldJointConf& object, NonNegative<Frequency> value) noexcept
+        {
+            object.UseFrequency(value);
+        }
+
+        /// @relatedalso WeldJointConf
+        constexpr void SetDampingRatio(WeldJointConf& object, Real value) noexcept
+        {
+            object.UseDampingRatio(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::WeldJointConf</code>.
+    template<>
+    struct TypeInfo<d2::WeldJointConf>
     {
-        dampingRatio = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::WeldJointConf";
+    };
 
-    /// The local anchor point relative to body A's origin.
-    Length2 localAnchorA = Length2{};
+}// namespace playrho
 
-    /// The local anchor point relative to body B's origin.
-    Length2 localAnchorB = Length2{};
-
-    /// The body-B angle minus body-A angle in the reference state (radians).
-    Angle referenceAngle = 0_deg;
-
-    /// @brief Mass-spring-damper frequency.
-    /// @note Rotation only.
-    /// @note Disable softness with a value of 0.
-    NonNegative<Frequency> frequency{}; // 0_Hz
-
-    /// @brief Damping ratio.
-    /// @note 0 = no damping, 1 = critical damping.
-    Real dampingRatio = 0;
-
-    // Solver shared
-    Vec3 impulse = Vec3{}; ///< Impulse.
-
-    // Solver temp
-    InvRotInertia gamma = {}; ///< Gamma.
-    AngularVelocity bias = {}; ///< Bias.
-    Length2 rA = {}; ///< Relative A.
-    Length2 rB = {}; ///< Relative B.
-    Mat33 mass = {}; ///< Mass.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-WeldJointConf GetWeldJointConf(const Joint& joint);
-
-/// @brief Gets the configuration for the given parameters.
-/// @relatedalso World
-WeldJointConf GetWeldJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                               const Length2 anchor = Length2{});
-
-/// @brief Gets the current linear reaction of the given configuration.
-/// @relatedalso WeldJointConf
-constexpr Momentum2 GetLinearReaction(const WeldJointConf& object) noexcept
-{
-    return Momentum2{GetX(object.impulse) * NewtonSecond, GetY(object.impulse) * NewtonSecond};
-}
-
-/// @brief Gets the current angular reaction of the given configuration.
-/// @relatedalso WeldJointConf
-constexpr AngularMomentum GetAngularReaction(const WeldJointConf& object) noexcept
-{
-    // AngularMomentum is L^2 M T^-1 QP^-1
-    return AngularMomentum{GetZ(object.impulse) * SquareMeter * Kilogram / (Second * Radian)};
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso WeldJointConf
-constexpr auto ShiftOrigin(WeldJointConf&, Length2) noexcept
-{
-    return false;
-}
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso WeldJointConf
-void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso WeldJointConf
-bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso WeldJointConf
-bool SolvePosition(const WeldJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Free function for setting the frequency of the given configuration.
-/// @relatedalso WeldJointConf
-constexpr void SetFrequency(WeldJointConf& object, NonNegative<Frequency> value) noexcept
-{
-    object.UseFrequency(value);
-}
-
-/// @relatedalso WeldJointConf
-constexpr void SetDampingRatio(WeldJointConf& object, Real value) noexcept
-{
-    object.UseDampingRatio(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::WeldJointConf</code>.
-template <>
-struct TypeInfo<d2::WeldJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::WeldJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_WELDJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_WELDJOINTCONF_HPP

--- a/PlayRho/Dynamics/Joints/WheelJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.cpp
@@ -21,318 +21,320 @@
 
 #include <PlayRho/Dynamics/Joints/WheelJointConf.hpp>
 
-#include <PlayRho/Dynamics/Joints/Joint.hpp>
-#include <PlayRho/Dynamics/WorldBody.hpp>
-#include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp> // for ConstraintSolverConf
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>// for ConstraintSolverConf
+#include <PlayRho/Dynamics/Joints/Joint.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
+#include <PlayRho/Dynamics/WorldBody.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<WheelJointConf>::value,
-              "WheelJointConf should be default constructible!");
-static_assert(std::is_copy_constructible<WheelJointConf>::value,
-              "WheelJointConf should be copy constructible!");
-static_assert(std::is_copy_assignable<WheelJointConf>::value,
-              "WheelJointConf should be copy assignable!");
-static_assert(std::is_move_constructible<WheelJointConf>::value,
-              "WheelJointConf should be move constructible!");
-static_assert(std::is_move_assignable<WheelJointConf>::value,
-              "WheelJointConf should be move assignable!");
-static_assert(std::is_nothrow_destructible<WheelJointConf>::value,
-              "WheelJointConf should be nothrow destructible!");
-
-// Linear constraint (point-to-line)
-// d = pB - pA = xB + rB - xA - rA
-// C = dot(ay, d)
-// Cdot = dot(d, cross(wA, ay)) + dot(ay, vB + cross(wB, rB) - vA - cross(wA, rA))
-//      = -dot(ay, vA) - dot(cross(d + rA, ay), wA) + dot(ay, vB) + dot(cross(rB, ay), vB)
-// J = [-ay, -cross(d + rA, ay), ay, cross(rB, ay)]
-
-// Spring linear constraint
-// C = dot(ax, d)
-// Cdot = = -dot(ax, vA) - dot(cross(d + rA, ax), wA) + dot(ax, vB) + dot(cross(rB, ax), vB)
-// J = [-ax -cross(d+rA, ax) ax cross(rB, ax)]
-
-// Motor rotational constraint
-// Cdot = wB - wA
-// J = [0 0 -1 0 0 1]
-
-WheelJointConf::WheelJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB,
-                               UnitVec axis) noexcept:
-    super{super{}.UseBodyA(bA).UseBodyB(bB)},
-    localAnchorA{laA}, localAnchorB{laB},
-    localXAxisA{axis}, localYAxisA{GetRevPerpendicular(axis)}
+namespace playrho
 {
-    // Intentionally empty.
-}
-
-WheelJointConf GetWheelJointConf(const Joint& joint)
-{
-    return TypeCast<WheelJointConf>(joint);
-}
-
-WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                 Length2 anchor, UnitVec axis)
-{
-    return WheelJointConf{
-        bodyA, bodyB,
-        GetLocalPoint(world, bodyA, anchor), GetLocalPoint(world, bodyB, anchor),
-        GetLocalVector(world, bodyA, axis)};
-}
-
-AngularVelocity GetAngularVelocity(const World& world, const WheelJointConf& conf)
-{
-    return GetVelocity(world, GetBodyB(conf)).angular
-         - GetVelocity(world, GetBodyA(conf)).angular;
-}
-
-void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf&)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
-
-    const auto posA = bodyConstraintA.GetPosition();
-    auto velA = bodyConstraintA.GetVelocity();
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
-
-    const auto posB = bodyConstraintB.GetPosition();
-    auto velB = bodyConstraintB.GetVelocity();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
-
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
-
-    // Compute the effective masses.
-    const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
-    const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
-    const auto dd = Length2{(posB.linear + rB) - (posA.linear + rA)};
-
-    // Point to line constraint
+    namespace d2
     {
-        object.ay = Rotate(object.localYAxisA, qA);
-        object.sAy = Cross(dd + rA, object.ay);
-        object.sBy = Cross(rB, object.ay);
 
-        const auto invRotMassA = invRotInertiaA * Square(object.sAy) / SquareRadian;
-        const auto invRotMassB = invRotInertiaB * Square(object.sBy) / SquareRadian;
-        const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
+        static_assert(std::is_default_constructible<WheelJointConf>::value,
+                      "WheelJointConf should be default constructible!");
+        static_assert(std::is_copy_constructible<WheelJointConf>::value,
+                      "WheelJointConf should be copy constructible!");
+        static_assert(std::is_copy_assignable<WheelJointConf>::value,
+                      "WheelJointConf should be copy assignable!");
+        static_assert(std::is_move_constructible<WheelJointConf>::value,
+                      "WheelJointConf should be move constructible!");
+        static_assert(std::is_move_assignable<WheelJointConf>::value,
+                      "WheelJointConf should be move assignable!");
+        static_assert(std::is_nothrow_destructible<WheelJointConf>::value,
+                      "WheelJointConf should be nothrow destructible!");
 
-        object.mass = (invMass > InvMass{0})? Real{1} / invMass: 0;
-    }
+        // Linear constraint (point-to-line)
+        // d = pB - pA = xB + rB - xA - rA
+        // C = dot(ay, d)
+        // Cdot = dot(d, cross(wA, ay)) + dot(ay, vB + cross(wB, rB) - vA - cross(wA, rA))
+        //      = -dot(ay, vA) - dot(cross(d + rA, ay), wA) + dot(ay, vB) + dot(cross(rB, ay), vB)
+        // J = [-ay, -cross(d + rA, ay), ay, cross(rB, ay)]
 
-    // Spring constraint
-    object.springMass = 0_kg;
-    object.bias = 0;
-    object.gamma = 0;
-    if (object.frequency > 0_Hz)
-    {
-        object.ax = Rotate(object.localXAxisA, qA);
-        object.sAx = Cross(dd + rA, object.ax);
-        object.sBx = Cross(rB, object.ax);
+        // Spring linear constraint
+        // C = dot(ax, d)
+        // Cdot = = -dot(ax, vA) - dot(cross(d + rA, ax), wA) + dot(ax, vB) + dot(cross(rB, ax), vB)
+        // J = [-ax -cross(d+rA, ax) ax cross(rB, ax)]
 
-        const auto invRotMassA = invRotInertiaA * Square(object.sAx) / SquareRadian;
-        const auto invRotMassB = invRotInertiaB * Square(object.sBx) / SquareRadian;
-        const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
+        // Motor rotational constraint
+        // Cdot = wB - wA
+        // J = [0 0 -1 0 0 1]
 
-        if (invMass > InvMass{0})
+        WheelJointConf::WheelJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB,
+                                       UnitVec axis) noexcept
+            : super{super{}.UseBodyA(bA).UseBodyB(bB)},
+              localAnchorA{laA}, localAnchorB{laB},
+              localXAxisA{axis}, localYAxisA{GetRevPerpendicular(axis)}
         {
-            object.springMass = Real{1} / invMass;
-
-            const auto C = Length{Dot(dd, object.ax)};
-
-            // Frequency
-            const auto omega = Real{2} * Pi * object.frequency;
-
-            // Damping coefficient
-            const auto d = Real{2} * object.springMass * object.dampingRatio * omega;
-
-            // Spring stiffness
-            const auto k = object.springMass * omega * omega;
-
-            // magic formulas
-            const auto h = step.deltaTime;
-
-            const auto invGamma = Mass{h * (d + h * k)};
-            object.gamma = (invGamma > 0_kg)? Real{1} / invGamma: 0;
-            object.bias = LinearVelocity{C * h * k * object.gamma};
-
-            const auto totalInvMass = invMass + object.gamma;
-            object.springMass = (totalInvMass > InvMass{0})? Real{1} / totalInvMass: 0_kg;
+            // Intentionally empty.
         }
-    }
-    else
-    {
-        object.springImpulse = 0;
 
-        object.ax = UnitVec::GetZero();
-        object.sAx = 0_m;
-        object.sBx = 0_m;
-    }
+        WheelJointConf GetWheelJointConf(const Joint& joint)
+        {
+            return TypeCast<WheelJointConf>(joint);
+        }
 
-    // Rotational motor
-    if (object.enableMotor)
-    {
-        const auto invRotInertia = invRotInertiaA + invRotInertiaB;
-        object.angularMass = (invRotInertia > InvRotInertia{0})? Real{1} / invRotInertia: RotInertia{0};
-    }
-    else
-    {
-        object.angularMass = RotInertia{0};
-        object.angularImpulse = 0;
-    }
+        WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB,
+                                         Length2 anchor, UnitVec axis)
+        {
+            return WheelJointConf{
+                bodyA, bodyB,
+                GetLocalPoint(world, bodyA, anchor), GetLocalPoint(world, bodyB, anchor),
+                GetLocalVector(world, bodyA, axis)};
+        }
 
-    if (step.doWarmStart)
-    {
-        // Account for variable time step.
-        object.impulse *= step.dtRatio;
-        object.springImpulse *= step.dtRatio;
-        object.angularImpulse *= step.dtRatio;
+        AngularVelocity GetAngularVelocity(const World& world, const WheelJointConf& conf)
+        {
+            return GetVelocity(world, GetBodyB(conf)).angular
+                   - GetVelocity(world, GetBodyA(conf)).angular;
+        }
 
-        const auto P = object.impulse * object.ay + object.springImpulse * object.ax;
+        void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf&)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-        // Momentum is M L T^-1. Length * momentum is L^2 M T^-1
-        // Angular momentum is L^2 M T^-1 QP^-1
-        const auto LA = AngularMomentum{(object.impulse * object.sAy + object.springImpulse * object.sAx) / Radian + object.angularImpulse};
-        const auto LB = AngularMomentum{(object.impulse * object.sBy + object.springImpulse * object.sBx) / Radian + object.angularImpulse};
+            const auto posA = bodyConstraintA.GetPosition();
+            auto velA = bodyConstraintA.GetVelocity();
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
-    else
-    {
-        object.impulse = 0;
-        object.springImpulse = 0;
-        object.angularImpulse = 0;
-    }
+            const auto posB = bodyConstraintB.GetPosition();
+            auto velB = bodyConstraintB.GetVelocity();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
 
-    bodyConstraintA.SetVelocity(velA);
-    bodyConstraintB.SetVelocity(velB);
-}
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
 
-bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+            // Compute the effective masses.
+            const auto rA = Length2{Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA)};
+            const auto rB = Length2{Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB)};
+            const auto dd = Length2{(posB.linear + rB) - (posA.linear + rA)};
 
-    const auto oldVelA = bodyConstraintA.GetVelocity();
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            // Point to line constraint
+            {
+                object.ay = Rotate(object.localYAxisA, qA);
+                object.sAy = Cross(dd + rA, object.ay);
+                object.sBy = Cross(rB, object.ay);
 
-    const auto oldVelB = bodyConstraintB.GetVelocity();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+                const auto invRotMassA = invRotInertiaA * Square(object.sAy) / SquareRadian;
+                const auto invRotMassB = invRotInertiaB * Square(object.sBy) / SquareRadian;
+                const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
 
-    auto velA = oldVelA;
-    auto velB = oldVelB;
+                object.mass = (invMass > InvMass{0}) ? Real{1} / invMass : 0;
+            }
 
-    // Solve spring constraint
-    {
-        const auto dot = LinearVelocity{Dot(object.ax, velB.linear - velA.linear)};
-        const auto Cdot = dot + object.sBx * velB.angular / Radian - object.sAx * velA.angular / Radian;
-        const auto impulse = -object.springMass * (Cdot + object.bias + object.gamma * object.springImpulse);
-        object.springImpulse += impulse;
+            // Spring constraint
+            object.springMass = 0_kg;
+            object.bias = 0;
+            object.gamma = 0;
+            if (object.frequency > 0_Hz)
+            {
+                object.ax = Rotate(object.localXAxisA, qA);
+                object.sAx = Cross(dd + rA, object.ax);
+                object.sBx = Cross(rB, object.ax);
 
-        const auto P = impulse * object.ax;
-        const auto LA = AngularMomentum{impulse * object.sAx / Radian};
-        const auto LB = AngularMomentum{impulse * object.sBx / Radian};
+                const auto invRotMassA = invRotInertiaA * Square(object.sAx) / SquareRadian;
+                const auto invRotMassB = invRotInertiaB * Square(object.sBx) / SquareRadian;
+                const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
+                if (invMass > InvMass{0})
+                {
+                    object.springMass = Real{1} / invMass;
 
-    // Solve rotational motor constraint
-    {
-        const auto Cdot = (velB.angular - velA.angular - object.motorSpeed);
-        auto impulse = AngularMomentum{-object.angularMass * Cdot};
+                    const auto C = Length{Dot(dd, object.ax)};
 
-        const auto oldImpulse = object.angularImpulse;
-        const auto maxImpulse = AngularMomentum{step.deltaTime * object.maxMotorTorque};
-        object.angularImpulse = std::clamp(object.angularImpulse + impulse,
-                                           -maxImpulse, maxImpulse);
-        impulse = object.angularImpulse - oldImpulse;
+                    // Frequency
+                    const auto omega = Real{2} * Pi * object.frequency;
 
-        velA.angular -= AngularVelocity{invRotInertiaA * impulse};
-        velB.angular += AngularVelocity{invRotInertiaB * impulse};
-    }
+                    // Damping coefficient
+                    const auto d = Real{2} * object.springMass * object.dampingRatio * omega;
 
-    // Solve point to line constraint
-    {
-        const auto dot = LinearVelocity{Dot(object.ay, velB.linear - velA.linear)};
-        const auto Cdot = dot + object.sBy * velB.angular / Radian - object.sAy * velA.angular / Radian;
-        const auto impulse = -object.mass * Cdot;
-        object.impulse += impulse;
+                    // Spring stiffness
+                    const auto k = object.springMass * omega * omega;
 
-        const auto P = impulse * object.ay;
-        const auto LA = AngularMomentum{impulse * object.sAy / Radian};
-        const auto LB = AngularMomentum{impulse * object.sBy / Radian};
+                    // magic formulas
+                    const auto h = step.deltaTime;
 
-        velA -= Velocity{invMassA * P, invRotInertiaA * LA};
-        velB += Velocity{invMassB * P, invRotInertiaB * LB};
-    }
+                    const auto invGamma = Mass{h * (d + h * k)};
+                    object.gamma = (invGamma > 0_kg) ? Real{1} / invGamma : 0;
+                    object.bias = LinearVelocity{C * h * k * object.gamma};
 
-    if ((velA != oldVelA) || (velB != oldVelB))
-    {
-        bodyConstraintA.SetVelocity(velA);
-        bodyConstraintB.SetVelocity(velB);
-        return false;
-    }
-    return true;
-}
+                    const auto totalInvMass = invMass + object.gamma;
+                    object.springMass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
+                }
+            }
+            else
+            {
+                object.springImpulse = 0;
 
-bool SolvePosition(const WheelJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf)
-{
-    auto& bodyConstraintA = At(bodies, GetBodyA(object));
-    auto& bodyConstraintB = At(bodies, GetBodyB(object));
+                object.ax = UnitVec::GetZero();
+                object.sAx = 0_m;
+                object.sBx = 0_m;
+            }
 
-    auto posA = bodyConstraintA.GetPosition();
-    const auto invMassA = bodyConstraintA.GetInvMass();
-    const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+            // Rotational motor
+            if (object.enableMotor)
+            {
+                const auto invRotInertia = invRotInertiaA + invRotInertiaB;
+                object.angularMass = (invRotInertia > InvRotInertia{0}) ? Real{1} / invRotInertia : RotInertia{0};
+            }
+            else
+            {
+                object.angularMass = RotInertia{0};
+                object.angularImpulse = 0;
+            }
 
-    auto posB = bodyConstraintB.GetPosition();
-    const auto invMassB = bodyConstraintB.GetInvMass();
-    const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+            if (step.doWarmStart)
+            {
+                // Account for variable time step.
+                object.impulse *= step.dtRatio;
+                object.springImpulse *= step.dtRatio;
+                object.angularImpulse *= step.dtRatio;
 
-    const auto qA = UnitVec::Get(posA.angular);
-    const auto qB = UnitVec::Get(posB.angular);
+                const auto P = object.impulse * object.ay + object.springImpulse * object.ax;
 
-    const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
-    const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
-    const auto d = Length2{(posB.linear - posA.linear) + (rB - rA)};
+                // Momentum is M L T^-1. Length * momentum is L^2 M T^-1
+                // Angular momentum is L^2 M T^-1 QP^-1
+                const auto LA = AngularMomentum{(object.impulse * object.sAy + object.springImpulse * object.sAx) / Radian + object.angularImpulse};
+                const auto LB = AngularMomentum{(object.impulse * object.sBy + object.springImpulse * object.sBx) / Radian + object.angularImpulse};
 
-    const auto ay = Rotate(object.localYAxisA, qA);
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+            else
+            {
+                object.impulse = 0;
+                object.springImpulse = 0;
+                object.angularImpulse = 0;
+            }
 
-    const auto sAy = Cross(d + rA, ay);
-    const auto sBy = Cross(rB, ay);
+            bodyConstraintA.SetVelocity(velA);
+            bodyConstraintB.SetVelocity(velB);
+        }
 
-    const auto C = Length{Dot(d, ay)};
+        bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
 
-    const auto invRotMassA = invRotInertiaA * Square(object.sAy) / SquareRadian;
-    const auto invRotMassB = invRotInertiaB * Square(object.sBy) / SquareRadian;
+            const auto oldVelA = bodyConstraintA.GetVelocity();
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
 
-    const auto k = InvMass{invMassA + invMassB + invRotMassA + invRotMassB};
+            const auto oldVelB = bodyConstraintB.GetVelocity();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
 
-    const auto impulse = (k != InvMass{0})? -(C / k): 0 * Kilogram * Meter;
+            auto velA = oldVelA;
+            auto velB = oldVelB;
 
-    const auto P = impulse * ay;
-    const auto LA = impulse * sAy / Radian;
-    const auto LB = impulse * sBy / Radian;
+            // Solve spring constraint
+            {
+                const auto dot = LinearVelocity{Dot(object.ax, velB.linear - velA.linear)};
+                const auto Cdot = dot + object.sBx * velB.angular / Radian - object.sAx * velA.angular / Radian;
+                const auto impulse = -object.springMass * (Cdot + object.bias + object.gamma * object.springImpulse);
+                object.springImpulse += impulse;
 
-    posA -= Position{invMassA * P, invRotInertiaA * LA};
-    posB += Position{invMassB * P, invRotInertiaB * LB};
+                const auto P = impulse * object.ax;
+                const auto LA = AngularMomentum{impulse * object.sAx / Radian};
+                const auto LB = AngularMomentum{impulse * object.sBx / Radian};
 
-    bodyConstraintA.SetPosition(posA);
-    bodyConstraintB.SetPosition(posB);
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
 
-    return abs(C) <= conf.linearSlop;
-}
+            // Solve rotational motor constraint
+            {
+                const auto Cdot = (velB.angular - velA.angular - object.motorSpeed);
+                auto impulse = AngularMomentum{-object.angularMass * Cdot};
 
-} // namespace d2
-} // namespace playrho
+                const auto oldImpulse = object.angularImpulse;
+                const auto maxImpulse = AngularMomentum{step.deltaTime * object.maxMotorTorque};
+                object.angularImpulse = std::clamp(object.angularImpulse + impulse,
+                                                   -maxImpulse, maxImpulse);
+                impulse = object.angularImpulse - oldImpulse;
+
+                velA.angular -= AngularVelocity{invRotInertiaA * impulse};
+                velB.angular += AngularVelocity{invRotInertiaB * impulse};
+            }
+
+            // Solve point to line constraint
+            {
+                const auto dot = LinearVelocity{Dot(object.ay, velB.linear - velA.linear)};
+                const auto Cdot = dot + object.sBy * velB.angular / Radian - object.sAy * velA.angular / Radian;
+                const auto impulse = -object.mass * Cdot;
+                object.impulse += impulse;
+
+                const auto P = impulse * object.ay;
+                const auto LA = AngularMomentum{impulse * object.sAy / Radian};
+                const auto LB = AngularMomentum{impulse * object.sBy / Radian};
+
+                velA -= Velocity{invMassA * P, invRotInertiaA * LA};
+                velB += Velocity{invMassB * P, invRotInertiaB * LB};
+            }
+
+            if ((velA != oldVelA) || (velB != oldVelB))
+            {
+                bodyConstraintA.SetVelocity(velA);
+                bodyConstraintB.SetVelocity(velB);
+                return false;
+            }
+            return true;
+        }
+
+        bool SolvePosition(const WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf)
+        {
+            auto& bodyConstraintA = At(bodies, GetBodyA(object));
+            auto& bodyConstraintB = At(bodies, GetBodyB(object));
+
+            auto posA = bodyConstraintA.GetPosition();
+            const auto invMassA = bodyConstraintA.GetInvMass();
+            const auto invRotInertiaA = bodyConstraintA.GetInvRotInertia();
+
+            auto posB = bodyConstraintB.GetPosition();
+            const auto invMassB = bodyConstraintB.GetInvMass();
+            const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
+
+            const auto qA = UnitVec::Get(posA.angular);
+            const auto qB = UnitVec::Get(posB.angular);
+
+            const auto rA = Rotate(object.localAnchorA - bodyConstraintA.GetLocalCenter(), qA);
+            const auto rB = Rotate(object.localAnchorB - bodyConstraintB.GetLocalCenter(), qB);
+            const auto d = Length2{(posB.linear - posA.linear) + (rB - rA)};
+
+            const auto ay = Rotate(object.localYAxisA, qA);
+
+            const auto sAy = Cross(d + rA, ay);
+            const auto sBy = Cross(rB, ay);
+
+            const auto C = Length{Dot(d, ay)};
+
+            const auto invRotMassA = invRotInertiaA * Square(object.sAy) / SquareRadian;
+            const auto invRotMassB = invRotInertiaB * Square(object.sBy) / SquareRadian;
+
+            const auto k = InvMass{invMassA + invMassB + invRotMassA + invRotMassB};
+
+            const auto impulse = (k != InvMass{0}) ? -(C / k) : 0 * Kilogram * Meter;
+
+            const auto P = impulse * ay;
+            const auto LA = impulse * sAy / Radian;
+            const auto LB = impulse * sBy / Radian;
+
+            posA -= Position{invMassA * P, invRotInertiaA * LA};
+            posB += Position{invMassB * P, invRotInertiaB * LB};
+
+            bodyConstraintA.SetPosition(posA);
+            bodyConstraintB.SetPosition(posB);
+
+            return abs(C) <= conf.linearSlop;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/Joints/WheelJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.hpp
@@ -26,204 +26,206 @@
 
 #include <PlayRho/Common/Math.hpp>
 
-namespace playrho {
-
-struct ConstraintSolverConf;
-struct StepConf;
-
-namespace d2 {
-
-class World;
-class BodyConstraint;
-
-/// @brief Wheel joint definition.
-/// @details This joint provides two degrees of freedom: translation along an axis fixed
-///   in body A and rotation in the plane. In other words, it is a point to line constraint
-///   with a rotational motor and a linear spring/damper. This requires defining a line of
-///   motion using an axis and an anchor point. The definition uses local anchor points and
-///   a local axis so that the initial configuration can violate the constraint slightly.
-///   The joint translation is zero when the local anchor points coincide in world space.
-///   Using local anchors and a local axis helps when saving and loading a game.
-/// @note This joint is designed for vehicle suspensions.
-/// @ingroup JointsGroup
-/// @image html WheelJoint.png
-/// @see Joint, World::CreateJoint
-struct WheelJointConf : public JointBuilder<WheelJointConf>
+namespace playrho
 {
-    /// @brief Super type.
-    using super = JointBuilder<WheelJointConf>;
 
-    /// @brief Default constructor.
-    constexpr WheelJointConf() = default;
+    struct ConstraintSolverConf;
+    struct StepConf;
 
-    /// Initialize the bodies, anchors, axis, and reference angle using the world
-    /// anchor and world axis.
-    WheelJointConf(BodyID bA, BodyID bB,
-                   Length2 laA = Length2{}, Length2 laB = Length2{},
-                   UnitVec axis = UnitVec::GetRight()) noexcept;
-
-    /// @brief Uses the given enable motor state value.
-    constexpr auto& UseEnableMotor(bool v) noexcept
+    namespace d2
     {
-        enableMotor = v;
-        return *this;
-    }
 
-    /// @brief Uses the given max motor toque value.
-    constexpr auto& UseMaxMotorTorque(Torque v) noexcept
+        class World;
+        class BodyConstraint;
+
+        /// @brief Wheel joint definition.
+        /// @details This joint provides two degrees of freedom: translation along an axis fixed
+        ///   in body A and rotation in the plane. In other words, it is a point to line constraint
+        ///   with a rotational motor and a linear spring/damper. This requires defining a line of
+        ///   motion using an axis and an anchor point. The definition uses local anchor points and
+        ///   a local axis so that the initial configuration can violate the constraint slightly.
+        ///   The joint translation is zero when the local anchor points coincide in world space.
+        ///   Using local anchors and a local axis helps when saving and loading a game.
+        /// @note This joint is designed for vehicle suspensions.
+        /// @ingroup JointsGroup
+        /// @image html WheelJoint.png
+        /// @see Joint, World::CreateJoint
+        struct WheelJointConf : public JointBuilder<WheelJointConf>
+        {
+            /// @brief Super type.
+            using super = JointBuilder<WheelJointConf>;
+
+            /// @brief Default constructor.
+            constexpr WheelJointConf() = default;
+
+            /// Initialize the bodies, anchors, axis, and reference angle using the world
+            /// anchor and world axis.
+            WheelJointConf(BodyID bA, BodyID bB,
+                           Length2 laA = Length2{}, Length2 laB = Length2{},
+                           UnitVec axis = UnitVec::GetRight()) noexcept;
+
+            /// @brief Uses the given enable motor state value.
+            constexpr auto& UseEnableMotor(bool v) noexcept
+            {
+                enableMotor = v;
+                return *this;
+            }
+
+            /// @brief Uses the given max motor toque value.
+            constexpr auto& UseMaxMotorTorque(Torque v) noexcept
+            {
+                maxMotorTorque = v;
+                return *this;
+            }
+
+            /// @brief Uses the given motor speed value.
+            constexpr auto& UseMotorSpeed(AngularVelocity v) noexcept
+            {
+                motorSpeed = v;
+                return *this;
+            }
+
+            /// @brief Uses the given frequency value.
+            constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
+            {
+                frequency = v;
+                return *this;
+            }
+
+            /// @brief Uses the given damping ratio value.
+            constexpr auto& UseDampingRatio(Real v) noexcept
+            {
+                dampingRatio = v;
+                return *this;
+            }
+
+            /// The local anchor point relative to body A's origin.
+            Length2 localAnchorA = Length2{};
+
+            /// The local anchor point relative to body B's origin.
+            Length2 localAnchorB = Length2{};
+
+            /// The local X translation axis in body-A.
+            UnitVec localXAxisA = UnitVec::GetRight();
+
+            /// The local Y translation axis in body-A.
+            UnitVec localYAxisA = GetRevPerpendicular(UnitVec::GetRight());
+
+            /// Enable/disable the joint motor.
+            bool enableMotor = false;
+
+            /// The maximum motor torque.
+            Torque maxMotorTorque = Torque{0};
+
+            /// The desired angular motor speed.
+            AngularVelocity motorSpeed = 0_rpm;
+
+            /// Suspension frequency, zero indicates no suspension
+            NonNegative<Frequency> frequency = 2_Hz;
+
+            /// Suspension damping ratio, one indicates critical damping
+            Real dampingRatio = 0.7f;
+
+            Momentum impulse = 0;              ///< Impulse.
+            AngularMomentum angularImpulse = 0;///< Angular impulse.
+            Momentum springImpulse = 0;        ///< Spring impulse.
+
+            UnitVec ax;///< Solver A X directional.
+            UnitVec ay;///< Solver A Y directional.
+
+            Length sAx = 0_m;///< Solver A x location.
+            Length sBx = 0_m;///< Solver B x location.
+            Length sAy = 0_m;///< Solver A y location.
+            Length sBy = 0_m;///< Solver B y location.
+
+            Mass mass = 0_kg;                      ///< Mass.
+            RotInertia angularMass = RotInertia{0};///< Motor mass.
+            Mass springMass = 0_kg;                ///< Spring mass.
+
+            LinearVelocity bias = 0_mps;///< Bias.
+            InvMass gamma = InvMass{0}; ///< Gamma.
+        };
+
+        /// @brief Gets the definition data for the given joint.
+        /// @relatedalso Joint
+        WheelJointConf GetWheelJointConf(const Joint& joint);
+
+        /// @brief Gets the definition data for the given parameters.
+        /// @relatedalso World
+        WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB,
+                                         Length2 anchor, UnitVec axis = UnitVec::GetRight());
+
+        /// @brief Gets the angular velocity for the given configuration within the specified world.
+        /// @relatedalso World
+        AngularVelocity GetAngularVelocity(const World& world, const WheelJointConf& conf);
+
+        /// @brief Gets the current linear reaction for the given configuration.
+        /// @relatedalso WheelJointConf
+        constexpr Momentum2 GetLinearReaction(const WheelJointConf& object)
+        {
+            return object.impulse * object.ay + object.springImpulse * object.ax;
+        }
+
+        /// @brief Shifts the origin notion of the given configuration.
+        /// @relatedalso WheelJointConf
+        constexpr auto ShiftOrigin(WheelJointConf&, Length2)
+        {
+            return false;
+        }
+
+        /// @brief Initializes velocity constraint data based on the given solver data.
+        /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
+        /// @see SolveVelocity.
+        /// @relatedalso WheelJointConf
+        void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+                          const StepConf& step,
+                          const ConstraintSolverConf& conf);
+
+        /// @brief Solves velocity constraint.
+        /// @pre <code>InitVelocity</code> has been called.
+        /// @see InitVelocity.
+        /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
+        /// @relatedalso WheelJointConf
+        bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const StepConf& step);
+
+        /// @brief Solves the position constraint.
+        /// @return <code>true</code> if the position errors are within tolerance.
+        /// @relatedalso WheelJointConf
+        bool SolvePosition(const WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+                           const ConstraintSolverConf& conf);
+
+        /// @brief Sets the maximum motor torque for the given configuration.
+        /// @relatedalso WheelJointConf
+        constexpr void SetMaxMotorTorque(WheelJointConf& object, Torque value) noexcept
+        {
+            object.UseMaxMotorTorque(value);
+        }
+
+        /// @brief Free function for setting the frequency of the given configuration.
+        /// @relatedalso WheelJointConf
+        constexpr void SetFrequency(WheelJointConf& object, NonNegative<Frequency> value) noexcept
+        {
+            object.UseFrequency(value);
+        }
+
+        /// @brief Free function for setting the damping ratio of the given configuration.
+        /// @relatedalso WheelJointConf
+        constexpr void SetDampingRatio(WheelJointConf& object, Real value) noexcept
+        {
+            object.UseDampingRatio(value);
+        }
+
+    }// namespace d2
+
+    /// @brief Type info specialization for <code>d2::WheelJointConf</code>.
+    template<>
+    struct TypeInfo<d2::WheelJointConf>
     {
-        maxMotorTorque = v;
-        return *this;
-    }
+        /// @brief Provides a null-terminated string name for the type.
+        static constexpr const char* name = "d2::WheelJointConf";
+    };
 
-    /// @brief Uses the given motor speed value.
-    constexpr auto& UseMotorSpeed(AngularVelocity v) noexcept
-    {
-        motorSpeed = v;
-        return *this;
-    }
+}// namespace playrho
 
-    /// @brief Uses the given frequency value.
-    constexpr auto& UseFrequency(NonNegative<Frequency> v) noexcept
-    {
-        frequency = v;
-        return *this;
-    }
-
-    /// @brief Uses the given damping ratio value.
-    constexpr auto& UseDampingRatio(Real v) noexcept
-    {
-        dampingRatio = v;
-        return *this;
-    }
-
-    /// The local anchor point relative to body A's origin.
-    Length2 localAnchorA = Length2{};
-
-    /// The local anchor point relative to body B's origin.
-    Length2 localAnchorB = Length2{};
-
-    /// The local X translation axis in body-A.
-    UnitVec localXAxisA = UnitVec::GetRight();
-
-    /// The local Y translation axis in body-A.
-    UnitVec localYAxisA = GetRevPerpendicular(UnitVec::GetRight());
-
-    /// Enable/disable the joint motor.
-    bool enableMotor = false;
-
-    /// The maximum motor torque.
-    Torque maxMotorTorque = Torque{0};
-
-    /// The desired angular motor speed.
-    AngularVelocity motorSpeed = 0_rpm;
-
-    /// Suspension frequency, zero indicates no suspension
-    NonNegative<Frequency> frequency = 2_Hz;
-
-    /// Suspension damping ratio, one indicates critical damping
-    Real dampingRatio = 0.7f;
-
-    Momentum impulse = 0; ///< Impulse.
-    AngularMomentum angularImpulse = 0; ///< Angular impulse.
-    Momentum springImpulse = 0; ///< Spring impulse.
-
-    UnitVec ax; ///< Solver A X directional.
-    UnitVec ay; ///< Solver A Y directional.
-
-    Length sAx = 0_m; ///< Solver A x location.
-    Length sBx = 0_m; ///< Solver B x location.
-    Length sAy = 0_m; ///< Solver A y location.
-    Length sBy = 0_m; ///< Solver B y location.
-
-    Mass mass = 0_kg; ///< Mass.
-    RotInertia angularMass = RotInertia{0}; ///< Motor mass.
-    Mass springMass = 0_kg; ///< Spring mass.
-
-    LinearVelocity bias = 0_mps; ///< Bias.
-    InvMass gamma = InvMass{0}; ///< Gamma.
-};
-
-/// @brief Gets the definition data for the given joint.
-/// @relatedalso Joint
-WheelJointConf GetWheelJointConf(const Joint& joint);
-
-/// @brief Gets the definition data for the given parameters.
-/// @relatedalso World
-WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                 Length2 anchor, UnitVec axis = UnitVec::GetRight());
-
-/// @brief Gets the angular velocity for the given configuration within the specified world.
-/// @relatedalso World
-AngularVelocity GetAngularVelocity(const World& world, const WheelJointConf& conf);
-
-/// @brief Gets the current linear reaction for the given configuration.
-/// @relatedalso WheelJointConf
-constexpr Momentum2 GetLinearReaction(const WheelJointConf& object)
-{
-    return object.impulse * object.ay + object.springImpulse * object.ax;
-}
-
-/// @brief Shifts the origin notion of the given configuration.
-/// @relatedalso WheelJointConf
-constexpr auto ShiftOrigin(WheelJointConf&, Length2)
-{
-    return false;
-}
-
-/// @brief Initializes velocity constraint data based on the given solver data.
-/// @note This MUST be called prior to calling <code>SolveVelocity</code>.
-/// @see SolveVelocity.
-/// @relatedalso WheelJointConf
-void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
-                  const StepConf& step,
-                  const ConstraintSolverConf& conf);
-
-/// @brief Solves velocity constraint.
-/// @pre <code>InitVelocity</code> has been called.
-/// @see InitVelocity.
-/// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
-/// @relatedalso WheelJointConf
-bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const StepConf& step);
-
-/// @brief Solves the position constraint.
-/// @return <code>true</code> if the position errors are within tolerance.
-/// @relatedalso WheelJointConf
-bool SolvePosition(const WheelJointConf& object, std::vector<BodyConstraint>& bodies,
-                   const ConstraintSolverConf& conf);
-
-/// @brief Sets the maximum motor torque for the given configuration.
-/// @relatedalso WheelJointConf
-constexpr void SetMaxMotorTorque(WheelJointConf& object, Torque value) noexcept
-{
-    object.UseMaxMotorTorque(value);
-}
-
-/// @brief Free function for setting the frequency of the given configuration.
-/// @relatedalso WheelJointConf
-constexpr void SetFrequency(WheelJointConf& object, NonNegative<Frequency> value) noexcept
-{
-    object.UseFrequency(value);
-}
-
-/// @brief Free function for setting the damping ratio of the given configuration.
-/// @relatedalso WheelJointConf
-constexpr void SetDampingRatio(WheelJointConf& object, Real value) noexcept
-{
-    object.UseDampingRatio(value);
-}
-
-} // namespace d2
-
-/// @brief Type info specialization for <code>d2::WheelJointConf</code>.
-template <>
-struct TypeInfo<d2::WheelJointConf>
-{
-    /// @brief Provides a null-terminated string name for the type.
-    static constexpr const char* name = "d2::WheelJointConf";
-};
-
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_JOINTS_WHEELJOINTCONF_HPP
+#endif// PLAYRHO_DYNAMICS_JOINTS_WHEELJOINTCONF_HPP

--- a/PlayRho/Dynamics/MovementConf.cpp
+++ b/PlayRho/Dynamics/MovementConf.cpp
@@ -21,11 +21,12 @@
 #include <PlayRho/Dynamics/MovementConf.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 
-namespace playrho {
-
-MovementConf GetMovementConf(const StepConf& conf) noexcept
+namespace playrho
 {
-    return MovementConf{conf.maxTranslation, conf.maxRotation};
-}
 
-} // namespace playrho
+    MovementConf GetMovementConf(const StepConf& conf) noexcept
+    {
+        return MovementConf{conf.maxTranslation, conf.maxRotation};
+    }
+
+}// namespace playrho

--- a/PlayRho/Dynamics/MovementConf.hpp
+++ b/PlayRho/Dynamics/MovementConf.hpp
@@ -23,23 +23,24 @@
 
 #include <PlayRho/Common/Units.hpp>
 
-namespace playrho {
-
-struct StepConf;
-
-/// @brief Movement configuration.
-struct MovementConf
+namespace playrho
 {
-    Length maxTranslation; ///< Maximum translation.
-    Angle maxRotation; ///< Maximum rotation.
-};
 
-/// @brief Gets the movement configuration from the given value.
-/// @return The <code>maxTranslation</code> and <code>maxRotation</code> fields
-///   of the given value respectively are returned.
-/// @relatedalso StepConf
-MovementConf GetMovementConf(const StepConf& conf) noexcept;
+    struct StepConf;
 
-} // namespace playrho
+    /// @brief Movement configuration.
+    struct MovementConf
+    {
+        Length maxTranslation;///< Maximum translation.
+        Angle maxRotation;    ///< Maximum rotation.
+    };
 
-#endif // PLAYRHO_DYNAMICS_MOVEMENTCONF_HPP
+    /// @brief Gets the movement configuration from the given value.
+    /// @return The <code>maxTranslation</code> and <code>maxRotation</code> fields
+    ///   of the given value respectively are returned.
+    /// @relatedalso StepConf
+    MovementConf GetMovementConf(const StepConf& conf) noexcept;
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_MOVEMENTCONF_HPP

--- a/PlayRho/Dynamics/StepConf.cpp
+++ b/PlayRho/Dynamics/StepConf.cpp
@@ -19,15 +19,16 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
 
-namespace playrho {
-
-bool IsMaxTranslationWithinTolerance(const StepConf& conf) noexcept
+namespace playrho
 {
-    const auto delta = Real{1} - nextafter(Real{1}, Real{0});
-    return (conf.maxTranslation * delta) < Length{conf.tolerance};
-}
 
-} // namespace playrho
+    bool IsMaxTranslationWithinTolerance(const StepConf& conf) noexcept
+    {
+        const auto delta = Real{1} - nextafter(Real{1}, Real{0});
+        return (conf.maxTranslation * delta) < Length{conf.tolerance};
+    }
+
+}// namespace playrho

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -25,274 +25,275 @@
 /// @file
 /// Declarations of the StepConf class, and free functions associated with it.
 
-#include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Positive.hpp>
+#include <PlayRho/Common/Settings.hpp>
 
-namespace playrho {
-
-/// @brief Step configuration.
-/// @details
-/// Provides the primary means for configuring the per-step world physics simulation. All
-/// the values have defaults. These defaults are intended to most likely be the values desired.
-/// @note Be sure to confirm that the delta time (the time-per-step i.e. <code>deltaTime</code>)
-///   is correct for your use.
-/// @note This data structure is 104-bytes large (with 4-byte Real on at least one 64-bit platform).
-/// @see World::Step.
-struct StepConf
+namespace playrho
 {
-    /// @brief Step iterations type.
-    /// @details A type for counting iterations per-step.
-    /// @note The special value of -1 is reserved for signifying an invalid iteration value.
-    using iteration_type = TimestepIters;
 
-    /// @brief Invalid iteration value.
-    static constexpr auto InvalidIteration = static_cast<iteration_type>(-1);
-
-    /// @brief Delta time.
-    /// @details This is the time step in seconds.
-    Time deltaTime = DefaultStepTime;
-
-    /// @brief Delta time ratio.
-    /// @details This is the delta-time multiplied by the inverse delta time from the previous
-    ///    world step. The value of 1 indicates that the time step has not varied.
-    /// @note Used in the regular phase processing of the step.
-    Real dtRatio = 1;
-
-    /// @brief Minimum still time to sleep.
-    /// @details The time that a body must be still before it will be put to sleep.
-    /// @note Set to infinity to disable sleeping.
-    /// @note Used in the regular phase processing of the step.
-    Time minStillTimeToSleep = DefaultMinStillTimeToSleep;
-
-    /// @brief Linear slop.
-    /// @details Linear slop for position resolution.
-    /// @note Must be greater than 0.
-    /// @note Used in both the regular and TOI phases of step processing.
-    Positive<Length> linearSlop = DefaultLinearSlop;
-
-    /// @brief Angular slop.
-    /// @note Must be greater than 0.
-    /// @note Used in both the regular and TOI phases of step processing.
-    Positive<Angle> angularSlop = DefaultAngularSlop;
-
-    /// @brief Regular resolution rate.
+    /// @brief Step configuration.
     /// @details
-    /// This scale factor controls how fast positional overlap is resolved.
-    /// Ideally this would be 1 so that overlap is removed in one time step.
-    /// However using values close to 1 often lead to overshoot.
-    /// @note Must be greater than 0 for any regular-phase positional resolution to get done.
-    /// @note Used in the regular phase of step processing.
-    Real regResolutionRate = Real{2} / 10; // aka 0.2.
+    /// Provides the primary means for configuring the per-step world physics simulation. All
+    /// the values have defaults. These defaults are intended to most likely be the values desired.
+    /// @note Be sure to confirm that the delta time (the time-per-step i.e. <code>deltaTime</code>)
+    ///   is correct for your use.
+    /// @note This data structure is 104-bytes large (with 4-byte Real on at least one 64-bit platform).
+    /// @see World::Step.
+    struct StepConf
+    {
+        /// @brief Step iterations type.
+        /// @details A type for counting iterations per-step.
+        /// @note The special value of -1 is reserved for signifying an invalid iteration value.
+        using iteration_type = TimestepIters;
 
-    /// @brief Regular minimum separation.
-    /// @details
-    /// This is the minimum amount of separation there must be between regular-phase interacting
-    /// bodies for intra-step position resolution to be considered successful and end before all
-    /// of the regular position iterations have been done.
-    /// @note Used in the regular phase of step processing.
-    /// @see regPositionIterations.
-    Length regMinSeparation = -DefaultLinearSlop * Real{3};
+        /// @brief Invalid iteration value.
+        static constexpr auto InvalidIteration = static_cast<iteration_type>(-1);
 
-    /// @brief Regular-phase minimum momentum.
-    Momentum regMinMomentum = DefaultRegMinMomentum;
+        /// @brief Delta time.
+        /// @details This is the time step in seconds.
+        Time deltaTime = DefaultStepTime;
 
-    /// @brief Time of impact resolution rate.
-    /// @details
-    /// This scale factor controls how fast positional overlap is resolved.
-    /// Ideally this would be 1 so that overlap is removed in one time step.
-    /// However using values close to 1 often lead to overshoot.
-    /// @note Used in the TOI phase of step processing.
-    /// @note Must be greater than 0 for any TOI-phase positional resolution to get done.
-    Real toiResolutionRate = Real{75} / 100; // aka .75
+        /// @brief Delta time ratio.
+        /// @details This is the delta-time multiplied by the inverse delta time from the previous
+        ///    world step. The value of 1 indicates that the time step has not varied.
+        /// @note Used in the regular phase processing of the step.
+        Real dtRatio = 1;
 
-    /// @brief Time of impact minimum separation.
-    /// @details
-    /// This is the minimum amount of separation there must be between TOI-phase interacting
-    /// bodies for intra-step position resolution to be considered successful and end before all
-    /// of the TOI position iterations have been done.
-    /// @note Used in the TOI phase of step processing.
-    /// @see toiPositionIterations.
-    Length toiMinSeparation = -DefaultLinearSlop * Real(1.5f);
+        /// @brief Minimum still time to sleep.
+        /// @details The time that a body must be still before it will be put to sleep.
+        /// @note Set to infinity to disable sleeping.
+        /// @note Used in the regular phase processing of the step.
+        Time minStillTimeToSleep = DefaultMinStillTimeToSleep;
 
-    /// @brief TOI-phase minimum momentum.
-    Momentum toiMinMomentum = DefaultToiMinMomentum;
+        /// @brief Linear slop.
+        /// @details Linear slop for position resolution.
+        /// @note Must be greater than 0.
+        /// @note Used in both the regular and TOI phases of step processing.
+        Positive<Length> linearSlop = DefaultLinearSlop;
 
-    /// @brief Target depth.
-    /// @details Target depth of overlap for calculating the TOI for CCD eligible bodies.
-    /// @note Recommend value that's less than twice the world's minimum vertex radius.
-    /// @note Used in the TOI phase of step processing.
-    Length targetDepth = DefaultLinearSlop * Real{3};
+        /// @brief Angular slop.
+        /// @note Must be greater than 0.
+        /// @note Used in both the regular and TOI phases of step processing.
+        Positive<Angle> angularSlop = DefaultAngularSlop;
 
-    /// @brief Tolerance.
-    /// @details The acceptable plus or minus tolerance from the target depth for TOI calculations.
-    /// @note Must be greater than 0.
-    /// @note Must not be subnormal.
-    /// @note Must be less than the target depth.
-    /// @note Used in the TOI phase of step processing.
-    NonNegative<Length> tolerance = DefaultLinearSlop / Real{4};
+        /// @brief Regular resolution rate.
+        /// @details
+        /// This scale factor controls how fast positional overlap is resolved.
+        /// Ideally this would be 1 so that overlap is removed in one time step.
+        /// However using values close to 1 often lead to overshoot.
+        /// @note Must be greater than 0 for any regular-phase positional resolution to get done.
+        /// @note Used in the regular phase of step processing.
+        Real regResolutionRate = Real{2} / 10;// aka 0.2.
 
-    /// @brief Velocity threshold.
-    /// @details A velocity threshold for elastic collisions. Any collision with a relative linear
-    /// velocity below this threshold will be treated as inelastic.
-    /// @note Used in both the regular and TOI phases of step processing.
-    LinearVelocity velocityThreshold = DefaultVelocityThreshold;
+        /// @brief Regular minimum separation.
+        /// @details
+        /// This is the minimum amount of separation there must be between regular-phase interacting
+        /// bodies for intra-step position resolution to be considered successful and end before all
+        /// of the regular position iterations have been done.
+        /// @note Used in the regular phase of step processing.
+        /// @see regPositionIterations.
+        Length regMinSeparation = -DefaultLinearSlop * Real{3};
 
-    /// @brief Maximum translation.
-    ///
-    /// @details The maximum amount a body can translate in a single step. This represents
-    ///   an upper bound on the maximum linear velocity of a body of max-translation per time.
-    ///
-    /// @note If you want or need to support a higher maximum linear speed, then instead
-    ///   of changing this value, decrease the step's time value. So for example, rather
-    ///   than simulating 1/60th of a second steps, simulating 1/120th of a second steps
-    ///   will double the maximum linear speed any body can have.
-    /// @note This limit is meant to prevent numerical problems. Adjusting this value
-    ///   isn't advised.
-    /// @note Used in both the regular and TOI phases of step processing.
-    ///
-    Length maxTranslation = DefaultMaxTranslation;
+        /// @brief Regular-phase minimum momentum.
+        Momentum regMinMomentum = DefaultRegMinMomentum;
 
-    /// @brief Maximum rotation.
-    ///
-    /// @details The maximum amount a body can rotate in a single step. This represents
-    ///   an upper bound on the maximum angular speed of a body of max rotation / time.
-    ///
-    /// @warning This value should be less than Pi * Radian.
-    ///
-    /// @note If you want or need to support a higher maximum angular speed, then instead
-    ///   of changing this value, decrease the step's time value. So for example, rather
-    ///   than simulating 1/60th of a second steps, simulating 1/120th of a second steps
-    ///   will double the maximum angular rotation any body can have.
-    /// @note This limit is meant to prevent numerical problems. Adjusting this value
-    ///   isn't advised.
-    /// @note If this value is less than half a turn (less than Pi), then the turning
-    ///   direction will be the direction of the smaller change in angular orientation.
-    ///   This is an appealing property as it means that a body's angular position
-    ///   can be represented by a unit vector rather than an angular quantity. The
-    ///   benefit of using a unit vector is potentially two-fold: (a) unit vectors
-    ///   have well-defined and understood wrap-around semantics, (b) unit vectors
-    ///   can cache sine/cosine calculations thereby reducing their costs in time.
-    /// @note Used in both the regular and TOI phases of step processing.
-    ///
-    Angle maxRotation = DefaultMaxRotation;
+        /// @brief Time of impact resolution rate.
+        /// @details
+        /// This scale factor controls how fast positional overlap is resolved.
+        /// Ideally this would be 1 so that overlap is removed in one time step.
+        /// However using values close to 1 often lead to overshoot.
+        /// @note Used in the TOI phase of step processing.
+        /// @note Must be greater than 0 for any TOI-phase positional resolution to get done.
+        Real toiResolutionRate = Real{75} / 100;// aka .75
 
-    /// @brief Maximum linear correction.
-    /// @note Must be greater than 0 for any positional resolution to get done.
-    /// @note This value should be greater than the linear slop value.
-    /// @note Used in both the regular and TOI phases of step processing.
-    Length maxLinearCorrection = DefaultMaxLinearCorrection;
+        /// @brief Time of impact minimum separation.
+        /// @details
+        /// This is the minimum amount of separation there must be between TOI-phase interacting
+        /// bodies for intra-step position resolution to be considered successful and end before all
+        /// of the TOI position iterations have been done.
+        /// @note Used in the TOI phase of step processing.
+        /// @see toiPositionIterations.
+        Length toiMinSeparation = -DefaultLinearSlop * Real(1.5f);
 
-    /// @brief Maximum angular correction.
-    /// @note Used in both the regular and TOI phases of step processing.
-    Angle maxAngularCorrection = DefaultMaxAngularCorrection;
+        /// @brief TOI-phase minimum momentum.
+        Momentum toiMinMomentum = DefaultToiMinMomentum;
 
-    /// @brief Linear sleep tolerance.
-    /// @note Used in the regular phase of step processing.
-    LinearVelocity linearSleepTolerance = DefaultLinearSleepTolerance;
+        /// @brief Target depth.
+        /// @details Target depth of overlap for calculating the TOI for CCD eligible bodies.
+        /// @note Recommend value that's less than twice the world's minimum vertex radius.
+        /// @note Used in the TOI phase of step processing.
+        Length targetDepth = DefaultLinearSlop * Real{3};
 
-    /// @brief Angular sleep tolerance.
-    /// @note Used in the regular phase of step processing.
-    AngularVelocity angularSleepTolerance = DefaultAngularSleepTolerance;
+        /// @brief Tolerance.
+        /// @details The acceptable plus or minus tolerance from the target depth for TOI calculations.
+        /// @note Must be greater than 0.
+        /// @note Must not be subnormal.
+        /// @note Must be less than the target depth.
+        /// @note Used in the TOI phase of step processing.
+        NonNegative<Length> tolerance = DefaultLinearSlop / Real{4};
 
-    /// @brief Displacement multiplier for directional AABB fattening.
-    Real displaceMultiplier = DefaultDistanceMultiplier;
+        /// @brief Velocity threshold.
+        /// @details A velocity threshold for elastic collisions. Any collision with a relative linear
+        /// velocity below this threshold will be treated as inelastic.
+        /// @note Used in both the regular and TOI phases of step processing.
+        LinearVelocity velocityThreshold = DefaultVelocityThreshold;
 
-    /// @brief AABB extension.
-    /// @details This is the extension that will be applied to Axis Aligned Bounding Box
-    ///    objects used in broad phase collision detection. This fattens AABBs in the
-    ///    dynamic tree. This allows proxies to move by a small amount without triggering
-    ///    a tree adjustment.
-    /// @note Should be greater than 0.
-    Length aabbExtension = DefaultAabbExtension;
+        /// @brief Maximum translation.
+        ///
+        /// @details The maximum amount a body can translate in a single step. This represents
+        ///   an upper bound on the maximum linear velocity of a body of max-translation per time.
+        ///
+        /// @note If you want or need to support a higher maximum linear speed, then instead
+        ///   of changing this value, decrease the step's time value. So for example, rather
+        ///   than simulating 1/60th of a second steps, simulating 1/120th of a second steps
+        ///   will double the maximum linear speed any body can have.
+        /// @note This limit is meant to prevent numerical problems. Adjusting this value
+        ///   isn't advised.
+        /// @note Used in both the regular and TOI phases of step processing.
+        ///
+        Length maxTranslation = DefaultMaxTranslation;
 
-    /// @brief Max. circles ratio.
-    /// @details When the ratio of the closest face's length to the vertex radius is
-    ///   more than this amount, then face-manifolds are forced, else circles-manifolds
-    ///   may be computed for new contact manifolds.
-    /// @note This is used in the calculation of new contact manifolds.
-    Real maxCirclesRatio = DefaultCirclesRatio;
+        /// @brief Maximum rotation.
+        ///
+        /// @details The maximum amount a body can rotate in a single step. This represents
+        ///   an upper bound on the maximum angular speed of a body of max rotation / time.
+        ///
+        /// @warning This value should be less than Pi * Radian.
+        ///
+        /// @note If you want or need to support a higher maximum angular speed, then instead
+        ///   of changing this value, decrease the step's time value. So for example, rather
+        ///   than simulating 1/60th of a second steps, simulating 1/120th of a second steps
+        ///   will double the maximum angular rotation any body can have.
+        /// @note This limit is meant to prevent numerical problems. Adjusting this value
+        ///   isn't advised.
+        /// @note If this value is less than half a turn (less than Pi), then the turning
+        ///   direction will be the direction of the smaller change in angular orientation.
+        ///   This is an appealing property as it means that a body's angular position
+        ///   can be represented by a unit vector rather than an angular quantity. The
+        ///   benefit of using a unit vector is potentially two-fold: (a) unit vectors
+        ///   have well-defined and understood wrap-around semantics, (b) unit vectors
+        ///   can cache sine/cosine calculations thereby reducing their costs in time.
+        /// @note Used in both the regular and TOI phases of step processing.
+        ///
+        Angle maxRotation = DefaultMaxRotation;
 
-    /// @brief Regular velocity iterations.
-    /// @details The number of iterations of velocity resolution that will be done in the step.
-    /// @note Used in the regular phase of step processing.
-    iteration_type regVelocityIterations = 8;
+        /// @brief Maximum linear correction.
+        /// @note Must be greater than 0 for any positional resolution to get done.
+        /// @note This value should be greater than the linear slop value.
+        /// @note Used in both the regular and TOI phases of step processing.
+        Length maxLinearCorrection = DefaultMaxLinearCorrection;
 
-    /// @brief Regular position iterations.
-    /// @details
-    /// This is the maximum number of iterations of position resolution that will
-    /// be done before leaving any remaining unsatisfied positions for the next step.
-    /// In this context, positions are satisfied when the minimum separation is greater than
-    /// or equal to the regular minimum separation amount.
-    /// @note Used in the regular phase of step processing.
-    /// @see regMinSeparation.
-    iteration_type regPositionIterations = 3;
+        /// @brief Maximum angular correction.
+        /// @note Used in both the regular and TOI phases of step processing.
+        Angle maxAngularCorrection = DefaultMaxAngularCorrection;
 
-    /// @brief TOI velocity iterations.
-    /// @details
-    /// This is the number of iterations of velocity resolution that will be done in the step.
-    /// @note Used in the TOI phase of step processing.
-    iteration_type toiVelocityIterations = 8;
+        /// @brief Linear sleep tolerance.
+        /// @note Used in the regular phase of step processing.
+        LinearVelocity linearSleepTolerance = DefaultLinearSleepTolerance;
 
-    /// @brief TOI position iterations.
-    /// @details
-    /// This value is the maximum number of iterations of position resolution that will
-    /// be done before leaving any remaining unsatisfied positions for the next step.
-    /// In this context, positions are satisfied when the minimum separation is greater than
-    /// or equal to the TOI minimum separation amount.
-    /// @note Used in the TOI phase of step processing.
-    /// @see toiMinSeparation.
-    iteration_type toiPositionIterations = 20;
+        /// @brief Angular sleep tolerance.
+        /// @note Used in the regular phase of step processing.
+        AngularVelocity angularSleepTolerance = DefaultAngularSleepTolerance;
 
-    /// @brief Max TOI root finder iterations.
-    /// @note Used in the TOI phase of step processing.
-    iteration_type maxToiRootIters = DefaultMaxToiRootIters;
+        /// @brief Displacement multiplier for directional AABB fattening.
+        Real displaceMultiplier = DefaultDistanceMultiplier;
 
-    /// @brief Max TOI iterations.
-    /// @note Used in the TOI phase of step processing.
-    iteration_type maxToiIters = DefaultMaxToiIters;
+        /// @brief AABB extension.
+        /// @details This is the extension that will be applied to Axis Aligned Bounding Box
+        ///    objects used in broad phase collision detection. This fattens AABBs in the
+        ///    dynamic tree. This allows proxies to move by a small amount without triggering
+        ///    a tree adjustment.
+        /// @note Should be greater than 0.
+        Length aabbExtension = DefaultAabbExtension;
 
-    /// @brief Max distance iterations.
-    /// @note Used in the TOI phase of step processing.
-    iteration_type maxDistanceIters = DefaultMaxDistanceIters;
+        /// @brief Max. circles ratio.
+        /// @details When the ratio of the closest face's length to the vertex radius is
+        ///   more than this amount, then face-manifolds are forced, else circles-manifolds
+        ///   may be computed for new contact manifolds.
+        /// @note This is used in the calculation of new contact manifolds.
+        Real maxCirclesRatio = DefaultCirclesRatio;
 
-    /// @brief Maximum sub steps.
-    /// @details
-    /// This is the maximum number of sub-steps per contact in continuous physics simulation.
-    /// In other words, this is the maximum number of times in a world step that a contact will
-    /// have continuous collision resolution done for it.
-    /// @note Used in the TOI phase of step processing.
-    iteration_type maxSubSteps = DefaultMaxSubSteps;
+        /// @brief Regular velocity iterations.
+        /// @details The number of iterations of velocity resolution that will be done in the step.
+        /// @note Used in the regular phase of step processing.
+        iteration_type regVelocityIterations = 8;
 
-    /// @brief Do warm start.
-    /// @details Whether or not to perform warm starting (in the regular phase).
-    /// @note Used in the regular phase of step processing.
-    bool doWarmStart = true;
+        /// @brief Regular position iterations.
+        /// @details
+        /// This is the maximum number of iterations of position resolution that will
+        /// be done before leaving any remaining unsatisfied positions for the next step.
+        /// In this context, positions are satisfied when the minimum separation is greater than
+        /// or equal to the regular minimum separation amount.
+        /// @note Used in the regular phase of step processing.
+        /// @see regMinSeparation.
+        iteration_type regPositionIterations = 3;
 
-    /// @brief Do time of impact (TOI) calculations.
-    /// @details Whether or not to perform any time of impact (TOI) calculations used for doing
-    ///   continuous collision detection. Without this, steps can potentially be computed
-    ///   faster but with increased chance of bodies passing unobstructed through other bodies
-    ///   (a process called "tunneling") even when they're not supposed to be able to go through
-    ///   them.
-    /// @note Used in the TOI phase of step processing.
-    bool doToi = true;
+        /// @brief TOI velocity iterations.
+        /// @details
+        /// This is the number of iterations of velocity resolution that will be done in the step.
+        /// @note Used in the TOI phase of step processing.
+        iteration_type toiVelocityIterations = 8;
 
-    /// @brief Do the block-solve algorithm.
-    bool doBlocksolve = true;
-};
+        /// @brief TOI position iterations.
+        /// @details
+        /// This value is the maximum number of iterations of position resolution that will
+        /// be done before leaving any remaining unsatisfied positions for the next step.
+        /// In this context, positions are satisfied when the minimum separation is greater than
+        /// or equal to the TOI minimum separation amount.
+        /// @note Used in the TOI phase of step processing.
+        /// @see toiMinSeparation.
+        iteration_type toiPositionIterations = 20;
 
-/// @brief Gets the maximum regular linear correction from the given value.
-/// @relatedalso StepConf
-inline Length GetMaxRegLinearCorrection(const StepConf& conf) noexcept
-{
-    return conf.maxLinearCorrection * static_cast<Real>(conf.regPositionIterations);
-}
+        /// @brief Max TOI root finder iterations.
+        /// @note Used in the TOI phase of step processing.
+        iteration_type maxToiRootIters = DefaultMaxToiRootIters;
 
-/// @brief Determines whether the maximum translation is within tolerance.
-/// @relatedalso StepConf
-bool IsMaxTranslationWithinTolerance(const StepConf& conf) noexcept;
+        /// @brief Max TOI iterations.
+        /// @note Used in the TOI phase of step processing.
+        iteration_type maxToiIters = DefaultMaxToiIters;
 
-} // namespace playrho
+        /// @brief Max distance iterations.
+        /// @note Used in the TOI phase of step processing.
+        iteration_type maxDistanceIters = DefaultMaxDistanceIters;
 
-#endif // PLAYRHO_DYNAMICS_STEPCONF_HPP
+        /// @brief Maximum sub steps.
+        /// @details
+        /// This is the maximum number of sub-steps per contact in continuous physics simulation.
+        /// In other words, this is the maximum number of times in a world step that a contact will
+        /// have continuous collision resolution done for it.
+        /// @note Used in the TOI phase of step processing.
+        iteration_type maxSubSteps = DefaultMaxSubSteps;
+
+        /// @brief Do warm start.
+        /// @details Whether or not to perform warm starting (in the regular phase).
+        /// @note Used in the regular phase of step processing.
+        bool doWarmStart = true;
+
+        /// @brief Do time of impact (TOI) calculations.
+        /// @details Whether or not to perform any time of impact (TOI) calculations used for doing
+        ///   continuous collision detection. Without this, steps can potentially be computed
+        ///   faster but with increased chance of bodies passing unobstructed through other bodies
+        ///   (a process called "tunneling") even when they're not supposed to be able to go through
+        ///   them.
+        /// @note Used in the TOI phase of step processing.
+        bool doToi = true;
+
+        /// @brief Do the block-solve algorithm.
+        bool doBlocksolve = true;
+    };
+
+    /// @brief Gets the maximum regular linear correction from the given value.
+    /// @relatedalso StepConf
+    inline Length GetMaxRegLinearCorrection(const StepConf& conf) noexcept
+    {
+        return conf.maxLinearCorrection * static_cast<Real>(conf.regPositionIterations);
+    }
+
+    /// @brief Determines whether the maximum translation is within tolerance.
+    /// @relatedalso StepConf
+    bool IsMaxTranslationWithinTolerance(const StepConf& conf) noexcept;
+
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_STEPCONF_HPP

--- a/PlayRho/Dynamics/StepStats.cpp
+++ b/PlayRho/Dynamics/StepStats.cpp
@@ -22,19 +22,20 @@
 
 #include <PlayRho/Dynamics/IslandStats.hpp>
 
-#include <algorithm> // for std::min, std::max
+#include <algorithm>// for std::min, std::max
 
-namespace playrho {
-
-RegStepStats& Update(RegStepStats& lhs, const IslandStats& rhs) noexcept
+namespace playrho
 {
-    lhs.maxIncImpulse = std::max(lhs.maxIncImpulse, rhs.maxIncImpulse);
-    lhs.minSeparation = std::min(lhs.minSeparation, rhs.minSeparation);
-    lhs.islandsSolved += rhs.solved;
-    lhs.sumPosIters += rhs.positionIterations;
-    lhs.sumVelIters += rhs.velocityIterations;
-    lhs.bodiesSlept += rhs.bodiesSlept;
-    return lhs;
-}
 
-} // namespace playrho
+    RegStepStats& Update(RegStepStats& lhs, const IslandStats& rhs) noexcept
+    {
+        lhs.maxIncImpulse = std::max(lhs.maxIncImpulse, rhs.maxIncImpulse);
+        lhs.minSeparation = std::min(lhs.minSeparation, rhs.minSeparation);
+        lhs.islandsSolved += rhs.solved;
+        lhs.sumPosIters += rhs.positionIterations;
+        lhs.sumVelIters += rhs.velocityIterations;
+        lhs.bodiesSlept += rhs.bodiesSlept;
+        return lhs;
+    }
+
+}// namespace playrho

--- a/PlayRho/Dynamics/StepStats.hpp
+++ b/PlayRho/Dynamics/StepStats.hpp
@@ -23,112 +23,113 @@
 
 #include <PlayRho/Common/Settings.hpp>
 
-namespace playrho {
-
-/// @brief Pre-phase per-step statistics.
-/// @note This data structure is 24-bytes large (on at least one 64-bit platform).
-struct PreStepStats
+namespace playrho
 {
-    /// @brief Counter type.
-    using counter_type = std::uint32_t;
 
-    counter_type proxiesMoved = 0; ///< Proxies moved count.
-    counter_type destroyed = 0; ///< Count of contacts destroyed.
-    counter_type added = 0; ///< Count of contacts added.
-    counter_type ignored = 0; ///< Count of contacts ignored during update processing.
-    counter_type updated = 0; ///< Count of contacts updated (during update processing).
-    counter_type skipped = 0; ///< Count of contacts Skipped (during update processing).
-};
+    /// @brief Pre-phase per-step statistics.
+    /// @note This data structure is 24-bytes large (on at least one 64-bit platform).
+    struct PreStepStats
+    {
+        /// @brief Counter type.
+        using counter_type = std::uint32_t;
 
-/// @brief Regular-phase per-step statistics.
-/// @note This data structure is 32-bytes large (on at least one 64-bit platform with
-///   4-byte Real type).
-struct RegStepStats
-{
-    /// @brief Counter type.
-    using counter_type = std::uint32_t;
+        counter_type proxiesMoved = 0;///< Proxies moved count.
+        counter_type destroyed = 0;   ///< Count of contacts destroyed.
+        counter_type added = 0;       ///< Count of contacts added.
+        counter_type ignored = 0;     ///< Count of contacts ignored during update processing.
+        counter_type updated = 0;     ///< Count of contacts updated (during update processing).
+        counter_type skipped = 0;     ///< Count of contacts Skipped (during update processing).
+    };
 
-    /// @brief Min separation.
-    Length minSeparation = std::numeric_limits<Length>::infinity();
+    /// @brief Regular-phase per-step statistics.
+    /// @note This data structure is 32-bytes large (on at least one 64-bit platform with
+    ///   4-byte Real type).
+    struct RegStepStats
+    {
+        /// @brief Counter type.
+        using counter_type = std::uint32_t;
 
-    /// @brief Max incremental impulse.
-    Momentum maxIncImpulse = 0;
+        /// @brief Min separation.
+        Length minSeparation = std::numeric_limits<Length>::infinity();
 
-    BodyCounter islandsFound = 0; ///< Islands found count.
-    BodyCounter islandsSolved = 0; ///< Islands solved count.
-    counter_type contactsAdded = 0; ///< Contacts added count.
-    counter_type bodiesSlept = 0; ///< Bodies slept count.
-    counter_type proxiesMoved = 0; ///< Proxies moved count.
-    counter_type sumPosIters = 0; ///< Sum of the position iterations.
-    counter_type sumVelIters = 0; ///< Sum of the velocity iterations.
-};
+        /// @brief Max incremental impulse.
+        Momentum maxIncImpulse = 0;
 
-/// @brief TOI-phase per-step statistics.
-/// @note This data structure is 60-bytes large (on at least one 64-bit platform with
-///   4-byte Real type).
-struct ToiStepStats
-{
-    /// @brief Counter type.
-    using counter_type = std::uint32_t;
+        BodyCounter islandsFound = 0;  ///< Islands found count.
+        BodyCounter islandsSolved = 0; ///< Islands solved count.
+        counter_type contactsAdded = 0;///< Contacts added count.
+        counter_type bodiesSlept = 0;  ///< Bodies slept count.
+        counter_type proxiesMoved = 0; ///< Proxies moved count.
+        counter_type sumPosIters = 0;  ///< Sum of the position iterations.
+        counter_type sumVelIters = 0;  ///< Sum of the velocity iterations.
+    };
 
-    /// @brief Min separation.
-    Length minSeparation = std::numeric_limits<Length>::infinity();
+    /// @brief TOI-phase per-step statistics.
+    /// @note This data structure is 60-bytes large (on at least one 64-bit platform with
+    ///   4-byte Real type).
+    struct ToiStepStats
+    {
+        /// @brief Counter type.
+        using counter_type = std::uint32_t;
 
-    /// @brief Max incremental impulse.
-    Momentum maxIncImpulse = 0;
+        /// @brief Min separation.
+        Length minSeparation = std::numeric_limits<Length>::infinity();
 
-    counter_type islandsFound = 0; ///< Islands found count.
-    counter_type islandsSolved = 0; ///< Islands solved count.
-    counter_type contactsFound = 0; ///< Contacts found count.
-    counter_type contactsAtMaxSubSteps = 0; ///< Contacts at max substeps count.
-    counter_type contactsUpdatedToi = 0; ///< Contacts updated TOI count.
-    counter_type contactsUpdatedTouching = 0; ///< Contacts updated touching count.
-    counter_type contactsSkippedTouching = 0; ///< Contacts skipped touching count.
-    counter_type contactsAdded = 0; ///< Contacts added count.
-    counter_type proxiesMoved = 0; ///< Proxies moved count.
-    counter_type sumPosIters = 0; ///< Sum position iterations count.
-    counter_type sumVelIters = 0; ///< Sum velocity iterations count.
-    counter_type maxSimulContacts = 0; ///< Max contacts occurring simultaneously.
+        /// @brief Max incremental impulse.
+        Momentum maxIncImpulse = 0;
 
-    /// @brief Distance iteration type.
-    using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+        counter_type islandsFound = 0;           ///< Islands found count.
+        counter_type islandsSolved = 0;          ///< Islands solved count.
+        counter_type contactsFound = 0;          ///< Contacts found count.
+        counter_type contactsAtMaxSubSteps = 0;  ///< Contacts at max substeps count.
+        counter_type contactsUpdatedToi = 0;     ///< Contacts updated TOI count.
+        counter_type contactsUpdatedTouching = 0;///< Contacts updated touching count.
+        counter_type contactsSkippedTouching = 0;///< Contacts skipped touching count.
+        counter_type contactsAdded = 0;          ///< Contacts added count.
+        counter_type proxiesMoved = 0;           ///< Proxies moved count.
+        counter_type sumPosIters = 0;            ///< Sum position iterations count.
+        counter_type sumVelIters = 0;            ///< Sum velocity iterations count.
+        counter_type maxSimulContacts = 0;       ///< Max contacts occurring simultaneously.
 
-    /// @brief TOI iteration type.
-    using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
+        /// @brief Distance iteration type.
+        using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
 
-    /// @brief Root iteration type.
-    using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
+        /// @brief TOI iteration type.
+        using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
 
-    dist_iter_type maxDistIters = 0; ///< Max distance iterations.
-    toi_iter_type maxToiIters = 0; ///< Max TOI iterations.
-    root_iter_type maxRootIters = 0; ///< Max root iterations.
-};
+        /// @brief Root iteration type.
+        using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
 
-/// @brief Per-step statistics.
-///
-/// @details These are statistics output from the <code>d2::World::Step</code> method.
-/// @note This data structure is 116-bytes large (on at least one 64-bit platform with
-///   4-byte Real type).
-/// @note Efficient transfer of this data is predicated on compiler support for
-///   "named-return-value-optimization" (N.R.V.O.) - a form of "copy elision".
-///
-/// @see d2::World::Step.
-/// @see https://en.wikipedia.org/wiki/Return_value_optimization
-/// @see https://en.cppreference.com/w/cpp/language/copy_elision
-///
-struct StepStats
-{
-    PreStepStats pre; ///< Pre-phase step statistics.
-    RegStepStats reg; ///< Reg-phase step statistics.
-    ToiStepStats toi; ///< TOI-phase step statistics.
-};
+        dist_iter_type maxDistIters = 0;///< Max distance iterations.
+        toi_iter_type maxToiIters = 0;  ///< Max TOI iterations.
+        root_iter_type maxRootIters = 0;///< Max root iterations.
+    };
 
-struct IslandStats;
+    /// @brief Per-step statistics.
+    ///
+    /// @details These are statistics output from the <code>d2::World::Step</code> method.
+    /// @note This data structure is 116-bytes large (on at least one 64-bit platform with
+    ///   4-byte Real type).
+    /// @note Efficient transfer of this data is predicated on compiler support for
+    ///   "named-return-value-optimization" (N.R.V.O.) - a form of "copy elision".
+    ///
+    /// @see d2::World::Step.
+    /// @see https://en.wikipedia.org/wiki/Return_value_optimization
+    /// @see https://en.cppreference.com/w/cpp/language/copy_elision
+    ///
+    struct StepStats
+    {
+        PreStepStats pre;///< Pre-phase step statistics.
+        RegStepStats reg;///< Reg-phase step statistics.
+        ToiStepStats toi;///< TOI-phase step statistics.
+    };
 
-/// @brief Updates regular-phase per-step statistics with island statistics.
-/// @relatedalso RegStepStats
-RegStepStats& Update(RegStepStats& lhs, const IslandStats& rhs) noexcept;
+    struct IslandStats;
 
-} // namespace playrho
+    /// @brief Updates regular-phase per-step statistics with island statistics.
+    /// @relatedalso RegStepStats
+    RegStepStats& Update(RegStepStats& lhs, const IslandStats& rhs) noexcept;
 
-#endif // PLAYRHO_DYNAMICS_STEPSTATS_HPP
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_STEPSTATS_HPP

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -30,604 +30,606 @@
 #include <PlayRho/Dynamics/BodyConf.hpp>
 #include <PlayRho/Dynamics/StepConf.hpp>
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<World>::value, "World must be default constructible!");
-static_assert(std::is_copy_constructible<World>::value, "World must be copy constructible!");
-static_assert(std::is_copy_assignable<World>::value, "World must be copy assignable!");
-static_assert(std::is_move_constructible<World>::value, "World must be move constructible!");
-static_assert(std::is_move_assignable<World>::value, "World must be move assignable!");
-static_assert(std::is_nothrow_destructible<World>::value, "World must be nothrow destructible!");
-
-// Special member functions are off in their own .cpp file to avoid their
-// necessary includes being in this file!!
-
-void World::Clear() noexcept
-{
-    ::playrho::d2::Clear(*m_impl);
-}
-
-void World::SetFixtureDestructionListener(const FixtureListener& listener) noexcept
-{
-    ::playrho::d2::SetFixtureDestructionListener(*m_impl, listener);
-}
-
-void World::SetJointDestructionListener(const JointListener& listener) noexcept
-{
-    ::playrho::d2::SetJointDestructionListener(*m_impl, listener);
-}
-
-void World::SetBeginContactListener(ContactListener listener) noexcept
-{
-    ::playrho::d2::SetBeginContactListener(*m_impl, listener);
-}
-
-void World::SetEndContactListener(ContactListener listener) noexcept
-{
-    ::playrho::d2::SetEndContactListener(*m_impl, listener);
-}
-
-void World::SetPreSolveContactListener(ManifoldContactListener listener) noexcept
-{
-    ::playrho::d2::SetPreSolveContactListener(*m_impl, listener);
-}
-
-void World::SetPostSolveContactListener(ImpulsesContactListener listener) noexcept
-{
-    ::playrho::d2::SetPostSolveContactListener(*m_impl, listener);
-}
-
-BodyID World::CreateBody(const BodyConf& def)
-{
-    return ::playrho::d2::CreateBody(*m_impl, def);
-}
-
-void World::Destroy(BodyID id)
-{
-    ::playrho::d2::Destroy(*m_impl, id);
-}
-
-JointID World::CreateJoint(const Joint& def)
-{
-    return ::playrho::d2::CreateJoint(*m_impl, def);
-}
-
-void World::Destroy(JointID id)
-{
-    ::playrho::d2::Destroy(*m_impl, id);
-}
-    
-StepStats World::Step(const StepConf& conf)
-{
-    return ::playrho::d2::Step(*m_impl, conf);
-}
-
-void World::ShiftOrigin(Length2 newOrigin)
-{
-    ::playrho::d2::ShiftOrigin(*m_impl, newOrigin);
-}
-
-BodyCounter World::GetBodyRange() const noexcept
-{
-    return ::playrho::d2::GetBodyRange(*m_impl);
-}
-
-SizedRange<World::Bodies::const_iterator> World::GetBodies() const noexcept
-{
-    return ::playrho::d2::GetBodies(*m_impl);
-}
-
-SizedRange<World::Bodies::const_iterator> World::GetBodiesForProxies() const noexcept
-{
-    return ::playrho::d2::GetBodiesForProxies(*m_impl);
-}
-
-SizedRange<World::Fixtures::const_iterator> World::GetFixturesForProxies() const noexcept
-{
-    return ::playrho::d2::GetFixturesForProxies(*m_impl);
-}
-
-SizedRange<World::Joints::const_iterator> World::GetJoints() const noexcept
-{
-    return ::playrho::d2::GetJoints(*m_impl);
-}
-
-SizedRange<World::BodyJoints::const_iterator> World::GetJoints(BodyID id) const
-{
-    return ::playrho::d2::GetJoints(*m_impl, id);
-}
-
-bool World::IsSpeedable(BodyID id) const
-{
-    return ::playrho::d2::IsSpeedable(*m_impl, id);
-}
-
-bool World::IsAccelerable(BodyID id) const
-{
-    return ::playrho::d2::IsAccelerable(*m_impl, id);
-}
-
-bool World::IsImpenetrable(BodyID id) const
-{
-    return ::playrho::d2::IsImpenetrable(*m_impl, id);
-}
-
-void World::SetImpenetrable(BodyID id)
-{
-    ::playrho::d2::SetImpenetrable(*m_impl, id);
-}
-
-void World::UnsetImpenetrable(BodyID id)
-{
-    ::playrho::d2::UnsetImpenetrable(*m_impl, id);
-}
-
-bool World::IsSleepingAllowed(BodyID id) const
-{
-    return ::playrho::d2::IsSleepingAllowed(*m_impl, id);
-}
-
-void World::SetSleepingAllowed(BodyID id, bool value)
-{
-    ::playrho::d2::SetSleepingAllowed(*m_impl, id, value);
-}
-
-SizedRange<World::Contacts::const_iterator> World::GetContacts(BodyID id) const
-{
-    return ::playrho::d2::GetContacts(*m_impl, id);
-}
-
-SizedRange<World::Contacts::const_iterator> World::GetContacts() const noexcept
-{
-    return ::playrho::d2::GetContacts(*m_impl);
-}
-
-bool World::IsLocked() const noexcept
-{
-    return m_impl && ::playrho::d2::IsLocked(*m_impl);
-}
-
-bool World::IsStepComplete() const noexcept
-{
-    return ::playrho::d2::IsStepComplete(*m_impl);
-}
-
-bool World::GetSubStepping() const noexcept
-{
-    return ::playrho::d2::GetSubStepping(*m_impl);
-}
-
-void World::SetSubStepping(bool flag) noexcept
-{
-    ::playrho::d2::SetSubStepping(*m_impl, flag);
-}
-
-Length World::GetMinVertexRadius() const noexcept
-{
-    return ::playrho::d2::GetMinVertexRadius(*m_impl);
-}
-
-Length World::GetMaxVertexRadius() const noexcept
-{
-    return ::playrho::d2::GetMaxVertexRadius(*m_impl);
-}
-
-Frequency World::GetInvDeltaTime() const noexcept
-{
-    return ::playrho::d2::GetInvDeltaTime(*m_impl);
-}
-
-const DynamicTree& World::GetTree() const noexcept
-{
-    return ::playrho::d2::GetTree(*m_impl);
-}
-
-Filter World::GetFilterData(FixtureID id) const
-{
-    return ::playrho::d2::GetFilterData(*m_impl, id);
-}
-
-void World::Refilter(FixtureID id)
-{
-    ::playrho::d2::Refilter(*m_impl, id);
-}
-
-void World::SetFilterData(FixtureID id, const Filter& filter)
-{
-    ::playrho::d2::SetFilterData(*m_impl, id, filter);
-}
-
-void World::SetType(BodyID id, BodyType type)
-{
-    ::playrho::d2::SetType(*m_impl, id, type);
-}
-
-FixtureID World::CreateFixture(BodyID body, const Shape& shape, const FixtureConf& def,
-                              bool resetMassData)
-{
-    return ::playrho::d2::CreateFixture(*m_impl, body, shape, def, resetMassData);
-}
-
-bool World::Destroy(FixtureID id, bool resetMassData)
-{
-    return ::playrho::d2::Destroy(*m_impl, id, resetMassData);
-}
-
-void World::DestroyFixtures(BodyID id)
-{
-    ::playrho::d2::DestroyFixtures(*m_impl, id);
-}
-
-bool World::IsEnabled(BodyID id) const
-{
-    return ::playrho::d2::IsEnabled(*m_impl, id);
-}
-
-void World::SetEnabled(BodyID id, bool flag)
-{
-    ::playrho::d2::SetEnabled(*m_impl, id, flag);
-}
-
-MassData World::ComputeMassData(BodyID id) const
-{
-    return ::playrho::d2::ComputeMassData(*m_impl, id);
-}
-
-void World::SetMassData(BodyID id, const MassData& massData)
-{
-    ::playrho::d2::SetMassData(*m_impl, id, massData);
-}
-
-Frequency World::GetLinearDamping(BodyID id) const
-{
-    return ::playrho::d2::GetLinearDamping(*m_impl, id);
-}
-
-void World::SetLinearDamping(BodyID id, NonNegative<Frequency> value)
-{
-    ::playrho::d2::SetLinearDamping(*m_impl, id, value);
-}
-
-Frequency World::GetAngularDamping(BodyID id) const
-{
-    return ::playrho::d2::GetAngularDamping(*m_impl, id);
-}
-
-void World::SetAngularDamping(BodyID id, NonNegative<Frequency> value)
-{
-    ::playrho::d2::SetAngularDamping(*m_impl, id, value);
-}
-
-SizedRange<World::Fixtures::const_iterator> World::GetFixtures(BodyID id) const
-{
-    return ::playrho::d2::GetFixtures(*m_impl, id);
-}
-
-FixtureCounter World::GetShapeCount() const noexcept
-{
-    return ::playrho::d2::GetShapeCount(*m_impl);
-}
-
-BodyConf World::GetBodyConf(BodyID id) const
-{
-    return ::playrho::d2::GetBodyConf(*m_impl, id);
-}
-
-BodyID World::GetBody(FixtureID id) const
-{
-    return ::playrho::d2::GetBody(*m_impl, id);
-}
-
-Shape World::GetShape(FixtureID id) const
-{
-    return ::playrho::d2::GetShape(*m_impl, id);
-}
-
-void World::SetSensor(FixtureID id, bool value)
-{
-    ::playrho::d2::SetSensor(*m_impl, id, value);
-}
-
-bool World::IsSensor(FixtureID id) const
-{
-    return ::playrho::d2::IsSensor(*m_impl, id);
-}
-
-AreaDensity World::GetDensity(FixtureID id) const
-{
-    return ::playrho::d2::GetDensity(*m_impl, id);
-}
-
-const World::FixtureProxies& World::GetProxies(FixtureID id) const
-{
-    return ::playrho::d2::GetProxies(*m_impl, id);
-}
-
-Angle World::GetAngle(BodyID id) const
-{
-    return ::playrho::d2::GetAngle(*m_impl, id);
-}
-
-Transformation World::GetTransformation(BodyID id) const
-{
-    return ::playrho::d2::GetTransformation(*m_impl, id);
-}
-
-void World::SetTransformation(BodyID id, Transformation xfm)
-{
-    return ::playrho::d2::SetTransformation(*m_impl, id, xfm);
-}
-
-Length2 World::GetLocalCenter(BodyID id) const
-{
-    return ::playrho::d2::GetLocalCenter(*m_impl, id);
-}
-
-Length2 World::GetWorldCenter(BodyID id) const
-{
-    return ::playrho::d2::GetWorldCenter(*m_impl, id);
-}
-
-Velocity World::GetVelocity(BodyID id) const
-{
-    return ::playrho::d2::GetVelocity(*m_impl, id);
-}
-
-void World::SetVelocity(BodyID id, const Velocity& value)
-{
-    ::playrho::d2::SetVelocity(*m_impl, id, value);
-}
-
-void World::UnsetAwake(BodyID id)
-{
-    ::playrho::d2::UnsetAwake(*m_impl, id);
-}
-
-void World::SetAwake(BodyID id)
-{
-    ::playrho::d2::SetAwake(*m_impl, id);
-}
-
-void World::SetAwake(JointID id)
-{
-    ::playrho::d2::SetAwake(*m_impl, id);
-}
-
-bool World::IsAwake(ContactID id) const
-{
-    return ::playrho::d2::IsAwake(*m_impl, id);
-}
-
-void World::SetAwake(ContactID id)
-{
-    ::playrho::d2::SetAwake(*m_impl, id);
-}
-
-LinearVelocity World::GetTangentSpeed(ContactID id) const
-{
-    return ::playrho::d2::GetTangentSpeed(*m_impl, id);
-}
-
-void World::SetTangentSpeed(ContactID id, LinearVelocity value)
-{
-    ::playrho::d2::SetTangentSpeed(*m_impl, id, value);
-}
-
-bool World::IsMassDataDirty(BodyID id) const
-{
-    return ::playrho::d2::IsMassDataDirty(*m_impl, id);
-}
-
-bool World::IsFixedRotation(BodyID id) const
-{
-    return ::playrho::d2::IsFixedRotation(*m_impl, id);
-}
-
-void World::SetFixedRotation(BodyID id, bool value)
-{
-    ::playrho::d2::SetFixedRotation(*m_impl, id, value);
-}
-
-BodyType World::GetType(BodyID id) const
-{
-    return ::playrho::d2::GetType(*m_impl, id);
-}
-
-JointType World::GetType(JointID id) const
-{
-    return ::playrho::d2::GetType(*m_impl, id);
-}
-
-bool World::IsAwake(BodyID id) const
-{
-    return ::playrho::d2::IsAwake(*m_impl, id);
-}
-
-LinearAcceleration2 World::GetLinearAcceleration(BodyID id) const
-{
-    return ::playrho::d2::GetLinearAcceleration(*m_impl, id);
-}
-
-AngularAcceleration World::GetAngularAcceleration(BodyID id) const
-{
-    return ::playrho::d2::GetAngularAcceleration(*m_impl, id);
-}
-
-void World::SetAcceleration(BodyID id, LinearAcceleration2 linear, AngularAcceleration angular)
-{
-    ::playrho::d2::SetAcceleration(*m_impl, id, linear, angular);
-}
-
-InvMass World::GetInvMass(BodyID id) const
-{
-    return ::playrho::d2::GetInvMass(*m_impl, id);
-}
-
-InvRotInertia World::GetInvRotInertia(BodyID id) const
-{
-    return ::playrho::d2::GetInvRotInertia(*m_impl, id);
-}
-
-const Joint& World::GetJoint(JointID id) const
-{
-    return ::playrho::d2::GetJoint(*m_impl, id);
-}
-
-void World::SetJoint(JointID id, const Joint& def)
-{
-    ::playrho::d2::SetJoint(*m_impl, id, def);
-}
-
-bool World::GetCollideConnected(JointID id) const
-{
-    return ::playrho::d2::GetCollideConnected(*m_impl, id);
-}
-
-BodyID World::GetBodyA(JointID id) const
-{
-    return ::playrho::d2::GetBodyA(*m_impl, id);
-}
-
-BodyID World::GetBodyB(JointID id) const
-{
-    return ::playrho::d2::GetBodyB(*m_impl, id);
-}
-
-Length2 World::GetLocalAnchorA(JointID id) const
-{
-    return ::playrho::d2::GetLocalAnchorA(*m_impl, id);
-}
-
-Length2 World::GetLocalAnchorB(JointID id) const
-{
-    return ::playrho::d2::GetLocalAnchorB(*m_impl, id);
-}
-
-Momentum2 World::GetLinearReaction(JointID id) const
-{
-    return ::playrho::d2::GetLinearReaction(*m_impl, id);
-}
-
-AngularMomentum World::GetAngularReaction(JointID id) const
-{
-    return ::playrho::d2::GetAngularReaction(*m_impl, id);
-}
-
-Angle World::GetReferenceAngle(JointID id) const
-{
-    return ::playrho::d2::GetReferenceAngle(*m_impl, id);
-}
-
-bool World::IsTouching(ContactID id) const
-{
-    return ::playrho::d2::IsTouching(*m_impl, id);
-}
-
-bool World::NeedsFiltering(ContactID id) const
-{
-    return ::playrho::d2::NeedsFiltering(*m_impl, id);
-}
-
-bool World::NeedsUpdating(ContactID id) const
-{
-    return ::playrho::d2::NeedsUpdating(*m_impl, id);
-}
-
-bool World::HasValidToi(ContactID id) const
-{
-    return ::playrho::d2::HasValidToi(*m_impl, id);
-}
-
-Real World::GetToi(ContactID id) const
-{
-    return ::playrho::d2::GetToi(*m_impl, id);
-}
-
-FixtureID World::GetFixtureA(ContactID id) const
-{
-    return ::playrho::d2::GetFixtureA(*m_impl, id);
-}
-
-FixtureID World::GetFixtureB(ContactID id) const
-{
-    return ::playrho::d2::GetFixtureB(*m_impl, id);
-}
-
-BodyID World::GetBodyA(ContactID id) const
-{
-    return ::playrho::d2::GetBodyA(*m_impl, id);
-}
-
-BodyID World::GetBodyB(ContactID id) const
-{
-    return ::playrho::d2::GetBodyB(*m_impl, id);
-}
-
-ChildCounter World::GetChildIndexA(ContactID id) const
-{
-    return ::playrho::d2::GetChildIndexA(*m_impl, id);
-}
-
-ChildCounter World::GetChildIndexB(ContactID id) const
-{
-    return ::playrho::d2::GetChildIndexB(*m_impl, id);
-}
-
-TimestepIters World::GetToiCount(ContactID id) const
-{
-    return ::playrho::d2::GetToiCount(*m_impl, id);
-}
-
-Real World::GetDefaultFriction(ContactID id) const
-{
-    return ::playrho::d2::GetDefaultFriction(*m_impl, id);
-}
-
-Real World::GetDefaultRestitution(ContactID id) const
-{
-    return ::playrho::d2::GetDefaultRestitution(*m_impl, id);
-}
-
-Real World::GetFriction(ContactID id) const
-{
-    return ::playrho::d2::GetFriction(*m_impl, id);
-}
-
-Real World::GetRestitution(ContactID id) const
-{
-    return ::playrho::d2::GetRestitution(*m_impl, id);
-}
-
-void World::SetFriction(ContactID id, Real value)
-{
-    ::playrho::d2::SetFriction(*m_impl, id, value);
-}
-
-void World::SetRestitution(ContactID id, Real value)
-{
-    ::playrho::d2::SetRestitution(*m_impl, id, value);
-}
-
-const Manifold& World::GetManifold(ContactID id) const
-{
-    return ::playrho::d2::GetManifold(*m_impl, id);
-}
-
-bool World::IsEnabled(ContactID id) const
-{
-    return ::playrho::d2::IsEnabled(*m_impl, id);
-}
-
-void World::SetEnabled(ContactID id)
-{
-    ::playrho::d2::SetEnabled(*m_impl, id);
-}
-
-void World::UnsetEnabled(ContactID id)
-{
-    ::playrho::d2::UnsetEnabled(*m_impl, id);
-}
-
-} // namespace d2
-} // namespace playrho
+namespace playrho
+{
+    namespace d2
+    {
+
+        static_assert(std::is_default_constructible<World>::value, "World must be default constructible!");
+        static_assert(std::is_copy_constructible<World>::value, "World must be copy constructible!");
+        static_assert(std::is_copy_assignable<World>::value, "World must be copy assignable!");
+        static_assert(std::is_move_constructible<World>::value, "World must be move constructible!");
+        static_assert(std::is_move_assignable<World>::value, "World must be move assignable!");
+        static_assert(std::is_nothrow_destructible<World>::value, "World must be nothrow destructible!");
+
+        // Special member functions are off in their own .cpp file to avoid their
+        // necessary includes being in this file!!
+
+        void World::Clear() noexcept
+        {
+            ::playrho::d2::Clear(*m_impl);
+        }
+
+        void World::SetFixtureDestructionListener(const FixtureListener& listener) noexcept
+        {
+            ::playrho::d2::SetFixtureDestructionListener(*m_impl, listener);
+        }
+
+        void World::SetJointDestructionListener(const JointListener& listener) noexcept
+        {
+            ::playrho::d2::SetJointDestructionListener(*m_impl, listener);
+        }
+
+        void World::SetBeginContactListener(ContactListener listener) noexcept
+        {
+            ::playrho::d2::SetBeginContactListener(*m_impl, listener);
+        }
+
+        void World::SetEndContactListener(ContactListener listener) noexcept
+        {
+            ::playrho::d2::SetEndContactListener(*m_impl, listener);
+        }
+
+        void World::SetPreSolveContactListener(ManifoldContactListener listener) noexcept
+        {
+            ::playrho::d2::SetPreSolveContactListener(*m_impl, listener);
+        }
+
+        void World::SetPostSolveContactListener(ImpulsesContactListener listener) noexcept
+        {
+            ::playrho::d2::SetPostSolveContactListener(*m_impl, listener);
+        }
+
+        BodyID World::CreateBody(const BodyConf& def)
+        {
+            return ::playrho::d2::CreateBody(*m_impl, def);
+        }
+
+        void World::Destroy(BodyID id)
+        {
+            ::playrho::d2::Destroy(*m_impl, id);
+        }
+
+        JointID World::CreateJoint(const Joint& def)
+        {
+            return ::playrho::d2::CreateJoint(*m_impl, def);
+        }
+
+        void World::Destroy(JointID id)
+        {
+            ::playrho::d2::Destroy(*m_impl, id);
+        }
+
+        StepStats World::Step(const StepConf& conf)
+        {
+            return ::playrho::d2::Step(*m_impl, conf);
+        }
+
+        void World::ShiftOrigin(Length2 newOrigin)
+        {
+            ::playrho::d2::ShiftOrigin(*m_impl, newOrigin);
+        }
+
+        BodyCounter World::GetBodyRange() const noexcept
+        {
+            return ::playrho::d2::GetBodyRange(*m_impl);
+        }
+
+        SizedRange<World::Bodies::const_iterator> World::GetBodies() const noexcept
+        {
+            return ::playrho::d2::GetBodies(*m_impl);
+        }
+
+        SizedRange<World::Bodies::const_iterator> World::GetBodiesForProxies() const noexcept
+        {
+            return ::playrho::d2::GetBodiesForProxies(*m_impl);
+        }
+
+        SizedRange<World::Fixtures::const_iterator> World::GetFixturesForProxies() const noexcept
+        {
+            return ::playrho::d2::GetFixturesForProxies(*m_impl);
+        }
+
+        SizedRange<World::Joints::const_iterator> World::GetJoints() const noexcept
+        {
+            return ::playrho::d2::GetJoints(*m_impl);
+        }
+
+        SizedRange<World::BodyJoints::const_iterator> World::GetJoints(BodyID id) const
+        {
+            return ::playrho::d2::GetJoints(*m_impl, id);
+        }
+
+        bool World::IsSpeedable(BodyID id) const
+        {
+            return ::playrho::d2::IsSpeedable(*m_impl, id);
+        }
+
+        bool World::IsAccelerable(BodyID id) const
+        {
+            return ::playrho::d2::IsAccelerable(*m_impl, id);
+        }
+
+        bool World::IsImpenetrable(BodyID id) const
+        {
+            return ::playrho::d2::IsImpenetrable(*m_impl, id);
+        }
+
+        void World::SetImpenetrable(BodyID id)
+        {
+            ::playrho::d2::SetImpenetrable(*m_impl, id);
+        }
+
+        void World::UnsetImpenetrable(BodyID id)
+        {
+            ::playrho::d2::UnsetImpenetrable(*m_impl, id);
+        }
+
+        bool World::IsSleepingAllowed(BodyID id) const
+        {
+            return ::playrho::d2::IsSleepingAllowed(*m_impl, id);
+        }
+
+        void World::SetSleepingAllowed(BodyID id, bool value)
+        {
+            ::playrho::d2::SetSleepingAllowed(*m_impl, id, value);
+        }
+
+        SizedRange<World::Contacts::const_iterator> World::GetContacts(BodyID id) const
+        {
+            return ::playrho::d2::GetContacts(*m_impl, id);
+        }
+
+        SizedRange<World::Contacts::const_iterator> World::GetContacts() const noexcept
+        {
+            return ::playrho::d2::GetContacts(*m_impl);
+        }
+
+        bool World::IsLocked() const noexcept
+        {
+            return m_impl && ::playrho::d2::IsLocked(*m_impl);
+        }
+
+        bool World::IsStepComplete() const noexcept
+        {
+            return ::playrho::d2::IsStepComplete(*m_impl);
+        }
+
+        bool World::GetSubStepping() const noexcept
+        {
+            return ::playrho::d2::GetSubStepping(*m_impl);
+        }
+
+        void World::SetSubStepping(bool flag) noexcept
+        {
+            ::playrho::d2::SetSubStepping(*m_impl, flag);
+        }
+
+        Length World::GetMinVertexRadius() const noexcept
+        {
+            return ::playrho::d2::GetMinVertexRadius(*m_impl);
+        }
+
+        Length World::GetMaxVertexRadius() const noexcept
+        {
+            return ::playrho::d2::GetMaxVertexRadius(*m_impl);
+        }
+
+        Frequency World::GetInvDeltaTime() const noexcept
+        {
+            return ::playrho::d2::GetInvDeltaTime(*m_impl);
+        }
+
+        const DynamicTree& World::GetTree() const noexcept
+        {
+            return ::playrho::d2::GetTree(*m_impl);
+        }
+
+        Filter World::GetFilterData(FixtureID id) const
+        {
+            return ::playrho::d2::GetFilterData(*m_impl, id);
+        }
+
+        void World::Refilter(FixtureID id)
+        {
+            ::playrho::d2::Refilter(*m_impl, id);
+        }
+
+        void World::SetFilterData(FixtureID id, const Filter& filter)
+        {
+            ::playrho::d2::SetFilterData(*m_impl, id, filter);
+        }
+
+        void World::SetType(BodyID id, BodyType type)
+        {
+            ::playrho::d2::SetType(*m_impl, id, type);
+        }
+
+        FixtureID World::CreateFixture(BodyID body, const Shape& shape, const FixtureConf& def,
+                                       bool resetMassData)
+        {
+            return ::playrho::d2::CreateFixture(*m_impl, body, shape, def, resetMassData);
+        }
+
+        bool World::Destroy(FixtureID id, bool resetMassData)
+        {
+            return ::playrho::d2::Destroy(*m_impl, id, resetMassData);
+        }
+
+        void World::DestroyFixtures(BodyID id)
+        {
+            ::playrho::d2::DestroyFixtures(*m_impl, id);
+        }
+
+        bool World::IsEnabled(BodyID id) const
+        {
+            return ::playrho::d2::IsEnabled(*m_impl, id);
+        }
+
+        void World::SetEnabled(BodyID id, bool flag)
+        {
+            ::playrho::d2::SetEnabled(*m_impl, id, flag);
+        }
+
+        MassData World::ComputeMassData(BodyID id) const
+        {
+            return ::playrho::d2::ComputeMassData(*m_impl, id);
+        }
+
+        void World::SetMassData(BodyID id, const MassData& massData)
+        {
+            ::playrho::d2::SetMassData(*m_impl, id, massData);
+        }
+
+        Frequency World::GetLinearDamping(BodyID id) const
+        {
+            return ::playrho::d2::GetLinearDamping(*m_impl, id);
+        }
+
+        void World::SetLinearDamping(BodyID id, NonNegative<Frequency> value)
+        {
+            ::playrho::d2::SetLinearDamping(*m_impl, id, value);
+        }
+
+        Frequency World::GetAngularDamping(BodyID id) const
+        {
+            return ::playrho::d2::GetAngularDamping(*m_impl, id);
+        }
+
+        void World::SetAngularDamping(BodyID id, NonNegative<Frequency> value)
+        {
+            ::playrho::d2::SetAngularDamping(*m_impl, id, value);
+        }
+
+        SizedRange<World::Fixtures::const_iterator> World::GetFixtures(BodyID id) const
+        {
+            return ::playrho::d2::GetFixtures(*m_impl, id);
+        }
+
+        FixtureCounter World::GetShapeCount() const noexcept
+        {
+            return ::playrho::d2::GetShapeCount(*m_impl);
+        }
+
+        BodyConf World::GetBodyConf(BodyID id) const
+        {
+            return ::playrho::d2::GetBodyConf(*m_impl, id);
+        }
+
+        BodyID World::GetBody(FixtureID id) const
+        {
+            return ::playrho::d2::GetBody(*m_impl, id);
+        }
+
+        Shape World::GetShape(FixtureID id) const
+        {
+            return ::playrho::d2::GetShape(*m_impl, id);
+        }
+
+        void World::SetSensor(FixtureID id, bool value)
+        {
+            ::playrho::d2::SetSensor(*m_impl, id, value);
+        }
+
+        bool World::IsSensor(FixtureID id) const
+        {
+            return ::playrho::d2::IsSensor(*m_impl, id);
+        }
+
+        AreaDensity World::GetDensity(FixtureID id) const
+        {
+            return ::playrho::d2::GetDensity(*m_impl, id);
+        }
+
+        const World::FixtureProxies& World::GetProxies(FixtureID id) const
+        {
+            return ::playrho::d2::GetProxies(*m_impl, id);
+        }
+
+        Angle World::GetAngle(BodyID id) const
+        {
+            return ::playrho::d2::GetAngle(*m_impl, id);
+        }
+
+        Transformation World::GetTransformation(BodyID id) const
+        {
+            return ::playrho::d2::GetTransformation(*m_impl, id);
+        }
+
+        void World::SetTransformation(BodyID id, Transformation xfm)
+        {
+            return ::playrho::d2::SetTransformation(*m_impl, id, xfm);
+        }
+
+        Length2 World::GetLocalCenter(BodyID id) const
+        {
+            return ::playrho::d2::GetLocalCenter(*m_impl, id);
+        }
+
+        Length2 World::GetWorldCenter(BodyID id) const
+        {
+            return ::playrho::d2::GetWorldCenter(*m_impl, id);
+        }
+
+        Velocity World::GetVelocity(BodyID id) const
+        {
+            return ::playrho::d2::GetVelocity(*m_impl, id);
+        }
+
+        void World::SetVelocity(BodyID id, const Velocity& value)
+        {
+            ::playrho::d2::SetVelocity(*m_impl, id, value);
+        }
+
+        void World::UnsetAwake(BodyID id)
+        {
+            ::playrho::d2::UnsetAwake(*m_impl, id);
+        }
+
+        void World::SetAwake(BodyID id)
+        {
+            ::playrho::d2::SetAwake(*m_impl, id);
+        }
+
+        void World::SetAwake(JointID id)
+        {
+            ::playrho::d2::SetAwake(*m_impl, id);
+        }
+
+        bool World::IsAwake(ContactID id) const
+        {
+            return ::playrho::d2::IsAwake(*m_impl, id);
+        }
+
+        void World::SetAwake(ContactID id)
+        {
+            ::playrho::d2::SetAwake(*m_impl, id);
+        }
+
+        LinearVelocity World::GetTangentSpeed(ContactID id) const
+        {
+            return ::playrho::d2::GetTangentSpeed(*m_impl, id);
+        }
+
+        void World::SetTangentSpeed(ContactID id, LinearVelocity value)
+        {
+            ::playrho::d2::SetTangentSpeed(*m_impl, id, value);
+        }
+
+        bool World::IsMassDataDirty(BodyID id) const
+        {
+            return ::playrho::d2::IsMassDataDirty(*m_impl, id);
+        }
+
+        bool World::IsFixedRotation(BodyID id) const
+        {
+            return ::playrho::d2::IsFixedRotation(*m_impl, id);
+        }
+
+        void World::SetFixedRotation(BodyID id, bool value)
+        {
+            ::playrho::d2::SetFixedRotation(*m_impl, id, value);
+        }
+
+        BodyType World::GetType(BodyID id) const
+        {
+            return ::playrho::d2::GetType(*m_impl, id);
+        }
+
+        JointType World::GetType(JointID id) const
+        {
+            return ::playrho::d2::GetType(*m_impl, id);
+        }
+
+        bool World::IsAwake(BodyID id) const
+        {
+            return ::playrho::d2::IsAwake(*m_impl, id);
+        }
+
+        LinearAcceleration2 World::GetLinearAcceleration(BodyID id) const
+        {
+            return ::playrho::d2::GetLinearAcceleration(*m_impl, id);
+        }
+
+        AngularAcceleration World::GetAngularAcceleration(BodyID id) const
+        {
+            return ::playrho::d2::GetAngularAcceleration(*m_impl, id);
+        }
+
+        void World::SetAcceleration(BodyID id, LinearAcceleration2 linear, AngularAcceleration angular)
+        {
+            ::playrho::d2::SetAcceleration(*m_impl, id, linear, angular);
+        }
+
+        InvMass World::GetInvMass(BodyID id) const
+        {
+            return ::playrho::d2::GetInvMass(*m_impl, id);
+        }
+
+        InvRotInertia World::GetInvRotInertia(BodyID id) const
+        {
+            return ::playrho::d2::GetInvRotInertia(*m_impl, id);
+        }
+
+        const Joint& World::GetJoint(JointID id) const
+        {
+            return ::playrho::d2::GetJoint(*m_impl, id);
+        }
+
+        void World::SetJoint(JointID id, const Joint& def)
+        {
+            ::playrho::d2::SetJoint(*m_impl, id, def);
+        }
+
+        bool World::GetCollideConnected(JointID id) const
+        {
+            return ::playrho::d2::GetCollideConnected(*m_impl, id);
+        }
+
+        BodyID World::GetBodyA(JointID id) const
+        {
+            return ::playrho::d2::GetBodyA(*m_impl, id);
+        }
+
+        BodyID World::GetBodyB(JointID id) const
+        {
+            return ::playrho::d2::GetBodyB(*m_impl, id);
+        }
+
+        Length2 World::GetLocalAnchorA(JointID id) const
+        {
+            return ::playrho::d2::GetLocalAnchorA(*m_impl, id);
+        }
+
+        Length2 World::GetLocalAnchorB(JointID id) const
+        {
+            return ::playrho::d2::GetLocalAnchorB(*m_impl, id);
+        }
+
+        Momentum2 World::GetLinearReaction(JointID id) const
+        {
+            return ::playrho::d2::GetLinearReaction(*m_impl, id);
+        }
+
+        AngularMomentum World::GetAngularReaction(JointID id) const
+        {
+            return ::playrho::d2::GetAngularReaction(*m_impl, id);
+        }
+
+        Angle World::GetReferenceAngle(JointID id) const
+        {
+            return ::playrho::d2::GetReferenceAngle(*m_impl, id);
+        }
+
+        bool World::IsTouching(ContactID id) const
+        {
+            return ::playrho::d2::IsTouching(*m_impl, id);
+        }
+
+        bool World::NeedsFiltering(ContactID id) const
+        {
+            return ::playrho::d2::NeedsFiltering(*m_impl, id);
+        }
+
+        bool World::NeedsUpdating(ContactID id) const
+        {
+            return ::playrho::d2::NeedsUpdating(*m_impl, id);
+        }
+
+        bool World::HasValidToi(ContactID id) const
+        {
+            return ::playrho::d2::HasValidToi(*m_impl, id);
+        }
+
+        Real World::GetToi(ContactID id) const
+        {
+            return ::playrho::d2::GetToi(*m_impl, id);
+        }
+
+        FixtureID World::GetFixtureA(ContactID id) const
+        {
+            return ::playrho::d2::GetFixtureA(*m_impl, id);
+        }
+
+        FixtureID World::GetFixtureB(ContactID id) const
+        {
+            return ::playrho::d2::GetFixtureB(*m_impl, id);
+        }
+
+        BodyID World::GetBodyA(ContactID id) const
+        {
+            return ::playrho::d2::GetBodyA(*m_impl, id);
+        }
+
+        BodyID World::GetBodyB(ContactID id) const
+        {
+            return ::playrho::d2::GetBodyB(*m_impl, id);
+        }
+
+        ChildCounter World::GetChildIndexA(ContactID id) const
+        {
+            return ::playrho::d2::GetChildIndexA(*m_impl, id);
+        }
+
+        ChildCounter World::GetChildIndexB(ContactID id) const
+        {
+            return ::playrho::d2::GetChildIndexB(*m_impl, id);
+        }
+
+        TimestepIters World::GetToiCount(ContactID id) const
+        {
+            return ::playrho::d2::GetToiCount(*m_impl, id);
+        }
+
+        Real World::GetDefaultFriction(ContactID id) const
+        {
+            return ::playrho::d2::GetDefaultFriction(*m_impl, id);
+        }
+
+        Real World::GetDefaultRestitution(ContactID id) const
+        {
+            return ::playrho::d2::GetDefaultRestitution(*m_impl, id);
+        }
+
+        Real World::GetFriction(ContactID id) const
+        {
+            return ::playrho::d2::GetFriction(*m_impl, id);
+        }
+
+        Real World::GetRestitution(ContactID id) const
+        {
+            return ::playrho::d2::GetRestitution(*m_impl, id);
+        }
+
+        void World::SetFriction(ContactID id, Real value)
+        {
+            ::playrho::d2::SetFriction(*m_impl, id, value);
+        }
+
+        void World::SetRestitution(ContactID id, Real value)
+        {
+            ::playrho::d2::SetRestitution(*m_impl, id, value);
+        }
+
+        const Manifold& World::GetManifold(ContactID id) const
+        {
+            return ::playrho::d2::GetManifold(*m_impl, id);
+        }
+
+        bool World::IsEnabled(ContactID id) const
+        {
+            return ::playrho::d2::IsEnabled(*m_impl, id);
+        }
+
+        void World::SetEnabled(ContactID id)
+        {
+            ::playrho::d2::SetEnabled(*m_impl, id);
+        }
+
+        void World::UnsetEnabled(ContactID id)
+        {
+            ::playrho::d2::UnsetEnabled(*m_impl, id);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -26,959 +26,961 @@
 /// Declarations of the World class.
 
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Range.hpp> // for SizedRange
+#include <PlayRho/Common/Range.hpp>// for SizedRange
 #include <PlayRho/Common/propagate_const.hpp>
 
 #include <PlayRho/Collision/MassData.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 
-#include <PlayRho/Dynamics/StepConf.hpp>
+#include <PlayRho/Dynamics/BodyConf.hpp>// for GetDefaultBodyConf
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
-#include <PlayRho/Dynamics/BodyConf.hpp> // for GetDefaultBodyConf
-#include <PlayRho/Dynamics/StepStats.hpp>
-#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp> // for KeyedContactPtr
+#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp>// for KeyedContactPtr
 #include <PlayRho/Dynamics/FixtureConf.hpp>
-#include <PlayRho/Dynamics/WorldConf.hpp>
+#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 #include <PlayRho/Dynamics/Joints/JointType.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
+#include <PlayRho/Dynamics/StepStats.hpp>
+#include <PlayRho/Dynamics/WorldConf.hpp>
 
+#include <functional>// for std::function
 #include <iterator>
-#include <vector>
-#include <memory> // for std::unique_ptr
+#include <memory>// for std::unique_ptr
 #include <stdexcept>
-#include <functional> // for std::function
-#include <type_traits> // for std::add_pointer_t, std::add_const_t
+#include <type_traits>// for std::add_pointer_t, std::add_const_t
+#include <vector>
 
-namespace playrho {
-
-struct StepConf;
-struct Filter;
-struct FixtureProxy;
-
-namespace d2 {
-
-class WorldImpl;
-class Manifold;
-class ContactImpulsesList;
-class DynamicTree;
-struct JointConf;
-
-/// @defgroup PhysicalEntities Physical Entities
-///
-/// @brief Concepts and types associated with physical entities within a world.
-///
-/// @details Concepts and types of creatable and destroyable instances that associate
-///   physical properties to simulations. These instances are typically created via a
-///   method whose name begins with the prefix of <code>Create</code>. Similarly, these
-///   instances are typically destroyed using a method whose name begins with the prefix
-///   of <code>Destroy</code>.
-///
-/// @note For example, the following could be used to create a dynamic body having a one meter
-///   radius disk shape:
-/// @code{.cpp}
-/// auto world = World{};
-/// const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
-/// const auto fixture = world.CreateFixture(body, Shape{DiskShapeConf{1_m}});
-/// @endcode
-///
-/// @see World.
-/// @see BodyID, World::CreateBody, World::Destroy(BodyID), World::GetBodies().
-/// @see FixtureID, World::CreateFixture, World::Destroy(FixtureID).
-/// @see JointID, World::CreateJoint, World::Destroy(JointID), World::GetJoints().
-/// @see ContactID, World::GetContacts().
-/// @see BodyType, Shape, DiskShapeConf.
-
-/// @brief Definition of an independent and simulatable "world".
-///
-/// @details The world class manages physics entities, dynamic simulation, and queries.
-///   In a physical sense, perhaps this is more like a universe in that entities in a
-///   world have no interaction with entities in other worlds. In any case, there's
-///   precedence, from a physics-engine standpoint, for this being called a world.
-///
-/// @note World instances do not themselves have any force or acceleration properties.
-///  They simply utilize the acceleration property of the bodies they manage. This is
-///  different than some other engines (like <code>Box2D</code> which provides a world
-///  gravity property).
-/// @note World instances are composed of &mdash; i.e. contain and own &mdash; body, contact,
-///   fixture, and joint entities. These are identified by <code>BodyID</code>,
-///   <code>ContactID</code>, <code>FixtureID</code>, and <code>JointID</code> values respectively.
-/// @note This class uses the pointer to implementation (PIMPL) technique and non-vitural
-///   interface (NVI) pattern to provide a complete layer of abstraction from the actual
-///   implementations used. This forms a "compilation firewall" &mdash; or application
-///   binary interface (ABI) &mdash; to help provide binary stability while facilitating
-///   experimentation and optimization.
-/// @note This data structure is 8-bytes large (on at least one 64-bit platform).
-///
-/// @attention For example, the following could be used to create a dynamic body having a one
-///   meter radius disk shape:
-/// @code{.cpp}
-/// auto world = World{};
-/// const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
-/// const auto fixture = world.CreateFixture(body, Shape{DiskShapeConf{1_m}});
-/// @endcode
-///
-/// @see BodyID, ContactID, FixtureID, JointID, PhysicalEntities.
-/// @see https://en.wikipedia.org/wiki/Non-virtual_interface_pattern
-/// @see https://en.wikipedia.org/wiki/Application_binary_interface
-/// @see https://en.cppreference.com/w/cpp/language/pimpl
-///
-class World
+namespace playrho
 {
-public:
-    /// @brief Bodies container type.
-    using Bodies = std::vector<BodyID>;
 
-    /// @brief Contacts container type.
-    using Contacts = std::vector<KeyedContactPtr>;
-
-    /// @brief Joints container type.
-    /// @note Cannot be container of Joint instances since joints are polymorphic types.
-    using Joints = std::vector<JointID>;
-
-    /// @brief Body joints container type.
-    using BodyJoints = std::vector<std::pair<BodyID, JointID>>;
-
-    /// @brief Fixtures container type.
-    using Fixtures = std::vector<FixtureID>;
-
-    /// @brief Fixture proxies.
-    using FixtureProxies = std::vector<FixtureProxy>;
-
-    /// @brief Fixture listener.
-    using FixtureListener = std::function<void(FixtureID)>;
-
-    /// @brief Joint listener.
-    using JointListener = std::function<void(JointID)>;
-
-    /// @brief Contact listener.
-    using ContactListener = std::function<void(ContactID)>;
-
-    /// @brief Manifold contact listener.
-    using ManifoldContactListener = std::function<void(ContactID, const Manifold&)>;
-
-    /// @brief Impulses contact listener.
-    using ImpulsesContactListener = std::function<void(ContactID, const ContactImpulsesList&,
-                                                       unsigned)>;
-
-    /// @name Special Member Functions
-    /// Special member functions that are explicitly defined.
-    ///@{
-
-    /// @brief Constructs a world object.
-    /// @param def A customized world configuration or its default value.
-    /// @note A lot more configurability can be had via the <code>StepConf</code>
-    ///   data that's given to the world's <code>Step</code> method.
-    /// @throws InvalidArgument if the given max vertex radius is less than the min.
-    /// @see Step.
-    explicit World(const WorldConf& def = GetDefaultWorldConf());
-
-    /// @brief Copy constructor.
-    /// @details Copy constructs this world with a deep copy of the given world.
-    /// @post The state of this world is like that of the given world except this world now
-    ///   has deep copies of the given world with pointers having the new addresses of the
-    ///   new memory required for those copies.
-    World(const World& other);
-
-    /// @brief Assignment operator.
-    /// @details Copy assigns this world with a deep copy of the given world.
-    /// @post The state of this world is like that of the given world except this world now
-    ///   has deep copies of the given world with pointers having the new addresses of the
-    ///   new memory required for those copies.
-    /// @warning This method should not be called while the world is locked!
-    /// @throws WrongState if this method is called while the world is locked.
-    World& operator= (const World& other);
-
-    /// @brief Destructor.
-    /// @details All physics entities are destroyed and all allocated memory is released.
-    /// @note This will call the <code>Clear()</code> function.
-    /// @see Clear.
-    ~World() noexcept;
-
-    /// @}
-
-    /// @name Listener Member Functions
-    ///@{
-
-    /// @brief Register a destruction listener for fixtures.
-    void SetFixtureDestructionListener(const FixtureListener& listener) noexcept;
-
-    /// @brief Register a destruction listener for joints.
-    void SetJointDestructionListener(const JointListener& listener) noexcept;
-
-    /// @brief Register a begin contact event listener.
-    void SetBeginContactListener(ContactListener listener) noexcept;
-
-    /// @brief Register an end contact event listener.
-    void SetEndContactListener(ContactListener listener) noexcept;
-
-    /// @brief Register a pre-solve contact event listener.
-    void SetPreSolveContactListener(ManifoldContactListener listener) noexcept;
-
-    /// @brief Register a post-solve contact event listener.
-    void SetPostSolveContactListener(ImpulsesContactListener listener) noexcept;
-
-    /// @}
-
-    /// @name Miscellaneous Member Functions
-    /// @{
-
-    /// @brief Clears this world.
-    /// @note This calls the joint and fixture destruction listeners (if they're set)
-    ///   before clearing anything.
-    /// @post The contents of this world have all been destroyed and this world's internal
-    ///   state reset as though it had just been constructed.
-    void Clear() noexcept;
-
-    /// @brief Steps the world simulation according to the given configuration.
-    ///
-    /// @details
-    /// Performs position and velocity updating, sleeping of non-moving bodies, updating
-    /// of the contacts, and notifying the contact listener of begin-contact, end-contact,
-    /// pre-solve, and post-solve events.
-    ///
-    /// @warning Behavior is undefined if given a negative step time delta.
-    /// @warning Varying the step time delta may lead to non-physical behaviors.
-    ///
-    /// @note Calling this with a zero step time delta results only in fixtures and bodies
-    ///   registered for proxy handling being processed. No physics is performed.
-    /// @note If the given velocity and position iterations are zero, this method doesn't
-    ///   do velocity or position resolutions respectively of the contacting bodies.
-    /// @note While body velocities are updated accordingly (per the sum of forces acting on them),
-    ///   body positions (barring any collisions) are updated as if they had moved the entire time
-    ///   step at those resulting velocities. In other words, a body initially at position 0
-    ///   (<code>p0</code>) going velocity 0 (<code>v0</code>) fast with a sum acceleration of
-    ///   <code>a</code>, after time <code>t</code> and barring any collisions, will have a new
-    ///   velocity (<code>v1</code>) of <code>v0 + (a * t)</code> and a new position
-    ///   (<code>p1</code>) of <code>p0 + v1 * t</code>.
-    ///
-    /// @post Static bodies are unmoved.
-    /// @post Kinetic bodies are moved based on their previous velocities.
-    /// @post Dynamic bodies are moved based on their previous velocities, gravity, applied
-    ///   forces, applied impulses, masses, damping, and the restitution and friction values
-    ///   of their fixtures when they experience collisions.
-    /// @post The bodies for proxies queue will be empty.
-    /// @post The fixtures for proxies queue will be empty.
-    ///
-    /// @param conf Configuration for the simulation step.
-    ///
-    /// @return Statistics for the step.
-    ///
-    /// @throws WrongState if this method is called while the world is locked.
-    ///
-    /// @see GetBodiesForProxies, GetFixturesForProxies.
-    ///
-    StepStats Step(const StepConf& conf = StepConf{});
-
-    /// @brief Whether or not "step" is complete.
-    /// @details The "step" is completed when there are no more TOI events for the current time step.
-    /// @return <code>true</code> unless sub-stepping is enabled and the step method returned
-    ///   without finishing all of its sub-steps.
-    /// @see GetSubStepping, SetSubStepping.
-    bool IsStepComplete() const noexcept;
-    
-    /// @brief Gets whether or not sub-stepping is enabled.
-    /// @see SetSubStepping, IsStepComplete.
-    bool GetSubStepping() const noexcept;
-
-    /// @brief Enables/disables single stepped continuous physics.
-    /// @note This is not normally used. Enabling sub-stepping is meant for testing.
-    /// @post The <code>GetSubStepping()</code> method will return the value this method was
-    ///   called with.
-    /// @see IsStepComplete, GetSubStepping.
-    void SetSubStepping(bool flag) noexcept;
-
-    /// @brief Gets access to the broad-phase dynamic tree information.
-    const DynamicTree& GetTree() const noexcept;
-
-    /// @brief Is the world locked (in the middle of a time step).
-    bool IsLocked() const noexcept;
-
-    /// @brief Shifts the world origin.
-    /// @note Useful for large worlds.
-    /// @note The body shift formula is: <code>position -= newOrigin</code>.
-    /// @post The "origin" of this world's bodies, joints, and the board-phase dynamic tree
-    ///   have been translated per the shift amount and direction.
-    /// @param newOrigin the new origin with respect to the old origin
-    /// @throws WrongState if this method is called while the world is locked.
-    void ShiftOrigin(Length2 newOrigin);
-
-    /// @brief Gets the minimum vertex radius that shapes in this world can be.
-    Length GetMinVertexRadius() const noexcept;
-    
-    /// @brief Gets the maximum vertex radius that shapes in this world can be.
-    Length GetMaxVertexRadius() const noexcept;
-
-    /// @brief Gets the inverse delta time.
-    /// @details Gets the inverse delta time that was set on construction or assignment, and
-    ///   updated on every call to the <code>Step()</code> method having a non-zero delta-time.
-    /// @see Step.
-    Frequency GetInvDeltaTime() const noexcept;
-
-    /// @brief Gets the shape count.
-    /// @todo Consider removing this function.
-    FixtureCounter GetShapeCount() const noexcept;
-
-    /// @}
-
-    /// @name Body Member Functions
-    /// Member functions relating to bodies.
-    ///@{
-
-    /// @brief Gets the extent of the currently valid body range.
-    /// @note This is one higher than the maxium BodyID that is in range for body related
-    ///   functions.
-    BodyCounter GetBodyRange() const noexcept;
-
-    /// @brief Gets the world body range for this constant world.
-    /// @details Gets a range enumerating the bodies currently existing within this world.
-    ///   These are the bodies that had been created from previous calls to the
-    ///   <code>CreateBody(const BodyConf&)</code> method that haven't yet been destroyed.
-    /// @return Body range that can be iterated over using its begin and end methods
-    ///   or using ranged-based for-loops.
-    /// @see CreateBody(const BodyConf&).
-    SizedRange<Bodies::const_iterator> GetBodies() const noexcept;
-
-    /// @brief Gets the bodies-for-proxies range for this world.
-    /// @details Provides insight on what bodies have been queued for proxy processing
-    ///   during the next call to the world step method.
-    /// @see Step.
-    SizedRange<Bodies::const_iterator> GetBodiesForProxies() const noexcept;
-
-    /// @brief Creates a rigid body with the given configuration.
-    /// @warning This function should not be used while the world is locked &mdash; as it is
-    ///   during callbacks. If it is, it will throw an exception or abort your program.
-    /// @note No references to the configuration are retained. Its value is copied.
-    /// @post The created body will be present in the range returned from the
-    ///   <code>GetBodies()</code> method.
-    /// @param def A customized body configuration or its default value.
-    /// @return Identifier of the newly created body which can later be destroyed by calling
-    ///   the <code>Destroy(BodyID)</code> method.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @throws LengthError if this operation would create more than <code>MaxBodies</code>.
-    /// @see Destroy(BodyID), GetBodies.
-    /// @see PhysicalEntities.
-    BodyID CreateBody(const BodyConf& def = GetDefaultBodyConf());
-
-    /// @brief Destroys the given body.
-    /// @details Destroys a given body that had previously been created by a call to this
-    ///   world's <code>CreateBody(const BodyConf&)</code> method.
-    /// @warning This automatically deletes all associated shapes and joints.
-    /// @warning This function is locked during callbacks.
-    /// @warning Behavior is undefined if given a null body.
-    /// @warning Behavior is undefined if the passed body was not created by this world.
-    /// @note This function is locked during callbacks.
-    /// @post The destroyed body will no longer be present in the range returned from the
-    ///   <code>GetBodies()</code> method.
-    /// @post None of the body's fixtures will be present in the fixtures-for-proxies
-    ///   collection.
-    /// @param id Body to destroy that had been created by this world.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see CreateBody(const BodyConf&), GetBodies, GetFixturesForProxies.
-    /// @see PhysicalEntities.
-    void Destroy(BodyID id);
-
-    /// @brief Gets the type of this body.
-    BodyType GetType(BodyID id) const;
-
-    /// @brief Sets the type of the given body.
-    /// @note This may alter the body's mass and velocity.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void SetType(BodyID id, BodyType type);
-
-    /// @brief Destroys fixtures of the given body.
-    /// @details Destroys all of the fixtures previously created for this body by the
-    ///   <code>CreateFixture(const Shape&, const FixtureConf&, bool)</code> method.
-    /// @note This unconditionally calls the <code>ResetMassData()</code> method.
-    /// @post After this call, no fixtures will show up in the fixture enumeration
-    ///   returned by the <code>GetFixtures()</code> methods.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see CreateFixture, GetFixtures, ResetMassData.
-    /// @see PhysicalEntities
-    void DestroyFixtures(BodyID id);
-
-    /// @brief Gets the enabled/disabled state of the body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see SetEnabled(BodyID).
-    bool IsEnabled(BodyID id) const;
-
-    /// @brief Sets the enabled state of the body.
-    ///
-    /// @details A disabled body is not simulated and cannot be collided with or woken up.
-    ///   If you pass a flag of true, all fixtures will be added to the broad-phase.
-    ///   If you pass a flag of false, all fixtures will be removed from the broad-phase
-    ///   and all contacts will be destroyed. Fixtures and joints are otherwise unaffected.
-    ///
-    /// @note A disabled body is still owned by a World object and remains in the world's
-    ///   body container.
-    /// @note You may continue to create/destroy fixtures and joints on disabled bodies.
-    /// @note Fixtures on a disabled body are implicitly disabled and will not participate in
-    ///   collisions, ray-casts, or queries.
-    /// @note Joints connected to a disabled body are implicitly disabled.
-    ///
-    /// @throws WrongState If call would change body's state when world is locked.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    ///
-    /// @post <code>IsEnabled()</code> returns the state given to this function.
-    ///
-    /// @see IsEnabled(BodyID).
-    ///
-    void SetEnabled(BodyID id, bool flag);
-
-    /// @brief Gets the range of all joints attached to this body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    SizedRange<BodyJoints::const_iterator> GetJoints(BodyID id) const;
-
-    /// @brief Computes the body's mass data.
-    /// @details This basically accumulates the mass data over all fixtures.
-    /// @return accumulated mass data for all fixtures associated with the given body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    MassData ComputeMassData(BodyID id) const;
-
-    /// @brief Set the mass properties to override the mass properties of the fixtures.
-    /// @note This changes the center of mass position.
-    /// @note Creating or destroying fixtures can also alter the mass.
-    /// @note This function has no effect if the body isn't dynamic.
-    /// @param id Identifier of the body to change.
-    /// @param massData the mass properties.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void SetMassData(BodyID id, const MassData& massData);
-
-    /// @brief Gets the body configuration for the identified body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    BodyConf GetBodyConf(BodyID id) const;
-
-    /// @brief Gets the range of all constant fixtures attached to the given body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    SizedRange<Fixtures::const_iterator> GetFixtures(BodyID id) const;
-
-    /// @brief Get the angle.
-    /// @return the current world rotation angle.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    Angle GetAngle(BodyID id) const;
-
-    /// @brief Gets the body's transformation.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see SetTransformation(BodyID id, Transformation xfm).
-    Transformation GetTransformation(BodyID id) const;
-
-    /// @brief Sets the transformation of the body.
-    /// @details This instantly adjusts the body to be at the new transformation.
-    /// @warning Manipulating a body's transformation can cause non-physical behavior!
-    /// @note Contacts are updated on the next call to World::Step.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see GetTransformation(BodyID id).
-    void SetTransformation(BodyID id, Transformation xfm);
-
-    /// @brief Gets the local position of the center of mass of the specified body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    Length2 GetLocalCenter(BodyID id) const;
-
-    /// @brief Gets the world position of the center of mass of the specified body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    Length2 GetWorldCenter(BodyID id) const;
-
-    /// @brief Gets the velocity of the identified body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see SetVelocity(BodyID id, const Velocity& value).
-    Velocity GetVelocity(BodyID id) const;
-
-    /// @brief Sets the body's velocity (linear and angular velocity).
-    /// @note This method does nothing if this body is not speedable.
-    /// @note A non-zero velocity will awaken this body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see GetVelocity(BodyID), SetAwake, SetUnderActiveTime.
-    void SetVelocity(BodyID id, const Velocity& value);
-
-    /// @brief Gets the awake/asleep state of this body.
-    /// @warning Being awake may or may not imply being speedable.
-    /// @return true if the body is awake.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    bool IsAwake(BodyID id) const;
-
-    /// @brief Wakes up the identified body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void SetAwake(BodyID id);
-
-    /// @brief Sleeps the identified body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see IsAwake(BodyID id), SetAwake(BodyID id).
-    void UnsetAwake(BodyID id);
-
-    /// @brief Gets this body's linear acceleration.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    LinearAcceleration2 GetLinearAcceleration(BodyID id) const;
-
-    /// @brief Gets this body's angular acceleration.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    AngularAcceleration GetAngularAcceleration(BodyID id) const;
-
-    /// @brief Sets the linear and rotational accelerations on the body.
-    /// @note This has no effect on non-accelerable bodies.
-    /// @note A non-zero acceleration will also awaken the body.
-    /// @param id Body whose acceleration should be set.
-    /// @param linear Linear acceleration.
-    /// @param angular Angular acceleration.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void SetAcceleration(BodyID id, LinearAcceleration2 linear, AngularAcceleration angular);
-
-    /// @brief Gets the linear damping of the body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    Frequency GetLinearDamping(BodyID id) const;
-
-    /// @brief Sets the linear damping of the body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void SetLinearDamping(BodyID id, NonNegative<Frequency> value);
-
-    /// @brief Gets the angular damping of the body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    Frequency GetAngularDamping(BodyID id) const;
-
-    /// @brief Sets the angular damping of the body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void SetAngularDamping(BodyID id, NonNegative<Frequency> angularDamping);
-
-    /// @brief Gets whether the body's mass-data is dirty.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    bool IsMassDataDirty(BodyID id) const;
-
-    /// @brief Gets whether the body has fixed rotation.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see SetFixedRotation(BodyID id, bool value).
-    bool IsFixedRotation(BodyID id) const;
-
-    /// @brief Sets the body to have fixed rotation.
-    /// @note This causes the mass to be reset.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see IsFixedRotation(BodyID id).
-    void SetFixedRotation(BodyID id, bool value);
-
-    /// @brief Gets the inverse total mass of the body.
-    /// @return Value of zero or more representing the body's inverse mass (in 1/kg).
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see SetMassData.
-    InvMass GetInvMass(BodyID id) const;
-
-    /// @brief Gets the inverse rotational inertia of the body.
-    /// @return Inverse rotational inertia (in 1/kg-m^2).
-    /// @throws std::out_of_range If given an invalid body identifier.
-    InvRotInertia GetInvRotInertia(BodyID id) const;
-
-    /// @brief Is identified body "speedable".
-    /// @details Is the body able to have a non-zero speed associated with it.
-    /// Kinematic and Dynamic bodies are speedable. Static bodies are not.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    bool IsSpeedable(BodyID id) const;
-
-    /// @brief Is identified body "accelerable"?
-    /// @details Indicates whether the body is accelerable, i.e. whether it is effected by
-    ///   forces. Only Dynamic bodies are accelerable.
-    /// @return true if the body is accelerable, false otherwise.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    bool IsAccelerable(BodyID id) const;
-
-    /// @brief Is the body treated like a bullet for continuous collision detection?
-    /// @throws std::out_of_range If given an invalid body identifier.
-    bool IsImpenetrable(BodyID id) const;
-
-    /// @brief Sets the bullet status of this body.
-    /// @details Sets that the body should be treated like a bullet for continuous
-    ///   collision detection.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void SetImpenetrable(BodyID id);
-
-    /// @brief Unsets the bullet status of this body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    void UnsetImpenetrable(BodyID id);
-
-    /// @brief Gets whether or not the identified body allowed to sleep.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see SetSleepingAllowed
-    bool IsSleepingAllowed(BodyID id) const;
-
-    /// @brief Sets whether sleeping is allowed for the identified body.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @see IsSleepingAllowed
-    void SetSleepingAllowed(BodyID id, bool value);
-
-    /// @brief Gets the container of all contacts attached to the body.
-    /// @warning This collection changes during the time step and you may
-    ///   miss some collisions if you don't use <code>ContactListener</code>.
-    /// @throws std::out_of_range If given an invalid body identifier.
-    SizedRange<Contacts::const_iterator> GetContacts(BodyID id) const;
-
-    ///@}
-
-    /// @name Fixture Member Functions
-    /// Member functions relating to fixtures.
-    ///@{
-
-    /// @brief Creates a fixture and attaches it to the given body.
-    /// @details Creates a fixture for attaching a shape and other characteristics to this
-    ///   body. Fixtures automatically go away when this body is destroyed. Fixtures can
-    ///   also be manually removed and destroyed using the
-    ///   <code>Destroy(FixtureID, bool)</code>, or <code>DestroyFixtures()</code> methods.
-    ///
-    /// @note This function should not be called if the world is locked.
-    /// @warning This function is locked during callbacks.
-    ///
-    /// @post After creating a new fixture, it will show up in the fixture enumeration
-    ///   returned by the <code>GetFixtures()</code> methods.
-    ///
-    /// @param body Identifier of the body to associate the new fixture with.
-    /// @param shape Shareable shape definition.
-    ///   Its vertex radius must be less than the minimum or more than the maximum allowed by
-    ///   the body's world.
-    /// @param def Initial fixture settings.
-    ///   Friction and density must be >= 0.
-    ///   Restitution must be > -infinity and < infinity.
-    /// @param resetMassData Whether or not to reset the mass data of the body.
-    ///
-    /// @return Identifier for the created fixture.
-    ///
-    /// @throws WrongState if called while the world is "locked".
-    /// @throws std::out_of_range If given an invalid body identifier.
-    /// @throws InvalidArgument if called for a shape with a vertex radius less than the
-    ///    minimum vertex radius.
-    /// @throws InvalidArgument if called for a shape with a vertex radius greater than the
-    ///    maximum vertex radius.
-    ///
-    /// @see Destroy(FixtureID), GetFixtures
-    /// @see PhysicalEntities
-    ///
-    FixtureID CreateFixture(BodyID body, const Shape& shape,
-                            const FixtureConf& def = GetDefaultFixtureConf(),
-                            bool resetMassData = true);
-
-    /// @brief Destroys the identified fixture.
-    ///
-    /// @details Destroys a fixture previously created by the
-    ///   <code>CreateFixture(const Shape&, const FixtureConf&, bool)</code>
-    ///   method. This removes the fixture from the broad-phase and destroys all contacts
-    ///   associated with this fixture. All fixtures attached to a body are implicitly
-    ///   destroyed when the body is destroyed.
-    ///
-    /// @warning This function is locked during callbacks.
-    /// @note Make sure to explicitly call <code>ResetMassData()</code> after fixtures have
-    ///   been destroyed if resetting the mass data is not requested via the reset mass data
-    ///   parameter.
-    /// @throws WrongState if this function is called while the world is locked.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    ///
-    /// @post After destroying a fixture, it will no longer show up in the fixture enumeration
-    ///   returned by the <code>GetFixtures()</code> methods.
-    ///
-    /// @param id the fixture to be removed.
-    /// @param resetMassData Whether or not to reset the mass data of the associated body.
-    ///
-    /// @see CreateFixture, Body::GetFixtures, Body::ResetMassData.
-    /// @see PhysicalEntities
-    ///
-    bool Destroy(FixtureID id, bool resetMassData = true);
-
-    /// @brief Gets the fixtures-for-proxies range for this world.
-    /// @details Provides insight on what fixtures have been queued for proxy processing
-    ///   during the next call to the world step method.
-    /// @see Step.
-    SizedRange<Fixtures::const_iterator> GetFixturesForProxies() const noexcept;
-
-    /// @brief Re-filter the fixture.
-    /// @note Call this if you want to establish collision that was previously disabled by
-    ///   <code>ShouldCollide(const Fixture&, const Fixture&)</code>.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    /// @see bool ShouldCollide(const Fixture& fixtureA, const Fixture& fixtureB) noexcept
-    void Refilter(FixtureID id);
-
-    /// @brief Gets the filter data for the identified fixture.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    Filter GetFilterData(FixtureID id) const;
-
-    /// @brief Sets the contact filtering data.
-    /// @note This won't update contacts until the next time step when either parent body
-    ///    is speedable and awake.
-    /// @note This automatically calls <code>Refilter</code>.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    void SetFilterData(FixtureID id, const Filter& filter);
-
-    /// @brief Gets the identifier of the body associated with the identified fixture.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    BodyID GetBody(FixtureID id) const;
-
-    /// @brief Gets the shape associated with the identified fixture.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    Shape GetShape(FixtureID id) const;
-
-    /// @brief Is the specified fixture a sensor (non-solid)?
-    /// @return the true if the fixture is a sensor.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    bool IsSensor(FixtureID id) const;
-
-    /// @brief Sets whether the fixture is a sensor or not.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    /// @see IsSensor(FixtureID id).
-    void SetSensor(FixtureID id, bool value);
-
-    /// @brief Gets the density value associated with the identified fixture.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    AreaDensity GetDensity(FixtureID id) const;
-
-    /// @brief Gets the proxies of the identified fixture.
-    /// @throws std::out_of_range If given an invalid fixture identifier.
-    const FixtureProxies& GetProxies(FixtureID id) const;
-
-    /// @}
-
-    /// @name Joint Member Functions
-    /// Member functions relating to joints.
-    ///@{
-
-    /// @brief Gets the world joint range.
-    /// @details Gets a range enumerating the joints currently existing within this world.
-    ///   These are the joints that had been created from previous calls to the
-    ///   <code>CreateJoint(const JointConf&)</code> method that haven't yet been destroyed.
-    /// @return World joints sized-range.
-    /// @see CreateJoint(const JointConf&).
-    SizedRange<Joints::const_iterator> GetJoints() const noexcept;
-
-    /// @brief Creates a joint to constrain one or more bodies.
-    /// @warning This function is locked during callbacks.
-    /// @post The created joint will be present in the range returned from the
-    ///   <code>GetJoints()</code> method.
-    /// @return Identifier of newly created joint which can later be destroyed by calling the
-    ///   <code>Destroy(JointID)</code> method.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @throws LengthError if this operation would create more than <code>MaxJoints</code>.
-    /// @see PhysicalEntities.
-    /// @see Destroy(JointID), GetJoints.
-    JointID CreateJoint(const Joint& def);
-
-    /// @brief Destroys the identified joint.
-    /// @details Destroys a given joint that had previously been created by a call to this
-    ///   world's <code>CreateJoint(const Joint&)</code> method.
-    /// @warning This function is locked during callbacks.
-    /// @note This may cause the connected bodies to begin colliding.
-    /// @post The destroyed joint will no longer be present in the range returned from the
-    ///   <code>GetJoints()</code> method.
-    /// @param id Joint to destroy that had been created by this world.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    /// @see CreateJoint(const Joint&), GetJoints.
-    /// @see PhysicalEntities.
-    void Destroy(JointID id);
-
-    /// @brief Gets the value of the identified joint.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    const Joint& GetJoint(JointID id) const;
-
-    /// @brief Sets the identified joint to the given value.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    void SetJoint(JointID id, const Joint& def);
-
-    /// @brief Wakes up the joined bodies.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    void SetAwake(JointID id);
-
-    /// @brief Gets collide connected for the specified joint.
-    /// @note Modifying the collide connect flag won't work correctly because
-    ///   the flag is only checked when fixture AABBs begin to overlap.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    bool GetCollideConnected(JointID id) const;
-
-    /// @brief Gets the type of the identified joint.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    JointType GetType(JointID id) const;
-
-    /// @brief Gets the identifier of body-A of the identified joint.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    BodyID GetBodyA(JointID id) const;
-
-    /// @brief Gets the identifier of body-B of the identified joint.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    BodyID GetBodyB(JointID id) const;
-
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    Length2 GetLocalAnchorA(JointID id) const;
-
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    Length2 GetLocalAnchorB(JointID id) const;
-
-    /// Gets the linear reaction on body-B at the joint anchor.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    Momentum2 GetLinearReaction(JointID id) const;
-
-    /// @brief Get the angular reaction on body-B for the identified joint.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    AngularMomentum GetAngularReaction(JointID id) const;
-
-    /// @brief Gets the reference angle of the identified joint.
-    /// @throws std::out_of_range If given an invalid joint identifier.
-    Angle GetReferenceAngle(JointID id) const;
-
-    /// @}
-
-    /// @name Contact Member Functions
-    /// Member functions relating to contacts.
-    ///@{
-
-    /// @brief Gets the world contact range.
-    /// @warning contacts are created and destroyed in the middle of a time step.
-    /// Use <code>ContactListener</code> to avoid missing contacts.
-    /// @return World contacts sized-range.
-    SizedRange<Contacts::const_iterator> GetContacts() const noexcept;
-
-    /// @brief Gets the awake status of the specified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    /// @see SetAwake(ContactID id)
-    bool IsAwake(ContactID id) const;
-
-    /// @brief Sets the awake status of the specified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    /// @see IsAwake(ContactID id)
-    void SetAwake(ContactID id);
-
-    /// @brief Gets the desired tangent speed.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    /// @see SetTangentSpeed(ContactID id, LinearVelocity value).
-    LinearVelocity GetTangentSpeed(ContactID id) const;
-
-    /// @brief Sets the desired tangent speed for a conveyor belt behavior.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    /// @see GetTangentSpeed(ContactID id) const.
-    void SetTangentSpeed(ContactID id, LinearVelocity value);
-
-    /// @brief Is this contact touching?
-    /// @details
-    /// Touching is defined as either:
-    ///   1. This contact's manifold has more than 0 contact points, or
-    ///   2. This contact has sensors and the two shapes of this contact are found to be
-    ///      overlapping.
-    /// @return true if this contact is said to be touching, false otherwise.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    bool IsTouching(ContactID id) const;
-
-    /// @brief Whether or not the contact needs filtering.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    bool NeedsFiltering(ContactID id) const;
-
-    /// @brief Whether or not the contact needs updating.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    bool NeedsUpdating(ContactID id) const;
-
-    /// @brief Gets body-A of the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    BodyID GetBodyA(ContactID id) const;
-
-    /// @brief Gets body-B of the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    BodyID GetBodyB(ContactID id) const;
-
-    /// @brief Gets fixture A of the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    FixtureID GetFixtureA(ContactID id) const;
-
-    /// @brief Gets fixture B of the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    FixtureID GetFixtureB(ContactID id) const;
-
-    /// @brief Get the child primitive index for fixture A.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    ChildCounter GetChildIndexA(ContactID id) const;
-
-    /// @brief Get the child primitive index for fixture B.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    ChildCounter GetChildIndexB(ContactID id) const;
-
-    /// @brief Whether or not the contact has a valid TOI.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    /// @see GetToi.
-    bool HasValidToi(ContactID id) const;
-
-    /// @brief Gets the time of impact (TOI) as a fraction.
-    /// @note This is only valid if a TOI has been set.
-    /// @return Time of impact fraction in the range of 0 to 1 if set (where 1
-    ///   means no actual impact in current time slot), otherwise undefined.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    Real GetToi(ContactID id) const;
-
-    /// @brief Gets the time of impact count of the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    TimestepIters GetToiCount(ContactID id) const;
-
-    /// @brief Gets the default friction value for the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    Real GetDefaultFriction(ContactID id) const;
-
-    /// @brief Gets the default restitution value for the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    Real GetDefaultRestitution(ContactID id) const;
-
-    /// @brief Gets the friction used with the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    /// @see SetFriction(ContactID id, Real value)
-    Real GetFriction(ContactID id) const;
-
-    /// @brief Gets the restitution used with the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    /// @see SetRestitution(ContactID id, Real value)
-    Real GetRestitution(ContactID id) const;
-
-    /// @brief Sets the friction value for the identified contact.
-    /// @details Overrides the default friction mixture.
-    /// @note You can call this in "pre-solve" listeners.
-    /// @note This value persists until set or reset.
-    /// @warning Behavior is undefined if given a negative friction value.
-    /// @param id Contact identifier.
-    /// @param value Co-efficient of friction value of zero or greater.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    void SetFriction(ContactID id, Real value);
-
-    /// @brief Sets the restitution value for the identified contact.
-    /// @details This override the default restitution mixture.
-    /// @note You can call this in "pre-solve" listeners.
-    /// @note The value persists until you set or reset.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    void SetRestitution(ContactID id, Real value);
-
-    /// @brief Gets the collision manifold for the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    const Manifold& GetManifold(ContactID id) const;
-
-    /// @brief Gets whether or not the identified contact is enabled.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    bool IsEnabled(ContactID id) const;
-
-    /// @brief Enables the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    void SetEnabled(ContactID id);
-
-    /// @brief Disables the identified contact.
-    /// @throws std::out_of_range If given an invalid contact identifier.
-    void UnsetEnabled(ContactID id);
-
-    /// @}
-
-private:
-    /// @brief Pointer to implementation (PIMPL)
-    /// @see https://en.cppreference.com/w/cpp/language/pimpl
-    propagate_const<std::unique_ptr<WorldImpl>> m_impl;
-};
-
-/// @example HelloWorld.cpp
-/// This is the source file for the <code>HelloWorld</code> application that demonstrates
-/// use of the <code>playrho::d2::World</code> class and more.
-/// After instantiating a world, the code creates a body and its fixture to act as the ground,
-/// creates another body and a fixture for it to act like a ball, then steps the world using
-/// the world <code>playrho::d2::World::Step(const StepConf&)</code> function which simulates a ball falling to the ground
-/// and outputs the position of the ball after each step.
-
-/// @example World.cpp
-/// This is the <code>googletest</code> based unit testing file for the
-/// <code>playrho::d2::World</code> class.
-
-} // namespace d2
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_WORLD_HPP
+    struct StepConf;
+    struct Filter;
+    struct FixtureProxy;
+
+    namespace d2
+    {
+
+        class WorldImpl;
+        class Manifold;
+        class ContactImpulsesList;
+        class DynamicTree;
+        struct JointConf;
+
+        /// @defgroup PhysicalEntities Physical Entities
+        ///
+        /// @brief Concepts and types associated with physical entities within a world.
+        ///
+        /// @details Concepts and types of creatable and destroyable instances that associate
+        ///   physical properties to simulations. These instances are typically created via a
+        ///   method whose name begins with the prefix of <code>Create</code>. Similarly, these
+        ///   instances are typically destroyed using a method whose name begins with the prefix
+        ///   of <code>Destroy</code>.
+        ///
+        /// @note For example, the following could be used to create a dynamic body having a one meter
+        ///   radius disk shape:
+        /// @code{.cpp}
+        /// auto world = World{};
+        /// const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+        /// const auto fixture = world.CreateFixture(body, Shape{DiskShapeConf{1_m}});
+        /// @endcode
+        ///
+        /// @see World.
+        /// @see BodyID, World::CreateBody, World::Destroy(BodyID), World::GetBodies().
+        /// @see FixtureID, World::CreateFixture, World::Destroy(FixtureID).
+        /// @see JointID, World::CreateJoint, World::Destroy(JointID), World::GetJoints().
+        /// @see ContactID, World::GetContacts().
+        /// @see BodyType, Shape, DiskShapeConf.
+
+        /// @brief Definition of an independent and simulatable "world".
+        ///
+        /// @details The world class manages physics entities, dynamic simulation, and queries.
+        ///   In a physical sense, perhaps this is more like a universe in that entities in a
+        ///   world have no interaction with entities in other worlds. In any case, there's
+        ///   precedence, from a physics-engine standpoint, for this being called a world.
+        ///
+        /// @note World instances do not themselves have any force or acceleration properties.
+        ///  They simply utilize the acceleration property of the bodies they manage. This is
+        ///  different than some other engines (like <code>Box2D</code> which provides a world
+        ///  gravity property).
+        /// @note World instances are composed of &mdash; i.e. contain and own &mdash; body, contact,
+        ///   fixture, and joint entities. These are identified by <code>BodyID</code>,
+        ///   <code>ContactID</code>, <code>FixtureID</code>, and <code>JointID</code> values respectively.
+        /// @note This class uses the pointer to implementation (PIMPL) technique and non-vitural
+        ///   interface (NVI) pattern to provide a complete layer of abstraction from the actual
+        ///   implementations used. This forms a "compilation firewall" &mdash; or application
+        ///   binary interface (ABI) &mdash; to help provide binary stability while facilitating
+        ///   experimentation and optimization.
+        /// @note This data structure is 8-bytes large (on at least one 64-bit platform).
+        ///
+        /// @attention For example, the following could be used to create a dynamic body having a one
+        ///   meter radius disk shape:
+        /// @code{.cpp}
+        /// auto world = World{};
+        /// const auto body = world.CreateBody(BodyConf{}.UseType(BodyType::Dynamic));
+        /// const auto fixture = world.CreateFixture(body, Shape{DiskShapeConf{1_m}});
+        /// @endcode
+        ///
+        /// @see BodyID, ContactID, FixtureID, JointID, PhysicalEntities.
+        /// @see https://en.wikipedia.org/wiki/Non-virtual_interface_pattern
+        /// @see https://en.wikipedia.org/wiki/Application_binary_interface
+        /// @see https://en.cppreference.com/w/cpp/language/pimpl
+        ///
+        class World
+        {
+         public:
+            /// @brief Bodies container type.
+            using Bodies = std::vector<BodyID>;
+
+            /// @brief Contacts container type.
+            using Contacts = std::vector<KeyedContactPtr>;
+
+            /// @brief Joints container type.
+            /// @note Cannot be container of Joint instances since joints are polymorphic types.
+            using Joints = std::vector<JointID>;
+
+            /// @brief Body joints container type.
+            using BodyJoints = std::vector<std::pair<BodyID, JointID>>;
+
+            /// @brief Fixtures container type.
+            using Fixtures = std::vector<FixtureID>;
+
+            /// @brief Fixture proxies.
+            using FixtureProxies = std::vector<FixtureProxy>;
+
+            /// @brief Fixture listener.
+            using FixtureListener = std::function<void(FixtureID)>;
+
+            /// @brief Joint listener.
+            using JointListener = std::function<void(JointID)>;
+
+            /// @brief Contact listener.
+            using ContactListener = std::function<void(ContactID)>;
+
+            /// @brief Manifold contact listener.
+            using ManifoldContactListener = std::function<void(ContactID, const Manifold&)>;
+
+            /// @brief Impulses contact listener.
+            using ImpulsesContactListener = std::function<void(ContactID, const ContactImpulsesList&,
+                                                               unsigned)>;
+
+            /// @name Special Member Functions
+            /// Special member functions that are explicitly defined.
+            ///@{
+
+            /// @brief Constructs a world object.
+            /// @param def A customized world configuration or its default value.
+            /// @note A lot more configurability can be had via the <code>StepConf</code>
+            ///   data that's given to the world's <code>Step</code> method.
+            /// @throws InvalidArgument if the given max vertex radius is less than the min.
+            /// @see Step.
+            explicit World(const WorldConf& def = GetDefaultWorldConf());
+
+            /// @brief Copy constructor.
+            /// @details Copy constructs this world with a deep copy of the given world.
+            /// @post The state of this world is like that of the given world except this world now
+            ///   has deep copies of the given world with pointers having the new addresses of the
+            ///   new memory required for those copies.
+            World(const World& other);
+
+            /// @brief Assignment operator.
+            /// @details Copy assigns this world with a deep copy of the given world.
+            /// @post The state of this world is like that of the given world except this world now
+            ///   has deep copies of the given world with pointers having the new addresses of the
+            ///   new memory required for those copies.
+            /// @warning This method should not be called while the world is locked!
+            /// @throws WrongState if this method is called while the world is locked.
+            World& operator=(const World& other);
+
+            /// @brief Destructor.
+            /// @details All physics entities are destroyed and all allocated memory is released.
+            /// @note This will call the <code>Clear()</code> function.
+            /// @see Clear.
+            ~World() noexcept;
+
+            /// @}
+
+            /// @name Listener Member Functions
+            ///@{
+
+            /// @brief Register a destruction listener for fixtures.
+            void SetFixtureDestructionListener(const FixtureListener& listener) noexcept;
+
+            /// @brief Register a destruction listener for joints.
+            void SetJointDestructionListener(const JointListener& listener) noexcept;
+
+            /// @brief Register a begin contact event listener.
+            void SetBeginContactListener(ContactListener listener) noexcept;
+
+            /// @brief Register an end contact event listener.
+            void SetEndContactListener(ContactListener listener) noexcept;
+
+            /// @brief Register a pre-solve contact event listener.
+            void SetPreSolveContactListener(ManifoldContactListener listener) noexcept;
+
+            /// @brief Register a post-solve contact event listener.
+            void SetPostSolveContactListener(ImpulsesContactListener listener) noexcept;
+
+            /// @}
+
+            /// @name Miscellaneous Member Functions
+            /// @{
+
+            /// @brief Clears this world.
+            /// @note This calls the joint and fixture destruction listeners (if they're set)
+            ///   before clearing anything.
+            /// @post The contents of this world have all been destroyed and this world's internal
+            ///   state reset as though it had just been constructed.
+            void Clear() noexcept;
+
+            /// @brief Steps the world simulation according to the given configuration.
+            ///
+            /// @details
+            /// Performs position and velocity updating, sleeping of non-moving bodies, updating
+            /// of the contacts, and notifying the contact listener of begin-contact, end-contact,
+            /// pre-solve, and post-solve events.
+            ///
+            /// @warning Behavior is undefined if given a negative step time delta.
+            /// @warning Varying the step time delta may lead to non-physical behaviors.
+            ///
+            /// @note Calling this with a zero step time delta results only in fixtures and bodies
+            ///   registered for proxy handling being processed. No physics is performed.
+            /// @note If the given velocity and position iterations are zero, this method doesn't
+            ///   do velocity or position resolutions respectively of the contacting bodies.
+            /// @note While body velocities are updated accordingly (per the sum of forces acting on them),
+            ///   body positions (barring any collisions) are updated as if they had moved the entire time
+            ///   step at those resulting velocities. In other words, a body initially at position 0
+            ///   (<code>p0</code>) going velocity 0 (<code>v0</code>) fast with a sum acceleration of
+            ///   <code>a</code>, after time <code>t</code> and barring any collisions, will have a new
+            ///   velocity (<code>v1</code>) of <code>v0 + (a * t)</code> and a new position
+            ///   (<code>p1</code>) of <code>p0 + v1 * t</code>.
+            ///
+            /// @post Static bodies are unmoved.
+            /// @post Kinetic bodies are moved based on their previous velocities.
+            /// @post Dynamic bodies are moved based on their previous velocities, gravity, applied
+            ///   forces, applied impulses, masses, damping, and the restitution and friction values
+            ///   of their fixtures when they experience collisions.
+            /// @post The bodies for proxies queue will be empty.
+            /// @post The fixtures for proxies queue will be empty.
+            ///
+            /// @param conf Configuration for the simulation step.
+            ///
+            /// @return Statistics for the step.
+            ///
+            /// @throws WrongState if this method is called while the world is locked.
+            ///
+            /// @see GetBodiesForProxies, GetFixturesForProxies.
+            ///
+            StepStats Step(const StepConf& conf = StepConf{});
+
+            /// @brief Whether or not "step" is complete.
+            /// @details The "step" is completed when there are no more TOI events for the current time step.
+            /// @return <code>true</code> unless sub-stepping is enabled and the step method returned
+            ///   without finishing all of its sub-steps.
+            /// @see GetSubStepping, SetSubStepping.
+            bool IsStepComplete() const noexcept;
+
+            /// @brief Gets whether or not sub-stepping is enabled.
+            /// @see SetSubStepping, IsStepComplete.
+            bool GetSubStepping() const noexcept;
+
+            /// @brief Enables/disables single stepped continuous physics.
+            /// @note This is not normally used. Enabling sub-stepping is meant for testing.
+            /// @post The <code>GetSubStepping()</code> method will return the value this method was
+            ///   called with.
+            /// @see IsStepComplete, GetSubStepping.
+            void SetSubStepping(bool flag) noexcept;
+
+            /// @brief Gets access to the broad-phase dynamic tree information.
+            const DynamicTree& GetTree() const noexcept;
+
+            /// @brief Is the world locked (in the middle of a time step).
+            bool IsLocked() const noexcept;
+
+            /// @brief Shifts the world origin.
+            /// @note Useful for large worlds.
+            /// @note The body shift formula is: <code>position -= newOrigin</code>.
+            /// @post The "origin" of this world's bodies, joints, and the board-phase dynamic tree
+            ///   have been translated per the shift amount and direction.
+            /// @param newOrigin the new origin with respect to the old origin
+            /// @throws WrongState if this method is called while the world is locked.
+            void ShiftOrigin(Length2 newOrigin);
+
+            /// @brief Gets the minimum vertex radius that shapes in this world can be.
+            Length GetMinVertexRadius() const noexcept;
+
+            /// @brief Gets the maximum vertex radius that shapes in this world can be.
+            Length GetMaxVertexRadius() const noexcept;
+
+            /// @brief Gets the inverse delta time.
+            /// @details Gets the inverse delta time that was set on construction or assignment, and
+            ///   updated on every call to the <code>Step()</code> method having a non-zero delta-time.
+            /// @see Step.
+            Frequency GetInvDeltaTime() const noexcept;
+
+            /// @brief Gets the shape count.
+            /// @todo Consider removing this function.
+            FixtureCounter GetShapeCount() const noexcept;
+
+            /// @}
+
+            /// @name Body Member Functions
+            /// Member functions relating to bodies.
+            ///@{
+
+            /// @brief Gets the extent of the currently valid body range.
+            /// @note This is one higher than the maxium BodyID that is in range for body related
+            ///   functions.
+            BodyCounter GetBodyRange() const noexcept;
+
+            /// @brief Gets the world body range for this constant world.
+            /// @details Gets a range enumerating the bodies currently existing within this world.
+            ///   These are the bodies that had been created from previous calls to the
+            ///   <code>CreateBody(const BodyConf&)</code> method that haven't yet been destroyed.
+            /// @return Body range that can be iterated over using its begin and end methods
+            ///   or using ranged-based for-loops.
+            /// @see CreateBody(const BodyConf&).
+            SizedRange<Bodies::const_iterator> GetBodies() const noexcept;
+
+            /// @brief Gets the bodies-for-proxies range for this world.
+            /// @details Provides insight on what bodies have been queued for proxy processing
+            ///   during the next call to the world step method.
+            /// @see Step.
+            SizedRange<Bodies::const_iterator> GetBodiesForProxies() const noexcept;
+
+            /// @brief Creates a rigid body with the given configuration.
+            /// @warning This function should not be used while the world is locked &mdash; as it is
+            ///   during callbacks. If it is, it will throw an exception or abort your program.
+            /// @note No references to the configuration are retained. Its value is copied.
+            /// @post The created body will be present in the range returned from the
+            ///   <code>GetBodies()</code> method.
+            /// @param def A customized body configuration or its default value.
+            /// @return Identifier of the newly created body which can later be destroyed by calling
+            ///   the <code>Destroy(BodyID)</code> method.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @throws LengthError if this operation would create more than <code>MaxBodies</code>.
+            /// @see Destroy(BodyID), GetBodies.
+            /// @see PhysicalEntities.
+            BodyID CreateBody(const BodyConf& def = GetDefaultBodyConf());
+
+            /// @brief Destroys the given body.
+            /// @details Destroys a given body that had previously been created by a call to this
+            ///   world's <code>CreateBody(const BodyConf&)</code> method.
+            /// @warning This automatically deletes all associated shapes and joints.
+            /// @warning This function is locked during callbacks.
+            /// @warning Behavior is undefined if given a null body.
+            /// @warning Behavior is undefined if the passed body was not created by this world.
+            /// @note This function is locked during callbacks.
+            /// @post The destroyed body will no longer be present in the range returned from the
+            ///   <code>GetBodies()</code> method.
+            /// @post None of the body's fixtures will be present in the fixtures-for-proxies
+            ///   collection.
+            /// @param id Body to destroy that had been created by this world.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see CreateBody(const BodyConf&), GetBodies, GetFixturesForProxies.
+            /// @see PhysicalEntities.
+            void Destroy(BodyID id);
+
+            /// @brief Gets the type of this body.
+            BodyType GetType(BodyID id) const;
+
+            /// @brief Sets the type of the given body.
+            /// @note This may alter the body's mass and velocity.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void SetType(BodyID id, BodyType type);
+
+            /// @brief Destroys fixtures of the given body.
+            /// @details Destroys all of the fixtures previously created for this body by the
+            ///   <code>CreateFixture(const Shape&, const FixtureConf&, bool)</code> method.
+            /// @note This unconditionally calls the <code>ResetMassData()</code> method.
+            /// @post After this call, no fixtures will show up in the fixture enumeration
+            ///   returned by the <code>GetFixtures()</code> methods.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see CreateFixture, GetFixtures, ResetMassData.
+            /// @see PhysicalEntities
+            void DestroyFixtures(BodyID id);
+
+            /// @brief Gets the enabled/disabled state of the body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see SetEnabled(BodyID).
+            bool IsEnabled(BodyID id) const;
+
+            /// @brief Sets the enabled state of the body.
+            ///
+            /// @details A disabled body is not simulated and cannot be collided with or woken up.
+            ///   If you pass a flag of true, all fixtures will be added to the broad-phase.
+            ///   If you pass a flag of false, all fixtures will be removed from the broad-phase
+            ///   and all contacts will be destroyed. Fixtures and joints are otherwise unaffected.
+            ///
+            /// @note A disabled body is still owned by a World object and remains in the world's
+            ///   body container.
+            /// @note You may continue to create/destroy fixtures and joints on disabled bodies.
+            /// @note Fixtures on a disabled body are implicitly disabled and will not participate in
+            ///   collisions, ray-casts, or queries.
+            /// @note Joints connected to a disabled body are implicitly disabled.
+            ///
+            /// @throws WrongState If call would change body's state when world is locked.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            ///
+            /// @post <code>IsEnabled()</code> returns the state given to this function.
+            ///
+            /// @see IsEnabled(BodyID).
+            ///
+            void SetEnabled(BodyID id, bool flag);
+
+            /// @brief Gets the range of all joints attached to this body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            SizedRange<BodyJoints::const_iterator> GetJoints(BodyID id) const;
+
+            /// @brief Computes the body's mass data.
+            /// @details This basically accumulates the mass data over all fixtures.
+            /// @return accumulated mass data for all fixtures associated with the given body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            MassData ComputeMassData(BodyID id) const;
+
+            /// @brief Set the mass properties to override the mass properties of the fixtures.
+            /// @note This changes the center of mass position.
+            /// @note Creating or destroying fixtures can also alter the mass.
+            /// @note This function has no effect if the body isn't dynamic.
+            /// @param id Identifier of the body to change.
+            /// @param massData the mass properties.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void SetMassData(BodyID id, const MassData& massData);
+
+            /// @brief Gets the body configuration for the identified body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            BodyConf GetBodyConf(BodyID id) const;
+
+            /// @brief Gets the range of all constant fixtures attached to the given body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            SizedRange<Fixtures::const_iterator> GetFixtures(BodyID id) const;
+
+            /// @brief Get the angle.
+            /// @return the current world rotation angle.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            Angle GetAngle(BodyID id) const;
+
+            /// @brief Gets the body's transformation.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see SetTransformation(BodyID id, Transformation xfm).
+            Transformation GetTransformation(BodyID id) const;
+
+            /// @brief Sets the transformation of the body.
+            /// @details This instantly adjusts the body to be at the new transformation.
+            /// @warning Manipulating a body's transformation can cause non-physical behavior!
+            /// @note Contacts are updated on the next call to World::Step.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see GetTransformation(BodyID id).
+            void SetTransformation(BodyID id, Transformation xfm);
+
+            /// @brief Gets the local position of the center of mass of the specified body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            Length2 GetLocalCenter(BodyID id) const;
+
+            /// @brief Gets the world position of the center of mass of the specified body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            Length2 GetWorldCenter(BodyID id) const;
+
+            /// @brief Gets the velocity of the identified body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see SetVelocity(BodyID id, const Velocity& value).
+            Velocity GetVelocity(BodyID id) const;
+
+            /// @brief Sets the body's velocity (linear and angular velocity).
+            /// @note This method does nothing if this body is not speedable.
+            /// @note A non-zero velocity will awaken this body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see GetVelocity(BodyID), SetAwake, SetUnderActiveTime.
+            void SetVelocity(BodyID id, const Velocity& value);
+
+            /// @brief Gets the awake/asleep state of this body.
+            /// @warning Being awake may or may not imply being speedable.
+            /// @return true if the body is awake.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            bool IsAwake(BodyID id) const;
+
+            /// @brief Wakes up the identified body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void SetAwake(BodyID id);
+
+            /// @brief Sleeps the identified body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see IsAwake(BodyID id), SetAwake(BodyID id).
+            void UnsetAwake(BodyID id);
+
+            /// @brief Gets this body's linear acceleration.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            LinearAcceleration2 GetLinearAcceleration(BodyID id) const;
+
+            /// @brief Gets this body's angular acceleration.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            AngularAcceleration GetAngularAcceleration(BodyID id) const;
+
+            /// @brief Sets the linear and rotational accelerations on the body.
+            /// @note This has no effect on non-accelerable bodies.
+            /// @note A non-zero acceleration will also awaken the body.
+            /// @param id Body whose acceleration should be set.
+            /// @param linear Linear acceleration.
+            /// @param angular Angular acceleration.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void SetAcceleration(BodyID id, LinearAcceleration2 linear, AngularAcceleration angular);
+
+            /// @brief Gets the linear damping of the body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            Frequency GetLinearDamping(BodyID id) const;
+
+            /// @brief Sets the linear damping of the body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void SetLinearDamping(BodyID id, NonNegative<Frequency> value);
+
+            /// @brief Gets the angular damping of the body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            Frequency GetAngularDamping(BodyID id) const;
+
+            /// @brief Sets the angular damping of the body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void SetAngularDamping(BodyID id, NonNegative<Frequency> angularDamping);
+
+            /// @brief Gets whether the body's mass-data is dirty.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            bool IsMassDataDirty(BodyID id) const;
+
+            /// @brief Gets whether the body has fixed rotation.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see SetFixedRotation(BodyID id, bool value).
+            bool IsFixedRotation(BodyID id) const;
+
+            /// @brief Sets the body to have fixed rotation.
+            /// @note This causes the mass to be reset.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see IsFixedRotation(BodyID id).
+            void SetFixedRotation(BodyID id, bool value);
+
+            /// @brief Gets the inverse total mass of the body.
+            /// @return Value of zero or more representing the body's inverse mass (in 1/kg).
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see SetMassData.
+            InvMass GetInvMass(BodyID id) const;
+
+            /// @brief Gets the inverse rotational inertia of the body.
+            /// @return Inverse rotational inertia (in 1/kg-m^2).
+            /// @throws std::out_of_range If given an invalid body identifier.
+            InvRotInertia GetInvRotInertia(BodyID id) const;
+
+            /// @brief Is identified body "speedable".
+            /// @details Is the body able to have a non-zero speed associated with it.
+            /// Kinematic and Dynamic bodies are speedable. Static bodies are not.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            bool IsSpeedable(BodyID id) const;
+
+            /// @brief Is identified body "accelerable"?
+            /// @details Indicates whether the body is accelerable, i.e. whether it is effected by
+            ///   forces. Only Dynamic bodies are accelerable.
+            /// @return true if the body is accelerable, false otherwise.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            bool IsAccelerable(BodyID id) const;
+
+            /// @brief Is the body treated like a bullet for continuous collision detection?
+            /// @throws std::out_of_range If given an invalid body identifier.
+            bool IsImpenetrable(BodyID id) const;
+
+            /// @brief Sets the bullet status of this body.
+            /// @details Sets that the body should be treated like a bullet for continuous
+            ///   collision detection.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void SetImpenetrable(BodyID id);
+
+            /// @brief Unsets the bullet status of this body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            void UnsetImpenetrable(BodyID id);
+
+            /// @brief Gets whether or not the identified body allowed to sleep.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see SetSleepingAllowed
+            bool IsSleepingAllowed(BodyID id) const;
+
+            /// @brief Sets whether sleeping is allowed for the identified body.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @see IsSleepingAllowed
+            void SetSleepingAllowed(BodyID id, bool value);
+
+            /// @brief Gets the container of all contacts attached to the body.
+            /// @warning This collection changes during the time step and you may
+            ///   miss some collisions if you don't use <code>ContactListener</code>.
+            /// @throws std::out_of_range If given an invalid body identifier.
+            SizedRange<Contacts::const_iterator> GetContacts(BodyID id) const;
+
+            ///@}
+
+            /// @name Fixture Member Functions
+            /// Member functions relating to fixtures.
+            ///@{
+
+            /// @brief Creates a fixture and attaches it to the given body.
+            /// @details Creates a fixture for attaching a shape and other characteristics to this
+            ///   body. Fixtures automatically go away when this body is destroyed. Fixtures can
+            ///   also be manually removed and destroyed using the
+            ///   <code>Destroy(FixtureID, bool)</code>, or <code>DestroyFixtures()</code> methods.
+            ///
+            /// @note This function should not be called if the world is locked.
+            /// @warning This function is locked during callbacks.
+            ///
+            /// @post After creating a new fixture, it will show up in the fixture enumeration
+            ///   returned by the <code>GetFixtures()</code> methods.
+            ///
+            /// @param body Identifier of the body to associate the new fixture with.
+            /// @param shape Shareable shape definition.
+            ///   Its vertex radius must be less than the minimum or more than the maximum allowed by
+            ///   the body's world.
+            /// @param def Initial fixture settings.
+            ///   Friction and density must be >= 0.
+            ///   Restitution must be > -infinity and < infinity.
+            /// @param resetMassData Whether or not to reset the mass data of the body.
+            ///
+            /// @return Identifier for the created fixture.
+            ///
+            /// @throws WrongState if called while the world is "locked".
+            /// @throws std::out_of_range If given an invalid body identifier.
+            /// @throws InvalidArgument if called for a shape with a vertex radius less than the
+            ///    minimum vertex radius.
+            /// @throws InvalidArgument if called for a shape with a vertex radius greater than the
+            ///    maximum vertex radius.
+            ///
+            /// @see Destroy(FixtureID), GetFixtures
+            /// @see PhysicalEntities
+            ///
+            FixtureID CreateFixture(BodyID body, const Shape& shape,
+                                    const FixtureConf& def = GetDefaultFixtureConf(),
+                                    bool resetMassData = true);
+
+            /// @brief Destroys the identified fixture.
+            ///
+            /// @details Destroys a fixture previously created by the
+            ///   <code>CreateFixture(const Shape&, const FixtureConf&, bool)</code>
+            ///   method. This removes the fixture from the broad-phase and destroys all contacts
+            ///   associated with this fixture. All fixtures attached to a body are implicitly
+            ///   destroyed when the body is destroyed.
+            ///
+            /// @warning This function is locked during callbacks.
+            /// @note Make sure to explicitly call <code>ResetMassData()</code> after fixtures have
+            ///   been destroyed if resetting the mass data is not requested via the reset mass data
+            ///   parameter.
+            /// @throws WrongState if this function is called while the world is locked.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            ///
+            /// @post After destroying a fixture, it will no longer show up in the fixture enumeration
+            ///   returned by the <code>GetFixtures()</code> methods.
+            ///
+            /// @param id the fixture to be removed.
+            /// @param resetMassData Whether or not to reset the mass data of the associated body.
+            ///
+            /// @see CreateFixture, Body::GetFixtures, Body::ResetMassData.
+            /// @see PhysicalEntities
+            ///
+            bool Destroy(FixtureID id, bool resetMassData = true);
+
+            /// @brief Gets the fixtures-for-proxies range for this world.
+            /// @details Provides insight on what fixtures have been queued for proxy processing
+            ///   during the next call to the world step method.
+            /// @see Step.
+            SizedRange<Fixtures::const_iterator> GetFixturesForProxies() const noexcept;
+
+            /// @brief Re-filter the fixture.
+            /// @note Call this if you want to establish collision that was previously disabled by
+            ///   <code>ShouldCollide(const Fixture&, const Fixture&)</code>.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            /// @see bool ShouldCollide(const Fixture& fixtureA, const Fixture& fixtureB) noexcept
+            void Refilter(FixtureID id);
+
+            /// @brief Gets the filter data for the identified fixture.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            Filter GetFilterData(FixtureID id) const;
+
+            /// @brief Sets the contact filtering data.
+            /// @note This won't update contacts until the next time step when either parent body
+            ///    is speedable and awake.
+            /// @note This automatically calls <code>Refilter</code>.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            void SetFilterData(FixtureID id, const Filter& filter);
+
+            /// @brief Gets the identifier of the body associated with the identified fixture.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            BodyID GetBody(FixtureID id) const;
+
+            /// @brief Gets the shape associated with the identified fixture.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            Shape GetShape(FixtureID id) const;
+
+            /// @brief Is the specified fixture a sensor (non-solid)?
+            /// @return the true if the fixture is a sensor.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            bool IsSensor(FixtureID id) const;
+
+            /// @brief Sets whether the fixture is a sensor or not.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            /// @see IsSensor(FixtureID id).
+            void SetSensor(FixtureID id, bool value);
+
+            /// @brief Gets the density value associated with the identified fixture.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            AreaDensity GetDensity(FixtureID id) const;
+
+            /// @brief Gets the proxies of the identified fixture.
+            /// @throws std::out_of_range If given an invalid fixture identifier.
+            const FixtureProxies& GetProxies(FixtureID id) const;
+
+            /// @}
+
+            /// @name Joint Member Functions
+            /// Member functions relating to joints.
+            ///@{
+
+            /// @brief Gets the world joint range.
+            /// @details Gets a range enumerating the joints currently existing within this world.
+            ///   These are the joints that had been created from previous calls to the
+            ///   <code>CreateJoint(const JointConf&)</code> method that haven't yet been destroyed.
+            /// @return World joints sized-range.
+            /// @see CreateJoint(const JointConf&).
+            SizedRange<Joints::const_iterator> GetJoints() const noexcept;
+
+            /// @brief Creates a joint to constrain one or more bodies.
+            /// @warning This function is locked during callbacks.
+            /// @post The created joint will be present in the range returned from the
+            ///   <code>GetJoints()</code> method.
+            /// @return Identifier of newly created joint which can later be destroyed by calling the
+            ///   <code>Destroy(JointID)</code> method.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @throws LengthError if this operation would create more than <code>MaxJoints</code>.
+            /// @see PhysicalEntities.
+            /// @see Destroy(JointID), GetJoints.
+            JointID CreateJoint(const Joint& def);
+
+            /// @brief Destroys the identified joint.
+            /// @details Destroys a given joint that had previously been created by a call to this
+            ///   world's <code>CreateJoint(const Joint&)</code> method.
+            /// @warning This function is locked during callbacks.
+            /// @note This may cause the connected bodies to begin colliding.
+            /// @post The destroyed joint will no longer be present in the range returned from the
+            ///   <code>GetJoints()</code> method.
+            /// @param id Joint to destroy that had been created by this world.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            /// @see CreateJoint(const Joint&), GetJoints.
+            /// @see PhysicalEntities.
+            void Destroy(JointID id);
+
+            /// @brief Gets the value of the identified joint.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            const Joint& GetJoint(JointID id) const;
+
+            /// @brief Sets the identified joint to the given value.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            void SetJoint(JointID id, const Joint& def);
+
+            /// @brief Wakes up the joined bodies.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            void SetAwake(JointID id);
+
+            /// @brief Gets collide connected for the specified joint.
+            /// @note Modifying the collide connect flag won't work correctly because
+            ///   the flag is only checked when fixture AABBs begin to overlap.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            bool GetCollideConnected(JointID id) const;
+
+            /// @brief Gets the type of the identified joint.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            JointType GetType(JointID id) const;
+
+            /// @brief Gets the identifier of body-A of the identified joint.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            BodyID GetBodyA(JointID id) const;
+
+            /// @brief Gets the identifier of body-B of the identified joint.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            BodyID GetBodyB(JointID id) const;
+
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            Length2 GetLocalAnchorA(JointID id) const;
+
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            Length2 GetLocalAnchorB(JointID id) const;
+
+            /// Gets the linear reaction on body-B at the joint anchor.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            Momentum2 GetLinearReaction(JointID id) const;
+
+            /// @brief Get the angular reaction on body-B for the identified joint.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            AngularMomentum GetAngularReaction(JointID id) const;
+
+            /// @brief Gets the reference angle of the identified joint.
+            /// @throws std::out_of_range If given an invalid joint identifier.
+            Angle GetReferenceAngle(JointID id) const;
+
+            /// @}
+
+            /// @name Contact Member Functions
+            /// Member functions relating to contacts.
+            ///@{
+
+            /// @brief Gets the world contact range.
+            /// @warning contacts are created and destroyed in the middle of a time step.
+            /// Use <code>ContactListener</code> to avoid missing contacts.
+            /// @return World contacts sized-range.
+            SizedRange<Contacts::const_iterator> GetContacts() const noexcept;
+
+            /// @brief Gets the awake status of the specified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            /// @see SetAwake(ContactID id)
+            bool IsAwake(ContactID id) const;
+
+            /// @brief Sets the awake status of the specified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            /// @see IsAwake(ContactID id)
+            void SetAwake(ContactID id);
+
+            /// @brief Gets the desired tangent speed.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            /// @see SetTangentSpeed(ContactID id, LinearVelocity value).
+            LinearVelocity GetTangentSpeed(ContactID id) const;
+
+            /// @brief Sets the desired tangent speed for a conveyor belt behavior.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            /// @see GetTangentSpeed(ContactID id) const.
+            void SetTangentSpeed(ContactID id, LinearVelocity value);
+
+            /// @brief Is this contact touching?
+            /// @details
+            /// Touching is defined as either:
+            ///   1. This contact's manifold has more than 0 contact points, or
+            ///   2. This contact has sensors and the two shapes of this contact are found to be
+            ///      overlapping.
+            /// @return true if this contact is said to be touching, false otherwise.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            bool IsTouching(ContactID id) const;
+
+            /// @brief Whether or not the contact needs filtering.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            bool NeedsFiltering(ContactID id) const;
+
+            /// @brief Whether or not the contact needs updating.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            bool NeedsUpdating(ContactID id) const;
+
+            /// @brief Gets body-A of the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            BodyID GetBodyA(ContactID id) const;
+
+            /// @brief Gets body-B of the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            BodyID GetBodyB(ContactID id) const;
+
+            /// @brief Gets fixture A of the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            FixtureID GetFixtureA(ContactID id) const;
+
+            /// @brief Gets fixture B of the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            FixtureID GetFixtureB(ContactID id) const;
+
+            /// @brief Get the child primitive index for fixture A.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            ChildCounter GetChildIndexA(ContactID id) const;
+
+            /// @brief Get the child primitive index for fixture B.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            ChildCounter GetChildIndexB(ContactID id) const;
+
+            /// @brief Whether or not the contact has a valid TOI.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            /// @see GetToi.
+            bool HasValidToi(ContactID id) const;
+
+            /// @brief Gets the time of impact (TOI) as a fraction.
+            /// @note This is only valid if a TOI has been set.
+            /// @return Time of impact fraction in the range of 0 to 1 if set (where 1
+            ///   means no actual impact in current time slot), otherwise undefined.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            Real GetToi(ContactID id) const;
+
+            /// @brief Gets the time of impact count of the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            TimestepIters GetToiCount(ContactID id) const;
+
+            /// @brief Gets the default friction value for the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            Real GetDefaultFriction(ContactID id) const;
+
+            /// @brief Gets the default restitution value for the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            Real GetDefaultRestitution(ContactID id) const;
+
+            /// @brief Gets the friction used with the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            /// @see SetFriction(ContactID id, Real value)
+            Real GetFriction(ContactID id) const;
+
+            /// @brief Gets the restitution used with the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            /// @see SetRestitution(ContactID id, Real value)
+            Real GetRestitution(ContactID id) const;
+
+            /// @brief Sets the friction value for the identified contact.
+            /// @details Overrides the default friction mixture.
+            /// @note You can call this in "pre-solve" listeners.
+            /// @note This value persists until set or reset.
+            /// @warning Behavior is undefined if given a negative friction value.
+            /// @param id Contact identifier.
+            /// @param value Co-efficient of friction value of zero or greater.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            void SetFriction(ContactID id, Real value);
+
+            /// @brief Sets the restitution value for the identified contact.
+            /// @details This override the default restitution mixture.
+            /// @note You can call this in "pre-solve" listeners.
+            /// @note The value persists until you set or reset.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            void SetRestitution(ContactID id, Real value);
+
+            /// @brief Gets the collision manifold for the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            const Manifold& GetManifold(ContactID id) const;
+
+            /// @brief Gets whether or not the identified contact is enabled.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            bool IsEnabled(ContactID id) const;
+
+            /// @brief Enables the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            void SetEnabled(ContactID id);
+
+            /// @brief Disables the identified contact.
+            /// @throws std::out_of_range If given an invalid contact identifier.
+            void UnsetEnabled(ContactID id);
+
+            /// @}
+
+         private:
+            /// @brief Pointer to implementation (PIMPL)
+            /// @see https://en.cppreference.com/w/cpp/language/pimpl
+            propagate_const<std::unique_ptr<WorldImpl>> m_impl;
+        };
+
+        /// @example HelloWorld.cpp
+        /// This is the source file for the <code>HelloWorld</code> application that demonstrates
+        /// use of the <code>playrho::d2::World</code> class and more.
+        /// After instantiating a world, the code creates a body and its fixture to act as the ground,
+        /// creates another body and a fixture for it to act like a ball, then steps the world using
+        /// the world <code>playrho::d2::World::Step(const StepConf&)</code> function which simulates a ball falling to the ground
+        /// and outputs the position of the ball after each step.
+
+        /// @example World.cpp
+        /// This is the <code>googletest</code> based unit testing file for the
+        /// <code>playrho::d2::World</code> class.
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_WORLD_HPP

--- a/PlayRho/Dynamics/WorldBody.cpp
+++ b/PlayRho/Dynamics/WorldBody.cpp
@@ -33,476 +33,476 @@ using std::sort;
 using std::transform;
 using std::unique;
 
-namespace playrho {
-namespace d2 {
-
-using playrho::size;
-
-BodyCounter GetBodyRange(const World& world) noexcept
+namespace playrho
 {
-    return world.GetBodyRange();
-}
-
-SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const World& world) noexcept
-{
-    return world.GetBodies();
-}
-
-SizedRange<std::vector<BodyID>::const_iterator>
-GetBodiesForProxies(const World& world) noexcept
-{
-    return world.GetBodiesForProxies();
-}
-
-BodyID CreateBody(World& world, const BodyConf& def)
-{
-    return world.CreateBody(def);
-}
-
-void Destroy(World& world, BodyID id)
-{
-    world.Destroy(id);
-}
-
-SizedRange<std::vector<FixtureID>::const_iterator>
-GetFixtures(const World& world, BodyID id)
-{
-    return world.GetFixtures(id);
-}
-
-LinearAcceleration2 GetLinearAcceleration(const World& world, BodyID id)
-{
-    return world.GetLinearAcceleration(id);
-}
-
-AngularAcceleration GetAngularAcceleration(const World& world, BodyID id)
-{
-    return world.GetAngularAcceleration(id);
-}
-
-Acceleration GetAcceleration(const World& world, BodyID id)
-{
-    return Acceleration{
-        world.GetLinearAcceleration(id),
-        world.GetAngularAcceleration(id)
-    };
-}
-
-void SetAcceleration(World& world, BodyID id,
-                     LinearAcceleration2 linear, AngularAcceleration angular)
-{
-    world.SetAcceleration(id, linear, angular);
-}
-
-void SetAcceleration(World& world, BodyID id, LinearAcceleration2 value)
-{
-    world.SetAcceleration(id, value, world.GetAngularAcceleration(id));
-}
-
-void SetAcceleration(World& world, BodyID id, AngularAcceleration value)
-{
-    world.SetAcceleration(id, world.GetLinearAcceleration(id), value);
-}
-
-void SetAcceleration(World& world, BodyID id, Acceleration value)
-{
-    world.SetAcceleration(id, value.linear, value.angular);
-}
-
-void SetTransformation(World& world, BodyID id, Transformation xfm)
-{
-    world.SetTransformation(id, xfm);
-}
-
-void SetLocation(World& world, BodyID body, Length2 value)
-{
-    SetTransform(world, body, value, GetAngle(world, body));
-}
-
-void SetAngle(World& world, BodyID body, Angle value)
-{
-    SetTransform(world, body, GetLocation(world, body), value);
-}
-
-void RotateAboutWorldPoint(World& world, BodyID body, Angle amount, Length2 worldPoint)
-{
-    const auto xfm = GetTransformation(world, body);
-    const auto p = xfm.p - worldPoint;
-    const auto c = cos(amount);
-    const auto s = sin(amount);
-    const auto x = GetX(p) * c - GetY(p) * s;
-    const auto y = GetX(p) * s + GetY(p) * c;
-    const auto pos = Length2{x, y} + worldPoint;
-    const auto angle = GetAngle(xfm.q) + amount;
-    SetTransform(world, body, pos, angle);
-}
-
-void RotateAboutLocalPoint(World& world, BodyID body, Angle amount, Length2 localPoint)
-{
-    RotateAboutWorldPoint(world, body, amount, GetWorldPoint(world, body, localPoint));
-}
-
-Acceleration CalcGravitationalAcceleration(const World& world, BodyID body)
-{
-    const auto m1 = GetMass(world, body);
-    if (m1 != 0_kg)
+    namespace d2
     {
-        auto sumForce = Force2{};
-        const auto loc1 = GetLocation(world, body);
-        for (const auto& b2: world.GetBodies())
+
+        using playrho::size;
+
+        BodyCounter GetBodyRange(const World& world) noexcept
         {
-            if (b2 == body)
+            return world.GetBodyRange();
+        }
+
+        SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const World& world) noexcept
+        {
+            return world.GetBodies();
+        }
+
+        SizedRange<std::vector<BodyID>::const_iterator>
+        GetBodiesForProxies(const World& world) noexcept
+        {
+            return world.GetBodiesForProxies();
+        }
+
+        BodyID CreateBody(World& world, const BodyConf& def)
+        {
+            return world.CreateBody(def);
+        }
+
+        void Destroy(World& world, BodyID id)
+        {
+            world.Destroy(id);
+        }
+
+        SizedRange<std::vector<FixtureID>::const_iterator>
+        GetFixtures(const World& world, BodyID id)
+        {
+            return world.GetFixtures(id);
+        }
+
+        LinearAcceleration2 GetLinearAcceleration(const World& world, BodyID id)
+        {
+            return world.GetLinearAcceleration(id);
+        }
+
+        AngularAcceleration GetAngularAcceleration(const World& world, BodyID id)
+        {
+            return world.GetAngularAcceleration(id);
+        }
+
+        Acceleration GetAcceleration(const World& world, BodyID id)
+        {
+            return Acceleration{
+                world.GetLinearAcceleration(id),
+                world.GetAngularAcceleration(id)};
+        }
+
+        void SetAcceleration(World& world, BodyID id,
+                             LinearAcceleration2 linear, AngularAcceleration angular)
+        {
+            world.SetAcceleration(id, linear, angular);
+        }
+
+        void SetAcceleration(World& world, BodyID id, LinearAcceleration2 value)
+        {
+            world.SetAcceleration(id, value, world.GetAngularAcceleration(id));
+        }
+
+        void SetAcceleration(World& world, BodyID id, AngularAcceleration value)
+        {
+            world.SetAcceleration(id, world.GetLinearAcceleration(id), value);
+        }
+
+        void SetAcceleration(World& world, BodyID id, Acceleration value)
+        {
+            world.SetAcceleration(id, value.linear, value.angular);
+        }
+
+        void SetTransformation(World& world, BodyID id, Transformation xfm)
+        {
+            world.SetTransformation(id, xfm);
+        }
+
+        void SetLocation(World& world, BodyID body, Length2 value)
+        {
+            SetTransform(world, body, value, GetAngle(world, body));
+        }
+
+        void SetAngle(World& world, BodyID body, Angle value)
+        {
+            SetTransform(world, body, GetLocation(world, body), value);
+        }
+
+        void RotateAboutWorldPoint(World& world, BodyID body, Angle amount, Length2 worldPoint)
+        {
+            const auto xfm = GetTransformation(world, body);
+            const auto p = xfm.p - worldPoint;
+            const auto c = cos(amount);
+            const auto s = sin(amount);
+            const auto x = GetX(p) * c - GetY(p) * s;
+            const auto y = GetX(p) * s + GetY(p) * c;
+            const auto pos = Length2{x, y} + worldPoint;
+            const auto angle = GetAngle(xfm.q) + amount;
+            SetTransform(world, body, pos, angle);
+        }
+
+        void RotateAboutLocalPoint(World& world, BodyID body, Angle amount, Length2 localPoint)
+        {
+            RotateAboutWorldPoint(world, body, amount, GetWorldPoint(world, body, localPoint));
+        }
+
+        Acceleration CalcGravitationalAcceleration(const World& world, BodyID body)
+        {
+            const auto m1 = GetMass(world, body);
+            if (m1 != 0_kg)
             {
-                continue;
+                auto sumForce = Force2{};
+                const auto loc1 = GetLocation(world, body);
+                for (const auto& b2 : world.GetBodies())
+                {
+                    if (b2 == body)
+                    {
+                        continue;
+                    }
+                    const auto m2 = GetMass(world, b2);
+                    const auto delta = GetLocation(world, b2) - loc1;
+                    const auto dir = GetUnitVector(delta);
+                    const auto rr = GetMagnitudeSquared(delta);
+
+                    // Uses Newton's law of universal gravitation: F = G * m1 * m2 / rr.
+                    // See: https://en.wikipedia.org/wiki/Newton%27s_law_of_universal_gravitation
+                    // Note that BigG is typically very small numerically compared to either mass
+                    // or the square of the radius between the masses. That's important to recognize
+                    // in order to avoid operational underflows or overflows especially when
+                    // playrho::Real has less exponential range like when it's defined to be float
+                    // instead of double. The operational ordering is deliberately established here
+                    // to help with this.
+                    const auto orderedMass = std::minmax(m1, m2);
+                    const auto f = (BigG * std::get<0>(orderedMass)) * (std::get<1>(orderedMass) / rr);
+                    sumForce += f * dir;
+                }
+                // F = m a... i.e.  a = F / m.
+                return Acceleration{sumForce / m1, 0 * RadianPerSquareSecond};
             }
-            const auto m2 = GetMass(world, b2);
-            const auto delta = GetLocation(world, b2) - loc1;
-            const auto dir = GetUnitVector(delta);
-            const auto rr = GetMagnitudeSquared(delta);
-
-            // Uses Newton's law of universal gravitation: F = G * m1 * m2 / rr.
-            // See: https://en.wikipedia.org/wiki/Newton%27s_law_of_universal_gravitation
-            // Note that BigG is typically very small numerically compared to either mass
-            // or the square of the radius between the masses. That's important to recognize
-            // in order to avoid operational underflows or overflows especially when
-            // playrho::Real has less exponential range like when it's defined to be float
-            // instead of double. The operational ordering is deliberately established here
-            // to help with this.
-            const auto orderedMass = std::minmax(m1, m2);
-            const auto f = (BigG * std::get<0>(orderedMass)) * (std::get<1>(orderedMass) / rr);
-            sumForce += f * dir;
+            return Acceleration{};
         }
-        // F = m a... i.e.  a = F / m.
-        return Acceleration{sumForce / m1, 0 * RadianPerSquareSecond};
-    }
-    return Acceleration{};
-}
 
-BodyCounter GetWorldIndex(const World& world, BodyID id) noexcept
-{
-    const auto elems = world.GetBodies();
-    const auto it = std::find(cbegin(elems), cend(elems), id);
-    if (it != cend(elems))
-    {
-        return static_cast<BodyCounter>(std::distance(cbegin(elems), it));
-    }
-    return BodyCounter(-1);
-}
-
-BodyConf GetBodyConf(const World& world, BodyID id)
-{
-    return world.GetBodyConf(id);
-}
-
-void SetType(World& world, BodyID id, BodyType value)
-{
-    world.SetType(id, value);
-}
-
-BodyType GetType(const World& world, BodyID id)
-{
-    return world.GetType(id);
-}
-
-Transformation GetTransformation(const World& world, BodyID id)
-{
-    return world.GetTransformation(id);
-}
-
-Angle GetAngle(const World& world, BodyID id)
-{
-    return world.GetAngle(id);
-}
-
-Velocity GetVelocity(const World& world, BodyID id)
-{
-    return world.GetVelocity(id);
-}
-
-void SetVelocity(World& world, BodyID id, const Velocity& value)
-{
-    world.SetVelocity(id, value);
-}
-
-void SetVelocity(World& world, BodyID id, const LinearVelocity2& value)
-{
-    world.SetVelocity(id, Velocity{value, GetVelocity(world, id).angular});
-}
-
-void SetVelocity(World& world, BodyID id, AngularVelocity value)
-{
-    world.SetVelocity(id, Velocity{GetVelocity(world, id).linear, value});
-}
-
-void DestroyFixtures(World& world, BodyID id)
-{
-    world.DestroyFixtures(id);
-}
-
-bool IsEnabled(const World& world, BodyID id)
-{
-    return world.IsEnabled(id);
-}
-
-void SetEnabled(World& world, BodyID id, bool value)
-{
-    world.SetEnabled(id, value);
-}
-
-bool IsAwake(const World& world, BodyID id)
-{
-    return world.IsAwake(id);
-}
-
-void SetAwake(World& world, BodyID id)
-{
-    world.SetAwake(id);
-}
-
-void UnsetAwake(World& world, BodyID id)
-{
-    world.UnsetAwake(id);
-}
-
-bool IsMassDataDirty(const World& world, BodyID id)
-{
-    return world.IsMassDataDirty(id);
-}
-
-bool IsFixedRotation(const World& world, BodyID id)
-{
-    return world.IsFixedRotation(id);
-}
-
-void SetFixedRotation(World& world, BodyID id, bool value)
-{
-    world.SetFixedRotation(id, value);
-}
-
-Length2 GetWorldCenter(const World& world, BodyID id)
-{
-    return world.GetWorldCenter(id);
-}
-
-InvMass GetInvMass(const World& world, BodyID id)
-{
-    return world.GetInvMass(id);
-}
-
-InvRotInertia GetInvRotInertia(const World& world, BodyID id)
-{
-    return world.GetInvRotInertia(id);
-}
-
-Length2 GetLocalCenter(const World& world, BodyID id)
-{
-    return world.GetLocalCenter(id);
-}
-
-MassData ComputeMassData(const World& world, BodyID id)
-{
-    return world.ComputeMassData(id);
-}
-
-void SetMassData(World& world, BodyID id, const MassData& massData)
-{
-    world.SetMassData(id, massData);
-}
-
-SizedRange<std::vector<std::pair<BodyID, JointID>>::const_iterator>
-GetJoints(const World& world, BodyID id)
-{
-    return world.GetJoints(id);
-}
-
-bool IsSpeedable(const World& world, BodyID id)
-{
-    return world.IsSpeedable(id);
-}
-
-bool IsAccelerable(const World& world, BodyID id)
-{
-    return world.IsAccelerable(id);
-}
-
-bool IsImpenetrable(const World& world, BodyID id)
-{
-    return world.IsImpenetrable(id);
-}
-
-void SetImpenetrable(World& world, BodyID id)
-{
-    world.SetImpenetrable(id);
-}
-
-void UnsetImpenetrable(World& world, BodyID id)
-{
-    world.UnsetImpenetrable(id);
-}
-
-bool IsSleepingAllowed(const World& world, BodyID id)
-{
-    return world.IsSleepingAllowed(id);
-}
-
-void SetSleepingAllowed(World& world, BodyID id, bool value)
-{
-    world.SetSleepingAllowed(id, value);
-}
-
-Frequency GetLinearDamping(const World& world, BodyID id)
-{
-    return world.GetLinearDamping(id);
-}
-
-void SetLinearDamping(World& world, BodyID id, NonNegative<Frequency> value)
-{
-    world.SetLinearDamping(id, value);
-}
-
-Frequency GetAngularDamping(const World& world, BodyID id)
-{
-    return world.GetAngularDamping(id);
-}
-
-void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> value)
-{
-    world.SetAngularDamping(id, value);
-}
-
-SizedRange<std::vector<KeyedContactPtr>::const_iterator>
-GetContacts(const World& world, BodyID id)
-{
-    return world.GetContacts(id);
-}
-
-bool ShouldCollide(const World& world, BodyID lhs, BodyID rhs)
-{
-    // At least one body should be accelerable/dynamic.
-    if (!IsAccelerable(GetType(world, lhs)) && !IsAccelerable(GetType(world, rhs)))
-    {
-        return false;
-    }
-
-    // Does a joint prevent collision?
-    const auto joints = GetJoints(world, lhs);
-    const auto it = std::find_if(cbegin(joints), cend(joints), [&](const auto& ji) {
-        return (std::get<BodyID>(ji) == rhs) && !world.GetCollideConnected(std::get<JointID>(ji));
-    });
-    return it == end(joints);
-}
-
-Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis)
-{
-    // For background on centripetal force, see:
-    //   https://en.wikipedia.org/wiki/Centripetal_force
-
-    // Force is M L T^-2.
-    const auto velocity = GetLinearVelocity(world, id);
-    const auto magnitudeOfVelocity = GetMagnitude(GetVec2(velocity)) * MeterPerSecond;
-    const auto location = GetLocation(world, id);
-    const auto mass = GetMass(world, id);
-    const auto delta = axis - location;
-    const auto invRadius = Real{1} / GetMagnitude(delta);
-    const auto dir = delta * invRadius;
-    return Force2{dir * mass * Square(magnitudeOfVelocity) * invRadius};
-}
-
-void ApplyForce(World& world, BodyID id, Force2 force, Length2 point)
-{
-    // Torque is L^2 M T^-2 QP^-1.
-    const auto linAccel = LinearAcceleration2{force * world.GetInvMass(id)};
-    const auto invRotI = world.GetInvRotInertia(id); // L^-2 M^-1 QP^2
-    const auto dp = Length2{point - world.GetWorldCenter(id)}; // L
-    const auto cp = Torque{Cross(dp, force) / Radian}; // L * M L T^-2 is L^2 M T^-2
-                                                       // L^2 M T^-2 QP^-1 * L^-2 M^-1 QP^2 = QP T^-2;
-    const auto angAccel = AngularAcceleration{cp * invRotI};
-    SetAcceleration(world, id,
-                    GetLinearAcceleration(world, id) + linAccel,
-                    GetAngularAcceleration(world, id) + angAccel);
-}
-
-void ApplyTorque(World& world, BodyID id, Torque torque)
-{
-    const auto linAccel = GetLinearAcceleration(world, id);
-    const auto invRotI = GetInvRotInertia(world, id);
-    const auto angAccel = GetAngularAcceleration(world, id) + torque * invRotI;
-    SetAcceleration(world, id, linAccel, angAccel);
-}
-
-void ApplyLinearImpulse(World& world, BodyID id, Momentum2 impulse, Length2 point)
-{
-    auto velocity = GetVelocity(world, id);
-    velocity.linear += GetInvMass(world, id) * impulse;
-    const auto invRotI = GetInvRotInertia(world, id);
-    const auto dp = point - GetWorldCenter(world, id);
-    velocity.angular += AngularVelocity{invRotI * Cross(dp, impulse) / Radian};
-    SetVelocity(world, id, velocity);
-}
-
-void ApplyAngularImpulse(World& world, BodyID id, AngularMomentum impulse)
-{
-    auto velocity = GetVelocity(world, id);
-    const auto invRotI = GetInvRotInertia(world, id);
-    velocity.angular += AngularVelocity{invRotI * impulse};
-    SetVelocity(world, id, velocity);
-}
-
-BodyCounter GetAwakeCount(const World& world) noexcept
-{
-    const auto bodies = world.GetBodies();
-    return static_cast<BodyCounter>(count_if(cbegin(bodies), cend(bodies),
-                                             [&](const auto &b) {
-        return IsAwake(world, b); }));
-}
-
-BodyCounter Awaken(World& world) noexcept
-{
-    // Can't use count_if since body gets modified.
-    auto awoken = BodyCounter{0};
-    const auto bodies = world.GetBodies();
-    for_each(begin(bodies), end(bodies), [&world,&awoken](const auto &b) {
-        if (::playrho::d2::Awaken(world, b))
+        BodyCounter GetWorldIndex(const World& world, BodyID id) noexcept
         {
-            ++awoken;
+            const auto elems = world.GetBodies();
+            const auto it = std::find(cbegin(elems), cend(elems), id);
+            if (it != cend(elems))
+            {
+                return static_cast<BodyCounter>(std::distance(cbegin(elems), it));
+            }
+            return BodyCounter(-1);
         }
-    });
-    return awoken;
-}
 
-void SetAccelerations(World& world, Acceleration acceleration) noexcept
-{
-    const auto bodies = world.GetBodies();
-    for_each(begin(bodies), end(bodies), [&world, acceleration](const auto &b) {
-        SetAcceleration(world, b, acceleration);
-    });
-}
-
-void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept
-{
-    const auto bodies = world.GetBodies();
-    for_each(begin(bodies), end(bodies), [&world, acceleration](const auto &b) {
-        SetAcceleration(world, b, acceleration);
-    });
-}
-
-BodyID FindClosestBody(const World& world, Length2 location) noexcept
-{
-    const auto bodies = world.GetBodies();
-    auto found = InvalidBodyID;
-    auto minLengthSquared = std::numeric_limits<Area>::infinity();
-    for (const auto& body: bodies)
-    {
-        const auto bodyLoc = GetLocation(world, body);
-        const auto lengthSquared = GetMagnitudeSquared(bodyLoc - location);
-        if (minLengthSquared > lengthSquared)
+        BodyConf GetBodyConf(const World& world, BodyID id)
         {
-            minLengthSquared = lengthSquared;
-            found = body;
+            return world.GetBodyConf(id);
         }
-    }
-    return found;
-}
 
-} // namespace d2
-} // namespace playrho
+        void SetType(World& world, BodyID id, BodyType value)
+        {
+            world.SetType(id, value);
+        }
+
+        BodyType GetType(const World& world, BodyID id)
+        {
+            return world.GetType(id);
+        }
+
+        Transformation GetTransformation(const World& world, BodyID id)
+        {
+            return world.GetTransformation(id);
+        }
+
+        Angle GetAngle(const World& world, BodyID id)
+        {
+            return world.GetAngle(id);
+        }
+
+        Velocity GetVelocity(const World& world, BodyID id)
+        {
+            return world.GetVelocity(id);
+        }
+
+        void SetVelocity(World& world, BodyID id, const Velocity& value)
+        {
+            world.SetVelocity(id, value);
+        }
+
+        void SetVelocity(World& world, BodyID id, const LinearVelocity2& value)
+        {
+            world.SetVelocity(id, Velocity{value, GetVelocity(world, id).angular});
+        }
+
+        void SetVelocity(World& world, BodyID id, AngularVelocity value)
+        {
+            world.SetVelocity(id, Velocity{GetVelocity(world, id).linear, value});
+        }
+
+        void DestroyFixtures(World& world, BodyID id)
+        {
+            world.DestroyFixtures(id);
+        }
+
+        bool IsEnabled(const World& world, BodyID id)
+        {
+            return world.IsEnabled(id);
+        }
+
+        void SetEnabled(World& world, BodyID id, bool value)
+        {
+            world.SetEnabled(id, value);
+        }
+
+        bool IsAwake(const World& world, BodyID id)
+        {
+            return world.IsAwake(id);
+        }
+
+        void SetAwake(World& world, BodyID id)
+        {
+            world.SetAwake(id);
+        }
+
+        void UnsetAwake(World& world, BodyID id)
+        {
+            world.UnsetAwake(id);
+        }
+
+        bool IsMassDataDirty(const World& world, BodyID id)
+        {
+            return world.IsMassDataDirty(id);
+        }
+
+        bool IsFixedRotation(const World& world, BodyID id)
+        {
+            return world.IsFixedRotation(id);
+        }
+
+        void SetFixedRotation(World& world, BodyID id, bool value)
+        {
+            world.SetFixedRotation(id, value);
+        }
+
+        Length2 GetWorldCenter(const World& world, BodyID id)
+        {
+            return world.GetWorldCenter(id);
+        }
+
+        InvMass GetInvMass(const World& world, BodyID id)
+        {
+            return world.GetInvMass(id);
+        }
+
+        InvRotInertia GetInvRotInertia(const World& world, BodyID id)
+        {
+            return world.GetInvRotInertia(id);
+        }
+
+        Length2 GetLocalCenter(const World& world, BodyID id)
+        {
+            return world.GetLocalCenter(id);
+        }
+
+        MassData ComputeMassData(const World& world, BodyID id)
+        {
+            return world.ComputeMassData(id);
+        }
+
+        void SetMassData(World& world, BodyID id, const MassData& massData)
+        {
+            world.SetMassData(id, massData);
+        }
+
+        SizedRange<std::vector<std::pair<BodyID, JointID>>::const_iterator>
+        GetJoints(const World& world, BodyID id)
+        {
+            return world.GetJoints(id);
+        }
+
+        bool IsSpeedable(const World& world, BodyID id)
+        {
+            return world.IsSpeedable(id);
+        }
+
+        bool IsAccelerable(const World& world, BodyID id)
+        {
+            return world.IsAccelerable(id);
+        }
+
+        bool IsImpenetrable(const World& world, BodyID id)
+        {
+            return world.IsImpenetrable(id);
+        }
+
+        void SetImpenetrable(World& world, BodyID id)
+        {
+            world.SetImpenetrable(id);
+        }
+
+        void UnsetImpenetrable(World& world, BodyID id)
+        {
+            world.UnsetImpenetrable(id);
+        }
+
+        bool IsSleepingAllowed(const World& world, BodyID id)
+        {
+            return world.IsSleepingAllowed(id);
+        }
+
+        void SetSleepingAllowed(World& world, BodyID id, bool value)
+        {
+            world.SetSleepingAllowed(id, value);
+        }
+
+        Frequency GetLinearDamping(const World& world, BodyID id)
+        {
+            return world.GetLinearDamping(id);
+        }
+
+        void SetLinearDamping(World& world, BodyID id, NonNegative<Frequency> value)
+        {
+            world.SetLinearDamping(id, value);
+        }
+
+        Frequency GetAngularDamping(const World& world, BodyID id)
+        {
+            return world.GetAngularDamping(id);
+        }
+
+        void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> value)
+        {
+            world.SetAngularDamping(id, value);
+        }
+
+        SizedRange<std::vector<KeyedContactPtr>::const_iterator>
+        GetContacts(const World& world, BodyID id)
+        {
+            return world.GetContacts(id);
+        }
+
+        bool ShouldCollide(const World& world, BodyID lhs, BodyID rhs)
+        {
+            // At least one body should be accelerable/dynamic.
+            if (!IsAccelerable(GetType(world, lhs)) && !IsAccelerable(GetType(world, rhs)))
+            {
+                return false;
+            }
+
+            // Does a joint prevent collision?
+            const auto joints = GetJoints(world, lhs);
+            const auto it = std::find_if(cbegin(joints), cend(joints), [&](const auto& ji) {
+                return (std::get<BodyID>(ji) == rhs) && !world.GetCollideConnected(std::get<JointID>(ji));
+            });
+            return it == end(joints);
+        }
+
+        Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis)
+        {
+            // For background on centripetal force, see:
+            //   https://en.wikipedia.org/wiki/Centripetal_force
+
+            // Force is M L T^-2.
+            const auto velocity = GetLinearVelocity(world, id);
+            const auto magnitudeOfVelocity = GetMagnitude(GetVec2(velocity)) * MeterPerSecond;
+            const auto location = GetLocation(world, id);
+            const auto mass = GetMass(world, id);
+            const auto delta = axis - location;
+            const auto invRadius = Real{1} / GetMagnitude(delta);
+            const auto dir = delta * invRadius;
+            return Force2{dir * mass * Square(magnitudeOfVelocity) * invRadius};
+        }
+
+        void ApplyForce(World& world, BodyID id, Force2 force, Length2 point)
+        {
+            // Torque is L^2 M T^-2 QP^-1.
+            const auto linAccel = LinearAcceleration2{force * world.GetInvMass(id)};
+            const auto invRotI = world.GetInvRotInertia(id);          // L^-2 M^-1 QP^2
+            const auto dp = Length2{point - world.GetWorldCenter(id)};// L
+            const auto cp = Torque{Cross(dp, force) / Radian};        // L * M L T^-2 is L^2 M T^-2
+                                                                      // L^2 M T^-2 QP^-1 * L^-2 M^-1 QP^2 = QP T^-2;
+            const auto angAccel = AngularAcceleration{cp * invRotI};
+            SetAcceleration(world, id,
+                            GetLinearAcceleration(world, id) + linAccel,
+                            GetAngularAcceleration(world, id) + angAccel);
+        }
+
+        void ApplyTorque(World& world, BodyID id, Torque torque)
+        {
+            const auto linAccel = GetLinearAcceleration(world, id);
+            const auto invRotI = GetInvRotInertia(world, id);
+            const auto angAccel = GetAngularAcceleration(world, id) + torque * invRotI;
+            SetAcceleration(world, id, linAccel, angAccel);
+        }
+
+        void ApplyLinearImpulse(World& world, BodyID id, Momentum2 impulse, Length2 point)
+        {
+            auto velocity = GetVelocity(world, id);
+            velocity.linear += GetInvMass(world, id) * impulse;
+            const auto invRotI = GetInvRotInertia(world, id);
+            const auto dp = point - GetWorldCenter(world, id);
+            velocity.angular += AngularVelocity{invRotI * Cross(dp, impulse) / Radian};
+            SetVelocity(world, id, velocity);
+        }
+
+        void ApplyAngularImpulse(World& world, BodyID id, AngularMomentum impulse)
+        {
+            auto velocity = GetVelocity(world, id);
+            const auto invRotI = GetInvRotInertia(world, id);
+            velocity.angular += AngularVelocity{invRotI * impulse};
+            SetVelocity(world, id, velocity);
+        }
+
+        BodyCounter GetAwakeCount(const World& world) noexcept
+        {
+            const auto bodies = world.GetBodies();
+            return static_cast<BodyCounter>(count_if(cbegin(bodies), cend(bodies),
+                                                     [&](const auto& b) { return IsAwake(world, b); }));
+        }
+
+        BodyCounter Awaken(World& world) noexcept
+        {
+            // Can't use count_if since body gets modified.
+            auto awoken = BodyCounter{0};
+            const auto bodies = world.GetBodies();
+            for_each(begin(bodies), end(bodies), [&world, &awoken](const auto& b) {
+                if (::playrho::d2::Awaken(world, b))
+                {
+                    ++awoken;
+                }
+            });
+            return awoken;
+        }
+
+        void SetAccelerations(World& world, Acceleration acceleration) noexcept
+        {
+            const auto bodies = world.GetBodies();
+            for_each(begin(bodies), end(bodies), [&world, acceleration](const auto& b) {
+                SetAcceleration(world, b, acceleration);
+            });
+        }
+
+        void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept
+        {
+            const auto bodies = world.GetBodies();
+            for_each(begin(bodies), end(bodies), [&world, acceleration](const auto& b) {
+                SetAcceleration(world, b, acceleration);
+            });
+        }
+
+        BodyID FindClosestBody(const World& world, Length2 location) noexcept
+        {
+            const auto bodies = world.GetBodies();
+            auto found = InvalidBodyID;
+            auto minLengthSquared = std::numeric_limits<Area>::infinity();
+            for (const auto& body : bodies)
+            {
+                const auto bodyLoc = GetLocation(world, body);
+                const auto lengthSquared = GetMagnitudeSquared(bodyLoc - location);
+                if (minLengthSquared > lengthSquared)
+                {
+                    minLengthSquared = lengthSquared;
+                    found = body;
+                }
+            }
+            return found;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldBody.hpp
+++ b/PlayRho/Dynamics/WorldBody.hpp
@@ -26,739 +26,741 @@
 /// Declarations of free functions of World for bodies identified by <code>BodyID</code>.
 
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Range.hpp> // for SizedRange
+#include <PlayRho/Common/Range.hpp>// for SizedRange
 
 #include <PlayRho/Collision/MassData.hpp>
 
+#include <PlayRho/Dynamics/BodyConf.hpp>// for GetDefaultBodyConf
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
+#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp>// for KeyedContactPtr
 #include <PlayRho/Dynamics/FixtureConf.hpp>
-#include <PlayRho/Dynamics/BodyConf.hpp> // for GetDefaultBodyConf
-#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp> // for KeyedContactPtr
+#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 
+#include <functional>
 #include <iterator>
 #include <vector>
-#include <functional>
 
-namespace playrho {
-namespace d2 {
-
-class World;
-class Shape;
-
-/// @example WorldBody.cpp
-/// This is the <code>googletest</code> based unit testing file for the free function
-///   interfaces to <code>playrho::d2::World</code> body member functions and additional
-///   functionality.
-
-/// @defgroup WorldBodyFreeFunctions World Body Related Free Functions
-/// @brief Collection of "free" functions related to bodies within a <code>World</code>.
-/// @details This is a collection of non-member non-friend functions - also called "free"
-///   functions - that are related to bodies within an instance of a <code>World</code>.
-///   Many are just "wrappers" to similarly named member functions but some are additional
-///   functionality built on those member functions. A benefit to using free functions that
-///   are now just wrappers, is that of helping to isolate your code from future changes that
-///   might occur to the underlying <code>World</code> member functions. Free functions in
-///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
-///   when compiled without any compiler optimizations enabled, enabling optimizations
-///   should entirely eliminate that overhead.
-/// @note The four basic categories of these functions are "CRUD": create, read, update,
-///   and delete.
-/// @see World, BodyID.
-/// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
-/// @{
-
-/// @brief Gets the extent of the currently valid body range.
-/// @note This is one higher than the maxium BodyID that is in range for body related
-///   functions.
-/// @relatedalso World
-BodyCounter GetBodyRange(const World& world) noexcept;
-
-/// @brief Gets the bodies of the specified world.
-/// @relatedalso World
-SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const World& world) noexcept;
-
-/// @brief Gets the bodies-for-proxies range for the given world.
-/// @relatedalso World
-SizedRange<std::vector<BodyID>::const_iterator>
-GetBodiesForProxies(const World& world) noexcept;
-
-/// @brief Creates a rigid body with the given configuration.
-/// @warning This function should not be used while the world is locked &mdash; as it is
-///   during callbacks. If it is, it will throw an exception or abort your program.
-/// @note No references to the configuration are retained. Its value is copied.
-/// @post The created body will be present in the range returned from the
-///   <code>GetBodies(const World&)</code> method.
-/// @param world The world within which to create the body.
-/// @param def A customized body configuration or its default value.
-/// @return Identifier of the newly created body which can later be destroyed by calling
-///   the <code>Destroy(World&, BodyID)</code> method.
-/// @throws WrongState if this method is called while the world is locked.
-/// @throws LengthError if this operation would create more than <code>MaxBodies</code>.
-/// @see Destroy(BodyID), GetBodies(const World&).
-/// @see PhysicalEntities.
-/// @relatedalso World
-BodyID CreateBody(World& world, const BodyConf& def = GetDefaultBodyConf());
-
-/// @brief Destroys the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see CreateBody(World&, const BodyConf&).
-/// @relatedalso World
-void Destroy(World& world, BodyID id);
-
-/// @brief Gets the range of all constant fixtures attached to the given body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-SizedRange<std::vector<FixtureID>::const_iterator> GetFixtures(const World& world, BodyID id);
-
-/// @brief Gets the count of fixtures associated with the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline FixtureCounter GetFixtureCount(const World& world, BodyID id)
+namespace playrho
 {
-    using std::size;
-    return static_cast<FixtureCounter>(size(GetFixtures(world, id)));
-}
-
-/// @copydoc World::GetLinearAcceleration
-/// @relatedalso World
-LinearAcceleration2 GetLinearAcceleration(const World& world, BodyID id);
-
-/// @copydoc World::GetAngularAcceleration
-/// @relatedalso World
-AngularAcceleration GetAngularAcceleration(const World& world, BodyID id);
-
-/// @brief Gets the acceleration of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-Acceleration GetAcceleration(const World& world, BodyID id);
-
-/// @brief Sets the linear and rotational accelerations on the body.
-/// @note This has no effect on non-accelerable bodies.
-/// @note A non-zero acceleration will also awaken the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetAcceleration(World& world, BodyID id,
-                     LinearAcceleration2 linear, AngularAcceleration angular);
-
-/// @brief Sets the linear accelerations on the body.
-/// @note This has no effect on non-accelerable bodies.
-/// @note A non-zero acceleration will also awaken the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetAcceleration(World& world, BodyID id, LinearAcceleration2 value);
-
-/// @brief Sets the rotational accelerations on the body.
-/// @note This has no effect on non-accelerable bodies.
-/// @note A non-zero acceleration will also awaken the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetAcceleration(World& world, BodyID id, AngularAcceleration value);
-
-/// @brief Sets the accelerations on the given body.
-/// @note This has no effect on non-accelerable bodies.
-/// @note A non-zero acceleration will also awaken the body.
-/// @param world The world in which the identified body's acceleration should be set.
-/// @param id Body whose acceleration should be set.
-/// @param value Acceleration value to set.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetAcceleration(World& world, BodyID id, Acceleration value);
-
-/// @brief Sets the body's transformation.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see GetTransformation
-/// @relatedalso World
-void SetTransformation(World& world, BodyID id, Transformation xfm);
-
-/// @brief Sets the position of the body's origin and rotation.
-/// @details This instantly adjusts the body to be at the new position and new orientation.
-/// @warning Manipulating a body's transform can cause non-physical behavior!
-/// @note Contacts are updated on the next call to World::Step.
-/// @param world The world in which the identified body's transform should be set.
-/// @param id Body whose transform is to be set.
-/// @param location Valid world location of the body's local origin. Behavior is undefined
-///   if value is invalid.
-/// @param angle Valid world rotation. Behavior is undefined if value is invalid.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline void SetTransform(World& world, BodyID id, Length2 location, Angle angle)
-{
-    SetTransformation(world, id, Transformation{location, UnitVec::Get(angle)});
-}
-
-/// @brief Sets the body's location.
-/// @details This instantly adjusts the body to be at the new location.
-/// @warning Manipulating a body's location this way can cause non-physical behavior!
-/// @param world The world in which the identified body's location should be set.
-/// @param id Body to move.
-/// @param value Valid world location of the body's local origin. Behavior is undefined
-///   if value is invalid.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see Body::SetTransform
-/// @relatedalso World
-void SetLocation(World& world, BodyID id, Length2 value);
-
-/// @brief Sets the body's angular orientation.
-/// @details This instantly adjusts the body to be at the new angular orientation.
-/// @warning Manipulating a body's angle this way can cause non-physical behavior!
-/// @param world The world in which the identified body's angle should be set.
-/// @param id Body to move.
-/// @param value Valid world angle of the body's local origin. Behavior is undefined
-///   if value is invalid.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see Body::SetTransform
-/// @relatedalso World
-void SetAngle(World& world, BodyID id, Angle value);
-
-/// @brief Rotates a body a given amount around a point in world coordinates.
-/// @details This changes both the linear and angular positions of the body.
-/// @note Manipulating a body's position this way may cause non-physical behavior.
-/// @param world The world in which the identified body exists.
-/// @param id Body to rotate.
-/// @param amount Amount to rotate body by (in counter-clockwise direction).
-/// @param worldPoint Point in world coordinates.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, Length2 worldPoint);
-
-/// @brief Rotates a body a given amount around a point in body local coordinates.
-/// @details This changes both the linear and angular positions of the body.
-/// @note Manipulating a body's position this way may cause non-physical behavior.
-/// @note This is a convenience function that translates the local point into world coordinates
-///   and then calls the <code>RotateAboutWorldPoint</code> function.
-/// @param world The world in which the identified body exists.
-/// @param id Body to rotate.
-/// @param amount Amount to rotate body by (in counter-clockwise direction).
-/// @param localPoint Point in local coordinates.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void RotateAboutLocalPoint(World& world, BodyID id, Angle amount, Length2 localPoint);
-
-/// @brief Calculates the gravitationally associated acceleration for the given body within its world.
-/// @return Zero acceleration if given body is has no mass, else the acceleration of
-///    the body due to the gravitational attraction to the other bodies.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-Acceleration CalcGravitationalAcceleration(const World& world, BodyID id);
-
-/// @brief Gets the world index for the given body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-BodyCounter GetWorldIndex(const World& world, const BodyID id) noexcept;
-
-/// @brief Gets the body configuration for the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-BodyConf GetBodyConf(const World& world, BodyID id);
-
-/// @copydoc World::SetType
-/// @see GetType(const World& world, BodyID id)
-/// @relatedalso World
-void SetType(World& world, BodyID id, BodyType value);
-
-/// @copydoc World::GetType
-/// @see SetType(World& world, BodyID id, BodyType value)
-/// @relatedalso World
-BodyType GetType(const World& world, BodyID id);
-
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see SetTransformation
-/// @relatedalso World
-Transformation GetTransformation(const World& world, BodyID id);
-
-/// @brief Convenience function for getting just the location of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline Length2 GetLocation(const World& world, BodyID id)
-{
-    return GetTransformation(world, id).p;
-}
-
-/// @brief Gets the world coordinates of a point given in coordinates relative to the body's origin.
-/// @param world World context.
-/// @param id Body that the given point is relative to.
-/// @param localPoint a point measured relative the the body's origin.
-/// @return the same point expressed in world coordinates.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline Length2 GetWorldPoint(const World& world, BodyID id, const Length2 localPoint)
-{
-    return Transform(localPoint, GetTransformation(world, id));
-}
-
-/// @brief Convenience function for getting the local vector of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline UnitVec GetLocalVector(const World& world, BodyID body, const UnitVec uv)
-{
-    return InverseRotate(uv, GetTransformation(world, body).q);
-}
-
-/// @brief Gets a local point relative to the body's origin given a world point.
-/// @param world The world in which the identified body exists.
-/// @param body Body that the returned point should be relative to.
-/// @param worldPoint point in world coordinates.
-/// @return the corresponding local point relative to the body's origin.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline Length2 GetLocalPoint(const World& world, BodyID body, const Length2 worldPoint)
-{
-    return InverseTransform(worldPoint, GetTransformation(world, body));
-}
-
-/// @copydoc World::GetAngle
-/// @relatedalso World
-Angle GetAngle(const World& world, BodyID id);
-
-/// @brief Convenience function for getting the position of the identified body.
-inline Position GetPosition(const World& world, BodyID id)
-{
-    return Position{GetLocation(world, id), GetAngle(world, id)};
-}
-
-/// @brief Convenience function for getting a world vector of the identified body.
-/// @relatedalso World
-inline UnitVec GetWorldVector(const World& world, BodyID body, UnitVec localVector)
-{
-    return Rotate(localVector, GetTransformation(world, body).q);
-}
-
-/// @copydoc World::GetVelocity
-/// @relatedalso World
-Velocity GetVelocity(const World& world, BodyID id);
-
-/// @brief Gets the linear velocity of the center of mass of the identified body.
-/// @param world World in which body is identified for.
-/// @param id Body to get the linear velocity for.
-/// @return the linear velocity of the center of mass.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline LinearVelocity2 GetLinearVelocity(const World& world, BodyID id)
-{
-    return GetVelocity(world, id).linear;
-}
-
-/// @brief Gets the angular velocity.
-/// @param world World in which body is identified for.
-/// @param id Body to get the angular velocity for.
-/// @return the angular velocity.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline AngularVelocity GetAngularVelocity(const World& world, BodyID id)
-{
-    return GetVelocity(world, id).angular;
-}
-
-/// @copydoc World::SetVelocity
-/// @see GetVelocity(const World& world, BodyID id)
-/// @relatedalso World
-void SetVelocity(World& world, BodyID id, const Velocity& value);
-
-/// @brief Sets the velocity of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetVelocity(World& world, BodyID id, const LinearVelocity2& value);
-
-/// @brief Sets the velocity of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetVelocity(World& world, BodyID id, AngularVelocity value);
-
-/// @copydoc World::DestroyFixtures()
-/// @relatedalso World
-void DestroyFixtures(World& world, BodyID id);
-
-/// @copydoc World::IsEnabled()
-/// @see SetEnabled(World& world, BodyID id, bool value).
-/// @relatedalso World
-bool IsEnabled(const World& world, BodyID id);
-
-/// @copydoc World::SetEnabled()
-/// @see IsEnabled(const World& world, BodyID id).
-/// @relatedalso World
-void SetEnabled(World& world, BodyID id, bool value);
-
-/// @brief Gets the awake/asleep state of this body.
-/// @warning Being awake may or may not imply being speedable.
-/// @return true if the body is awake.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-bool IsAwake(const World& world, BodyID id);
-
-/// @copydoc World::SetAwake(BodyID)
-/// @relatedalso World
-void SetAwake(World& world, BodyID id);
-
-/// @copydoc World::UnsetAwake(BodyID)
-/// @relatedalso World
-void UnsetAwake(World& world, BodyID id);
-
-/// @brief Awakens the body if it's asleep.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline bool Awaken(World& world, BodyID id)
-{
-    if (!IsAwake(world, id) && IsSpeedable(GetType(world, id)))
+    namespace d2
     {
-        SetAwake(world, id);
-        return true;
-    }
-    return false;
-}
 
-/// @brief Gets whether the body's mass-data is dirty.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-bool IsMassDataDirty(const World& world, BodyID id);
+        class World;
+        class Shape;
 
-/// @brief Gets whether the body has fixed rotation.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see SetFixedRotation.
-/// @relatedalso World
-bool IsFixedRotation(const World& world, BodyID id);
+        /// @example WorldBody.cpp
+        /// This is the <code>googletest</code> based unit testing file for the free function
+        ///   interfaces to <code>playrho::d2::World</code> body member functions and additional
+        ///   functionality.
 
-/// @brief Sets this body to have fixed rotation.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @note This causes the mass to be reset.
-/// @relatedalso World
-void SetFixedRotation(World& world, BodyID id, bool value);
+        /// @defgroup WorldBodyFreeFunctions World Body Related Free Functions
+        /// @brief Collection of "free" functions related to bodies within a <code>World</code>.
+        /// @details This is a collection of non-member non-friend functions - also called "free"
+        ///   functions - that are related to bodies within an instance of a <code>World</code>.
+        ///   Many are just "wrappers" to similarly named member functions but some are additional
+        ///   functionality built on those member functions. A benefit to using free functions that
+        ///   are now just wrappers, is that of helping to isolate your code from future changes that
+        ///   might occur to the underlying <code>World</code> member functions. Free functions in
+        ///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
+        ///   when compiled without any compiler optimizations enabled, enabling optimizations
+        ///   should entirely eliminate that overhead.
+        /// @note The four basic categories of these functions are "CRUD": create, read, update,
+        ///   and delete.
+        /// @see World, BodyID.
+        /// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
+        /// @{
 
-/// @brief Get the world position of the center of mass of the specified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-Length2 GetWorldCenter(const World& world, BodyID id);
+        /// @brief Gets the extent of the currently valid body range.
+        /// @note This is one higher than the maxium BodyID that is in range for body related
+        ///   functions.
+        /// @relatedalso World
+        BodyCounter GetBodyRange(const World& world) noexcept;
 
-/// @brief Gets the inverse total mass of the body.
-/// @return Value of zero or more representing the body's inverse mass (in 1/kg).
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see SetMassData.
-/// @relatedalso World
-InvMass GetInvMass(const World& world, BodyID id);
+        /// @brief Gets the bodies of the specified world.
+        /// @relatedalso World
+        SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const World& world) noexcept;
 
-/// @brief Gets the inverse rotational inertia of the body.
-/// @return Inverse rotational inertia (in 1/kg-m^2).
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-InvRotInertia GetInvRotInertia(const World& world, BodyID id);
+        /// @brief Gets the bodies-for-proxies range for the given world.
+        /// @relatedalso World
+        SizedRange<std::vector<BodyID>::const_iterator>
+        GetBodiesForProxies(const World& world) noexcept;
 
-/// @brief Gets the mass of the body.
-/// @note This may be the total calculated mass or it may be the set mass of the body.
-/// @return Value of zero or more representing the body's mass.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see GetInvMass, SetMassData
-/// @relatedalso World
-inline Mass GetMass(const World& world, BodyID id)
-{
-    const auto invMass = GetInvMass(world, id);
-    return (invMass != InvMass{0})? Mass{Real{1} / invMass}: 0_kg;
-}
+        /// @brief Creates a rigid body with the given configuration.
+        /// @warning This function should not be used while the world is locked &mdash; as it is
+        ///   during callbacks. If it is, it will throw an exception or abort your program.
+        /// @note No references to the configuration are retained. Its value is copied.
+        /// @post The created body will be present in the range returned from the
+        ///   <code>GetBodies(const World&)</code> method.
+        /// @param world The world within which to create the body.
+        /// @param def A customized body configuration or its default value.
+        /// @return Identifier of the newly created body which can later be destroyed by calling
+        ///   the <code>Destroy(World&, BodyID)</code> method.
+        /// @throws WrongState if this method is called while the world is locked.
+        /// @throws LengthError if this operation would create more than <code>MaxBodies</code>.
+        /// @see Destroy(BodyID), GetBodies(const World&).
+        /// @see PhysicalEntities.
+        /// @relatedalso World
+        BodyID CreateBody(World& world, const BodyConf& def = GetDefaultBodyConf());
 
-/// @brief Gets the rotational inertia of the body.
-/// @param world The world in which the identified body exists.
-/// @param id Body to get the rotational inertia for.
-/// @return the rotational inertia.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline RotInertia GetRotInertia(const World& world, BodyID id)
-{
-    return Real{1} / GetInvRotInertia(world, id);
-}
+        /// @brief Destroys the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see CreateBody(World&, const BodyConf&).
+        /// @relatedalso World
+        void Destroy(World& world, BodyID id);
 
-/// @brief Gets the local position of the center of mass of the specified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-Length2 GetLocalCenter(const World& world, BodyID id);
+        /// @brief Gets the range of all constant fixtures attached to the given body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        SizedRange<std::vector<FixtureID>::const_iterator> GetFixtures(const World& world, BodyID id);
 
-/// @brief Gets the rotational inertia of the body about the local origin.
-/// @return the rotational inertia.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline RotInertia GetLocalRotInertia(const World& world, BodyID id)
-{
-    return GetRotInertia(world, id)
-         + GetMass(world, id) * GetMagnitudeSquared(GetLocalCenter(world, id)) / SquareRadian;
-}
+        /// @brief Gets the count of fixtures associated with the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline FixtureCounter GetFixtureCount(const World& world, BodyID id)
+        {
+            using std::size;
+            return static_cast<FixtureCounter>(size(GetFixtures(world, id)));
+        }
 
-/// @brief Gets the mass data of the body.
-/// @return Data structure containing the mass, inertia, and center of the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline MassData GetMassData(const World& world, BodyID id)
-{
-    return MassData{GetLocalCenter(world, id), GetMass(world, id), GetLocalRotInertia(world, id)};
-}
+        /// @copydoc World::GetLinearAcceleration
+        /// @relatedalso World
+        LinearAcceleration2 GetLinearAcceleration(const World& world, BodyID id);
 
-/// @brief Computes the body's mass data.
-/// @details This basically accumulates the mass data over all fixtures.
-/// @note The center is the mass weighted sum of all fixture centers. Divide it by the
-///   mass to get the averaged center.
-/// @return accumulated mass data for all fixtures associated with the given body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-MassData ComputeMassData(const World& world, BodyID id);
+        /// @copydoc World::GetAngularAcceleration
+        /// @relatedalso World
+        AngularAcceleration GetAngularAcceleration(const World& world, BodyID id);
 
-/// @brief Sets the mass properties to override the mass properties of the fixtures.
-/// @note This changes the center of mass position.
-/// @note Creating or destroying fixtures can also alter the mass.
-/// @note This function has no effect if the body isn't dynamic.
-/// @param world The world in which the identified body exists.
-/// @param id Identifier of the body.
-/// @param massData the mass properties.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetMassData(World& world, BodyID id, const MassData& massData);
+        /// @brief Gets the acceleration of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        Acceleration GetAcceleration(const World& world, BodyID id);
 
-/// @brief Resets the mass data properties.
-/// @details This resets the mass data to the sum of the mass properties of the fixtures.
-/// @note This method must be called after calling <code>CreateFixture</code> to update the
-///   body mass data properties unless <code>SetMassData</code> is used.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @see SetMassData.
-/// @relatedalso World
-inline void ResetMassData(World& world, BodyID id)
-{
-    SetMassData(world, id, ComputeMassData(world, id));
-}
+        /// @brief Sets the linear and rotational accelerations on the body.
+        /// @note This has no effect on non-accelerable bodies.
+        /// @note A non-zero acceleration will also awaken the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetAcceleration(World& world, BodyID id,
+                             LinearAcceleration2 linear, AngularAcceleration angular);
 
-/// @brief Should collide.
-/// @details Determines whether a body should possibly be able to collide with the other body.
-/// @return true if either body is dynamic and no joint prevents collision, false otherwise.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-bool ShouldCollide(const World& world, BodyID lhs, BodyID rhs);
+        /// @brief Sets the linear accelerations on the body.
+        /// @note This has no effect on non-accelerable bodies.
+        /// @note A non-zero acceleration will also awaken the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetAcceleration(World& world, BodyID id, LinearAcceleration2 value);
 
-/// @brief Gets the range of all joints attached to the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-SizedRange<std::vector<std::pair<BodyID, JointID>>::const_iterator>
-GetJoints(const World& world, BodyID id);
+        /// @brief Sets the rotational accelerations on the body.
+        /// @note This has no effect on non-accelerable bodies.
+        /// @note A non-zero acceleration will also awaken the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetAcceleration(World& world, BodyID id, AngularAcceleration value);
 
-/// @brief Is identified body "speedable".
-/// @details Is the body able to have a non-zero speed associated with it.
-///  Kinematic and Dynamic bodies are speedable. Static bodies are not.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-bool IsSpeedable(const World& world, BodyID id);
+        /// @brief Sets the accelerations on the given body.
+        /// @note This has no effect on non-accelerable bodies.
+        /// @note A non-zero acceleration will also awaken the body.
+        /// @param world The world in which the identified body's acceleration should be set.
+        /// @param id Body whose acceleration should be set.
+        /// @param value Acceleration value to set.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetAcceleration(World& world, BodyID id, Acceleration value);
 
-/// @brief Is identified body "accelerable"?
-/// @details Indicates whether the body is accelerable, i.e. whether it is effected by
-///   forces. Only Dynamic bodies are accelerable.
-/// @return true if the body is accelerable, false otherwise.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-bool IsAccelerable(const World& world, BodyID id);
+        /// @brief Sets the body's transformation.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see GetTransformation
+        /// @relatedalso World
+        void SetTransformation(World& world, BodyID id, Transformation xfm);
 
-/// @copydoc World::IsImpenetrable
-/// @relatedalso World
-bool IsImpenetrable(const World& world, BodyID id);
+        /// @brief Sets the position of the body's origin and rotation.
+        /// @details This instantly adjusts the body to be at the new position and new orientation.
+        /// @warning Manipulating a body's transform can cause non-physical behavior!
+        /// @note Contacts are updated on the next call to World::Step.
+        /// @param world The world in which the identified body's transform should be set.
+        /// @param id Body whose transform is to be set.
+        /// @param location Valid world location of the body's local origin. Behavior is undefined
+        ///   if value is invalid.
+        /// @param angle Valid world rotation. Behavior is undefined if value is invalid.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline void SetTransform(World& world, BodyID id, Length2 location, Angle angle)
+        {
+            SetTransformation(world, id, Transformation{location, UnitVec::Get(angle)});
+        }
 
-/// @brief Sets the impenetrable status of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetImpenetrable(World& world, BodyID id);
+        /// @brief Sets the body's location.
+        /// @details This instantly adjusts the body to be at the new location.
+        /// @warning Manipulating a body's location this way can cause non-physical behavior!
+        /// @param world The world in which the identified body's location should be set.
+        /// @param id Body to move.
+        /// @param value Valid world location of the body's local origin. Behavior is undefined
+        ///   if value is invalid.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see Body::SetTransform
+        /// @relatedalso World
+        void SetLocation(World& world, BodyID id, Length2 value);
 
-/// @brief Unsets the impenetrable status of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void UnsetImpenetrable(World& world, BodyID id);
+        /// @brief Sets the body's angular orientation.
+        /// @details This instantly adjusts the body to be at the new angular orientation.
+        /// @warning Manipulating a body's angle this way can cause non-physical behavior!
+        /// @param world The world in which the identified body's angle should be set.
+        /// @param id Body to move.
+        /// @param value Valid world angle of the body's local origin. Behavior is undefined
+        ///   if value is invalid.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see Body::SetTransform
+        /// @relatedalso World
+        void SetAngle(World& world, BodyID id, Angle value);
 
-/// @brief Convenience function that sets/unsets the impenetrable status of the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline void SetImpenetrable(World& world, BodyID id, bool value)
-{
-    if (value)
-        SetImpenetrable(world, id);
-    else
-        UnsetImpenetrable(world, id);
-}
+        /// @brief Rotates a body a given amount around a point in world coordinates.
+        /// @details This changes both the linear and angular positions of the body.
+        /// @note Manipulating a body's position this way may cause non-physical behavior.
+        /// @param world The world in which the identified body exists.
+        /// @param id Body to rotate.
+        /// @param amount Amount to rotate body by (in counter-clockwise direction).
+        /// @param worldPoint Point in world coordinates.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, Length2 worldPoint);
 
-/// @brief Gets whether the identified body is allowed to sleep.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-bool IsSleepingAllowed(const World& world, BodyID id);
+        /// @brief Rotates a body a given amount around a point in body local coordinates.
+        /// @details This changes both the linear and angular positions of the body.
+        /// @note Manipulating a body's position this way may cause non-physical behavior.
+        /// @note This is a convenience function that translates the local point into world coordinates
+        ///   and then calls the <code>RotateAboutWorldPoint</code> function.
+        /// @param world The world in which the identified body exists.
+        /// @param id Body to rotate.
+        /// @param amount Amount to rotate body by (in counter-clockwise direction).
+        /// @param localPoint Point in local coordinates.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void RotateAboutLocalPoint(World& world, BodyID id, Angle amount, Length2 localPoint);
 
-/// @brief Sets whether the identified body is allowed to sleep.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetSleepingAllowed(World& world, BodyID, bool value);
+        /// @brief Calculates the gravitationally associated acceleration for the given body within its world.
+        /// @return Zero acceleration if given body is has no mass, else the acceleration of
+        ///    the body due to the gravitational attraction to the other bodies.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        Acceleration CalcGravitationalAcceleration(const World& world, BodyID id);
 
-/// @brief Gets the container of all contacts attached to the identified body.
-/// @warning This collection changes during the time step and you may
-///   miss some collisions if you don't use <code>ContactListener</code>.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-SizedRange<std::vector<KeyedContactPtr>::const_iterator>
-GetContacts(const World& world, BodyID id);
+        /// @brief Gets the world index for the given body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        BodyCounter GetWorldIndex(const World& world, const BodyID id) noexcept;
 
-/// @brief Gets the centripetal force necessary to put the body into an orbit having
-///    the given radius.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis);
+        /// @brief Gets the body configuration for the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        BodyConf GetBodyConf(const World& world, BodyID id);
 
-/// @brief Applies a force to the center of mass of the given body.
-/// @note Non-zero forces wakes up the body.
-/// @param world The world in which the identified body exists.
-/// @param id Body to apply the force to.
-/// @param force World force vector.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline void ApplyForceToCenter(World& world, BodyID id, Force2 force)
-{
-    const auto linAccel = GetLinearAcceleration(world, id) + force * GetInvMass(world, id);
-    const auto angAccel = GetAngularAcceleration(world, id);
-    SetAcceleration(world, id, linAccel, angAccel);
-}
+        /// @copydoc World::SetType
+        /// @see GetType(const World& world, BodyID id)
+        /// @relatedalso World
+        void SetType(World& world, BodyID id, BodyType value);
 
-/// @brief Apply a force at a world point.
-/// @note If the force is not applied at the center of mass, it will generate a torque and
-///   affect the angular velocity.
-/// @note Non-zero forces wakes up the body.
-/// @param world World in which body exists.
-/// @param id Identity of body to apply the force to.
-/// @param force World force vector.
-/// @param point World position of the point of application.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void ApplyForce(World& world, BodyID id, Force2 force, Length2 point);
+        /// @copydoc World::GetType
+        /// @see SetType(World& world, BodyID id, BodyType value)
+        /// @relatedalso World
+        BodyType GetType(const World& world, BodyID id);
 
-/// @brief Applies a torque.
-/// @note This affects the angular velocity without affecting the linear velocity of the
-///   center of mass.
-/// @note Non-zero forces wakes up the body.
-/// @param world The world in which the identified body exists.
-/// @param id Body to apply the torque to.
-/// @param torque about the z-axis (out of the screen).
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void ApplyTorque(World& world, BodyID id, Torque torque);
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see SetTransformation
+        /// @relatedalso World
+        Transformation GetTransformation(const World& world, BodyID id);
 
-/// @brief Applies an impulse at a point.
-/// @note This immediately modifies the velocity.
-/// @note This also modifies the angular velocity if the point of application
-///   is not at the center of mass.
-/// @note Non-zero impulses wakes up the body.
-/// @param world The world in which the identified body exists.
-/// @param id Body to apply the impulse to.
-/// @param impulse the world impulse vector.
-/// @param point the world position of the point of application.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void ApplyLinearImpulse(World& world, BodyID id, Momentum2 impulse, Length2 point);
+        /// @brief Convenience function for getting just the location of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline Length2 GetLocation(const World& world, BodyID id)
+        {
+            return GetTransformation(world, id).p;
+        }
 
-/// @brief Applies an angular impulse.
-/// @param world The world in which the identified body exists.
-/// @param id Body to apply the angular impulse to.
-/// @param impulse Angular impulse to be applied.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void ApplyAngularImpulse(World& world, BodyID id, AngularMomentum impulse);
+        /// @brief Gets the world coordinates of a point given in coordinates relative to the body's origin.
+        /// @param world World context.
+        /// @param id Body that the given point is relative to.
+        /// @param localPoint a point measured relative the the body's origin.
+        /// @return the same point expressed in world coordinates.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline Length2 GetWorldPoint(const World& world, BodyID id, const Length2 localPoint)
+        {
+            return Transform(localPoint, GetTransformation(world, id));
+        }
 
-/// @brief Sets the given amount of force at the given point to the given body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline void SetForce(World& world, BodyID id, Force2 force, Length2 point) noexcept
-{
-    const auto linAccel = LinearAcceleration2{force * GetInvMass(world, id)};
-    const auto invRotI = GetInvRotInertia(world, id);
-    const auto dp = point - GetWorldCenter(world, id);
-    const auto cp = Torque{Cross(dp, force) / Radian};
-    const auto angAccel = AngularAcceleration{cp * invRotI};
-    SetAcceleration(world, id, linAccel, angAccel);
-}
+        /// @brief Convenience function for getting the local vector of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline UnitVec GetLocalVector(const World& world, BodyID body, const UnitVec uv)
+        {
+            return InverseRotate(uv, GetTransformation(world, body).q);
+        }
 
-/// @brief Sets the given amount of torque to the given body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-inline void SetTorque(World& world, BodyID id, Torque torque) noexcept
-{
-    const auto linAccel = GetLinearAcceleration(world, id);
-    const auto invRotI = GetInvRotInertia(world, id);
-    const auto angAccel = torque * invRotI;
-    SetAcceleration(world, id, linAccel, angAccel);
-}
+        /// @brief Gets a local point relative to the body's origin given a world point.
+        /// @param world The world in which the identified body exists.
+        /// @param body Body that the returned point should be relative to.
+        /// @param worldPoint point in world coordinates.
+        /// @return the corresponding local point relative to the body's origin.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline Length2 GetLocalPoint(const World& world, BodyID body, const Length2 worldPoint)
+        {
+            return InverseTransform(worldPoint, GetTransformation(world, body));
+        }
 
-/// @brief Gets the linear damping of the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-Frequency GetLinearDamping(const World& world, BodyID id);
+        /// @copydoc World::GetAngle
+        /// @relatedalso World
+        Angle GetAngle(const World& world, BodyID id);
 
-/// @brief Sets the linear damping of the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetLinearDamping(World& world, BodyID id, NonNegative<Frequency> linearDamping);
+        /// @brief Convenience function for getting the position of the identified body.
+        inline Position GetPosition(const World& world, BodyID id)
+        {
+            return Position{GetLocation(world, id), GetAngle(world, id)};
+        }
 
-/// @brief Gets the angular damping of the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-Frequency GetAngularDamping(const World& world, BodyID id);
+        /// @brief Convenience function for getting a world vector of the identified body.
+        /// @relatedalso World
+        inline UnitVec GetWorldVector(const World& world, BodyID body, UnitVec localVector)
+        {
+            return Rotate(localVector, GetTransformation(world, body).q);
+        }
 
-/// @brief Sets the angular damping of the body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> angularDamping);
+        /// @copydoc World::GetVelocity
+        /// @relatedalso World
+        Velocity GetVelocity(const World& world, BodyID id);
 
-/// @brief Gets the count of awake bodies in the given world.
-/// @relatedalso World
-BodyCounter GetAwakeCount(const World& world) noexcept;
+        /// @brief Gets the linear velocity of the center of mass of the identified body.
+        /// @param world World in which body is identified for.
+        /// @param id Body to get the linear velocity for.
+        /// @return the linear velocity of the center of mass.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline LinearVelocity2 GetLinearVelocity(const World& world, BodyID id)
+        {
+            return GetVelocity(world, id).linear;
+        }
 
-/// @brief Awakens all of the bodies in the given world.
-/// @details Calls all of the world's bodies' <code>SetAwake</code> method.
-/// @return Sum total of calls to bodies' <code>SetAwake</code> method that returned true.
-/// @see Body::SetAwake.
-/// @relatedalso World
-BodyCounter Awaken(World& world) noexcept;
+        /// @brief Gets the angular velocity.
+        /// @param world World in which body is identified for.
+        /// @param id Body to get the angular velocity for.
+        /// @return the angular velocity.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline AngularVelocity GetAngularVelocity(const World& world, BodyID id)
+        {
+            return GetVelocity(world, id).angular;
+        }
 
-/// @brief Finds body in given world that's closest to the given location.
-/// @relatedalso World
-BodyID FindClosestBody(const World& world, Length2 location) noexcept;
+        /// @copydoc World::SetVelocity
+        /// @see GetVelocity(const World& world, BodyID id)
+        /// @relatedalso World
+        void SetVelocity(World& world, BodyID id, const Velocity& value);
 
-/// @brief Gets the body count in the given world.
-/// @return 0 or higher.
-/// @relatedalso World
-inline BodyCounter GetBodyCount(const World& world) noexcept
-{
-    using std::size;
-    return static_cast<BodyCounter>(size(GetBodies(world)));
-}
+        /// @brief Sets the velocity of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetVelocity(World& world, BodyID id, const LinearVelocity2& value);
 
-/// @brief Sets the accelerations of all the world's bodies to the given value.
-/// @relatedalso World
-void SetAccelerations(World& world, Acceleration acceleration) noexcept;
+        /// @brief Sets the velocity of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetVelocity(World& world, BodyID id, AngularVelocity value);
 
-/// @brief Sets the accelerations of all the world's bodies to the given value.
-/// @note This will leave the angular acceleration alone.
-/// @relatedalso World
-void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept;
+        /// @copydoc World::DestroyFixtures()
+        /// @relatedalso World
+        void DestroyFixtures(World& world, BodyID id);
 
-/// @brief Clears forces.
-/// @details Manually clear the force buffer on all bodies.
-/// @relatedalso World
-inline void ClearForces(World& world) noexcept
-{
-    SetAccelerations(world, Acceleration{});
-}
+        /// @copydoc World::IsEnabled()
+        /// @see SetEnabled(World& world, BodyID id, bool value).
+        /// @relatedalso World
+        bool IsEnabled(const World& world, BodyID id);
 
-/// @brief Sets the accelerations of all the world's bodies.
-/// @param world World instance to set the acceleration of all contained bodies for.
-/// @param fn Function or functor with a signature like:
-///   <code>Acceleration (*fn)(const Body& body)</code>.
-/// @relatedalso World
-template <class F>
-void SetAccelerations(World& world, F fn)
-{
-    const auto bodies = GetBodies(world);
-    std::for_each(begin(bodies), end(bodies), [&](const auto &b) {
-        SetAcceleration(world, b, fn(world, b));
-    });
-}
+        /// @copydoc World::SetEnabled()
+        /// @see IsEnabled(const World& world, BodyID id).
+        /// @relatedalso World
+        void SetEnabled(World& world, BodyID id, bool value);
 
-/// @}
+        /// @brief Gets the awake/asleep state of this body.
+        /// @warning Being awake may or may not imply being speedable.
+        /// @return true if the body is awake.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        bool IsAwake(const World& world, BodyID id);
 
-} // namespace d2
-} // namespace playrho
+        /// @copydoc World::SetAwake(BodyID)
+        /// @relatedalso World
+        void SetAwake(World& world, BodyID id);
 
-#endif // PLAYRHO_DYNAMICS_WORLDBODY_HPP
+        /// @copydoc World::UnsetAwake(BodyID)
+        /// @relatedalso World
+        void UnsetAwake(World& world, BodyID id);
+
+        /// @brief Awakens the body if it's asleep.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline bool Awaken(World& world, BodyID id)
+        {
+            if (!IsAwake(world, id) && IsSpeedable(GetType(world, id)))
+            {
+                SetAwake(world, id);
+                return true;
+            }
+            return false;
+        }
+
+        /// @brief Gets whether the body's mass-data is dirty.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        bool IsMassDataDirty(const World& world, BodyID id);
+
+        /// @brief Gets whether the body has fixed rotation.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see SetFixedRotation.
+        /// @relatedalso World
+        bool IsFixedRotation(const World& world, BodyID id);
+
+        /// @brief Sets this body to have fixed rotation.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @note This causes the mass to be reset.
+        /// @relatedalso World
+        void SetFixedRotation(World& world, BodyID id, bool value);
+
+        /// @brief Get the world position of the center of mass of the specified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        Length2 GetWorldCenter(const World& world, BodyID id);
+
+        /// @brief Gets the inverse total mass of the body.
+        /// @return Value of zero or more representing the body's inverse mass (in 1/kg).
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see SetMassData.
+        /// @relatedalso World
+        InvMass GetInvMass(const World& world, BodyID id);
+
+        /// @brief Gets the inverse rotational inertia of the body.
+        /// @return Inverse rotational inertia (in 1/kg-m^2).
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        InvRotInertia GetInvRotInertia(const World& world, BodyID id);
+
+        /// @brief Gets the mass of the body.
+        /// @note This may be the total calculated mass or it may be the set mass of the body.
+        /// @return Value of zero or more representing the body's mass.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see GetInvMass, SetMassData
+        /// @relatedalso World
+        inline Mass GetMass(const World& world, BodyID id)
+        {
+            const auto invMass = GetInvMass(world, id);
+            return (invMass != InvMass{0}) ? Mass{Real{1} / invMass} : 0_kg;
+        }
+
+        /// @brief Gets the rotational inertia of the body.
+        /// @param world The world in which the identified body exists.
+        /// @param id Body to get the rotational inertia for.
+        /// @return the rotational inertia.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline RotInertia GetRotInertia(const World& world, BodyID id)
+        {
+            return Real{1} / GetInvRotInertia(world, id);
+        }
+
+        /// @brief Gets the local position of the center of mass of the specified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        Length2 GetLocalCenter(const World& world, BodyID id);
+
+        /// @brief Gets the rotational inertia of the body about the local origin.
+        /// @return the rotational inertia.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline RotInertia GetLocalRotInertia(const World& world, BodyID id)
+        {
+            return GetRotInertia(world, id)
+                   + GetMass(world, id) * GetMagnitudeSquared(GetLocalCenter(world, id)) / SquareRadian;
+        }
+
+        /// @brief Gets the mass data of the body.
+        /// @return Data structure containing the mass, inertia, and center of the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline MassData GetMassData(const World& world, BodyID id)
+        {
+            return MassData{GetLocalCenter(world, id), GetMass(world, id), GetLocalRotInertia(world, id)};
+        }
+
+        /// @brief Computes the body's mass data.
+        /// @details This basically accumulates the mass data over all fixtures.
+        /// @note The center is the mass weighted sum of all fixture centers. Divide it by the
+        ///   mass to get the averaged center.
+        /// @return accumulated mass data for all fixtures associated with the given body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        MassData ComputeMassData(const World& world, BodyID id);
+
+        /// @brief Sets the mass properties to override the mass properties of the fixtures.
+        /// @note This changes the center of mass position.
+        /// @note Creating or destroying fixtures can also alter the mass.
+        /// @note This function has no effect if the body isn't dynamic.
+        /// @param world The world in which the identified body exists.
+        /// @param id Identifier of the body.
+        /// @param massData the mass properties.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetMassData(World& world, BodyID id, const MassData& massData);
+
+        /// @brief Resets the mass data properties.
+        /// @details This resets the mass data to the sum of the mass properties of the fixtures.
+        /// @note This method must be called after calling <code>CreateFixture</code> to update the
+        ///   body mass data properties unless <code>SetMassData</code> is used.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @see SetMassData.
+        /// @relatedalso World
+        inline void ResetMassData(World& world, BodyID id)
+        {
+            SetMassData(world, id, ComputeMassData(world, id));
+        }
+
+        /// @brief Should collide.
+        /// @details Determines whether a body should possibly be able to collide with the other body.
+        /// @return true if either body is dynamic and no joint prevents collision, false otherwise.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        bool ShouldCollide(const World& world, BodyID lhs, BodyID rhs);
+
+        /// @brief Gets the range of all joints attached to the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        SizedRange<std::vector<std::pair<BodyID, JointID>>::const_iterator>
+        GetJoints(const World& world, BodyID id);
+
+        /// @brief Is identified body "speedable".
+        /// @details Is the body able to have a non-zero speed associated with it.
+        ///  Kinematic and Dynamic bodies are speedable. Static bodies are not.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        bool IsSpeedable(const World& world, BodyID id);
+
+        /// @brief Is identified body "accelerable"?
+        /// @details Indicates whether the body is accelerable, i.e. whether it is effected by
+        ///   forces. Only Dynamic bodies are accelerable.
+        /// @return true if the body is accelerable, false otherwise.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        bool IsAccelerable(const World& world, BodyID id);
+
+        /// @copydoc World::IsImpenetrable
+        /// @relatedalso World
+        bool IsImpenetrable(const World& world, BodyID id);
+
+        /// @brief Sets the impenetrable status of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetImpenetrable(World& world, BodyID id);
+
+        /// @brief Unsets the impenetrable status of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void UnsetImpenetrable(World& world, BodyID id);
+
+        /// @brief Convenience function that sets/unsets the impenetrable status of the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline void SetImpenetrable(World& world, BodyID id, bool value)
+        {
+            if (value)
+                SetImpenetrable(world, id);
+            else
+                UnsetImpenetrable(world, id);
+        }
+
+        /// @brief Gets whether the identified body is allowed to sleep.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        bool IsSleepingAllowed(const World& world, BodyID id);
+
+        /// @brief Sets whether the identified body is allowed to sleep.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetSleepingAllowed(World& world, BodyID, bool value);
+
+        /// @brief Gets the container of all contacts attached to the identified body.
+        /// @warning This collection changes during the time step and you may
+        ///   miss some collisions if you don't use <code>ContactListener</code>.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        SizedRange<std::vector<KeyedContactPtr>::const_iterator>
+        GetContacts(const World& world, BodyID id);
+
+        /// @brief Gets the centripetal force necessary to put the body into an orbit having
+        ///    the given radius.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis);
+
+        /// @brief Applies a force to the center of mass of the given body.
+        /// @note Non-zero forces wakes up the body.
+        /// @param world The world in which the identified body exists.
+        /// @param id Body to apply the force to.
+        /// @param force World force vector.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline void ApplyForceToCenter(World& world, BodyID id, Force2 force)
+        {
+            const auto linAccel = GetLinearAcceleration(world, id) + force * GetInvMass(world, id);
+            const auto angAccel = GetAngularAcceleration(world, id);
+            SetAcceleration(world, id, linAccel, angAccel);
+        }
+
+        /// @brief Apply a force at a world point.
+        /// @note If the force is not applied at the center of mass, it will generate a torque and
+        ///   affect the angular velocity.
+        /// @note Non-zero forces wakes up the body.
+        /// @param world World in which body exists.
+        /// @param id Identity of body to apply the force to.
+        /// @param force World force vector.
+        /// @param point World position of the point of application.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void ApplyForce(World& world, BodyID id, Force2 force, Length2 point);
+
+        /// @brief Applies a torque.
+        /// @note This affects the angular velocity without affecting the linear velocity of the
+        ///   center of mass.
+        /// @note Non-zero forces wakes up the body.
+        /// @param world The world in which the identified body exists.
+        /// @param id Body to apply the torque to.
+        /// @param torque about the z-axis (out of the screen).
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void ApplyTorque(World& world, BodyID id, Torque torque);
+
+        /// @brief Applies an impulse at a point.
+        /// @note This immediately modifies the velocity.
+        /// @note This also modifies the angular velocity if the point of application
+        ///   is not at the center of mass.
+        /// @note Non-zero impulses wakes up the body.
+        /// @param world The world in which the identified body exists.
+        /// @param id Body to apply the impulse to.
+        /// @param impulse the world impulse vector.
+        /// @param point the world position of the point of application.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void ApplyLinearImpulse(World& world, BodyID id, Momentum2 impulse, Length2 point);
+
+        /// @brief Applies an angular impulse.
+        /// @param world The world in which the identified body exists.
+        /// @param id Body to apply the angular impulse to.
+        /// @param impulse Angular impulse to be applied.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void ApplyAngularImpulse(World& world, BodyID id, AngularMomentum impulse);
+
+        /// @brief Sets the given amount of force at the given point to the given body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline void SetForce(World& world, BodyID id, Force2 force, Length2 point) noexcept
+        {
+            const auto linAccel = LinearAcceleration2{force * GetInvMass(world, id)};
+            const auto invRotI = GetInvRotInertia(world, id);
+            const auto dp = point - GetWorldCenter(world, id);
+            const auto cp = Torque{Cross(dp, force) / Radian};
+            const auto angAccel = AngularAcceleration{cp * invRotI};
+            SetAcceleration(world, id, linAccel, angAccel);
+        }
+
+        /// @brief Sets the given amount of torque to the given body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        inline void SetTorque(World& world, BodyID id, Torque torque) noexcept
+        {
+            const auto linAccel = GetLinearAcceleration(world, id);
+            const auto invRotI = GetInvRotInertia(world, id);
+            const auto angAccel = torque * invRotI;
+            SetAcceleration(world, id, linAccel, angAccel);
+        }
+
+        /// @brief Gets the linear damping of the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        Frequency GetLinearDamping(const World& world, BodyID id);
+
+        /// @brief Sets the linear damping of the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetLinearDamping(World& world, BodyID id, NonNegative<Frequency> linearDamping);
+
+        /// @brief Gets the angular damping of the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        Frequency GetAngularDamping(const World& world, BodyID id);
+
+        /// @brief Sets the angular damping of the body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> angularDamping);
+
+        /// @brief Gets the count of awake bodies in the given world.
+        /// @relatedalso World
+        BodyCounter GetAwakeCount(const World& world) noexcept;
+
+        /// @brief Awakens all of the bodies in the given world.
+        /// @details Calls all of the world's bodies' <code>SetAwake</code> method.
+        /// @return Sum total of calls to bodies' <code>SetAwake</code> method that returned true.
+        /// @see Body::SetAwake.
+        /// @relatedalso World
+        BodyCounter Awaken(World& world) noexcept;
+
+        /// @brief Finds body in given world that's closest to the given location.
+        /// @relatedalso World
+        BodyID FindClosestBody(const World& world, Length2 location) noexcept;
+
+        /// @brief Gets the body count in the given world.
+        /// @return 0 or higher.
+        /// @relatedalso World
+        inline BodyCounter GetBodyCount(const World& world) noexcept
+        {
+            using std::size;
+            return static_cast<BodyCounter>(size(GetBodies(world)));
+        }
+
+        /// @brief Sets the accelerations of all the world's bodies to the given value.
+        /// @relatedalso World
+        void SetAccelerations(World& world, Acceleration acceleration) noexcept;
+
+        /// @brief Sets the accelerations of all the world's bodies to the given value.
+        /// @note This will leave the angular acceleration alone.
+        /// @relatedalso World
+        void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept;
+
+        /// @brief Clears forces.
+        /// @details Manually clear the force buffer on all bodies.
+        /// @relatedalso World
+        inline void ClearForces(World& world) noexcept
+        {
+            SetAccelerations(world, Acceleration{});
+        }
+
+        /// @brief Sets the accelerations of all the world's bodies.
+        /// @param world World instance to set the acceleration of all contained bodies for.
+        /// @param fn Function or functor with a signature like:
+        ///   <code>Acceleration (*fn)(const Body& body)</code>.
+        /// @relatedalso World
+        template<class F>
+        void SetAccelerations(World& world, F fn)
+        {
+            const auto bodies = GetBodies(world);
+            std::for_each(begin(bodies), end(bodies), [&](const auto& b) {
+                SetAcceleration(world, b, fn(world, b));
+            });
+        }
+
+        /// @}
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_WORLDBODY_HPP

--- a/PlayRho/Dynamics/WorldConf.hpp
+++ b/PlayRho/Dynamics/WorldConf.hpp
@@ -26,74 +26,76 @@
 
 #include <PlayRho/Common/Positive.hpp>
 
-namespace playrho {
-namespace d2 {
-
-/// @brief World configuration data.
-struct WorldConf
+namespace playrho
 {
-    /// @brief Uses the given min vertex radius value.
-    constexpr WorldConf& UseMinVertexRadius(Positive<Length> value) noexcept;
+    namespace d2
+    {
 
-    /// @brief Uses the given max vertex radius value.
-    constexpr WorldConf& UseMaxVertexRadius(Positive<Length> value) noexcept;
+        /// @brief World configuration data.
+        struct WorldConf
+        {
+            /// @brief Uses the given min vertex radius value.
+            constexpr WorldConf& UseMinVertexRadius(Positive<Length> value) noexcept;
 
-    /// @brief Uses the given value as the initial dynamic tree size.
-    constexpr WorldConf& UseInitialTreeSize(ContactCounter value) noexcept;
+            /// @brief Uses the given max vertex radius value.
+            constexpr WorldConf& UseMaxVertexRadius(Positive<Length> value) noexcept;
 
-    /// @brief Minimum vertex radius.
-    /// @details This is the minimum vertex radius that this world establishes which bodies
-    ///    shall allow fixtures to be created with. Trying to create a fixture with a shape
-    ///    having a smaller vertex radius shall be rejected with a <code>nullptr</code>
-    ///    returned value.
-    /// @note This value probably should not be changed except to experiment with what
-    ///    can happen.
-    /// @note Making it smaller means some shapes could have insufficient buffer for
-    ///    continuous collision.
-    /// @note Making it larger may create artifacts for vertex collision.
-    Positive<Length> minVertexRadius = DefaultMinVertexRadius;
+            /// @brief Uses the given value as the initial dynamic tree size.
+            constexpr WorldConf& UseInitialTreeSize(ContactCounter value) noexcept;
 
-    /// @brief Maximum vertex radius.
-    /// @details This is the maximum vertex radius that this world establishes which bodies
-    ///    shall allow fixtures to be created with. Trying to create a fixture with a shape
-    ///    having a larger vertex radius shall be rejected with a <code>nullptr</code>
-    ///    returned value.
-    Positive<Length> maxVertexRadius = DefaultMaxVertexRadius;
+            /// @brief Minimum vertex radius.
+            /// @details This is the minimum vertex radius that this world establishes which bodies
+            ///    shall allow fixtures to be created with. Trying to create a fixture with a shape
+            ///    having a smaller vertex radius shall be rejected with a <code>nullptr</code>
+            ///    returned value.
+            /// @note This value probably should not be changed except to experiment with what
+            ///    can happen.
+            /// @note Making it smaller means some shapes could have insufficient buffer for
+            ///    continuous collision.
+            /// @note Making it larger may create artifacts for vertex collision.
+            Positive<Length> minVertexRadius = DefaultMinVertexRadius;
 
-    /// @brief Initial tree size.
-    ContactCounter initialTreeSize = 4096;
-};
+            /// @brief Maximum vertex radius.
+            /// @details This is the maximum vertex radius that this world establishes which bodies
+            ///    shall allow fixtures to be created with. Trying to create a fixture with a shape
+            ///    having a larger vertex radius shall be rejected with a <code>nullptr</code>
+            ///    returned value.
+            Positive<Length> maxVertexRadius = DefaultMaxVertexRadius;
 
-constexpr WorldConf& WorldConf::UseMinVertexRadius(Positive<Length> value) noexcept
-{
-    minVertexRadius = value;
-    return *this;
-}
+            /// @brief Initial tree size.
+            ContactCounter initialTreeSize = 4096;
+        };
 
-constexpr WorldConf& WorldConf::UseMaxVertexRadius(Positive<Length> value) noexcept
-{
-    maxVertexRadius = value;
-    return *this;
-}
+        constexpr WorldConf& WorldConf::UseMinVertexRadius(Positive<Length> value) noexcept
+        {
+            minVertexRadius = value;
+            return *this;
+        }
 
-constexpr WorldConf& WorldConf::UseInitialTreeSize(ContactCounter value) noexcept
-{
-    initialTreeSize = value;
-    return *this;
-}
+        constexpr WorldConf& WorldConf::UseMaxVertexRadius(Positive<Length> value) noexcept
+        {
+            maxVertexRadius = value;
+            return *this;
+        }
 
-/// Gets the default definitions value.
-/// @note This method exists as a work-around for providing the World constructor a default
-///   value without otherwise getting a compiler error such as:
-///     "cannot use defaulted constructor of '<code>Conf</code>' within '<code>World</code>'
-///     outside of member functions because 'gravity' has an initializer"
-/// @relatedalso WorldConf
-constexpr WorldConf GetDefaultWorldConf() noexcept
-{
-    return WorldConf{};
-}
+        constexpr WorldConf& WorldConf::UseInitialTreeSize(ContactCounter value) noexcept
+        {
+            initialTreeSize = value;
+            return *this;
+        }
 
-} // namespace d2
-} // namespace playrho
+        /// Gets the default definitions value.
+        /// @note This method exists as a work-around for providing the World constructor a default
+        ///   value without otherwise getting a compiler error such as:
+        ///     "cannot use defaulted constructor of '<code>Conf</code>' within '<code>World</code>'
+        ///     outside of member functions because 'gravity' has an initializer"
+        /// @relatedalso WorldConf
+        constexpr WorldConf GetDefaultWorldConf() noexcept
+        {
+            return WorldConf{};
+        }
 
-#endif // PLAYRHO_DYNAMICS_WORLDCONF_HPP
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_WORLDCONF_HPP

--- a/PlayRho/Dynamics/WorldContact.cpp
+++ b/PlayRho/Dynamics/WorldContact.cpp
@@ -25,169 +25,171 @@
 
 #include <PlayRho/Collision/Manifold.hpp>
 
-namespace playrho {
-namespace d2 {
-
-SizedRange<std::vector<KeyedContactPtr>::const_iterator>
-GetContacts(const World& world) noexcept
+namespace playrho
 {
-    return world.GetContacts();
-}
+    namespace d2
+    {
 
-bool IsTouching(const World& world, ContactID id)
-{
-    return world.IsTouching(id);
-}
+        SizedRange<std::vector<KeyedContactPtr>::const_iterator>
+        GetContacts(const World& world) noexcept
+        {
+            return world.GetContacts();
+        }
 
-bool IsAwake(const World& world, ContactID id)
-{
-    return world.IsAwake(id);
-}
+        bool IsTouching(const World& world, ContactID id)
+        {
+            return world.IsTouching(id);
+        }
 
-void SetAwake(World& world, ContactID id)
-{
-    world.SetAwake(id);
-}
+        bool IsAwake(const World& world, ContactID id)
+        {
+            return world.IsAwake(id);
+        }
 
-ChildCounter GetChildIndexA(const World& world, ContactID id)
-{
-    return world.GetChildIndexA(id);
-}
+        void SetAwake(World& world, ContactID id)
+        {
+            world.SetAwake(id);
+        }
 
-ChildCounter GetChildIndexB(const World& world, ContactID id)
-{
-    return world.GetChildIndexB(id);
-}
+        ChildCounter GetChildIndexA(const World& world, ContactID id)
+        {
+            return world.GetChildIndexA(id);
+        }
 
-FixtureID GetFixtureA(const World& world, ContactID id)
-{
-    return world.GetFixtureA(id);
-}
+        ChildCounter GetChildIndexB(const World& world, ContactID id)
+        {
+            return world.GetChildIndexB(id);
+        }
 
-FixtureID GetFixtureB(const World& world, ContactID id)
-{
-    return world.GetFixtureB(id);
-}
+        FixtureID GetFixtureA(const World& world, ContactID id)
+        {
+            return world.GetFixtureA(id);
+        }
 
-BodyID GetBodyA(const World& world, ContactID id)
-{
-    return world.GetBodyA(id);
-}
+        FixtureID GetFixtureB(const World& world, ContactID id)
+        {
+            return world.GetFixtureB(id);
+        }
 
-BodyID GetBodyB(const World& world, ContactID id)
-{
-    return world.GetBodyB(id);
-}
+        BodyID GetBodyA(const World& world, ContactID id)
+        {
+            return world.GetBodyA(id);
+        }
 
-TimestepIters GetToiCount(const World& world, ContactID id)
-{
-    return world.GetToiCount(id);
-}
+        BodyID GetBodyB(const World& world, ContactID id)
+        {
+            return world.GetBodyB(id);
+        }
 
-bool NeedsFiltering(const World& world, ContactID id)
-{
-    return world.NeedsFiltering(id);
-}
+        TimestepIters GetToiCount(const World& world, ContactID id)
+        {
+            return world.GetToiCount(id);
+        }
 
-bool NeedsUpdating(const World& world, ContactID id)
-{
-    return world.NeedsUpdating(id);
-}
+        bool NeedsFiltering(const World& world, ContactID id)
+        {
+            return world.NeedsFiltering(id);
+        }
 
-bool HasValidToi(const World& world, ContactID id)
-{
-    return world.HasValidToi(id);
-}
+        bool NeedsUpdating(const World& world, ContactID id)
+        {
+            return world.NeedsUpdating(id);
+        }
 
-Real GetToi(const World& world, ContactID id)
-{
-    return world.GetToi(id);
-}
+        bool HasValidToi(const World& world, ContactID id)
+        {
+            return world.HasValidToi(id);
+        }
 
-Real GetDefaultFriction(const World& world, ContactID id)
-{
-    return world.GetDefaultFriction(id);
-}
+        Real GetToi(const World& world, ContactID id)
+        {
+            return world.GetToi(id);
+        }
 
-Real GetDefaultRestitution(const World& world, ContactID id)
-{
-    return world.GetDefaultRestitution(id);
-}
+        Real GetDefaultFriction(const World& world, ContactID id)
+        {
+            return world.GetDefaultFriction(id);
+        }
 
-Real GetFriction(const World& world, ContactID id)
-{
-    return world.GetFriction(id);
-}
+        Real GetDefaultRestitution(const World& world, ContactID id)
+        {
+            return world.GetDefaultRestitution(id);
+        }
 
-Real GetRestitution(const World& world, ContactID id)
-{
-    return world.GetRestitution(id);
-}
+        Real GetFriction(const World& world, ContactID id)
+        {
+            return world.GetFriction(id);
+        }
 
-void SetFriction(World& world, ContactID id, Real friction)
-{
-    world.SetFriction(id, friction);
-}
+        Real GetRestitution(const World& world, ContactID id)
+        {
+            return world.GetRestitution(id);
+        }
 
-void SetRestitution(World& world, ContactID id, Real restitution)
-{
-    world.SetRestitution(id, restitution);
-}
+        void SetFriction(World& world, ContactID id, Real friction)
+        {
+            world.SetFriction(id, friction);
+        }
 
-const Manifold& GetManifold(const World& world, ContactID id)
-{
-    return world.GetManifold(id);
-}
+        void SetRestitution(World& world, ContactID id, Real restitution)
+        {
+            world.SetRestitution(id, restitution);
+        }
 
-WorldManifold GetWorldManifold(const World& world, ContactID id)
-{
-    const auto bA = GetBodyA(world, id);
-    const auto fA = GetFixtureA(world, id);
-    const auto iA = GetChildIndexA(world, id);
-    const auto bB = GetBodyB(world, id);
-    const auto fB = GetFixtureB(world, id);
-    const auto iB = GetChildIndexB(world, id);
-    const auto manifold = GetManifold(world, id);
-    const auto xfA = world.GetTransformation(bA);
-    const auto radiusA = GetVertexRadius(world.GetShape(fA), iA);
-    const auto xfB = world.GetTransformation(bB);
-    const auto radiusB = GetVertexRadius(world.GetShape(fB), iB);
-    return GetWorldManifold(manifold, xfA, radiusA, xfB, radiusB);
-}
+        const Manifold& GetManifold(const World& world, ContactID id)
+        {
+            return world.GetManifold(id);
+        }
 
-LinearVelocity GetTangentSpeed(const World& world, ContactID id)
-{
-    return world.GetTangentSpeed(id);
-}
+        WorldManifold GetWorldManifold(const World& world, ContactID id)
+        {
+            const auto bA = GetBodyA(world, id);
+            const auto fA = GetFixtureA(world, id);
+            const auto iA = GetChildIndexA(world, id);
+            const auto bB = GetBodyB(world, id);
+            const auto fB = GetFixtureB(world, id);
+            const auto iB = GetChildIndexB(world, id);
+            const auto manifold = GetManifold(world, id);
+            const auto xfA = world.GetTransformation(bA);
+            const auto radiusA = GetVertexRadius(world.GetShape(fA), iA);
+            const auto xfB = world.GetTransformation(bB);
+            const auto radiusB = GetVertexRadius(world.GetShape(fB), iB);
+            return GetWorldManifold(manifold, xfA, radiusA, xfB, radiusB);
+        }
 
-void SetTangentSpeed(World& world, ContactID id, LinearVelocity value)
-{
-    world.SetTangentSpeed(id, value);
-}
+        LinearVelocity GetTangentSpeed(const World& world, ContactID id)
+        {
+            return world.GetTangentSpeed(id);
+        }
 
-bool IsEnabled(const World& world, ContactID id)
-{
-    return world.IsEnabled(id);
-}
+        void SetTangentSpeed(World& world, ContactID id, LinearVelocity value)
+        {
+            world.SetTangentSpeed(id, value);
+        }
 
-void SetEnabled(World& world, ContactID id)
-{
-    world.SetEnabled(id);
-}
+        bool IsEnabled(const World& world, ContactID id)
+        {
+            return world.IsEnabled(id);
+        }
 
-void UnsetEnabled(World& world, ContactID id)
-{
-    world.UnsetEnabled(id);
-}
+        void SetEnabled(World& world, ContactID id)
+        {
+            world.SetEnabled(id);
+        }
 
-ContactCounter GetTouchingCount(const World& world) noexcept
-{
-    const auto contacts = world.GetContacts();
-    return static_cast<ContactCounter>(count_if(cbegin(contacts), cend(contacts),
-                                                [&](const auto &c) {
-        return world.IsTouching(std::get<ContactID>(c));
-    }));
-}
+        void UnsetEnabled(World& world, ContactID id)
+        {
+            world.UnsetEnabled(id);
+        }
 
-} // namespace d2
-} // namespace playrho
+        ContactCounter GetTouchingCount(const World& world) noexcept
+        {
+            const auto contacts = world.GetContacts();
+            return static_cast<ContactCounter>(count_if(cbegin(contacts), cend(contacts),
+                                                        [&](const auto& c) {
+                                                            return world.IsTouching(std::get<ContactID>(c));
+                                                        }));
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldContact.hpp
+++ b/PlayRho/Dynamics/WorldContact.hpp
@@ -25,243 +25,247 @@
 /// @file
 /// Declarations of free functions of World for contacts identified by <code>ContactID</code>.
 
+#include <PlayRho/Common/Range.hpp>// for SizedRange
 #include <PlayRho/Common/Settings.hpp>
-#include <PlayRho/Common/Range.hpp> // for SizedRange
 
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactID.hpp>
-#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp> // for KeyedContactPtr
+#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp>// for KeyedContactPtr
+#include <PlayRho/Dynamics/FixtureID.hpp>
 
 #include <PlayRho/Collision/WorldManifold.hpp>
 
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-class World;
-class Manifold;
-
-/// @example WorldContact.cpp
-/// This is the <code>googletest</code> based unit testing file for the free function
-///   interfaces to <code>playrho::d2::World</code> contact member functions and additional
-///   functionality.
-
-/// @defgroup WorldContactFreeFunctions World Contacts Related Free Functions
-/// @brief Collection of "free" functions related to contacts within a <code>World</code>.
-/// @details This is a collection of non-member non-friend functions - also called "free"
-///   functions - that are related to contacts within an instance of a <code>World</code>.
-///   Many are just "wrappers" to similarly named member functions but some are additional
-///   functionality built on those member functions. A benefit to using free functions that
-///   are now just wrappers, is that of helping to isolate your code from future changes that
-///   might occur to the underlying <code>World</code> member functions. Free functions in
-///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
-///   when compiled without any compiler optimizations enabled, enabling optimizations
-///   should entirely eliminate that overhead.
-/// @note The four basic categories of these functions are "CRUD": create, read, update,
-///   and delete.
-/// @see World, ContactID.
-/// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
-/// @{
-
-/// @brief Gets the contacts recognized within the given world.
-/// @relatedalso World
-SizedRange<std::vector<KeyedContactPtr>::const_iterator>
-GetContacts(const World& world) noexcept;
-
-/// @copydoc World::IsTouching
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-bool IsTouching(const World& world, ContactID id);
-
-/// @brief Gets the awake status of the specified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-bool IsAwake(const World& world, ContactID id);
-
-/// @brief Sets awake the bodies of the fixtures of the given contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-void SetAwake(World& world, ContactID id);
-
-/// @brief Gets the body-A of the identified contact if it has one.
-/// @return Identification of the body-A or <code>InvalidBodyID</code>.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-BodyID GetBodyA(const World& world, ContactID id);
-
-/// @brief Gets the body-B of the identified contact if it has one.
-/// @return Identification of the body-B or <code>InvalidBodyID</code>.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-BodyID GetBodyB(const World& world, ContactID id);
-
-/// @brief Gets fixture A of the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-FixtureID GetFixtureA(const World& world, ContactID id);
-
-/// @brief Gets fixture B of the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-FixtureID GetFixtureB(const World& world, ContactID id);
-
-/// @brief Get the child primitive index for fixture A.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-ChildCounter GetChildIndexA(const World& world, ContactID id);
-
-/// @brief Get the child primitive index for fixture B.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-ChildCounter GetChildIndexB(const World& world, ContactID id);
-
-/// @brief Gets the Time Of Impact (TOI) count.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-TimestepIters GetToiCount(const World& world, ContactID id);
-
-/// @copydoc World::NeedsFiltering
-/// @relatedalso World
-bool NeedsFiltering(const World& world, ContactID id);
-
-/// @copydoc World::NeedsUpdating
-/// @relatedalso World
-bool NeedsUpdating(const World& world, ContactID id);
-
-/// @copydoc World::HasValidToi
-/// @relatedalso World
-bool HasValidToi(const World& world, ContactID id);
-
-/// @brief Gets the time of impact associated with the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-Real GetToi(const World& world, ContactID id);
-
-/// @brief Gets the default friction amount for the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-Real GetDefaultFriction(const World& world, ContactID id);
-
-/// @brief Gets the default restitution amount for the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-Real GetDefaultRestitution(const World& world, ContactID id);
-
-/// @brief Gets the friction used with the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @see SetFriction(World& world, ContactID id, Real friction)
-/// @relatedalso World
-Real GetFriction(const World& world, ContactID id);
-
-/// @brief Gets the restitution used with the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @see SetRestitution(World& world, ContactID id, Real restitution)
-/// @relatedalso World
-Real GetRestitution(const World& world, ContactID id);
-
-/// @brief Sets the friction value for the identified contact.
-/// @details Overrides the default friction mixture.
-/// @note You can call this in "pre-solve" listeners.
-/// @note This value persists until set or reset.
-/// @warning Behavior is undefined if given a negative friction value.
-/// @param world The world in which the contact is identified in.
-/// @param id Identifier of the contact whose friction value should be set.
-/// @param friction Co-efficient of friction value of zero or greater.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-void SetFriction(World& world, ContactID id, Real friction);
-
-/// @brief Sets the restitution value for the specified contact.
-/// @details This override the default restitution mixture.
-/// @note You can call this in "pre-solve" listeners.
-/// @note The value persists until you set or reset.
-/// @relatedalso World
-void SetRestitution(World& world, ContactID id, Real restitution);
-
-/// @brief Gets the manifold for the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-const Manifold& GetManifold(const World& world, ContactID id);
-
-/// @brief Gets the world manifold for the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-WorldManifold GetWorldManifold(const World& world, ContactID id);
-
-/// Resets the friction mixture to the default value.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-inline void ResetFriction(World& world, ContactID id)
+namespace playrho
 {
-    SetFriction(world, id, GetDefaultFriction(world, id));
-}
+    namespace d2
+    {
 
-/// Resets the restitution to the default value.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-inline void ResetRestitution(World& world, ContactID id)
-{
-    SetRestitution(world, id, GetDefaultRestitution(world, id));
-}
+        class World;
+        class Manifold;
 
-/// @copydoc World::GetTangentSpeed
-/// @relatedalso World
-LinearVelocity GetTangentSpeed(const World& world, ContactID id);
+        /// @example WorldContact.cpp
+        /// This is the <code>googletest</code> based unit testing file for the free function
+        ///   interfaces to <code>playrho::d2::World</code> contact member functions and additional
+        ///   functionality.
 
-/// @copydoc World::SetTangentSpeed
-/// @relatedalso World
-void SetTangentSpeed(World& world, ContactID id, LinearVelocity value);
+        /// @defgroup WorldContactFreeFunctions World Contacts Related Free Functions
+        /// @brief Collection of "free" functions related to contacts within a <code>World</code>.
+        /// @details This is a collection of non-member non-friend functions - also called "free"
+        ///   functions - that are related to contacts within an instance of a <code>World</code>.
+        ///   Many are just "wrappers" to similarly named member functions but some are additional
+        ///   functionality built on those member functions. A benefit to using free functions that
+        ///   are now just wrappers, is that of helping to isolate your code from future changes that
+        ///   might occur to the underlying <code>World</code> member functions. Free functions in
+        ///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
+        ///   when compiled without any compiler optimizations enabled, enabling optimizations
+        ///   should entirely eliminate that overhead.
+        /// @note The four basic categories of these functions are "CRUD": create, read, update,
+        ///   and delete.
+        /// @see World, ContactID.
+        /// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
+        /// @{
 
-/// @brief Gets the enabled status of the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-bool IsEnabled(const World& world, ContactID id);
+        /// @brief Gets the contacts recognized within the given world.
+        /// @relatedalso World
+        SizedRange<std::vector<KeyedContactPtr>::const_iterator>
+        GetContacts(const World& world) noexcept;
 
-/// @brief Sets the enabled status of the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-void SetEnabled(World& world, ContactID id);
+        /// @copydoc World::IsTouching
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        bool IsTouching(const World& world, ContactID id);
 
-/// @brief Unsets the enabled status of the identified contact.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @relatedalso World
-void UnsetEnabled(World& world, ContactID id);
+        /// @brief Gets the awake status of the specified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        bool IsAwake(const World& world, ContactID id);
 
-/// @brief Gets the touching count for the given world.
-/// @relatedalso World
-ContactCounter GetTouchingCount(const World& world) noexcept;
+        /// @brief Sets awake the bodies of the fixtures of the given contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        void SetAwake(World& world, ContactID id);
 
-/// @brief Convenience function for setting/unsetting the enabled status of the identified
-///   contact based on the value parameter.
-/// @throws std::out_of_range If given an invalid contact identifier.
-/// @see IsEnabled(const World&, ContactID).
-/// @relatedalso World
-inline void SetEnabled(World& world, ContactID id, bool value)
-{
-    if (value) {
-        SetEnabled(world, id);
-    }
-    else {
-        UnsetEnabled(world, id);
-    }
-}
+        /// @brief Gets the body-A of the identified contact if it has one.
+        /// @return Identification of the body-A or <code>InvalidBodyID</code>.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        BodyID GetBodyA(const World& world, ContactID id);
 
-/// @brief Gets the count of contacts in the given world.
-/// @note Not all contacts are for shapes that are actually touching. Some contacts are for
-///   shapes which merely have overlapping AABBs.
-/// @return 0 or higher.
-/// @relatedalso World
-inline ContactCounter GetContactCount(const World& world) noexcept
-{
-    using std::size;
-    return static_cast<ContactCounter>(size(GetContacts(world)));
-}
+        /// @brief Gets the body-B of the identified contact if it has one.
+        /// @return Identification of the body-B or <code>InvalidBodyID</code>.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        BodyID GetBodyB(const World& world, ContactID id);
 
-/// @}
+        /// @brief Gets fixture A of the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        FixtureID GetFixtureA(const World& world, ContactID id);
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Gets fixture B of the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        FixtureID GetFixtureB(const World& world, ContactID id);
 
-#endif // PLAYRHO_DYNAMICS_WORLDCONTACT_HPP
+        /// @brief Get the child primitive index for fixture A.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        ChildCounter GetChildIndexA(const World& world, ContactID id);
+
+        /// @brief Get the child primitive index for fixture B.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        ChildCounter GetChildIndexB(const World& world, ContactID id);
+
+        /// @brief Gets the Time Of Impact (TOI) count.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        TimestepIters GetToiCount(const World& world, ContactID id);
+
+        /// @copydoc World::NeedsFiltering
+        /// @relatedalso World
+        bool NeedsFiltering(const World& world, ContactID id);
+
+        /// @copydoc World::NeedsUpdating
+        /// @relatedalso World
+        bool NeedsUpdating(const World& world, ContactID id);
+
+        /// @copydoc World::HasValidToi
+        /// @relatedalso World
+        bool HasValidToi(const World& world, ContactID id);
+
+        /// @brief Gets the time of impact associated with the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        Real GetToi(const World& world, ContactID id);
+
+        /// @brief Gets the default friction amount for the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        Real GetDefaultFriction(const World& world, ContactID id);
+
+        /// @brief Gets the default restitution amount for the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        Real GetDefaultRestitution(const World& world, ContactID id);
+
+        /// @brief Gets the friction used with the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @see SetFriction(World& world, ContactID id, Real friction)
+        /// @relatedalso World
+        Real GetFriction(const World& world, ContactID id);
+
+        /// @brief Gets the restitution used with the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @see SetRestitution(World& world, ContactID id, Real restitution)
+        /// @relatedalso World
+        Real GetRestitution(const World& world, ContactID id);
+
+        /// @brief Sets the friction value for the identified contact.
+        /// @details Overrides the default friction mixture.
+        /// @note You can call this in "pre-solve" listeners.
+        /// @note This value persists until set or reset.
+        /// @warning Behavior is undefined if given a negative friction value.
+        /// @param world The world in which the contact is identified in.
+        /// @param id Identifier of the contact whose friction value should be set.
+        /// @param friction Co-efficient of friction value of zero or greater.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        void SetFriction(World& world, ContactID id, Real friction);
+
+        /// @brief Sets the restitution value for the specified contact.
+        /// @details This override the default restitution mixture.
+        /// @note You can call this in "pre-solve" listeners.
+        /// @note The value persists until you set or reset.
+        /// @relatedalso World
+        void SetRestitution(World& world, ContactID id, Real restitution);
+
+        /// @brief Gets the manifold for the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        const Manifold& GetManifold(const World& world, ContactID id);
+
+        /// @brief Gets the world manifold for the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        WorldManifold GetWorldManifold(const World& world, ContactID id);
+
+        /// Resets the friction mixture to the default value.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        inline void ResetFriction(World& world, ContactID id)
+        {
+            SetFriction(world, id, GetDefaultFriction(world, id));
+        }
+
+        /// Resets the restitution to the default value.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        inline void ResetRestitution(World& world, ContactID id)
+        {
+            SetRestitution(world, id, GetDefaultRestitution(world, id));
+        }
+
+        /// @copydoc World::GetTangentSpeed
+        /// @relatedalso World
+        LinearVelocity GetTangentSpeed(const World& world, ContactID id);
+
+        /// @copydoc World::SetTangentSpeed
+        /// @relatedalso World
+        void SetTangentSpeed(World& world, ContactID id, LinearVelocity value);
+
+        /// @brief Gets the enabled status of the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        bool IsEnabled(const World& world, ContactID id);
+
+        /// @brief Sets the enabled status of the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        void SetEnabled(World& world, ContactID id);
+
+        /// @brief Unsets the enabled status of the identified contact.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @relatedalso World
+        void UnsetEnabled(World& world, ContactID id);
+
+        /// @brief Gets the touching count for the given world.
+        /// @relatedalso World
+        ContactCounter GetTouchingCount(const World& world) noexcept;
+
+        /// @brief Convenience function for setting/unsetting the enabled status of the identified
+        ///   contact based on the value parameter.
+        /// @throws std::out_of_range If given an invalid contact identifier.
+        /// @see IsEnabled(const World&, ContactID).
+        /// @relatedalso World
+        inline void SetEnabled(World& world, ContactID id, bool value)
+        {
+            if (value)
+            {
+                SetEnabled(world, id);
+            }
+            else
+            {
+                UnsetEnabled(world, id);
+            }
+        }
+
+        /// @brief Gets the count of contacts in the given world.
+        /// @note Not all contacts are for shapes that are actually touching. Some contacts are for
+        ///   shapes which merely have overlapping AABBs.
+        /// @return 0 or higher.
+        /// @relatedalso World
+        inline ContactCounter GetContactCount(const World& world) noexcept
+        {
+            using std::size;
+            return static_cast<ContactCounter>(size(GetContacts(world)));
+        }
+
+        /// @}
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_WORLDCONTACT_HPP

--- a/PlayRho/Dynamics/WorldFixture.cpp
+++ b/PlayRho/Dynamics/WorldFixture.cpp
@@ -23,97 +23,99 @@
 
 #include <PlayRho/Dynamics/World.hpp>
 
-namespace playrho {
-namespace d2 {
-
-using playrho::size;
-
-SizedRange<std::vector<FixtureID>::const_iterator>
-GetFixturesForProxies(const World& world) noexcept
+namespace playrho
 {
-    return world.GetFixturesForProxies();
-}
+    namespace d2
+    {
 
-FixtureCounter GetFixtureCount(const World& world) noexcept
-{
-    auto sum = FixtureCounter{0};
-    const auto bodies = world.GetBodies();
-    for_each(begin(bodies), end(bodies), [&world,&sum](const auto &b) {
-        sum += static_cast<FixtureCounter>(size(world.GetFixtures(b)));
-    });
-    return sum;
-}
+        using playrho::size;
 
-FixtureID CreateFixture(World& world, BodyID id, const Shape& shape,
-                        const FixtureConf& def, bool resetMassData)
-{
-    return world.CreateFixture(id, shape, def, resetMassData);
-}
+        SizedRange<std::vector<FixtureID>::const_iterator>
+        GetFixturesForProxies(const World& world) noexcept
+        {
+            return world.GetFixturesForProxies();
+        }
 
-bool Destroy(World& world, FixtureID id, bool resetMassData)
-{
-    return world.Destroy(id, resetMassData);
-}
+        FixtureCounter GetFixtureCount(const World& world) noexcept
+        {
+            auto sum = FixtureCounter{0};
+            const auto bodies = world.GetBodies();
+            for_each(begin(bodies), end(bodies), [&world, &sum](const auto& b) {
+                sum += static_cast<FixtureCounter>(size(world.GetFixtures(b)));
+            });
+            return sum;
+        }
 
-Filter GetFilterData(const World& world, FixtureID id)
-{
-    return world.GetFilterData(id);
-}
+        FixtureID CreateFixture(World& world, BodyID id, const Shape& shape,
+                                const FixtureConf& def, bool resetMassData)
+        {
+            return world.CreateFixture(id, shape, def, resetMassData);
+        }
 
-void SetFilterData(World& world, FixtureID id, const Filter& value)
-{
-    world.SetFilterData(id, value);
-}
+        bool Destroy(World& world, FixtureID id, bool resetMassData)
+        {
+            return world.Destroy(id, resetMassData);
+        }
 
-void Refilter(World& world, FixtureID id)
-{
-    world.Refilter(id);
-}
+        Filter GetFilterData(const World& world, FixtureID id)
+        {
+            return world.GetFilterData(id);
+        }
 
-BodyID GetBody(const World& world, FixtureID id)
-{
-    return world.GetBody(id);
-}
+        void SetFilterData(World& world, FixtureID id, const Filter& value)
+        {
+            world.SetFilterData(id, value);
+        }
 
-Transformation GetTransformation(const World& world, FixtureID id)
-{
-    return world.GetTransformation(GetBody(world, id));
-}
+        void Refilter(World& world, FixtureID id)
+        {
+            world.Refilter(id);
+        }
 
-Shape GetShape(const World& world, FixtureID id)
-{
-    return world.GetShape(id);
-}
+        BodyID GetBody(const World& world, FixtureID id)
+        {
+            return world.GetBody(id);
+        }
 
-void SetSensor(World& world, FixtureID id, bool value)
-{
-    world.SetSensor(id, value);
-}
+        Transformation GetTransformation(const World& world, FixtureID id)
+        {
+            return world.GetTransformation(GetBody(world, id));
+        }
 
-bool IsSensor(const World& world, FixtureID id)
-{
-    return world.IsSensor(id);
-}
+        Shape GetShape(const World& world, FixtureID id)
+        {
+            return world.GetShape(id);
+        }
 
-AreaDensity GetDensity(const World& world, FixtureID id)
-{
-    return world.GetDensity(id);
-}
+        void SetSensor(World& world, FixtureID id, bool value)
+        {
+            world.SetSensor(id, value);
+        }
 
-const std::vector<FixtureProxy>& GetProxies(const World& world, FixtureID id)
-{
-    return world.GetProxies(id);
-}
+        bool IsSensor(const World& world, FixtureID id)
+        {
+            return world.IsSensor(id);
+        }
 
-const FixtureProxy& GetProxy(const World& world, FixtureID id, ChildCounter child)
-{
-    return GetProxies(world, id).at(child);
-}
+        AreaDensity GetDensity(const World& world, FixtureID id)
+        {
+            return world.GetDensity(id);
+        }
 
-bool TestPoint(const World& world, FixtureID id, Length2 p)
-{
-    return TestPoint(GetShape(world, id), InverseTransform(p, GetTransformation(world, id)));
-}
+        const std::vector<FixtureProxy>& GetProxies(const World& world, FixtureID id)
+        {
+            return world.GetProxies(id);
+        }
 
-} // namespace d2
-} // namespace playrho
+        const FixtureProxy& GetProxy(const World& world, FixtureID id, ChildCounter child)
+        {
+            return GetProxies(world, id).at(child);
+        }
+
+        bool TestPoint(const World& world, FixtureID id, Length2 p)
+        {
+            return TestPoint(GetShape(world, id), InverseTransform(p, GetTransformation(world, id)));
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldFixture.hpp
+++ b/PlayRho/Dynamics/WorldFixture.hpp
@@ -26,175 +26,177 @@
 /// Declarations of free functions of World for fixtures identified by <code>FixtureID</code>.
 
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Range.hpp> // for SizedRange
+#include <PlayRho/Common/Range.hpp>// for SizedRange
 
 #include <PlayRho/Collision/MassData.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/FixtureConf.hpp>
+#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
 
 #include <iterator>
 #include <vector>
 
-namespace playrho {
-
-struct Filter;
-
-namespace d2 {
-
-class World;
-
-/// @example WorldFixture.cpp
-/// This is the <code>googletest</code> based unit testing file for the free function
-///   interfaces to <code>playrho::d2::World</code> fixture member functions and additional
-///   functionality.
-
-/// @defgroup WorldFixtureFreeFunctions World Fixture Related Free Functions
-/// @brief Collection of "free" functions related to fixtures within a <code>World</code>.
-/// @details This is a collection of non-member non-friend functions - also called "free"
-///   functions - that are related to fixtures within an instance of a <code>World</code>.
-///   Many are just "wrappers" to similarly named member functions but some are additional
-///   functionality built on those member functions. A benefit to using free functions that
-///   are now just wrappers, is that of helping to isolate your code from future changes that
-///   might occur to the underlying <code>World</code> member functions. Free functions in
-///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
-///   when compiled without any compiler optimizations enabled, enabling optimizations
-///   should entirely eliminate that overhead.
-/// @note The four basic categories of these functions are "CRUD": create, read, update,
-///   and delete.
-/// @see World, FixtureID.
-/// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
-/// @{
-
-/// @copydoc World::GetFixturesForProxies
-/// @relatedalso World
-SizedRange<std::vector<FixtureID>::const_iterator>
-GetFixturesForProxies(const World& world) noexcept;
-
-/// @brief Gets the count of fixtures in the given world.
-/// @throws WrongState if called while the world is "locked".
-/// @relatedalso World
-FixtureCounter GetFixtureCount(const World& world) noexcept;
-
-/// @brief Creates a fixture within the specified world.
-/// @throws WrongState if called while the world is "locked".
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso World
-FixtureID CreateFixture(World& world, BodyID id, const Shape& shape,
-                        const FixtureConf& def = GetDefaultFixtureConf(),
-                        bool resetMassData = true);
-
-/// @brief Destroys the identified fixture.
-/// @throws WrongState if this function is called while the world is locked.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-bool Destroy(World& world, FixtureID id, bool resetMassData = true);
-
-/// @copydoc World::GetFilterData
-/// @relatedalso World
-Filter GetFilterData(const World& world, FixtureID id);
-
-/// @copydoc World::SetFilterData
-/// @relatedalso World
-void SetFilterData(World& world, FixtureID id, const Filter& filter);
-
-/// @copydoc World::Refilter
-/// @relatedalso World
-void Refilter(World& world, FixtureID id);
-
-/// @brief Gets the identifier of the body associated with the identified fixture.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-BodyID GetBody(const World& world, FixtureID id);
-
-/// @brief Gets the transformation associated with the given fixture.
-/// @warning Behavior is undefined if the fixture doesn't have an associated body - i.e.
-///   behavior is undefined if the fixture has <code>nullptr</code> as its associated body.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-Transformation GetTransformation(const World& world, FixtureID id);
-
-/// @brief Gets the shape associated with the identified fixture.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-Shape GetShape(const World& world, FixtureID id);
-
-/// @brief Gets the coefficient of friction of the specified fixture.
-/// @return Value of 0 or higher.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-inline Real GetFriction(const World& world, FixtureID id)
+namespace playrho
 {
-    return GetFriction(GetShape(world, id));
-}
 
-/// @brief Gets the coefficient of restitution of the specified fixture.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-inline Real GetRestitution(const World& world, FixtureID id)
-{
-    return GetRestitution(GetShape(world, id));
-}
+    struct Filter;
 
-/// @brief Sets whether the fixture is a sensor or not.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @see IsSensor.
-/// @relatedalso World
-void SetSensor(World& world, FixtureID id, bool value);
+    namespace d2
+    {
 
-/// @brief Is the specified fixture a sensor (non-solid)?
-/// @return the true if the fixture is a sensor.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @see SetSensor.
-/// @relatedalso World
-bool IsSensor(const World& world, FixtureID id);
+        class World;
 
-/// @brief Gets the density of this fixture.
-/// @return Non-negative density (in mass per area).
-/// @throws std::out_of_range If given an invalid fixture identifier.
-AreaDensity GetDensity(const World& world, FixtureID id);
+        /// @example WorldFixture.cpp
+        /// This is the <code>googletest</code> based unit testing file for the free function
+        ///   interfaces to <code>playrho::d2::World</code> fixture member functions and additional
+        ///   functionality.
 
-/// @brief Gets the proxies of the identified fixture.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-const std::vector<FixtureProxy>& GetProxies(const World& world, FixtureID id);
+        /// @defgroup WorldFixtureFreeFunctions World Fixture Related Free Functions
+        /// @brief Collection of "free" functions related to fixtures within a <code>World</code>.
+        /// @details This is a collection of non-member non-friend functions - also called "free"
+        ///   functions - that are related to fixtures within an instance of a <code>World</code>.
+        ///   Many are just "wrappers" to similarly named member functions but some are additional
+        ///   functionality built on those member functions. A benefit to using free functions that
+        ///   are now just wrappers, is that of helping to isolate your code from future changes that
+        ///   might occur to the underlying <code>World</code> member functions. Free functions in
+        ///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
+        ///   when compiled without any compiler optimizations enabled, enabling optimizations
+        ///   should entirely eliminate that overhead.
+        /// @note The four basic categories of these functions are "CRUD": create, read, update,
+        ///   and delete.
+        /// @see World, FixtureID.
+        /// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
+        /// @{
 
-/// @brief Gets the count of proxies of the identified fixture.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-inline ChildCounter GetProxyCount(const World& world, FixtureID id)
-{
-    return static_cast<ChildCounter>(std::size(GetProxies(world, id)));
-}
+        /// @copydoc World::GetFixturesForProxies
+        /// @relatedalso World
+        SizedRange<std::vector<FixtureID>::const_iterator>
+        GetFixturesForProxies(const World& world) noexcept;
 
-/// @brief Gets the specified proxy of the identified fixture.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-const FixtureProxy& GetProxy(const World& world, FixtureID id, ChildCounter child);
+        /// @brief Gets the count of fixtures in the given world.
+        /// @throws WrongState if called while the world is "locked".
+        /// @relatedalso World
+        FixtureCounter GetFixtureCount(const World& world) noexcept;
 
-/// @brief Gets the mass data for the identified fixture in the given world.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-inline MassData GetMassData(const World& world, FixtureID id)
-{
-    return GetMassData(GetShape(world, id));
-}
+        /// @brief Creates a fixture within the specified world.
+        /// @throws WrongState if called while the world is "locked".
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso World
+        FixtureID CreateFixture(World& world, BodyID id, const Shape& shape,
+                                const FixtureConf& def = GetDefaultFixtureConf(),
+                                bool resetMassData = true);
 
-/// @brief Tests a point for containment in a fixture.
-/// @param world The world that the given fixture ID exists within.
-/// @param id Fixture to use for test.
-/// @param p Point in world coordinates.
-/// @throws std::out_of_range If given an invalid fixture identifier.
-/// @relatedalso World
-/// @ingroup TestPointGroup
-bool TestPoint(const World& world, FixtureID id, Length2 p);
+        /// @brief Destroys the identified fixture.
+        /// @throws WrongState if this function is called while the world is locked.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        bool Destroy(World& world, FixtureID id, bool resetMassData = true);
 
-/// @}
+        /// @copydoc World::GetFilterData
+        /// @relatedalso World
+        Filter GetFilterData(const World& world, FixtureID id);
 
-} // namespace d2
-} // namespace playrho
+        /// @copydoc World::SetFilterData
+        /// @relatedalso World
+        void SetFilterData(World& world, FixtureID id, const Filter& filter);
 
-#endif // PLAYRHO_DYNAMICS_WORLDFIXTURE_HPP
+        /// @copydoc World::Refilter
+        /// @relatedalso World
+        void Refilter(World& world, FixtureID id);
+
+        /// @brief Gets the identifier of the body associated with the identified fixture.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        BodyID GetBody(const World& world, FixtureID id);
+
+        /// @brief Gets the transformation associated with the given fixture.
+        /// @warning Behavior is undefined if the fixture doesn't have an associated body - i.e.
+        ///   behavior is undefined if the fixture has <code>nullptr</code> as its associated body.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        Transformation GetTransformation(const World& world, FixtureID id);
+
+        /// @brief Gets the shape associated with the identified fixture.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        Shape GetShape(const World& world, FixtureID id);
+
+        /// @brief Gets the coefficient of friction of the specified fixture.
+        /// @return Value of 0 or higher.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        inline Real GetFriction(const World& world, FixtureID id)
+        {
+            return GetFriction(GetShape(world, id));
+        }
+
+        /// @brief Gets the coefficient of restitution of the specified fixture.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        inline Real GetRestitution(const World& world, FixtureID id)
+        {
+            return GetRestitution(GetShape(world, id));
+        }
+
+        /// @brief Sets whether the fixture is a sensor or not.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @see IsSensor.
+        /// @relatedalso World
+        void SetSensor(World& world, FixtureID id, bool value);
+
+        /// @brief Is the specified fixture a sensor (non-solid)?
+        /// @return the true if the fixture is a sensor.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @see SetSensor.
+        /// @relatedalso World
+        bool IsSensor(const World& world, FixtureID id);
+
+        /// @brief Gets the density of this fixture.
+        /// @return Non-negative density (in mass per area).
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        AreaDensity GetDensity(const World& world, FixtureID id);
+
+        /// @brief Gets the proxies of the identified fixture.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        const std::vector<FixtureProxy>& GetProxies(const World& world, FixtureID id);
+
+        /// @brief Gets the count of proxies of the identified fixture.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        inline ChildCounter GetProxyCount(const World& world, FixtureID id)
+        {
+            return static_cast<ChildCounter>(std::size(GetProxies(world, id)));
+        }
+
+        /// @brief Gets the specified proxy of the identified fixture.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        const FixtureProxy& GetProxy(const World& world, FixtureID id, ChildCounter child);
+
+        /// @brief Gets the mass data for the identified fixture in the given world.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        inline MassData GetMassData(const World& world, FixtureID id)
+        {
+            return GetMassData(GetShape(world, id));
+        }
+
+        /// @brief Tests a point for containment in a fixture.
+        /// @param world The world that the given fixture ID exists within.
+        /// @param id Fixture to use for test.
+        /// @param p Point in world coordinates.
+        /// @throws std::out_of_range If given an invalid fixture identifier.
+        /// @relatedalso World
+        /// @ingroup TestPointGroup
+        bool TestPoint(const World& world, FixtureID id, Length2 p);
+
+        /// @}
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_WORLDFIXTURE_HPP

--- a/PlayRho/Dynamics/WorldImpl.cpp
+++ b/PlayRho/Dynamics/WorldImpl.cpp
@@ -23,47 +23,47 @@
 
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyConf.hpp>
-#include <PlayRho/Dynamics/StepConf.hpp>
+#include <PlayRho/Dynamics/ContactImpulsesList.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
 #include <PlayRho/Dynamics/Island.hpp>
 #include <PlayRho/Dynamics/MovementConf.hpp>
-#include <PlayRho/Dynamics/ContactImpulsesList.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
 
-#include <PlayRho/Dynamics/Joints/Joint.hpp>
-#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/DistanceJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/GearJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/WheelJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/FrictionJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/RopeJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/GearJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/MotorJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/RopeJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/WheelJointConf.hpp>
 
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
-#include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
 #include <PlayRho/Dynamics/Contacts/PositionConstraint.hpp>
+#include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
 
-#include <PlayRho/Collision/WorldManifold.hpp>
-#include <PlayRho/Collision/TimeOfImpact.hpp>
-#include <PlayRho/Collision/RayCastOutput.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
+#include <PlayRho/Collision/RayCastOutput.hpp>
+#include <PlayRho/Collision/TimeOfImpact.hpp>
+#include <PlayRho/Collision/WorldManifold.hpp>
 
-#include <PlayRho/Common/LengthError.hpp>
 #include <PlayRho/Common/DynamicMemory.hpp>
 #include <PlayRho/Common/FlagGuard.hpp>
+#include <PlayRho/Common/LengthError.hpp>
 #include <PlayRho/Common/WrongState.hpp>
 
 #include <algorithm>
-#include <new>
 #include <functional>
-#include <type_traits>
 #include <memory>
+#include <new>
 #include <set>
+#include <type_traits>
 #include <vector>
 
 #ifdef DO_PAR_UNSEQ
@@ -81,229 +81,230 @@ using std::sort;
 using std::transform;
 using std::unique;
 
-namespace playrho {
-namespace d2 {
-
-static_assert(std::is_default_constructible<WorldImpl>::value,
-              "WorldImpl must be default constructible!");
-static_assert(std::is_copy_constructible<WorldImpl>::value,
-              "WorldImpl must be copy constructible!");
-static_assert(std::is_copy_assignable<WorldImpl>::value,
-              "WorldImpl must be copy assignable!");
-static_assert(std::is_nothrow_destructible<WorldImpl>::value,
-              "WorldImpl must be nothrow destructible!");
-
-using playrho::size;
-
-/// @brief A body pointer and body constraint pointer pair.
-using BodyConstraintsPair = std::pair<const Body* const, BodyConstraint*>;
-
-/// @brief Collection of body constraints.
-using BodyConstraints = std::vector<BodyConstraint>;
-
-/// @brief Collection of position constraints.
-using PositionConstraints = std::vector<PositionConstraint>;
-
-/// @brief Collection of velocity constraints.
-using VelocityConstraints = std::vector<VelocityConstraint>;
-
-/// @brief Contact updating configuration.
-struct WorldImpl::ContactUpdateConf
+namespace playrho
 {
-    DistanceConf distance; ///< Distance configuration data.
-    Manifold::Conf manifold; ///< Manifold configuration data.
-};
-
-namespace {
-
-inline void IntegratePositions(BodyConstraints& bodies, Time h)
-{
-    assert(IsValid(h));
-    for_each(begin(bodies), end(bodies), [&](BodyConstraint& bc) {
-        const auto velocity = bc.GetVelocity();
-        const auto translation = h * velocity.linear;
-        const auto rotation = h * velocity.angular;
-        bc.SetPosition(bc.GetPosition() + Position{translation, rotation});
-    });
-}
-
-/// Reports the given constraints to the listener.
-/// @details
-/// This calls the listener's PostSolve method for all size(contacts) elements of
-/// the given array of constraints.
-/// @param listener Listener to call.
-/// @param constraints Array of m_contactCount contact velocity constraint elements.
-inline void Report(const WorldImpl::ImpulsesContactListener& listener,
-                   const std::vector<ContactID>& contacts,
-                   const VelocityConstraints& constraints,
-                   StepConf::iteration_type solved)
-{
-    const auto numContacts = size(contacts);
-    for (auto i = decltype(numContacts){0}; i < numContacts; ++i)
+    namespace d2
     {
-        listener(contacts[i], GetContactImpulses(constraints[i]), solved);
-    }
-}
 
-inline void AssignImpulses(Manifold& var, const VelocityConstraint& vc)
-{
-    assert(var.GetPointCount() >= vc.GetPointCount());
-    
-    auto assignProc = [&](VelocityConstraint::size_type i) {
-        var.SetPointImpulses(i, GetNormalImpulseAtPoint(vc, i), GetTangentImpulseAtPoint(vc, i));
-    };
+        static_assert(std::is_default_constructible<WorldImpl>::value,
+                      "WorldImpl must be default constructible!");
+        static_assert(std::is_copy_constructible<WorldImpl>::value,
+                      "WorldImpl must be copy constructible!");
+        static_assert(std::is_copy_assignable<WorldImpl>::value,
+                      "WorldImpl must be copy assignable!");
+        static_assert(std::is_nothrow_destructible<WorldImpl>::value,
+                      "WorldImpl must be nothrow destructible!");
+
+        using playrho::size;
+
+        /// @brief A body pointer and body constraint pointer pair.
+        using BodyConstraintsPair = std::pair<const Body* const, BodyConstraint*>;
+
+        /// @brief Collection of body constraints.
+        using BodyConstraints = std::vector<BodyConstraint>;
+
+        /// @brief Collection of position constraints.
+        using PositionConstraints = std::vector<PositionConstraint>;
+
+        /// @brief Collection of velocity constraints.
+        using VelocityConstraints = std::vector<VelocityConstraint>;
+
+        /// @brief Contact updating configuration.
+        struct WorldImpl::ContactUpdateConf
+        {
+            DistanceConf distance;  ///< Distance configuration data.
+            Manifold::Conf manifold;///< Manifold configuration data.
+        };
+
+        namespace
+        {
+
+            inline void IntegratePositions(BodyConstraints& bodies, Time h)
+            {
+                assert(IsValid(h));
+                for_each(begin(bodies), end(bodies), [&](BodyConstraint& bc) {
+                    const auto velocity = bc.GetVelocity();
+                    const auto translation = h * velocity.linear;
+                    const auto rotation = h * velocity.angular;
+                    bc.SetPosition(bc.GetPosition() + Position{translation, rotation});
+                });
+            }
+
+            /// Reports the given constraints to the listener.
+            /// @details
+            /// This calls the listener's PostSolve method for all size(contacts) elements of
+            /// the given array of constraints.
+            /// @param listener Listener to call.
+            /// @param constraints Array of m_contactCount contact velocity constraint elements.
+            inline void Report(const WorldImpl::ImpulsesContactListener& listener,
+                               const std::vector<ContactID>& contacts,
+                               const VelocityConstraints& constraints,
+                               StepConf::iteration_type solved)
+            {
+                const auto numContacts = size(contacts);
+                for (auto i = decltype(numContacts){0}; i < numContacts; ++i)
+                {
+                    listener(contacts[i], GetContactImpulses(constraints[i]), solved);
+                }
+            }
+
+            inline void AssignImpulses(Manifold& var, const VelocityConstraint& vc)
+            {
+                assert(var.GetPointCount() >= vc.GetPointCount());
+
+                auto assignProc = [&](VelocityConstraint::size_type i) {
+                    var.SetPointImpulses(i, GetNormalImpulseAtPoint(vc, i), GetTangentImpulseAtPoint(vc, i));
+                };
 #if 0
     // Branch free assignment causes problems in TilesComeToRest test.
     assignProc(1);
     assignProc(0);
 #else
-    const auto count = vc.GetPointCount();
-    for (auto i = decltype(count){0}; i < count; ++i)
-    {
-        assignProc(i);
-    }
+                const auto count = vc.GetPointCount();
+                for (auto i = decltype(count){0}; i < count; ++i)
+                {
+                    assignProc(i);
+                }
 #endif
-}
+            }
 
-inline void WarmStartVelocities(const VelocityConstraints& velConstraints)
-{
-    for_each(cbegin(velConstraints), cend(velConstraints),
-                  [&](const VelocityConstraint& vc) {
-        const auto vp = CalcWarmStartVelocityDeltas(vc);
-        const auto bodyA = vc.GetBodyA();
-        const auto bodyB = vc.GetBodyB();
-        bodyA->SetVelocity(bodyA->GetVelocity() + std::get<0>(vp));
-        bodyB->SetVelocity(bodyB->GetVelocity() + std::get<1>(vp));
-    });
-}
+            inline void WarmStartVelocities(const VelocityConstraints& velConstraints)
+            {
+                for_each(cbegin(velConstraints), cend(velConstraints),
+                         [&](const VelocityConstraint& vc) {
+                             const auto vp = CalcWarmStartVelocityDeltas(vc);
+                             const auto bodyA = vc.GetBodyA();
+                             const auto bodyB = vc.GetBodyB();
+                             bodyA->SetVelocity(bodyA->GetVelocity() + std::get<0>(vp));
+                             bodyB->SetVelocity(bodyB->GetVelocity() + std::get<1>(vp));
+                         });
+            }
 
-BodyConstraints GetBodyConstraints(const Island::Bodies& bodies,
-                                   const ArrayAllocator<Body>& bodyBuffer,
-                                   Time h, MovementConf conf)
-{
-    auto constraints = std::vector<BodyConstraint>{};
-    constraints.resize(size(bodyBuffer));
-    for (const auto& id : bodies)
-    {
-        constraints[UnderlyingValue(id)] =
-            GetBodyConstraint(bodyBuffer[UnderlyingValue(id)], h, conf);
-    }
-    return constraints;
-}
+            BodyConstraints GetBodyConstraints(const Island::Bodies& bodies,
+                                               const ArrayAllocator<Body>& bodyBuffer,
+                                               Time h, MovementConf conf)
+            {
+                auto constraints = std::vector<BodyConstraint>{};
+                constraints.resize(size(bodyBuffer));
+                for (const auto& id : bodies)
+                {
+                    constraints[UnderlyingValue(id)] =
+                        GetBodyConstraint(bodyBuffer[UnderlyingValue(id)], h, conf);
+                }
+                return constraints;
+            }
 
-PositionConstraints GetPositionConstraints(const Island::Contacts& contacts,
-                                           const ArrayAllocator<Fixture>& fixtureBuffer,
-                                           const ArrayAllocator<Contact>& contactBuffer,
-                                           const ArrayAllocator<Manifold>& manifoldBuffer,
-                                           BodyConstraints& bodies)
-{
-    auto constraints = PositionConstraints{};
-    constraints.reserve(size(contacts));
-    transform(cbegin(contacts), cend(contacts), back_inserter(constraints),
-              [&](const auto& contactID) {
-        const auto& contact = contactBuffer[UnderlyingValue(contactID)];
-        const auto& manifold = manifoldBuffer[UnderlyingValue(contactID)];
-        const auto fixtureA = GetFixtureA(contact);
-        const auto fixtureB = GetFixtureB(contact);
-        const auto indexA = GetChildIndexA(contact);
-        const auto indexB = GetChildIndexB(contact);
-        const auto bodyA = GetBodyA(contact);
-        const auto bodyB = GetBodyB(contact);
-        const auto shapeA = fixtureBuffer[UnderlyingValue(fixtureA)].GetShape();
-        const auto shapeB = fixtureBuffer[UnderlyingValue(fixtureB)].GetShape();
-        auto& bodyConstraintA = bodies[UnderlyingValue(bodyA)];
-        auto& bodyConstraintB = bodies[UnderlyingValue(bodyB)];
-        const auto radiusA = GetVertexRadius(shapeA, indexA);
-        const auto radiusB = GetVertexRadius(shapeB, indexB);
-        return PositionConstraint{
-            manifold, bodyConstraintA, radiusA, bodyConstraintB, radiusB
-        };
-    });
-    return constraints;
-}
+            PositionConstraints GetPositionConstraints(const Island::Contacts& contacts,
+                                                       const ArrayAllocator<Fixture>& fixtureBuffer,
+                                                       const ArrayAllocator<Contact>& contactBuffer,
+                                                       const ArrayAllocator<Manifold>& manifoldBuffer,
+                                                       BodyConstraints& bodies)
+            {
+                auto constraints = PositionConstraints{};
+                constraints.reserve(size(contacts));
+                transform(cbegin(contacts), cend(contacts), back_inserter(constraints),
+                          [&](const auto& contactID) {
+                              const auto& contact = contactBuffer[UnderlyingValue(contactID)];
+                              const auto& manifold = manifoldBuffer[UnderlyingValue(contactID)];
+                              const auto fixtureA = GetFixtureA(contact);
+                              const auto fixtureB = GetFixtureB(contact);
+                              const auto indexA = GetChildIndexA(contact);
+                              const auto indexB = GetChildIndexB(contact);
+                              const auto bodyA = GetBodyA(contact);
+                              const auto bodyB = GetBodyB(contact);
+                              const auto shapeA = fixtureBuffer[UnderlyingValue(fixtureA)].GetShape();
+                              const auto shapeB = fixtureBuffer[UnderlyingValue(fixtureB)].GetShape();
+                              auto& bodyConstraintA = bodies[UnderlyingValue(bodyA)];
+                              auto& bodyConstraintB = bodies[UnderlyingValue(bodyB)];
+                              const auto radiusA = GetVertexRadius(shapeA, indexA);
+                              const auto radiusB = GetVertexRadius(shapeB, indexB);
+                              return PositionConstraint{
+                                  manifold, bodyConstraintA, radiusA, bodyConstraintB, radiusB};
+                          });
+                return constraints;
+            }
 
-/// @brief Gets the velocity constraints for the given inputs.
-/// @details Inializes the velocity constraints with the position dependent portions of
-///   the current position constraints.
-/// @post Velocity constraints will have their "normal" field set to the world manifold
-///   normal for them.
-/// @post Velocity constraints will have their constraint points set.
-/// @see SolveVelocityConstraints.
-VelocityConstraints GetVelocityConstraints(const Island::Contacts& contacts,
-                                           const ArrayAllocator<Fixture>& fixtureBuffer,
-                                           const ArrayAllocator<Contact>& contactBuffer,
-                                           const ArrayAllocator<Manifold>& manifoldBuffer,
-                                           BodyConstraints& bodies,
-                                           const VelocityConstraint::Conf conf)
-{
-    auto velConstraints = VelocityConstraints{};
-    velConstraints.reserve(size(contacts));
-    transform(cbegin(contacts), cend(contacts), back_inserter(velConstraints),
-              [&](const auto& contactID) {
-        const auto& contact = contactBuffer[UnderlyingValue(contactID)];
-        const auto& manifold = manifoldBuffer[UnderlyingValue(contactID)];
-        const auto fixtureA = contact.GetFixtureA();
-        const auto fixtureB = contact.GetFixtureB();
-        const auto friction = contact.GetFriction();
-        const auto restitution = contact.GetRestitution();
-        const auto tangentSpeed = contact.GetTangentSpeed();
-        const auto indexA = GetChildIndexA(contact);
-        const auto indexB = GetChildIndexB(contact);
-        const auto bodyA = fixtureBuffer[UnderlyingValue(fixtureA)].GetBody();
-        const auto shapeA = fixtureBuffer[UnderlyingValue(fixtureA)].GetShape();
-        const auto bodyB = fixtureBuffer[UnderlyingValue(fixtureB)].GetBody();
-        const auto shapeB = fixtureBuffer[UnderlyingValue(fixtureB)].GetShape();
-        auto& bodyConstraintA = bodies[UnderlyingValue(bodyA)];
-        auto& bodyConstraintB = bodies[UnderlyingValue(bodyB)];
-        const auto radiusA = GetVertexRadius(shapeA, indexA);
-        const auto radiusB = GetVertexRadius(shapeB, indexB);
-        const auto xfA = GetTransformation(bodyConstraintA.GetPosition(),
-                                           bodyConstraintA.GetLocalCenter());
-        const auto xfB = GetTransformation(bodyConstraintB.GetPosition(),
-                                           bodyConstraintB.GetLocalCenter());
-        const auto worldManifold = GetWorldManifold(manifold, xfA, radiusA, xfB, radiusB);
-        return VelocityConstraint{friction, restitution, tangentSpeed, worldManifold,
-            bodyConstraintA, bodyConstraintB, conf};
-    });
-    return velConstraints;
-}
+            /// @brief Gets the velocity constraints for the given inputs.
+            /// @details Inializes the velocity constraints with the position dependent portions of
+            ///   the current position constraints.
+            /// @post Velocity constraints will have their "normal" field set to the world manifold
+            ///   normal for them.
+            /// @post Velocity constraints will have their constraint points set.
+            /// @see SolveVelocityConstraints.
+            VelocityConstraints GetVelocityConstraints(const Island::Contacts& contacts,
+                                                       const ArrayAllocator<Fixture>& fixtureBuffer,
+                                                       const ArrayAllocator<Contact>& contactBuffer,
+                                                       const ArrayAllocator<Manifold>& manifoldBuffer,
+                                                       BodyConstraints& bodies,
+                                                       const VelocityConstraint::Conf conf)
+            {
+                auto velConstraints = VelocityConstraints{};
+                velConstraints.reserve(size(contacts));
+                transform(cbegin(contacts), cend(contacts), back_inserter(velConstraints),
+                          [&](const auto& contactID) {
+                              const auto& contact = contactBuffer[UnderlyingValue(contactID)];
+                              const auto& manifold = manifoldBuffer[UnderlyingValue(contactID)];
+                              const auto fixtureA = contact.GetFixtureA();
+                              const auto fixtureB = contact.GetFixtureB();
+                              const auto friction = contact.GetFriction();
+                              const auto restitution = contact.GetRestitution();
+                              const auto tangentSpeed = contact.GetTangentSpeed();
+                              const auto indexA = GetChildIndexA(contact);
+                              const auto indexB = GetChildIndexB(contact);
+                              const auto bodyA = fixtureBuffer[UnderlyingValue(fixtureA)].GetBody();
+                              const auto shapeA = fixtureBuffer[UnderlyingValue(fixtureA)].GetShape();
+                              const auto bodyB = fixtureBuffer[UnderlyingValue(fixtureB)].GetBody();
+                              const auto shapeB = fixtureBuffer[UnderlyingValue(fixtureB)].GetShape();
+                              auto& bodyConstraintA = bodies[UnderlyingValue(bodyA)];
+                              auto& bodyConstraintB = bodies[UnderlyingValue(bodyB)];
+                              const auto radiusA = GetVertexRadius(shapeA, indexA);
+                              const auto radiusB = GetVertexRadius(shapeB, indexB);
+                              const auto xfA = GetTransformation(bodyConstraintA.GetPosition(),
+                                                                 bodyConstraintA.GetLocalCenter());
+                              const auto xfB = GetTransformation(bodyConstraintB.GetPosition(),
+                                                                 bodyConstraintB.GetLocalCenter());
+                              const auto worldManifold = GetWorldManifold(manifold, xfA, radiusA, xfB, radiusB);
+                              return VelocityConstraint{friction, restitution, tangentSpeed, worldManifold,
+                                                        bodyConstraintA, bodyConstraintB, conf};
+                          });
+                return velConstraints;
+            }
 
-/// "Solves" the velocity constraints.
-/// @details Updates the velocities and velocity constraint points' normal and tangent impulses.
-/// @pre <code>UpdateVelocityConstraints</code> has been called on the velocity constraints.
-/// @return Maximum momentum used for solving both the tangential and normal portions of
-///   the velocity constraints.
-Momentum SolveVelocityConstraintsViaGS(VelocityConstraints& velConstraints)
-{
-    auto maxIncImpulse = 0_Ns;
-    for_each(begin(velConstraints), end(velConstraints), [&](VelocityConstraint& vc)
-    {
-        maxIncImpulse = std::max(maxIncImpulse, GaussSeidel::SolveVelocityConstraint(vc));
-    });
-    return maxIncImpulse;
-}
+            /// "Solves" the velocity constraints.
+            /// @details Updates the velocities and velocity constraint points' normal and tangent impulses.
+            /// @pre <code>UpdateVelocityConstraints</code> has been called on the velocity constraints.
+            /// @return Maximum momentum used for solving both the tangential and normal portions of
+            ///   the velocity constraints.
+            Momentum SolveVelocityConstraintsViaGS(VelocityConstraints& velConstraints)
+            {
+                auto maxIncImpulse = 0_Ns;
+                for_each(begin(velConstraints), end(velConstraints), [&](VelocityConstraint& vc) {
+                    maxIncImpulse = std::max(maxIncImpulse, GaussSeidel::SolveVelocityConstraint(vc));
+                });
+                return maxIncImpulse;
+            }
 
-/// Solves the given position constraints.
-/// @details This updates positions (and nothing else) by calling the position constraint solving function.
-/// @note Can't expect the returned minimum separation to be greater than or equal to
-///  <code>-conf.linearSlop</code> because code won't push the separation above this
-///   amount to begin with.
-/// @return Minimum separation.
-Length SolvePositionConstraintsViaGS(PositionConstraints& posConstraints,
-                                     ConstraintSolverConf conf)
-{
-    auto minSeparation = std::numeric_limits<Length>::infinity();
-    
-    for_each(begin(posConstraints), end(posConstraints), [&](PositionConstraint &pc) {
-        assert(pc.GetBodyA() != pc.GetBodyB()); // Confirms ContactManager::Add() did its job.
-        const auto res = GaussSeidel::SolvePositionConstraint(pc, true, true, conf);
-        pc.GetBodyA()->SetPosition(res.pos_a);
-        pc.GetBodyB()->SetPosition(res.pos_b);
-        minSeparation = std::min(minSeparation, res.min_separation);
-    });
-    
-    return minSeparation;
-}
+            /// Solves the given position constraints.
+            /// @details This updates positions (and nothing else) by calling the position constraint solving function.
+            /// @note Can't expect the returned minimum separation to be greater than or equal to
+            ///  <code>-conf.linearSlop</code> because code won't push the separation above this
+            ///   amount to begin with.
+            /// @return Minimum separation.
+            Length SolvePositionConstraintsViaGS(PositionConstraints& posConstraints,
+                                                 ConstraintSolverConf conf)
+            {
+                auto minSeparation = std::numeric_limits<Length>::infinity();
+
+                for_each(begin(posConstraints), end(posConstraints), [&](PositionConstraint& pc) {
+                    assert(pc.GetBodyA() != pc.GetBodyB());// Confirms ContactManager::Add() did its job.
+                    const auto res = GaussSeidel::SolvePositionConstraint(pc, true, true, conf);
+                    pc.GetBodyA()->SetPosition(res.pos_a);
+                    pc.GetBodyB()->SetPosition(res.pos_b);
+                    minSeparation = std::min(minSeparation, res.min_separation);
+                });
+
+                return minSeparation;
+            }
 
 #if 0
 /// Solves the given position constraints.
@@ -342,652 +343,664 @@ Length SolvePositionConstraints(PositionConstraints& posConstraints,
 }
 #endif
 
-inline Time GetUnderActiveTime(const Body& b, const StepConf& conf) noexcept
-{
-    const auto underactive = IsUnderActive(b.GetVelocity(), conf.linearSleepTolerance,
-                                           conf.angularSleepTolerance);
-    const auto sleepable = b.IsSleepingAllowed();
-    return (sleepable && underactive)? b.GetUnderActiveTime() + conf.deltaTime: 0_s;
-}
-
-inline Time UpdateUnderActiveTimes(const Island::Bodies& bodies,
-                                   ArrayAllocator<Body>& bodyBuffer,
-                                   const StepConf& conf)
-{
-    auto minUnderActiveTime = std::numeric_limits<Time>::infinity();
-    for_each(cbegin(bodies), cend(bodies), [&](const auto& bodyID)
-    {
-        auto& b = bodyBuffer[UnderlyingValue(bodyID)];
-        if (b.IsSpeedable())
-        {
-            const auto underActiveTime = GetUnderActiveTime(b, conf);
-            b.SetUnderActiveTime(underActiveTime);
-            minUnderActiveTime = std::min(minUnderActiveTime, underActiveTime);
-        }
-    });
-    return minUnderActiveTime;
-}
-
-inline BodyCounter Sleepem(const Island::Bodies& bodies,
-                           ArrayAllocator<Body>& bodyBuffer)
-{
-    auto unawoken = BodyCounter{0};
-    for_each(cbegin(bodies), cend(bodies), [&](const auto& bodyID)
-    {
-        if (Unawaken(bodyBuffer[UnderlyingValue(bodyID)]))
-        {
-            ++unawoken;
-        }
-    });
-    return unawoken;
-}
-
-inline bool IsValidForTime(TOIOutput::State state) noexcept
-{
-    return state == TOIOutput::e_touching;
-}
-
-void FlagContactsForFiltering(ArrayAllocator<Contact>& contactBuffer, BodyID bodyA,
-                              const SizedRange<Body::Contacts::const_iterator>& contactsBodyB,
-                              BodyID bodyB) noexcept
-{
-    for (auto& ci: contactsBodyB)
-    {
-        auto& contact = contactBuffer[UnderlyingValue(GetContactPtr(ci))];
-        const auto bA = contact.GetBodyA();
-        const auto bB = contact.GetBodyB();
-        const auto other = (bA != bodyB)? bA: bB;
-        if (other == bodyA)
-        {
-            // Flag the contact for filtering at the next time step (where either
-            // body is awake).
-            contact.FlagForFiltering();
-        }
-    }
-}
-
-/// @brief Gets the update configuration from the given step configuration data.
-WorldImpl::ContactUpdateConf GetUpdateConf(const StepConf& conf) noexcept
-{
-    return WorldImpl::ContactUpdateConf{GetDistanceConf(conf), GetManifoldConf(conf)};
-}
-
-[[maybe_unused]]
-bool HasSensor(const ArrayAllocator<Fixture>& fixtures, const Contact& c)
-{
-    return fixtures[UnderlyingValue(c.GetFixtureA())].IsSensor() || fixtures[UnderlyingValue(c.GetFixtureB())].IsSensor();
-}
-
-void FlagForUpdating(ArrayAllocator<Contact>& contactsBuffer,
-                     SizedRange<Body::Contacts::const_iterator> contacts)
-{
-    std::for_each(begin(contacts), end(contacts), [&](const auto& ci) {
-        contactsBuffer[UnderlyingValue(std::get<ContactID>(ci))].FlagForUpdating();
-    });
-}
-
-bool ShouldCollide(const ArrayAllocator<Joint>& jointBuffer,
-                   const Body& lhs, const Body& rhs, BodyID rhsID)
-{
-    // At least one body should be accelerable/dynamic.
-    if (!lhs.IsAccelerable() && !rhs.IsAccelerable())
-    {
-        return false;
-    }
-
-    // Does a joint prevent collision?
-    const auto joints = lhs.GetJoints();
-    const auto it = std::find_if(cbegin(joints), cend(joints), [&](const auto& ji) {
-        return (std::get<BodyID>(ji) == rhsID) &&
-            !GetCollideConnected(jointBuffer[UnderlyingValue(std::get<JointID>(ji))]);
-    });
-    return it == end(joints);
-}
-
-/// @brief Executes function for all the fixtures of the given body.
-void ForallFixtures(Body& b, std::function<void(FixtureID)> callback)
-{
-    for (const auto& f: b.GetFixtures()) {
-        callback(f);
-    }
-}
-
-void Unset(std::vector<bool>& islanded, const WorldImpl::Bodies& elements)
-{
-    for (const auto& element: elements) {
-        islanded[UnderlyingValue(element)] = false;
-    }
-}
-
-void Unset(std::vector<bool>& islanded, const SizedRange<Body::Contacts::const_iterator>& elements)
-{
-    for (const auto& element: elements) {
-        islanded[UnderlyingValue(std::get<ContactID>(element))] = false;
-    }
-}
-
-void Unset(std::vector<bool>& islanded, const WorldImpl::Contacts& elements)
-{
-    for (const auto& element: elements) {
-        islanded[UnderlyingValue(std::get<ContactID>(element))] = false;
-    }
-}
-
-/// @brief Reset bodies for solve TOI.
-void ResetBodiesForSolveTOI(WorldImpl::Bodies& bodies, ArrayAllocator<Body>& buffer) noexcept
-{
-    for_each(begin(bodies), end(bodies), [&](const auto& body) {
-        buffer[UnderlyingValue(body)].ResetAlpha0();
-    });
-}
-
-/// @brief Reset contacts for solve TOI.
-void ResetContactsForSolveTOI(ArrayAllocator<Contact>& buffer,
-                              const Body& body) noexcept
-{
-    // Invalidate all contact TOIs on this displaced body.
-    const auto contacts = body.GetContacts();
-    for_each(cbegin(contacts), cend(contacts), [&buffer](const auto& ci) {
-        auto& contact = buffer[UnderlyingValue(std::get<ContactID>(ci))];
-        contact.UnsetToi();
-    });
-}
-
-/// @brief Reset contacts for solve TOI.
-void ResetContactsForSolveTOI(ArrayAllocator<Contact>& buffer,
-                              const WorldImpl::Contacts& contacts) noexcept
-{
-    for_each(begin(contacts), end(contacts), [&buffer](const auto& c) {
-        auto& contact = buffer[UnderlyingValue(std::get<ContactID>(c))];
-        contact.UnsetToi();
-        contact.SetToiCount(0);
-    });
-}
-
-/// @brief Destroys all of the given fixture's proxies.
-void DestroyProxies(Fixture& fixture,
-                    std::vector<DynamicTree::Size>& proxies, DynamicTree& tree) noexcept
-{
-    const auto fixtureProxies = fixture.GetProxies();
-    const auto childCount = size(fixtureProxies);
-    if (childCount > 0)
-    {
-        // Destroy proxies in reverse order from what they were created in.
-        for (auto i = childCount - 1; i < childCount; --i)
-        {
-            const auto treeId = fixtureProxies[i].treeId;
-            EraseFirst(proxies, treeId);
-            tree.DestroyLeaf(treeId);
-        }
-    }
-    fixture.SetProxies(std::vector<FixtureProxy>{});
-}
-
-} // anonymous namespace
-
-WorldImpl::WorldImpl(const WorldConf& def):
-    m_tree(def.initialTreeSize),
-    m_minVertexRadius{def.minVertexRadius},
-    m_maxVertexRadius{def.maxVertexRadius}
-{
-    if (def.minVertexRadius > def.maxVertexRadius)
-    {
-        throw InvalidArgument("max vertex radius must be >= min vertex radius");
-    }
-    m_proxyKeys.reserve(1024);
-    m_proxies.reserve(1024);
-}
-
-WorldImpl::~WorldImpl() noexcept
-{
-    Clear();
-}
-
-void WorldImpl::Clear() noexcept
-{
-    if (m_jointDestructionListener) {
-        for_each(cbegin(m_joints), cend(m_joints), [this](const auto& id) {
-            m_jointDestructionListener(id);
-        });
-    }
-    if (m_fixtureDestructionListener) {
-        for_each(cbegin(m_bodies), cend(m_bodies), [this](const auto& id) {
-            const auto& b = m_bodyBuffer[UnderlyingValue(id)];
-            for (const auto& fixture: b.GetFixtures()) {
-                m_fixtureDestructionListener(fixture);
+            inline Time GetUnderActiveTime(const Body& b, const StepConf& conf) noexcept
+            {
+                const auto underactive = IsUnderActive(b.GetVelocity(), conf.linearSleepTolerance,
+                                                       conf.angularSleepTolerance);
+                const auto sleepable = b.IsSleepingAllowed();
+                return (sleepable && underactive) ? b.GetUnderActiveTime() + conf.deltaTime : 0_s;
             }
-        });
-    }
-    m_contacts.clear();
-    m_joints.clear();
-    m_bodies.clear();
-    m_bodiesForProxies.clear();
-    m_fixturesForProxies.clear();
-    m_proxies.clear();
-    m_proxyKeys.clear();
-    m_tree.Clear();
-    m_manifoldBuffer.clear();
-    m_contactBuffer.clear();
-    m_jointBuffer.clear();
-    m_fixtureBuffer.clear();
-    m_bodyBuffer.clear();
-}
 
-BodyCounter WorldImpl::GetBodyRange() const noexcept
-{
-    return static_cast<BodyCounter>(m_bodyBuffer.size());
-}
+            inline Time UpdateUnderActiveTimes(const Island::Bodies& bodies,
+                                               ArrayAllocator<Body>& bodyBuffer,
+                                               const StepConf& conf)
+            {
+                auto minUnderActiveTime = std::numeric_limits<Time>::infinity();
+                for_each(cbegin(bodies), cend(bodies), [&](const auto& bodyID) {
+                    auto& b = bodyBuffer[UnderlyingValue(bodyID)];
+                    if (b.IsSpeedable())
+                    {
+                        const auto underActiveTime = GetUnderActiveTime(b, conf);
+                        b.SetUnderActiveTime(underActiveTime);
+                        minUnderActiveTime = std::min(minUnderActiveTime, underActiveTime);
+                    }
+                });
+                return minUnderActiveTime;
+            }
 
-BodyID WorldImpl::CreateBody(const BodyConf& def)
-{
-    if (IsLocked())
-    {
-        throw WrongState("CreateBody: world is locked");
-    }
-    if (size(m_bodies) >= MaxBodies)
-    {
-        throw LengthError("CreateBody: operation would exceed MaxBodies");
-    }
-    const auto id = static_cast<BodyID>(
-        static_cast<BodyID::underlying_type>(m_bodyBuffer.Allocate(def)));
-    m_bodies.push_back(id);
-    return id;
-}
+            inline BodyCounter Sleepem(const Island::Bodies& bodies,
+                                       ArrayAllocator<Body>& bodyBuffer)
+            {
+                auto unawoken = BodyCounter{0};
+                for_each(cbegin(bodies), cend(bodies), [&](const auto& bodyID) {
+                    if (Unawaken(bodyBuffer[UnderlyingValue(bodyID)]))
+                    {
+                        ++unawoken;
+                    }
+                });
+                return unawoken;
+            }
 
-void WorldImpl::Remove(BodyID id) noexcept
-{
-    m_bodiesForProxies.erase(remove(begin(m_bodiesForProxies), end(m_bodiesForProxies), id),
-                             end(m_bodiesForProxies));
-    const auto it = find(cbegin(m_bodies), cend(m_bodies), id);
-    if (it != cend(m_bodies))
-    {
-        m_bodies.erase(it);
-        m_bodyBuffer.Free(UnderlyingValue(id));
-    }
-}
+            inline bool IsValidForTime(TOIOutput::State state) noexcept
+            {
+                return state == TOIOutput::e_touching;
+            }
 
-void WorldImpl::Destroy(BodyID id)
-{
-    if (IsLocked())
-    {
-        throw WrongState("Destroy: world is locked");
-    }
+            void FlagContactsForFiltering(ArrayAllocator<Contact>& contactBuffer, BodyID bodyA,
+                                          const SizedRange<Body::Contacts::const_iterator>& contactsBodyB,
+                                          BodyID bodyB) noexcept
+            {
+                for (auto& ci : contactsBodyB)
+                {
+                    auto& contact = contactBuffer[UnderlyingValue(GetContactPtr(ci))];
+                    const auto bA = contact.GetBodyA();
+                    const auto bB = contact.GetBodyB();
+                    const auto other = (bA != bodyB) ? bA : bB;
+                    if (other == bodyA)
+                    {
+                        // Flag the contact for filtering at the next time step (where either
+                        // body is awake).
+                        contact.FlagForFiltering();
+                    }
+                }
+            }
 
-    auto& body = GetBody(id);
+            /// @brief Gets the update configuration from the given step configuration data.
+            WorldImpl::ContactUpdateConf GetUpdateConf(const StepConf& conf) noexcept
+            {
+                return WorldImpl::ContactUpdateConf{GetDistanceConf(conf), GetManifoldConf(conf)};
+            }
 
-    // Delete the attached joints.
-    auto joints = body.GetJoints();
-    while (!joints.empty()) {
-        const auto jointID = std::get<JointID>(*begin(joints));
-        if (m_jointDestructionListener) {
-            m_jointDestructionListener(jointID);
-        }
-        const auto endIter = cend(m_joints);
-        const auto iter = find(cbegin(m_joints), endIter, jointID);
-        if (iter != endIter)
+            [[maybe_unused]] bool HasSensor(const ArrayAllocator<Fixture>& fixtures, const Contact& c)
+            {
+                return fixtures[UnderlyingValue(c.GetFixtureA())].IsSensor() || fixtures[UnderlyingValue(c.GetFixtureB())].IsSensor();
+            }
+
+            void FlagForUpdating(ArrayAllocator<Contact>& contactsBuffer,
+                                 SizedRange<Body::Contacts::const_iterator> contacts)
+            {
+                std::for_each(begin(contacts), end(contacts), [&](const auto& ci) {
+                    contactsBuffer[UnderlyingValue(std::get<ContactID>(ci))].FlagForUpdating();
+                });
+            }
+
+            bool ShouldCollide(const ArrayAllocator<Joint>& jointBuffer,
+                               const Body& lhs, const Body& rhs, BodyID rhsID)
+            {
+                // At least one body should be accelerable/dynamic.
+                if (!lhs.IsAccelerable() && !rhs.IsAccelerable())
+                {
+                    return false;
+                }
+
+                // Does a joint prevent collision?
+                const auto joints = lhs.GetJoints();
+                const auto it = std::find_if(cbegin(joints), cend(joints), [&](const auto& ji) {
+                    return (std::get<BodyID>(ji) == rhsID) && !GetCollideConnected(jointBuffer[UnderlyingValue(std::get<JointID>(ji))]);
+                });
+                return it == end(joints);
+            }
+
+            /// @brief Executes function for all the fixtures of the given body.
+            void ForallFixtures(Body& b, std::function<void(FixtureID)> callback)
+            {
+                for (const auto& f : b.GetFixtures())
+                {
+                    callback(f);
+                }
+            }
+
+            void Unset(std::vector<bool>& islanded, const WorldImpl::Bodies& elements)
+            {
+                for (const auto& element : elements)
+                {
+                    islanded[UnderlyingValue(element)] = false;
+                }
+            }
+
+            void Unset(std::vector<bool>& islanded, const SizedRange<Body::Contacts::const_iterator>& elements)
+            {
+                for (const auto& element : elements)
+                {
+                    islanded[UnderlyingValue(std::get<ContactID>(element))] = false;
+                }
+            }
+
+            void Unset(std::vector<bool>& islanded, const WorldImpl::Contacts& elements)
+            {
+                for (const auto& element : elements)
+                {
+                    islanded[UnderlyingValue(std::get<ContactID>(element))] = false;
+                }
+            }
+
+            /// @brief Reset bodies for solve TOI.
+            void ResetBodiesForSolveTOI(WorldImpl::Bodies& bodies, ArrayAllocator<Body>& buffer) noexcept
+            {
+                for_each(begin(bodies), end(bodies), [&](const auto& body) {
+                    buffer[UnderlyingValue(body)].ResetAlpha0();
+                });
+            }
+
+            /// @brief Reset contacts for solve TOI.
+            void ResetContactsForSolveTOI(ArrayAllocator<Contact>& buffer,
+                                          const Body& body) noexcept
+            {
+                // Invalidate all contact TOIs on this displaced body.
+                const auto contacts = body.GetContacts();
+                for_each(cbegin(contacts), cend(contacts), [&buffer](const auto& ci) {
+                    auto& contact = buffer[UnderlyingValue(std::get<ContactID>(ci))];
+                    contact.UnsetToi();
+                });
+            }
+
+            /// @brief Reset contacts for solve TOI.
+            void ResetContactsForSolveTOI(ArrayAllocator<Contact>& buffer,
+                                          const WorldImpl::Contacts& contacts) noexcept
+            {
+                for_each(begin(contacts), end(contacts), [&buffer](const auto& c) {
+                    auto& contact = buffer[UnderlyingValue(std::get<ContactID>(c))];
+                    contact.UnsetToi();
+                    contact.SetToiCount(0);
+                });
+            }
+
+            /// @brief Destroys all of the given fixture's proxies.
+            void DestroyProxies(Fixture& fixture,
+                                std::vector<DynamicTree::Size>& proxies, DynamicTree& tree) noexcept
+            {
+                const auto fixtureProxies = fixture.GetProxies();
+                const auto childCount = size(fixtureProxies);
+                if (childCount > 0)
+                {
+                    // Destroy proxies in reverse order from what they were created in.
+                    for (auto i = childCount - 1; i < childCount; --i)
+                    {
+                        const auto treeId = fixtureProxies[i].treeId;
+                        EraseFirst(proxies, treeId);
+                        tree.DestroyLeaf(treeId);
+                    }
+                }
+                fixture.SetProxies(std::vector<FixtureProxy>{});
+            }
+
+        }// anonymous namespace
+
+        WorldImpl::WorldImpl(const WorldConf& def)
+            : m_tree(def.initialTreeSize),
+              m_minVertexRadius{def.minVertexRadius},
+              m_maxVertexRadius{def.maxVertexRadius}
         {
-            Remove(jointID); // removes joint from body!
-            m_joints.erase(iter);
-            m_jointBuffer.Free(UnderlyingValue(id));
+            if (def.minVertexRadius > def.maxVertexRadius)
+            {
+                throw InvalidArgument("max vertex radius must be >= min vertex radius");
+            }
+            m_proxyKeys.reserve(1024);
+            m_proxies.reserve(1024);
         }
-        joints = body.GetJoints();
-    }
 
-    // Destroy the attached contacts.
-    body.Erase([this,&body](ContactID contactID) {
-        Destroy(contactID, &body);
-        return true;
-    });
-
-    // Delete the attached fixtures. This destroys broad-phase proxies.
-    ForallFixtures(body, [this](FixtureID fixtureID) {
-        if (m_fixtureDestructionListener)
+        WorldImpl::~WorldImpl() noexcept
         {
-            m_fixtureDestructionListener(fixtureID);
+            Clear();
         }
-        EraseAll(m_fixturesForProxies, fixtureID);
-        DestroyProxies(m_fixtureBuffer[UnderlyingValue(fixtureID)], m_proxies, m_tree);
-        m_fixtureBuffer.Free(UnderlyingValue(fixtureID));
-    });
-    body.ClearFixtures();
 
-    Remove(id);
-}
+        void WorldImpl::Clear() noexcept
+        {
+            if (m_jointDestructionListener)
+            {
+                for_each(cbegin(m_joints), cend(m_joints), [this](const auto& id) {
+                    m_jointDestructionListener(id);
+                });
+            }
+            if (m_fixtureDestructionListener)
+            {
+                for_each(cbegin(m_bodies), cend(m_bodies), [this](const auto& id) {
+                    const auto& b = m_bodyBuffer[UnderlyingValue(id)];
+                    for (const auto& fixture : b.GetFixtures())
+                    {
+                        m_fixtureDestructionListener(fixture);
+                    }
+                });
+            }
+            m_contacts.clear();
+            m_joints.clear();
+            m_bodies.clear();
+            m_bodiesForProxies.clear();
+            m_fixturesForProxies.clear();
+            m_proxies.clear();
+            m_proxyKeys.clear();
+            m_tree.Clear();
+            m_manifoldBuffer.clear();
+            m_contactBuffer.clear();
+            m_jointBuffer.clear();
+            m_fixtureBuffer.clear();
+            m_bodyBuffer.clear();
+        }
 
-void WorldImpl::SetJoint(JointID id, const Joint& def)
-{
-    if (IsLocked())
-    {
-        throw WrongState("SetJoint: world is locked");
-    }
-    const auto endIter = cend(m_joints);
-    const auto iter = find(cbegin(m_joints), endIter, id);
-    if (iter != endIter)
-    {
-        Remove(id);
-        m_jointBuffer[UnderlyingValue(id)] = def;
-        Add(id, !GetCollideConnected(def));
-    }
-}
+        BodyCounter WorldImpl::GetBodyRange() const noexcept
+        {
+            return static_cast<BodyCounter>(m_bodyBuffer.size());
+        }
 
-JointID WorldImpl::CreateJoint(const Joint& def)
-{
-    if (IsLocked())
-    {
-        throw WrongState("CreateJoint: world is locked");
-    }
-    
-    if (size(m_joints) >= MaxJoints)
-    {
-        throw LengthError("CreateJoint: operation would exceed MaxJoints");
-    }
+        BodyID WorldImpl::CreateBody(const BodyConf& def)
+        {
+            if (IsLocked())
+            {
+                throw WrongState("CreateBody: world is locked");
+            }
+            if (size(m_bodies) >= MaxBodies)
+            {
+                throw LengthError("CreateBody: operation would exceed MaxBodies");
+            }
+            const auto id = static_cast<BodyID>(
+                static_cast<BodyID::underlying_type>(m_bodyBuffer.Allocate(def)));
+            m_bodies.push_back(id);
+            return id;
+        }
 
-    const auto id = static_cast<JointID>(
-        static_cast<JointID::underlying_type>(m_jointBuffer.Allocate(def)));
-    m_joints.push_back(id);
-    // Note: creating a joint doesn't wake the bodies.
-    Add(id, !GetCollideConnected(def));
-    return id;
-}
+        void WorldImpl::Remove(BodyID id) noexcept
+        {
+            m_bodiesForProxies.erase(remove(begin(m_bodiesForProxies), end(m_bodiesForProxies), id),
+                                     end(m_bodiesForProxies));
+            const auto it = find(cbegin(m_bodies), cend(m_bodies), id);
+            if (it != cend(m_bodies))
+            {
+                m_bodies.erase(it);
+                m_bodyBuffer.Free(UnderlyingValue(id));
+            }
+        }
 
-void WorldImpl::Add(JointID id, bool flagForFiltering)
-{
-    const auto& joint = m_jointBuffer[UnderlyingValue(id)];
-    const auto bodyA = GetBodyA(joint);
-    const auto bodyB = GetBodyB(joint);
-    if (bodyA != InvalidBodyID)
-    {
-        m_bodyBuffer[UnderlyingValue(bodyA)].Insert(id, bodyB);
-    }
-    if (bodyB != InvalidBodyID)
-    {
-        m_bodyBuffer[UnderlyingValue(bodyB)].Insert(id, bodyA);
-    }
-    if (flagForFiltering && (bodyA != InvalidBodyID) && (bodyB != InvalidBodyID))
-    {
-        FlagContactsForFiltering(m_contactBuffer, bodyA, m_bodyBuffer[UnderlyingValue(bodyB)].GetContacts(), bodyB);
-    }
-}
+        void WorldImpl::Destroy(BodyID id)
+        {
+            if (IsLocked())
+            {
+                throw WrongState("Destroy: world is locked");
+            }
 
-void WorldImpl::Remove(JointID id) noexcept
-{
-    // Disconnect from island graph.
-    const auto& joint = m_jointBuffer[UnderlyingValue(id)];
-    const auto bodyIdA = GetBodyA(joint);
-    const auto bodyIdB = GetBodyB(joint);
-    const auto collideConnected = GetCollideConnected(joint);
+            auto& body = GetBody(id);
 
-    // If the joint prevented collisions, then flag any contacts for filtering.
-    if ((!collideConnected) && (bodyIdA != InvalidBodyID) && (bodyIdB != InvalidBodyID))
-    {
-        FlagContactsForFiltering(m_contactBuffer, bodyIdA,
-                                 m_bodyBuffer[UnderlyingValue(bodyIdB)].GetContacts(), bodyIdB);
-    }
+            // Delete the attached joints.
+            auto joints = body.GetJoints();
+            while (!joints.empty())
+            {
+                const auto jointID = std::get<JointID>(*begin(joints));
+                if (m_jointDestructionListener)
+                {
+                    m_jointDestructionListener(jointID);
+                }
+                const auto endIter = cend(m_joints);
+                const auto iter = find(cbegin(m_joints), endIter, jointID);
+                if (iter != endIter)
+                {
+                    Remove(jointID);// removes joint from body!
+                    m_joints.erase(iter);
+                    m_jointBuffer.Free(UnderlyingValue(id));
+                }
+                joints = body.GetJoints();
+            }
 
-    // Wake up connected bodies.
-    if (bodyIdA != InvalidBodyID)
-    {
-        auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
-        bodyA.SetAwake();
-        bodyA.Erase(id);
-    }
-    if (bodyIdB != InvalidBodyID)
-    {
-        auto& bodyB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
-        bodyB.SetAwake();
-        bodyB.Erase(id);
-    }
-}
+            // Destroy the attached contacts.
+            body.Erase([this, &body](ContactID contactID) {
+                Destroy(contactID, &body);
+                return true;
+            });
 
-void WorldImpl::Destroy(JointID id)
-{
-    if (IsLocked()) {
-        throw WrongState("Destroy: world is locked");
-    }
-    const auto endIter = cend(m_joints);
-    const auto iter = find(cbegin(m_joints), endIter, id);
-    if (iter != endIter) {
-        Remove(id);
-        m_joints.erase(iter);
-        m_jointBuffer.Free(UnderlyingValue(id));
-    }
-}
+            // Delete the attached fixtures. This destroys broad-phase proxies.
+            ForallFixtures(body, [this](FixtureID fixtureID) {
+                if (m_fixtureDestructionListener)
+                {
+                    m_fixtureDestructionListener(fixtureID);
+                }
+                EraseAll(m_fixturesForProxies, fixtureID);
+                DestroyProxies(m_fixtureBuffer[UnderlyingValue(fixtureID)], m_proxies, m_tree);
+                m_fixtureBuffer.Free(UnderlyingValue(fixtureID));
+            });
+            body.ClearFixtures();
 
-void WorldImpl::AddToIsland(Island& island, BodyID seedID,
-                            BodyCounter& remNumBodies,
-                            ContactCounter& remNumContacts,
-                            JointCounter& remNumJoints)
-{
+            Remove(id);
+        }
+
+        void WorldImpl::SetJoint(JointID id, const Joint& def)
+        {
+            if (IsLocked())
+            {
+                throw WrongState("SetJoint: world is locked");
+            }
+            const auto endIter = cend(m_joints);
+            const auto iter = find(cbegin(m_joints), endIter, id);
+            if (iter != endIter)
+            {
+                Remove(id);
+                m_jointBuffer[UnderlyingValue(id)] = def;
+                Add(id, !GetCollideConnected(def));
+            }
+        }
+
+        JointID WorldImpl::CreateJoint(const Joint& def)
+        {
+            if (IsLocked())
+            {
+                throw WrongState("CreateJoint: world is locked");
+            }
+
+            if (size(m_joints) >= MaxJoints)
+            {
+                throw LengthError("CreateJoint: operation would exceed MaxJoints");
+            }
+
+            const auto id = static_cast<JointID>(
+                static_cast<JointID::underlying_type>(m_jointBuffer.Allocate(def)));
+            m_joints.push_back(id);
+            // Note: creating a joint doesn't wake the bodies.
+            Add(id, !GetCollideConnected(def));
+            return id;
+        }
+
+        void WorldImpl::Add(JointID id, bool flagForFiltering)
+        {
+            const auto& joint = m_jointBuffer[UnderlyingValue(id)];
+            const auto bodyA = GetBodyA(joint);
+            const auto bodyB = GetBodyB(joint);
+            if (bodyA != InvalidBodyID)
+            {
+                m_bodyBuffer[UnderlyingValue(bodyA)].Insert(id, bodyB);
+            }
+            if (bodyB != InvalidBodyID)
+            {
+                m_bodyBuffer[UnderlyingValue(bodyB)].Insert(id, bodyA);
+            }
+            if (flagForFiltering && (bodyA != InvalidBodyID) && (bodyB != InvalidBodyID))
+            {
+                FlagContactsForFiltering(m_contactBuffer, bodyA, m_bodyBuffer[UnderlyingValue(bodyB)].GetContacts(), bodyB);
+            }
+        }
+
+        void WorldImpl::Remove(JointID id) noexcept
+        {
+            // Disconnect from island graph.
+            const auto& joint = m_jointBuffer[UnderlyingValue(id)];
+            const auto bodyIdA = GetBodyA(joint);
+            const auto bodyIdB = GetBodyB(joint);
+            const auto collideConnected = GetCollideConnected(joint);
+
+            // If the joint prevented collisions, then flag any contacts for filtering.
+            if ((!collideConnected) && (bodyIdA != InvalidBodyID) && (bodyIdB != InvalidBodyID))
+            {
+                FlagContactsForFiltering(m_contactBuffer, bodyIdA,
+                                         m_bodyBuffer[UnderlyingValue(bodyIdB)].GetContacts(), bodyIdB);
+            }
+
+            // Wake up connected bodies.
+            if (bodyIdA != InvalidBodyID)
+            {
+                auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
+                bodyA.SetAwake();
+                bodyA.Erase(id);
+            }
+            if (bodyIdB != InvalidBodyID)
+            {
+                auto& bodyB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
+                bodyB.SetAwake();
+                bodyB.Erase(id);
+            }
+        }
+
+        void WorldImpl::Destroy(JointID id)
+        {
+            if (IsLocked())
+            {
+                throw WrongState("Destroy: world is locked");
+            }
+            const auto endIter = cend(m_joints);
+            const auto iter = find(cbegin(m_joints), endIter, id);
+            if (iter != endIter)
+            {
+                Remove(id);
+                m_joints.erase(iter);
+                m_jointBuffer.Free(UnderlyingValue(id));
+            }
+        }
+
+        void WorldImpl::AddToIsland(Island& island, BodyID seedID,
+                                    BodyCounter& remNumBodies,
+                                    ContactCounter& remNumContacts,
+                                    JointCounter& remNumJoints)
+        {
 #ifndef NDEBUG
-    assert(!m_islandedBodies[UnderlyingValue(seedID)]);
-    auto& seed = m_bodyBuffer[UnderlyingValue(seedID)];
-    assert(seed.IsSpeedable());
-    assert(seed.IsAwake());
-    assert(seed.IsEnabled());
-    assert(remNumBodies != 0);
-    assert(remNumBodies < MaxBodies);
+            assert(!m_islandedBodies[UnderlyingValue(seedID)]);
+            auto& seed = m_bodyBuffer[UnderlyingValue(seedID)];
+            assert(seed.IsSpeedable());
+            assert(seed.IsAwake());
+            assert(seed.IsEnabled());
+            assert(remNumBodies != 0);
+            assert(remNumBodies < MaxBodies);
 #endif
-    // Perform a depth first search (DFS) on the constraint graph.
-    // Create a stack for bodies to be is-in-island that aren't already in the island.
-    auto bodies = std::vector<BodyID>{};
-    bodies.reserve(remNumBodies);
-    bodies.push_back(seedID);
-    auto stack = BodyStack{std::move(bodies)};
-    m_islandedBodies[UnderlyingValue(seedID)] = true;
-    AddToIsland(island, stack, remNumBodies, remNumContacts, remNumJoints);
-}
+            // Perform a depth first search (DFS) on the constraint graph.
+            // Create a stack for bodies to be is-in-island that aren't already in the island.
+            auto bodies = std::vector<BodyID>{};
+            bodies.reserve(remNumBodies);
+            bodies.push_back(seedID);
+            auto stack = BodyStack{std::move(bodies)};
+            m_islandedBodies[UnderlyingValue(seedID)] = true;
+            AddToIsland(island, stack, remNumBodies, remNumContacts, remNumJoints);
+        }
 
-void WorldImpl::AddToIsland(Island& island, BodyStack& stack,
-                            BodyCounter& remNumBodies,
-                            ContactCounter& remNumContacts,
-                            JointCounter& remNumJoints)
-{
-    while (!empty(stack))
-    {
-        // Grab the next body off the stack and add it to the island.
-        const auto bodyID = stack.top();
-        stack.pop();
-
-        auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
-
-        assert(body.IsEnabled());
-        island.bodies.push_back(bodyID);
-        assert(remNumBodies > 0);
-        --remNumBodies;
-
-        // Don't propagate islands across bodies that can't have a velocity (static bodies).
-        // This keeps islands smaller and helps with isolating separable collision clusters.
-        if (!body.IsSpeedable())
+        void WorldImpl::AddToIsland(Island& island, BodyStack& stack,
+                                    BodyCounter& remNumBodies,
+                                    ContactCounter& remNumContacts,
+                                    JointCounter& remNumJoints)
         {
-            continue;
-        }
-
-        // Make sure the body is awake (without resetting sleep timer).
-        body.SetAwakeFlag();
-
-        const auto oldNumContacts = size(island.contacts);
-        // Adds appropriate contacts of current body and appropriate 'other' bodies of those contacts.
-        AddContactsToIsland(island, stack, body.GetContacts(), bodyID);
-
-        const auto newNumContacts = size(island.contacts);
-        assert(newNumContacts >= oldNumContacts);
-        const auto netNumContacts = newNumContacts - oldNumContacts;
-        assert(remNumContacts >= netNumContacts);
-        remNumContacts -= netNumContacts;
-        
-        const auto numJoints = size(island.joints);
-        // Adds appropriate joints of current body and appropriate 'other' bodies of those joint.
-        AddJointsToIsland(island, stack, body.GetJoints());
-
-        remNumJoints -= size(island.joints) - numJoints;
-    }
-}
-
-void WorldImpl::AddContactsToIsland(Island& island, BodyStack& stack,
-                                    SizedRange<Contacts::const_iterator> contacts, BodyID bodyID)
-{
-    for_each(cbegin(contacts), cend(contacts), [&](const KeyedContactPtr& ci) {
-        const auto contactID = std::get<ContactID>(ci);
-        if (!m_islandedContacts[UnderlyingValue(contactID)]) {
-            auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-            if (IsEnabled(contact) && IsTouching(contact) && !IsSensor(contact))
+            while (!empty(stack))
             {
-                const auto bodyA = GetBodyA(contact);
-                const auto bodyB = GetBodyB(contact);
-                const auto other = (bodyID != bodyA)? bodyA: bodyB;
-                island.contacts.push_back(contactID);
-                m_islandedContacts[UnderlyingValue(contactID)] = true;
-                if (!m_islandedBodies[UnderlyingValue(other)])
+                // Grab the next body off the stack and add it to the island.
+                const auto bodyID = stack.top();
+                stack.pop();
+
+                auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
+
+                assert(body.IsEnabled());
+                island.bodies.push_back(bodyID);
+                assert(remNumBodies > 0);
+                --remNumBodies;
+
+                // Don't propagate islands across bodies that can't have a velocity (static bodies).
+                // This keeps islands smaller and helps with isolating separable collision clusters.
+                if (!body.IsSpeedable())
                 {
-                    m_islandedBodies[UnderlyingValue(other)] = true;
-                    stack.push(other);
+                    continue;
                 }
+
+                // Make sure the body is awake (without resetting sleep timer).
+                body.SetAwakeFlag();
+
+                const auto oldNumContacts = size(island.contacts);
+                // Adds appropriate contacts of current body and appropriate 'other' bodies of those contacts.
+                AddContactsToIsland(island, stack, body.GetContacts(), bodyID);
+
+                const auto newNumContacts = size(island.contacts);
+                assert(newNumContacts >= oldNumContacts);
+                const auto netNumContacts = newNumContacts - oldNumContacts;
+                assert(remNumContacts >= netNumContacts);
+                remNumContacts -= netNumContacts;
+
+                const auto numJoints = size(island.joints);
+                // Adds appropriate joints of current body and appropriate 'other' bodies of those joint.
+                AddJointsToIsland(island, stack, body.GetJoints());
+
+                remNumJoints -= size(island.joints) - numJoints;
             }
         }
-    });
-}
 
-void WorldImpl::AddJointsToIsland(Island& island, BodyStack& stack,
-                                  SizedRange<BodyJoints::const_iterator> joints)
-{
-    for_each(cbegin(joints), cend(joints), [&](const Body::KeyedJointPtr& ji) {
-        const auto jointID = std::get<JointID>(ji);
-        assert(jointID != InvalidJointID);
-        if (!m_islandedJoints[UnderlyingValue(jointID)]) {
-            const auto otherID = std::get<BodyID>(ji);
-            const auto other = (otherID == InvalidBodyID)? static_cast<Body*>(nullptr): &m_bodyBuffer[UnderlyingValue(otherID)];
-            assert(!other || other->IsEnabled() || !other->IsAwake());
-            if (!other || other->IsEnabled())
-            {
-                m_islandedJoints[UnderlyingValue(jointID)] = true;
-                island.joints.push_back(jointID);
-                if ((otherID != InvalidBodyID) && !m_islandedBodies[UnderlyingValue(otherID)])
+        void WorldImpl::AddContactsToIsland(Island& island, BodyStack& stack,
+                                            SizedRange<Contacts::const_iterator> contacts, BodyID bodyID)
+        {
+            for_each(cbegin(contacts), cend(contacts), [&](const KeyedContactPtr& ci) {
+                const auto contactID = std::get<ContactID>(ci);
+                if (!m_islandedContacts[UnderlyingValue(contactID)])
                 {
-                    m_islandedBodies[UnderlyingValue(otherID)] = true;
-                    stack.push(otherID);
+                    auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+                    if (IsEnabled(contact) && IsTouching(contact) && !IsSensor(contact))
+                    {
+                        const auto bodyA = GetBodyA(contact);
+                        const auto bodyB = GetBodyB(contact);
+                        const auto other = (bodyID != bodyA) ? bodyA : bodyB;
+                        island.contacts.push_back(contactID);
+                        m_islandedContacts[UnderlyingValue(contactID)] = true;
+                        if (!m_islandedBodies[UnderlyingValue(other)])
+                        {
+                            m_islandedBodies[UnderlyingValue(other)] = true;
+                            stack.push(other);
+                        }
+                    }
                 }
-            }
+            });
         }
-    });
-}
 
-WorldImpl::Bodies::size_type
-WorldImpl::RemoveUnspeedablesFromIslanded(const std::vector<BodyID>& bodies,
-                                          const ArrayAllocator<Body>& buffer,
-                                          std::vector<bool>& islanded)
-{
-    // Allow static bodies to participate in other islands.
-    auto numRemoved = Bodies::size_type{0};
-    for_each(begin(bodies), end(bodies), [&](BodyID id) {
-        if (!buffer[UnderlyingValue(id)].IsSpeedable()) {
-            islanded[UnderlyingValue(id)] = false;
-            ++numRemoved;
+        void WorldImpl::AddJointsToIsland(Island& island, BodyStack& stack,
+                                          SizedRange<BodyJoints::const_iterator> joints)
+        {
+            for_each(cbegin(joints), cend(joints), [&](const Body::KeyedJointPtr& ji) {
+                const auto jointID = std::get<JointID>(ji);
+                assert(jointID != InvalidJointID);
+                if (!m_islandedJoints[UnderlyingValue(jointID)])
+                {
+                    const auto otherID = std::get<BodyID>(ji);
+                    const auto other = (otherID == InvalidBodyID) ? static_cast<Body*>(nullptr) : &m_bodyBuffer[UnderlyingValue(otherID)];
+                    assert(!other || other->IsEnabled() || !other->IsAwake());
+                    if (!other || other->IsEnabled())
+                    {
+                        m_islandedJoints[UnderlyingValue(jointID)] = true;
+                        island.joints.push_back(jointID);
+                        if ((otherID != InvalidBodyID) && !m_islandedBodies[UnderlyingValue(otherID)])
+                        {
+                            m_islandedBodies[UnderlyingValue(otherID)] = true;
+                            stack.push(otherID);
+                        }
+                    }
+                }
+            });
         }
-    });
-    return numRemoved;
-}
 
-RegStepStats WorldImpl::SolveReg(const StepConf& conf)
-{
-    auto stats = RegStepStats{};
-    auto remNumBodies = static_cast<BodyCounter>(size(m_bodies)); // Remaining # of bodies.
-    auto remNumContacts = static_cast<ContactCounter>(size(m_contacts)); // Remaining # of contacts.
-    auto remNumJoints = static_cast<JointCounter>(size(m_joints)); // Remaining # of joints.
+        WorldImpl::Bodies::size_type
+        WorldImpl::RemoveUnspeedablesFromIslanded(const std::vector<BodyID>& bodies,
+                                                  const ArrayAllocator<Body>& buffer,
+                                                  std::vector<bool>& islanded)
+        {
+            // Allow static bodies to participate in other islands.
+            auto numRemoved = Bodies::size_type{0};
+            for_each(begin(bodies), end(bodies), [&](BodyID id) {
+                if (!buffer[UnderlyingValue(id)].IsSpeedable())
+                {
+                    islanded[UnderlyingValue(id)] = false;
+                    ++numRemoved;
+                }
+            });
+            return numRemoved;
+        }
 
-    // Clear all the island flags.
-    // This builds the logical set of bodies, contacts, and joints eligible for resolution.
-    // As bodies, contacts, or joints get added to resolution islands, they're essentially
-    // removed from this eligible set.
-    m_islandedBodies.clear();
-    m_islandedContacts.clear();
-    m_islandedJoints.clear();
-    m_islandedBodies.resize(size(m_bodyBuffer));
-    m_islandedContacts.resize(size(m_contactBuffer));
-    m_islandedJoints.resize(size(m_jointBuffer));
+        RegStepStats WorldImpl::SolveReg(const StepConf& conf)
+        {
+            auto stats = RegStepStats{};
+            auto remNumBodies = static_cast<BodyCounter>(size(m_bodies));       // Remaining # of bodies.
+            auto remNumContacts = static_cast<ContactCounter>(size(m_contacts));// Remaining # of contacts.
+            auto remNumJoints = static_cast<JointCounter>(size(m_joints));      // Remaining # of joints.
+
+            // Clear all the island flags.
+            // This builds the logical set of bodies, contacts, and joints eligible for resolution.
+            // As bodies, contacts, or joints get added to resolution islands, they're essentially
+            // removed from this eligible set.
+            m_islandedBodies.clear();
+            m_islandedContacts.clear();
+            m_islandedJoints.clear();
+            m_islandedBodies.resize(size(m_bodyBuffer));
+            m_islandedContacts.resize(size(m_contactBuffer));
+            m_islandedJoints.resize(size(m_jointBuffer));
 
 #if defined(DO_THREADED)
-    std::vector<std::future<IslandStats>> futures;
-    futures.reserve(remNumBodies);
+            std::vector<std::future<IslandStats>> futures;
+            futures.reserve(remNumBodies);
 #endif
-    // Build and simulate all awake islands.
-    for (const auto& b: m_bodies)
-    {
-        if (!m_islandedBodies[UnderlyingValue(b)]) {
-            auto& body = m_bodyBuffer[UnderlyingValue(b)];
-            assert(!body.IsAwake() || body.IsSpeedable());
-            if (body.IsAwake() && body.IsEnabled())
+            // Build and simulate all awake islands.
+            for (const auto& b : m_bodies)
             {
-                ++stats.islandsFound;
-                ::playrho::d2::Clear(m_island);
-                // Size the island for the remaining un-evaluated bodies, contacts, and joints.
-                Reserve(m_island, remNumBodies, remNumContacts, remNumJoints);
-                AddToIsland(m_island, b, remNumBodies, remNumContacts, remNumJoints);
-                remNumBodies += RemoveUnspeedablesFromIslanded(m_island.bodies, m_bodyBuffer,
-                                                               m_islandedBodies);
+                if (!m_islandedBodies[UnderlyingValue(b)])
+                {
+                    auto& body = m_bodyBuffer[UnderlyingValue(b)];
+                    assert(!body.IsAwake() || body.IsSpeedable());
+                    if (body.IsAwake() && body.IsEnabled())
+                    {
+                        ++stats.islandsFound;
+                        ::playrho::d2::Clear(m_island);
+                        // Size the island for the remaining un-evaluated bodies, contacts, and joints.
+                        Reserve(m_island, remNumBodies, remNumContacts, remNumJoints);
+                        AddToIsland(m_island, b, remNumBodies, remNumContacts, remNumJoints);
+                        remNumBodies += RemoveUnspeedablesFromIslanded(m_island.bodies, m_bodyBuffer,
+                                                                       m_islandedBodies);
 #if defined(DO_THREADED)
-                // Updates bodies' sweep.pos0 to current sweep.pos1 and bodies' sweep.pos1 to new positions
-                futures.push_back(std::async(std::launch::async, &WorldImpl::SolveRegIslandViaGS,
-                                             this, conf, m_island));
+                        // Updates bodies' sweep.pos0 to current sweep.pos1 and bodies' sweep.pos1 to new positions
+                        futures.push_back(std::async(std::launch::async, &WorldImpl::SolveRegIslandViaGS,
+                                                     this, conf, m_island));
 #else
-                const auto solverResults = SolveRegIslandViaGS(conf, m_island);
-                ::playrho::Update(stats, solverResults);
+                        const auto solverResults = SolveRegIslandViaGS(conf, m_island);
+                        ::playrho::Update(stats, solverResults);
 #endif
+                    }
+                }
             }
-        }
-    }
 
 #if defined(DO_THREADED)
-    for (auto&& future: futures)
-    {
-        const auto solverResults = future.get();
-        ::playrho::Update(stats, solverResults);
-    }
+            for (auto&& future : futures)
+            {
+                const auto solverResults = future.get();
+                ::playrho::Update(stats, solverResults);
+            }
 #endif
 
-    for (const auto& b: m_bodies)
-    {
-        if (m_islandedBodies[UnderlyingValue(b)]) {
-            // A non-static body that was in an island may have moved.
-            auto& body = m_bodyBuffer[UnderlyingValue(b)];
-            if (body.IsSpeedable())
+            for (const auto& b : m_bodies)
             {
-                // Update fixtures (for broad-phase).
-                stats.proxiesMoved += Synchronize(body, GetTransform0(body.GetSweep()),
-                                                  body.GetTransformation(),
-                                                  conf.displaceMultiplier, conf.aabbExtension);
+                if (m_islandedBodies[UnderlyingValue(b)])
+                {
+                    // A non-static body that was in an island may have moved.
+                    auto& body = m_bodyBuffer[UnderlyingValue(b)];
+                    if (body.IsSpeedable())
+                    {
+                        // Update fixtures (for broad-phase).
+                        stats.proxiesMoved += Synchronize(body, GetTransform0(body.GetSweep()),
+                                                          body.GetTransformation(),
+                                                          conf.displaceMultiplier, conf.aabbExtension);
+                    }
+                }
             }
+
+            // Look for new contacts.
+            stats.contactsAdded = FindNewContacts();
+
+            return stats;
         }
-    }
 
-    // Look for new contacts.
-    stats.contactsAdded = FindNewContacts();
-    
-    return stats;
-}
+        IslandStats WorldImpl::SolveRegIslandViaGS(const StepConf& conf, const Island& island)
+        {
+            assert(!empty(island.bodies) || !empty(island.contacts) || !empty(island.joints));
 
-IslandStats WorldImpl::SolveRegIslandViaGS(const StepConf& conf, const Island& island)
-{
-    assert(!empty(island.bodies) || !empty(island.contacts) || !empty(island.joints));
-    
-    auto results = IslandStats{};
-    results.positionIterations = conf.regPositionIterations;
-    const auto h = conf.deltaTime; ///< Time step.
+            auto results = IslandStats{};
+            results.positionIterations = conf.regPositionIterations;
+            const auto h = conf.deltaTime;///< Time step.
 
-    // Update bodies' pos0 values.
-    for_each(cbegin(island.bodies), cend(island.bodies), [&](const auto& bodyID) {
-        auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
-        body.SetPosition0(GetPosition1(body)); // like Advance0(1) on the sweep.
-    });
+            // Update bodies' pos0 values.
+            for_each(cbegin(island.bodies), cend(island.bodies), [&](const auto& bodyID) {
+                auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
+                body.SetPosition0(GetPosition1(body));// like Advance0(1) on the sweep.
+            });
 
-    // Copy bodies' pos1 and velocity data into local arrays.
-    auto bodyConstraints = GetBodyConstraints(island.bodies, m_bodyBuffer, h, GetMovementConf(conf));
-    auto posConstraints = GetPositionConstraints(island.contacts,
-                                                 m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
-                                                 bodyConstraints);
-    auto velConstraints = GetVelocityConstraints(island.contacts,
-                                                 m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
-                                                 bodyConstraints,
-                                                 GetRegVelocityConstraintConf(conf));
+            // Copy bodies' pos1 and velocity data into local arrays.
+            auto bodyConstraints = GetBodyConstraints(island.bodies, m_bodyBuffer, h, GetMovementConf(conf));
+            auto posConstraints = GetPositionConstraints(island.contacts,
+                                                         m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
+                                                         bodyConstraints);
+            auto velConstraints = GetVelocityConstraints(island.contacts,
+                                                         m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
+                                                         bodyConstraints,
+                                                         GetRegVelocityConstraintConf(conf));
 #if 0
     auto constraints = std::vector<BodyConstraint*>{};
     for_each(cbegin(island.m_joints), cend(island.m_joints), [&](const auto& id) {
@@ -997,389 +1010,391 @@ IslandStats WorldImpl::SolveRegIslandViaGS(const StepConf& conf, const Island& i
         }
     });
 #endif
-    if (conf.doWarmStart)
-    {
-        WarmStartVelocities(velConstraints);
-    }
+            if (conf.doWarmStart)
+            {
+                WarmStartVelocities(velConstraints);
+            }
 
-    const auto psConf = GetRegConstraintSolverConf(conf);
+            const auto psConf = GetRegConstraintSolverConf(conf);
 
-    for_each(cbegin(island.joints), cend(island.joints), [&](const auto& id) {
-        auto& joint = m_jointBuffer[UnderlyingValue(id)];
-        InitVelocity(joint, bodyConstraints, conf, psConf);
-    });
-    
-    results.velocityIterations = conf.regVelocityIterations;
-    for (auto i = decltype(conf.regVelocityIterations){0}; i < conf.regVelocityIterations; ++i)
-    {
-        auto jointsOkay = true;
-        for_each(cbegin(island.joints), cend(island.joints), [&](const auto& id) {
-            auto& joint = m_jointBuffer[UnderlyingValue(id)];
-            jointsOkay &= SolveVelocity(joint, bodyConstraints, conf);
-        });
+            for_each(cbegin(island.joints), cend(island.joints), [&](const auto& id) {
+                auto& joint = m_jointBuffer[UnderlyingValue(id)];
+                InitVelocity(joint, bodyConstraints, conf, psConf);
+            });
 
-        // Note that the new incremental impulse can potentially be orders of magnitude
-        // greater than the last incremental impulse used in this loop.
-        const auto newIncImpulse = SolveVelocityConstraintsViaGS(velConstraints);
-        results.maxIncImpulse = std::max(results.maxIncImpulse, newIncImpulse);
+            results.velocityIterations = conf.regVelocityIterations;
+            for (auto i = decltype(conf.regVelocityIterations){0}; i < conf.regVelocityIterations; ++i)
+            {
+                auto jointsOkay = true;
+                for_each(cbegin(island.joints), cend(island.joints), [&](const auto& id) {
+                    auto& joint = m_jointBuffer[UnderlyingValue(id)];
+                    jointsOkay &= SolveVelocity(joint, bodyConstraints, conf);
+                });
 
-        if (jointsOkay && (newIncImpulse <= conf.regMinMomentum))
-        {
-            // No joint related velocity constraints were out of tolerance.
-            // No body related velocity constraints were out of tolerance.
-            // There does not appear to be any benefit to doing more loops now.
-            // XXX: Is it really safe to bail now? Not certain of that.
-            // Bail now assuming that this is helpful to do...
-            results.velocityIterations = i + 1;
-            break;
-        }
-    }
-    
-    // updates array of tentative new body positions per the velocities as if there were no obstacles...
-    IntegratePositions(bodyConstraints, h);
-    
-    // Solve position constraints
-    for (auto i = decltype(conf.regPositionIterations){0}; i < conf.regPositionIterations; ++i)
-    {
-        const auto minSeparation = SolvePositionConstraintsViaGS(posConstraints, psConf);
-        results.minSeparation = std::min(results.minSeparation, minSeparation);
-        const auto contactsOkay = (minSeparation >= conf.regMinSeparation);
+                // Note that the new incremental impulse can potentially be orders of magnitude
+                // greater than the last incremental impulse used in this loop.
+                const auto newIncImpulse = SolveVelocityConstraintsViaGS(velConstraints);
+                results.maxIncImpulse = std::max(results.maxIncImpulse, newIncImpulse);
 
-        auto jointsOkay = true;
-        for_each(cbegin(island.joints), cend(island.joints), [&](const auto& id) {
-            auto& joint = m_jointBuffer[UnderlyingValue(id)];
-            jointsOkay &= SolvePosition(joint, bodyConstraints, psConf);
-        });
+                if (jointsOkay && (newIncImpulse <= conf.regMinMomentum))
+                {
+                    // No joint related velocity constraints were out of tolerance.
+                    // No body related velocity constraints were out of tolerance.
+                    // There does not appear to be any benefit to doing more loops now.
+                    // XXX: Is it really safe to bail now? Not certain of that.
+                    // Bail now assuming that this is helpful to do...
+                    results.velocityIterations = i + 1;
+                    break;
+                }
+            }
 
-        if (contactsOkay && jointsOkay)
-        {
-            // Reached tolerance, early out...
-            results.positionIterations = i + 1;
-            results.solved = true;
-            break;
-        }
-    }
-    
-    // Update normal and tangent impulses of contacts' manifold points
-    for_each(cbegin(velConstraints), cend(velConstraints), [&](const VelocityConstraint& vc) {
-        const auto i = static_cast<VelocityConstraints::size_type>(&vc - data(velConstraints));
-        auto& manifold = m_manifoldBuffer[UnderlyingValue(island.contacts[i])];
-        AssignImpulses(manifold, vc);
-    });
+            // updates array of tentative new body positions per the velocities as if there were no obstacles...
+            IntegratePositions(bodyConstraints, h);
 
-    for (const auto& id: island.bodies)
-    {
-        const auto i = UnderlyingValue(id);
-        const auto& bc = bodyConstraints[i];
-        auto& body = m_bodyBuffer[i];
-        // Could normalize position here to avoid unbounded angles but angular
-        // normalization isn't handled correctly by joints that constrain rotation.
-        body.JustSetVelocity(bc.GetVelocity());
-        if (UpdateBody(body, bc.GetPosition()))
-        {
-            FlagForUpdating(m_contactBuffer, body.GetContacts());
-        }
-    }
+            // Solve position constraints
+            for (auto i = decltype(conf.regPositionIterations){0}; i < conf.regPositionIterations; ++i)
+            {
+                const auto minSeparation = SolvePositionConstraintsViaGS(posConstraints, psConf);
+                results.minSeparation = std::min(results.minSeparation, minSeparation);
+                const auto contactsOkay = (minSeparation >= conf.regMinSeparation);
 
-    // XXX: Should contacts needing updating be updated now??
+                auto jointsOkay = true;
+                for_each(cbegin(island.joints), cend(island.joints), [&](const auto& id) {
+                    auto& joint = m_jointBuffer[UnderlyingValue(id)];
+                    jointsOkay &= SolvePosition(joint, bodyConstraints, psConf);
+                });
 
-    if (m_postSolveContactListener)
-    {
-        Report(m_postSolveContactListener, island.contacts, velConstraints,
-               results.solved? results.positionIterations - 1: StepConf::InvalidIteration);
-    }
-    
-    results.bodiesSlept = BodyCounter{0};
-    const auto minUnderActiveTime = UpdateUnderActiveTimes(island.bodies, m_bodyBuffer, conf);
-    if ((minUnderActiveTime >= conf.minStillTimeToSleep) && results.solved)
-    {
-        results.bodiesSlept = static_cast<decltype(results.bodiesSlept)>(Sleepem(island.bodies,
-                                                                                 m_bodyBuffer));
-    }
+                if (contactsOkay && jointsOkay)
+                {
+                    // Reached tolerance, early out...
+                    results.positionIterations = i + 1;
+                    results.solved = true;
+                    break;
+                }
+            }
 
-    return results;
-}
+            // Update normal and tangent impulses of contacts' manifold points
+            for_each(cbegin(velConstraints), cend(velConstraints), [&](const VelocityConstraint& vc) {
+                const auto i = static_cast<VelocityConstraints::size_type>(&vc - data(velConstraints));
+                auto& manifold = m_manifoldBuffer[UnderlyingValue(island.contacts[i])];
+                AssignImpulses(manifold, vc);
+            });
 
-WorldImpl::UpdateContactsData WorldImpl::UpdateContactTOIs(ArrayAllocator<Contact>& contactBuffer,
-                                                           ArrayAllocator<Body>& bodyBuffer,
-                                                           const ArrayAllocator<Fixture>& fixtureBuffer,
-                                                           const Contacts& contacts, const StepConf& conf)
-{
-    auto results = UpdateContactsData{};
+            for (const auto& id : island.bodies)
+            {
+                const auto i = UnderlyingValue(id);
+                const auto& bc = bodyConstraints[i];
+                auto& body = m_bodyBuffer[i];
+                // Could normalize position here to avoid unbounded angles but angular
+                // normalization isn't handled correctly by joints that constrain rotation.
+                body.JustSetVelocity(bc.GetVelocity());
+                if (UpdateBody(body, bc.GetPosition()))
+                {
+                    FlagForUpdating(m_contactBuffer, body.GetContacts());
+                }
+            }
 
-    const auto toiConf = GetToiConf(conf);
-    for (const auto& contact: contacts)
-    {
-        auto& c = contactBuffer[UnderlyingValue(std::get<ContactID>(contact))];
-        if (c.HasValidToi())
-        {
-            ++results.numValidTOI;
-            continue;
-        }
-        if (!IsEnabled(c) || IsSensor(c) || !IsActive(c) || !IsImpenetrable(c))
-        {
-            continue;
-        }
-        if (c.GetToiCount() >= conf.maxSubSteps)
-        {
-            // What are the pros/cons of this?
-            // Larger m_maxSubSteps slows down the simulation.
-            // m_maxSubSteps of 44 and higher seems to decrease the occurrance of tunneling
-            // of multiple bullet body collisions with static objects.
-            ++results.numAtMaxSubSteps;
-            continue;
+            // XXX: Should contacts needing updating be updated now??
+
+            if (m_postSolveContactListener)
+            {
+                Report(m_postSolveContactListener, island.contacts, velConstraints,
+                       results.solved ? results.positionIterations - 1 : StepConf::InvalidIteration);
+            }
+
+            results.bodiesSlept = BodyCounter{0};
+            const auto minUnderActiveTime = UpdateUnderActiveTimes(island.bodies, m_bodyBuffer, conf);
+            if ((minUnderActiveTime >= conf.minStillTimeToSleep) && results.solved)
+            {
+                results.bodiesSlept = static_cast<decltype(results.bodiesSlept)>(Sleepem(island.bodies,
+                                                                                         m_bodyBuffer));
+            }
+
+            return results;
         }
 
-        auto& bA = bodyBuffer[UnderlyingValue(c.GetBodyA())];
-        auto& bB = bodyBuffer[UnderlyingValue(c.GetBodyB())];
+        WorldImpl::UpdateContactsData WorldImpl::UpdateContactTOIs(ArrayAllocator<Contact>& contactBuffer,
+                                                                   ArrayAllocator<Body>& bodyBuffer,
+                                                                   const ArrayAllocator<Fixture>& fixtureBuffer,
+                                                                   const Contacts& contacts, const StepConf& conf)
+        {
+            auto results = UpdateContactsData{};
 
-        /*
+            const auto toiConf = GetToiConf(conf);
+            for (const auto& contact : contacts)
+            {
+                auto& c = contactBuffer[UnderlyingValue(std::get<ContactID>(contact))];
+                if (c.HasValidToi())
+                {
+                    ++results.numValidTOI;
+                    continue;
+                }
+                if (!IsEnabled(c) || IsSensor(c) || !IsActive(c) || !IsImpenetrable(c))
+                {
+                    continue;
+                }
+                if (c.GetToiCount() >= conf.maxSubSteps)
+                {
+                    // What are the pros/cons of this?
+                    // Larger m_maxSubSteps slows down the simulation.
+                    // m_maxSubSteps of 44 and higher seems to decrease the occurrance of tunneling
+                    // of multiple bullet body collisions with static objects.
+                    ++results.numAtMaxSubSteps;
+                    continue;
+                }
+
+                auto& bA = bodyBuffer[UnderlyingValue(c.GetBodyA())];
+                auto& bB = bodyBuffer[UnderlyingValue(c.GetBodyB())];
+
+                /*
          * Put the sweeps onto the same time interval.
          * Presumably no unresolved collisions happen before the maximum of the bodies'
          * alpha-0 times. So long as the least TOI of the contacts is always the first
          * collision that gets dealt with, this presumption is safe.
          */
-        const auto alpha0 = std::max(bA.GetSweep().GetAlpha0(), bB.GetSweep().GetAlpha0());
-        assert(alpha0 >= 0 && alpha0 < 1);
-        bA.Advance0(alpha0);
-        bB.Advance0(alpha0);
+                const auto alpha0 = std::max(bA.GetSweep().GetAlpha0(), bB.GetSweep().GetAlpha0());
+                assert(alpha0 >= 0 && alpha0 < 1);
+                bA.Advance0(alpha0);
+                bB.Advance0(alpha0);
 
-        // Compute the TOI for this contact (one or both bodies are active and impenetrable).
-        // Computes the time of impact in interval [0, 1]
-        const auto proxyA = GetChild(fixtureBuffer[UnderlyingValue(c.GetFixtureA())].GetShape(),
-                                     c.GetChildIndexA());
-        const auto proxyB = GetChild(fixtureBuffer[UnderlyingValue(c.GetFixtureB())].GetShape(),
-                                     c.GetChildIndexB());
+                // Compute the TOI for this contact (one or both bodies are active and impenetrable).
+                // Computes the time of impact in interval [0, 1]
+                const auto proxyA = GetChild(fixtureBuffer[UnderlyingValue(c.GetFixtureA())].GetShape(),
+                                             c.GetChildIndexA());
+                const auto proxyB = GetChild(fixtureBuffer[UnderlyingValue(c.GetFixtureB())].GetShape(),
+                                             c.GetChildIndexB());
 
-        // Large rotations can make the root finder of TimeOfImpact fail, so normalize sweep angles.
-        const auto sweepA = GetNormalized(bA.GetSweep());
-        const auto sweepB = GetNormalized(bB.GetSweep());
+                // Large rotations can make the root finder of TimeOfImpact fail, so normalize sweep angles.
+                const auto sweepA = GetNormalized(bA.GetSweep());
+                const auto sweepB = GetNormalized(bB.GetSweep());
 
-        // Compute the TOI for this contact (one or both bodies are active and impenetrable).
-        // Computes the time of impact in interval [0, 1]
-        // Large rotations can make the root finder of TimeOfImpact fail, so normalize the sweep angles.
-        const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, toiConf);
+                // Compute the TOI for this contact (one or both bodies are active and impenetrable).
+                // Computes the time of impact in interval [0, 1]
+                // Large rotations can make the root finder of TimeOfImpact fail, so normalize the sweep angles.
+                const auto output = GetToiViaSat(proxyA, sweepA, proxyB, sweepB, toiConf);
 
-        // Use Min function to handle floating point imprecision which possibly otherwise
-        // could provide a TOI that's greater than 1.
-        const auto toi = IsValidForTime(output.state)?
-            std::min(alpha0 + (1 - alpha0) * output.time, Real{1}): Real{1};
-        assert(toi >= alpha0 && toi <= 1);
-        c.SetToi(toi);
-        
-        results.maxDistIters = std::max(results.maxDistIters, output.stats.max_dist_iters);
-        results.maxToiIters = std::max(results.maxToiIters, output.stats.toi_iters);
-        results.maxRootIters = std::max(results.maxRootIters, output.stats.max_root_iters);
-        ++results.numUpdatedTOI;
-    }
+                // Use Min function to handle floating point imprecision which possibly otherwise
+                // could provide a TOI that's greater than 1.
+                const auto toi = IsValidForTime(output.state) ? std::min(alpha0 + (1 - alpha0) * output.time, Real{1}) : Real{1};
+                assert(toi >= alpha0 && toi <= 1);
+                c.SetToi(toi);
 
-    return results;
-}
-
-WorldImpl::ContactToiData WorldImpl::GetSoonestContact(const Contacts& contacts,
-                                                       const ArrayAllocator<Contact>& buffer) noexcept
-{
-    auto minToi = nextafter(Real{1}, Real{0});
-    auto found = InvalidContactID;
-    auto count = ContactCounter{0};
-    for (const auto& contact: contacts)
-    {
-        const auto contactID = std::get<ContactID>(contact);
-        const auto& c = buffer[UnderlyingValue(contactID)];
-        if (c.HasValidToi())
-        {
-            const auto toi = c.GetToi();
-            if (minToi > toi)
-            {
-                minToi = toi;
-                found = contactID;
-                count = 1;
+                results.maxDistIters = std::max(results.maxDistIters, output.stats.max_dist_iters);
+                results.maxToiIters = std::max(results.maxToiIters, output.stats.toi_iters);
+                results.maxRootIters = std::max(results.maxRootIters, output.stats.max_root_iters);
+                ++results.numUpdatedTOI;
             }
-            else if (minToi == toi)
-            {
-                // Have multiple contacts at the current minimum time of impact.
-                ++count;
-            }
-        }
-    }
-    return ContactToiData{found, minToi, count};
-}
 
-ToiStepStats WorldImpl::SolveToi(const StepConf& conf)
-{
-    auto stats = ToiStepStats{};
-
-    if (IsStepComplete())
-    {
-        ResetBodiesForSolveTOI(m_bodies, m_bodyBuffer);
-        Unset(m_islandedBodies, m_bodies);
-        ResetContactsForSolveTOI(m_contactBuffer, m_contacts);
-        Unset(m_islandedContacts, m_contacts);
-    }
-
-    const auto subStepping = GetSubStepping();
-
-    // Find TOI events and solve them.
-    for (;;)
-    {
-        const auto updateData = UpdateContactTOIs(m_contactBuffer, m_bodyBuffer, m_fixtureBuffer,
-                                                  m_contacts, conf);
-        stats.contactsAtMaxSubSteps += updateData.numAtMaxSubSteps;
-        stats.contactsUpdatedToi += updateData.numUpdatedTOI;
-        stats.maxDistIters = std::max(stats.maxDistIters, updateData.maxDistIters);
-        stats.maxRootIters = std::max(stats.maxRootIters, updateData.maxRootIters);
-        stats.maxToiIters = std::max(stats.maxToiIters, updateData.maxToiIters);
-        
-        const auto next = GetSoonestContact(m_contacts, m_contactBuffer);
-        const auto contactID = next.contact;
-        const auto ncount = next.simultaneous;
-        if (contactID == InvalidContactID)
-        {
-            // No more TOI events to handle within the current time step. Done!
-            SetStepComplete(true);
-            break;
+            return results;
         }
 
-        stats.maxSimulContacts = std::max(stats.maxSimulContacts,
-                                          static_cast<decltype(stats.maxSimulContacts)>(ncount));
-        stats.contactsFound += ncount;
-        auto islandsFound = 0u;
-        if (!m_islandedContacts[UnderlyingValue(contactID)]) {
+        WorldImpl::ContactToiData WorldImpl::GetSoonestContact(const Contacts& contacts,
+                                                               const ArrayAllocator<Contact>& buffer) noexcept
+        {
+            auto minToi = nextafter(Real{1}, Real{0});
+            auto found = InvalidContactID;
+            auto count = ContactCounter{0};
+            for (const auto& contact : contacts)
+            {
+                const auto contactID = std::get<ContactID>(contact);
+                const auto& c = buffer[UnderlyingValue(contactID)];
+                if (c.HasValidToi())
+                {
+                    const auto toi = c.GetToi();
+                    if (minToi > toi)
+                    {
+                        minToi = toi;
+                        found = contactID;
+                        count = 1;
+                    }
+                    else if (minToi == toi)
+                    {
+                        // Have multiple contacts at the current minimum time of impact.
+                        ++count;
+                    }
+                }
+            }
+            return ContactToiData{found, minToi, count};
+        }
+
+        ToiStepStats WorldImpl::SolveToi(const StepConf& conf)
+        {
+            auto stats = ToiStepStats{};
+
+            if (IsStepComplete())
+            {
+                ResetBodiesForSolveTOI(m_bodies, m_bodyBuffer);
+                Unset(m_islandedBodies, m_bodies);
+                ResetContactsForSolveTOI(m_contactBuffer, m_contacts);
+                Unset(m_islandedContacts, m_contacts);
+            }
+
+            const auto subStepping = GetSubStepping();
+
+            // Find TOI events and solve them.
+            for (;;)
+            {
+                const auto updateData = UpdateContactTOIs(m_contactBuffer, m_bodyBuffer, m_fixtureBuffer,
+                                                          m_contacts, conf);
+                stats.contactsAtMaxSubSteps += updateData.numAtMaxSubSteps;
+                stats.contactsUpdatedToi += updateData.numUpdatedTOI;
+                stats.maxDistIters = std::max(stats.maxDistIters, updateData.maxDistIters);
+                stats.maxRootIters = std::max(stats.maxRootIters, updateData.maxRootIters);
+                stats.maxToiIters = std::max(stats.maxToiIters, updateData.maxToiIters);
+
+                const auto next = GetSoonestContact(m_contacts, m_contactBuffer);
+                const auto contactID = next.contact;
+                const auto ncount = next.simultaneous;
+                if (contactID == InvalidContactID)
+                {
+                    // No more TOI events to handle within the current time step. Done!
+                    SetStepComplete(true);
+                    break;
+                }
+
+                stats.maxSimulContacts = std::max(stats.maxSimulContacts,
+                                                  static_cast<decltype(stats.maxSimulContacts)>(ncount));
+                stats.contactsFound += ncount;
+                auto islandsFound = 0u;
+                if (!m_islandedContacts[UnderlyingValue(contactID)])
+                {
 #ifndef NDEBUG
-            auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-            /*
+                    auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+                    /*
              * Confirm that contact is as it's supposed to be according to contract of the
              * GetSoonestContact method from which this contact was obtained.
              */
+                    assert(contact.IsEnabled());
+                    assert(!HasSensor(m_fixtureBuffer, contact));
+                    assert(IsActive(contact));
+                    assert(IsImpenetrable(contact));
+#endif
+                    const auto solverResults = SolveToi(contactID, conf);
+                    stats.minSeparation = std::min(stats.minSeparation, solverResults.minSeparation);
+                    stats.maxIncImpulse = std::max(stats.maxIncImpulse, solverResults.maxIncImpulse);
+                    stats.islandsSolved += solverResults.solved;
+                    stats.sumPosIters += solverResults.positionIterations;
+                    stats.sumVelIters += solverResults.velocityIterations;
+                    if ((solverResults.positionIterations > 0) || (solverResults.velocityIterations > 0))
+                    {
+                        ++islandsFound;
+                    }
+                    stats.contactsUpdatedTouching += solverResults.contactsUpdated;
+                    stats.contactsSkippedTouching += solverResults.contactsSkipped;
+                }
+                stats.islandsFound += islandsFound;
+
+                // Reset island flags and synchronize broad-phase proxies.
+                for (const auto& b : m_bodies)
+                {
+                    if (m_islandedBodies[UnderlyingValue(b)])
+                    {
+                        m_islandedBodies[UnderlyingValue(b)] = false;
+                        auto& body = m_bodyBuffer[UnderlyingValue(b)];
+                        if (body.IsAccelerable())
+                        {
+                            const auto xfm0 = GetTransform0(body.GetSweep());
+                            const auto xfm1 = body.GetTransformation();
+                            stats.proxiesMoved += Synchronize(body, xfm0, xfm1,
+                                                              conf.displaceMultiplier, conf.aabbExtension);
+                            ResetContactsForSolveTOI(m_contactBuffer, body);
+                            Unset(m_islandedContacts, body.GetContacts());
+                        }
+                    }
+                }
+
+                // Commit fixture proxy movements to the broad-phase so that new contacts are created.
+                // Also, some contacts can be destroyed.
+                stats.contactsAdded += FindNewContacts();
+
+                if (subStepping)
+                {
+                    SetStepComplete(false);
+                    break;
+                }
+            }
+            return stats;
+        }
+
+        IslandStats WorldImpl::SolveToi(ContactID contactID, const StepConf& conf)
+        {
+            // Note:
+            //   This method is what used to be b2World::SolveToi(const b2TimeStep& step).
+            //   It also differs internally from Erin's implementation.
+            //
+            //   Here's some specific behavioral differences:
+            //   1. Bodies don't get their under-active times reset (like they do in Erin's code).
+
+            auto contactsUpdated = ContactCounter{0};
+            auto contactsSkipped = ContactCounter{0};
+
+            auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+
+            /*
+     * Confirm that contact is as it's supposed to be according to contract of the
+     * GetSoonestContacts method from which this contact should have been obtained.
+     */
             assert(contact.IsEnabled());
             assert(!HasSensor(m_fixtureBuffer, contact));
             assert(IsActive(contact));
             assert(IsImpenetrable(contact));
-#endif
-            const auto solverResults = SolveToi(contactID, conf);
-            stats.minSeparation = std::min(stats.minSeparation, solverResults.minSeparation);
-            stats.maxIncImpulse = std::max(stats.maxIncImpulse, solverResults.maxIncImpulse);
-            stats.islandsSolved += solverResults.solved;
-            stats.sumPosIters += solverResults.positionIterations;
-            stats.sumVelIters += solverResults.velocityIterations;
-            if ((solverResults.positionIterations > 0) || (solverResults.velocityIterations > 0))
-            {
-                ++islandsFound;
-            }
-            stats.contactsUpdatedTouching += solverResults.contactsUpdated;
-            stats.contactsSkippedTouching += solverResults.contactsSkipped;
-        }
-        stats.islandsFound += islandsFound;
+            assert(!m_islandedContacts[UnderlyingValue(contactID)]);
 
-        // Reset island flags and synchronize broad-phase proxies.
-        for (const auto& b: m_bodies) {
-            if (m_islandedBodies[UnderlyingValue(b)]) {
-                m_islandedBodies[UnderlyingValue(b)] = false;
-                auto& body = m_bodyBuffer[UnderlyingValue(b)];
-                if (body.IsAccelerable())
+            const auto toi = contact.GetToi();
+            const auto bodyIdA = contact.GetBodyA();
+            const auto bodyIdB = contact.GetBodyB();
+            auto& bA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
+            auto& bB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
+
+            /* XXX: if (toi != 0)? */
+            /* if (bA->GetSweep().GetAlpha0() != toi || bB->GetSweep().GetAlpha0() != toi) */
+            // Seems contact manifold needs updating regardless.
+            {
+                const auto backupA = bA.GetSweep();
+                const auto backupB = bB.GetSweep();
+
+                // Advance the bodies to the TOI.
+                assert(toi != 0 || (bA.GetSweep().GetAlpha0() == 0 && bB.GetSweep().GetAlpha0() == 0));
+                bA.Advance(toi);
+                FlagForUpdating(m_contactBuffer, bA.GetContacts());
+                bB.Advance(toi);
+                FlagForUpdating(m_contactBuffer, bB.GetContacts());
+
+                // The TOI contact likely has some new contact points.
+                contact.SetEnabled();
+                if (contact.NeedsUpdating())
                 {
-                    const auto xfm0 = GetTransform0(body.GetSweep());
-                    const auto xfm1 = body.GetTransformation();
-                    stats.proxiesMoved += Synchronize(body, xfm0, xfm1,
-                                                      conf.displaceMultiplier, conf.aabbExtension);
-                    ResetContactsForSolveTOI(m_contactBuffer, body);
-                    Unset(m_islandedContacts, body.GetContacts());
+                    Update(contactID, GetUpdateConf(conf));
+                    ++contactsUpdated;
+                }
+                else
+                {
+                    ++contactsSkipped;
+                }
+                contact.UnsetToi();
+                contact.IncrementToiCount();
+
+                // Is contact disabled or separated?
+                //
+                // XXX: Not often, but sometimes, contact.IsTouching() is false now.
+                //      Seems like this is a bug, or at least suboptimal, condition.
+                //      This method shouldn't be getting called unless contact has an
+                //      impact indeed at the given TOI. Seen this happen in an edge-polygon
+                //      contact situation where the polygon had a larger than default
+                //      vertex radius. CollideShapes had called GetManifoldFaceB which
+                //      was failing to see 2 clip points after GetClipPoints was called.
+                if (!contact.IsEnabled() || !contact.IsTouching())
+                {
+                    // assert(!contact.IsEnabled() || contact.IsTouching());
+                    contact.UnsetEnabled();
+                    bA.Restore(backupA);
+                    bB.Restore(backupB);
+                    auto results = IslandStats{};
+                    results.contactsUpdated += contactsUpdated;
+                    results.contactsSkipped += contactsSkipped;
+                    return results;
                 }
             }
-        }
-
-        // Commit fixture proxy movements to the broad-phase so that new contacts are created.
-        // Also, some contacts can be destroyed.
-        stats.contactsAdded += FindNewContacts();
-
-        if (subStepping)
-        {
-            SetStepComplete(false);
-            break;
-        }
-    }
-    return stats;
-}
-
-IslandStats WorldImpl::SolveToi(ContactID contactID, const StepConf& conf)
-{
-    // Note:
-    //   This method is what used to be b2World::SolveToi(const b2TimeStep& step).
-    //   It also differs internally from Erin's implementation.
-    //
-    //   Here's some specific behavioral differences:
-    //   1. Bodies don't get their under-active times reset (like they do in Erin's code).
-
-    auto contactsUpdated = ContactCounter{0};
-    auto contactsSkipped = ContactCounter{0};
-
-    auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-
-    /*
-     * Confirm that contact is as it's supposed to be according to contract of the
-     * GetSoonestContacts method from which this contact should have been obtained.
-     */
-    assert(contact.IsEnabled());
-    assert(!HasSensor(m_fixtureBuffer, contact));
-    assert(IsActive(contact));
-    assert(IsImpenetrable(contact));
-    assert(!m_islandedContacts[UnderlyingValue(contactID)]);
-
-    const auto toi = contact.GetToi();
-    const auto bodyIdA = contact.GetBodyA();
-    const auto bodyIdB = contact.GetBodyB();
-    auto& bA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
-    auto& bB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
-
-    /* XXX: if (toi != 0)? */
-    /* if (bA->GetSweep().GetAlpha0() != toi || bB->GetSweep().GetAlpha0() != toi) */
-    // Seems contact manifold needs updating regardless.
-    {
-        const auto backupA = bA.GetSweep();
-        const auto backupB = bB.GetSweep();
-
-        // Advance the bodies to the TOI.
-        assert(toi != 0 || (bA.GetSweep().GetAlpha0() == 0 && bB.GetSweep().GetAlpha0() == 0));
-        bA.Advance(toi);
-        FlagForUpdating(m_contactBuffer, bA.GetContacts());
-        bB.Advance(toi);
-        FlagForUpdating(m_contactBuffer, bB.GetContacts());
-
-        // The TOI contact likely has some new contact points.
-        contact.SetEnabled();
-        if (contact.NeedsUpdating())
-        {
-            Update(contactID, GetUpdateConf(conf));
-            ++contactsUpdated;
-        }
-        else
-        {
-            ++contactsSkipped;
-        }
-        contact.UnsetToi();
-        contact.IncrementToiCount();
-
-        // Is contact disabled or separated?
-        //
-        // XXX: Not often, but sometimes, contact.IsTouching() is false now.
-        //      Seems like this is a bug, or at least suboptimal, condition.
-        //      This method shouldn't be getting called unless contact has an
-        //      impact indeed at the given TOI. Seen this happen in an edge-polygon
-        //      contact situation where the polygon had a larger than default
-        //      vertex radius. CollideShapes had called GetManifoldFaceB which
-        //      was failing to see 2 clip points after GetClipPoints was called.
-        if (!contact.IsEnabled() || !contact.IsTouching())
-        {
-            // assert(!contact.IsEnabled() || contact.IsTouching());
-            contact.UnsetEnabled();
-            bA.Restore(backupA);
-            bB.Restore(backupB);
-            auto results = IslandStats{};
-            results.contactsUpdated += contactsUpdated;
-            results.contactsSkipped += contactsSkipped;
-            return results;
-        }
-    }
 #if 0
     else if (!contact.IsTouching())
     {
@@ -1388,93 +1403,93 @@ IslandStats WorldImpl::SolveToi(ContactID contactID, const StepConf& conf)
         return IslandSolverResults{};
     }
 #endif
-    if (bA.IsSpeedable())
-    {
-        bA.SetAwakeFlag();
-        // XXX should the body's under-active time be reset here?
-        //   Erin's code does for here but not in b2World::Solve(const b2TimeStep& step).
-        //   Calling Body::ResetUnderActiveTime() has performance implications.
-    }
-    if (bB.IsSpeedable())
-    {
-        bB.SetAwakeFlag();
-        // XXX should the body's under-active time be reset here?
-        //   Erin's code does for here but not in b2World::Solve(const b2TimeStep& step).
-        //   Calling Body::ResetUnderActiveTime() has performance implications.
-    }
+            if (bA.IsSpeedable())
+            {
+                bA.SetAwakeFlag();
+                // XXX should the body's under-active time be reset here?
+                //   Erin's code does for here but not in b2World::Solve(const b2TimeStep& step).
+                //   Calling Body::ResetUnderActiveTime() has performance implications.
+            }
+            if (bB.IsSpeedable())
+            {
+                bB.SetAwakeFlag();
+                // XXX should the body's under-active time be reset here?
+                //   Erin's code does for here but not in b2World::Solve(const b2TimeStep& step).
+                //   Calling Body::ResetUnderActiveTime() has performance implications.
+            }
 
-    // Build the island
-    ::playrho::d2::Clear(m_island);
-    ::playrho::d2::Reserve(m_island,
-                           static_cast<BodyCounter>(used(m_bodyBuffer)),
-                           static_cast<ContactCounter>(used(m_contactBuffer)),
-                           static_cast<JointCounter>(0));
+            // Build the island
+            ::playrho::d2::Clear(m_island);
+            ::playrho::d2::Reserve(m_island,
+                                   static_cast<BodyCounter>(used(m_bodyBuffer)),
+                                   static_cast<ContactCounter>(used(m_contactBuffer)),
+                                   static_cast<JointCounter>(0));
 
-     // These asserts get triggered sometimes if contacts within TOI are iterated over.
-    assert(!m_islandedBodies[UnderlyingValue(bodyIdA)]);
-    assert(!m_islandedBodies[UnderlyingValue(bodyIdB)]);
-    m_islandedBodies[UnderlyingValue(bodyIdA)] = true;
-    m_islandedBodies[UnderlyingValue(bodyIdB)] = true;
-    m_islandedContacts[UnderlyingValue(contactID)] = true;
-    m_island.bodies.push_back(bodyIdA);
-    m_island.bodies.push_back(bodyIdB);
-    m_island.contacts.push_back(contactID);
+            // These asserts get triggered sometimes if contacts within TOI are iterated over.
+            assert(!m_islandedBodies[UnderlyingValue(bodyIdA)]);
+            assert(!m_islandedBodies[UnderlyingValue(bodyIdB)]);
+            m_islandedBodies[UnderlyingValue(bodyIdA)] = true;
+            m_islandedBodies[UnderlyingValue(bodyIdB)] = true;
+            m_islandedContacts[UnderlyingValue(contactID)] = true;
+            m_island.bodies.push_back(bodyIdA);
+            m_island.bodies.push_back(bodyIdB);
+            m_island.contacts.push_back(contactID);
 
-    // Process the contacts of the two bodies, adding appropriate ones to the island,
-    // adding appropriate other bodies of added contacts, and advancing those other
-    // bodies sweeps and transforms to the minimum contact's TOI.
-    if (bA.IsAccelerable())
-    {
-        const auto procOut = ProcessContactsForTOI(bodyIdA, m_island, toi, conf);
-        contactsUpdated += procOut.contactsUpdated;
-        contactsSkipped += procOut.contactsSkipped;
-    }
-    if (bB.IsAccelerable())
-    {
-        const auto procOut = ProcessContactsForTOI(bodyIdB, m_island, toi, conf);
-        contactsUpdated += procOut.contactsUpdated;
-        contactsSkipped += procOut.contactsSkipped;
-    }
+            // Process the contacts of the two bodies, adding appropriate ones to the island,
+            // adding appropriate other bodies of added contacts, and advancing those other
+            // bodies sweeps and transforms to the minimum contact's TOI.
+            if (bA.IsAccelerable())
+            {
+                const auto procOut = ProcessContactsForTOI(bodyIdA, m_island, toi, conf);
+                contactsUpdated += procOut.contactsUpdated;
+                contactsSkipped += procOut.contactsSkipped;
+            }
+            if (bB.IsAccelerable())
+            {
+                const auto procOut = ProcessContactsForTOI(bodyIdB, m_island, toi, conf);
+                contactsUpdated += procOut.contactsUpdated;
+                contactsSkipped += procOut.contactsSkipped;
+            }
 
-    RemoveUnspeedablesFromIslanded(m_island.bodies, m_bodyBuffer, m_islandedBodies);
+            RemoveUnspeedablesFromIslanded(m_island.bodies, m_bodyBuffer, m_islandedBodies);
 
-    // Now solve for remainder of time step.
-    auto subConf = StepConf{conf};
-    subConf.deltaTime = (1 - toi) * conf.deltaTime;
-    auto results = SolveToiViaGS(m_island, subConf);
-    results.contactsUpdated += contactsUpdated;
-    results.contactsSkipped += contactsSkipped;
-    return results;
-}
+            // Now solve for remainder of time step.
+            auto subConf = StepConf{conf};
+            subConf.deltaTime = (1 - toi) * conf.deltaTime;
+            auto results = SolveToiViaGS(m_island, subConf);
+            results.contactsUpdated += contactsUpdated;
+            results.contactsSkipped += contactsSkipped;
+            return results;
+        }
 
-bool WorldImpl::UpdateBody(Body& body, const Position& pos)
-{
-    assert(IsValid(pos));
-    body.SetPosition1(pos);
-    const auto oldXfm = body.GetTransformation();
-    const auto newXfm = GetTransformation(GetPosition1(body), body.GetLocalCenter());
-    if (newXfm != oldXfm)
-    {
-        body.SetTransformation(newXfm);
-        return true;
-    }
-    return false;
-}
+        bool WorldImpl::UpdateBody(Body& body, const Position& pos)
+        {
+            assert(IsValid(pos));
+            body.SetPosition1(pos);
+            const auto oldXfm = body.GetTransformation();
+            const auto newXfm = GetTransformation(GetPosition1(body), body.GetLocalCenter());
+            if (newXfm != oldXfm)
+            {
+                body.SetTransformation(newXfm);
+                return true;
+            }
+            return false;
+        }
 
-IslandStats WorldImpl::SolveToiViaGS(const Island& island, const StepConf& conf)
-{
-    auto results = IslandStats{};
+        IslandStats WorldImpl::SolveToiViaGS(const Island& island, const StepConf& conf)
+        {
+            auto results = IslandStats{};
 
-    /*
+            /*
      * Presumably the regular phase resolution has already taken care of updating the
      * body's velocity w.r.t. acceleration and damping such that this call here to get
      * the body constraint doesn't need to pass an elapsed time (and doesn't need to
      * update the velocity from what it already is).
      */
-    auto bodyConstraints = GetBodyConstraints(island.bodies, m_bodyBuffer, 0_s,
-                                              GetMovementConf(conf));
+            auto bodyConstraints = GetBodyConstraints(island.bodies, m_bodyBuffer, 0_s,
+                                                      GetMovementConf(conf));
 
-    // Initialize the body state.
+            // Initialize the body state.
 #if 0
     for (auto&& contact: island.m_contacts)
     {
@@ -1488,545 +1503,543 @@ IslandStats WorldImpl::SolveToiViaGS(const Island& island, const StepConf& conf)
     }
 #endif
 
-    auto posConstraints = GetPositionConstraints(island.contacts,
-                                                 m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
-                                                 bodyConstraints);
+            auto posConstraints = GetPositionConstraints(island.contacts,
+                                                         m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
+                                                         bodyConstraints);
 
-    // Solve TOI-based position constraints.
-    assert(results.minSeparation == std::numeric_limits<Length>::infinity());
-    assert(results.solved == false);
-    results.positionIterations = conf.toiPositionIterations;
-    {
-        const auto psConf = GetToiConstraintSolverConf(conf);
-
-        for (auto i = decltype(conf.toiPositionIterations){0}; i < conf.toiPositionIterations; ++i)
-        {
-            //
-            // Note: There are two flavors of the SolvePositionConstraints function.
-            //   One takes an extra two arguments that are the indexes of two bodies that are
-            //   okay tomove. The other one does not.
-            //   Calling the selective solver (that takes the two additional arguments) appears
-            //   to result in phsyics simulations that are more prone to tunneling. Meanwhile,
-            //   using the non-selective solver would presumably be slower (since it appears to
-            //   have more that it will do). Assuming that slower is preferable to tunnelling,
-            //   then the non-selective function is the one to be calling here.
-            //
-            const auto minSeparation = SolvePositionConstraintsViaGS(posConstraints, psConf);
-            results.minSeparation = std::min(results.minSeparation, minSeparation);
-            if (minSeparation >= conf.toiMinSeparation)
+            // Solve TOI-based position constraints.
+            assert(results.minSeparation == std::numeric_limits<Length>::infinity());
+            assert(results.solved == false);
+            results.positionIterations = conf.toiPositionIterations;
             {
-                // Reached tolerance, early out...
-                results.positionIterations = i + 1;
-                results.solved = true;
-                break;
-            }
-        }
-    }
+                const auto psConf = GetToiConstraintSolverConf(conf);
 
-    // Leap of faith to new safe state.
-    // Not doing this results in slower simulations.
-    // Originally this update was only done to island.bodies 0 and 1.
-    // Unclear whether rest of bodies should also be updated. No difference noticed.
-    for (const auto& id: island.bodies)
-    {
-        const auto& bc = bodyConstraints[UnderlyingValue(id)];
-        m_bodyBuffer[UnderlyingValue(id)].SetPosition0(bc.GetPosition());
-    }
-
-    auto velConstraints = GetVelocityConstraints(island.contacts,
-                                                 m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
-                                                 bodyConstraints,
-                                                 GetToiVelocityConstraintConf(conf));
-
-    // No warm starting is needed for TOI events because warm
-    // starting impulses were applied in the discrete solver.
-
-    // Solve velocity constraints.
-    assert(results.maxIncImpulse == 0_Ns);
-    results.velocityIterations = conf.toiVelocityIterations;
-    for (auto i = decltype(conf.toiVelocityIterations){0}; i < conf.toiVelocityIterations; ++i)
-    {
-        const auto newIncImpulse = SolveVelocityConstraintsViaGS(velConstraints);
-        if (newIncImpulse <= conf.toiMinMomentum)
-        {
-            // No body related velocity constraints were out of tolerance.
-            // There does not appear to be any benefit to doing more loops now.
-            // XXX: Is it really safe to bail now? Not certain of that.
-            // Bail now assuming that this is helpful to do...
-            results.velocityIterations = i + 1;
-            break;
-        }
-        results.maxIncImpulse = std::max(results.maxIncImpulse, newIncImpulse);
-    }
-
-    // Don't store TOI contact forces for warm starting because they can be quite large.
-
-    IntegratePositions(bodyConstraints, conf.deltaTime);
-
-    for (const auto& id: island.bodies)
-    {
-        const auto i = UnderlyingValue(id);
-        auto& body = m_bodyBuffer[i];
-        auto& bc = bodyConstraints[i];
-        body.JustSetVelocity(bc.GetVelocity());
-        if (UpdateBody(body, bc.GetPosition()))
-        {
-            FlagForUpdating(m_contactBuffer, body.GetContacts());
-        }
-    }
-
-    if (m_postSolveContactListener)
-    {
-        Report(m_postSolveContactListener, island.contacts, velConstraints, results.positionIterations);
-    }
-
-    return results;
-}
-
-WorldImpl::ProcessContactsOutput
-WorldImpl::ProcessContactsForTOI(BodyID id, Island& island, Real toi, const StepConf& conf)
-{
-    const auto& body = m_bodyBuffer[UnderlyingValue(id)];
-
-    assert(m_islandedBodies[UnderlyingValue(id)]);
-    assert(body.IsAccelerable());
-    assert(toi >= 0 && toi <= 1);
-
-    auto results = ProcessContactsOutput{};
-    assert(results.contactsUpdated == 0);
-    assert(results.contactsSkipped == 0);
-    
-    const auto updateConf = GetUpdateConf(conf);
-
-    // Note: the original contact (for body of which this method was called) already is-in-island.
-    const auto bodyImpenetrable = body.IsImpenetrable();
-    for (const auto& ci: body.GetContacts())
-    {
-        const auto contactID = std::get<ContactID>(ci);
-        if (!m_islandedContacts[UnderlyingValue(contactID)]) {
-            auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-            if (!contact.IsSensor())
-            {
-                const auto bodyIdA = contact.GetBodyA();
-                const auto bodyIdB = contact.GetBodyB();
-                const auto otherId = (bodyIdA != id)? bodyIdA: bodyIdB;
-                auto& other = m_bodyBuffer[UnderlyingValue(otherId)];
-                if (bodyImpenetrable || other.IsImpenetrable())
+                for (auto i = decltype(conf.toiPositionIterations){0}; i < conf.toiPositionIterations; ++i)
                 {
-                    const auto otherIslanded = m_islandedBodies[UnderlyingValue(otherId)];
+                    //
+                    // Note: There are two flavors of the SolvePositionConstraints function.
+                    //   One takes an extra two arguments that are the indexes of two bodies that are
+                    //   okay tomove. The other one does not.
+                    //   Calling the selective solver (that takes the two additional arguments) appears
+                    //   to result in phsyics simulations that are more prone to tunneling. Meanwhile,
+                    //   using the non-selective solver would presumably be slower (since it appears to
+                    //   have more that it will do). Assuming that slower is preferable to tunnelling,
+                    //   then the non-selective function is the one to be calling here.
+                    //
+                    const auto minSeparation = SolvePositionConstraintsViaGS(posConstraints, psConf);
+                    results.minSeparation = std::min(results.minSeparation, minSeparation);
+                    if (minSeparation >= conf.toiMinSeparation)
                     {
-                        const auto backup = other.GetSweep();
-                        if (!otherIslanded /* && other->GetSweep().GetAlpha0() != toi */)
-                        {
-                            other.Advance(toi);
-                            FlagForUpdating(m_contactBuffer, other.GetContacts());
-                        }
-
-                        // Update the contact points
-                        contact.SetEnabled();
-                        if (contact.NeedsUpdating())
-                        {
-                            Update(contactID, updateConf);
-                            ++results.contactsUpdated;
-                        }
-                        else
-                        {
-                            ++results.contactsSkipped;
-                        }
-
-                        // Revert and skip if contact disabled by user or not touching anymore (very possible).
-                        if (!contact.IsEnabled() || !contact.IsTouching())
-                        {
-                            other.Restore(backup);
-                            continue;
-                        }
+                        // Reached tolerance, early out...
+                        results.positionIterations = i + 1;
+                        results.solved = true;
+                        break;
                     }
-                    island.contacts.push_back(contactID);
-                    m_islandedContacts[UnderlyingValue(contactID)] = true;
-                    if (!otherIslanded)
+                }
+            }
+
+            // Leap of faith to new safe state.
+            // Not doing this results in slower simulations.
+            // Originally this update was only done to island.bodies 0 and 1.
+            // Unclear whether rest of bodies should also be updated. No difference noticed.
+            for (const auto& id : island.bodies)
+            {
+                const auto& bc = bodyConstraints[UnderlyingValue(id)];
+                m_bodyBuffer[UnderlyingValue(id)].SetPosition0(bc.GetPosition());
+            }
+
+            auto velConstraints = GetVelocityConstraints(island.contacts,
+                                                         m_fixtureBuffer, m_contactBuffer, m_manifoldBuffer,
+                                                         bodyConstraints,
+                                                         GetToiVelocityConstraintConf(conf));
+
+            // No warm starting is needed for TOI events because warm
+            // starting impulses were applied in the discrete solver.
+
+            // Solve velocity constraints.
+            assert(results.maxIncImpulse == 0_Ns);
+            results.velocityIterations = conf.toiVelocityIterations;
+            for (auto i = decltype(conf.toiVelocityIterations){0}; i < conf.toiVelocityIterations; ++i)
+            {
+                const auto newIncImpulse = SolveVelocityConstraintsViaGS(velConstraints);
+                if (newIncImpulse <= conf.toiMinMomentum)
+                {
+                    // No body related velocity constraints were out of tolerance.
+                    // There does not appear to be any benefit to doing more loops now.
+                    // XXX: Is it really safe to bail now? Not certain of that.
+                    // Bail now assuming that this is helpful to do...
+                    results.velocityIterations = i + 1;
+                    break;
+                }
+                results.maxIncImpulse = std::max(results.maxIncImpulse, newIncImpulse);
+            }
+
+            // Don't store TOI contact forces for warm starting because they can be quite large.
+
+            IntegratePositions(bodyConstraints, conf.deltaTime);
+
+            for (const auto& id : island.bodies)
+            {
+                const auto i = UnderlyingValue(id);
+                auto& body = m_bodyBuffer[i];
+                auto& bc = bodyConstraints[i];
+                body.JustSetVelocity(bc.GetVelocity());
+                if (UpdateBody(body, bc.GetPosition()))
+                {
+                    FlagForUpdating(m_contactBuffer, body.GetContacts());
+                }
+            }
+
+            if (m_postSolveContactListener)
+            {
+                Report(m_postSolveContactListener, island.contacts, velConstraints, results.positionIterations);
+            }
+
+            return results;
+        }
+
+        WorldImpl::ProcessContactsOutput
+        WorldImpl::ProcessContactsForTOI(BodyID id, Island& island, Real toi, const StepConf& conf)
+        {
+            const auto& body = m_bodyBuffer[UnderlyingValue(id)];
+
+            assert(m_islandedBodies[UnderlyingValue(id)]);
+            assert(body.IsAccelerable());
+            assert(toi >= 0 && toi <= 1);
+
+            auto results = ProcessContactsOutput{};
+            assert(results.contactsUpdated == 0);
+            assert(results.contactsSkipped == 0);
+
+            const auto updateConf = GetUpdateConf(conf);
+
+            // Note: the original contact (for body of which this method was called) already is-in-island.
+            const auto bodyImpenetrable = body.IsImpenetrable();
+            for (const auto& ci : body.GetContacts())
+            {
+                const auto contactID = std::get<ContactID>(ci);
+                if (!m_islandedContacts[UnderlyingValue(contactID)])
+                {
+                    auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+                    if (!contact.IsSensor())
                     {
-                        if (other.IsSpeedable())
+                        const auto bodyIdA = contact.GetBodyA();
+                        const auto bodyIdB = contact.GetBodyB();
+                        const auto otherId = (bodyIdA != id) ? bodyIdA : bodyIdB;
+                        auto& other = m_bodyBuffer[UnderlyingValue(otherId)];
+                        if (bodyImpenetrable || other.IsImpenetrable())
                         {
-                            other.SetAwakeFlag();
-                        }
-                        island.bodies.push_back(otherId);
-                        m_islandedBodies[UnderlyingValue(otherId)] = true;
+                            const auto otherIslanded = m_islandedBodies[UnderlyingValue(otherId)];
+                            {
+                                const auto backup = other.GetSweep();
+                                if (!otherIslanded /* && other->GetSweep().GetAlpha0() != toi */)
+                                {
+                                    other.Advance(toi);
+                                    FlagForUpdating(m_contactBuffer, other.GetContacts());
+                                }
+
+                                // Update the contact points
+                                contact.SetEnabled();
+                                if (contact.NeedsUpdating())
+                                {
+                                    Update(contactID, updateConf);
+                                    ++results.contactsUpdated;
+                                }
+                                else
+                                {
+                                    ++results.contactsSkipped;
+                                }
+
+                                // Revert and skip if contact disabled by user or not touching anymore (very possible).
+                                if (!contact.IsEnabled() || !contact.IsTouching())
+                                {
+                                    other.Restore(backup);
+                                    continue;
+                                }
+                            }
+                            island.contacts.push_back(contactID);
+                            m_islandedContacts[UnderlyingValue(contactID)] = true;
+                            if (!otherIslanded)
+                            {
+                                if (other.IsSpeedable())
+                                {
+                                    other.SetAwakeFlag();
+                                }
+                                island.bodies.push_back(otherId);
+                                m_islandedBodies[UnderlyingValue(otherId)] = true;
 #if 0
                         if (other.IsAccelerable())
                         {
                             contactsUpdated += ProcessContactsForTOI(island, other, toi);
                         }
 #endif
-                    }
+                            }
 #ifndef NDEBUG
-                    else
-                    {
-                        /*
+                            else
+                            {
+                                /*
                          * If other is-in-island but not in current island, then something's gone wrong.
                          * Other needs to be in current island but was already in the island.
                          * A previous contact island didn't grow to include all the bodies it needed or
                          * perhaps the current contact is-touching while another one wasn't and the
                          * inconsistency is throwing things off.
                          */
-                        assert(Count(island, otherId) > 0);
-                    }
+                                assert(Count(island, otherId) > 0);
+                            }
 #endif
+                        }
+                    }
                 }
             }
-        }
-    }
-    return results;
-}
-
-StepStats WorldImpl::Step(const StepConf& conf)
-{
-    assert((Length{m_maxVertexRadius} * Real{2}) +
-           (Length{conf.linearSlop} / Real{4}) > (Length{m_maxVertexRadius} * Real{2}));
-    
-    if (IsLocked())
-    {
-        throw WrongState("Step: world is locked");
-    }
-
-    // "Named return value optimization" (NRVO) will make returning this more efficient.
-    auto stepStats = StepStats{};
-    {
-        FlagGuard<decltype(m_flags)> flagGaurd(m_flags, e_locked);
-
-        CreateAndDestroyProxies(conf.aabbExtension);
-        m_fixturesForProxies.clear();
-
-        stepStats.pre.proxiesMoved = SynchronizeProxies(conf);
-        // pre.proxiesMoved is usually zero but sometimes isn't.
-
-        {
-            // Note: this may update bodies (in addition to the contacts container).
-            const auto destroyStats = DestroyContacts(m_contacts);
-            stepStats.pre.destroyed = destroyStats.erased;
+            return results;
         }
 
-        if (HasNewFixtures())
+        StepStats WorldImpl::Step(const StepConf& conf)
         {
-            UnsetNewFixtures();
-            
-            // New fixtures were added: need to find and create the new contacts.
-            // Note: this may update bodies (in addition to the contacts container).
-            stepStats.pre.added = FindNewContacts();
-        }
+            assert((Length{m_maxVertexRadius} * Real{2}) + (Length{conf.linearSlop} / Real{4}) > (Length{m_maxVertexRadius} * Real{2}));
 
-        if (conf.deltaTime != 0_s)
-        {
-            m_inv_dt0 = (conf.deltaTime != 0_s)? Real(1) / conf.deltaTime: 0_Hz;
-
-            // Could potentially run UpdateContacts multithreaded over split lists...
-            const auto updateStats = UpdateContacts(conf);
-            stepStats.pre.ignored = updateStats.ignored;
-            stepStats.pre.updated = updateStats.updated;
-            stepStats.pre.skipped = updateStats.skipped;
-
-            // Integrate velocities, solve velocity constraints, and integrate positions.
-            if (IsStepComplete())
+            if (IsLocked())
             {
-                stepStats.reg = SolveReg(conf);
+                throw WrongState("Step: world is locked");
             }
 
-            // Handle TOI events.
-            if (conf.doToi)
+            // "Named return value optimization" (NRVO) will make returning this more efficient.
+            auto stepStats = StepStats{};
             {
-                stepStats.toi = SolveToi(conf);
+                FlagGuard<decltype(m_flags)> flagGaurd(m_flags, e_locked);
+
+                CreateAndDestroyProxies(conf.aabbExtension);
+                m_fixturesForProxies.clear();
+
+                stepStats.pre.proxiesMoved = SynchronizeProxies(conf);
+                // pre.proxiesMoved is usually zero but sometimes isn't.
+
+                {
+                    // Note: this may update bodies (in addition to the contacts container).
+                    const auto destroyStats = DestroyContacts(m_contacts);
+                    stepStats.pre.destroyed = destroyStats.erased;
+                }
+
+                if (HasNewFixtures())
+                {
+                    UnsetNewFixtures();
+
+                    // New fixtures were added: need to find and create the new contacts.
+                    // Note: this may update bodies (in addition to the contacts container).
+                    stepStats.pre.added = FindNewContacts();
+                }
+
+                if (conf.deltaTime != 0_s)
+                {
+                    m_inv_dt0 = (conf.deltaTime != 0_s) ? Real(1) / conf.deltaTime : 0_Hz;
+
+                    // Could potentially run UpdateContacts multithreaded over split lists...
+                    const auto updateStats = UpdateContacts(conf);
+                    stepStats.pre.ignored = updateStats.ignored;
+                    stepStats.pre.updated = updateStats.updated;
+                    stepStats.pre.skipped = updateStats.skipped;
+
+                    // Integrate velocities, solve velocity constraints, and integrate positions.
+                    if (IsStepComplete())
+                    {
+                        stepStats.reg = SolveReg(conf);
+                    }
+
+                    // Handle TOI events.
+                    if (conf.doToi)
+                    {
+                        stepStats.toi = SolveToi(conf);
+                    }
+                }
             }
-        }
-    }
-    return stepStats;
-}
-
-void WorldImpl::ShiftOrigin(Length2 newOrigin)
-{
-    if (IsLocked())
-    {
-        throw WrongState("ShiftOrigin: world is locked");
-    }
-
-    // Optimize for newOrigin being different than current...
-    const auto bodies = GetBodies();
-    for (const auto& body: bodies)
-    {
-        auto& b = m_bodyBuffer[UnderlyingValue(body)];
-        auto transformation = b.GetTransformation();
-        transformation.p -= newOrigin;
-        b.SetTransformation(transformation);
-        FlagForUpdating(m_contactBuffer, b.GetContacts());
-        auto sweep = b.GetSweep();
-        sweep.pos0.linear -= newOrigin;
-        sweep.pos1.linear -= newOrigin;
-        b.SetSweep(sweep);
-    }
-
-    for_each(begin(m_joints), end(m_joints), [&](const auto& joint) {
-        auto& j = m_jointBuffer[UnderlyingValue(joint)];
-        ::playrho::d2::ShiftOrigin(j, newOrigin);
-    });
-
-    m_tree.ShiftOrigin(newOrigin);
-}
-
-void WorldImpl::InternalDestroy(ContactID contactID,
-                                ArrayAllocator<Body>& bodyBuffer,
-                                ArrayAllocator<Contact>& contactBuffer,
-                                ArrayAllocator<Manifold>& manifoldBuffer,
-                                ContactListener listener, Body* from)
-{
-    assert(contactID != InvalidContactID);
-    auto& contact = contactBuffer[UnderlyingValue(contactID)];
-    if (listener && contact.IsTouching())
-    {
-        // EndContact hadn't been called in DestroyOrUpdateContacts() since is-touching, so call it now
-        listener(contactID);
-    }
-    const auto bodyIdA = contact.GetBodyA();
-    const auto bodyIdB = contact.GetBodyB();
-    const auto bodyA = &bodyBuffer[UnderlyingValue(bodyIdA)];
-    const auto bodyB = &bodyBuffer[UnderlyingValue(bodyIdB)];
-    if (bodyA != from)
-    {
-        bodyA->Erase(contactID);
-    }
-    if (bodyB != from)
-    {
-        bodyB->Erase(contactID);
-    }
-    auto& manifold = manifoldBuffer[UnderlyingValue(contactID)];
-    if ((manifold.GetPointCount() > 0) && !contact.IsSensor())
-    {
-        // Contact may have been keeping accelerable bodies of fixture A or B from moving.
-        // Need to awaken those bodies now in case they are again movable.
-        bodyA->SetAwake();
-        bodyB->SetAwake();
-    }
-    contactBuffer.Free(UnderlyingValue(contactID));
-    manifoldBuffer.Free(UnderlyingValue(contactID));
-}
-
-void WorldImpl::Destroy(ContactID contactID, Body* from)
-{
-    assert(contactID != InvalidContactID);
-    const auto it = find_if(cbegin(m_contacts), cend(m_contacts),
-                            [&](const Contacts::value_type& c) {
-        return std::get<ContactID>(c) == contactID;
-    });
-    if (it != cend(m_contacts))
-    {
-        m_contacts.erase(it);
-    }
-    InternalDestroy(contactID, m_bodyBuffer, m_contactBuffer, m_manifoldBuffer,
-                    m_endContactListener, from);
-}
-
-WorldImpl::DestroyContactsStats WorldImpl::DestroyContacts(Contacts& contacts)
-{
-    const auto beforeSize = size(contacts);
-    contacts.erase(std::remove_if(begin(contacts), end(contacts), [&](const auto& c)
-    {
-        const auto key = std::get<ContactKey>(c);
-        const auto contactID = std::get<ContactID>(c);
-
-        if (!TestOverlap(m_tree, key.GetMin(), key.GetMax()))
-        {
-            // Destroy contacts that cease to overlap in the broad-phase.
-            InternalDestroy(contactID, m_bodyBuffer, m_contactBuffer, m_manifoldBuffer,
-                            m_endContactListener);
-            return true;
+            return stepStats;
         }
 
-        // Is this contact flagged for filtering?
-        auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-        if (contact.NeedsFiltering())
+        void WorldImpl::ShiftOrigin(Length2 newOrigin)
         {
+            if (IsLocked())
+            {
+                throw WrongState("ShiftOrigin: world is locked");
+            }
+
+            // Optimize for newOrigin being different than current...
+            const auto bodies = GetBodies();
+            for (const auto& body : bodies)
+            {
+                auto& b = m_bodyBuffer[UnderlyingValue(body)];
+                auto transformation = b.GetTransformation();
+                transformation.p -= newOrigin;
+                b.SetTransformation(transformation);
+                FlagForUpdating(m_contactBuffer, b.GetContacts());
+                auto sweep = b.GetSweep();
+                sweep.pos0.linear -= newOrigin;
+                sweep.pos1.linear -= newOrigin;
+                b.SetSweep(sweep);
+            }
+
+            for_each(begin(m_joints), end(m_joints), [&](const auto& joint) {
+                auto& j = m_jointBuffer[UnderlyingValue(joint)];
+                ::playrho::d2::ShiftOrigin(j, newOrigin);
+            });
+
+            m_tree.ShiftOrigin(newOrigin);
+        }
+
+        void WorldImpl::InternalDestroy(ContactID contactID,
+                                        ArrayAllocator<Body>& bodyBuffer,
+                                        ArrayAllocator<Contact>& contactBuffer,
+                                        ArrayAllocator<Manifold>& manifoldBuffer,
+                                        ContactListener listener, Body* from)
+        {
+            assert(contactID != InvalidContactID);
+            auto& contact = contactBuffer[UnderlyingValue(contactID)];
+            if (listener && contact.IsTouching())
+            {
+                // EndContact hadn't been called in DestroyOrUpdateContacts() since is-touching, so call it now
+                listener(contactID);
+            }
             const auto bodyIdA = contact.GetBodyA();
-            const auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
-            const auto& bodyB = m_bodyBuffer[UnderlyingValue(contact.GetBodyB())];
-            const auto& fixtureA = m_fixtureBuffer[UnderlyingValue(contact.GetFixtureA())];
-            const auto& fixtureB = m_fixtureBuffer[UnderlyingValue(contact.GetFixtureB())];
-            if (!ShouldCollide(m_jointBuffer, bodyB, bodyA, bodyIdA)
-                || !ShouldCollide(fixtureA, fixtureB))
+            const auto bodyIdB = contact.GetBodyB();
+            const auto bodyA = &bodyBuffer[UnderlyingValue(bodyIdA)];
+            const auto bodyB = &bodyBuffer[UnderlyingValue(bodyIdB)];
+            if (bodyA != from)
             {
-                InternalDestroy(contactID, m_bodyBuffer, m_contactBuffer, m_manifoldBuffer,
-                                m_endContactListener);
-                return true;
+                bodyA->Erase(contactID);
             }
-            contact.UnflagForFiltering();
+            if (bodyB != from)
+            {
+                bodyB->Erase(contactID);
+            }
+            auto& manifold = manifoldBuffer[UnderlyingValue(contactID)];
+            if ((manifold.GetPointCount() > 0) && !contact.IsSensor())
+            {
+                // Contact may have been keeping accelerable bodies of fixture A or B from moving.
+                // Need to awaken those bodies now in case they are again movable.
+                bodyA->SetAwake();
+                bodyB->SetAwake();
+            }
+            contactBuffer.Free(UnderlyingValue(contactID));
+            manifoldBuffer.Free(UnderlyingValue(contactID));
         }
 
-        return false;
-    }), end(contacts));
-    const auto afterSize = size(contacts);
+        void WorldImpl::Destroy(ContactID contactID, Body* from)
+        {
+            assert(contactID != InvalidContactID);
+            const auto it = find_if(cbegin(m_contacts), cend(m_contacts),
+                                    [&](const Contacts::value_type& c) {
+                                        return std::get<ContactID>(c) == contactID;
+                                    });
+            if (it != cend(m_contacts))
+            {
+                m_contacts.erase(it);
+            }
+            InternalDestroy(contactID, m_bodyBuffer, m_contactBuffer, m_manifoldBuffer,
+                            m_endContactListener, from);
+        }
 
-    auto stats = DestroyContactsStats{};
-    stats.ignored = static_cast<ContactCounter>(afterSize);
-    stats.erased = static_cast<ContactCounter>(beforeSize - afterSize);
-    return stats;
-}
+        WorldImpl::DestroyContactsStats WorldImpl::DestroyContacts(Contacts& contacts)
+        {
+            const auto beforeSize = size(contacts);
+            contacts.erase(std::remove_if(begin(contacts), end(contacts), [&](const auto& c) {
+                               const auto key = std::get<ContactKey>(c);
+                               const auto contactID = std::get<ContactID>(c);
 
-WorldImpl::UpdateContactsStats WorldImpl::UpdateContacts(const StepConf& conf)
-{
+                               if (!TestOverlap(m_tree, key.GetMin(), key.GetMax()))
+                               {
+                                   // Destroy contacts that cease to overlap in the broad-phase.
+                                   InternalDestroy(contactID, m_bodyBuffer, m_contactBuffer, m_manifoldBuffer,
+                                                   m_endContactListener);
+                                   return true;
+                               }
+
+                               // Is this contact flagged for filtering?
+                               auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+                               if (contact.NeedsFiltering())
+                               {
+                                   const auto bodyIdA = contact.GetBodyA();
+                                   const auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
+                                   const auto& bodyB = m_bodyBuffer[UnderlyingValue(contact.GetBodyB())];
+                                   const auto& fixtureA = m_fixtureBuffer[UnderlyingValue(contact.GetFixtureA())];
+                                   const auto& fixtureB = m_fixtureBuffer[UnderlyingValue(contact.GetFixtureB())];
+                                   if (!ShouldCollide(m_jointBuffer, bodyB, bodyA, bodyIdA)
+                                       || !ShouldCollide(fixtureA, fixtureB))
+                                   {
+                                       InternalDestroy(contactID, m_bodyBuffer, m_contactBuffer, m_manifoldBuffer,
+                                                       m_endContactListener);
+                                       return true;
+                                   }
+                                   contact.UnflagForFiltering();
+                               }
+
+                               return false;
+                           }),
+                           end(contacts));
+            const auto afterSize = size(contacts);
+
+            auto stats = DestroyContactsStats{};
+            stats.ignored = static_cast<ContactCounter>(afterSize);
+            stats.erased = static_cast<ContactCounter>(beforeSize - afterSize);
+            return stats;
+        }
+
+        WorldImpl::UpdateContactsStats WorldImpl::UpdateContacts(const StepConf& conf)
+        {
 #ifdef DO_PAR_UNSEQ
-    atomic<uint32_t> ignored;
-    atomic<uint32_t> updated;
-    atomic<uint32_t> skipped;
+            atomic<uint32_t> ignored;
+            atomic<uint32_t> updated;
+            atomic<uint32_t> skipped;
 #else
-    auto ignored = uint32_t{0};
-    auto updated = uint32_t{0};
-    auto skipped = uint32_t{0};
+            auto ignored = uint32_t{0};
+            auto updated = uint32_t{0};
+            auto skipped = uint32_t{0};
 #endif
 
-    const auto updateConf = GetUpdateConf(conf);
-    
+            const auto updateConf = GetUpdateConf(conf);
+
 #if defined(DO_THREADED)
-    std::vector<ContactID> contactsNeedingUpdate;
-    contactsNeedingUpdate.reserve(size(m_contacts));
-    std::vector<std::future<void>> futures;
-    futures.reserve(size(m_contacts));
+            std::vector<ContactID> contactsNeedingUpdate;
+            contactsNeedingUpdate.reserve(size(m_contacts));
+            std::vector<std::future<void>> futures;
+            futures.reserve(size(m_contacts));
 #endif
 
-    // Update awake contacts.
-    for_each(/*execution::par_unseq,*/ begin(m_contacts), end(m_contacts), [&](const auto& c) {
-        const auto contactID = std::get<ContactID>(c);
-        auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+            // Update awake contacts.
+            for_each(/*execution::par_unseq,*/ begin(m_contacts), end(m_contacts), [&](const auto& c) {
+                const auto contactID = std::get<ContactID>(c);
+                auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
 #if 0
         Update(contact, updateConf);
         ++updated;
 #else
-        const auto& bodyA = m_bodyBuffer[UnderlyingValue(contact.GetBodyA())];
-        const auto& bodyB = m_bodyBuffer[UnderlyingValue(contact.GetBodyB())];
+                const auto& bodyA = m_bodyBuffer[UnderlyingValue(contact.GetBodyA())];
+                const auto& bodyB = m_bodyBuffer[UnderlyingValue(contact.GetBodyB())];
 
-        // Awake && speedable (dynamic or kinematic) means collidable.
-        // At least one body must be collidable
-        assert(!bodyA.IsAwake() || bodyA.IsSpeedable());
-        assert(!bodyB.IsAwake() || bodyB.IsSpeedable());
-        if (!bodyA.IsAwake() && !bodyB.IsAwake())
-        {
-            // This sometimes fails... is it important?
-            //assert(!contact.HasValidToi());
-            ++ignored;
-            return;
-        }
+                // Awake && speedable (dynamic or kinematic) means collidable.
+                // At least one body must be collidable
+                assert(!bodyA.IsAwake() || bodyA.IsSpeedable());
+                assert(!bodyB.IsAwake() || bodyB.IsSpeedable());
+                if (!bodyA.IsAwake() && !bodyB.IsAwake())
+                {
+                    // This sometimes fails... is it important?
+                    //assert(!contact.HasValidToi());
+                    ++ignored;
+                    return;
+                }
 
-        // Possible that bodyA->GetSweep().GetAlpha0() != 0
-        // Possible that bodyB->GetSweep().GetAlpha0() != 0
+                // Possible that bodyA->GetSweep().GetAlpha0() != 0
+                // Possible that bodyB->GetSweep().GetAlpha0() != 0
 
-        // Update the contact manifold and notify the listener.
-        contact.SetEnabled();
+                // Update the contact manifold and notify the listener.
+                contact.SetEnabled();
 
-        // Note: ideally contacts are only updated if there was a change to:
-        //   - The fixtures' sensor states.
-        //   - The fixtures bodies' transformations.
-        //   - The "maxCirclesRatio" per-step configuration state if contact IS NOT for sensor.
-        //   - The "maxDistanceIters" per-step configuration state if contact IS for sensor.
-        //
-        if (contact.NeedsUpdating())
-        {
-            // The following may call listener but is otherwise thread-safe.
+                // Note: ideally contacts are only updated if there was a change to:
+                //   - The fixtures' sensor states.
+                //   - The fixtures bodies' transformations.
+                //   - The "maxCirclesRatio" per-step configuration state if contact IS NOT for sensor.
+                //   - The "maxDistanceIters" per-step configuration state if contact IS for sensor.
+                //
+                if (contact.NeedsUpdating())
+                {
+                    // The following may call listener but is otherwise thread-safe.
 #if defined(DO_THREADED)
-            contactsNeedingUpdate.push_back(contactID);
-            //futures.push_back(async(&Update, this, *contact, conf)));
-            //futures.push_back(async(launch::async, [=]{ Update(*contact, conf); }));
+                    contactsNeedingUpdate.push_back(contactID);
+                    //futures.push_back(async(&Update, this, *contact, conf)));
+                    //futures.push_back(async(launch::async, [=]{ Update(*contact, conf); }));
 #else
-            Update(contactID, updateConf);
+                    Update(contactID, updateConf);
 #endif
-        	++updated;
-        }
-        else
-        {
-            ++skipped;
-        }
+                    ++updated;
+                }
+                else
+                {
+                    ++skipped;
+                }
 #endif
-    });
-    
+            });
+
 #if defined(DO_THREADED)
-    auto numJobs = size(contactsNeedingUpdate);
-    const auto jobsPerCore = numJobs / 4;
-    for (auto i = decltype(numJobs){0}; numJobs > 0 && i < 3; ++i)
-    {
-        futures.push_back(std::async(std::launch::async, [=]{
-            const auto offset = jobsPerCore * i;
-            for (auto j = decltype(jobsPerCore){0}; j < jobsPerCore; ++j)
+            auto numJobs = size(contactsNeedingUpdate);
+            const auto jobsPerCore = numJobs / 4;
+            for (auto i = decltype(numJobs){0}; numJobs > 0 && i < 3; ++i)
             {
-	            Update(contactsNeedingUpdate[offset + j], updateConf);
+                futures.push_back(std::async(std::launch::async, [=] {
+                    const auto offset = jobsPerCore * i;
+                    for (auto j = decltype(jobsPerCore){0}; j < jobsPerCore; ++j)
+                    {
+                        Update(contactsNeedingUpdate[offset + j], updateConf);
+                    }
+                }));
+                numJobs -= jobsPerCore;
             }
-        }));
-        numJobs -= jobsPerCore;
-    }
-    if (numJobs > 0)
-    {
-        futures.push_back(std::async(std::launch::async, [=]{
-            const auto offset = jobsPerCore * 3;
-            for (auto j = decltype(numJobs){0}; j < numJobs; ++j)
+            if (numJobs > 0)
             {
-                Update(contactsNeedingUpdate[offset + j], updateConf);
+                futures.push_back(std::async(std::launch::async, [=] {
+                    const auto offset = jobsPerCore * 3;
+                    for (auto j = decltype(numJobs){0}; j < numJobs; ++j)
+                    {
+                        Update(contactsNeedingUpdate[offset + j], updateConf);
+                    }
+                }));
             }
-        }));
-    }
-    for (auto&& future: futures)
-    {
-        future.get();
-    }
+            for (auto&& future : futures)
+            {
+                future.get();
+            }
 #endif
-    
-    return UpdateContactsStats{
-        static_cast<ContactCounter>(ignored),
-        static_cast<ContactCounter>(updated),
-        static_cast<ContactCounter>(skipped)
-    };
-}
 
-ContactCounter WorldImpl::FindNewContacts()
-{
-    m_proxyKeys.clear();
+            return UpdateContactsStats{
+                static_cast<ContactCounter>(ignored),
+                static_cast<ContactCounter>(updated),
+                static_cast<ContactCounter>(skipped)};
+        }
 
-    // Accumalate contact keys for pairs of nodes that are overlapping and aren't identical.
-    // Note that if the dynamic tree node provides the body pointer, it's assumed to be faster
-    // to eliminate any node pairs that have the same body here before the key pairs are
-    // sorted.
-    for_each(cbegin(m_proxies), cend(m_proxies), [&](ProxyId pid) {
-        const auto body0 = m_tree.GetLeafData(pid).body;
-        const auto aabb = m_tree.GetAABB(pid);
-        Query(m_tree, aabb, [&](ProxyId nodeId) {
-            const auto body1 = m_tree.GetLeafData(nodeId).body;
-            // A proxy cannot form a pair with itself.
-            if ((nodeId != pid) && (body0 != body1))
-            {
-                m_proxyKeys.push_back(ContactKey{nodeId, pid});
-            }
-            return DynamicTreeOpcode::Continue;
-        });
-    });
-    m_proxies.clear();
+        ContactCounter WorldImpl::FindNewContacts()
+        {
+            m_proxyKeys.clear();
 
-    // Sort and eliminate any duplicate contact keys.
-    sort(begin(m_proxyKeys), end(m_proxyKeys));
-    m_proxyKeys.erase(unique(begin(m_proxyKeys), end(m_proxyKeys)), end(m_proxyKeys));
+            // Accumalate contact keys for pairs of nodes that are overlapping and aren't identical.
+            // Note that if the dynamic tree node provides the body pointer, it's assumed to be faster
+            // to eliminate any node pairs that have the same body here before the key pairs are
+            // sorted.
+            for_each(cbegin(m_proxies), cend(m_proxies), [&](ProxyId pid) {
+                const auto body0 = m_tree.GetLeafData(pid).body;
+                const auto aabb = m_tree.GetAABB(pid);
+                Query(m_tree, aabb, [&](ProxyId nodeId) {
+                    const auto body1 = m_tree.GetLeafData(nodeId).body;
+                    // A proxy cannot form a pair with itself.
+                    if ((nodeId != pid) && (body0 != body1))
+                    {
+                        m_proxyKeys.push_back(ContactKey{nodeId, pid});
+                    }
+                    return DynamicTreeOpcode::Continue;
+                });
+            });
+            m_proxies.clear();
 
-    const auto numContactsBefore = size(m_contacts);
-    for_each(cbegin(m_proxyKeys), cend(m_proxyKeys), [&](ContactKey key)
-    {
-        Add(key);
-    });
-    const auto numContactsAfter = size(m_contacts);
-    m_islandedContacts.resize(numContactsAfter);
-    return static_cast<ContactCounter>(numContactsAfter - numContactsBefore);
-}
+            // Sort and eliminate any duplicate contact keys.
+            sort(begin(m_proxyKeys), end(m_proxyKeys));
+            m_proxyKeys.erase(unique(begin(m_proxyKeys), end(m_proxyKeys)), end(m_proxyKeys));
 
-bool WorldImpl::Add(ContactKey key)
-{
-    const auto minKeyLeafData = m_tree.GetLeafData(key.GetMin());
-    const auto maxKeyLeafData = m_tree.GetLeafData(key.GetMax());
+            const auto numContactsBefore = size(m_contacts);
+            for_each(cbegin(m_proxyKeys), cend(m_proxyKeys), [&](ContactKey key) {
+                Add(key);
+            });
+            const auto numContactsAfter = size(m_contacts);
+            m_islandedContacts.resize(numContactsAfter);
+            return static_cast<ContactCounter>(numContactsAfter - numContactsBefore);
+        }
 
-    const auto bodyIdA = minKeyLeafData.body; // fixtureA->GetBody();
-    const auto fixtureIdA = minKeyLeafData.fixture;
-    const auto indexA = minKeyLeafData.childIndex;
-    const auto bodyIdB = maxKeyLeafData.body; // fixtureB->GetBody();
-    const auto fixtureIdB = maxKeyLeafData.fixture;
-    const auto indexB = maxKeyLeafData.childIndex;
+        bool WorldImpl::Add(ContactKey key)
+        {
+            const auto minKeyLeafData = m_tree.GetLeafData(key.GetMin());
+            const auto maxKeyLeafData = m_tree.GetLeafData(key.GetMax());
+
+            const auto bodyIdA = minKeyLeafData.body;// fixtureA->GetBody();
+            const auto fixtureIdA = minKeyLeafData.fixture;
+            const auto indexA = minKeyLeafData.childIndex;
+            const auto bodyIdB = maxKeyLeafData.body;// fixtureB->GetBody();
+            const auto fixtureIdB = maxKeyLeafData.fixture;
+            const auto indexB = maxKeyLeafData.childIndex;
 
 #if 0
     // Are the fixtures on the same body? They can be, and they often are.
@@ -2036,288 +2049,288 @@ bool WorldImpl::Add(ContactKey key)
         return false;
     }
 #endif
-    assert(bodyIdA != bodyIdB);
-    assert(fixtureIdA != fixtureIdB);
+            assert(bodyIdA != bodyIdB);
+            assert(fixtureIdA != fixtureIdB);
 
-    auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
-    auto& bodyB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
-    auto& fixtureA = m_fixtureBuffer[UnderlyingValue(fixtureIdA)];
-    auto& fixtureB = m_fixtureBuffer[UnderlyingValue(fixtureIdB)];
+            auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
+            auto& bodyB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
+            auto& fixtureA = m_fixtureBuffer[UnderlyingValue(fixtureIdA)];
+            auto& fixtureB = m_fixtureBuffer[UnderlyingValue(fixtureIdB)];
 
-    // Does a joint override collision? Is at least one body dynamic?
-    if (!ShouldCollide(m_jointBuffer, bodyB, bodyA, bodyIdA) || !ShouldCollide(fixtureA, fixtureB))
-    {
-        return false;
-    }
-   
+            // Does a joint override collision? Is at least one body dynamic?
+            if (!ShouldCollide(m_jointBuffer, bodyB, bodyA, bodyIdA) || !ShouldCollide(fixtureA, fixtureB))
+            {
+                return false;
+            }
+
 #ifndef NO_RACING
-    // Code herein may be racey in a multithreaded context...
-    // Would need a lock on bodyA, bodyB, and contacts.
-    // A global lock on the world instance should work but then would it have so much
-    // contention as to make multi-threaded handing of adding new connections senseless?
+            // Code herein may be racey in a multithreaded context...
+            // Would need a lock on bodyA, bodyB, and contacts.
+            // A global lock on the world instance should work but then would it have so much
+            // contention as to make multi-threaded handing of adding new connections senseless?
 
-    // Have to quickly figure out if there's a contact already added for the current
-    // fixture-childindex pair that this method's been called for.
-    //
-    // In cases where there's a bigger bullet-enabled object that's colliding with lots of
-    // smaller objects packed tightly together and overlapping like in the Add Pair Stress
-    // Test demo that has some 400 smaller objects, the bigger object could have 387 contacts
-    // while the smaller object has 369 or more, and the total world contact count can be over
-    // 30,495. While searching linearly through the object with less contacts should help,
-    // that may still be a lot of contacts to be going through in the context this method
-    // is being called. OTOH, speed seems to be dominated by cache hit-ratio...
-    //
-    // With compiler optimization enabled and 400 small bodies and Real=double...
-    // For world:
-    //   World::set<Contact*> shows up as .524 seconds max step
-    //   World::list<Contact> shows up as .482 seconds max step.
-    // For body:
-    //    using contact map w/ proxy ID keys shows up as .561
-    // W/ unordered_map: .529 seconds max step (step 15).
-    // W/ World::list<Contact> and Body::list<ContactKey,Contact*>   .444s@step15, 1.063s-sumstep20
-    // W/ World::list<Contact> and Body::list<ContactKey,Contact*>   .393s@step15, 1.063s-sumstep20
-    // W/ World::list<Contact> and Body::list<ContactKey,Contact*>   .412s@step15, 1.012s-sumstep20
-    // W/ World::list<Contact> and Body::vector<ContactKey,Contact*> .219s@step15, 0.659s-sumstep20
+            // Have to quickly figure out if there's a contact already added for the current
+            // fixture-childindex pair that this method's been called for.
+            //
+            // In cases where there's a bigger bullet-enabled object that's colliding with lots of
+            // smaller objects packed tightly together and overlapping like in the Add Pair Stress
+            // Test demo that has some 400 smaller objects, the bigger object could have 387 contacts
+            // while the smaller object has 369 or more, and the total world contact count can be over
+            // 30,495. While searching linearly through the object with less contacts should help,
+            // that may still be a lot of contacts to be going through in the context this method
+            // is being called. OTOH, speed seems to be dominated by cache hit-ratio...
+            //
+            // With compiler optimization enabled and 400 small bodies and Real=double...
+            // For world:
+            //   World::set<Contact*> shows up as .524 seconds max step
+            //   World::list<Contact> shows up as .482 seconds max step.
+            // For body:
+            //    using contact map w/ proxy ID keys shows up as .561
+            // W/ unordered_map: .529 seconds max step (step 15).
+            // W/ World::list<Contact> and Body::list<ContactKey,Contact*>   .444s@step15, 1.063s-sumstep20
+            // W/ World::list<Contact> and Body::list<ContactKey,Contact*>   .393s@step15, 1.063s-sumstep20
+            // W/ World::list<Contact> and Body::list<ContactKey,Contact*>   .412s@step15, 1.012s-sumstep20
+            // W/ World::list<Contact> and Body::vector<ContactKey,Contact*> .219s@step15, 0.659s-sumstep20
 
-    // Does a contact already exist?
-    // Identify body with least contacts and search it.
-    // NOTE: Time trial testing found the following rough ordering of data structures, to be
-    // fastest to slowest: vector, list, unorderered_set, unordered_map,
-    //     set, map.
-    const auto contactsA = bodyA.GetContacts();
-    const auto contactsB = bodyB.GetContacts();
-    const auto& bodyContacts = (size(contactsA) < size(contactsB))? contactsA: contactsB;
-    const auto it = find_if(cbegin(bodyContacts), cend(bodyContacts), [&](KeyedContactPtr ci) {
-        return std::get<ContactKey>(ci) == key;
-    });
-    if (it != cend(bodyContacts))
-    {
-        return false;
-    }
+            // Does a contact already exist?
+            // Identify body with least contacts and search it.
+            // NOTE: Time trial testing found the following rough ordering of data structures, to be
+            // fastest to slowest: vector, list, unorderered_set, unordered_map,
+            //     set, map.
+            const auto contactsA = bodyA.GetContacts();
+            const auto contactsB = bodyB.GetContacts();
+            const auto& bodyContacts = (size(contactsA) < size(contactsB)) ? contactsA : contactsB;
+            const auto it = find_if(cbegin(bodyContacts), cend(bodyContacts), [&](KeyedContactPtr ci) {
+                return std::get<ContactKey>(ci) == key;
+            });
+            if (it != cend(bodyContacts))
+            {
+                return false;
+            }
 
-    if (size(m_contacts) >= MaxContacts)
-    {
-        // New contact was needed, but denied due to MaxContacts count being reached.
-        return false;
-    }
+            if (size(m_contacts) >= MaxContacts)
+            {
+                // New contact was needed, but denied due to MaxContacts count being reached.
+                return false;
+            }
 
-    const auto contactID = static_cast<ContactID>(static_cast<ContactID::underlying_type>(
-        m_contactBuffer.Allocate(bodyIdA, fixtureIdA, indexA, bodyIdB, fixtureIdB, indexB)));
-    m_manifoldBuffer.Allocate();
-    auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-    if (bodyA.IsImpenetrable() || bodyB.IsImpenetrable())
-    {
-        contact.SetImpenetrable();
-    }
-    if (bodyA.IsAwake() || bodyB.IsAwake())
-    {
-        contact.SetIsActive();
-    }
-    if (fixtureA.IsSensor() || fixtureB.IsSensor())
-    {
-        contact.SetIsSensor();
-    }
-    contact.SetFriction(GetDefaultFriction(fixtureA, fixtureB));
-    contact.SetRestitution(GetDefaultRestitution(fixtureA, fixtureB));
+            const auto contactID = static_cast<ContactID>(static_cast<ContactID::underlying_type>(
+                m_contactBuffer.Allocate(bodyIdA, fixtureIdA, indexA, bodyIdB, fixtureIdB, indexB)));
+            m_manifoldBuffer.Allocate();
+            auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+            if (bodyA.IsImpenetrable() || bodyB.IsImpenetrable())
+            {
+                contact.SetImpenetrable();
+            }
+            if (bodyA.IsAwake() || bodyB.IsAwake())
+            {
+                contact.SetIsActive();
+            }
+            if (fixtureA.IsSensor() || fixtureB.IsSensor())
+            {
+                contact.SetIsSensor();
+            }
+            contact.SetFriction(GetDefaultFriction(fixtureA, fixtureB));
+            contact.SetRestitution(GetDefaultRestitution(fixtureA, fixtureB));
 
-    // Insert into the contacts container.
-    //
-    // Should the new contact be added at front or back?
-    //
-    // Original strategy added to the front. Since processing done front to back, front
-    // adding means container more a LIFO container, while back adding means more a FIFO.
-    //
-    m_contacts.push_back(KeyedContactPtr{key, contactID});
+            // Insert into the contacts container.
+            //
+            // Should the new contact be added at front or back?
+            //
+            // Original strategy added to the front. Since processing done front to back, front
+            // adding means container more a LIFO container, while back adding means more a FIFO.
+            //
+            m_contacts.push_back(KeyedContactPtr{key, contactID});
 
-    bodyA.Insert(key, contactID);
-    bodyB.Insert(key, contactID);
+            bodyA.Insert(key, contactID);
+            bodyB.Insert(key, contactID);
 
-    // Wake up the bodies
-    if (!contact.IsSensor())
-    {
-        if (bodyA.IsSpeedable())
-        {
-            bodyA.SetAwakeFlag();
-        }
-        if (bodyB.IsSpeedable())
-        {
-            bodyB.SetAwakeFlag();
-        }
-    }
+            // Wake up the bodies
+            if (!contact.IsSensor())
+            {
+                if (bodyA.IsSpeedable())
+                {
+                    bodyA.SetAwakeFlag();
+                }
+                if (bodyB.IsSpeedable())
+                {
+                    bodyB.SetAwakeFlag();
+                }
+            }
 #endif
 
-    return true;
-}
+            return true;
+        }
 
-void WorldImpl::SetSensor(FixtureID id, bool value)
-{
-    auto& fixture = GetFixture(id);
-    if (fixture.IsSensor() != value)
-    {
-        // sensor state is changing...
-        fixture.SetSensor(value);
-        auto& body = m_bodyBuffer[UnderlyingValue(fixture.GetBody())];
-        body.SetAwake();
-        FlagForUpdating(m_contactBuffer, body.GetContacts());
-    }
-}
-
-void WorldImpl::CreateAndDestroyProxies(Length extension)
-{
-    for_each(begin(m_fixturesForProxies), end(m_fixturesForProxies), [&](const auto& fixtureID) {
-        auto& fixture = m_fixtureBuffer[UnderlyingValue(fixtureID)];
-        auto& body = m_bodyBuffer[UnderlyingValue(fixture.GetBody())];
-        const auto enabled = body.IsEnabled();
-
-        if (fixture.GetProxies().empty())
+        void WorldImpl::SetSensor(FixtureID id, bool value)
         {
-            if (enabled)
+            auto& fixture = GetFixture(id);
+            if (fixture.IsSensor() != value)
             {
-                CreateProxies(fixtureID, fixture, body.GetTransformation(), m_proxies, m_tree, extension);
+                // sensor state is changing...
+                fixture.SetSensor(value);
+                auto& body = m_bodyBuffer[UnderlyingValue(fixture.GetBody())];
+                body.SetAwake();
+                FlagForUpdating(m_contactBuffer, body.GetContacts());
             }
         }
-        else
-        {
-            if (!enabled)
-            {
-                DestroyProxies(fixture, m_proxies, m_tree);
 
-                // Destroy any contacts associated with the fixture.
-                body.Erase([&](ContactID contactID) {
-                    const auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-                    const auto fixtureA = contact.GetFixtureA();
-                    const auto fixtureB = contact.GetFixtureB();
-                    if ((fixtureA == fixtureID) || (fixtureB == fixtureID))
+        void WorldImpl::CreateAndDestroyProxies(Length extension)
+        {
+            for_each(begin(m_fixturesForProxies), end(m_fixturesForProxies), [&](const auto& fixtureID) {
+                auto& fixture = m_fixtureBuffer[UnderlyingValue(fixtureID)];
+                auto& body = m_bodyBuffer[UnderlyingValue(fixture.GetBody())];
+                const auto enabled = body.IsEnabled();
+
+                if (fixture.GetProxies().empty())
+                {
+                    if (enabled)
                     {
-                        Destroy(contactID, &body);
-                        return true;
+                        CreateProxies(fixtureID, fixture, body.GetTransformation(), m_proxies, m_tree, extension);
                     }
-                    return false;
+                }
+                else
+                {
+                    if (!enabled)
+                    {
+                        DestroyProxies(fixture, m_proxies, m_tree);
+
+                        // Destroy any contacts associated with the fixture.
+                        body.Erase([&](ContactID contactID) {
+                            const auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+                            const auto fixtureA = contact.GetFixtureA();
+                            const auto fixtureB = contact.GetFixtureB();
+                            if ((fixtureA == fixtureID) || (fixtureB == fixtureID))
+                            {
+                                Destroy(contactID, &body);
+                                return true;
+                            }
+                            return false;
+                        });
+                    }
+                }
+            });
+        }
+
+        PreStepStats::counter_type WorldImpl::SynchronizeProxies(const StepConf& conf)
+        {
+            auto proxiesMoved = PreStepStats::counter_type{0};
+            for_each(begin(m_bodiesForProxies), end(m_bodiesForProxies), [&](const auto& bodyID) {
+                const auto& b = m_bodyBuffer[UnderlyingValue(bodyID)];
+                const auto xfm = b.GetTransformation();
+                // Not always true: assert(GetTransform0(b->GetSweep()) == xfm);
+                proxiesMoved += Synchronize(b, xfm, xfm, conf.displaceMultiplier, conf.aabbExtension);
+            });
+            m_bodiesForProxies.clear();
+            return proxiesMoved;
+        }
+
+        void WorldImpl::SetType(BodyID bodyID, playrho::BodyType type)
+        {
+            auto& body = GetBody(bodyID);
+            if (body.GetType() == type)
+            {
+                return;
+            }
+
+            if (IsLocked())
+            {
+                throw WrongState("SetType: world is locked");
+            }
+
+            body.SetType(type);
+            SetMassData(bodyID, ComputeMassData(bodyID));
+
+            // Destroy the attached contacts.
+            body.Erase([&](ContactID contactID) {
+                Destroy(contactID, &body);
+                return true;
+            });
+
+            if (type == BodyType::Static)
+            {
+#ifndef NDEBUG
+                const auto xfm1 = GetTransform0(body.GetSweep());
+                const auto xfm2 = body.GetTransformation();
+                assert(xfm1 == xfm2);
+#endif
+                m_bodiesForProxies.push_back(bodyID);
+            }
+            else
+            {
+                body.SetAwake();
+                const auto fixtures = body.GetFixtures();
+                for_each(begin(fixtures), end(fixtures), [&](const auto& fixtureID) {
+                    InternalTouchProxies(m_proxies, m_fixtureBuffer[UnderlyingValue(fixtureID)]);
                 });
             }
         }
-    });
-}
 
-PreStepStats::counter_type WorldImpl::SynchronizeProxies(const StepConf& conf)
-{
-    auto proxiesMoved = PreStepStats::counter_type{0};
-    for_each(begin(m_bodiesForProxies), end(m_bodiesForProxies), [&](const auto& bodyID) {
-        const auto& b = m_bodyBuffer[UnderlyingValue(bodyID)];
-        const auto xfm = b.GetTransformation();
-        // Not always true: assert(GetTransform0(b->GetSweep()) == xfm);
-        proxiesMoved += Synchronize(b, xfm, xfm, conf.displaceMultiplier, conf.aabbExtension);
-    });
-    m_bodiesForProxies.clear();
-    return proxiesMoved;
-}
-
-void WorldImpl::SetType(BodyID bodyID, playrho::BodyType type)
-{
-    auto& body = GetBody(bodyID);
-    if (body.GetType() == type)
-    {
-        return;
-    }
-
-    if (IsLocked())
-    {
-        throw WrongState("SetType: world is locked");
-    }
-
-    body.SetType(type);
-    SetMassData(bodyID, ComputeMassData(bodyID));
-
-    // Destroy the attached contacts.
-    body.Erase([&](ContactID contactID) {
-        Destroy(contactID, &body);
-        return true;
-    });
-
-    if (type == BodyType::Static)
-    {
-#ifndef NDEBUG
-        const auto xfm1 = GetTransform0(body.GetSweep());
-        const auto xfm2 = body.GetTransformation();
-        assert(xfm1 == xfm2);
-#endif
-        m_bodiesForProxies.push_back(bodyID);
-    }
-    else
-    {
-        body.SetAwake();
-        const auto fixtures = body.GetFixtures();
-        for_each(begin(fixtures), end(fixtures), [&](const auto& fixtureID) {
-            InternalTouchProxies(m_proxies, m_fixtureBuffer[UnderlyingValue(fixtureID)]);
-        });
-    }
-}
-
-FixtureID WorldImpl::CreateFixture(BodyID bodyID, const Shape& shape,
-                                   const FixtureConf& def, bool resetMassData)
-{
-    {
-        const auto childCount = GetChildCount(shape);
-        const auto minVertexRadius = GetMinVertexRadius();
-        const auto maxVertexRadius = GetMaxVertexRadius();
-        for (auto i = ChildCounter{0}; i < childCount; ++i)
+        FixtureID WorldImpl::CreateFixture(BodyID bodyID, const Shape& shape,
+                                           const FixtureConf& def, bool resetMassData)
         {
-            const auto vr = GetVertexRadius(shape, i);
-            if (!(vr >= minVertexRadius))
             {
-                throw InvalidArgument("CreateFixture: vertex radius < min");
+                const auto childCount = GetChildCount(shape);
+                const auto minVertexRadius = GetMinVertexRadius();
+                const auto maxVertexRadius = GetMaxVertexRadius();
+                for (auto i = ChildCounter{0}; i < childCount; ++i)
+                {
+                    const auto vr = GetVertexRadius(shape, i);
+                    if (!(vr >= minVertexRadius))
+                    {
+                        throw InvalidArgument("CreateFixture: vertex radius < min");
+                    }
+                    if (!(vr <= maxVertexRadius))
+                    {
+                        throw InvalidArgument("CreateFixture: vertex radius > max");
+                    }
+                }
             }
-            if (!(vr <= maxVertexRadius))
+
+            if (IsLocked())
             {
-                throw InvalidArgument("CreateFixture: vertex radius > max");
+                throw WrongState("CreateFixture: world is locked");
             }
+
+            if (size(m_fixtureBuffer) >= MaxFixtures)
+            {
+                throw LengthError("CreateFixture: operation would exceed MaxFixtures");
+            }
+
+            auto& body = GetBody(bodyID);// must be called before any mutating actions to validate bodyID!
+
+            const auto fixtureID = static_cast<FixtureID>(
+                static_cast<FixtureID::underlying_type>(m_fixtureBuffer.Allocate(bodyID, shape, def)));
+            body.AddFixture(fixtureID);
+
+            if (body.IsEnabled())
+            {
+                m_fixturesForProxies.push_back(fixtureID);
+            }
+
+            // Adjust mass properties if needed.
+            if (m_fixtureBuffer[UnderlyingValue(fixtureID)].GetDensity() > 0_kgpm2)
+            {
+                body.SetMassDataDirty();
+                if (resetMassData)
+                {
+                    SetMassData(bodyID, ComputeMassData(bodyID));
+                }
+            }
+
+            // Let the world know we have a new fixture. This will cause new contacts
+            // to be created at the beginning of the next time step.
+            m_flags |= e_newFixture;
+
+            return fixtureID;
         }
-    }
 
-    if (IsLocked())
-    {
-        throw WrongState("CreateFixture: world is locked");
-    }
-
-    if (size(m_fixtureBuffer) >= MaxFixtures)
-    {
-        throw LengthError("CreateFixture: operation would exceed MaxFixtures");
-    }
-
-    auto& body = GetBody(bodyID); // must be called before any mutating actions to validate bodyID!
-
-    const auto fixtureID = static_cast<FixtureID>(
-        static_cast<FixtureID::underlying_type>(m_fixtureBuffer.Allocate(bodyID, shape, def)));
-    body.AddFixture(fixtureID);
-
-    if (body.IsEnabled())
-    {
-        m_fixturesForProxies.push_back(fixtureID);
-    }
-
-    // Adjust mass properties if needed.
-    if (m_fixtureBuffer[UnderlyingValue(fixtureID)].GetDensity() > 0_kgpm2)
-    {
-        body.SetMassDataDirty();
-        if (resetMassData)
+        bool WorldImpl::Destroy(FixtureID id, bool resetMassData)
         {
-            SetMassData(bodyID, ComputeMassData(bodyID));
-        }
-    }
-
-    // Let the world know we have a new fixture. This will cause new contacts
-    // to be created at the beginning of the next time step.
-    m_flags |= e_newFixture;
-
-    return fixtureID;
-}
-
-bool WorldImpl::Destroy(FixtureID id, bool resetMassData)
-{
-    if (IsLocked())
-    {
-        throw WrongState("Destroy: world is locked");
-    }
+            if (IsLocked())
+            {
+                throw WrongState("Destroy: world is locked");
+            }
 
 #if 0
     /*
@@ -2330,497 +2343,494 @@ bool WorldImpl::Destroy(FixtureID id, bool resetMassData)
     }
 #endif
 
-    auto& fixture = GetFixture(id);
-    const auto bodyID = fixture.GetBody();
-    auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
+            auto& fixture = GetFixture(id);
+            const auto bodyID = fixture.GetBody();
+            auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
 
-    // Destroy any contacts associated with the fixture.
-    body.Erase([&](ContactID contactID) {
-        auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-        const auto fixtureA = contact.GetFixtureA();
-        const auto fixtureB = contact.GetFixtureB();
-        if ((fixtureA == id) || (fixtureB == id))
-        {
-            Destroy(contactID, &body);
+            // Destroy any contacts associated with the fixture.
+            body.Erase([&](ContactID contactID) {
+                auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+                const auto fixtureA = contact.GetFixtureA();
+                const auto fixtureB = contact.GetFixtureB();
+                if ((fixtureA == id) || (fixtureB == id))
+                {
+                    Destroy(contactID, &body);
+                    return true;
+                }
+                return false;
+            });
+
+            EraseAll(m_fixturesForProxies, id);
+            DestroyProxies(fixture, m_proxies, m_tree);
+
+            if (!body.RemoveFixture(id))
+            {
+                // Fixture probably destroyed already.
+                return false;
+            }
+            m_fixtureBuffer.Free(UnderlyingValue(id));
+
+            body.SetMassDataDirty();
+            if (resetMassData)
+            {
+                SetMassData(bodyID, ComputeMassData(bodyID));
+            }
             return true;
         }
-        return false;
-    });
 
-    EraseAll(m_fixturesForProxies, id);
-    DestroyProxies(fixture, m_proxies, m_tree);
-
-    if (!body.RemoveFixture(id))
-    {
-        // Fixture probably destroyed already.
-        return false;
-    }
-    m_fixtureBuffer.Free(UnderlyingValue(id));
-
-    body.SetMassDataDirty();
-    if (resetMassData)
-    {
-        SetMassData(bodyID, ComputeMassData(bodyID));
-    }
-    return true;
-}
-
-void WorldImpl::DestroyFixtures(BodyID id)
-{
-    auto& body = GetBody(id);
-    while (!empty(body.GetFixtures()))
-    {
-        const auto fixtureID = *body.GetFixtures().begin();
-        Destroy(fixtureID, false);
-    }
-    SetMassData(id, ComputeMassData(id));
-}
-
-void WorldImpl::CreateProxies(FixtureID fixtureID, Fixture& fixture, const Transformation& xfm,
-                              ProxyQueue& proxies, DynamicTree& tree, Length aabbExtension)
-{
-    assert(fixture.GetProxies().empty());
-
-    const auto bodyID = fixture.GetBody();
-    const auto shape = fixture.GetShape();
-
-    // Reserve proxy space and create proxies in the broad-phase.
-    const auto childCount = GetChildCount(shape);
-    auto fixtureProxies = std::vector<FixtureProxy>{};
-    fixtureProxies.reserve(childCount);
-    for (auto childIndex = decltype(childCount){0}; childIndex < childCount; ++childIndex)
-    {
-        const auto dp = GetChild(shape, childIndex);
-        const auto aabb = playrho::d2::ComputeAABB(dp, xfm);
-
-        // Note: treeId from CreateLeaf can be higher than the number of fixture proxies.
-        const auto fattenedAABB = GetFattenedAABB(aabb, aabbExtension);
-        const auto treeId = tree.CreateLeaf(fattenedAABB, DynamicTree::LeafData{
-            bodyID, fixtureID, childIndex});
-        proxies.push_back(treeId);
-        fixtureProxies.push_back(FixtureProxy{treeId});
-    }
-
-    fixture.SetProxies(fixtureProxies);
-}
-
-void WorldImpl::InternalTouchProxies(ProxyQueue& proxies, const Fixture& fixture) noexcept
-{
-    for (const auto& proxy: fixture.GetProxies()) {
-        proxies.push_back(proxy.treeId);
-    }
-}
-
-ContactCounter WorldImpl::Synchronize(const Body& body,
-                                      const Transformation& xfm1, const Transformation& xfm2,
-                                      Real multiplier, Length extension)
-{
-    assert(::playrho::IsValid(xfm1));
-    assert(::playrho::IsValid(xfm2));
-
-    auto updatedCount = ContactCounter{0};
-    const auto displacement = multiplier * (xfm2.p - xfm1.p);
-    const auto fixtures = body.GetFixtures();
-    for_each(cbegin(fixtures), cend(fixtures), [&](const auto& fixtureID) {
-        updatedCount += Synchronize(m_fixtureBuffer[UnderlyingValue(fixtureID)],
-                                    xfm1, xfm2, displacement, extension);
-    });
-    return updatedCount;
-}
-
-ContactCounter WorldImpl::Synchronize(const Fixture& fixture,
-                                        const Transformation& xfm1, const Transformation& xfm2,
-                                        Length2 displacement, Length extension)
-{
-    assert(::playrho::IsValid(xfm1));
-    assert(::playrho::IsValid(xfm2));
-    
-    auto updatedCount = ContactCounter{0};
-    const auto shape = fixture.GetShape();
-    const auto proxies = fixture.GetProxies();
-    auto childIndex = ChildCounter{0};
-    for (const auto& proxy: proxies)
-    {
-        const auto treeId = proxy.treeId;
-        
-        // Compute an AABB that covers the swept shape (may miss some rotation effect).
-        const auto aabb = ComputeAABB(GetChild(shape, childIndex), xfm1, xfm2);
-        if (!Contains(m_tree.GetAABB(treeId), aabb))
+        void WorldImpl::DestroyFixtures(BodyID id)
         {
-            const auto newAabb = GetDisplacedAABB(GetFattenedAABB(aabb, extension),
-                                                  displacement);
-            m_tree.UpdateLeaf(treeId, newAabb);
-            m_proxies.push_back(treeId);
-            ++updatedCount;
+            auto& body = GetBody(id);
+            while (!empty(body.GetFixtures()))
+            {
+                const auto fixtureID = *body.GetFixtures().begin();
+                Destroy(fixtureID, false);
+            }
+            SetMassData(id, ComputeMassData(id));
         }
-        ++childIndex;
-    }
-    return updatedCount;
-}
 
-void WorldImpl::Refilter(FixtureID id)
-{
-    const auto& fixture = GetFixture(id);
-    const auto bodyID = fixture.GetBody();
-    const auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
-
-    // Flag associated contacts for filtering.
-    const auto contacts = body.GetContacts();
-    std::for_each(cbegin(contacts), cend(contacts), [&](KeyedContactPtr ci) {
-        const auto contactID = std::get<ContactID>(ci);
-        auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
-        const auto fixtureIdA = contact.GetFixtureA();
-        const auto fixtureIdB = contact.GetFixtureB();
-        if ((fixtureIdA == id) || (fixtureIdB == id))
+        void WorldImpl::CreateProxies(FixtureID fixtureID, Fixture& fixture, const Transformation& xfm,
+                                      ProxyQueue& proxies, DynamicTree& tree, Length aabbExtension)
         {
-            contact.FlagForFiltering();
+            assert(fixture.GetProxies().empty());
+
+            const auto bodyID = fixture.GetBody();
+            const auto shape = fixture.GetShape();
+
+            // Reserve proxy space and create proxies in the broad-phase.
+            const auto childCount = GetChildCount(shape);
+            auto fixtureProxies = std::vector<FixtureProxy>{};
+            fixtureProxies.reserve(childCount);
+            for (auto childIndex = decltype(childCount){0}; childIndex < childCount; ++childIndex)
+            {
+                const auto dp = GetChild(shape, childIndex);
+                const auto aabb = playrho::d2::ComputeAABB(dp, xfm);
+
+                // Note: treeId from CreateLeaf can be higher than the number of fixture proxies.
+                const auto fattenedAABB = GetFattenedAABB(aabb, aabbExtension);
+                const auto treeId = tree.CreateLeaf(fattenedAABB, DynamicTree::LeafData{
+                                                                      bodyID, fixtureID, childIndex});
+                proxies.push_back(treeId);
+                fixtureProxies.push_back(FixtureProxy{treeId});
+            }
+
+            fixture.SetProxies(fixtureProxies);
         }
-    });
-    InternalTouchProxies(m_proxies, fixture);
-}
 
-void WorldImpl::SetFilterData(FixtureID id, Filter filter)
-{
-    GetFixture(id).SetFilterData(filter);
-    Refilter(id);
-}
-
-void WorldImpl::SetEnabled(BodyID id, bool flag)
-{
-    auto& body = GetBody(id);
-    if (body.IsEnabled() == flag)
-    {
-        return;
-    }
-
-    if (IsLocked())
-    {
-        throw WrongState("Body::SetEnabled: world is locked");
-    }
-
-    if (flag)
-    {
-        body.SetEnabledFlag();
-    }
-    else
-    {
-        body.UnsetEnabledFlag();
-    }
-
-    // Register for proxies so contacts created or destroyed the next time step.
-    ForallFixtures(body, [this](const auto& fixtureID) {
-        m_fixturesForProxies.push_back(fixtureID);
-    });
-}
-
-MassData WorldImpl::ComputeMassData(BodyID id) const
-{
-    auto mass = 0_kg;
-    auto I = RotInertia{0};
-    auto weightedCenter = Length2{};
-    const auto& body = GetBody(id);
-    for (const auto& f: body.GetFixtures())
-    {
-        const auto& fixture = m_fixtureBuffer[UnderlyingValue(f)];
-        if (fixture.GetDensity() > 0_kgpm2)
+        void WorldImpl::InternalTouchProxies(ProxyQueue& proxies, const Fixture& fixture) noexcept
         {
-            const auto massData = GetMassData(fixture.GetShape());
-            mass += Mass{massData.mass};
-            weightedCenter += Real{massData.mass / Kilogram} * massData.center;
-            I += RotInertia{massData.I};
+            for (const auto& proxy : fixture.GetProxies())
+            {
+                proxies.push_back(proxy.treeId);
+            }
         }
-    }
-    const auto center = (mass > 0_kg)? (weightedCenter / (Real{mass/1_kg})): Length2{};
-    return MassData{center, mass, I};
-}
 
-void WorldImpl::SetMassData(BodyID id, const MassData& massData)
-{
-    if (IsLocked())
-    {
-        throw WrongState("SetMassData: world is locked");
-    }
+        ContactCounter WorldImpl::Synchronize(const Body& body,
+                                              const Transformation& xfm1, const Transformation& xfm2,
+                                              Real multiplier, Length extension)
+        {
+            assert(::playrho::IsValid(xfm1));
+            assert(::playrho::IsValid(xfm2));
 
-    auto& body = GetBody(id);
-    if (!body.IsAccelerable())
-    {
-        body.SetInvMass(InvMass{});
-        body.SetInvRotI(InvRotInertia{});
-        body.SetSweep(Sweep{Position{body.GetLocation(), body.GetAngle()}});
-        body.UnsetMassDataDirty();
-        return;
-    }
+            auto updatedCount = ContactCounter{0};
+            const auto displacement = multiplier * (xfm2.p - xfm1.p);
+            const auto fixtures = body.GetFixtures();
+            for_each(cbegin(fixtures), cend(fixtures), [&](const auto& fixtureID) {
+                updatedCount += Synchronize(m_fixtureBuffer[UnderlyingValue(fixtureID)],
+                                            xfm1, xfm2, displacement, extension);
+            });
+            return updatedCount;
+        }
 
-    const auto mass = (massData.mass > 0_kg)? Mass{massData.mass}: 1_kg;
-    body.SetInvMass(Real{1} / mass);
+        ContactCounter WorldImpl::Synchronize(const Fixture& fixture,
+                                              const Transformation& xfm1, const Transformation& xfm2,
+                                              Length2 displacement, Length extension)
+        {
+            assert(::playrho::IsValid(xfm1));
+            assert(::playrho::IsValid(xfm2));
 
-    if ((massData.I > RotInertia{0}) && (!body.IsFixedRotation()))
-    {
-        const auto lengthSquared = GetMagnitudeSquared(massData.center);
-        // L^2 M QP^-2
-        const auto I = RotInertia{massData.I} - RotInertia{(mass * lengthSquared) / SquareRadian};
-        assert(I > RotInertia{0});
-        body.SetInvRotI(Real{1} / I);
-    }
-    else
-    {
-        body.SetInvRotI(0);
-    }
+            auto updatedCount = ContactCounter{0};
+            const auto shape = fixture.GetShape();
+            const auto proxies = fixture.GetProxies();
+            auto childIndex = ChildCounter{0};
+            for (const auto& proxy : proxies)
+            {
+                const auto treeId = proxy.treeId;
 
-    // Move center of mass.
-    const auto oldCenter = body.GetWorldCenter();
-    body.SetSweep(Sweep{
-        Position{Transform(massData.center, body.GetTransformation()), body.GetAngle()},
-        massData.center
-    });
+                // Compute an AABB that covers the swept shape (may miss some rotation effect).
+                const auto aabb = ComputeAABB(GetChild(shape, childIndex), xfm1, xfm2);
+                if (!Contains(m_tree.GetAABB(treeId), aabb))
+                {
+                    const auto newAabb = GetDisplacedAABB(GetFattenedAABB(aabb, extension),
+                                                          displacement);
+                    m_tree.UpdateLeaf(treeId, newAabb);
+                    m_proxies.push_back(treeId);
+                    ++updatedCount;
+                }
+                ++childIndex;
+            }
+            return updatedCount;
+        }
 
-    // Update center of mass velocity.
-    const auto newCenter = body.GetWorldCenter();
-    const auto deltaCenter = newCenter - oldCenter;
-    auto newVelocity = body.GetVelocity();
-    newVelocity.linear += GetRevPerpendicular(deltaCenter) * (newVelocity.angular / Radian);
-    body.JustSetVelocity(newVelocity);
-    body.UnsetMassDataDirty();
-}
+        void WorldImpl::Refilter(FixtureID id)
+        {
+            const auto& fixture = GetFixture(id);
+            const auto bodyID = fixture.GetBody();
+            const auto& body = m_bodyBuffer[UnderlyingValue(bodyID)];
 
-void WorldImpl::SetTransformation(BodyID id, Transformation xfm)
-{
-    assert(IsValid(xfm));
-    if (IsLocked())
-    {
-        throw WrongState("SetTransformation: world is locked");
-    }
-    auto& body = GetBody(id);
-    if (body.GetTransformation() != xfm)
-    {
-        FlagForUpdating(m_contactBuffer, body.GetContacts());
-        body.SetTransformation(xfm);
-        body.SetSweep(Sweep{
-            Position{Transform(body.GetLocalCenter(), xfm), GetAngle(xfm.q)}, body.GetLocalCenter()
-        });
-        m_bodiesForProxies.push_back(id);
-    }
-}
+            // Flag associated contacts for filtering.
+            const auto contacts = body.GetContacts();
+            std::for_each(cbegin(contacts), cend(contacts), [&](KeyedContactPtr ci) {
+                const auto contactID = std::get<ContactID>(ci);
+                auto& contact = m_contactBuffer[UnderlyingValue(contactID)];
+                const auto fixtureIdA = contact.GetFixtureA();
+                const auto fixtureIdB = contact.GetFixtureB();
+                if ((fixtureIdA == id) || (fixtureIdB == id))
+                {
+                    contact.FlagForFiltering();
+                }
+            });
+            InternalTouchProxies(m_proxies, fixture);
+        }
 
-FixtureCounter WorldImpl::GetShapeCount() const noexcept
-{
-    auto shapes = std::set<const void*>();
-    for_each(cbegin(m_bodies), cend(m_bodies), [&](const auto& b) {
-        const auto fixtures = m_bodyBuffer[UnderlyingValue(b)].GetFixtures();
-        for_each(cbegin(fixtures), cend(fixtures), [&](const auto& f) {
-            const auto& fixture = m_fixtureBuffer[UnderlyingValue(f)];
-            shapes.insert(GetData(fixture.GetShape()));
-        });
-    });
-    return static_cast<FixtureCounter>(size(shapes));
-}
+        void WorldImpl::SetFilterData(FixtureID id, Filter filter)
+        {
+            GetFixture(id).SetFilterData(filter);
+            Refilter(id);
+        }
 
-void WorldImpl::Update(ContactID contactID, const ContactUpdateConf& conf)
-{
-    auto& c = m_contactBuffer[UnderlyingValue(contactID)];
-    auto& manifold = m_manifoldBuffer[UnderlyingValue(contactID)];
-    const auto oldManifold = manifold;
+        void WorldImpl::SetEnabled(BodyID id, bool flag)
+        {
+            auto& body = GetBody(id);
+            if (body.IsEnabled() == flag)
+            {
+                return;
+            }
 
-    // Note: do not assume the fixture AABBs are overlapping or are valid.
-    const auto oldTouching = c.IsTouching();
-    auto newTouching = false;
+            if (IsLocked())
+            {
+                throw WrongState("Body::SetEnabled: world is locked");
+            }
 
-    const auto bodyIdA = c.GetBodyA();
-    const auto fixtureIdA = c.GetFixtureA();
-    const auto indexA = c.GetChildIndexA();
-    const auto bodyIdB = c.GetBodyB();
-    const auto fixtureIdB = c.GetFixtureB();
-    const auto indexB = c.GetChildIndexB();
-    const auto& fixtureA = m_fixtureBuffer[UnderlyingValue(fixtureIdA)];
-    const auto& fixtureB = m_fixtureBuffer[UnderlyingValue(fixtureIdB)];
-    const auto shapeA = fixtureA.GetShape();
-    const auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
-    const auto& bodyB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
-    const auto xfA = bodyA.GetTransformation();
-    const auto shapeB = fixtureB.GetShape();
-    const auto xfB = bodyB.GetTransformation();
-    const auto childA = GetChild(shapeA, indexA);
-    const auto childB = GetChild(shapeB, indexB);
+            if (flag)
+            {
+                body.SetEnabledFlag();
+            }
+            else
+            {
+                body.UnsetEnabledFlag();
+            }
 
-    // NOTE: Ideally, the touching state returned by the TestOverlap function
-    //   agrees 100% of the time with that returned from the CollideShapes function.
-    //   This is not always the case however especially as the separation or overlap
-    //   approaches zero.
+            // Register for proxies so contacts created or destroyed the next time step.
+            ForallFixtures(body, [this](const auto& fixtureID) {
+                m_fixturesForProxies.push_back(fixtureID);
+            });
+        }
+
+        MassData WorldImpl::ComputeMassData(BodyID id) const
+        {
+            auto mass = 0_kg;
+            auto I = RotInertia{0};
+            auto weightedCenter = Length2{};
+            const auto& body = GetBody(id);
+            for (const auto& f : body.GetFixtures())
+            {
+                const auto& fixture = m_fixtureBuffer[UnderlyingValue(f)];
+                if (fixture.GetDensity() > 0_kgpm2)
+                {
+                    const auto massData = GetMassData(fixture.GetShape());
+                    mass += Mass{massData.mass};
+                    weightedCenter += Real{massData.mass / Kilogram} * massData.center;
+                    I += RotInertia{massData.I};
+                }
+            }
+            const auto center = (mass > 0_kg) ? (weightedCenter / (Real{mass / 1_kg})) : Length2{};
+            return MassData{center, mass, I};
+        }
+
+        void WorldImpl::SetMassData(BodyID id, const MassData& massData)
+        {
+            if (IsLocked())
+            {
+                throw WrongState("SetMassData: world is locked");
+            }
+
+            auto& body = GetBody(id);
+            if (!body.IsAccelerable())
+            {
+                body.SetInvMass(InvMass{});
+                body.SetInvRotI(InvRotInertia{});
+                body.SetSweep(Sweep{Position{body.GetLocation(), body.GetAngle()}});
+                body.UnsetMassDataDirty();
+                return;
+            }
+
+            const auto mass = (massData.mass > 0_kg) ? Mass{massData.mass} : 1_kg;
+            body.SetInvMass(Real{1} / mass);
+
+            if ((massData.I > RotInertia{0}) && (!body.IsFixedRotation()))
+            {
+                const auto lengthSquared = GetMagnitudeSquared(massData.center);
+                // L^2 M QP^-2
+                const auto I = RotInertia{massData.I} - RotInertia{(mass * lengthSquared) / SquareRadian};
+                assert(I > RotInertia{0});
+                body.SetInvRotI(Real{1} / I);
+            }
+            else
+            {
+                body.SetInvRotI(0);
+            }
+
+            // Move center of mass.
+            const auto oldCenter = body.GetWorldCenter();
+            body.SetSweep(Sweep{
+                Position{Transform(massData.center, body.GetTransformation()), body.GetAngle()},
+                massData.center});
+
+            // Update center of mass velocity.
+            const auto newCenter = body.GetWorldCenter();
+            const auto deltaCenter = newCenter - oldCenter;
+            auto newVelocity = body.GetVelocity();
+            newVelocity.linear += GetRevPerpendicular(deltaCenter) * (newVelocity.angular / Radian);
+            body.JustSetVelocity(newVelocity);
+            body.UnsetMassDataDirty();
+        }
+
+        void WorldImpl::SetTransformation(BodyID id, Transformation xfm)
+        {
+            assert(IsValid(xfm));
+            if (IsLocked())
+            {
+                throw WrongState("SetTransformation: world is locked");
+            }
+            auto& body = GetBody(id);
+            if (body.GetTransformation() != xfm)
+            {
+                FlagForUpdating(m_contactBuffer, body.GetContacts());
+                body.SetTransformation(xfm);
+                body.SetSweep(Sweep{
+                    Position{Transform(body.GetLocalCenter(), xfm), GetAngle(xfm.q)}, body.GetLocalCenter()});
+                m_bodiesForProxies.push_back(id);
+            }
+        }
+
+        FixtureCounter WorldImpl::GetShapeCount() const noexcept
+        {
+            auto shapes = std::set<const void*>();
+            for_each(cbegin(m_bodies), cend(m_bodies), [&](const auto& b) {
+                const auto fixtures = m_bodyBuffer[UnderlyingValue(b)].GetFixtures();
+                for_each(cbegin(fixtures), cend(fixtures), [&](const auto& f) {
+                    const auto& fixture = m_fixtureBuffer[UnderlyingValue(f)];
+                    shapes.insert(GetData(fixture.GetShape()));
+                });
+            });
+            return static_cast<FixtureCounter>(size(shapes));
+        }
+
+        void WorldImpl::Update(ContactID contactID, const ContactUpdateConf& conf)
+        {
+            auto& c = m_contactBuffer[UnderlyingValue(contactID)];
+            auto& manifold = m_manifoldBuffer[UnderlyingValue(contactID)];
+            const auto oldManifold = manifold;
+
+            // Note: do not assume the fixture AABBs are overlapping or are valid.
+            const auto oldTouching = c.IsTouching();
+            auto newTouching = false;
+
+            const auto bodyIdA = c.GetBodyA();
+            const auto fixtureIdA = c.GetFixtureA();
+            const auto indexA = c.GetChildIndexA();
+            const auto bodyIdB = c.GetBodyB();
+            const auto fixtureIdB = c.GetFixtureB();
+            const auto indexB = c.GetChildIndexB();
+            const auto& fixtureA = m_fixtureBuffer[UnderlyingValue(fixtureIdA)];
+            const auto& fixtureB = m_fixtureBuffer[UnderlyingValue(fixtureIdB)];
+            const auto shapeA = fixtureA.GetShape();
+            const auto& bodyA = m_bodyBuffer[UnderlyingValue(bodyIdA)];
+            const auto& bodyB = m_bodyBuffer[UnderlyingValue(bodyIdB)];
+            const auto xfA = bodyA.GetTransformation();
+            const auto shapeB = fixtureB.GetShape();
+            const auto xfB = bodyB.GetTransformation();
+            const auto childA = GetChild(shapeA, indexA);
+            const auto childB = GetChild(shapeB, indexB);
+
+            // NOTE: Ideally, the touching state returned by the TestOverlap function
+            //   agrees 100% of the time with that returned from the CollideShapes function.
+            //   This is not always the case however especially as the separation or overlap
+            //   approaches zero.
 #define OVERLAP_TOLERANCE (SquareMeter / Real(20))
 
-    const auto sensor = fixtureA.IsSensor() || fixtureB.IsSensor();
-    if (sensor)
-    {
-        const auto overlapping = TestOverlap(childA, xfA, childB, xfB, conf.distance);
-        newTouching = (overlapping >= 0_m2);
-
-#ifdef OVERLAP_TOLERANCE
-#ifndef NDEBUG
-        const auto tolerance = OVERLAP_TOLERANCE;
-        const auto newManifold = CollideShapes(childA, xfA, childB, xfB, conf.manifold);
-        assert(newTouching == (newManifold.GetPointCount() > 0) ||
-               abs(overlapping) < tolerance);
-#endif
-#endif
-
-        // Sensors don't generate manifolds.
-        manifold = Manifold{};
-    }
-    else
-    {
-        auto newManifold = CollideShapes(childA, xfA, childB, xfB, conf.manifold);
-
-        const auto old_point_count = oldManifold.GetPointCount();
-        const auto new_point_count = newManifold.GetPointCount();
-
-        newTouching = new_point_count > 0;
-
-#ifdef OVERLAP_TOLERANCE
-#ifndef NDEBUG
-        const auto tolerance = OVERLAP_TOLERANCE;
-        const auto overlapping = TestOverlap(childA, xfA, childB, xfB, conf.distance);
-        assert(newTouching == (overlapping >= 0_m2) ||
-               abs(overlapping) < tolerance);
-#endif
-#endif
-        // Match old contact ids to new contact ids and copy the stored impulses to warm
-        // start the solver. Note: missing any opportunities to warm start the solver
-        // results in squishier stacking and less stable simulations.
-        bool found[2] = {false, new_point_count < 2};
-        for (auto i = decltype(new_point_count){0}; i < new_point_count; ++i)
-        {
-            const auto new_cf = newManifold.GetContactFeature(i);
-            for (auto j = decltype(old_point_count){0}; j < old_point_count; ++j)
+            const auto sensor = fixtureA.IsSensor() || fixtureB.IsSensor();
+            if (sensor)
             {
-                if (new_cf == oldManifold.GetContactFeature(j))
-                {
-                    found[i] = true;
-                    newManifold.SetContactImpulses(i, oldManifold.GetContactImpulses(j));
-                    break;
-                }
+                const auto overlapping = TestOverlap(childA, xfA, childB, xfB, conf.distance);
+                newTouching = (overlapping >= 0_m2);
+
+#ifdef OVERLAP_TOLERANCE
+#ifndef NDEBUG
+                const auto tolerance = OVERLAP_TOLERANCE;
+                const auto newManifold = CollideShapes(childA, xfA, childB, xfB, conf.manifold);
+                assert(newTouching == (newManifold.GetPointCount() > 0) || abs(overlapping) < tolerance);
+#endif
+#endif
+
+                // Sensors don't generate manifolds.
+                manifold = Manifold{};
             }
-        }
-        // If warm starting data wasn't found for a manifold point via contact feature
-        // matching, it's better to just set the data to whatever old point is closest
-        // to the new one.
-        for (auto i = decltype(new_point_count){0}; i < new_point_count; ++i)
-        {
-            if (!found[i])
+            else
             {
-                auto leastSquareDiff = std::numeric_limits<Area>::infinity();
-                const auto newPt = newManifold.GetPoint(i);
-                for (auto j = decltype(old_point_count){0}; j < old_point_count; ++j)
+                auto newManifold = CollideShapes(childA, xfA, childB, xfB, conf.manifold);
+
+                const auto old_point_count = oldManifold.GetPointCount();
+                const auto new_point_count = newManifold.GetPointCount();
+
+                newTouching = new_point_count > 0;
+
+#ifdef OVERLAP_TOLERANCE
+#ifndef NDEBUG
+                const auto tolerance = OVERLAP_TOLERANCE;
+                const auto overlapping = TestOverlap(childA, xfA, childB, xfB, conf.distance);
+                assert(newTouching == (overlapping >= 0_m2) || abs(overlapping) < tolerance);
+#endif
+#endif
+                // Match old contact ids to new contact ids and copy the stored impulses to warm
+                // start the solver. Note: missing any opportunities to warm start the solver
+                // results in squishier stacking and less stable simulations.
+                bool found[2] = {false, new_point_count < 2};
+                for (auto i = decltype(new_point_count){0}; i < new_point_count; ++i)
                 {
-                    const auto oldPt = oldManifold.GetPoint(j);
-                    const auto squareDiff = GetMagnitudeSquared(oldPt.localPoint - newPt.localPoint);
-                    if (leastSquareDiff > squareDiff)
+                    const auto new_cf = newManifold.GetContactFeature(i);
+                    for (auto j = decltype(old_point_count){0}; j < old_point_count; ++j)
                     {
-                        leastSquareDiff = squareDiff;
-                        newManifold.SetContactImpulses(i, oldManifold.GetContactImpulses(j));
+                        if (new_cf == oldManifold.GetContactFeature(j))
+                        {
+                            found[i] = true;
+                            newManifold.SetContactImpulses(i, oldManifold.GetContactImpulses(j));
+                            break;
+                        }
                     }
                 }
-            }
-        }
+                // If warm starting data wasn't found for a manifold point via contact feature
+                // matching, it's better to just set the data to whatever old point is closest
+                // to the new one.
+                for (auto i = decltype(new_point_count){0}; i < new_point_count; ++i)
+                {
+                    if (!found[i])
+                    {
+                        auto leastSquareDiff = std::numeric_limits<Area>::infinity();
+                        const auto newPt = newManifold.GetPoint(i);
+                        for (auto j = decltype(old_point_count){0}; j < old_point_count; ++j)
+                        {
+                            const auto oldPt = oldManifold.GetPoint(j);
+                            const auto squareDiff = GetMagnitudeSquared(oldPt.localPoint - newPt.localPoint);
+                            if (leastSquareDiff > squareDiff)
+                            {
+                                leastSquareDiff = squareDiff;
+                                newManifold.SetContactImpulses(i, oldManifold.GetContactImpulses(j));
+                            }
+                        }
+                    }
+                }
 
-        // Ideally this method is **NEVER** called unless a dependency changed such
-        // that the following assertion is **ALWAYS** valid.
-        //assert(newManifold != oldManifold);
+                // Ideally this method is **NEVER** called unless a dependency changed such
+                // that the following assertion is **ALWAYS** valid.
+                //assert(newManifold != oldManifold);
 
-        manifold = newManifold;
+                manifold = newManifold;
 
 #ifdef MAKE_CONTACT_PROCESSING_ORDER_DEPENDENT
-        /*
+                /*
          * The following code creates an ordering dependency in terms of update processing
          * over a container of contacts. It also puts this method into the situation of
          * modifying bodies which adds race potential in a multi-threaded mode of operation.
          * Lastly, without this code, the step-statistics show a world getting to sleep in
          * less TOI position iterations.
          */
-        if (newTouching != oldTouching)
-        {
-            bodyA.SetAwake();
-            bodyB.SetAwake();
-        }
+                if (newTouching != oldTouching)
+                {
+                    bodyA.SetAwake();
+                    bodyB.SetAwake();
+                }
 #endif
-    }
+            }
 
-    c.UnflagForUpdating();
+            c.UnflagForUpdating();
 
-    if (!oldTouching && newTouching)
-    {
-        c.SetTouching();
-        if (m_beginContactListener)
-        {
-            m_beginContactListener(contactID);
+            if (!oldTouching && newTouching)
+            {
+                c.SetTouching();
+                if (m_beginContactListener)
+                {
+                    m_beginContactListener(contactID);
+                }
+            }
+            else if (oldTouching && !newTouching)
+            {
+                c.UnsetTouching();
+                if (m_endContactListener)
+                {
+                    m_endContactListener(contactID);
+                }
+            }
+
+            if (!sensor && newTouching)
+            {
+                if (m_preSolveContactListener)
+                {
+                    m_preSolveContactListener(contactID, oldManifold);
+                }
+            }
         }
-    }
-    else if (oldTouching && !newTouching)
-    {
-        c.UnsetTouching();
-        if (m_endContactListener)
+
+        const Fixture& WorldImpl::GetFixture(FixtureID id) const
         {
-            m_endContactListener(contactID);
+            return m_fixtureBuffer.at(UnderlyingValue(id));
         }
-    }
 
-    if (!sensor && newTouching)
-    {
-        if (m_preSolveContactListener)
+        Fixture& WorldImpl::GetFixture(FixtureID id)
         {
-            m_preSolveContactListener(contactID, oldManifold);
+            return m_fixtureBuffer.at(UnderlyingValue(id));
         }
-    }
-}
 
-const Fixture& WorldImpl::GetFixture(FixtureID id) const
-{
-    return m_fixtureBuffer.at(UnderlyingValue(id));
-}
+        const Body& WorldImpl::GetBody(BodyID id) const
+        {
+            return m_bodyBuffer.at(UnderlyingValue(id));
+        }
 
-Fixture& WorldImpl::GetFixture(FixtureID id)
-{
-    return m_fixtureBuffer.at(UnderlyingValue(id));
-}
+        Body& WorldImpl::GetBody(BodyID id)
+        {
+            return m_bodyBuffer.at(UnderlyingValue(id));
+        }
 
-const Body& WorldImpl::GetBody(BodyID id) const
-{
-    return m_bodyBuffer.at(UnderlyingValue(id));
-}
+        const Joint& WorldImpl::GetJoint(JointID id) const
+        {
+            return m_jointBuffer.at(UnderlyingValue(id));
+        }
 
-Body& WorldImpl::GetBody(BodyID id)
-{
-    return m_bodyBuffer.at(UnderlyingValue(id));
-}
+        Joint& WorldImpl::GetJoint(JointID id)
+        {
+            return m_jointBuffer.at(UnderlyingValue(id));
+        }
 
-const Joint& WorldImpl::GetJoint(JointID id) const
-{
-    return m_jointBuffer.at(UnderlyingValue(id));
-}
+        const Contact& WorldImpl::GetContact(ContactID id) const
+        {
+            return m_contactBuffer.at(UnderlyingValue(id));
+        }
 
-Joint& WorldImpl::GetJoint(JointID id)
-{
-    return m_jointBuffer.at(UnderlyingValue(id));
-}
+        Contact& WorldImpl::GetContact(ContactID id)
+        {
+            return m_contactBuffer.at(UnderlyingValue(id));
+        }
 
-const Contact& WorldImpl::GetContact(ContactID id) const
-{
-    return m_contactBuffer.at(UnderlyingValue(id));
-}
+        const Manifold& WorldImpl::GetManifold(ContactID id) const
+        {
+            return m_manifoldBuffer.at(UnderlyingValue(id));
+        }
 
-Contact& WorldImpl::GetContact(ContactID id)
-{
-    return m_contactBuffer.at(UnderlyingValue(id));
-}
+        Manifold& WorldImpl::GetManifold(ContactID id)
+        {
+            return m_manifoldBuffer.at(UnderlyingValue(id));
+        }
 
-const Manifold& WorldImpl::GetManifold(ContactID id) const
-{
-    return m_manifoldBuffer.at(UnderlyingValue(id));
-}
-
-Manifold& WorldImpl::GetManifold(ContactID id)
-{
-    return m_manifoldBuffer.at(UnderlyingValue(id));
-}
-
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldImpl.hpp
+++ b/PlayRho/Dynamics/WorldImpl.hpp
@@ -25,977 +25,980 @@
 /// @file
 /// Declarations of the WorldImpl class.
 
-#include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Range.hpp> // for SizedRange
-#include <PlayRho/Common/Positive.hpp>
 #include <PlayRho/Common/ArrayAllocator.hpp>
+#include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Positive.hpp>
+#include <PlayRho/Common/Range.hpp>// for SizedRange
 
 #include <PlayRho/Collision/DynamicTree.hpp>
 #include <PlayRho/Collision/MassData.hpp>
 
+#include <PlayRho/Dynamics/BodyConf.hpp>// for GetDefaultBodyConf
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/Filter.hpp>
-#include <PlayRho/Dynamics/Island.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
-#include <PlayRho/Dynamics/FixtureConf.hpp> // for GetDefaultFixtureConf
-#include <PlayRho/Dynamics/BodyConf.hpp> // for GetDefaultBodyConf
-#include <PlayRho/Dynamics/StepStats.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactKey.hpp>
-#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp> // for KeyedContactPtr
+#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp>// for KeyedContactPtr
+#include <PlayRho/Dynamics/Filter.hpp>
+#include <PlayRho/Dynamics/FixtureConf.hpp>// for GetDefaultFixtureConf
+#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
-#include <PlayRho/Dynamics/WorldConf.hpp>
+#include <PlayRho/Dynamics/Island.hpp>
+#include <PlayRho/Dynamics/IslandStats.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 #include <PlayRho/Dynamics/Joints/JointType.hpp>
-#include <PlayRho/Dynamics/IslandStats.hpp>
+#include <PlayRho/Dynamics/StepStats.hpp>
+#include <PlayRho/Dynamics/WorldConf.hpp>
 
+#include <functional>
 #include <iterator>
-#include <vector>
 #include <map>
 #include <memory>
 #include <stack>
 #include <stdexcept>
-#include <functional>
+#include <vector>
 
-namespace playrho {
+namespace playrho
+{
 
-struct StepConf;
-enum class BodyType;
+    struct StepConf;
+    enum class BodyType;
 
-namespace d2 {
-
-struct JointConf;
-class Body;
-class Contact;
-class Fixture;
-class Joint;
-class Shape;
-class Manifold;
-class ContactImpulsesList;
-
-/// @brief Definition of a "world" implementation.
-/// @see World.
-class WorldImpl {
-public:
-    /// @brief Bodies container type.
-    using Bodies = std::vector<BodyID>;
-
-    /// @brief Contacts container type.
-    using Contacts = std::vector<KeyedContactPtr>;
-
-    /// @brief Joints container type.
-    /// @note Cannot be container of Joint instances since joints are polymorphic types.
-    using Joints = std::vector<JointID>;
-
-    /// @brief Body joints container type.
-    using BodyJoints = std::vector<std::pair<BodyID, JointID>>;
-
-    /// @brief Fixtures container type.
-    using Fixtures = std::vector<FixtureID>;
-
-    using FixtureProxies = std::vector<FixtureProxy>;
-
-    using FixtureListener = std::function<void(FixtureID)>;
-    using JointListener = std::function<void(JointID)>;
-    using ContactListener = std::function<void(ContactID)>;
-    using ManifoldContactListener = std::function<void(ContactID, const Manifold&)>;
-    using ImpulsesContactListener = std::function<void(ContactID, const ContactImpulsesList&, unsigned)>;
-
-    struct ContactUpdateConf;
-
-    /// @brief Constructs a world implementation for a world.
-    /// @param def A customized world configuration or its default value.
-    /// @note A lot more configurability can be had via the <code>StepConf</code>
-    ///   data that's given to the world's <code>Step</code> method.
-    /// @throws InvalidArgument if the given max vertex radius is less than the min.
-    /// @see Step.
-    explicit WorldImpl(const WorldConf& def = GetDefaultWorldConf());
-
-    /// @brief Copy constructor.
-    WorldImpl(const WorldImpl& other) = default;
-
-    WorldImpl& operator=(const WorldImpl& other) = default;
-
-    /// @brief Destructor.
-    /// @details All physics entities are destroyed and all dynamically allocated memory
-    ///    is released.
-    ~WorldImpl() noexcept;
-
-    /// @brief Clears this world.
-    /// @post The contents of this world have all been destroyed and this world's internal
-    ///   state reset as though it had just been constructed.
-    void Clear() noexcept;
-
-    /// @brief Register a destruction listener for fixtures.
-    void SetFixtureDestructionListener(FixtureListener listener) noexcept;
-
-    /// @brief Register a destruction listener for joints.
-    void SetJointDestructionListener(JointListener listener) noexcept;
-
-    /// @brief Register a begin contact event listener.
-    void SetBeginContactListener(ContactListener listener) noexcept;
-
-    /// @brief Register an end contact event listener.
-    void SetEndContactListener(ContactListener listener) noexcept;
-
-    /// @brief Register a pre-solve contact event listener.
-    void SetPreSolveContactListener(ManifoldContactListener listener) noexcept;
-
-    /// @brief Register a post-solve contact event listener.
-    void SetPostSolveContactListener(ImpulsesContactListener listener) noexcept;
-
-    /// @brief Creates a rigid body with the given configuration.
-    /// @warning This function should not be used while the world is locked &mdash; as it is
-    ///   during callbacks. If it is, it will throw an exception or abort your program.
-    /// @note No references to the configuration are retained. Its value is copied.
-    /// @post The created body will be present in the range returned from the
-    ///   <code>GetBodies()</code> method.
-    /// @param def A customized body configuration or its default value.
-    /// @return Identifier of the newly created body which can later be destroyed by calling
-    ///   the <code>Destroy(BodyID)</code> method.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @throws LengthError if this operation would create more than <code>MaxBodies</code>.
-    /// @see Destroy(BodyID), GetBodies.
-    /// @see PhysicalEntities.
-    BodyID CreateBody(const BodyConf& def = GetDefaultBodyConf());
-
-    /// @brief Destroys the given body.
-    /// @details Destroys a given body that had previously been created by a call to this
-    ///   world's <code>CreateBody(const BodyConf&)</code> method.
-    /// @warning This automatically deletes all associated shapes and joints.
-    /// @warning This function is locked during callbacks.
-    /// @warning Behavior is undefined if given a null body.
-    /// @warning Behavior is undefined if the passed body was not created by this world.
-    /// @note This function is locked during callbacks.
-    /// @post The destroyed body will no longer be present in the range returned from the
-    ///   <code>GetBodies()</code> method.
-    /// @post None of the body's fixtures will be present in the fixtures-for-proxies
-    ///   collection.
-    /// @param id Body to destroy that had been created by this world.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @see CreateBody(const BodyConf&), GetBodies, GetFixturesForProxies.
-    /// @see PhysicalEntities.
-    void Destroy(BodyID id);
-
-    /// @brief Creates a joint to constrain one or more bodies.
-    /// @warning This function is locked during callbacks.
-    /// @note No references to the configuration are retained. Its value is copied.
-    /// @post The created joint will be present in the range returned from the
-    ///   <code>GetJoints()</code> method.
-    /// @return Identifier for the newly created joint which can later be destroyed by calling
-    ///   the <code>Destroy(JointID)</code> method.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @throws LengthError if this operation would create more than <code>MaxJoints</code>.
-    /// @throws InvalidArgument if the given definition is not allowed.
-    /// @see PhysicalEntities.
-    /// @see Destroy(JointID), GetJoints.
-    JointID CreateJoint(const Joint& def);
-
-    /// @brief Destroys a joint.
-    /// @details Destroys a given joint that had previously been created by a call to this
-    ///   world's <code>CreateJoint(const JointConf&)</code> method.
-    /// @warning This function is locked during callbacks.
-    /// @warning Behavior is undefined if the passed joint was not created by this world.
-    /// @note This may cause the connected bodies to begin colliding.
-    /// @post The destroyed joint will no longer be present in the range returned from the
-    ///   <code>GetJoints()</code> method.
-    /// @param joint Joint to destroy that had been created by this world.
-    /// @throws WrongState if this method is called while the world is locked.
-    /// @see CreateJoint(const JointConf&), GetJoints.
-    /// @see PhysicalEntities.
-    void Destroy(JointID joint);
-
-    /// @brief Steps the world simulation according to the given configuration.
-    ///
-    /// @details
-    /// Performs position and velocity updating, sleeping of non-moving bodies, updating
-    /// of the contacts, and notifying the contact listener of begin-contact, end-contact,
-    /// pre-solve, and post-solve events.
-    ///
-    /// @warning Behavior is undefined if given a negative step time delta.
-    /// @warning Varying the step time delta may lead to non-physical behaviors.
-    ///
-    /// @note Calling this with a zero step time delta results only in fixtures and bodies
-    ///   registered for proxy handling being processed. No physics is performed.
-    /// @note If the given velocity and position iterations are zero, this method doesn't
-    ///   do velocity or position resolutions respectively of the contacting bodies.
-    /// @note While body velocities are updated accordingly (per the sum of forces acting on them),
-    ///   body positions (barring any collisions) are updated as if they had moved the entire time
-    ///   step at those resulting velocities. In other words, a body initially at position 0
-    ///   (<code>p0</code>) going velocity 0 (<code>v0</code>) fast with a sum acceleration of
-    ///   <code>a</code>, after time <code>t</code> and barring any collisions, will have a new
-    ///   velocity (<code>v1</code>) of <code>v0 + (a * t)</code> and a new position
-    ///   (<code>p1</code>) of <code>p0 + v1 * t</code>.
-    ///
-    /// @post Static bodies are unmoved.
-    /// @post Kinetic bodies are moved based on their previous velocities.
-    /// @post Dynamic bodies are moved based on their previous velocities, gravity, applied
-    ///   forces, applied impulses, masses, damping, and the restitution and friction values
-    ///   of their fixtures when they experience collisions.
-    /// @post The bodies for proxies queue will be empty.
-    /// @post The fixtures for proxies queue will be empty.
-    ///
-    /// @param conf Configuration for the simulation step.
-    ///
-    /// @return Statistics for the step.
-    ///
-    /// @throws WrongState if this method is called while the world is locked.
-    ///
-    /// @see GetBodiesForProxies, GetFixturesForProxies.
-    ///
-    StepStats Step(const StepConf& conf);
-
-    /// @brief Gets the world body range for this constant world.
-    /// @details Gets a range enumerating the bodies currently existing within this world.
-    ///   These are the bodies that had been created from previous calls to the
-    ///   <code>CreateBody(const BodyConf&)</code> method that haven't yet been destroyed.
-    /// @return Body range that can be iterated over using its begin and end methods
-    ///   or using ranged-based for-loops.
-    /// @see CreateBody(const BodyConf&).
-    SizedRange<Bodies::const_iterator> GetBodies() const noexcept;
-
-    /// @brief Gets the extent of the currently valid body range.
-    /// @note This is one higher than the maxium BodyID that is in range for body related
-    ///   functions.
-    BodyCounter GetBodyRange() const noexcept;
-
-    /// @brief Gets the bodies-for-proxies range for this world.
-    /// @details Provides insight on what bodies have been queued for proxy processing
-    ///   during the next call to the world step method.
-    /// @see Step.
-    SizedRange<Bodies::const_iterator> GetBodiesForProxies() const noexcept;
-
-    /// @brief Gets the fixtures-for-proxies range for this world.
-    /// @details Provides insight on what fixtures have been queued for proxy processing
-    ///   during the next call to the world step method.
-    /// @see Step.
-    SizedRange<Fixtures::const_iterator> GetFixturesForProxies() const noexcept;
-
-    /// @brief Gets the world joint range.
-    /// @details Gets a range enumerating the joints currently existing within this world.
-    ///   These are the joints that had been created from previous calls to the
-    ///   <code>CreateJoint(const JointConf&)</code> method that haven't yet been destroyed.
-    /// @return World joints sized-range.
-    /// @see CreateJoint(const JointConf&).
-    SizedRange<Joints::const_iterator> GetJoints() const noexcept;
-
-    /// @brief Gets the world contact range.
-    /// @warning contacts are created and destroyed in the middle of a time step.
-    /// Use <code>ContactListener</code> to avoid missing contacts.
-    /// @return World contacts sized-range.
-    SizedRange<Contacts::const_iterator> GetContacts() const noexcept;
-    
-    /// @brief Whether or not "step" is complete.
-    /// @details The "step" is completed when there are no more TOI events for the current time step.
-    /// @return <code>true</code> unless sub-stepping is enabled and the step method returned
-    ///   without finishing all of its sub-steps.
-    /// @see GetSubStepping, SetSubStepping.
-    bool IsStepComplete() const noexcept;
-    
-    /// @brief Gets whether or not sub-stepping is enabled.
-    /// @see SetSubStepping, IsStepComplete.
-    bool GetSubStepping() const noexcept;
-
-    /// @brief Enables/disables single stepped continuous physics.
-    /// @note This is not normally used. Enabling sub-stepping is meant for testing.
-    /// @post The <code>GetSubStepping()</code> method will return the value this method was
-    ///   called with.
-    /// @see IsStepComplete, GetSubStepping.
-    void SetSubStepping(bool flag) noexcept;
-
-    /// @brief Gets access to the broad-phase dynamic tree information.
-    const DynamicTree& GetTree() const noexcept;
-
-    /// @brief Is the world locked (in the middle of a time step).
-    bool IsLocked() const noexcept;
-
-    /// @brief Shifts the world origin.
-    /// @note Useful for large worlds.
-    /// @note The body shift formula is: <code>position -= newOrigin</code>.
-    /// @post The "origin" of this world's bodies, joints, and the board-phase dynamic tree
-    ///   have been translated per the shift amount and direction.
-    /// @param newOrigin the new origin with respect to the old origin
-    /// @throws WrongState if this method is called while the world is locked.
-    void ShiftOrigin(Length2 newOrigin);
-
-    /// @brief Gets the minimum vertex radius that shapes in this world can be.
-    Length GetMinVertexRadius() const noexcept;
-    
-    /// @brief Gets the maximum vertex radius that shapes in this world can be.
-    Length GetMaxVertexRadius() const noexcept;
-
-    /// @brief Gets the inverse delta time.
-    /// @details Gets the inverse delta time that was set on construction or assignment, and
-    ///   updated on every call to the <code>Step()</code> method having a non-zero delta-time.
-    /// @see Step.
-    Frequency GetInvDeltaTime() const noexcept;
-
-    /// @brief Re-filter the fixture.
-    /// @note Call this if you want to establish collision that was previously disabled by
-    ///   <code>ShouldCollide(const Fixture&, const Fixture&)</code>.
-    /// @see bool ShouldCollide(const Fixture& fixtureA, const Fixture& fixtureB)
-    void Refilter(FixtureID id);
-
-    /// @brief Sets the contact filtering data.
-    /// @note This won't update contacts until the next time step when either parent body
-    ///    is speedable and awake.
-    /// @note This automatically calls <code>Refilter</code>.
-    void SetFilterData(FixtureID id, Filter filter);
-
-    /// @brief Sets the type of the given body.
-    /// @note This may alter the body's mass and velocity.
-    /// @throws WrongState if this method is called while the world is locked.
-    void SetType(BodyID id, playrho::BodyType type);
-
-    /// @brief Creates a fixture with the given parameters.
-    /// @details Creates a fixture for attaching a shape and other characteristics to the
-    ///   given body. Fixtures automatically go away when the body is destroyed. Fixtures can
-    ///   also be manually removed and destroyed using the
-    ///   <code>Destroy(Fixture*, bool)</code>, or <code>DestroyFixtures()</code> methods.
-    ///
-    /// @note This function should not be called if the world is locked.
-    /// @warning This function is locked during callbacks.
-    ///
-    /// @post After creating a new fixture, it will show up in the fixture enumeration
-    ///   returned by the <code>GetFixtures()</code> methods.
-    ///
-    /// @param body Body to associated new fixture with.
-    /// @param shape Shareable shape definition.
-    ///   Its vertex radius must be less than the minimum or more than the maximum allowed by
-    ///   the body's world.
-    /// @param def Initial fixture settings.
-    ///   Friction and density must be >= 0.
-    ///   Restitution must be > -infinity and < infinity.
-    /// @param resetMassData Whether or not to reset the mass data of the body.
-    ///
-    /// @return Identifier for the created fixture.
-    ///
-    /// @throws WrongState if called while the world is "locked".
-    /// @throws InvalidArgument if called for a shape with a vertex radius less than the
-    ///    minimum vertex radius.
-    /// @throws InvalidArgument if called for a shape with a vertex radius greater than the
-    ///    maximum vertex radius.
-    ///
-    /// @see Destroy, GetFixtures
-    /// @see PhysicalEntities
-    ///
-    FixtureID CreateFixture(BodyID body, const Shape& shape,
-                            const FixtureConf& def = GetDefaultFixtureConf(),
-                            bool resetMassData = true);
-
-    /// @brief Destroys a fixture.
-    /// @details This removes the fixture from the broad-phase and destroys all contacts
-    ///   associated with this fixture.
-    ///   All fixtures attached to a body are implicitly destroyed when the body is destroyed.
-    /// @warning This function is locked during callbacks.
-    /// @note Make sure to explicitly call <code>Body::ResetMassData</code> after fixtures have
-    ///   been destroyed.
-    /// @param fixture the fixture to be removed.
-    /// @param resetMassData Whether or not to reset the mass data of the associated body.
-    /// @see Body::ResetMassData.
-    /// @throws WrongState if this method is called while the world is locked.
-    bool Destroy(FixtureID fixture, bool resetMassData = true);
-
-    /// @brief Destroys fixtures of the given body.
-    /// @details Destroys all of the fixtures previously created for this body by the
-    ///   <code>CreateFixture(const Shape&, const FixtureConf&, bool)</code> method.
-    /// @note This unconditionally calls the <code>ResetMassData()</code> method.
-    /// @post After this call, no fixtures will show up in the fixture enumeration
-    ///   returned by the <code>GetFixtures()</code> methods.
-    /// @see CreateFixture, GetFixtures, ResetMassData.
-    /// @see PhysicalEntities
-    void DestroyFixtures(BodyID id);
-
-    /// @brief Sets the enabled state of the body.
-    ///
-    /// @details A disabled body is not simulated and cannot be collided with or woken up.
-    ///   If you pass a flag of true, all fixtures will be added to the broad-phase.
-    ///   If you pass a flag of false, all fixtures will be removed from the broad-phase
-    ///   and all contacts will be destroyed. Fixtures and joints are otherwise unaffected.
-    ///
-    /// @note A disabled body is still owned by a World object and remains in the world's
-    ///   body container.
-    /// @note You may continue to create/destroy fixtures and joints on disabled bodies.
-    /// @note Fixtures on a disabled body are implicitly disabled and will not participate in
-    ///   collisions, ray-casts, or queries.
-    /// @note Joints connected to a disabled body are implicitly disabled.
-    ///
-    /// @throws WrongState If call would change body's state when world is locked.
-    ///
-    /// @post <code>IsEnabled()</code> returns the state given to this function.
-    ///
-    /// @see IsEnabled.
-    ///
-    void SetEnabled(BodyID id, bool flag);
-
-    /// @brief Computes the mass data of the identified body.
-    MassData ComputeMassData(BodyID id) const;
-
-    /// @brief Set the mass properties to override the mass properties of the fixtures.
-    /// @note This changes the center of mass position.
-    /// @note Creating or destroying fixtures can also alter the mass.
-    /// @note This function has no effect if the body isn't dynamic.
-    /// @param id Body to set mass data for.
-    /// @param massData the mass properties.
-    void SetMassData(BodyID id, const MassData& massData);
-
-    /// @brief Sets the transformation of the body.
-    /// @details This instantly adjusts the body to have the new transformation.
-    /// @warning Manipulating a body's transform can cause non-physical behavior!
-    /// @warning Behavior is undefined if the value is invalid.
-    /// @note Associated contacts may be flagged for updating on the next call to WorldImpl::Step.
-    /// @throws WrongState If call would change body's state when world is locked.
-    void SetTransformation(BodyID id, Transformation xfm);
-
-    FixtureCounter GetShapeCount() const noexcept;
-
-    const Fixture& GetFixture(FixtureID id) const;
-    Fixture& GetFixture(FixtureID id);
-
-    /// @throws std::out_of_range if given an invalid id.
-    const Body& GetBody(BodyID id) const;
-
-    /// @throws std::out_of_range if given an invalid id.
-    Body& GetBody(BodyID id);
-
-    const Contact& GetContact(ContactID id) const;
-    Contact& GetContact(ContactID id);
-
-    const Manifold& GetManifold(ContactID id) const;
-    Manifold& GetManifold(ContactID id);
-
-    const Joint& GetJoint(JointID id) const;
-    Joint& GetJoint(JointID id);
-
-    void SetJoint(JointID id, const Joint& def);
-
-    /// @brief Sets whether the fixture is a sensor or not.
-    /// @see IsSensor(FixtureID id).
-    void SetSensor(FixtureID id, bool value);
-
-private:
-    /// @brief Flags type data type.
-    using FlagsType = std::uint32_t;
-    
-    /// @brief Proxy ID type alias.
-    using ProxyId = DynamicTree::Size;
-    
-    /// @brief Contact key queue type alias.
-    using ContactKeyQueue = std::vector<ContactKey>;
-    
-    /// @brief Proxy queue type alias.
-    using ProxyQueue = std::vector<ProxyId>;
-    
-    /// @brief Flag enumeration.
-    enum Flag: FlagsType
+    namespace d2
     {
-        /// New fixture.
-        e_newFixture    = 0x0001,
-        
-        /// Locked.
-        e_locked        = 0x0002,
-        
-        /// Sub-stepping.
-        e_substepping   = 0x0020,
-        
-        /// Step complete. @details Used for sub-stepping. @see e_substepping.
-        e_stepComplete  = 0x0040,
-    };
-
-    /// @brief Solves the step.
-    /// @details Finds islands, integrates and solves constraints, solves position constraints.
-    /// @note This may miss collisions involving fast moving bodies and allow them to tunnel
-    ///   through each other.
-    RegStepStats SolveReg(const StepConf& conf);
-
-    /// @brief Solves the given island (regularly).
-    ///
-    /// @details This:
-    ///   1. Updates every island-body's <code>sweep.pos0</code> to its <code>sweep.pos1</code>.
-    ///   2. Updates every island-body's <code>sweep.pos1</code> to the new normalized "solved"
-    ///      position for it.
-    ///   3. Updates every island-body's velocity to the new accelerated, dampened, and "solved"
-    ///      velocity for it.
-    ///   4. Synchronizes every island-body's transform (by updating it to transform one of the
-    ///      body's sweep).
-    ///   5. Reports to the listener (if non-null).
-    ///
-    /// @param conf Time step configuration information.
-    /// @param island Island of bodies, contacts, and joints to solve for. Must contain at least
-    ///   one body, contact, or joint.
-    ///
-    /// @warning Behavior is undefined if the given island doesn't have at least one body,
-    ///   contact, or joint.
-    ///
-    /// @return Island solver results.
-    ///
-    IslandStats SolveRegIslandViaGS(const StepConf& conf, const Island& island);
-    
-    /// @brief Adds to the island based off of a given "seed" body.
-    /// @post Contacts are listed in the island in the order that bodies provide those contacts.
-    /// @post Joints are listed the island in the order that bodies provide those joints.
-    void AddToIsland(Island& island, BodyID seed,
-                     BodyCounter& remNumBodies,
-                     ContactCounter& remNumContacts,
-                     JointCounter& remNumJoints);
-    
-    /// @brief Body stack.
-    using BodyStack = std::stack<BodyID, std::vector<BodyID>>;
-    
-    /// @brief Adds to the island.
-    void AddToIsland(Island& island, BodyStack& stack,
-                     BodyCounter& remNumBodies,
-                     ContactCounter& remNumContacts,
-                     JointCounter& remNumJoints);
-    
-    /// @brief Adds contacts to the island.
-    void AddContactsToIsland(Island& island, BodyStack& stack,
-                             SizedRange<Contacts::const_iterator> contacts,
-                             BodyID bodyID);
-
-    /// @brief Adds joints to the island.
-    void AddJointsToIsland(Island& island, BodyStack& stack,
-                           SizedRange<BodyJoints::const_iterator> joints);
-    
-    /// @brief Removes <em>unspeedables</em> from the is <em>is-in-island</em> state.
-    static Bodies::size_type RemoveUnspeedablesFromIslanded(const std::vector<BodyID>& bodies,
-                                                            const ArrayAllocator<Body>& buffer,
-                                                            std::vector<bool>& islanded);
-    
-    /// @brief Solves the step using successive time of impact (TOI) events.
-    /// @details Used for continuous physics.
-    /// @note This is intended to detect and prevent the tunneling that the faster Solve method
-    ///    may miss.
-    /// @param conf Time step configuration to use.
-    ToiStepStats SolveToi(const StepConf& conf);
-
-    /// @brief Solves collisions for the given time of impact.
-    ///
-    /// @param contactID Identifier of contact to solve for.
-    /// @param conf Time step configuration to solve for.
-    ///
-    /// @note Precondition 1: there is no contact having a lower TOI in this time step that has
-    ///   not already been solved for.
-    /// @note Precondition 2: there is not a lower TOI in the time step for which collisions have
-    ///   not already been processed.
-    ///
-    IslandStats SolveToi(ContactID contactID, const StepConf& conf);
-
-    /// @brief Solves the time of impact for bodies 0 and 1 of the given island.
-    ///
-    /// @details This:
-    ///   1. Updates position 0 of the sweeps of bodies 0 and 1.
-    ///   2. Updates position 1 of the sweeps, the transforms, and the velocities of the other
-    ///      bodies in this island.
-    ///
-    /// @pre <code>island.bodies</code> contains at least two bodies, the first two of which
-    ///   are bodies 0 and 1.
-    /// @pre <code>island.bodies</code> contains appropriate other bodies of the contacts of
-    ///   the two bodies.
-    /// @pre <code>island.contacts</code> contains the contact that specified the two identified
-    ///   bodies.
-    /// @pre <code>island.contacts</code> contains appropriate other contacts of the two bodies.
-    ///
-    /// @param conf Time step configuration information.
-    /// @param island Island to do time of impact solving for.
-    ///
-    /// @return Island solver results.
-    ///
-    IslandStats SolveToiViaGS(const Island& island, const StepConf& conf);
-
-    /// @brief Updates the given body.
-    /// @details Updates the given body's sweep position 1, and its transformation.
-    /// @param body Body to update.
-    /// @param pos New position to set the given body to.
-    /// @return <code>true</code> if body's contacts should be flagged for updating,
-    ///   otherwise <code>false</code>.
-    static bool UpdateBody(Body& body, const Position& pos);
-
-    /// @brief Process contacts output.
-    struct ProcessContactsOutput
-    {
-        ContactCounter contactsUpdated = 0; ///< Contacts updated.
-        ContactCounter contactsSkipped = 0; ///< Contacts skipped.
-    };
-
-    /// @brief Processes the contacts of a given body for TOI handling.
-    /// @details This does the following:
-    ///   1. Advances the appropriate associated other bodies to the given TOI (advancing
-    ///      their sweeps and synchronizing their transforms to their new sweeps).
-    ///   2. Updates the contact manifolds and touching statuses and notifies listener (if one given) of
-    ///      the appropriate contacts of the body.
-    ///   3. Adds those contacts that are still enabled and still touching to the given island
-    ///      (or resets the other bodies advancement).
-    ///   4. Adds to the island, those other bodies that haven't already been added of the contacts that got added.
-    /// @note Precondition: there should be no lower TOI for which contacts have not already been processed.
-    /// @param[in,out] id Identifier of the dynamic/accelerable body to process contacts for.
-    /// @param[in,out] island Island. On return this may contain additional contacts or bodies.
-    /// @param[in] toi Time of impact (TOI). Value between 0 and 1.
-    /// @param[in] conf Step configuration data.
-    ProcessContactsOutput ProcessContactsForTOI(BodyID id, Island& island, Real toi,
-                                                const StepConf& conf);
-
-    /// @brief Removes the given body from this world.
-    void Remove(BodyID id) noexcept;
-
-    /// @brief Updates associated bodies and contacts for specified joint's addition.
-    void Add(JointID j, bool flagForFiltering = false);
-
-    /// @brief Updates associated bodies and contacts for specified joint's removal.
-    void Remove(JointID id) noexcept;
-
-    /// @brief Sets the step complete state.
-    /// @post <code>IsStepComplete()</code> will return the value set.
-    /// @see IsStepComplete.
-    void SetStepComplete(bool value) noexcept;
-
-    /// @brief Sets the allow sleeping state.
-    void SetAllowSleeping() noexcept;
-
-    /// @brief Unsets the allow sleeping state.
-    void UnsetAllowSleeping() noexcept;
-
-    /// @brief Update contacts statistics.
-    struct UpdateContactsStats
-    {
-        /// @brief Number of contacts ignored (because both bodies were asleep).
-        ContactCounter ignored = 0;
-
-        /// @brief Number of contacts updated.
-        ContactCounter updated = 0;
-
-        /// @brief Number of contacts skipped because they weren't marked as needing updating.
-        ContactCounter skipped = 0;
-    };
-
-    /// @brief Destroy contacts statistics.
-    struct DestroyContactsStats
-    {
-        ContactCounter ignored = 0; ///< Ignored.
-        ContactCounter erased = 0; ///< Erased.
-    };
-
-    /// @brief Contact TOI data.
-    struct ContactToiData
-    {
-        ContactID contact = InvalidContactID; ///< Contact for which the time of impact is relevant.
-        Real toi = std::numeric_limits<Real>::infinity(); ///< Time of impact (TOI) as a fractional value between 0 and 1.
-        ContactCounter simultaneous = 0; ///< Count of simultaneous contacts at this TOI.
-    };
-
-    /// @brief Update contacts data.
-    struct UpdateContactsData
-    {
-        ContactCounter numAtMaxSubSteps = 0; ///< # at max sub-steps (lower the better).
-        ContactCounter numUpdatedTOI = 0; ///< # updated TOIs (made valid).
-        ContactCounter numValidTOI = 0; ///< # already valid TOIs.
-
-        /// @brief Distance iterations type alias.
-        using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
-
-        /// @brief TOI iterations type alias.
-        using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
-
-        /// @brief Root iterations type alias.
-        using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
-
-        dist_iter_type maxDistIters = 0; ///< Max distance iterations.
-        toi_iter_type maxToiIters = 0; ///< Max TOI iterations.
-        root_iter_type maxRootIters = 0; ///< Max root iterations.
-    };
-
-    /// @brief Updates the contact times of impact.
-    static UpdateContactsData UpdateContactTOIs(ArrayAllocator<Contact>& contactBuffer,
-                                                ArrayAllocator<Body>& bodyBuffer,
-                                                const ArrayAllocator<Fixture>& fixtureBuffer,
-                                                const Contacts& contacts, const StepConf& conf);
-
-    /// @brief Gets the soonest contact.
-    /// @details This finds the contact with the lowest (soonest) time of impact.
-    /// @return Contact with the least time of impact and its time of impact, or null contact.
-    ///  A non-null contact will be enabled, not have sensors, be active, and impenetrable.
-    static ContactToiData GetSoonestContact(const Contacts& contacts, const ArrayAllocator<Contact>& buffer) noexcept;
-    
-    /// @brief Determines whether this world has new fixtures.
-    bool HasNewFixtures() const noexcept;
-    
-    /// @brief Unsets the new fixtures state.
-    void UnsetNewFixtures() noexcept;
-    
-    /// @brief Finds new contacts.
-    /// @details Finds and adds new valid contacts to the contacts container.
-    /// @note The new contacts will all have overlapping AABBs.
-    ContactCounter FindNewContacts();
-
-    /// @brief Processes the narrow phase collision for the contacts collection.
-    /// @details
-    /// This finds and destroys the contacts that need filtering and no longer should collide or
-    /// that no longer have AABB-based overlapping fixtures. Those contacts that persist and
-    /// have active bodies (either or both) get their Update methods called with the current
-    /// contact listener as its argument.
-    /// Essentially this really just purges contacts that are no longer relevant.
-    DestroyContactsStats DestroyContacts(Contacts& contacts);
-    
-    /// @brief Update contacts.
-    UpdateContactsStats UpdateContacts(const StepConf& conf);
-
-    /// @brief Destroys the given contact and removes it from its container.
-    /// @details This updates the contacts container, returns the memory to the allocator,
-    ///   and decrements the contact manager's contact count.
-    /// @param contact Contact to destroy.
-    /// @param from From body.
-    void Destroy(ContactID contact, Body* from);
-
-    /// @brief Adds a contact for the proxies identified by the key if appropriate.
-    /// @details Adds a new contact object to represent a contact between proxy A and proxy B
-    /// if all of the following are true:
-    ///   1. The bodies of the fixtures of the proxies are not the one and the same.
-    ///   2. No contact already exists for these two proxies.
-    ///   3. The bodies of the proxies should collide (according to <code>ShouldCollide</code>).
-    ///   4. The contact filter says the fixtures of the proxies should collide.
-    ///   5. There exists a contact-create function for the pair of shapes of the proxies.
-    /// @post The size of the <code>contacts</code> collection is one greater-than it was
-    ///   before this method is called if it returns <code>true</code>.
-    /// @param key ID's of dynamic tree entries identifying the fixture proxies involved.
-    /// @return <code>true</code> if a new contact was indeed added (and created),
-    ///   else <code>false</code>.
-    /// @see bool ShouldCollide(const Body& lhs, const Body& rhs) noexcept.
-    bool Add(ContactKey key);
-
-    /// @brief Destroys the given contact.
-    static void InternalDestroy(ContactID contact,
-                                ArrayAllocator<Body>& bodyBuffer,
-                                ArrayAllocator<Contact>& contactBuffer,
-                                ArrayAllocator<Manifold>& manifoldBuffer,
-                                ContactListener listener, Body* from = nullptr);
-
-    /// @brief Creates proxies for every child of the given fixture's shape.
-    /// @note This sets the proxy count to the child count of the shape.
-    static void CreateProxies(FixtureID id, Fixture& fixture, const Transformation& xfm,
-                              ProxyQueue& proxies, DynamicTree& tree, Length aabbExtension);
-
-    /// @brief Touches each proxy of the given fixture.
-    /// @note This sets things up so that pairs may be created for potentially new contacts.
-    static void InternalTouchProxies(ProxyQueue& proxies, const Fixture& fixture) noexcept;
-
-    /// @brief Synchronizes the given body.
-    /// @details This updates the broad phase dynamic tree data for all of the given
-    ///   body's fixtures.
-    ContactCounter Synchronize(const Body& body,
-                               const Transformation& xfm1, const Transformation& xfm2,
-                               Real multiplier, Length extension);
-    
-    /// @brief Synchronizes the given fixture.
-    /// @details This updates the broad phase dynamic tree data for all of the given
-    ///   fixture shape's children.
-    ContactCounter Synchronize(const Fixture& fixture,
-                               const Transformation& xfm1, const Transformation& xfm2,
-                               Length2 displacement, Length extension);
-
-    /// @brief Creates and destroys proxies.
-    void CreateAndDestroyProxies(Length extension);
-
-    /// @brief Synchronizes proxies of the bodies for proxies.
-    PreStepStats::counter_type SynchronizeProxies(const StepConf& conf);
-
-    /// @brief Updates the touching related state and notifies listener (if one given).
-    ///
-    /// @note Ideally this method is only called when a dependent change has occurred.
-    /// @note Touching related state depends on the following data:
-    ///   - The fixtures' sensor states.
-    ///   - The fixtures bodies' transformations.
-    ///   - The <code>maxCirclesRatio</code> per-step configuration state *OR* the
-    ///     <code>maxDistanceIters</code> per-step configuration state.
-    ///
-    /// @param id Identifies the contact to update.
-    /// @param conf Per-step configuration information.
-    ///
-    /// @see GetManifold, IsTouching
-    ///
-    void Update(ContactID id, const ContactUpdateConf& conf);
-
-    /******** Member variables. ********/
-
-    ArrayAllocator<Body> m_bodyBuffer;
-    ArrayAllocator<Fixture> m_fixtureBuffer;
-    ArrayAllocator<Joint> m_jointBuffer;
-    ArrayAllocator<Contact> m_contactBuffer;
-    ArrayAllocator<Manifold> m_manifoldBuffer;
-
-    DynamicTree m_tree; ///< Dynamic tree.
-
-    ContactKeyQueue m_proxyKeys; ///< Proxy keys.
-    ProxyQueue m_proxies; ///< Proxies queue.
-    Fixtures m_fixturesForProxies; ///< Fixtures for proxies queue.
-    Bodies m_bodiesForProxies; ///< Bodies for proxies queue.
-    
-    Bodies m_bodies; ///< Body collection.
-
-    Joints m_joints; ///< Joint collection.
-    
-    /// @brief Container of contacts.
-    /// @note In the <em>add pair</em> stress-test, 401 bodies can have some 31000 contacts
-    ///   during a given time step.
-    Contacts m_contacts;
-
-    Island m_island; ///< Island buffer.
-    std::vector<bool> m_islandedBodies;
-    std::vector<bool> m_islandedContacts;
-    std::vector<bool> m_islandedJoints;
-
-    FixtureListener m_fixtureDestructionListener;
-    JointListener m_jointDestructionListener;
-    ContactListener m_beginContactListener;
-    ContactListener m_endContactListener;
-    ManifoldContactListener m_preSolveContactListener;
-    ImpulsesContactListener m_postSolveContactListener;
-
-    FlagsType m_flags = e_stepComplete; ///< Flags.
-    
-    /// Inverse delta-t from previous step.
-    /// @details Used to compute time step ratio to support a variable time step.
-    /// @note 4-bytes large.
-    /// @see Step.
-    Frequency m_inv_dt0 = 0;
-    
-    /// @brief Minimum vertex radius.
-    Positive<Length> m_minVertexRadius;
-    
-    /// @brief Maximum vertex radius.
-    /// @details
-    /// This is the maximum shape vertex radius that any bodies' of this world should create
-    /// fixtures for. Requests to create fixtures for shapes with vertex radiuses bigger than
-    /// this must be rejected. As an upper bound, this value prevents shapes from getting
-    /// associated with this world that would otherwise not be able to be simulated due to
-    /// numerical issues. It can also be set below this upper bound to constrain the differences
-    /// between shape vertex radiuses to possibly more limited visual ranges.
-    Positive<Length> m_maxVertexRadius;
-};
-
-inline SizedRange<WorldImpl::Bodies::const_iterator> WorldImpl::GetBodies() const noexcept
-{
-    return {begin(m_bodies), end(m_bodies), size(m_bodies)};
-}
-
-inline SizedRange<WorldImpl::Bodies::const_iterator> WorldImpl::GetBodiesForProxies() const noexcept
-{
-    return {cbegin(m_bodiesForProxies), cend(m_bodiesForProxies), size(m_bodiesForProxies)};
-}
-
-inline SizedRange<WorldImpl::Fixtures::const_iterator> WorldImpl::GetFixturesForProxies() const noexcept
-{
-    return {cbegin(m_fixturesForProxies), cend(m_fixturesForProxies), size(m_fixturesForProxies)};
-}
-
-inline SizedRange<WorldImpl::Joints::const_iterator> WorldImpl::GetJoints() const noexcept
-{
-    return {begin(m_joints), end(m_joints), size(m_joints)};
-}
-
-inline SizedRange<WorldImpl::Contacts::const_iterator> WorldImpl::GetContacts() const noexcept
-{
-    return {begin(m_contacts), end(m_contacts), size(m_contacts)};
-}
-
-inline bool WorldImpl::IsLocked() const noexcept
-{
-    return (m_flags & e_locked) == e_locked;
-}
-
-inline bool WorldImpl::IsStepComplete() const noexcept
-{
-    return (m_flags & e_stepComplete) != 0u;
-}
-
-inline void WorldImpl::SetStepComplete(bool value) noexcept
-{
-    if (value)
-    {
-        m_flags |= e_stepComplete;
-    }
-    else
-    {
-        m_flags &= ~e_stepComplete;        
-    }
-}
-
-inline bool WorldImpl::GetSubStepping() const noexcept
-{
-    return (m_flags & e_substepping) != 0u;
-}
-
-inline void WorldImpl::SetSubStepping(bool flag) noexcept
-{
-    if (flag)
-    {
-        m_flags |= e_substepping;
-    }
-    else
-    {
-        m_flags &= ~e_substepping;
-    }
-}
-
-inline bool WorldImpl::HasNewFixtures() const noexcept
-{
-    return (m_flags & e_newFixture) != 0u;
-}
-
-inline void WorldImpl::UnsetNewFixtures() noexcept
-{
-    m_flags &= ~e_newFixture;
-}
-
-inline Length WorldImpl::GetMinVertexRadius() const noexcept
-{
-    return m_minVertexRadius;
-}
-
-inline Length WorldImpl::GetMaxVertexRadius() const noexcept
-{
-    return m_maxVertexRadius;
-}
-
-inline Frequency WorldImpl::GetInvDeltaTime() const noexcept
-{
-    return m_inv_dt0;
-}
-
-inline const DynamicTree& WorldImpl::GetTree() const noexcept
-{
-    return m_tree;
-}
-
-inline void WorldImpl::SetFixtureDestructionListener(FixtureListener listener) noexcept
-{
-    m_fixtureDestructionListener = std::move(listener);
-}
-
-inline void WorldImpl::SetJointDestructionListener(JointListener listener) noexcept
-{
-    m_jointDestructionListener = std::move(listener);
-}
-
-inline void WorldImpl::SetBeginContactListener(ContactListener listener) noexcept
-{
-    m_beginContactListener = std::move(listener);
-}
-
-inline void WorldImpl::SetEndContactListener(ContactListener listener) noexcept
-{
-    m_endContactListener = std::move(listener);
-}
-
-inline void WorldImpl::SetPreSolveContactListener(ManifoldContactListener listener) noexcept
-{
-    m_preSolveContactListener = std::move(listener);
-}
-
-inline void WorldImpl::SetPostSolveContactListener(ImpulsesContactListener listener) noexcept
-{
-    m_postSolveContactListener = std::move(listener);
-}
-
-} // namespace d2
-} // namespace playrho
-
-#endif // PLAYRHO_DYNAMICS_WORLDIMPL_HPP
+
+        struct JointConf;
+        class Body;
+        class Contact;
+        class Fixture;
+        class Joint;
+        class Shape;
+        class Manifold;
+        class ContactImpulsesList;
+
+        /// @brief Definition of a "world" implementation.
+        /// @see World.
+        class WorldImpl
+        {
+         public:
+            /// @brief Bodies container type.
+            using Bodies = std::vector<BodyID>;
+
+            /// @brief Contacts container type.
+            using Contacts = std::vector<KeyedContactPtr>;
+
+            /// @brief Joints container type.
+            /// @note Cannot be container of Joint instances since joints are polymorphic types.
+            using Joints = std::vector<JointID>;
+
+            /// @brief Body joints container type.
+            using BodyJoints = std::vector<std::pair<BodyID, JointID>>;
+
+            /// @brief Fixtures container type.
+            using Fixtures = std::vector<FixtureID>;
+
+            using FixtureProxies = std::vector<FixtureProxy>;
+
+            using FixtureListener = std::function<void(FixtureID)>;
+            using JointListener = std::function<void(JointID)>;
+            using ContactListener = std::function<void(ContactID)>;
+            using ManifoldContactListener = std::function<void(ContactID, const Manifold&)>;
+            using ImpulsesContactListener = std::function<void(ContactID, const ContactImpulsesList&, unsigned)>;
+
+            struct ContactUpdateConf;
+
+            /// @brief Constructs a world implementation for a world.
+            /// @param def A customized world configuration or its default value.
+            /// @note A lot more configurability can be had via the <code>StepConf</code>
+            ///   data that's given to the world's <code>Step</code> method.
+            /// @throws InvalidArgument if the given max vertex radius is less than the min.
+            /// @see Step.
+            explicit WorldImpl(const WorldConf& def = GetDefaultWorldConf());
+
+            /// @brief Copy constructor.
+            WorldImpl(const WorldImpl& other) = default;
+
+            WorldImpl& operator=(const WorldImpl& other) = default;
+
+            /// @brief Destructor.
+            /// @details All physics entities are destroyed and all dynamically allocated memory
+            ///    is released.
+            ~WorldImpl() noexcept;
+
+            /// @brief Clears this world.
+            /// @post The contents of this world have all been destroyed and this world's internal
+            ///   state reset as though it had just been constructed.
+            void Clear() noexcept;
+
+            /// @brief Register a destruction listener for fixtures.
+            void SetFixtureDestructionListener(FixtureListener listener) noexcept;
+
+            /// @brief Register a destruction listener for joints.
+            void SetJointDestructionListener(JointListener listener) noexcept;
+
+            /// @brief Register a begin contact event listener.
+            void SetBeginContactListener(ContactListener listener) noexcept;
+
+            /// @brief Register an end contact event listener.
+            void SetEndContactListener(ContactListener listener) noexcept;
+
+            /// @brief Register a pre-solve contact event listener.
+            void SetPreSolveContactListener(ManifoldContactListener listener) noexcept;
+
+            /// @brief Register a post-solve contact event listener.
+            void SetPostSolveContactListener(ImpulsesContactListener listener) noexcept;
+
+            /// @brief Creates a rigid body with the given configuration.
+            /// @warning This function should not be used while the world is locked &mdash; as it is
+            ///   during callbacks. If it is, it will throw an exception or abort your program.
+            /// @note No references to the configuration are retained. Its value is copied.
+            /// @post The created body will be present in the range returned from the
+            ///   <code>GetBodies()</code> method.
+            /// @param def A customized body configuration or its default value.
+            /// @return Identifier of the newly created body which can later be destroyed by calling
+            ///   the <code>Destroy(BodyID)</code> method.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @throws LengthError if this operation would create more than <code>MaxBodies</code>.
+            /// @see Destroy(BodyID), GetBodies.
+            /// @see PhysicalEntities.
+            BodyID CreateBody(const BodyConf& def = GetDefaultBodyConf());
+
+            /// @brief Destroys the given body.
+            /// @details Destroys a given body that had previously been created by a call to this
+            ///   world's <code>CreateBody(const BodyConf&)</code> method.
+            /// @warning This automatically deletes all associated shapes and joints.
+            /// @warning This function is locked during callbacks.
+            /// @warning Behavior is undefined if given a null body.
+            /// @warning Behavior is undefined if the passed body was not created by this world.
+            /// @note This function is locked during callbacks.
+            /// @post The destroyed body will no longer be present in the range returned from the
+            ///   <code>GetBodies()</code> method.
+            /// @post None of the body's fixtures will be present in the fixtures-for-proxies
+            ///   collection.
+            /// @param id Body to destroy that had been created by this world.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @see CreateBody(const BodyConf&), GetBodies, GetFixturesForProxies.
+            /// @see PhysicalEntities.
+            void Destroy(BodyID id);
+
+            /// @brief Creates a joint to constrain one or more bodies.
+            /// @warning This function is locked during callbacks.
+            /// @note No references to the configuration are retained. Its value is copied.
+            /// @post The created joint will be present in the range returned from the
+            ///   <code>GetJoints()</code> method.
+            /// @return Identifier for the newly created joint which can later be destroyed by calling
+            ///   the <code>Destroy(JointID)</code> method.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @throws LengthError if this operation would create more than <code>MaxJoints</code>.
+            /// @throws InvalidArgument if the given definition is not allowed.
+            /// @see PhysicalEntities.
+            /// @see Destroy(JointID), GetJoints.
+            JointID CreateJoint(const Joint& def);
+
+            /// @brief Destroys a joint.
+            /// @details Destroys a given joint that had previously been created by a call to this
+            ///   world's <code>CreateJoint(const JointConf&)</code> method.
+            /// @warning This function is locked during callbacks.
+            /// @warning Behavior is undefined if the passed joint was not created by this world.
+            /// @note This may cause the connected bodies to begin colliding.
+            /// @post The destroyed joint will no longer be present in the range returned from the
+            ///   <code>GetJoints()</code> method.
+            /// @param joint Joint to destroy that had been created by this world.
+            /// @throws WrongState if this method is called while the world is locked.
+            /// @see CreateJoint(const JointConf&), GetJoints.
+            /// @see PhysicalEntities.
+            void Destroy(JointID joint);
+
+            /// @brief Steps the world simulation according to the given configuration.
+            ///
+            /// @details
+            /// Performs position and velocity updating, sleeping of non-moving bodies, updating
+            /// of the contacts, and notifying the contact listener of begin-contact, end-contact,
+            /// pre-solve, and post-solve events.
+            ///
+            /// @warning Behavior is undefined if given a negative step time delta.
+            /// @warning Varying the step time delta may lead to non-physical behaviors.
+            ///
+            /// @note Calling this with a zero step time delta results only in fixtures and bodies
+            ///   registered for proxy handling being processed. No physics is performed.
+            /// @note If the given velocity and position iterations are zero, this method doesn't
+            ///   do velocity or position resolutions respectively of the contacting bodies.
+            /// @note While body velocities are updated accordingly (per the sum of forces acting on them),
+            ///   body positions (barring any collisions) are updated as if they had moved the entire time
+            ///   step at those resulting velocities. In other words, a body initially at position 0
+            ///   (<code>p0</code>) going velocity 0 (<code>v0</code>) fast with a sum acceleration of
+            ///   <code>a</code>, after time <code>t</code> and barring any collisions, will have a new
+            ///   velocity (<code>v1</code>) of <code>v0 + (a * t)</code> and a new position
+            ///   (<code>p1</code>) of <code>p0 + v1 * t</code>.
+            ///
+            /// @post Static bodies are unmoved.
+            /// @post Kinetic bodies are moved based on their previous velocities.
+            /// @post Dynamic bodies are moved based on their previous velocities, gravity, applied
+            ///   forces, applied impulses, masses, damping, and the restitution and friction values
+            ///   of their fixtures when they experience collisions.
+            /// @post The bodies for proxies queue will be empty.
+            /// @post The fixtures for proxies queue will be empty.
+            ///
+            /// @param conf Configuration for the simulation step.
+            ///
+            /// @return Statistics for the step.
+            ///
+            /// @throws WrongState if this method is called while the world is locked.
+            ///
+            /// @see GetBodiesForProxies, GetFixturesForProxies.
+            ///
+            StepStats Step(const StepConf& conf);
+
+            /// @brief Gets the world body range for this constant world.
+            /// @details Gets a range enumerating the bodies currently existing within this world.
+            ///   These are the bodies that had been created from previous calls to the
+            ///   <code>CreateBody(const BodyConf&)</code> method that haven't yet been destroyed.
+            /// @return Body range that can be iterated over using its begin and end methods
+            ///   or using ranged-based for-loops.
+            /// @see CreateBody(const BodyConf&).
+            SizedRange<Bodies::const_iterator> GetBodies() const noexcept;
+
+            /// @brief Gets the extent of the currently valid body range.
+            /// @note This is one higher than the maxium BodyID that is in range for body related
+            ///   functions.
+            BodyCounter GetBodyRange() const noexcept;
+
+            /// @brief Gets the bodies-for-proxies range for this world.
+            /// @details Provides insight on what bodies have been queued for proxy processing
+            ///   during the next call to the world step method.
+            /// @see Step.
+            SizedRange<Bodies::const_iterator> GetBodiesForProxies() const noexcept;
+
+            /// @brief Gets the fixtures-for-proxies range for this world.
+            /// @details Provides insight on what fixtures have been queued for proxy processing
+            ///   during the next call to the world step method.
+            /// @see Step.
+            SizedRange<Fixtures::const_iterator> GetFixturesForProxies() const noexcept;
+
+            /// @brief Gets the world joint range.
+            /// @details Gets a range enumerating the joints currently existing within this world.
+            ///   These are the joints that had been created from previous calls to the
+            ///   <code>CreateJoint(const JointConf&)</code> method that haven't yet been destroyed.
+            /// @return World joints sized-range.
+            /// @see CreateJoint(const JointConf&).
+            SizedRange<Joints::const_iterator> GetJoints() const noexcept;
+
+            /// @brief Gets the world contact range.
+            /// @warning contacts are created and destroyed in the middle of a time step.
+            /// Use <code>ContactListener</code> to avoid missing contacts.
+            /// @return World contacts sized-range.
+            SizedRange<Contacts::const_iterator> GetContacts() const noexcept;
+
+            /// @brief Whether or not "step" is complete.
+            /// @details The "step" is completed when there are no more TOI events for the current time step.
+            /// @return <code>true</code> unless sub-stepping is enabled and the step method returned
+            ///   without finishing all of its sub-steps.
+            /// @see GetSubStepping, SetSubStepping.
+            bool IsStepComplete() const noexcept;
+
+            /// @brief Gets whether or not sub-stepping is enabled.
+            /// @see SetSubStepping, IsStepComplete.
+            bool GetSubStepping() const noexcept;
+
+            /// @brief Enables/disables single stepped continuous physics.
+            /// @note This is not normally used. Enabling sub-stepping is meant for testing.
+            /// @post The <code>GetSubStepping()</code> method will return the value this method was
+            ///   called with.
+            /// @see IsStepComplete, GetSubStepping.
+            void SetSubStepping(bool flag) noexcept;
+
+            /// @brief Gets access to the broad-phase dynamic tree information.
+            const DynamicTree& GetTree() const noexcept;
+
+            /// @brief Is the world locked (in the middle of a time step).
+            bool IsLocked() const noexcept;
+
+            /// @brief Shifts the world origin.
+            /// @note Useful for large worlds.
+            /// @note The body shift formula is: <code>position -= newOrigin</code>.
+            /// @post The "origin" of this world's bodies, joints, and the board-phase dynamic tree
+            ///   have been translated per the shift amount and direction.
+            /// @param newOrigin the new origin with respect to the old origin
+            /// @throws WrongState if this method is called while the world is locked.
+            void ShiftOrigin(Length2 newOrigin);
+
+            /// @brief Gets the minimum vertex radius that shapes in this world can be.
+            Length GetMinVertexRadius() const noexcept;
+
+            /// @brief Gets the maximum vertex radius that shapes in this world can be.
+            Length GetMaxVertexRadius() const noexcept;
+
+            /// @brief Gets the inverse delta time.
+            /// @details Gets the inverse delta time that was set on construction or assignment, and
+            ///   updated on every call to the <code>Step()</code> method having a non-zero delta-time.
+            /// @see Step.
+            Frequency GetInvDeltaTime() const noexcept;
+
+            /// @brief Re-filter the fixture.
+            /// @note Call this if you want to establish collision that was previously disabled by
+            ///   <code>ShouldCollide(const Fixture&, const Fixture&)</code>.
+            /// @see bool ShouldCollide(const Fixture& fixtureA, const Fixture& fixtureB)
+            void Refilter(FixtureID id);
+
+            /// @brief Sets the contact filtering data.
+            /// @note This won't update contacts until the next time step when either parent body
+            ///    is speedable and awake.
+            /// @note This automatically calls <code>Refilter</code>.
+            void SetFilterData(FixtureID id, Filter filter);
+
+            /// @brief Sets the type of the given body.
+            /// @note This may alter the body's mass and velocity.
+            /// @throws WrongState if this method is called while the world is locked.
+            void SetType(BodyID id, playrho::BodyType type);
+
+            /// @brief Creates a fixture with the given parameters.
+            /// @details Creates a fixture for attaching a shape and other characteristics to the
+            ///   given body. Fixtures automatically go away when the body is destroyed. Fixtures can
+            ///   also be manually removed and destroyed using the
+            ///   <code>Destroy(Fixture*, bool)</code>, or <code>DestroyFixtures()</code> methods.
+            ///
+            /// @note This function should not be called if the world is locked.
+            /// @warning This function is locked during callbacks.
+            ///
+            /// @post After creating a new fixture, it will show up in the fixture enumeration
+            ///   returned by the <code>GetFixtures()</code> methods.
+            ///
+            /// @param body Body to associated new fixture with.
+            /// @param shape Shareable shape definition.
+            ///   Its vertex radius must be less than the minimum or more than the maximum allowed by
+            ///   the body's world.
+            /// @param def Initial fixture settings.
+            ///   Friction and density must be >= 0.
+            ///   Restitution must be > -infinity and < infinity.
+            /// @param resetMassData Whether or not to reset the mass data of the body.
+            ///
+            /// @return Identifier for the created fixture.
+            ///
+            /// @throws WrongState if called while the world is "locked".
+            /// @throws InvalidArgument if called for a shape with a vertex radius less than the
+            ///    minimum vertex radius.
+            /// @throws InvalidArgument if called for a shape with a vertex radius greater than the
+            ///    maximum vertex radius.
+            ///
+            /// @see Destroy, GetFixtures
+            /// @see PhysicalEntities
+            ///
+            FixtureID CreateFixture(BodyID body, const Shape& shape,
+                                    const FixtureConf& def = GetDefaultFixtureConf(),
+                                    bool resetMassData = true);
+
+            /// @brief Destroys a fixture.
+            /// @details This removes the fixture from the broad-phase and destroys all contacts
+            ///   associated with this fixture.
+            ///   All fixtures attached to a body are implicitly destroyed when the body is destroyed.
+            /// @warning This function is locked during callbacks.
+            /// @note Make sure to explicitly call <code>Body::ResetMassData</code> after fixtures have
+            ///   been destroyed.
+            /// @param fixture the fixture to be removed.
+            /// @param resetMassData Whether or not to reset the mass data of the associated body.
+            /// @see Body::ResetMassData.
+            /// @throws WrongState if this method is called while the world is locked.
+            bool Destroy(FixtureID fixture, bool resetMassData = true);
+
+            /// @brief Destroys fixtures of the given body.
+            /// @details Destroys all of the fixtures previously created for this body by the
+            ///   <code>CreateFixture(const Shape&, const FixtureConf&, bool)</code> method.
+            /// @note This unconditionally calls the <code>ResetMassData()</code> method.
+            /// @post After this call, no fixtures will show up in the fixture enumeration
+            ///   returned by the <code>GetFixtures()</code> methods.
+            /// @see CreateFixture, GetFixtures, ResetMassData.
+            /// @see PhysicalEntities
+            void DestroyFixtures(BodyID id);
+
+            /// @brief Sets the enabled state of the body.
+            ///
+            /// @details A disabled body is not simulated and cannot be collided with or woken up.
+            ///   If you pass a flag of true, all fixtures will be added to the broad-phase.
+            ///   If you pass a flag of false, all fixtures will be removed from the broad-phase
+            ///   and all contacts will be destroyed. Fixtures and joints are otherwise unaffected.
+            ///
+            /// @note A disabled body is still owned by a World object and remains in the world's
+            ///   body container.
+            /// @note You may continue to create/destroy fixtures and joints on disabled bodies.
+            /// @note Fixtures on a disabled body are implicitly disabled and will not participate in
+            ///   collisions, ray-casts, or queries.
+            /// @note Joints connected to a disabled body are implicitly disabled.
+            ///
+            /// @throws WrongState If call would change body's state when world is locked.
+            ///
+            /// @post <code>IsEnabled()</code> returns the state given to this function.
+            ///
+            /// @see IsEnabled.
+            ///
+            void SetEnabled(BodyID id, bool flag);
+
+            /// @brief Computes the mass data of the identified body.
+            MassData ComputeMassData(BodyID id) const;
+
+            /// @brief Set the mass properties to override the mass properties of the fixtures.
+            /// @note This changes the center of mass position.
+            /// @note Creating or destroying fixtures can also alter the mass.
+            /// @note This function has no effect if the body isn't dynamic.
+            /// @param id Body to set mass data for.
+            /// @param massData the mass properties.
+            void SetMassData(BodyID id, const MassData& massData);
+
+            /// @brief Sets the transformation of the body.
+            /// @details This instantly adjusts the body to have the new transformation.
+            /// @warning Manipulating a body's transform can cause non-physical behavior!
+            /// @warning Behavior is undefined if the value is invalid.
+            /// @note Associated contacts may be flagged for updating on the next call to WorldImpl::Step.
+            /// @throws WrongState If call would change body's state when world is locked.
+            void SetTransformation(BodyID id, Transformation xfm);
+
+            FixtureCounter GetShapeCount() const noexcept;
+
+            const Fixture& GetFixture(FixtureID id) const;
+            Fixture& GetFixture(FixtureID id);
+
+            /// @throws std::out_of_range if given an invalid id.
+            const Body& GetBody(BodyID id) const;
+
+            /// @throws std::out_of_range if given an invalid id.
+            Body& GetBody(BodyID id);
+
+            const Contact& GetContact(ContactID id) const;
+            Contact& GetContact(ContactID id);
+
+            const Manifold& GetManifold(ContactID id) const;
+            Manifold& GetManifold(ContactID id);
+
+            const Joint& GetJoint(JointID id) const;
+            Joint& GetJoint(JointID id);
+
+            void SetJoint(JointID id, const Joint& def);
+
+            /// @brief Sets whether the fixture is a sensor or not.
+            /// @see IsSensor(FixtureID id).
+            void SetSensor(FixtureID id, bool value);
+
+         private:
+            /// @brief Flags type data type.
+            using FlagsType = std::uint32_t;
+
+            /// @brief Proxy ID type alias.
+            using ProxyId = DynamicTree::Size;
+
+            /// @brief Contact key queue type alias.
+            using ContactKeyQueue = std::vector<ContactKey>;
+
+            /// @brief Proxy queue type alias.
+            using ProxyQueue = std::vector<ProxyId>;
+
+            /// @brief Flag enumeration.
+            enum Flag : FlagsType
+            {
+                /// New fixture.
+                e_newFixture = 0x0001,
+
+                /// Locked.
+                e_locked = 0x0002,
+
+                /// Sub-stepping.
+                e_substepping = 0x0020,
+
+                /// Step complete. @details Used for sub-stepping. @see e_substepping.
+                e_stepComplete = 0x0040,
+            };
+
+            /// @brief Solves the step.
+            /// @details Finds islands, integrates and solves constraints, solves position constraints.
+            /// @note This may miss collisions involving fast moving bodies and allow them to tunnel
+            ///   through each other.
+            RegStepStats SolveReg(const StepConf& conf);
+
+            /// @brief Solves the given island (regularly).
+            ///
+            /// @details This:
+            ///   1. Updates every island-body's <code>sweep.pos0</code> to its <code>sweep.pos1</code>.
+            ///   2. Updates every island-body's <code>sweep.pos1</code> to the new normalized "solved"
+            ///      position for it.
+            ///   3. Updates every island-body's velocity to the new accelerated, dampened, and "solved"
+            ///      velocity for it.
+            ///   4. Synchronizes every island-body's transform (by updating it to transform one of the
+            ///      body's sweep).
+            ///   5. Reports to the listener (if non-null).
+            ///
+            /// @param conf Time step configuration information.
+            /// @param island Island of bodies, contacts, and joints to solve for. Must contain at least
+            ///   one body, contact, or joint.
+            ///
+            /// @warning Behavior is undefined if the given island doesn't have at least one body,
+            ///   contact, or joint.
+            ///
+            /// @return Island solver results.
+            ///
+            IslandStats SolveRegIslandViaGS(const StepConf& conf, const Island& island);
+
+            /// @brief Adds to the island based off of a given "seed" body.
+            /// @post Contacts are listed in the island in the order that bodies provide those contacts.
+            /// @post Joints are listed the island in the order that bodies provide those joints.
+            void AddToIsland(Island& island, BodyID seed,
+                             BodyCounter& remNumBodies,
+                             ContactCounter& remNumContacts,
+                             JointCounter& remNumJoints);
+
+            /// @brief Body stack.
+            using BodyStack = std::stack<BodyID, std::vector<BodyID>>;
+
+            /// @brief Adds to the island.
+            void AddToIsland(Island& island, BodyStack& stack,
+                             BodyCounter& remNumBodies,
+                             ContactCounter& remNumContacts,
+                             JointCounter& remNumJoints);
+
+            /// @brief Adds contacts to the island.
+            void AddContactsToIsland(Island& island, BodyStack& stack,
+                                     SizedRange<Contacts::const_iterator> contacts,
+                                     BodyID bodyID);
+
+            /// @brief Adds joints to the island.
+            void AddJointsToIsland(Island& island, BodyStack& stack,
+                                   SizedRange<BodyJoints::const_iterator> joints);
+
+            /// @brief Removes <em>unspeedables</em> from the is <em>is-in-island</em> state.
+            static Bodies::size_type RemoveUnspeedablesFromIslanded(const std::vector<BodyID>& bodies,
+                                                                    const ArrayAllocator<Body>& buffer,
+                                                                    std::vector<bool>& islanded);
+
+            /// @brief Solves the step using successive time of impact (TOI) events.
+            /// @details Used for continuous physics.
+            /// @note This is intended to detect and prevent the tunneling that the faster Solve method
+            ///    may miss.
+            /// @param conf Time step configuration to use.
+            ToiStepStats SolveToi(const StepConf& conf);
+
+            /// @brief Solves collisions for the given time of impact.
+            ///
+            /// @param contactID Identifier of contact to solve for.
+            /// @param conf Time step configuration to solve for.
+            ///
+            /// @note Precondition 1: there is no contact having a lower TOI in this time step that has
+            ///   not already been solved for.
+            /// @note Precondition 2: there is not a lower TOI in the time step for which collisions have
+            ///   not already been processed.
+            ///
+            IslandStats SolveToi(ContactID contactID, const StepConf& conf);
+
+            /// @brief Solves the time of impact for bodies 0 and 1 of the given island.
+            ///
+            /// @details This:
+            ///   1. Updates position 0 of the sweeps of bodies 0 and 1.
+            ///   2. Updates position 1 of the sweeps, the transforms, and the velocities of the other
+            ///      bodies in this island.
+            ///
+            /// @pre <code>island.bodies</code> contains at least two bodies, the first two of which
+            ///   are bodies 0 and 1.
+            /// @pre <code>island.bodies</code> contains appropriate other bodies of the contacts of
+            ///   the two bodies.
+            /// @pre <code>island.contacts</code> contains the contact that specified the two identified
+            ///   bodies.
+            /// @pre <code>island.contacts</code> contains appropriate other contacts of the two bodies.
+            ///
+            /// @param conf Time step configuration information.
+            /// @param island Island to do time of impact solving for.
+            ///
+            /// @return Island solver results.
+            ///
+            IslandStats SolveToiViaGS(const Island& island, const StepConf& conf);
+
+            /// @brief Updates the given body.
+            /// @details Updates the given body's sweep position 1, and its transformation.
+            /// @param body Body to update.
+            /// @param pos New position to set the given body to.
+            /// @return <code>true</code> if body's contacts should be flagged for updating,
+            ///   otherwise <code>false</code>.
+            static bool UpdateBody(Body& body, const Position& pos);
+
+            /// @brief Process contacts output.
+            struct ProcessContactsOutput
+            {
+                ContactCounter contactsUpdated = 0;///< Contacts updated.
+                ContactCounter contactsSkipped = 0;///< Contacts skipped.
+            };
+
+            /// @brief Processes the contacts of a given body for TOI handling.
+            /// @details This does the following:
+            ///   1. Advances the appropriate associated other bodies to the given TOI (advancing
+            ///      their sweeps and synchronizing their transforms to their new sweeps).
+            ///   2. Updates the contact manifolds and touching statuses and notifies listener (if one given) of
+            ///      the appropriate contacts of the body.
+            ///   3. Adds those contacts that are still enabled and still touching to the given island
+            ///      (or resets the other bodies advancement).
+            ///   4. Adds to the island, those other bodies that haven't already been added of the contacts that got added.
+            /// @note Precondition: there should be no lower TOI for which contacts have not already been processed.
+            /// @param[in,out] id Identifier of the dynamic/accelerable body to process contacts for.
+            /// @param[in,out] island Island. On return this may contain additional contacts or bodies.
+            /// @param[in] toi Time of impact (TOI). Value between 0 and 1.
+            /// @param[in] conf Step configuration data.
+            ProcessContactsOutput ProcessContactsForTOI(BodyID id, Island& island, Real toi,
+                                                        const StepConf& conf);
+
+            /// @brief Removes the given body from this world.
+            void Remove(BodyID id) noexcept;
+
+            /// @brief Updates associated bodies and contacts for specified joint's addition.
+            void Add(JointID j, bool flagForFiltering = false);
+
+            /// @brief Updates associated bodies and contacts for specified joint's removal.
+            void Remove(JointID id) noexcept;
+
+            /// @brief Sets the step complete state.
+            /// @post <code>IsStepComplete()</code> will return the value set.
+            /// @see IsStepComplete.
+            void SetStepComplete(bool value) noexcept;
+
+            /// @brief Sets the allow sleeping state.
+            void SetAllowSleeping() noexcept;
+
+            /// @brief Unsets the allow sleeping state.
+            void UnsetAllowSleeping() noexcept;
+
+            /// @brief Update contacts statistics.
+            struct UpdateContactsStats
+            {
+                /// @brief Number of contacts ignored (because both bodies were asleep).
+                ContactCounter ignored = 0;
+
+                /// @brief Number of contacts updated.
+                ContactCounter updated = 0;
+
+                /// @brief Number of contacts skipped because they weren't marked as needing updating.
+                ContactCounter skipped = 0;
+            };
+
+            /// @brief Destroy contacts statistics.
+            struct DestroyContactsStats
+            {
+                ContactCounter ignored = 0;///< Ignored.
+                ContactCounter erased = 0; ///< Erased.
+            };
+
+            /// @brief Contact TOI data.
+            struct ContactToiData
+            {
+                ContactID contact = InvalidContactID;            ///< Contact for which the time of impact is relevant.
+                Real toi = std::numeric_limits<Real>::infinity();///< Time of impact (TOI) as a fractional value between 0 and 1.
+                ContactCounter simultaneous = 0;                 ///< Count of simultaneous contacts at this TOI.
+            };
+
+            /// @brief Update contacts data.
+            struct UpdateContactsData
+            {
+                ContactCounter numAtMaxSubSteps = 0;///< # at max sub-steps (lower the better).
+                ContactCounter numUpdatedTOI = 0;   ///< # updated TOIs (made valid).
+                ContactCounter numValidTOI = 0;     ///< # already valid TOIs.
+
+                /// @brief Distance iterations type alias.
+                using dist_iter_type = std::remove_const<decltype(DefaultMaxDistanceIters)>::type;
+
+                /// @brief TOI iterations type alias.
+                using toi_iter_type = std::remove_const<decltype(DefaultMaxToiIters)>::type;
+
+                /// @brief Root iterations type alias.
+                using root_iter_type = std::remove_const<decltype(DefaultMaxToiRootIters)>::type;
+
+                dist_iter_type maxDistIters = 0;///< Max distance iterations.
+                toi_iter_type maxToiIters = 0;  ///< Max TOI iterations.
+                root_iter_type maxRootIters = 0;///< Max root iterations.
+            };
+
+            /// @brief Updates the contact times of impact.
+            static UpdateContactsData UpdateContactTOIs(ArrayAllocator<Contact>& contactBuffer,
+                                                        ArrayAllocator<Body>& bodyBuffer,
+                                                        const ArrayAllocator<Fixture>& fixtureBuffer,
+                                                        const Contacts& contacts, const StepConf& conf);
+
+            /// @brief Gets the soonest contact.
+            /// @details This finds the contact with the lowest (soonest) time of impact.
+            /// @return Contact with the least time of impact and its time of impact, or null contact.
+            ///  A non-null contact will be enabled, not have sensors, be active, and impenetrable.
+            static ContactToiData GetSoonestContact(const Contacts& contacts, const ArrayAllocator<Contact>& buffer) noexcept;
+
+            /// @brief Determines whether this world has new fixtures.
+            bool HasNewFixtures() const noexcept;
+
+            /// @brief Unsets the new fixtures state.
+            void UnsetNewFixtures() noexcept;
+
+            /// @brief Finds new contacts.
+            /// @details Finds and adds new valid contacts to the contacts container.
+            /// @note The new contacts will all have overlapping AABBs.
+            ContactCounter FindNewContacts();
+
+            /// @brief Processes the narrow phase collision for the contacts collection.
+            /// @details
+            /// This finds and destroys the contacts that need filtering and no longer should collide or
+            /// that no longer have AABB-based overlapping fixtures. Those contacts that persist and
+            /// have active bodies (either or both) get their Update methods called with the current
+            /// contact listener as its argument.
+            /// Essentially this really just purges contacts that are no longer relevant.
+            DestroyContactsStats DestroyContacts(Contacts& contacts);
+
+            /// @brief Update contacts.
+            UpdateContactsStats UpdateContacts(const StepConf& conf);
+
+            /// @brief Destroys the given contact and removes it from its container.
+            /// @details This updates the contacts container, returns the memory to the allocator,
+            ///   and decrements the contact manager's contact count.
+            /// @param contact Contact to destroy.
+            /// @param from From body.
+            void Destroy(ContactID contact, Body* from);
+
+            /// @brief Adds a contact for the proxies identified by the key if appropriate.
+            /// @details Adds a new contact object to represent a contact between proxy A and proxy B
+            /// if all of the following are true:
+            ///   1. The bodies of the fixtures of the proxies are not the one and the same.
+            ///   2. No contact already exists for these two proxies.
+            ///   3. The bodies of the proxies should collide (according to <code>ShouldCollide</code>).
+            ///   4. The contact filter says the fixtures of the proxies should collide.
+            ///   5. There exists a contact-create function for the pair of shapes of the proxies.
+            /// @post The size of the <code>contacts</code> collection is one greater-than it was
+            ///   before this method is called if it returns <code>true</code>.
+            /// @param key ID's of dynamic tree entries identifying the fixture proxies involved.
+            /// @return <code>true</code> if a new contact was indeed added (and created),
+            ///   else <code>false</code>.
+            /// @see bool ShouldCollide(const Body& lhs, const Body& rhs) noexcept.
+            bool Add(ContactKey key);
+
+            /// @brief Destroys the given contact.
+            static void InternalDestroy(ContactID contact,
+                                        ArrayAllocator<Body>& bodyBuffer,
+                                        ArrayAllocator<Contact>& contactBuffer,
+                                        ArrayAllocator<Manifold>& manifoldBuffer,
+                                        ContactListener listener, Body* from = nullptr);
+
+            /// @brief Creates proxies for every child of the given fixture's shape.
+            /// @note This sets the proxy count to the child count of the shape.
+            static void CreateProxies(FixtureID id, Fixture& fixture, const Transformation& xfm,
+                                      ProxyQueue& proxies, DynamicTree& tree, Length aabbExtension);
+
+            /// @brief Touches each proxy of the given fixture.
+            /// @note This sets things up so that pairs may be created for potentially new contacts.
+            static void InternalTouchProxies(ProxyQueue& proxies, const Fixture& fixture) noexcept;
+
+            /// @brief Synchronizes the given body.
+            /// @details This updates the broad phase dynamic tree data for all of the given
+            ///   body's fixtures.
+            ContactCounter Synchronize(const Body& body,
+                                       const Transformation& xfm1, const Transformation& xfm2,
+                                       Real multiplier, Length extension);
+
+            /// @brief Synchronizes the given fixture.
+            /// @details This updates the broad phase dynamic tree data for all of the given
+            ///   fixture shape's children.
+            ContactCounter Synchronize(const Fixture& fixture,
+                                       const Transformation& xfm1, const Transformation& xfm2,
+                                       Length2 displacement, Length extension);
+
+            /// @brief Creates and destroys proxies.
+            void CreateAndDestroyProxies(Length extension);
+
+            /// @brief Synchronizes proxies of the bodies for proxies.
+            PreStepStats::counter_type SynchronizeProxies(const StepConf& conf);
+
+            /// @brief Updates the touching related state and notifies listener (if one given).
+            ///
+            /// @note Ideally this method is only called when a dependent change has occurred.
+            /// @note Touching related state depends on the following data:
+            ///   - The fixtures' sensor states.
+            ///   - The fixtures bodies' transformations.
+            ///   - The <code>maxCirclesRatio</code> per-step configuration state *OR* the
+            ///     <code>maxDistanceIters</code> per-step configuration state.
+            ///
+            /// @param id Identifies the contact to update.
+            /// @param conf Per-step configuration information.
+            ///
+            /// @see GetManifold, IsTouching
+            ///
+            void Update(ContactID id, const ContactUpdateConf& conf);
+
+            /******** Member variables. ********/
+
+            ArrayAllocator<Body> m_bodyBuffer;
+            ArrayAllocator<Fixture> m_fixtureBuffer;
+            ArrayAllocator<Joint> m_jointBuffer;
+            ArrayAllocator<Contact> m_contactBuffer;
+            ArrayAllocator<Manifold> m_manifoldBuffer;
+
+            DynamicTree m_tree;///< Dynamic tree.
+
+            ContactKeyQueue m_proxyKeys;  ///< Proxy keys.
+            ProxyQueue m_proxies;         ///< Proxies queue.
+            Fixtures m_fixturesForProxies;///< Fixtures for proxies queue.
+            Bodies m_bodiesForProxies;    ///< Bodies for proxies queue.
+
+            Bodies m_bodies;///< Body collection.
+
+            Joints m_joints;///< Joint collection.
+
+            /// @brief Container of contacts.
+            /// @note In the <em>add pair</em> stress-test, 401 bodies can have some 31000 contacts
+            ///   during a given time step.
+            Contacts m_contacts;
+
+            Island m_island;///< Island buffer.
+            std::vector<bool> m_islandedBodies;
+            std::vector<bool> m_islandedContacts;
+            std::vector<bool> m_islandedJoints;
+
+            FixtureListener m_fixtureDestructionListener;
+            JointListener m_jointDestructionListener;
+            ContactListener m_beginContactListener;
+            ContactListener m_endContactListener;
+            ManifoldContactListener m_preSolveContactListener;
+            ImpulsesContactListener m_postSolveContactListener;
+
+            FlagsType m_flags = e_stepComplete;///< Flags.
+
+            /// Inverse delta-t from previous step.
+            /// @details Used to compute time step ratio to support a variable time step.
+            /// @note 4-bytes large.
+            /// @see Step.
+            Frequency m_inv_dt0 = 0;
+
+            /// @brief Minimum vertex radius.
+            Positive<Length> m_minVertexRadius;
+
+            /// @brief Maximum vertex radius.
+            /// @details
+            /// This is the maximum shape vertex radius that any bodies' of this world should create
+            /// fixtures for. Requests to create fixtures for shapes with vertex radiuses bigger than
+            /// this must be rejected. As an upper bound, this value prevents shapes from getting
+            /// associated with this world that would otherwise not be able to be simulated due to
+            /// numerical issues. It can also be set below this upper bound to constrain the differences
+            /// between shape vertex radiuses to possibly more limited visual ranges.
+            Positive<Length> m_maxVertexRadius;
+        };
+
+        inline SizedRange<WorldImpl::Bodies::const_iterator> WorldImpl::GetBodies() const noexcept
+        {
+            return {begin(m_bodies), end(m_bodies), size(m_bodies)};
+        }
+
+        inline SizedRange<WorldImpl::Bodies::const_iterator> WorldImpl::GetBodiesForProxies() const noexcept
+        {
+            return {cbegin(m_bodiesForProxies), cend(m_bodiesForProxies), size(m_bodiesForProxies)};
+        }
+
+        inline SizedRange<WorldImpl::Fixtures::const_iterator> WorldImpl::GetFixturesForProxies() const noexcept
+        {
+            return {cbegin(m_fixturesForProxies), cend(m_fixturesForProxies), size(m_fixturesForProxies)};
+        }
+
+        inline SizedRange<WorldImpl::Joints::const_iterator> WorldImpl::GetJoints() const noexcept
+        {
+            return {begin(m_joints), end(m_joints), size(m_joints)};
+        }
+
+        inline SizedRange<WorldImpl::Contacts::const_iterator> WorldImpl::GetContacts() const noexcept
+        {
+            return {begin(m_contacts), end(m_contacts), size(m_contacts)};
+        }
+
+        inline bool WorldImpl::IsLocked() const noexcept
+        {
+            return (m_flags & e_locked) == e_locked;
+        }
+
+        inline bool WorldImpl::IsStepComplete() const noexcept
+        {
+            return (m_flags & e_stepComplete) != 0u;
+        }
+
+        inline void WorldImpl::SetStepComplete(bool value) noexcept
+        {
+            if (value)
+            {
+                m_flags |= e_stepComplete;
+            }
+            else
+            {
+                m_flags &= ~e_stepComplete;
+            }
+        }
+
+        inline bool WorldImpl::GetSubStepping() const noexcept
+        {
+            return (m_flags & e_substepping) != 0u;
+        }
+
+        inline void WorldImpl::SetSubStepping(bool flag) noexcept
+        {
+            if (flag)
+            {
+                m_flags |= e_substepping;
+            }
+            else
+            {
+                m_flags &= ~e_substepping;
+            }
+        }
+
+        inline bool WorldImpl::HasNewFixtures() const noexcept
+        {
+            return (m_flags & e_newFixture) != 0u;
+        }
+
+        inline void WorldImpl::UnsetNewFixtures() noexcept
+        {
+            m_flags &= ~e_newFixture;
+        }
+
+        inline Length WorldImpl::GetMinVertexRadius() const noexcept
+        {
+            return m_minVertexRadius;
+        }
+
+        inline Length WorldImpl::GetMaxVertexRadius() const noexcept
+        {
+            return m_maxVertexRadius;
+        }
+
+        inline Frequency WorldImpl::GetInvDeltaTime() const noexcept
+        {
+            return m_inv_dt0;
+        }
+
+        inline const DynamicTree& WorldImpl::GetTree() const noexcept
+        {
+            return m_tree;
+        }
+
+        inline void WorldImpl::SetFixtureDestructionListener(FixtureListener listener) noexcept
+        {
+            m_fixtureDestructionListener = std::move(listener);
+        }
+
+        inline void WorldImpl::SetJointDestructionListener(JointListener listener) noexcept
+        {
+            m_jointDestructionListener = std::move(listener);
+        }
+
+        inline void WorldImpl::SetBeginContactListener(ContactListener listener) noexcept
+        {
+            m_beginContactListener = std::move(listener);
+        }
+
+        inline void WorldImpl::SetEndContactListener(ContactListener listener) noexcept
+        {
+            m_endContactListener = std::move(listener);
+        }
+
+        inline void WorldImpl::SetPreSolveContactListener(ManifoldContactListener listener) noexcept
+        {
+            m_preSolveContactListener = std::move(listener);
+        }
+
+        inline void WorldImpl::SetPostSolveContactListener(ImpulsesContactListener listener) noexcept
+        {
+            m_postSolveContactListener = std::move(listener);
+        }
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_WORLDIMPL_HPP

--- a/PlayRho/Dynamics/WorldImplBody.cpp
+++ b/PlayRho/Dynamics/WorldImplBody.cpp
@@ -21,228 +21,230 @@
 
 #include <PlayRho/Dynamics/WorldImplBody.hpp>
 
-#include <PlayRho/Dynamics/WorldImpl.hpp>
-#include <PlayRho/Dynamics/WorldImplFixture.hpp> // for GetDensity, GetMassData
 #include <PlayRho/Dynamics/Body.hpp>
 #include <PlayRho/Dynamics/BodyConf.hpp>
-#include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/Fixture.hpp>
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
 #include <PlayRho/Dynamics/MovementConf.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
+#include <PlayRho/Dynamics/WorldImpl.hpp>
+#include <PlayRho/Dynamics/WorldImplFixture.hpp>// for GetDensity, GetMassData
 
 #include <PlayRho/Dynamics/Contacts/Contact.hpp>
 
 #include <PlayRho/Common/DynamicMemory.hpp>
 
 #include <algorithm>
-#include <new>
 #include <functional>
-#include <type_traits>
 #include <memory>
+#include <new>
+#include <type_traits>
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-BodyCounter GetBodyRange(const WorldImpl& world) noexcept
+namespace playrho
 {
-    return world.GetBodyRange();
-}
-
-void Destroy(WorldImpl& world, BodyID id)
-{
-    world.Destroy(id);
-}
-
-BodyConf GetBodyConf(const WorldImpl& world, BodyID id)
-{
-    return GetBodyConf(world.GetBody(id));
-}
-
-BodyType GetType(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetType();
-}
-
-void SetType(WorldImpl& world, BodyID id, BodyType value)
-{
-    world.SetType(id, value);
-}
-
-bool IsImpenetrable(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsImpenetrable();
-}
-
-void SetImpenetrable(WorldImpl& world, BodyID id)
-{
-    world.GetBody(id).SetImpenetrable();
-}
-
-void UnsetImpenetrable(WorldImpl& world, BodyID id)
-{
-    world.GetBody(id).UnsetImpenetrable();
-}
-
-bool IsSleepingAllowed(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsSleepingAllowed();
-}
-
-void SetSleepingAllowed(WorldImpl& world, BodyID id, bool value)
-{
-    world.GetBody(id).SetSleepingAllowed(value);
-}
-
-Angle GetAngle(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetAngle();
-}
-
-Transformation GetTransformation(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetTransformation();
-}
-
-void SetTransformation(WorldImpl& world, BodyID id, Transformation xfm)
-{
-    world.SetTransformation(id, xfm);
-}
-
-Velocity GetVelocity(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetVelocity();
-}
-
-void SetVelocity(WorldImpl& world, BodyID id, const Velocity& value)
-{
-    world.GetBody(id).SetVelocity(value);
-}
-
-void UnsetAwake(WorldImpl& world, BodyID id)
-{
-    world.GetBody(id).UnsetAwake();
-}
-
-void SetAwake(WorldImpl& world, BodyID id)
-{
-    world.GetBody(id).SetAwake();
-}
-
-bool IsAwake(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsAwake();
-}
-
-Length2 GetLocalCenter(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetLocalCenter();
-}
-
-Length2 GetWorldCenter(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetWorldCenter();
-}
-
-LinearAcceleration2 GetLinearAcceleration(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetLinearAcceleration();
-}
-
-AngularAcceleration GetAngularAcceleration(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetAngularAcceleration();
-}
-
-void SetAcceleration(WorldImpl& world, BodyID id, LinearAcceleration2 linear, AngularAcceleration angular)
-{
-    ::playrho::d2::SetAcceleration(world.GetBody(id), linear, angular);
-}
-
-void SetAcceleration(WorldImpl& world, BodyID id, Acceleration value)
-{
-    ::playrho::d2::SetAcceleration(world.GetBody(id), value);
-}
-
-void SetAcceleration(WorldImpl& world, BodyID id, LinearAcceleration2 value)
-{
-    ::playrho::d2::SetAcceleration(world.GetBody(id), value);
-}
-
-void SetAcceleration(WorldImpl& world, BodyID id, AngularAcceleration value)
-{
-    ::playrho::d2::SetAcceleration(world.GetBody(id), value);
-}
-
-MassData ComputeMassData(const WorldImpl& world, BodyID id)
-{
-    return world.ComputeMassData(id);
-}
-
-void SetMassData(WorldImpl& world, BodyID id, const MassData& massData)
-{
-    world.SetMassData(id, massData);
-}
-
-InvMass GetInvMass(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetInvMass();
-}
-
-InvRotInertia GetInvRotInertia(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetInvRotInertia();
-}
-
-SizedRange<WorldImpl::BodyJoints::const_iterator> GetJoints(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetJoints();
-}
-
-SizedRange<WorldImpl::Fixtures::const_iterator> GetFixtures(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetFixtures();
-}
-
-void DestroyFixtures(WorldImpl& world, BodyID id)
-{
-    world.DestroyFixtures(id);
-}
-
-bool IsSpeedable(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsSpeedable();
-}
-
-bool IsAccelerable(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsAccelerable();
-}
-
-SizedRange<WorldImpl::Contacts::const_iterator> GetContacts(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetContacts();
-}
-
-bool IsMassDataDirty(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsMassDataDirty();
-}
-
-bool IsFixedRotation(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsFixedRotation();
-}
-
-void SetFixedRotation(WorldImpl& world, BodyID id, bool value)
-{
-    auto& body = world.GetBody(id);
-    if (body.IsFixedRotation() != value)
+    namespace d2
     {
-        body.SetFixedRotation(value);
-        ResetMassData(world, id);
-    }
-}
+
+        BodyCounter GetBodyRange(const WorldImpl& world) noexcept
+        {
+            return world.GetBodyRange();
+        }
+
+        void Destroy(WorldImpl& world, BodyID id)
+        {
+            world.Destroy(id);
+        }
+
+        BodyConf GetBodyConf(const WorldImpl& world, BodyID id)
+        {
+            return GetBodyConf(world.GetBody(id));
+        }
+
+        BodyType GetType(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetType();
+        }
+
+        void SetType(WorldImpl& world, BodyID id, BodyType value)
+        {
+            world.SetType(id, value);
+        }
+
+        bool IsImpenetrable(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsImpenetrable();
+        }
+
+        void SetImpenetrable(WorldImpl& world, BodyID id)
+        {
+            world.GetBody(id).SetImpenetrable();
+        }
+
+        void UnsetImpenetrable(WorldImpl& world, BodyID id)
+        {
+            world.GetBody(id).UnsetImpenetrable();
+        }
+
+        bool IsSleepingAllowed(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsSleepingAllowed();
+        }
+
+        void SetSleepingAllowed(WorldImpl& world, BodyID id, bool value)
+        {
+            world.GetBody(id).SetSleepingAllowed(value);
+        }
+
+        Angle GetAngle(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetAngle();
+        }
+
+        Transformation GetTransformation(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetTransformation();
+        }
+
+        void SetTransformation(WorldImpl& world, BodyID id, Transformation xfm)
+        {
+            world.SetTransformation(id, xfm);
+        }
+
+        Velocity GetVelocity(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetVelocity();
+        }
+
+        void SetVelocity(WorldImpl& world, BodyID id, const Velocity& value)
+        {
+            world.GetBody(id).SetVelocity(value);
+        }
+
+        void UnsetAwake(WorldImpl& world, BodyID id)
+        {
+            world.GetBody(id).UnsetAwake();
+        }
+
+        void SetAwake(WorldImpl& world, BodyID id)
+        {
+            world.GetBody(id).SetAwake();
+        }
+
+        bool IsAwake(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsAwake();
+        }
+
+        Length2 GetLocalCenter(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetLocalCenter();
+        }
+
+        Length2 GetWorldCenter(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetWorldCenter();
+        }
+
+        LinearAcceleration2 GetLinearAcceleration(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetLinearAcceleration();
+        }
+
+        AngularAcceleration GetAngularAcceleration(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetAngularAcceleration();
+        }
+
+        void SetAcceleration(WorldImpl& world, BodyID id, LinearAcceleration2 linear, AngularAcceleration angular)
+        {
+            ::playrho::d2::SetAcceleration(world.GetBody(id), linear, angular);
+        }
+
+        void SetAcceleration(WorldImpl& world, BodyID id, Acceleration value)
+        {
+            ::playrho::d2::SetAcceleration(world.GetBody(id), value);
+        }
+
+        void SetAcceleration(WorldImpl& world, BodyID id, LinearAcceleration2 value)
+        {
+            ::playrho::d2::SetAcceleration(world.GetBody(id), value);
+        }
+
+        void SetAcceleration(WorldImpl& world, BodyID id, AngularAcceleration value)
+        {
+            ::playrho::d2::SetAcceleration(world.GetBody(id), value);
+        }
+
+        MassData ComputeMassData(const WorldImpl& world, BodyID id)
+        {
+            return world.ComputeMassData(id);
+        }
+
+        void SetMassData(WorldImpl& world, BodyID id, const MassData& massData)
+        {
+            world.SetMassData(id, massData);
+        }
+
+        InvMass GetInvMass(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetInvMass();
+        }
+
+        InvRotInertia GetInvRotInertia(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetInvRotInertia();
+        }
+
+        SizedRange<WorldImpl::BodyJoints::const_iterator> GetJoints(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetJoints();
+        }
+
+        SizedRange<WorldImpl::Fixtures::const_iterator> GetFixtures(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetFixtures();
+        }
+
+        void DestroyFixtures(WorldImpl& world, BodyID id)
+        {
+            world.DestroyFixtures(id);
+        }
+
+        bool IsSpeedable(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsSpeedable();
+        }
+
+        bool IsAccelerable(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsAccelerable();
+        }
+
+        SizedRange<WorldImpl::Contacts::const_iterator> GetContacts(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetContacts();
+        }
+
+        bool IsMassDataDirty(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsMassDataDirty();
+        }
+
+        bool IsFixedRotation(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsFixedRotation();
+        }
+
+        void SetFixedRotation(WorldImpl& world, BodyID id, bool value)
+        {
+            auto& body = world.GetBody(id);
+            if (body.IsFixedRotation() != value)
+            {
+                body.SetFixedRotation(value);
+                ResetMassData(world, id);
+            }
+        }
 
 #if 0
 bool ShouldCollide(const WorldImpl& world, BodyID lhs, BodyID rhs)
@@ -251,35 +253,35 @@ bool ShouldCollide(const WorldImpl& world, BodyID lhs, BodyID rhs)
 }
 #endif
 
-bool IsEnabled(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).IsEnabled();
-}
+        bool IsEnabled(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).IsEnabled();
+        }
 
-void SetEnabled(WorldImpl& world, BodyID body, bool flag)
-{
-    world.SetEnabled(body, flag);
-}
+        void SetEnabled(WorldImpl& world, BodyID body, bool flag)
+        {
+            world.SetEnabled(body, flag);
+        }
 
-Frequency GetLinearDamping(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetLinearDamping();
-}
+        Frequency GetLinearDamping(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetLinearDamping();
+        }
 
-void SetLinearDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value)
-{
-    world.GetBody(id).SetLinearDamping(value);
-}
+        void SetLinearDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value)
+        {
+            world.GetBody(id).SetLinearDamping(value);
+        }
 
-Frequency GetAngularDamping(const WorldImpl& world, BodyID id)
-{
-    return world.GetBody(id).GetAngularDamping();
-}
+        Frequency GetAngularDamping(const WorldImpl& world, BodyID id)
+        {
+            return world.GetBody(id).GetAngularDamping();
+        }
 
-void SetAngularDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value)
-{
-    world.GetBody(id).SetAngularDamping(value);
-}
+        void SetAngularDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value)
+        {
+            world.GetBody(id).SetAngularDamping(value);
+        }
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldImplBody.hpp
+++ b/PlayRho/Dynamics/WorldImplBody.hpp
@@ -26,210 +26,212 @@
 /// Declarations of free functions of WorldImpl for bodies.
 
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Units.hpp>
+#include <PlayRho/Common/Range.hpp>// for SizedRange
 #include <PlayRho/Common/Transformation.hpp>
-#include <PlayRho/Common/Range.hpp> // for SizedRange
+#include <PlayRho/Common/Units.hpp>
+#include <PlayRho/Common/Vector2.hpp>// for Length2, LinearAcceleration2
 #include <PlayRho/Common/Velocity.hpp>
-#include <PlayRho/Common/Vector2.hpp> // for Length2, LinearAcceleration2
 
-#include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
-#include <PlayRho/Dynamics/BodyType.hpp>
 #include <PlayRho/Dynamics/BodyConf.hpp>
+#include <PlayRho/Dynamics/BodyID.hpp>
+#include <PlayRho/Dynamics/BodyType.hpp>
 #include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp>
+#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 
 #include <PlayRho/Collision/MassData.hpp>
 
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-class WorldImpl;
-
-/// @brief Gets the extent of the currently valid body range.
-/// @note This is one higher than the maxium BodyID that is in range for body related
-///   functions.
-BodyCounter GetBodyRange(const WorldImpl& world) noexcept;
-
-/// @brief Destroys the identified body.
-/// @relatedalso WorldImpl
-void Destroy(WorldImpl& world, BodyID id);
-
-/// @brief Gets the body configuration for the identified body.
-/// @throws std::out_of_range If given an invalid body identifier.
-/// @relatedalso WorldImpl
-BodyConf GetBodyConf(const WorldImpl& world, BodyID id);
-
-/// @brief Gets the type of the body.
-/// @relatedalso WorldImpl
-BodyType GetType(const WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-void SetType(WorldImpl& world, BodyID id, BodyType value);
-
-/// @brief Is the body treated like a bullet for continuous collision detection?
-/// @relatedalso WorldImpl
-bool IsImpenetrable(const WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-void SetImpenetrable(WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-void UnsetImpenetrable(WorldImpl& world, BodyID id);
-
-/// @brief Gets whether or not the identified body is allowed to sleep.
-/// @relatedalso WorldImpl
-bool IsSleepingAllowed(const WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-void SetSleepingAllowed(WorldImpl& world, BodyID id, bool value);
-
-/// @relatedalso WorldImpl
-Angle GetAngle(const WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-Transformation GetTransformation(const WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-void SetTransformation(WorldImpl& world, BodyID id, Transformation xfm);
-
-/// @relatedalso WorldImpl
-Velocity GetVelocity(const WorldImpl& world, BodyID id);
-
-/// @brief Sets the body's velocity (linear and angular velocity).
-/// @note This method does nothing if this body is not speedable.
-/// @note A non-zero velocity will awaken this body.
-/// @see SetAwake, SetUnderActiveTime.
-/// @relatedalso WorldImpl
-void SetVelocity(WorldImpl& world, BodyID id, const Velocity& value);
-
-/// @brief Sleeps the body.
-/// @relatedalso WorldImpl
-void UnsetAwake(WorldImpl& world, BodyID id);
-
-/// @brief Wakes up the body.
-/// @relatedalso WorldImpl
-void SetAwake(WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-bool IsAwake(const WorldImpl& world, BodyID id);
-
-/// @brief Gets the linear damping of the body.
-/// @relatedalso WorldImpl
-Frequency GetLinearDamping(const WorldImpl& world, BodyID id);
-
-/// @brief Sets the linear damping of the body.
-/// @relatedalso WorldImpl
-void SetLinearDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value);
-
-/// @brief Gets the angular damping of the body.
-/// @relatedalso WorldImpl
-Frequency GetAngularDamping(const WorldImpl& world, BodyID id);
-
-/// @brief Sets the angular damping of the body.
-/// @relatedalso WorldImpl
-void SetAngularDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value);
-
-/// @brief Gets the local position of the center of mass of the specified body.
-/// @relatedalso WorldImpl
-Length2 GetLocalCenter(const WorldImpl& world, BodyID id);
-
-/// @brief Get the world position of the center of mass of the specified body.
-/// @relatedalso WorldImpl
-Length2 GetWorldCenter(const WorldImpl& world, BodyID id);
-
-/// @brief Gets this body's linear acceleration.
-/// @relatedalso WorldImpl
-LinearAcceleration2 GetLinearAcceleration(const WorldImpl& world, BodyID id);
-
-/// @brief Gets this body's angular acceleration.
-/// @relatedalso WorldImpl
-AngularAcceleration GetAngularAcceleration(const WorldImpl& world, BodyID id);
-
-/// @relatedalso WorldImpl
-void SetAcceleration(WorldImpl& world, BodyID id,
-                     LinearAcceleration2 linear, AngularAcceleration angular);
-
-/// @relatedalso WorldImpl
-void SetAcceleration(WorldImpl& world, BodyID id, Acceleration value);
-
-/// @relatedalso WorldImpl
-void SetAcceleration(WorldImpl& world, BodyID id, LinearAcceleration2 value);
-
-/// @relatedalso WorldImpl
-void SetAcceleration(WorldImpl& world, BodyID id, AngularAcceleration value);
-
-/// @brief Sets the mass properties to override the mass properties of the fixtures.
-/// @note This changes the center of mass position.
-/// @note Creating or destroying fixtures can also alter the mass.
-/// @note This function has no effect if the body isn't dynamic.
-/// @param world The world of the identified body.
-/// @param id Identification of body.
-/// @param massData the mass properties.
-/// @relatedalso WorldImpl
-void SetMassData(WorldImpl& world, BodyID id, const MassData& massData);
-
-/// @brief Computes the body's mass data.
-/// @details This basically accumulates the mass data over all fixtures.
-/// @note The center is the mass weighted sum of all fixture centers. Divide it by the
-///   mass to get the averaged center.
-/// @return accumulated mass data for all fixtures associated with the given body.
-/// @relatedalso WorldImpl
-MassData ComputeMassData(const WorldImpl& world, BodyID id);
-
-/// @brief Resets the mass data properties.
-/// @details This resets the mass data to the sum of the mass properties of the fixtures.
-/// @note This method must be called after calling <code>CreateFixture</code> to update the
-///   body mass data properties unless <code>SetMassData</code> is used.
-/// @see SetMassData.
-/// @relatedalso WorldImpl
-inline void ResetMassData(WorldImpl& world, BodyID id)
+namespace playrho
 {
-    SetMassData(world, id, ComputeMassData(world, id));
-}
+    namespace d2
+    {
 
-/// @brief Gets the inverse total mass of the body.
-/// @return Value of zero or more representing the body's inverse mass (in 1/kg).
-/// @see SetMassData.
-/// @relatedalso WorldImpl
-InvMass GetInvMass(const WorldImpl& world, BodyID id);
+        class WorldImpl;
 
-/// @brief Gets the mass of the body.
-/// @note This may be the total calculated mass or it may be the set mass of the body.
-/// @return Value of zero or more representing the body's mass.
-/// @see GetInvMass, SetMassData
-/// @relatedalso WorldImpl
-inline Mass GetMass(const WorldImpl& world, BodyID id)
-{
-    const auto invMass = GetInvMass(world, id);
-    return (invMass != InvMass{0})? Mass{Real{1} / invMass}: 0_kg;
-}
+        /// @brief Gets the extent of the currently valid body range.
+        /// @note This is one higher than the maxium BodyID that is in range for body related
+        ///   functions.
+        BodyCounter GetBodyRange(const WorldImpl& world) noexcept;
 
-/// @brief Gets the inverse rotational inertia of the body.
-/// @return Inverse rotational inertia (in 1/kg-m^2).
-/// @relatedalso WorldImpl
-InvRotInertia GetInvRotInertia(const WorldImpl& world, BodyID id);
+        /// @brief Destroys the identified body.
+        /// @relatedalso WorldImpl
+        void Destroy(WorldImpl& world, BodyID id);
 
-/// @brief Gets the rotational inertia of the body.
-/// @param world The world of the identified body.
-/// @param id Body to get the rotational inertia for.
-/// @return the rotational inertia.
-/// @relatedalso WorldImpl
-inline RotInertia GetRotInertia(const WorldImpl& world, BodyID id)
-{
-    return Real{1} / GetInvRotInertia(world, id);
-}
+        /// @brief Gets the body configuration for the identified body.
+        /// @throws std::out_of_range If given an invalid body identifier.
+        /// @relatedalso WorldImpl
+        BodyConf GetBodyConf(const WorldImpl& world, BodyID id);
 
-/// @brief Gets the rotational inertia of the body about the local origin.
-/// @return the rotational inertia.
-/// @relatedalso WorldImpl
-inline RotInertia GetLocalRotInertia(const WorldImpl& world, BodyID id)
-{
-    return GetRotInertia(world, id)
-         + GetMass(world, id) * GetMagnitudeSquared(GetLocalCenter(world, id)) / SquareRadian;
-}
+        /// @brief Gets the type of the body.
+        /// @relatedalso WorldImpl
+        BodyType GetType(const WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        void SetType(WorldImpl& world, BodyID id, BodyType value);
+
+        /// @brief Is the body treated like a bullet for continuous collision detection?
+        /// @relatedalso WorldImpl
+        bool IsImpenetrable(const WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        void SetImpenetrable(WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        void UnsetImpenetrable(WorldImpl& world, BodyID id);
+
+        /// @brief Gets whether or not the identified body is allowed to sleep.
+        /// @relatedalso WorldImpl
+        bool IsSleepingAllowed(const WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        void SetSleepingAllowed(WorldImpl& world, BodyID id, bool value);
+
+        /// @relatedalso WorldImpl
+        Angle GetAngle(const WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        Transformation GetTransformation(const WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        void SetTransformation(WorldImpl& world, BodyID id, Transformation xfm);
+
+        /// @relatedalso WorldImpl
+        Velocity GetVelocity(const WorldImpl& world, BodyID id);
+
+        /// @brief Sets the body's velocity (linear and angular velocity).
+        /// @note This method does nothing if this body is not speedable.
+        /// @note A non-zero velocity will awaken this body.
+        /// @see SetAwake, SetUnderActiveTime.
+        /// @relatedalso WorldImpl
+        void SetVelocity(WorldImpl& world, BodyID id, const Velocity& value);
+
+        /// @brief Sleeps the body.
+        /// @relatedalso WorldImpl
+        void UnsetAwake(WorldImpl& world, BodyID id);
+
+        /// @brief Wakes up the body.
+        /// @relatedalso WorldImpl
+        void SetAwake(WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        bool IsAwake(const WorldImpl& world, BodyID id);
+
+        /// @brief Gets the linear damping of the body.
+        /// @relatedalso WorldImpl
+        Frequency GetLinearDamping(const WorldImpl& world, BodyID id);
+
+        /// @brief Sets the linear damping of the body.
+        /// @relatedalso WorldImpl
+        void SetLinearDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value);
+
+        /// @brief Gets the angular damping of the body.
+        /// @relatedalso WorldImpl
+        Frequency GetAngularDamping(const WorldImpl& world, BodyID id);
+
+        /// @brief Sets the angular damping of the body.
+        /// @relatedalso WorldImpl
+        void SetAngularDamping(WorldImpl& world, BodyID id, NonNegative<Frequency> value);
+
+        /// @brief Gets the local position of the center of mass of the specified body.
+        /// @relatedalso WorldImpl
+        Length2 GetLocalCenter(const WorldImpl& world, BodyID id);
+
+        /// @brief Get the world position of the center of mass of the specified body.
+        /// @relatedalso WorldImpl
+        Length2 GetWorldCenter(const WorldImpl& world, BodyID id);
+
+        /// @brief Gets this body's linear acceleration.
+        /// @relatedalso WorldImpl
+        LinearAcceleration2 GetLinearAcceleration(const WorldImpl& world, BodyID id);
+
+        /// @brief Gets this body's angular acceleration.
+        /// @relatedalso WorldImpl
+        AngularAcceleration GetAngularAcceleration(const WorldImpl& world, BodyID id);
+
+        /// @relatedalso WorldImpl
+        void SetAcceleration(WorldImpl& world, BodyID id,
+                             LinearAcceleration2 linear, AngularAcceleration angular);
+
+        /// @relatedalso WorldImpl
+        void SetAcceleration(WorldImpl& world, BodyID id, Acceleration value);
+
+        /// @relatedalso WorldImpl
+        void SetAcceleration(WorldImpl& world, BodyID id, LinearAcceleration2 value);
+
+        /// @relatedalso WorldImpl
+        void SetAcceleration(WorldImpl& world, BodyID id, AngularAcceleration value);
+
+        /// @brief Sets the mass properties to override the mass properties of the fixtures.
+        /// @note This changes the center of mass position.
+        /// @note Creating or destroying fixtures can also alter the mass.
+        /// @note This function has no effect if the body isn't dynamic.
+        /// @param world The world of the identified body.
+        /// @param id Identification of body.
+        /// @param massData the mass properties.
+        /// @relatedalso WorldImpl
+        void SetMassData(WorldImpl& world, BodyID id, const MassData& massData);
+
+        /// @brief Computes the body's mass data.
+        /// @details This basically accumulates the mass data over all fixtures.
+        /// @note The center is the mass weighted sum of all fixture centers. Divide it by the
+        ///   mass to get the averaged center.
+        /// @return accumulated mass data for all fixtures associated with the given body.
+        /// @relatedalso WorldImpl
+        MassData ComputeMassData(const WorldImpl& world, BodyID id);
+
+        /// @brief Resets the mass data properties.
+        /// @details This resets the mass data to the sum of the mass properties of the fixtures.
+        /// @note This method must be called after calling <code>CreateFixture</code> to update the
+        ///   body mass data properties unless <code>SetMassData</code> is used.
+        /// @see SetMassData.
+        /// @relatedalso WorldImpl
+        inline void ResetMassData(WorldImpl& world, BodyID id)
+        {
+            SetMassData(world, id, ComputeMassData(world, id));
+        }
+
+        /// @brief Gets the inverse total mass of the body.
+        /// @return Value of zero or more representing the body's inverse mass (in 1/kg).
+        /// @see SetMassData.
+        /// @relatedalso WorldImpl
+        InvMass GetInvMass(const WorldImpl& world, BodyID id);
+
+        /// @brief Gets the mass of the body.
+        /// @note This may be the total calculated mass or it may be the set mass of the body.
+        /// @return Value of zero or more representing the body's mass.
+        /// @see GetInvMass, SetMassData
+        /// @relatedalso WorldImpl
+        inline Mass GetMass(const WorldImpl& world, BodyID id)
+        {
+            const auto invMass = GetInvMass(world, id);
+            return (invMass != InvMass{0}) ? Mass{Real{1} / invMass} : 0_kg;
+        }
+
+        /// @brief Gets the inverse rotational inertia of the body.
+        /// @return Inverse rotational inertia (in 1/kg-m^2).
+        /// @relatedalso WorldImpl
+        InvRotInertia GetInvRotInertia(const WorldImpl& world, BodyID id);
+
+        /// @brief Gets the rotational inertia of the body.
+        /// @param world The world of the identified body.
+        /// @param id Body to get the rotational inertia for.
+        /// @return the rotational inertia.
+        /// @relatedalso WorldImpl
+        inline RotInertia GetRotInertia(const WorldImpl& world, BodyID id)
+        {
+            return Real{1} / GetInvRotInertia(world, id);
+        }
+
+        /// @brief Gets the rotational inertia of the body about the local origin.
+        /// @return the rotational inertia.
+        /// @relatedalso WorldImpl
+        inline RotInertia GetLocalRotInertia(const WorldImpl& world, BodyID id)
+        {
+            return GetRotInertia(world, id)
+                   + GetMass(world, id) * GetMagnitudeSquared(GetLocalCenter(world, id)) / SquareRadian;
+        }
 
 #if 0
 /// @brief Should collide.
@@ -239,82 +241,82 @@ inline RotInertia GetLocalRotInertia(const WorldImpl& world, BodyID id)
 bool ShouldCollide(const WorldImpl& world, BodyID lhs, BodyID rhs);
 #endif
 
-/// @brief Gets the range of all joints attached to this body.
-/// @relatedalso WorldImpl
-SizedRange<std::vector<std::pair<BodyID, JointID>>::const_iterator>
-GetJoints(const WorldImpl& world, BodyID id);
+        /// @brief Gets the range of all joints attached to this body.
+        /// @relatedalso WorldImpl
+        SizedRange<std::vector<std::pair<BodyID, JointID>>::const_iterator>
+        GetJoints(const WorldImpl& world, BodyID id);
 
-/// @brief Gets the range of all constant fixtures attached to the given body.
-/// @relatedalso WorldImpl
-SizedRange<std::vector<FixtureID>::const_iterator>
-GetFixtures(const WorldImpl& world, BodyID id);
+        /// @brief Gets the range of all constant fixtures attached to the given body.
+        /// @relatedalso WorldImpl
+        SizedRange<std::vector<FixtureID>::const_iterator>
+        GetFixtures(const WorldImpl& world, BodyID id);
 
-/// @relatedalso WorldImpl
-void DestroyFixtures(WorldImpl& world, BodyID id);
+        /// @relatedalso WorldImpl
+        void DestroyFixtures(WorldImpl& world, BodyID id);
 
-/// @brief Gets the enabled/disabled state of the body.
-/// @see SetEnabled.
-/// @relatedalso WorldImpl
-bool IsEnabled(const WorldImpl& world, BodyID id);
+        /// @brief Gets the enabled/disabled state of the body.
+        /// @see SetEnabled.
+        /// @relatedalso WorldImpl
+        bool IsEnabled(const WorldImpl& world, BodyID id);
 
-/// @brief Sets the enabled state of the body.
-///
-/// @details A disabled body is not simulated and cannot be collided with or woken up.
-///   If you pass a flag of true, all fixtures will be added to the broad-phase.
-///   If you pass a flag of false, all fixtures will be removed from the broad-phase
-///   and all contacts will be destroyed. Fixtures and joints are otherwise unaffected.
-///
-/// @note A disabled body is still owned by a World object and remains in the world's
-///   body container.
-/// @note You may continue to create/destroy fixtures and joints on disabled bodies.
-/// @note Fixtures on a disabled body are implicitly disabled and will not participate in
-///   collisions, ray-casts, or queries.
-/// @note Joints connected to a disabled body are implicitly disabled.
-///
-/// @throws WrongState If call would change body's state when world is locked.
-///
-/// @post <code>IsEnabled()</code> returns the state given to this function.
-///
-/// @see IsEnabled.
-/// @relatedalso WorldImpl
-void SetEnabled(WorldImpl& world, BodyID body, bool flag);
+        /// @brief Sets the enabled state of the body.
+        ///
+        /// @details A disabled body is not simulated and cannot be collided with or woken up.
+        ///   If you pass a flag of true, all fixtures will be added to the broad-phase.
+        ///   If you pass a flag of false, all fixtures will be removed from the broad-phase
+        ///   and all contacts will be destroyed. Fixtures and joints are otherwise unaffected.
+        ///
+        /// @note A disabled body is still owned by a World object and remains in the world's
+        ///   body container.
+        /// @note You may continue to create/destroy fixtures and joints on disabled bodies.
+        /// @note Fixtures on a disabled body are implicitly disabled and will not participate in
+        ///   collisions, ray-casts, or queries.
+        /// @note Joints connected to a disabled body are implicitly disabled.
+        ///
+        /// @throws WrongState If call would change body's state when world is locked.
+        ///
+        /// @post <code>IsEnabled()</code> returns the state given to this function.
+        ///
+        /// @see IsEnabled.
+        /// @relatedalso WorldImpl
+        void SetEnabled(WorldImpl& world, BodyID body, bool flag);
 
-/// @brief Is identified body "speedable".
-/// @details Is the body able to have a non-zero speed associated with it.
-/// Kinematic and Dynamic bodies are speedable. Static bodies are not.
-/// @relatedalso WorldImpl
-bool IsSpeedable(const WorldImpl& world, BodyID id);
+        /// @brief Is identified body "speedable".
+        /// @details Is the body able to have a non-zero speed associated with it.
+        /// Kinematic and Dynamic bodies are speedable. Static bodies are not.
+        /// @relatedalso WorldImpl
+        bool IsSpeedable(const WorldImpl& world, BodyID id);
 
-/// @brief Is identified body "accelerable"?
-/// @details Indicates whether the body is accelerable, i.e. whether it is effected by
-///   forces. Only Dynamic bodies are accelerable.
-/// @return true if the body is accelerable, false otherwise.
-/// @relatedalso WorldImpl
-bool IsAccelerable(const WorldImpl& world, BodyID id);
+        /// @brief Is identified body "accelerable"?
+        /// @details Indicates whether the body is accelerable, i.e. whether it is effected by
+        ///   forces. Only Dynamic bodies are accelerable.
+        /// @return true if the body is accelerable, false otherwise.
+        /// @relatedalso WorldImpl
+        bool IsAccelerable(const WorldImpl& world, BodyID id);
 
-/// @brief Gets the container of all contacts attached to this body.
-/// @warning This collection changes during the time step and you may
-///   miss some collisions if you don't use <code>ContactListener</code>.
-/// @relatedalso WorldImpl
-SizedRange<std::vector<KeyedContactPtr>::const_iterator>
-GetContacts(const WorldImpl& world, BodyID id);
+        /// @brief Gets the container of all contacts attached to this body.
+        /// @warning This collection changes during the time step and you may
+        ///   miss some collisions if you don't use <code>ContactListener</code>.
+        /// @relatedalso WorldImpl
+        SizedRange<std::vector<KeyedContactPtr>::const_iterator>
+        GetContacts(const WorldImpl& world, BodyID id);
 
-/// @brief Gets whether the body's mass-data is dirty.
-/// @relatedalso WorldImpl
-bool IsMassDataDirty(const WorldImpl& world, BodyID id);
+        /// @brief Gets whether the body's mass-data is dirty.
+        /// @relatedalso WorldImpl
+        bool IsMassDataDirty(const WorldImpl& world, BodyID id);
 
-/// @brief Gets whether the body has fixed rotation.
-/// @see SetFixedRotation(WorldImpl& world, BodyID id, bool value).
-/// @relatedalso WorldImpl
-bool IsFixedRotation(const WorldImpl& world, BodyID id);
+        /// @brief Gets whether the body has fixed rotation.
+        /// @see SetFixedRotation(WorldImpl& world, BodyID id, bool value).
+        /// @relatedalso WorldImpl
+        bool IsFixedRotation(const WorldImpl& world, BodyID id);
 
-/// @brief Sets this body to have fixed rotation.
-/// @note This causes the mass to be reset.
-/// @see IsFixedRotation(const WorldImpl& world, BodyID id).
-/// @relatedalso WorldImpl
-void SetFixedRotation(WorldImpl& world, BodyID id, bool value);
+        /// @brief Sets this body to have fixed rotation.
+        /// @note This causes the mass to be reset.
+        /// @see IsFixedRotation(const WorldImpl& world, BodyID id).
+        /// @relatedalso WorldImpl
+        void SetFixedRotation(WorldImpl& world, BodyID id, bool value);
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_WORLDIMPLBODY_HPP
+#endif// PLAYRHO_DYNAMICS_WORLDIMPLBODY_HPP

--- a/PlayRho/Dynamics/WorldImplContact.cpp
+++ b/PlayRho/Dynamics/WorldImplContact.cpp
@@ -21,152 +21,154 @@
 
 #include <PlayRho/Dynamics/WorldImplContact.hpp>
 
+#include <PlayRho/Dynamics/Body.hpp>   // for use of GetBody
+#include <PlayRho/Dynamics/Fixture.hpp>// for GetDefaultFriction, GetDefaultRestitution
 #include <PlayRho/Dynamics/WorldImpl.hpp>
-#include <PlayRho/Dynamics/Body.hpp> // for use of GetBody
-#include <PlayRho/Dynamics/Fixture.hpp> // for GetDefaultFriction, GetDefaultRestitution
 
-#include <PlayRho/Dynamics/Contacts/Contact.hpp> // for use of GetContact
+#include <PlayRho/Dynamics/Contacts/Contact.hpp>// for use of GetContact
 
-namespace playrho {
-namespace d2 {
-
-bool IsAwake(const WorldImpl& world, ContactID id)
+namespace playrho
 {
-    return world.GetContact(id).IsActive();
-}
+    namespace d2
+    {
 
-void SetAwake(WorldImpl& world, ContactID id)
-{
-    const auto& contact = world.GetContact(id);
-    world.GetBody(contact.GetBodyA()).SetAwake();
-    world.GetBody(contact.GetBodyB()).SetAwake();
-}
+        bool IsAwake(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).IsActive();
+        }
 
-Real GetFriction(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetFriction();
-}
+        void SetAwake(WorldImpl& world, ContactID id)
+        {
+            const auto& contact = world.GetContact(id);
+            world.GetBody(contact.GetBodyA()).SetAwake();
+            world.GetBody(contact.GetBodyB()).SetAwake();
+        }
 
-Real GetRestitution(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetRestitution();
-}
+        Real GetFriction(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetFriction();
+        }
 
-void SetFriction(WorldImpl& world, ContactID id, Real value)
-{
-    world.GetContact(id).SetFriction(value);
-}
+        Real GetRestitution(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetRestitution();
+        }
 
-void SetRestitution(WorldImpl& world, ContactID id, Real value)
-{
-    world.GetContact(id).SetRestitution(value);
-}
+        void SetFriction(WorldImpl& world, ContactID id, Real value)
+        {
+            world.GetContact(id).SetFriction(value);
+        }
 
-const Manifold& GetManifold(const WorldImpl& world, ContactID id)
-{
-    return world.GetManifold(id);
-}
+        void SetRestitution(WorldImpl& world, ContactID id, Real value)
+        {
+            world.GetContact(id).SetRestitution(value);
+        }
 
-Real GetDefaultFriction(const WorldImpl& world, ContactID id)
-{
-    const auto& contact = world.GetContact(id);
-    const auto& fixtureA = world.GetFixture(contact.GetFixtureA());
-    const auto& fixtureB = world.GetFixture(contact.GetFixtureB());
-    return GetDefaultFriction(fixtureA, fixtureB);
-}
+        const Manifold& GetManifold(const WorldImpl& world, ContactID id)
+        {
+            return world.GetManifold(id);
+        }
 
-Real GetDefaultRestitution(const WorldImpl& world, ContactID id)
-{
-    const auto& contact = world.GetContact(id);
-    const auto& fixtureA = world.GetFixture(contact.GetFixtureA());
-    const auto& fixtureB = world.GetFixture(contact.GetFixtureB());
-    return GetDefaultRestitution(fixtureA, fixtureB);
-}
+        Real GetDefaultFriction(const WorldImpl& world, ContactID id)
+        {
+            const auto& contact = world.GetContact(id);
+            const auto& fixtureA = world.GetFixture(contact.GetFixtureA());
+            const auto& fixtureB = world.GetFixture(contact.GetFixtureB());
+            return GetDefaultFriction(fixtureA, fixtureB);
+        }
 
-bool IsTouching(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).IsTouching();
-}
+        Real GetDefaultRestitution(const WorldImpl& world, ContactID id)
+        {
+            const auto& contact = world.GetContact(id);
+            const auto& fixtureA = world.GetFixture(contact.GetFixtureA());
+            const auto& fixtureB = world.GetFixture(contact.GetFixtureB());
+            return GetDefaultRestitution(fixtureA, fixtureB);
+        }
 
-bool NeedsFiltering(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).NeedsFiltering();
-}
+        bool IsTouching(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).IsTouching();
+        }
 
-bool NeedsUpdating(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).NeedsUpdating();
-}
+        bool NeedsFiltering(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).NeedsFiltering();
+        }
 
-bool HasValidToi(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).HasValidToi();
-}
+        bool NeedsUpdating(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).NeedsUpdating();
+        }
 
-Real GetToi(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetToi();
-}
+        bool HasValidToi(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).HasValidToi();
+        }
 
-BodyID GetBodyA(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetBodyA();
-}
+        Real GetToi(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetToi();
+        }
 
-BodyID GetBodyB(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetBodyB();
-}
+        BodyID GetBodyA(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetBodyA();
+        }
 
-FixtureID GetFixtureA(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetFixtureA();
-}
+        BodyID GetBodyB(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetBodyB();
+        }
 
-FixtureID GetFixtureB(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetFixtureB();
-}
+        FixtureID GetFixtureA(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetFixtureA();
+        }
 
-ChildCounter GetChildIndexA(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetChildIndexA();
-}
+        FixtureID GetFixtureB(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetFixtureB();
+        }
 
-ChildCounter GetChildIndexB(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetChildIndexB();
-}
+        ChildCounter GetChildIndexA(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetChildIndexA();
+        }
 
-TimestepIters GetToiCount(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetToiCount();
-}
+        ChildCounter GetChildIndexB(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetChildIndexB();
+        }
 
-LinearVelocity GetTangentSpeed(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).GetTangentSpeed();
-}
+        TimestepIters GetToiCount(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetToiCount();
+        }
 
-void SetTangentSpeed(WorldImpl& world, ContactID id, LinearVelocity value)
-{
-    world.GetContact(id).SetTangentSpeed(value);
-}
+        LinearVelocity GetTangentSpeed(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).GetTangentSpeed();
+        }
 
-bool IsEnabled(const WorldImpl& world, ContactID id)
-{
-    return world.GetContact(id).IsEnabled();
-}
+        void SetTangentSpeed(WorldImpl& world, ContactID id, LinearVelocity value)
+        {
+            world.GetContact(id).SetTangentSpeed(value);
+        }
 
-void SetEnabled(WorldImpl& world, ContactID id)
-{
-    world.GetContact(id).SetEnabled();
-}
+        bool IsEnabled(const WorldImpl& world, ContactID id)
+        {
+            return world.GetContact(id).IsEnabled();
+        }
 
-void UnsetEnabled(WorldImpl& world, ContactID id)
-{
-    world.GetContact(id).UnsetEnabled();
-}
+        void SetEnabled(WorldImpl& world, ContactID id)
+        {
+            world.GetContact(id).SetEnabled();
+        }
 
-} // namespace d2
-} // namespace playrho
+        void UnsetEnabled(WorldImpl& world, ContactID id)
+        {
+            world.GetContact(id).UnsetEnabled();
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldImplContact.hpp
+++ b/PlayRho/Dynamics/WorldImplContact.hpp
@@ -28,126 +28,128 @@
 #include <PlayRho/Common/Real.hpp>
 
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactID.hpp>
+#include <PlayRho/Dynamics/FixtureID.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-class WorldImpl;
-class Manifold;
+        class WorldImpl;
+        class Manifold;
 
-/// @brief Gets the awake status of the specified contact.
-/// @see SetAwake(WorldImpl& world, ContactID id)
-/// @relatedalso WorldImpl
-bool IsAwake(const WorldImpl& world, ContactID id);
+        /// @brief Gets the awake status of the specified contact.
+        /// @see SetAwake(WorldImpl& world, ContactID id)
+        /// @relatedalso WorldImpl
+        bool IsAwake(const WorldImpl& world, ContactID id);
 
-/// @brief Sets awake the bodies of the fixtures of the given contact.
-/// @see IsAwake(const WorldImpl& world, ContactID id)
-/// @relatedalso WorldImpl
-void SetAwake(WorldImpl& world, ContactID id);
+        /// @brief Sets awake the bodies of the fixtures of the given contact.
+        /// @see IsAwake(const WorldImpl& world, ContactID id)
+        /// @relatedalso WorldImpl
+        void SetAwake(WorldImpl& world, ContactID id);
 
-/// @brief Is this contact touching?
-/// @details
-/// Touching is defined as either:
-///   1. This contact's manifold has more than 0 contact points, or
-///   2. This contact has sensors and the two shapes of this contact are found to be
-///      overlapping.
-/// @return true if this contact is said to be touching, false otherwise.
-/// @relatedalso WorldImpl
-bool IsTouching(const WorldImpl& world, ContactID id);
+        /// @brief Is this contact touching?
+        /// @details
+        /// Touching is defined as either:
+        ///   1. This contact's manifold has more than 0 contact points, or
+        ///   2. This contact has sensors and the two shapes of this contact are found to be
+        ///      overlapping.
+        /// @return true if this contact is said to be touching, false otherwise.
+        /// @relatedalso WorldImpl
+        bool IsTouching(const WorldImpl& world, ContactID id);
 
-/// @brief Whether or not the contact needs filtering.
-/// @relatedalso WorldImpl
-bool NeedsFiltering(const WorldImpl& world, ContactID id);
+        /// @brief Whether or not the contact needs filtering.
+        /// @relatedalso WorldImpl
+        bool NeedsFiltering(const WorldImpl& world, ContactID id);
 
-/// @brief Whether or not the contact needs updating.
-/// @relatedalso WorldImpl
-bool NeedsUpdating(const WorldImpl& world, ContactID id);
+        /// @brief Whether or not the contact needs updating.
+        /// @relatedalso WorldImpl
+        bool NeedsUpdating(const WorldImpl& world, ContactID id);
 
-/// @brief Whether or not the contact has a valid TOI.
-/// @relatedalso WorldImpl
-bool HasValidToi(const WorldImpl& world, ContactID id);
+        /// @brief Whether or not the contact has a valid TOI.
+        /// @relatedalso WorldImpl
+        bool HasValidToi(const WorldImpl& world, ContactID id);
 
-/// @brief Gets the time of impact (TOI) as a fraction.
-/// @note This is only valid if a TOI has been set.
-/// @return Time of impact fraction in the range of 0 to 1 if set (where 1
-///   means no actual impact in current time slot), otherwise undefined.
-/// @relatedalso WorldImpl
-Real GetToi(const WorldImpl& world, ContactID id);
+        /// @brief Gets the time of impact (TOI) as a fraction.
+        /// @note This is only valid if a TOI has been set.
+        /// @return Time of impact fraction in the range of 0 to 1 if set (where 1
+        ///   means no actual impact in current time slot), otherwise undefined.
+        /// @relatedalso WorldImpl
+        Real GetToi(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-BodyID GetBodyA(const WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        BodyID GetBodyA(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-BodyID GetBodyB(const WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        BodyID GetBodyB(const WorldImpl& world, ContactID id);
 
-/// @brief Gets fixture A of the given contact.
-/// @relatedalso WorldImpl
-FixtureID GetFixtureA(const WorldImpl& world, ContactID id);
+        /// @brief Gets fixture A of the given contact.
+        /// @relatedalso WorldImpl
+        FixtureID GetFixtureA(const WorldImpl& world, ContactID id);
 
-/// @brief Gets fixture B of the given contact.
-/// @relatedalso WorldImpl
-FixtureID GetFixtureB(const WorldImpl& world, ContactID id);
+        /// @brief Gets fixture B of the given contact.
+        /// @relatedalso WorldImpl
+        FixtureID GetFixtureB(const WorldImpl& world, ContactID id);
 
-/// @brief Get the child primitive index for fixture A.
-/// @relatedalso WorldImpl
-ChildCounter GetChildIndexA(const WorldImpl& world, ContactID id);
+        /// @brief Get the child primitive index for fixture A.
+        /// @relatedalso WorldImpl
+        ChildCounter GetChildIndexA(const WorldImpl& world, ContactID id);
 
-/// @brief Get the child primitive index for fixture B.
-/// @relatedalso WorldImpl
-ChildCounter GetChildIndexB(const WorldImpl& world, ContactID id);
+        /// @brief Get the child primitive index for fixture B.
+        /// @relatedalso WorldImpl
+        ChildCounter GetChildIndexB(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-TimestepIters GetToiCount(const WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        TimestepIters GetToiCount(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-Real GetDefaultFriction(const WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        Real GetDefaultFriction(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-Real GetDefaultRestitution(const WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        Real GetDefaultRestitution(const WorldImpl& world, ContactID id);
 
-/// @brief Gets the friction used with the specified contact.
-/// @see SetFriction(ContactID id, Real value)
-Real GetFriction(const WorldImpl& world, ContactID id);
+        /// @brief Gets the friction used with the specified contact.
+        /// @see SetFriction(ContactID id, Real value)
+        Real GetFriction(const WorldImpl& world, ContactID id);
 
-/// @brief Sets the friction value for the specified contact.
-/// @details Overrides the default friction mixture.
-/// @note You can call this in "pre-solve" listeners.
-/// @note This value persists until set or reset.
-/// @warning Behavior is undefined if given a negative friction value.
-/// @param value Co-efficient of friction value of zero or greater.
-void SetFriction(WorldImpl& world, ContactID id, Real value);
+        /// @brief Sets the friction value for the specified contact.
+        /// @details Overrides the default friction mixture.
+        /// @note You can call this in "pre-solve" listeners.
+        /// @note This value persists until set or reset.
+        /// @warning Behavior is undefined if given a negative friction value.
+        /// @param value Co-efficient of friction value of zero or greater.
+        void SetFriction(WorldImpl& world, ContactID id, Real value);
 
-/// @brief Gets the restitution used with the specified contact.
-/// @see SetRestitution(ContactID id, Real value)
-Real GetRestitution(const WorldImpl& world, ContactID id);
+        /// @brief Gets the restitution used with the specified contact.
+        /// @see SetRestitution(ContactID id, Real value)
+        Real GetRestitution(const WorldImpl& world, ContactID id);
 
-/// @brief Sets the restitution value for the specified contact.
-/// @details This override the default restitution mixture.
-/// @note You can call this in "pre-solve" listeners.
-/// @note The value persists until you set or reset.
-void SetRestitution(WorldImpl& world, ContactID id, Real value);
+        /// @brief Sets the restitution value for the specified contact.
+        /// @details This override the default restitution mixture.
+        /// @note You can call this in "pre-solve" listeners.
+        /// @note The value persists until you set or reset.
+        void SetRestitution(WorldImpl& world, ContactID id, Real value);
 
-/// @brief Gets the collision manifold for the identified contact.
-const Manifold& GetManifold(const WorldImpl& world, ContactID id);
+        /// @brief Gets the collision manifold for the identified contact.
+        const Manifold& GetManifold(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-LinearVelocity GetTangentSpeed(const WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        LinearVelocity GetTangentSpeed(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-void SetTangentSpeed(WorldImpl& world, ContactID id, LinearVelocity value);
+        /// @relatedalso WorldImpl
+        void SetTangentSpeed(WorldImpl& world, ContactID id, LinearVelocity value);
 
-/// @relatedalso WorldImpl
-bool IsEnabled(const WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        bool IsEnabled(const WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-void SetEnabled(WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        void SetEnabled(WorldImpl& world, ContactID id);
 
-/// @relatedalso WorldImpl
-void UnsetEnabled(WorldImpl& world, ContactID id);
+        /// @relatedalso WorldImpl
+        void UnsetEnabled(WorldImpl& world, ContactID id);
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_WORLDIMPLCONTACT_HPP
+#endif// PLAYRHO_DYNAMICS_WORLDIMPLCONTACT_HPP

--- a/PlayRho/Dynamics/WorldImplFixture.cpp
+++ b/PlayRho/Dynamics/WorldImplFixture.cpp
@@ -21,68 +21,70 @@
 
 #include <PlayRho/Dynamics/WorldImplFixture.hpp>
 
+#include <PlayRho/Dynamics/Fixture.hpp>// for use of GetFixture
 #include <PlayRho/Dynamics/WorldImpl.hpp>
 #include <PlayRho/Dynamics/WorldImplBody.hpp>
-#include <PlayRho/Dynamics/Fixture.hpp> // for use of GetFixture
 
-namespace playrho {
-namespace d2 {
-
-FixtureID CreateFixture(WorldImpl& world, BodyID id, const Shape& shape,
-                        const FixtureConf& def, bool resetMassData)
+namespace playrho
 {
-    return world.CreateFixture(id, shape, def, resetMassData);
-}
+    namespace d2
+    {
 
-bool Destroy(WorldImpl& world, FixtureID id, bool resetMassData)
-{
-    return world.Destroy(id, resetMassData);
-}
+        FixtureID CreateFixture(WorldImpl& world, BodyID id, const Shape& shape,
+                                const FixtureConf& def, bool resetMassData)
+        {
+            return world.CreateFixture(id, shape, def, resetMassData);
+        }
 
-BodyID GetBody(const WorldImpl& world, FixtureID id)
-{
-    return world.GetFixture(id).GetBody();
-}
+        bool Destroy(WorldImpl& world, FixtureID id, bool resetMassData)
+        {
+            return world.Destroy(id, resetMassData);
+        }
 
-Shape GetShape(const WorldImpl& world, FixtureID id)
-{
-    return world.GetFixture(id).GetShape();
-}
+        BodyID GetBody(const WorldImpl& world, FixtureID id)
+        {
+            return world.GetFixture(id).GetBody();
+        }
 
-bool IsSensor(const WorldImpl& world, FixtureID id)
-{
-    return world.GetFixture(id).IsSensor();
-}
+        Shape GetShape(const WorldImpl& world, FixtureID id)
+        {
+            return world.GetFixture(id).GetShape();
+        }
 
-void SetSensor(WorldImpl& world, FixtureID id, bool value)
-{
-    world.SetSensor(id, value);
-}
+        bool IsSensor(const WorldImpl& world, FixtureID id)
+        {
+            return world.GetFixture(id).IsSensor();
+        }
 
-AreaDensity GetDensity(const WorldImpl& world, FixtureID id)
-{
-    return world.GetFixture(id).GetDensity();
-}
+        void SetSensor(WorldImpl& world, FixtureID id, bool value)
+        {
+            world.SetSensor(id, value);
+        }
 
-const WorldImpl::FixtureProxies& GetProxies(const WorldImpl& world, FixtureID id)
-{
-    return world.GetFixture(id).GetProxies();
-}
+        AreaDensity GetDensity(const WorldImpl& world, FixtureID id)
+        {
+            return world.GetFixture(id).GetDensity();
+        }
 
-Filter GetFilterData(const WorldImpl& world, FixtureID id)
-{
-    return world.GetFixture(id).GetFilterData();
-}
+        const WorldImpl::FixtureProxies& GetProxies(const WorldImpl& world, FixtureID id)
+        {
+            return world.GetFixture(id).GetProxies();
+        }
 
-void Refilter(WorldImpl& world, FixtureID id)
-{
-    world.Refilter(id);
-}
+        Filter GetFilterData(const WorldImpl& world, FixtureID id)
+        {
+            return world.GetFixture(id).GetFilterData();
+        }
 
-void SetFilterData(WorldImpl& world, FixtureID id, const Filter& value)
-{
-    world.SetFilterData(id, value);
-}
+        void Refilter(WorldImpl& world, FixtureID id)
+        {
+            world.Refilter(id);
+        }
 
-} // namespace d2
-} // namespace playrho
+        void SetFilterData(WorldImpl& world, FixtureID id, const Filter& value)
+        {
+            world.SetFilterData(id, value);
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldImplFixture.hpp
+++ b/PlayRho/Dynamics/WorldImplFixture.hpp
@@ -25,65 +25,67 @@
 /// @file
 /// Declarations of free functions of WorldImpl for fixtures.
 
-#include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/Transformation.hpp>
+#include <PlayRho/Common/Units.hpp>
 
 #include <PlayRho/Dynamics/BodyID.hpp>
+#include <PlayRho/Dynamics/Filter.hpp>
 #include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
-#include <PlayRho/Dynamics/Filter.hpp>
 
 #include <PlayRho/Collision/MassData.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 
 #include <vector>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-class WorldImpl;
-struct FixtureConf; // for CreateFixture
+        class WorldImpl;
+        struct FixtureConf;// for CreateFixture
 
-/// @relatedalso WorldImpl
-FixtureID CreateFixture(WorldImpl& world, BodyID id, const Shape& shape,
-                        const FixtureConf& def, bool resetMassData = true);
+        /// @relatedalso WorldImpl
+        FixtureID CreateFixture(WorldImpl& world, BodyID id, const Shape& shape,
+                                const FixtureConf& def, bool resetMassData = true);
 
-/// @relatedalso WorldImpl
-bool Destroy(WorldImpl& world, FixtureID id, bool resetMassData);
+        /// @relatedalso WorldImpl
+        bool Destroy(WorldImpl& world, FixtureID id, bool resetMassData);
 
-/// @relatedalso WorldImpl
-BodyID GetBody(const WorldImpl& world, FixtureID id);
+        /// @relatedalso WorldImpl
+        BodyID GetBody(const WorldImpl& world, FixtureID id);
 
-/// @relatedalso WorldImpl
-Shape GetShape(const WorldImpl& world, FixtureID id);
+        /// @relatedalso WorldImpl
+        Shape GetShape(const WorldImpl& world, FixtureID id);
 
-/// @brief Is the specified fixture a sensor (non-solid)?
-/// @return the true if the fixture is a sensor.
-/// @relatedalso WorldImpl
-bool IsSensor(const WorldImpl& world, FixtureID id);
+        /// @brief Is the specified fixture a sensor (non-solid)?
+        /// @return the true if the fixture is a sensor.
+        /// @relatedalso WorldImpl
+        bool IsSensor(const WorldImpl& world, FixtureID id);
 
-/// @brief Gets the density of this fixture.
-/// @return Non-negative density (in mass per area).
-/// @relatedalso WorldImpl
-AreaDensity GetDensity(const WorldImpl& world, FixtureID id);
+        /// @brief Gets the density of this fixture.
+        /// @return Non-negative density (in mass per area).
+        /// @relatedalso WorldImpl
+        AreaDensity GetDensity(const WorldImpl& world, FixtureID id);
 
-/// @relatedalso WorldImpl
-const std::vector<FixtureProxy>& GetProxies(const WorldImpl& world, FixtureID id);
+        /// @relatedalso WorldImpl
+        const std::vector<FixtureProxy>& GetProxies(const WorldImpl& world, FixtureID id);
 
-/// @brief Sets whether the specified fixture is a sensor or not.
-/// @relatedalso WorldImpl
-void SetSensor(WorldImpl& world, FixtureID id, bool value);
+        /// @brief Sets whether the specified fixture is a sensor or not.
+        /// @relatedalso WorldImpl
+        void SetSensor(WorldImpl& world, FixtureID id, bool value);
 
-/// @relatedalso WorldImpl
-Filter GetFilterData(const WorldImpl& world, FixtureID id);
+        /// @relatedalso WorldImpl
+        Filter GetFilterData(const WorldImpl& world, FixtureID id);
 
-/// @relatedalso WorldImpl
-void Refilter(WorldImpl& world, FixtureID id);
+        /// @relatedalso WorldImpl
+        void Refilter(WorldImpl& world, FixtureID id);
 
-/// @relatedalso WorldImpl
-void SetFilterData(WorldImpl& world, FixtureID id, const Filter& value);
+        /// @relatedalso WorldImpl
+        void SetFilterData(WorldImpl& world, FixtureID id, const Filter& value);
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_WORLDIMPLFIXTURE_HPP
+#endif// PLAYRHO_DYNAMICS_WORLDIMPLFIXTURE_HPP

--- a/PlayRho/Dynamics/WorldImplJoint.cpp
+++ b/PlayRho/Dynamics/WorldImplJoint.cpp
@@ -21,106 +21,108 @@
 
 #include <PlayRho/Dynamics/WorldImplJoint.hpp>
 
+#include <PlayRho/Dynamics/Body.hpp>// for use of GetBody(BodyID)
 #include <PlayRho/Dynamics/WorldImpl.hpp>
-#include <PlayRho/Dynamics/Body.hpp> // for use of GetBody(BodyID)
 
-#include <PlayRho/Dynamics/Joints/Joint.hpp>
-#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/DistanceJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/GearJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/WheelJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/FrictionJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/RopeJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/GearJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/Joint.hpp>
 #include <PlayRho/Dynamics/Joints/MotorJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/RopeJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/WheelJointConf.hpp>
 
-#include <PlayRho/Common/OptionalValue.hpp> // for Optional
+#include <PlayRho/Common/OptionalValue.hpp>// for Optional
 
-namespace playrho {
-namespace d2 {
-
-JointID CreateJoint(WorldImpl& world, const Joint& def)
+namespace playrho
 {
-    return world.CreateJoint(def);
-}
-
-void Destroy(WorldImpl& world, JointID id)
-{
-    world.Destroy(id);
-}
-
-const Joint& GetJoint(const WorldImpl& world, JointID id)
-{
-    return world.GetJoint(id);
-}
-
-void SetJoint(WorldImpl& world, JointID id, const Joint& def)
-{
-    world.SetJoint(id, def);
-}
-
-JointType GetType(const WorldImpl& world, JointID id)
-{
-    return ::playrho::d2::GetType(world.GetJoint(id));
-}
-
-Momentum2 GetLinearReaction(const WorldImpl& world, JointID id)
-{
-    return GetLinearReaction(world.GetJoint(id));
-}
-
-AngularMomentum GetAngularReaction(const WorldImpl& world, JointID id)
-{
-    return GetAngularReaction(world.GetJoint(id));
-}
-
-void SetAwake(WorldImpl& world, JointID id)
-{
-    const auto& joint = world.GetJoint(id);
-    const auto bA = GetBodyA(joint);
-    const auto bB = GetBodyB(joint);
-    if (bA != InvalidBodyID)
+    namespace d2
     {
-        world.GetBody(bA).SetAwake();
-    }
-    if (bB != InvalidBodyID)
-    {
-        world.GetBody(bB).SetAwake();
-    }
-}
 
-bool GetCollideConnected(const WorldImpl& world, JointID id)
-{
-    return GetCollideConnected(world.GetJoint(id));
-}
+        JointID CreateJoint(WorldImpl& world, const Joint& def)
+        {
+            return world.CreateJoint(def);
+        }
 
-BodyID GetBodyA(const WorldImpl& world, JointID id)
-{
-    return GetBodyA(world.GetJoint(id));
-}
+        void Destroy(WorldImpl& world, JointID id)
+        {
+            world.Destroy(id);
+        }
 
-BodyID GetBodyB(const WorldImpl& world, JointID id)
-{
-    return GetBodyB(world.GetJoint(id));
-}
+        const Joint& GetJoint(const WorldImpl& world, JointID id)
+        {
+            return world.GetJoint(id);
+        }
 
-Length2 GetLocalAnchorA(const WorldImpl& world, JointID id)
-{
-    return GetLocalAnchorA(world.GetJoint(id));
-}
+        void SetJoint(WorldImpl& world, JointID id, const Joint& def)
+        {
+            world.SetJoint(id, def);
+        }
 
-Length2 GetLocalAnchorB(const WorldImpl& world, JointID id)
-{
-    return GetLocalAnchorB(world.GetJoint(id));
-}
+        JointType GetType(const WorldImpl& world, JointID id)
+        {
+            return ::playrho::d2::GetType(world.GetJoint(id));
+        }
 
-Angle GetReferenceAngle(const WorldImpl& world, JointID id)
-{
-    return GetReferenceAngle(world.GetJoint(id));
-}
+        Momentum2 GetLinearReaction(const WorldImpl& world, JointID id)
+        {
+            return GetLinearReaction(world.GetJoint(id));
+        }
 
-} // namespace d2
-} // namespace playrho
+        AngularMomentum GetAngularReaction(const WorldImpl& world, JointID id)
+        {
+            return GetAngularReaction(world.GetJoint(id));
+        }
+
+        void SetAwake(WorldImpl& world, JointID id)
+        {
+            const auto& joint = world.GetJoint(id);
+            const auto bA = GetBodyA(joint);
+            const auto bB = GetBodyB(joint);
+            if (bA != InvalidBodyID)
+            {
+                world.GetBody(bA).SetAwake();
+            }
+            if (bB != InvalidBodyID)
+            {
+                world.GetBody(bB).SetAwake();
+            }
+        }
+
+        bool GetCollideConnected(const WorldImpl& world, JointID id)
+        {
+            return GetCollideConnected(world.GetJoint(id));
+        }
+
+        BodyID GetBodyA(const WorldImpl& world, JointID id)
+        {
+            return GetBodyA(world.GetJoint(id));
+        }
+
+        BodyID GetBodyB(const WorldImpl& world, JointID id)
+        {
+            return GetBodyB(world.GetJoint(id));
+        }
+
+        Length2 GetLocalAnchorA(const WorldImpl& world, JointID id)
+        {
+            return GetLocalAnchorA(world.GetJoint(id));
+        }
+
+        Length2 GetLocalAnchorB(const WorldImpl& world, JointID id)
+        {
+            return GetLocalAnchorB(world.GetJoint(id));
+        }
+
+        Angle GetReferenceAngle(const WorldImpl& world, JointID id)
+        {
+            return GetReferenceAngle(world.GetJoint(id));
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldImplJoint.hpp
+++ b/PlayRho/Dynamics/WorldImplJoint.hpp
@@ -25,73 +25,75 @@
 /// @file
 /// Declarations of free functions of WorldImpl for joints.
 
-#include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/UnitVec.hpp>
-#include <PlayRho/Common/Vector2.hpp> // for Momentum2, Length2
+#include <PlayRho/Common/Units.hpp>
+#include <PlayRho/Common/Vector2.hpp>// for Momentum2, Length2
 
 #include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
 #include <PlayRho/Dynamics/Joints/JointType.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-class WorldImpl;
-class Joint;
+        class WorldImpl;
+        class Joint;
 
-/// @brief Creates a new joint.
-/// @relatedalso WorldImpl
-JointID CreateJoint(WorldImpl& world, const Joint& def);
+        /// @brief Creates a new joint.
+        /// @relatedalso WorldImpl
+        JointID CreateJoint(WorldImpl& world, const Joint& def);
 
-/// @brief Destroys the identified joint.
-/// @relatedalso WorldImpl
-void Destroy(WorldImpl& world, JointID id);
+        /// @brief Destroys the identified joint.
+        /// @relatedalso WorldImpl
+        void Destroy(WorldImpl& world, JointID id);
 
-/// @brief Gets the type of the joint.
-/// @relatedalso WorldImpl
-JointType GetType(const WorldImpl& world, JointID id);
+        /// @brief Gets the type of the joint.
+        /// @relatedalso WorldImpl
+        JointType GetType(const WorldImpl& world, JointID id);
 
-/// @brief Gets the identified joint's value.
-/// @relatedalso WorldImpl
-const Joint& GetJoint(const WorldImpl& world, JointID id);
+        /// @brief Gets the identified joint's value.
+        /// @relatedalso WorldImpl
+        const Joint& GetJoint(const WorldImpl& world, JointID id);
 
-/// @brief Sets the identified joint's new value.
-/// @relatedalso WorldImpl
-void SetJoint(WorldImpl& world, JointID id, const Joint& def);
+        /// @brief Sets the identified joint's new value.
+        /// @relatedalso WorldImpl
+        void SetJoint(WorldImpl& world, JointID id, const Joint& def);
 
-/// @brief Gets the linear reaction on body-B at the joint anchor.
-/// @relatedalso WorldImpl
-Momentum2 GetLinearReaction(const WorldImpl& world, JointID id);
+        /// @brief Gets the linear reaction on body-B at the joint anchor.
+        /// @relatedalso WorldImpl
+        Momentum2 GetLinearReaction(const WorldImpl& world, JointID id);
 
-/// @brief Get the angular reaction on body-B for the identified joint.
-/// @relatedalso WorldImpl
-AngularMomentum GetAngularReaction(const WorldImpl& world, JointID id);
+        /// @brief Get the angular reaction on body-B for the identified joint.
+        /// @relatedalso WorldImpl
+        AngularMomentum GetAngularReaction(const WorldImpl& world, JointID id);
 
-/// @brief Wakes up the joined bodies.
-/// @relatedalso WorldImpl
-void SetAwake(WorldImpl& world, JointID id);
+        /// @brief Wakes up the joined bodies.
+        /// @relatedalso WorldImpl
+        void SetAwake(WorldImpl& world, JointID id);
 
-/// @brief Gets collide connected for the specified joint.
-/// @note Modifying the collide connect flag won't work correctly because
-///   the flag is only checked when fixture AABBs begin to overlap.
-bool GetCollideConnected(const WorldImpl& world, JointID id);
+        /// @brief Gets collide connected for the specified joint.
+        /// @note Modifying the collide connect flag won't work correctly because
+        ///   the flag is only checked when fixture AABBs begin to overlap.
+        bool GetCollideConnected(const WorldImpl& world, JointID id);
 
-/// @relatedalso WorldImpl
-BodyID GetBodyA(const WorldImpl& world, JointID id);
+        /// @relatedalso WorldImpl
+        BodyID GetBodyA(const WorldImpl& world, JointID id);
 
-/// @relatedalso WorldImpl
-BodyID GetBodyB(const WorldImpl& world, JointID id);
+        /// @relatedalso WorldImpl
+        BodyID GetBodyB(const WorldImpl& world, JointID id);
 
-/// @relatedalso WorldImpl
-Length2 GetLocalAnchorA(const WorldImpl& world, JointID id);
+        /// @relatedalso WorldImpl
+        Length2 GetLocalAnchorA(const WorldImpl& world, JointID id);
 
-/// @relatedalso WorldImpl
-Length2 GetLocalAnchorB(const WorldImpl& world, JointID id);
+        /// @relatedalso WorldImpl
+        Length2 GetLocalAnchorB(const WorldImpl& world, JointID id);
 
-/// @relatedalso WorldImpl
-Angle GetReferenceAngle(const WorldImpl& world, JointID id);
+        /// @relatedalso WorldImpl
+        Angle GetReferenceAngle(const WorldImpl& world, JointID id);
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_WORLDIMPLJOINT_HPP
+#endif// PLAYRHO_DYNAMICS_WORLDIMPLJOINT_HPP

--- a/PlayRho/Dynamics/WorldImplMisc.cpp
+++ b/PlayRho/Dynamics/WorldImplMisc.cpp
@@ -21,155 +21,157 @@
 
 #include <PlayRho/Dynamics/WorldImplMisc.hpp>
 
-#include <PlayRho/Dynamics/WorldImpl.hpp>
-#include <PlayRho/Dynamics/WorldConf.hpp>
+#include <PlayRho/Collision/Manifold.hpp>// for WorldImpl not being incomplete
+#include <PlayRho/Dynamics/Body.hpp>     // for WorldImpl not being incomplete
 #include <PlayRho/Dynamics/BodyConf.hpp>
 #include <PlayRho/Dynamics/ContactImpulsesList.hpp>
-#include <PlayRho/Dynamics/Body.hpp> // for WorldImpl not being incomplete
-#include <PlayRho/Dynamics/Fixture.hpp> // for WorldImpl not being incomplete
-#include <PlayRho/Dynamics/Joints/Joint.hpp> // for WorldImpl not being incomplete
-#include <PlayRho/Dynamics/Contacts/Contact.hpp> // for WorldImpl not being incomplete
-#include <PlayRho/Collision/Manifold.hpp> // for WorldImpl not being incomplete
+#include <PlayRho/Dynamics/Contacts/Contact.hpp>// for WorldImpl not being incomplete
+#include <PlayRho/Dynamics/Fixture.hpp>         // for WorldImpl not being incomplete
+#include <PlayRho/Dynamics/Joints/Joint.hpp>    // for WorldImpl not being incomplete
+#include <PlayRho/Dynamics/WorldConf.hpp>
+#include <PlayRho/Dynamics/WorldImpl.hpp>
 
-namespace playrho {
-namespace d2 {
-
-std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldConf& def)
+namespace playrho
 {
-    return std::make_unique<WorldImpl>(def);
-}
+    namespace d2
+    {
 
-std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldImpl& other)
-{
-    return std::make_unique<WorldImpl>(other);
-}
+        std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldConf& def)
+        {
+            return std::make_unique<WorldImpl>(def);
+        }
 
-void Clear(WorldImpl& world) noexcept
-{
-    world.Clear();
-}
+        std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldImpl& other)
+        {
+            return std::make_unique<WorldImpl>(other);
+        }
 
-void SetFixtureDestructionListener(WorldImpl& world,
-                                   std::function<void(FixtureID)> listener) noexcept
-{
-    world.SetFixtureDestructionListener(listener);
-}
+        void Clear(WorldImpl& world) noexcept
+        {
+            world.Clear();
+        }
 
-void SetJointDestructionListener(WorldImpl& world,
-                                 std::function<void(JointID)> listener) noexcept
-{
-    world.SetJointDestructionListener(listener);
-}
+        void SetFixtureDestructionListener(WorldImpl& world,
+                                           std::function<void(FixtureID)> listener) noexcept
+        {
+            world.SetFixtureDestructionListener(listener);
+        }
 
-void SetBeginContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept
-{
-    world.SetBeginContactListener(listener);
-}
+        void SetJointDestructionListener(WorldImpl& world,
+                                         std::function<void(JointID)> listener) noexcept
+        {
+            world.SetJointDestructionListener(listener);
+        }
 
-void SetEndContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept
-{
-    world.SetEndContactListener(listener);
-}
+        void SetBeginContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept
+        {
+            world.SetBeginContactListener(listener);
+        }
 
-void SetPreSolveContactListener(WorldImpl& world,
-                                std::function<void(ContactID, const Manifold&)> listener) noexcept
-{
-    world.SetPreSolveContactListener(listener);
-}
+        void SetEndContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept
+        {
+            world.SetEndContactListener(listener);
+        }
 
-void SetPostSolveContactListener(WorldImpl& world,
-                                 std::function<void(ContactID, const ContactImpulsesList&, unsigned)> listener) noexcept
-{
-    world.SetPostSolveContactListener(listener);
-}
+        void SetPreSolveContactListener(WorldImpl& world,
+                                        std::function<void(ContactID, const Manifold&)> listener) noexcept
+        {
+            world.SetPreSolveContactListener(listener);
+        }
 
-BodyID CreateBody(WorldImpl& world, const BodyConf& def)
-{
-    return world.CreateBody(def);
-}
+        void SetPostSolveContactListener(WorldImpl& world,
+                                         std::function<void(ContactID, const ContactImpulsesList&, unsigned)> listener) noexcept
+        {
+            world.SetPostSolveContactListener(listener);
+        }
 
-StepStats Step(WorldImpl& world, const StepConf& conf)
-{
-    return world.Step(conf);
-}
+        BodyID CreateBody(WorldImpl& world, const BodyConf& def)
+        {
+            return world.CreateBody(def);
+        }
 
-void ShiftOrigin(WorldImpl& world, Length2 newOrigin)
-{
-    world.ShiftOrigin(newOrigin);
-}
+        StepStats Step(WorldImpl& world, const StepConf& conf)
+        {
+            return world.Step(conf);
+        }
 
-SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const WorldImpl& world) noexcept
-{
-    return world.GetBodies();
-}
+        void ShiftOrigin(WorldImpl& world, Length2 newOrigin)
+        {
+            world.ShiftOrigin(newOrigin);
+        }
 
-SizedRange<std::vector<BodyID>::const_iterator>
-GetBodiesForProxies(const WorldImpl& world) noexcept
-{
-    return world.GetBodiesForProxies();
-}
+        SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const WorldImpl& world) noexcept
+        {
+            return world.GetBodies();
+        }
 
-SizedRange<std::vector<FixtureID>::const_iterator>
-GetFixturesForProxies(const WorldImpl& world) noexcept
-{
-    return world.GetFixturesForProxies();
-}
+        SizedRange<std::vector<BodyID>::const_iterator>
+        GetBodiesForProxies(const WorldImpl& world) noexcept
+        {
+            return world.GetBodiesForProxies();
+        }
 
-SizedRange<std::vector<JointID>::const_iterator> GetJoints(const WorldImpl& world) noexcept
-{
-    return world.GetJoints();
-}
+        SizedRange<std::vector<FixtureID>::const_iterator>
+        GetFixturesForProxies(const WorldImpl& world) noexcept
+        {
+            return world.GetFixturesForProxies();
+        }
 
-SizedRange<std::vector<KeyedContactPtr>::const_iterator>
-GetContacts(const WorldImpl& world) noexcept
-{
-    return world.GetContacts();
-}
+        SizedRange<std::vector<JointID>::const_iterator> GetJoints(const WorldImpl& world) noexcept
+        {
+            return world.GetJoints();
+        }
 
-bool IsLocked(const WorldImpl& world) noexcept
-{
-    return world.IsLocked();
-}
+        SizedRange<std::vector<KeyedContactPtr>::const_iterator>
+        GetContacts(const WorldImpl& world) noexcept
+        {
+            return world.GetContacts();
+        }
 
-bool IsStepComplete(const WorldImpl& world) noexcept
-{
-    return world.IsStepComplete();
-}
+        bool IsLocked(const WorldImpl& world) noexcept
+        {
+            return world.IsLocked();
+        }
 
-bool GetSubStepping(const WorldImpl& world) noexcept
-{
-    return world.GetSubStepping();
-}
+        bool IsStepComplete(const WorldImpl& world) noexcept
+        {
+            return world.IsStepComplete();
+        }
 
-void SetSubStepping(WorldImpl& world, bool value) noexcept
-{
-    world.SetSubStepping(value);
-}
+        bool GetSubStepping(const WorldImpl& world) noexcept
+        {
+            return world.GetSubStepping();
+        }
 
-Length GetMinVertexRadius(const WorldImpl& world) noexcept
-{
-    return world.GetMinVertexRadius();
-}
+        void SetSubStepping(WorldImpl& world, bool value) noexcept
+        {
+            world.SetSubStepping(value);
+        }
 
-Length GetMaxVertexRadius(const WorldImpl& world) noexcept
-{
-    return world.GetMaxVertexRadius();
-}
+        Length GetMinVertexRadius(const WorldImpl& world) noexcept
+        {
+            return world.GetMinVertexRadius();
+        }
 
-Frequency GetInvDeltaTime(const WorldImpl& world) noexcept
-{
-    return world.GetInvDeltaTime();
-}
+        Length GetMaxVertexRadius(const WorldImpl& world) noexcept
+        {
+            return world.GetMaxVertexRadius();
+        }
 
-const DynamicTree& GetTree(const WorldImpl& world) noexcept
-{
-    return world.GetTree();
-}
+        Frequency GetInvDeltaTime(const WorldImpl& world) noexcept
+        {
+            return world.GetInvDeltaTime();
+        }
 
-FixtureCounter GetShapeCount(const WorldImpl& world) noexcept
-{
-    return world.GetShapeCount();
-}
+        const DynamicTree& GetTree(const WorldImpl& world) noexcept
+        {
+            return world.GetTree();
+        }
 
-} // namespace d2
-} // namespace playrho
+        FixtureCounter GetShapeCount(const WorldImpl& world) noexcept
+        {
+            return world.GetShapeCount();
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldImplMisc.hpp
+++ b/PlayRho/Dynamics/WorldImplMisc.hpp
@@ -25,95 +25,97 @@
 /// @file
 /// Declarations of free functions of WorldImpl.
 
-#include <PlayRho/Common/Units.hpp> // for Length, Frequency, etc.
-#include <PlayRho/Common/Vector2.hpp> // for Length2
-#include <PlayRho/Common/Range.hpp> // for SizedRange
+#include <PlayRho/Common/Range.hpp>  // for SizedRange
+#include <PlayRho/Common/Units.hpp>  // for Length, Frequency, etc.
+#include <PlayRho/Common/Vector2.hpp>// for Length2
 
-#include <PlayRho/Dynamics/StepStats.hpp>
 #include <PlayRho/Dynamics/BodyID.hpp>
-#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Contacts/ContactID.hpp>
-#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp> // for KeyedContactPtr
+#include <PlayRho/Dynamics/Contacts/KeyedContactID.hpp>// for KeyedContactPtr
+#include <PlayRho/Dynamics/FixtureID.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
+#include <PlayRho/Dynamics/StepStats.hpp>
 
-#include <functional> // for std::function
-#include <memory> // for std::unique_ptr
+#include <functional>// for std::function
+#include <memory>    // for std::unique_ptr
 #include <vector>
 
-namespace playrho {
+namespace playrho
+{
 
-struct StepConf;
+    struct StepConf;
 
-namespace d2 {
+    namespace d2
+    {
 
-class WorldImpl;
-class Manifold;
-struct BodyConf;
-struct JointConf;
-class DynamicTree;
-struct WorldConf;
-class ContactImpulsesList;
+        class WorldImpl;
+        class Manifold;
+        struct BodyConf;
+        struct JointConf;
+        class DynamicTree;
+        struct WorldConf;
+        class ContactImpulsesList;
 
-std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldConf& def);
+        std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldConf& def);
 
-std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldImpl& other);
+        std::unique_ptr<WorldImpl> CreateWorldImpl(const WorldImpl& other);
 
-void Clear(WorldImpl& world) noexcept;
+        void Clear(WorldImpl& world) noexcept;
 
-void SetFixtureDestructionListener(WorldImpl& world,
-                                   std::function<void(FixtureID)> listener) noexcept;
+        void SetFixtureDestructionListener(WorldImpl& world,
+                                           std::function<void(FixtureID)> listener) noexcept;
 
-void SetJointDestructionListener(WorldImpl& world,
-                                 std::function<void(JointID)> listener) noexcept;
+        void SetJointDestructionListener(WorldImpl& world,
+                                         std::function<void(JointID)> listener) noexcept;
 
-void SetBeginContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept;
+        void SetBeginContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept;
 
-void SetEndContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept;
+        void SetEndContactListener(WorldImpl& world, std::function<void(ContactID)> listener) noexcept;
 
-void SetPreSolveContactListener(WorldImpl& world,
-                                std::function<void(ContactID, const Manifold&)> listener) noexcept;
+        void SetPreSolveContactListener(WorldImpl& world,
+                                        std::function<void(ContactID, const Manifold&)> listener) noexcept;
 
-void SetPostSolveContactListener(WorldImpl& world,
-                                 std::function<void(ContactID, const ContactImpulsesList&, unsigned)> listener) noexcept;
+        void SetPostSolveContactListener(WorldImpl& world,
+                                         std::function<void(ContactID, const ContactImpulsesList&, unsigned)> listener) noexcept;
 
-BodyID CreateBody(WorldImpl& world, const BodyConf& def);
+        BodyID CreateBody(WorldImpl& world, const BodyConf& def);
 
-StepStats Step(WorldImpl& world, const StepConf& conf);
+        StepStats Step(WorldImpl& world, const StepConf& conf);
 
-void ShiftOrigin(WorldImpl& world, Length2 newOrigin);
+        void ShiftOrigin(WorldImpl& world, Length2 newOrigin);
 
-SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const WorldImpl& world) noexcept;
+        SizedRange<std::vector<BodyID>::const_iterator> GetBodies(const WorldImpl& world) noexcept;
 
-SizedRange<std::vector<BodyID>::const_iterator>
-GetBodiesForProxies(const WorldImpl& world) noexcept;
+        SizedRange<std::vector<BodyID>::const_iterator>
+        GetBodiesForProxies(const WorldImpl& world) noexcept;
 
-SizedRange<std::vector<FixtureID>::const_iterator>
-GetFixturesForProxies(const WorldImpl& world) noexcept;
+        SizedRange<std::vector<FixtureID>::const_iterator>
+        GetFixturesForProxies(const WorldImpl& world) noexcept;
 
-SizedRange<std::vector<JointID>::const_iterator> GetJoints(const WorldImpl& world) noexcept;
+        SizedRange<std::vector<JointID>::const_iterator> GetJoints(const WorldImpl& world) noexcept;
 
-SizedRange<std::vector<KeyedContactPtr>::const_iterator>
-GetContacts(const WorldImpl& world) noexcept;
+        SizedRange<std::vector<KeyedContactPtr>::const_iterator>
+        GetContacts(const WorldImpl& world) noexcept;
 
-bool IsLocked(const WorldImpl& world) noexcept;
+        bool IsLocked(const WorldImpl& world) noexcept;
 
-bool IsStepComplete(const WorldImpl& world) noexcept;
+        bool IsStepComplete(const WorldImpl& world) noexcept;
 
-bool GetSubStepping(const WorldImpl& world) noexcept;
+        bool GetSubStepping(const WorldImpl& world) noexcept;
 
-void SetSubStepping(WorldImpl& world, bool value) noexcept;
+        void SetSubStepping(WorldImpl& world, bool value) noexcept;
 
-Length GetMinVertexRadius(const WorldImpl& world) noexcept;
+        Length GetMinVertexRadius(const WorldImpl& world) noexcept;
 
-Length GetMaxVertexRadius(const WorldImpl& world) noexcept;
+        Length GetMaxVertexRadius(const WorldImpl& world) noexcept;
 
-Frequency GetInvDeltaTime(const WorldImpl& world) noexcept;
+        Frequency GetInvDeltaTime(const WorldImpl& world) noexcept;
 
-const DynamicTree& GetTree(const WorldImpl& world) noexcept;
+        const DynamicTree& GetTree(const WorldImpl& world) noexcept;
 
-FixtureCounter GetShapeCount(const WorldImpl& world) noexcept;
+        FixtureCounter GetShapeCount(const WorldImpl& world) noexcept;
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_WORLDIMPLMISC_HPP
+#endif// PLAYRHO_DYNAMICS_WORLDIMPLMISC_HPP

--- a/PlayRho/Dynamics/WorldJoint.cpp
+++ b/PlayRho/Dynamics/WorldJoint.cpp
@@ -27,319 +27,321 @@
 
 #include <algorithm>
 
-namespace playrho {
-namespace d2 {
-
-SizedRange<std::vector<JointID>::const_iterator> GetJoints(const World& world) noexcept
+namespace playrho
 {
-    return world.GetJoints();
-}
-
-JointID CreateJoint(World& world, const Joint& def)
-{
-    return world.CreateJoint(def);
-}
-
-void Destroy(World& world, JointID id)
-{
-    world.Destroy(id);
-}
-
-JointType GetType(const World& world, JointID id)
-{
-    return world.GetType(id);
-}
-
-const Joint& GetJoint(const World& world, JointID id)
-{
-    return world.GetJoint(id);
-}
-
-void SetJoint(World& world, JointID id, const Joint& def)
-{
-    world.SetJoint(id, def);
-}
-
-bool GetCollideConnected(const World& world, JointID id)
-{
-    return world.GetCollideConnected(id);
-}
-
-BodyID GetBodyA(const World& world, JointID id)
-{
-    return world.GetBodyA(id);
-}
-
-BodyID GetBodyB(const World& world, JointID id)
-{
-    return world.GetBodyB(id);
-}
-
-Length2 GetLocalAnchorA(const World& world, JointID id)
-{
-    return world.GetLocalAnchorA(id);
-}
-
-Length2 GetLocalAnchorB(const World& world, JointID id)
-{
-    return world.GetLocalAnchorB(id);
-}
-
-Momentum2 GetLinearReaction(const World& world, JointID id)
-{
-    return world.GetLinearReaction(id);
-}
-
-AngularMomentum GetAngularReaction(const World& world, JointID id)
-{
-    return world.GetAngularReaction(id);
-}
-
-Angle GetReferenceAngle(const World& world, JointID id)
-{
-    return world.GetReferenceAngle(id);
-}
-
-void SetAwake(World& world, JointID id)
-{
-    world.SetAwake(id);
-}
-
-UnitVec GetLocalXAxisA(const World& world, JointID id)
-{
-    return GetLocalXAxisA(GetJoint(world, id));
-}
-
-UnitVec GetLocalYAxisA(const World& world, JointID id)
-{
-    return GetLocalYAxisA(GetJoint(world, id));
-}
-
-AngularVelocity GetMotorSpeed(const World& world, JointID id)
-{
-    return GetMotorSpeed(GetJoint(world, id));
-}
-
-void SetMotorSpeed(World& world, JointID id, AngularVelocity value)
-{
-    auto joint = GetJoint(world, id);
-    SetMotorSpeed(joint, value);
-    SetJoint(world, id, joint);
-}
-
-AngularMomentum GetAngularMotorImpulse(const World& world, JointID id)
-{
-    return GetAngularMotorImpulse(GetJoint(world, id));
-}
-
-RotInertia GetAngularMass(const World& world, JointID id)
-{
-    return GetAngularMass(GetJoint(world, id));
-}
-
-Torque GetMaxMotorTorque(const World& world, JointID id)
-{
-    return GetMaxMotorTorque(GetJoint(world, id));
-}
-
-void SetMaxMotorTorque(World& world, JointID id, Torque value)
-{
-    auto joint = GetJoint(world, id);
-    SetMaxMotorTorque(joint, value);
-    SetJoint(world, id, joint);
-}
-
-Frequency GetFrequency(const World& world, JointID id)
-{
-    return GetFrequency(GetJoint(world, id));
-}
-
-void SetFrequency(World& world, JointID id, Frequency value)
-{
-    auto joint = GetJoint(world, id);
-    SetFrequency(joint, value);
-    SetJoint(world, id, joint);
-}
-
-AngularVelocity GetAngularVelocity(const World& world, JointID id)
-{
-    return world.GetVelocity(GetBodyB(world, id)).angular
-         - world.GetVelocity(GetBodyA(world, id)).angular;
-}
-
-bool IsEnabled(const World& world, JointID id)
-{
-    const auto bA = GetBodyA(world, id);
-    const auto bB = GetBodyB(world, id);
-    return (bA == InvalidBodyID || world.IsEnabled(bA))
-        && (bB == InvalidBodyID || world.IsEnabled(bB));
-}
-
-JointCounter GetWorldIndex(const World& world, JointID id) noexcept
-{
-    const auto elems = world.GetJoints();
-    const auto it = std::find(cbegin(elems), cend(elems), id);
-    if (it != cend(elems))
+    namespace d2
     {
-        return static_cast<JointCounter>(std::distance(cbegin(elems), it));
-    }
-    return JointCounter(-1);
-}
 
-Length2 GetAnchorA(const World& world, JointID id)
-{
-    return Transform(GetLocalAnchorA(world, id), world.GetTransformation(GetBodyA(world, id)));
-}
+        SizedRange<std::vector<JointID>::const_iterator> GetJoints(const World& world) noexcept
+        {
+            return world.GetJoints();
+        }
 
-Length2 GetAnchorB(const World& world, JointID id)
-{
-    return Transform(GetLocalAnchorB(world, id), world.GetTransformation(GetBodyB(world, id)));
-}
+        JointID CreateJoint(World& world, const Joint& def)
+        {
+            return world.CreateJoint(def);
+        }
 
-Real GetRatio(const World& world, JointID id)
-{
-    return GetRatio(GetJoint(world, id));
-}
+        void Destroy(World& world, JointID id)
+        {
+            world.Destroy(id);
+        }
 
-Length GetJointTranslation(const World& world, JointID id)
-{
-    const auto pA = GetAnchorA(world, id);
-    const auto pB = GetAnchorB(world, id);
-    const auto uv = Rotate(GetLocalXAxisA(world, id),
-                           world.GetTransformation(GetBodyA(world, id)).q);
-    return Dot(pB - pA, uv);
-}
+        JointType GetType(const World& world, JointID id)
+        {
+            return world.GetType(id);
+        }
 
-Angle GetAngle(const World& world, JointID id)
-{
-    return world.GetAngle(GetBodyB(world, id)) - world.GetAngle(GetBodyA(world, id))
-         - GetReferenceAngle(world, id);
-}
+        const Joint& GetJoint(const World& world, JointID id)
+        {
+            return world.GetJoint(id);
+        }
 
-bool IsLimitEnabled(const World& world, JointID id)
-{
-    return IsLimitEnabled(GetJoint(world, id));
-}
+        void SetJoint(World& world, JointID id, const Joint& def)
+        {
+            world.SetJoint(id, def);
+        }
 
-void EnableLimit(World& world, JointID id, bool value)
-{
-    auto joint = GetJoint(world, id);
-    EnableLimit(joint, value);
-    SetJoint(world, id, joint);
-}
+        bool GetCollideConnected(const World& world, JointID id)
+        {
+            return world.GetCollideConnected(id);
+        }
 
-bool IsMotorEnabled(const World& world, JointID id)
-{
-    return IsMotorEnabled(GetJoint(world, id));
-}
+        BodyID GetBodyA(const World& world, JointID id)
+        {
+            return world.GetBodyA(id);
+        }
 
-void EnableMotor(World& world, JointID id, bool value)
-{
-    auto joint = GetJoint(world, id);
-    EnableMotor(joint, value);
-    SetJoint(world, id, joint);
-}
+        BodyID GetBodyB(const World& world, JointID id)
+        {
+            return world.GetBodyB(id);
+        }
 
-Momentum GetLinearMotorImpulse(const World& world, JointID id)
-{
-    return GetLinearMotorImpulse(GetJoint(world, id));
-}
+        Length2 GetLocalAnchorA(const World& world, JointID id)
+        {
+            return world.GetLocalAnchorA(id);
+        }
 
-Length2 GetLinearOffset(const World& world, JointID id)
-{
-    return GetLinearOffset(GetJoint(world, id));
-}
+        Length2 GetLocalAnchorB(const World& world, JointID id)
+        {
+            return world.GetLocalAnchorB(id);
+        }
 
-void SetLinearOffset(World& world, JointID id, Length2 value)
-{
-    auto joint = GetJoint(world, id);
-    SetLinearOffset(joint, value);
-    SetJoint(world, id, joint);
-}
+        Momentum2 GetLinearReaction(const World& world, JointID id)
+        {
+            return world.GetLinearReaction(id);
+        }
 
-Angle GetAngularOffset(const World& world, JointID id)
-{
-    return GetAngularOffset(GetJoint(world, id));
-}
+        AngularMomentum GetAngularReaction(const World& world, JointID id)
+        {
+            return world.GetAngularReaction(id);
+        }
 
-void SetAngularOffset(World& world, JointID id, Angle value)
-{
-    auto joint = GetJoint(world, id);
-    SetAngularOffset(joint, value);
-    SetJoint(world, id, joint);
-}
+        Angle GetReferenceAngle(const World& world, JointID id)
+        {
+            return world.GetReferenceAngle(id);
+        }
 
-Length2 GetGroundAnchorA(const World& world,  JointID id)
-{
-    return GetGroundAnchorA(GetJoint(world, id));
-}
+        void SetAwake(World& world, JointID id)
+        {
+            world.SetAwake(id);
+        }
 
-Length2 GetGroundAnchorB(const World& world,  JointID id)
-{
-    return GetGroundAnchorB(GetJoint(world, id));
-}
+        UnitVec GetLocalXAxisA(const World& world, JointID id)
+        {
+            return GetLocalXAxisA(GetJoint(world, id));
+        }
 
-Length GetCurrentLengthA(const World& world, JointID id)
-{
-    return GetMagnitude(GetAnchorA(world, id) - GetGroundAnchorA(world, id));
-}
+        UnitVec GetLocalYAxisA(const World& world, JointID id)
+        {
+            return GetLocalYAxisA(GetJoint(world, id));
+        }
 
-Length GetCurrentLengthB(const World& world, JointID id)
-{
-    return GetMagnitude(GetAnchorB(world, id) - GetGroundAnchorB(world, id));
-}
+        AngularVelocity GetMotorSpeed(const World& world, JointID id)
+        {
+            return GetMotorSpeed(GetJoint(world, id));
+        }
 
-Length2 GetTarget(const World& world, JointID id)
-{
-    return GetTarget(GetJoint(world, id));
-}
+        void SetMotorSpeed(World& world, JointID id, AngularVelocity value)
+        {
+            auto joint = GetJoint(world, id);
+            SetMotorSpeed(joint, value);
+            SetJoint(world, id, joint);
+        }
 
-void SetTarget(World& world, JointID id, Length2 value)
-{
-    auto joint = GetJoint(world, id);
-    SetTarget(joint, value);
-    SetJoint(world, id, joint);
-}
+        AngularMomentum GetAngularMotorImpulse(const World& world, JointID id)
+        {
+            return GetAngularMotorImpulse(GetJoint(world, id));
+        }
 
-Angle GetAngularLowerLimit(const World& world, JointID id)
-{
-    return GetAngularLowerLimit(GetJoint(world, id));
-}
+        RotInertia GetAngularMass(const World& world, JointID id)
+        {
+            return GetAngularMass(GetJoint(world, id));
+        }
 
-Angle GetAngularUpperLimit(const World& world, JointID id)
-{
-    return GetAngularUpperLimit(GetJoint(world, id));
-}
+        Torque GetMaxMotorTorque(const World& world, JointID id)
+        {
+            return GetMaxMotorTorque(GetJoint(world, id));
+        }
 
-void SetAngularLimits(World& world, JointID id, Angle lower, Angle upper)
-{
-    auto joint = GetJoint(world, id);
-    SetAngularLimits(joint, lower, upper);
-    SetJoint(world, id, joint);
-}
+        void SetMaxMotorTorque(World& world, JointID id, Torque value)
+        {
+            auto joint = GetJoint(world, id);
+            SetMaxMotorTorque(joint, value);
+            SetJoint(world, id, joint);
+        }
 
-bool ShiftOrigin(World& world, JointID id, Length2 value)
-{
-    auto joint = GetJoint(world, id);
-    const auto shifted = ShiftOrigin(joint, value);
-    SetJoint(world, id, joint);
-    return shifted;
-}
+        Frequency GetFrequency(const World& world, JointID id)
+        {
+            return GetFrequency(GetJoint(world, id));
+        }
 
-Real GetDampingRatio(const World& world, JointID id)
-{
-    return GetDampingRatio(GetJoint(world, id));
-}
+        void SetFrequency(World& world, JointID id, Frequency value)
+        {
+            auto joint = GetJoint(world, id);
+            SetFrequency(joint, value);
+            SetJoint(world, id, joint);
+        }
 
-Length GetLength(const World& world, JointID id)
-{
-    return GetLength(GetJoint(world, id));
-}
+        AngularVelocity GetAngularVelocity(const World& world, JointID id)
+        {
+            return world.GetVelocity(GetBodyB(world, id)).angular
+                   - world.GetVelocity(GetBodyA(world, id)).angular;
+        }
 
-LimitState GetLimitState(const World& world, JointID id)
-{
-    return GetLimitState(GetJoint(world, id));
-}
+        bool IsEnabled(const World& world, JointID id)
+        {
+            const auto bA = GetBodyA(world, id);
+            const auto bB = GetBodyB(world, id);
+            return (bA == InvalidBodyID || world.IsEnabled(bA))
+                   && (bB == InvalidBodyID || world.IsEnabled(bB));
+        }
 
-} // namespace d2
-} // namespace playrho
+        JointCounter GetWorldIndex(const World& world, JointID id) noexcept
+        {
+            const auto elems = world.GetJoints();
+            const auto it = std::find(cbegin(elems), cend(elems), id);
+            if (it != cend(elems))
+            {
+                return static_cast<JointCounter>(std::distance(cbegin(elems), it));
+            }
+            return JointCounter(-1);
+        }
+
+        Length2 GetAnchorA(const World& world, JointID id)
+        {
+            return Transform(GetLocalAnchorA(world, id), world.GetTransformation(GetBodyA(world, id)));
+        }
+
+        Length2 GetAnchorB(const World& world, JointID id)
+        {
+            return Transform(GetLocalAnchorB(world, id), world.GetTransformation(GetBodyB(world, id)));
+        }
+
+        Real GetRatio(const World& world, JointID id)
+        {
+            return GetRatio(GetJoint(world, id));
+        }
+
+        Length GetJointTranslation(const World& world, JointID id)
+        {
+            const auto pA = GetAnchorA(world, id);
+            const auto pB = GetAnchorB(world, id);
+            const auto uv = Rotate(GetLocalXAxisA(world, id),
+                                   world.GetTransformation(GetBodyA(world, id)).q);
+            return Dot(pB - pA, uv);
+        }
+
+        Angle GetAngle(const World& world, JointID id)
+        {
+            return world.GetAngle(GetBodyB(world, id)) - world.GetAngle(GetBodyA(world, id))
+                   - GetReferenceAngle(world, id);
+        }
+
+        bool IsLimitEnabled(const World& world, JointID id)
+        {
+            return IsLimitEnabled(GetJoint(world, id));
+        }
+
+        void EnableLimit(World& world, JointID id, bool value)
+        {
+            auto joint = GetJoint(world, id);
+            EnableLimit(joint, value);
+            SetJoint(world, id, joint);
+        }
+
+        bool IsMotorEnabled(const World& world, JointID id)
+        {
+            return IsMotorEnabled(GetJoint(world, id));
+        }
+
+        void EnableMotor(World& world, JointID id, bool value)
+        {
+            auto joint = GetJoint(world, id);
+            EnableMotor(joint, value);
+            SetJoint(world, id, joint);
+        }
+
+        Momentum GetLinearMotorImpulse(const World& world, JointID id)
+        {
+            return GetLinearMotorImpulse(GetJoint(world, id));
+        }
+
+        Length2 GetLinearOffset(const World& world, JointID id)
+        {
+            return GetLinearOffset(GetJoint(world, id));
+        }
+
+        void SetLinearOffset(World& world, JointID id, Length2 value)
+        {
+            auto joint = GetJoint(world, id);
+            SetLinearOffset(joint, value);
+            SetJoint(world, id, joint);
+        }
+
+        Angle GetAngularOffset(const World& world, JointID id)
+        {
+            return GetAngularOffset(GetJoint(world, id));
+        }
+
+        void SetAngularOffset(World& world, JointID id, Angle value)
+        {
+            auto joint = GetJoint(world, id);
+            SetAngularOffset(joint, value);
+            SetJoint(world, id, joint);
+        }
+
+        Length2 GetGroundAnchorA(const World& world, JointID id)
+        {
+            return GetGroundAnchorA(GetJoint(world, id));
+        }
+
+        Length2 GetGroundAnchorB(const World& world, JointID id)
+        {
+            return GetGroundAnchorB(GetJoint(world, id));
+        }
+
+        Length GetCurrentLengthA(const World& world, JointID id)
+        {
+            return GetMagnitude(GetAnchorA(world, id) - GetGroundAnchorA(world, id));
+        }
+
+        Length GetCurrentLengthB(const World& world, JointID id)
+        {
+            return GetMagnitude(GetAnchorB(world, id) - GetGroundAnchorB(world, id));
+        }
+
+        Length2 GetTarget(const World& world, JointID id)
+        {
+            return GetTarget(GetJoint(world, id));
+        }
+
+        void SetTarget(World& world, JointID id, Length2 value)
+        {
+            auto joint = GetJoint(world, id);
+            SetTarget(joint, value);
+            SetJoint(world, id, joint);
+        }
+
+        Angle GetAngularLowerLimit(const World& world, JointID id)
+        {
+            return GetAngularLowerLimit(GetJoint(world, id));
+        }
+
+        Angle GetAngularUpperLimit(const World& world, JointID id)
+        {
+            return GetAngularUpperLimit(GetJoint(world, id));
+        }
+
+        void SetAngularLimits(World& world, JointID id, Angle lower, Angle upper)
+        {
+            auto joint = GetJoint(world, id);
+            SetAngularLimits(joint, lower, upper);
+            SetJoint(world, id, joint);
+        }
+
+        bool ShiftOrigin(World& world, JointID id, Length2 value)
+        {
+            auto joint = GetJoint(world, id);
+            const auto shifted = ShiftOrigin(joint, value);
+            SetJoint(world, id, joint);
+            return shifted;
+        }
+
+        Real GetDampingRatio(const World& world, JointID id)
+        {
+            return GetDampingRatio(GetJoint(world, id));
+        }
+
+        Length GetLength(const World& world, JointID id)
+        {
+            return GetLength(GetJoint(world, id));
+        }
+
+        LimitState GetLimitState(const World& world, JointID id)
+        {
+            return GetLimitState(GetJoint(world, id));
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldJoint.hpp
+++ b/PlayRho/Dynamics/WorldJoint.hpp
@@ -26,7 +26,7 @@
 /// Declarations of free functions of World for joints identified by <code>JointID</code>.
 
 #include <PlayRho/Common/Math.hpp>
-#include <PlayRho/Common/Range.hpp> // for SizedRange
+#include <PlayRho/Common/Range.hpp>// for SizedRange
 
 #include <PlayRho/Dynamics/BodyID.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
@@ -35,334 +35,336 @@
 
 #include <vector>
 
-namespace playrho {
-namespace d2 {
-
-class World;
-class Joint;
-struct JointConf;
-
-/// @defgroup WorldJointFreeFunctions World Joint Related Free Functions
-/// @brief Collection of "free" functions related to joints within a <code>World</code>.
-/// @details This is a collection of non-member non-friend functions - also called "free"
-///   functions - that are related to joints within an instance of a <code>World</code>.
-///   Many are just "wrappers" to similarly named member functions but some are additional
-///   functionality built on those member functions. A benefit to using free functions that
-///   are now just wrappers, is that of helping to isolate your code from future changes that
-///   might occur to the underlying <code>World</code> member functions. Free functions in
-///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
-///   when compiled without any compiler optimizations enabled, enabling optimizations
-///   should entirely eliminate that overhead.
-/// @note The four basic categories of these functions are "CRUD": create, read, update,
-///   and delete.
-/// @see World, JointID.
-/// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
-/// @{
-
-/// @brief Gets the joints of the specified world.
-/// @relatedalso World
-SizedRange<std::vector<JointID>::const_iterator> GetJoints(const World& world) noexcept;
-
-/// @brief Create a new joint.
-/// @relatedalso World
-JointID CreateJoint(World& world, const Joint& def);
-
-/// @brief Destroys the identified joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void Destroy(World& world, JointID id);
-
-/// @brief Gets the type of the joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-JointType GetType(const World& world, JointID id);
-
-/// @brief Gets the value of the identified joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-const Joint& GetJoint(const World& world, JointID id);
-
-/// @brief Sets the value of the identified joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void SetJoint(World& world, JointID id, const Joint& def);
-
-/// @copydoc World::GetCollideConnected
-/// @relatedalso World
-bool GetCollideConnected(const World& world, JointID id);
-
-/// Is the joint motor enabled?
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @see EnableMotor(World& world, JointID joint, bool value)
-/// @relatedalso World
-bool IsMotorEnabled(const World& world, JointID id);
-
-/// Enable/disable the joint motor.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void EnableMotor(World& world, JointID id, bool value);
-
-/// @brief Gets whether the identified joint's limit is enabled.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-bool IsLimitEnabled(const World& world, JointID id);
-
-/// @brief Sets whether the identified joint's limit is enabled or not.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void EnableLimit(World& world, JointID id, bool value);
-
-/// @brief Gets the identifier of body-A of the identified joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-BodyID GetBodyA(const World& world, JointID id);
-
-/// @brief Gets the identifier of body-B of the identified joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-BodyID GetBodyB(const World& world, JointID id);
-
-/// Get the anchor point on body-A in local coordinates.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetLocalAnchorA(const World& world, JointID id);
-
-/// Get the anchor point on body-B in local coordinates.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetLocalAnchorB(const World& world, JointID id);
-
-/// @copydoc World::GetLinearReaction
-/// @relatedalso World
-Momentum2 GetLinearReaction(const World& world, JointID id);
-
-/// @copydoc World::GetAngularReaction
-/// @relatedalso World
-AngularMomentum GetAngularReaction(const World& world, JointID id);
-
-/// @brief Gets the reference-angle property of the identified joint if it has it.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Angle GetReferenceAngle(const World& world, JointID id);
-
-/// @brief Gets the local-X-axis-A property of the identified joint if it has it.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-UnitVec GetLocalXAxisA(const World& world, JointID id);
-
-/// @brief Gets the local-Y-axis-A property of the identified joint if it has it.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-UnitVec GetLocalYAxisA(const World& world, JointID id);
-
-/// @brief Gets the motor-speed property of the identied joint if it supports it.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-/// @see SetMotorSpeed(World& world, JointID id, AngularVelocity value)
-AngularVelocity GetMotorSpeed(const World& world, JointID id);
-
-/// @brief Sets the motor-speed property of the identied joint if it supports it.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-/// @see GetMotorSpeed(const World& world, JointID id)
-void SetMotorSpeed(World& world, JointID id, AngularVelocity value);
-
-/// @brief Gets the max motor torque.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Torque GetMaxMotorTorque(const World& world, JointID id);
-
-/// Sets the maximum motor torque.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void SetMaxMotorTorque(World& world, JointID id, Torque value);
-
-/// @brief Gets the linear motor impulse of the identified joint if it supports that.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Momentum GetLinearMotorImpulse(const World& world, JointID id);
-
-/// @brief Gets the angular motor impulse of the identified joint if it has this property.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-AngularMomentum GetAngularMotorImpulse(const World& world, JointID id);
-
-/// @brief Gets the computed angular rotational inertia used by the joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-RotInertia GetAngularMass(const World& world, JointID id);
-
-/// @brief Gets the frequency of the identified joint if it has this property.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Frequency GetFrequency(const World& world, JointID id);
-
-/// @brief Sets the frequency of the identified joint if it has this property.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void SetFrequency(World& world, JointID id, Frequency value);
-
-/// @brief Gets the angular velocity of the identified joint if it has this property.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-AngularVelocity GetAngularVelocity(const World& world, JointID id);
-
-/// @brief Gets the enabled/disabled state of the joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-bool IsEnabled(const World& world, JointID id);
-
-/// @brief Gets the world index of the given joint.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-JointCounter GetWorldIndex(const World& world, JointID id) noexcept;
-
-/// Get the anchor point on body-A in world coordinates.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetAnchorA(const World& world, JointID id);
-
-/// Get the anchor point on body-B in world coordinates.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetAnchorB(const World& world, JointID id);
-
-/// @brief Gets the ratio property of the identified joint if it has it.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Real GetRatio(const World& world, JointID id);
-
-/// @brief Gets the current joint translation.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length GetJointTranslation(const World& world, JointID id);
-
-/// @brief Gets the angle property of the identified joint if it has it.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Angle GetAngle(const World& world, JointID id);
-
-/// @brief Gets the current motor force for the given joint, given the inverse time step.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-inline Force GetMotorForce(const World& world, JointID id, Frequency inv_dt)
+namespace playrho
 {
-    return GetLinearMotorImpulse(world, id) * inv_dt;
-}
+    namespace d2
+    {
 
-/// @brief Gets the current motor torque for the given joint given the inverse time step.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-inline Torque GetMotorTorque(const World& world, JointID id, Frequency inv_dt)
-{
-    return GetAngularMotorImpulse(world, id) * inv_dt;
-}
+        class World;
+        class Joint;
+        struct JointConf;
 
-/// @brief Gets the target linear offset, in frame A.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetLinearOffset(const World& world, JointID id);
+        /// @defgroup WorldJointFreeFunctions World Joint Related Free Functions
+        /// @brief Collection of "free" functions related to joints within a <code>World</code>.
+        /// @details This is a collection of non-member non-friend functions - also called "free"
+        ///   functions - that are related to joints within an instance of a <code>World</code>.
+        ///   Many are just "wrappers" to similarly named member functions but some are additional
+        ///   functionality built on those member functions. A benefit to using free functions that
+        ///   are now just wrappers, is that of helping to isolate your code from future changes that
+        ///   might occur to the underlying <code>World</code> member functions. Free functions in
+        ///   this sense are "cheap" abstractions. While using these incurs extra run-time overhead
+        ///   when compiled without any compiler optimizations enabled, enabling optimizations
+        ///   should entirely eliminate that overhead.
+        /// @note The four basic categories of these functions are "CRUD": create, read, update,
+        ///   and delete.
+        /// @see World, JointID.
+        /// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
+        /// @{
 
-/// @brief Sets the target linear offset, in frame A.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void SetLinearOffset(World& world, JointID id, Length2 value);
+        /// @brief Gets the joints of the specified world.
+        /// @relatedalso World
+        SizedRange<std::vector<JointID>::const_iterator> GetJoints(const World& world) noexcept;
 
-/// @brief Gets the target angular offset.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Angle GetAngularOffset(const World& world, JointID id);
+        /// @brief Create a new joint.
+        /// @relatedalso World
+        JointID CreateJoint(World& world, const Joint& def);
 
-/// @brief Sets the target angular offset.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void SetAngularOffset(World& world, JointID id, Angle value);
+        /// @brief Destroys the identified joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void Destroy(World& world, JointID id);
 
-/// Get the first ground anchor.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetGroundAnchorA(const World& world, JointID id);
+        /// @brief Gets the type of the joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        JointType GetType(const World& world, JointID id);
 
-/// Get the second ground anchor.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetGroundAnchorB(const World& world, JointID id);
+        /// @brief Gets the value of the identified joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        const Joint& GetJoint(const World& world, JointID id);
 
-/// @brief Get the current length of the segment attached to body-A.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length GetCurrentLengthA(const World& world, JointID id);
+        /// @brief Sets the value of the identified joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void SetJoint(World& world, JointID id, const Joint& def);
 
-/// @brief Get the current length of the segment attached to body-B.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length GetCurrentLengthB(const World& world, JointID id);
+        /// @copydoc World::GetCollideConnected
+        /// @relatedalso World
+        bool GetCollideConnected(const World& world, JointID id);
 
-/// @brief Gets the target point.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Length2 GetTarget(const World& world, JointID id);
+        /// Is the joint motor enabled?
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @see EnableMotor(World& world, JointID joint, bool value)
+        /// @relatedalso World
+        bool IsMotorEnabled(const World& world, JointID id);
 
-/// @brief Sets the target point.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void SetTarget(World& world, JointID id, Length2 value);
+        /// Enable/disable the joint motor.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void EnableMotor(World& world, JointID id, bool value);
 
-/// Get the lower joint limit.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Angle GetAngularLowerLimit(const World& world, JointID id);
+        /// @brief Gets whether the identified joint's limit is enabled.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        bool IsLimitEnabled(const World& world, JointID id);
 
-/// Get the upper joint limit.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-Angle GetAngularUpperLimit(const World& world, JointID id);
+        /// @brief Sets whether the identified joint's limit is enabled or not.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void EnableLimit(World& world, JointID id, bool value);
 
-/// Set the joint limits.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-void SetAngularLimits(World& world, JointID id, Angle lower, Angle upper);
+        /// @brief Gets the identifier of body-A of the identified joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        BodyID GetBodyA(const World& world, JointID id);
 
-/// @brief Shifts the origin of the identified joint.
-/// @note This only effects joints having points in world coordinates.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @relatedalso World
-bool ShiftOrigin(World& world, JointID id, Length2 value);
+        /// @brief Gets the identifier of body-B of the identified joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        BodyID GetBodyB(const World& world, JointID id);
 
-/// @brief Gets the damping ratio associated with the identified joint if it has one.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @throws std::invalid_argument If the identified joint's type doesn't support this.
-/// @relatedalso World
-Real GetDampingRatio(const World& world, JointID id);
+        /// Get the anchor point on body-A in local coordinates.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetLocalAnchorA(const World& world, JointID id);
 
-/// @brief Gets the length associated with the identified joint if it has one.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @throws std::invalid_argument If the identified joint's type doesn't support this.
-/// @relatedalso World
-Length GetLength(const World& world, JointID id);
+        /// Get the anchor point on body-B in local coordinates.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetLocalAnchorB(const World& world, JointID id);
 
-/// @brief Gets the joint's limit state if it has one.
-/// @throws std::out_of_range If given an invalid joint identifier.
-/// @throws std::invalid_argument If the identified joint's type doesn't support this.
-/// @relatedalso World
-LimitState GetLimitState(const World& world, JointID id);
+        /// @copydoc World::GetLinearReaction
+        /// @relatedalso World
+        Momentum2 GetLinearReaction(const World& world, JointID id);
 
-/// @copydoc World::SetAwake(JointID)
-/// @relatedalso World
-void SetAwake(World& world, JointID id);
+        /// @copydoc World::GetAngularReaction
+        /// @relatedalso World
+        AngularMomentum GetAngularReaction(const World& world, JointID id);
 
-/// Gets the count of joints in the given world.
-/// @return 0 or higher.
-/// @relatedalso World
-inline JointCounter GetJointCount(const World& world) noexcept
-{
-    using std::size;
-    return static_cast<JointCounter>(size(GetJoints(world)));
-}
+        /// @brief Gets the reference-angle property of the identified joint if it has it.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Angle GetReferenceAngle(const World& world, JointID id);
 
-/// @}
+        /// @brief Gets the local-X-axis-A property of the identified joint if it has it.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        UnitVec GetLocalXAxisA(const World& world, JointID id);
 
-} // namespace d2
-} // namespace playrho
+        /// @brief Gets the local-Y-axis-A property of the identified joint if it has it.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        UnitVec GetLocalYAxisA(const World& world, JointID id);
 
-#endif // PLAYRHO_DYNAMICS_WORLDJOINT_HPP
+        /// @brief Gets the motor-speed property of the identied joint if it supports it.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        /// @see SetMotorSpeed(World& world, JointID id, AngularVelocity value)
+        AngularVelocity GetMotorSpeed(const World& world, JointID id);
+
+        /// @brief Sets the motor-speed property of the identied joint if it supports it.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        /// @see GetMotorSpeed(const World& world, JointID id)
+        void SetMotorSpeed(World& world, JointID id, AngularVelocity value);
+
+        /// @brief Gets the max motor torque.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Torque GetMaxMotorTorque(const World& world, JointID id);
+
+        /// Sets the maximum motor torque.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void SetMaxMotorTorque(World& world, JointID id, Torque value);
+
+        /// @brief Gets the linear motor impulse of the identified joint if it supports that.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Momentum GetLinearMotorImpulse(const World& world, JointID id);
+
+        /// @brief Gets the angular motor impulse of the identified joint if it has this property.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        AngularMomentum GetAngularMotorImpulse(const World& world, JointID id);
+
+        /// @brief Gets the computed angular rotational inertia used by the joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        RotInertia GetAngularMass(const World& world, JointID id);
+
+        /// @brief Gets the frequency of the identified joint if it has this property.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Frequency GetFrequency(const World& world, JointID id);
+
+        /// @brief Sets the frequency of the identified joint if it has this property.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void SetFrequency(World& world, JointID id, Frequency value);
+
+        /// @brief Gets the angular velocity of the identified joint if it has this property.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        AngularVelocity GetAngularVelocity(const World& world, JointID id);
+
+        /// @brief Gets the enabled/disabled state of the joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        bool IsEnabled(const World& world, JointID id);
+
+        /// @brief Gets the world index of the given joint.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        JointCounter GetWorldIndex(const World& world, JointID id) noexcept;
+
+        /// Get the anchor point on body-A in world coordinates.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetAnchorA(const World& world, JointID id);
+
+        /// Get the anchor point on body-B in world coordinates.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetAnchorB(const World& world, JointID id);
+
+        /// @brief Gets the ratio property of the identified joint if it has it.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Real GetRatio(const World& world, JointID id);
+
+        /// @brief Gets the current joint translation.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length GetJointTranslation(const World& world, JointID id);
+
+        /// @brief Gets the angle property of the identified joint if it has it.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Angle GetAngle(const World& world, JointID id);
+
+        /// @brief Gets the current motor force for the given joint, given the inverse time step.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        inline Force GetMotorForce(const World& world, JointID id, Frequency inv_dt)
+        {
+            return GetLinearMotorImpulse(world, id) * inv_dt;
+        }
+
+        /// @brief Gets the current motor torque for the given joint given the inverse time step.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        inline Torque GetMotorTorque(const World& world, JointID id, Frequency inv_dt)
+        {
+            return GetAngularMotorImpulse(world, id) * inv_dt;
+        }
+
+        /// @brief Gets the target linear offset, in frame A.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetLinearOffset(const World& world, JointID id);
+
+        /// @brief Sets the target linear offset, in frame A.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void SetLinearOffset(World& world, JointID id, Length2 value);
+
+        /// @brief Gets the target angular offset.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Angle GetAngularOffset(const World& world, JointID id);
+
+        /// @brief Sets the target angular offset.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void SetAngularOffset(World& world, JointID id, Angle value);
+
+        /// Get the first ground anchor.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetGroundAnchorA(const World& world, JointID id);
+
+        /// Get the second ground anchor.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetGroundAnchorB(const World& world, JointID id);
+
+        /// @brief Get the current length of the segment attached to body-A.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length GetCurrentLengthA(const World& world, JointID id);
+
+        /// @brief Get the current length of the segment attached to body-B.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length GetCurrentLengthB(const World& world, JointID id);
+
+        /// @brief Gets the target point.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Length2 GetTarget(const World& world, JointID id);
+
+        /// @brief Sets the target point.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void SetTarget(World& world, JointID id, Length2 value);
+
+        /// Get the lower joint limit.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Angle GetAngularLowerLimit(const World& world, JointID id);
+
+        /// Get the upper joint limit.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        Angle GetAngularUpperLimit(const World& world, JointID id);
+
+        /// Set the joint limits.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        void SetAngularLimits(World& world, JointID id, Angle lower, Angle upper);
+
+        /// @brief Shifts the origin of the identified joint.
+        /// @note This only effects joints having points in world coordinates.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @relatedalso World
+        bool ShiftOrigin(World& world, JointID id, Length2 value);
+
+        /// @brief Gets the damping ratio associated with the identified joint if it has one.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @throws std::invalid_argument If the identified joint's type doesn't support this.
+        /// @relatedalso World
+        Real GetDampingRatio(const World& world, JointID id);
+
+        /// @brief Gets the length associated with the identified joint if it has one.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @throws std::invalid_argument If the identified joint's type doesn't support this.
+        /// @relatedalso World
+        Length GetLength(const World& world, JointID id);
+
+        /// @brief Gets the joint's limit state if it has one.
+        /// @throws std::out_of_range If given an invalid joint identifier.
+        /// @throws std::invalid_argument If the identified joint's type doesn't support this.
+        /// @relatedalso World
+        LimitState GetLimitState(const World& world, JointID id);
+
+        /// @copydoc World::SetAwake(JointID)
+        /// @relatedalso World
+        void SetAwake(World& world, JointID id);
+
+        /// Gets the count of joints in the given world.
+        /// @return 0 or higher.
+        /// @relatedalso World
+        inline JointCounter GetJointCount(const World& world) noexcept
+        {
+            using std::size;
+            return static_cast<JointCounter>(size(GetJoints(world)));
+        }
+
+        /// @}
+
+    }// namespace d2
+}// namespace playrho
+
+#endif// PLAYRHO_DYNAMICS_WORLDJOINT_HPP

--- a/PlayRho/Dynamics/WorldMisc.cpp
+++ b/PlayRho/Dynamics/WorldMisc.cpp
@@ -25,59 +25,61 @@
 #include <PlayRho/Dynamics/WorldBody.hpp>
 
 #include <PlayRho/Dynamics/BodyConf.hpp>
-#include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/FixtureProxy.hpp>
 #include <PlayRho/Dynamics/MovementConf.hpp>
+#include <PlayRho/Dynamics/StepConf.hpp>
 
-#include <algorithm> // for std::for_each
+#include <algorithm>// for std::for_each
 
 using std::for_each;
 
-namespace playrho {
-namespace d2 {
-
-using playrho::size;
-
-Length GetMinVertexRadius(const World& world) noexcept
+namespace playrho
 {
-    return world.GetMinVertexRadius();
-}
-
-Length GetMaxVertexRadius(const World& world) noexcept
-{
-    return world.GetMaxVertexRadius();
-}
-
-StepStats Step(World& world, const StepConf& conf)
-{
-    return world.Step(conf);
-}
-
-StepStats Step(World& world, Time delta, TimestepIters velocityIterations,
-               TimestepIters positionIterations)
-{
-    StepConf conf;
-    conf.deltaTime = delta;
-    conf.regVelocityIterations = velocityIterations;
-    conf.regPositionIterations = positionIterations;
-    conf.toiVelocityIterations = velocityIterations;
-    if (positionIterations == 0)
+    namespace d2
     {
-        conf.toiPositionIterations = 0;
-    }
-    conf.dtRatio = delta * world.GetInvDeltaTime();
-    return world.Step(conf);
-}
 
-const DynamicTree& GetTree(const World& world) noexcept
-{
-    return world.GetTree();
-}
+        using playrho::size;
 
-FixtureCounter GetShapeCount(const World& world) noexcept
-{
-    return world.GetShapeCount();
-}
+        Length GetMinVertexRadius(const World& world) noexcept
+        {
+            return world.GetMinVertexRadius();
+        }
 
-} // namespace d2
-} // namespace playrho
+        Length GetMaxVertexRadius(const World& world) noexcept
+        {
+            return world.GetMaxVertexRadius();
+        }
+
+        StepStats Step(World& world, const StepConf& conf)
+        {
+            return world.Step(conf);
+        }
+
+        StepStats Step(World& world, Time delta, TimestepIters velocityIterations,
+                       TimestepIters positionIterations)
+        {
+            StepConf conf;
+            conf.deltaTime = delta;
+            conf.regVelocityIterations = velocityIterations;
+            conf.regPositionIterations = positionIterations;
+            conf.toiVelocityIterations = velocityIterations;
+            if (positionIterations == 0)
+            {
+                conf.toiPositionIterations = 0;
+            }
+            conf.dtRatio = delta * world.GetInvDeltaTime();
+            return world.Step(conf);
+        }
+
+        const DynamicTree& GetTree(const World& world) noexcept
+        {
+            return world.GetTree();
+        }
+
+        FixtureCounter GetShapeCount(const World& world) noexcept
+        {
+            return world.GetShapeCount();
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/Dynamics/WorldMisc.hpp
+++ b/PlayRho/Dynamics/WorldMisc.hpp
@@ -30,68 +30,70 @@
 #include <PlayRho/Dynamics/StepConf.hpp>
 #include <PlayRho/Dynamics/StepStats.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho
+{
+    namespace d2
+    {
 
-class World;
-class DynamicTree;
+        class World;
+        class DynamicTree;
 
-/// @brief Steps the given world the specified amount.
-/// @relatedalso World
-StepStats Step(World& world, const StepConf& conf = StepConf{});
+        /// @brief Steps the given world the specified amount.
+        /// @relatedalso World
+        StepStats Step(World& world, const StepConf& conf = StepConf{});
 
-/// @brief Steps the world ahead by a given time amount.
-///
-/// @details Performs position and velocity updating, sleeping of non-moving bodies, updating
-///   of the contacts, and notifying the contact listener of begin-contact, end-contact,
-///   pre-solve, and post-solve events.
-///   If the given velocity and position iterations are more than zero, this method also
-///   respectively performs velocity and position resolution of the contacting bodies.
-///
-/// @note While body velocities are updated accordingly (per the sum of forces acting on them),
-///   body positions (barring any collisions) are updated as if they had moved the entire time
-///   step at those resulting velocities. In other words, a body initially at <code>p0</code>
-///   going <code>v0</code> fast with a sum acceleration of <code>a</code>, after time
-///   <code>t</code> and barring any collisions, will have a new velocity (<code>v1</code>) of
-///   <code>v0 + (a * t)</code> and a new position (<code>p1</code>) of <code>p0 + v1 * t</code>.
-///
-/// @warning Varying the time step may lead to non-physical behaviors.
-///
-/// @post Static bodies are unmoved.
-/// @post Kinetic bodies are moved based on their previous velocities.
-/// @post Dynamic bodies are moved based on their previous velocities, gravity,
-/// applied forces, applied impulses, masses, damping, and the restitution and friction values
-/// of their fixtures when they experience collisions.
-///
-/// @param world World to step.
-/// @param delta Time to simulate as a delta from the current state. This should not vary.
-/// @param velocityIterations Number of iterations for the velocity constraint solver.
-/// @param positionIterations Number of iterations for the position constraint solver.
-///   The position constraint solver resolves the positions of bodies that overlap.
-///
-/// @relatedalso World
-///
-StepStats Step(World& world, Time delta,
-               TimestepIters velocityIterations = 8,
-               TimestepIters positionIterations = 3);
+        /// @brief Steps the world ahead by a given time amount.
+        ///
+        /// @details Performs position and velocity updating, sleeping of non-moving bodies, updating
+        ///   of the contacts, and notifying the contact listener of begin-contact, end-contact,
+        ///   pre-solve, and post-solve events.
+        ///   If the given velocity and position iterations are more than zero, this method also
+        ///   respectively performs velocity and position resolution of the contacting bodies.
+        ///
+        /// @note While body velocities are updated accordingly (per the sum of forces acting on them),
+        ///   body positions (barring any collisions) are updated as if they had moved the entire time
+        ///   step at those resulting velocities. In other words, a body initially at <code>p0</code>
+        ///   going <code>v0</code> fast with a sum acceleration of <code>a</code>, after time
+        ///   <code>t</code> and barring any collisions, will have a new velocity (<code>v1</code>) of
+        ///   <code>v0 + (a * t)</code> and a new position (<code>p1</code>) of <code>p0 + v1 * t</code>.
+        ///
+        /// @warning Varying the time step may lead to non-physical behaviors.
+        ///
+        /// @post Static bodies are unmoved.
+        /// @post Kinetic bodies are moved based on their previous velocities.
+        /// @post Dynamic bodies are moved based on their previous velocities, gravity,
+        /// applied forces, applied impulses, masses, damping, and the restitution and friction values
+        /// of their fixtures when they experience collisions.
+        ///
+        /// @param world World to step.
+        /// @param delta Time to simulate as a delta from the current state. This should not vary.
+        /// @param velocityIterations Number of iterations for the velocity constraint solver.
+        /// @param positionIterations Number of iterations for the position constraint solver.
+        ///   The position constraint solver resolves the positions of bodies that overlap.
+        ///
+        /// @relatedalso World
+        ///
+        StepStats Step(World& world, Time delta,
+                       TimestepIters velocityIterations = 8,
+                       TimestepIters positionIterations = 3);
 
-/// @copydoc World::GetTree
-/// @relatedalso World
-const DynamicTree& GetTree(const World& world) noexcept;
+        /// @copydoc World::GetTree
+        /// @relatedalso World
+        const DynamicTree& GetTree(const World& world) noexcept;
 
-/// @brief Gets the count of unique shapes in the given world.
-/// @relatedalso World
-FixtureCounter GetShapeCount(const World& world) noexcept;
+        /// @brief Gets the count of unique shapes in the given world.
+        /// @relatedalso World
+        FixtureCounter GetShapeCount(const World& world) noexcept;
 
-/// @brief Gets the min vertex radius that shapes for the given world are allowed to be.
-/// @relatedalso World
-Length GetMinVertexRadius(const World& world) noexcept;
+        /// @brief Gets the min vertex radius that shapes for the given world are allowed to be.
+        /// @relatedalso World
+        Length GetMinVertexRadius(const World& world) noexcept;
 
-/// @brief Gets the max vertex radius that shapes for the given world are allowed to be.
-/// @relatedalso World
-Length GetMaxVertexRadius(const World& world) noexcept;
+        /// @brief Gets the max vertex radius that shapes for the given world are allowed to be.
+        /// @relatedalso World
+        Length GetMaxVertexRadius(const World& world) noexcept;
 
-} // namespace d2
-} // namespace playrho
+    }// namespace d2
+}// namespace playrho
 
-#endif // PLAYRHO_DYNAMICS_WORLDMISC_HPP
+#endif// PLAYRHO_DYNAMICS_WORLDMISC_HPP

--- a/PlayRho/Dynamics/WorldSpecial.cpp
+++ b/PlayRho/Dynamics/WorldSpecial.cpp
@@ -21,38 +21,43 @@
 
 #include <PlayRho/Dynamics/World.hpp>
 
-#include <PlayRho/Dynamics/WorldImpl.hpp> // for completing WorldImpl type
+#include <PlayRho/Collision/Manifold.hpp>       // for completing WorldImpl type
+#include <PlayRho/Dynamics/Body.hpp>            // for completing WorldImpl type
+#include <PlayRho/Dynamics/Contacts/Contact.hpp>// for completing WorldImpl type
+#include <PlayRho/Dynamics/Fixture.hpp>         // for completing WorldImpl type
+#include <PlayRho/Dynamics/WorldImpl.hpp>       // for completing WorldImpl type
 #include <PlayRho/Dynamics/WorldImplMisc.hpp>
-#include <PlayRho/Dynamics/Body.hpp> // for completing WorldImpl type
-#include <PlayRho/Dynamics/Fixture.hpp> // for completing WorldImpl type
-#include <PlayRho/Dynamics/Contacts/Contact.hpp> // for completing WorldImpl type
-#include <PlayRho/Collision/Manifold.hpp> // for completing WorldImpl type
 
-namespace playrho {
-namespace d2 {
-
-World::World(const WorldConf& def): m_impl{CreateWorldImpl(def)}
+namespace playrho
 {
-}
+    namespace d2
+    {
 
-World::World(const World& other): m_impl{CreateWorldImpl(*other.m_impl)}
-{
-}
+        World::World(const WorldConf& def)
+            : m_impl{CreateWorldImpl(def)}
+        {
+        }
 
-World::~World() noexcept
-{
-    if (m_impl) {
-        // Call implementation's clear while World still valid to give destruction
-        // listening callbacks chance to run while world data is still valid.
-        m_impl->Clear();
-    }
-}
+        World::World(const World& other)
+            : m_impl{CreateWorldImpl(*other.m_impl)}
+        {
+        }
 
-World& World::operator= (const World& other)
-{
-    *m_impl = *other.m_impl;
-    return *this;
-}
+        World::~World() noexcept
+        {
+            if (m_impl)
+            {
+                // Call implementation's clear while World still valid to give destruction
+                // listening callbacks chance to run while world data is still valid.
+                m_impl->Clear();
+            }
+        }
 
-} // namespace d2
-} // namespace playrho
+        World& World::operator=(const World& other)
+        {
+            *m_impl = *other.m_impl;
+            return *this;
+        }
+
+    }// namespace d2
+}// namespace playrho

--- a/PlayRho/PlayRho.hpp
+++ b/PlayRho/PlayRho.hpp
@@ -102,30 +102,30 @@ For a more elaborate example, that's of an entire application, see
 // For pragmatists, add these for free function interfaces to the world and some additional
 // functionality. Note that using these free function interfaces, instead of directly using
 // world member functions, may help isolate your code from changes to the World class.
-#include <PlayRho/Dynamics/WorldMisc.hpp>
 #include <PlayRho/Dynamics/WorldBody.hpp>
+#include <PlayRho/Dynamics/WorldContact.hpp>
 #include <PlayRho/Dynamics/WorldFixture.hpp>
 #include <PlayRho/Dynamics/WorldJoint.hpp>
-#include <PlayRho/Dynamics/WorldContact.hpp>
+#include <PlayRho/Dynamics/WorldMisc.hpp>
 
 // For any and all shape configurations, add one or more of the following.
+#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/DiskShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/EdgeShapeConf.hpp>
-#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
-#include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 #include <PlayRho/Collision/Shapes/MultiShapeConf.hpp>
+#include <PlayRho/Collision/Shapes/PolygonShapeConf.hpp>
 
 // For any and all joint configurations, add one or more of the following.
 #include <PlayRho/Dynamics/Joints/DistanceJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/FrictionJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/GearJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/MotorJointConf.hpp>
-#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/PrismaticJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/PulleyJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/RevoluteJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/RopeJointConf.hpp>
+#include <PlayRho/Dynamics/Joints/TargetJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/WeldJointConf.hpp>
 #include <PlayRho/Dynamics/Joints/WheelJointConf.hpp>
 
-#endif // PLAYRHO_PLAYRHO_HPP
+#endif// PLAYRHO_PLAYRHO_HPP

--- a/PlayRho/PlayRhoConfig.cmake.in
+++ b/PlayRho/PlayRhoConfig.cmake.in
@@ -1,29 +1,29 @@
-#                                               -*- cmake -*-
+#- * - cmake - * -
 #
-#  PlayRhoConfig.cmake(.in)
+#PlayRhoConfig.cmake(.in)
 #
 
-# Use the following variables to compile and link against PlayRho:
-#  PLAYRHO_FOUND          - True if PlayRho was found on your system
-#  PLAYRHO_USE_FILE       - The file making PlayRho usable
-#  PLAYRHO_DEFINITIONS    - Definitions needed to build with PlayRho
-#  PLAYRHO_INCLUDE_DIR    - PlayRho headers location
-#  PLAYRHO_INCLUDE_DIRS   - List of directories where PlayRho header file are
-#  PLAYRHO_LIBRARY        - Library name
-#  PLAYRHO_LIBRARIES      - List of libraries to link against
-#  PLAYRHO_LIBRARY_DIRS   - List of directories containing PlayRho libraries
-#  PLAYRHO_ROOT_DIR       - The base directory of PlayRho
-#  PLAYRHO_VERSION_STRING - A human-readable string containing the version
+#Use the following variables to compile and link against PlayRho:
+#PLAYRHO_FOUND - True if PlayRho was found on your system
+#PLAYRHO_USE_FILE - The file making PlayRho usable
+#PLAYRHO_DEFINITIONS - Definitions needed to build with PlayRho
+#PLAYRHO_INCLUDE_DIR - PlayRho headers location
+#PLAYRHO_INCLUDE_DIRS - List of directories where PlayRho header file are
+#PLAYRHO_LIBRARY - Library name
+#PLAYRHO_LIBRARIES - List of libraries to link against
+#PLAYRHO_LIBRARY_DIRS - List of directories containing PlayRho libraries
+#PLAYRHO_ROOT_DIR - The base directory of PlayRho
+#PLAYRHO_VERSION_STRING - A human - readable string containing the version
 
-set ( PLAYRHO_FOUND 1 )
-set ( PLAYRHO_USE_FILE     "@PLAYRHO_USE_FILE@" )
+set(PLAYRHO_FOUND 1)
+    set(PLAYRHO_USE_FILE "@PLAYRHO_USE_FILE@")
 
-set ( PLAYRHO_DEFINITIONS  "@PLAYRHO_DEFINITIONS@" )
-set ( PLAYRHO_INCLUDE_DIR  "@PLAYRHO_INCLUDE_DIR@" )
-set ( PLAYRHO_INCLUDE_DIRS "@PLAYRHO_INCLUDE_DIRS@" )
-set ( PLAYRHO_LIBRARY      "@PLAYRHO_LIBRARY@" )
-set ( PLAYRHO_LIBRARIES    "@PLAYRHO_LIBRARIES@" )
-set ( PLAYRHO_LIBRARY_DIRS "@PLAYRHO_LIBRARY_DIRS@" )
-set ( PLAYRHO_ROOT_DIR     "@CMAKE_INSTALL_PREFIX@" )
+        set(PLAYRHO_DEFINITIONS "@PLAYRHO_DEFINITIONS@")
+            set(PLAYRHO_INCLUDE_DIR "@PLAYRHO_INCLUDE_DIR@")
+                set(PLAYRHO_INCLUDE_DIRS "@PLAYRHO_INCLUDE_DIRS@")
+                    set(PLAYRHO_LIBRARY "@PLAYRHO_LIBRARY@")
+                        set(PLAYRHO_LIBRARIES "@PLAYRHO_LIBRARIES@")
+                            set(PLAYRHO_LIBRARY_DIRS "@PLAYRHO_LIBRARY_DIRS@")
+                                set(PLAYRHO_ROOT_DIR "@CMAKE_INSTALL_PREFIX@")
 
-set ( PLAYRHO_VERSION_STRING "@PLAYRHO_VERSION@" )
+                                    set(PLAYRHO_VERSION_STRING "@PLAYRHO_VERSION@")

--- a/PlayRho/UsePlayRho.cmake
+++ b/PlayRho/UsePlayRho.cmake
@@ -3,6 +3,6 @@
 #  UsePlayRho.cmake
 #
 
-add_definitions     ( ${PLAYRHO_DEFINITIONS} )
-include_directories ( ${PLAYRHO_INCLUDE_DIRS} )
-link_directories    ( ${PLAYRHO_LIBRARY_DIRS} )
+add_definitions(${PLAYRHO_DEFINITIONS})
+include_directories(${PLAYRHO_INCLUDE_DIRS})
+link_directories(${PLAYRHO_LIBRARY_DIRS})


### PR DESCRIPTION
#### Description - What's this PR do?

Replace `clang-format` [settings](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options) with a format derived from [Microsoft code style guidelines](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options?view=vs-2017).

Important bit: replaced the `style` option value with a valid one (`c++17`, not `Cpp11`).

#### Impacts/Risks of These Changes?

Code style only. Applied automatically with CLion.

#### Where should a reviewer start?

`.clang-format` or any source file (`*.hpp` or `*.cpp`). It is really just the spaces and blank lines.

#### How should this be tested?

n/a

#### Any background context you want to provide?

[A comment from FB](https://www.facebook.com/groups/cppEnthusiasts/permalink/3496258213766807?comment_id=3497222303670398&reply_comment_id=3497748800284415):

> Artem Shubovych
Sorry that the code format caused confusion. I imagine others could have the same problem with it. Can you suggest any changes to the formatting which would have helped you avoid this slipping from sight? I can think of a few things that might help but they all have trade offs. Were you reading that code from a web browser pointing at the github page for it? I ask because I'm wondering now if perhaps github itself provides maybe alternative coloring formats for C++ code that maybe would be easier to read.

#### Related Issues
List related issues.

#### Related Pull Requests
List related pull requests (if any).

#### Screenshots (if appropriate)
