### PR TITLE
Bug fixes for 1.0 pre-release 0.11.1

### DIFF
--- a/Documentation/Doxyfile
+++ b/Documentation/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = PlayRho
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.11.0
+PROJECT_NUMBER         = 0.11.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/PlayRho/Common/Version.cpp
+++ b/PlayRho/Common/Version.cpp
@@ -32,7 +32,7 @@ namespace playrho {
 
 Version GetVersion() noexcept
 {
-    return Version{0, 11, 0};
+    return Version{0, 11, 1};
 }
 
 std::string GetBuildDetails() noexcept

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
@@ -219,7 +219,9 @@ bool SolvePosition(const PulleyJointConf& object,
     const auto totalInvMass = totalInvMassA + object.ratio * object.ratio * totalInvMassB;
     const auto mass = (totalInvMass > InvMass{0})? Real{1} / totalInvMass: 0_kg;
 
-    const auto C = Length{object.constant - lengthA - (object.ratio * lengthB)};
+    const auto srcLengthRatio = object.lengthA + object.ratio * object.lengthB; // constant C0
+    const auto dstLengthRatio = lengthA + object.ratio * lengthB;
+    const auto C = srcLengthRatio - dstLengthRatio;
     const auto linearError = abs(C);
 
     const auto impulse = -mass * C;

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
@@ -104,8 +104,6 @@ struct PulleyJointConf : public JointBuilder<PulleyJointConf>
     /// The pulley ratio, used to simulate a block-and-tackle.
     Real ratio = 1;
 
-    Length constant = 0_m; ///< Constant.
-
     // Solver shared (between calls to InitVelocityConstraints).
     Momentum impulse = 0_Ns; ///< Impulse.
 
@@ -180,6 +178,13 @@ constexpr auto GetLengthA(const PulleyJointConf& object) noexcept
 constexpr auto GetLengthB(const PulleyJointConf& object) noexcept
 {
     return object.lengthB;
+}
+
+/// @brief Free function for setting the ratio value of the given configuration.
+/// @relatedalso PulleyJointConf
+constexpr auto SetRatio(PulleyJointConf& object, Real value) noexcept
+{
+    object.UseRatio(value);
 }
 
 } // namespace d2

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -1722,7 +1722,12 @@ static void EntityUI(PulleyJointConf& conf, BodyCounter bodyRange)
 {
     ImGui::LabelText("Length A (m)", "%f", static_cast<double>(Real{GetLengthA(conf)/Meter}));
     ImGui::LabelText("Length B (m)", "%f", static_cast<double>(Real{GetLengthB(conf)/Meter}));
-    ImGui::LabelText("Ratio", "%f", static_cast<double>(GetRatio(conf)));
+    {
+        auto v = static_cast<float>(GetRatio(conf));
+        if (ImGui::InputFloat("Ratio", &v)) {
+            SetRatio(conf, static_cast<Real>(v));
+        }
+    }
     {
         auto bodyA = static_cast<int>(UnderlyingValue(GetBodyA(conf)));
         ImGui::SliderInt("ID of Body A", &bodyA, 0, int(bodyRange) - 1);

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -932,6 +932,8 @@ static void AdvancedStepOptionsUI()
     
     if (ImGui::CollapsingHeader("Reg-Phase Processing", ImGuiTreeNodeFlags_DefaultOpen))
     {
+        ImGui::IdContext idContext{"Reg-Phase Processing"};
+
         ImGui::SliderInt("Vel Iters", &settings.regVelocityIterations, 0, 100);
         if (ImGui::IsItemHovered())
         {
@@ -964,6 +966,8 @@ static void AdvancedStepOptionsUI()
     }
     if (ImGui::CollapsingHeader("TOI-Phase Processing", ImGuiTreeNodeFlags_DefaultOpen))
     {
+        ImGui::IdContext idContext{"TOI-Phase Processing"};
+
         ImGui::Checkbox("Perform Continuous", &settings.enableContinuous);
 
         ImGui::SliderInt("Vel Iters", &settings.toiVelocityIterations, 0, 100);

--- a/Testbed/Tests/JointsTest.hpp
+++ b/Testbed/Tests/JointsTest.hpp
@@ -203,7 +203,7 @@ private:
             CreateFixture(GetWorld(), body2, shape);
             
             const auto pulleyConf = GetPulleyJointConf(GetWorld(), body1, body2, ganchor1, ganchor2,
-                anchor1, anchor2).UseRatio(1.3f);
+                                                       anchor1, anchor2).UseRatio(1.3f);
             m_pulleyJoint = CreateJoint(GetWorld(), pulleyConf);
         }
     }

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -51,7 +51,6 @@ TEST(PulleyJointConf, DefaultConstruction)
     EXPECT_EQ(def.lengthA, 0_m);
     EXPECT_EQ(def.lengthB, 0_m);
     EXPECT_EQ(def.ratio, Real(1));
-    EXPECT_EQ(def.constant, 0_m);
 
     EXPECT_EQ(def.impulse, 0_Ns);
     ASSERT_EQ(UnitVec(), UnitVec::GetZero());
@@ -139,13 +138,13 @@ TEST(PulleyJointConf, ByteSize)
     {
         case  4:
 #if defined(_WIN32) && !defined(_WIN64)
-            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(96));
+            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(92));
 #else
-            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(96));
+            EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(92));
 #endif
             break;
-        case  8: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(184)); break;
-        case 16: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(368)); break;
+        case  8: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(176)); break;
+        case 16: EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(352)); break;
         default: FAIL(); break;
     }
 }
@@ -381,20 +380,38 @@ TEST(PulleyJointConf, SolveVelocity)
 TEST(PulleyJointConf, SolvePosition)
 {
     auto jd = PulleyJointConf{};
+    jd.localAnchorA = Length2{};
+    jd.localAnchorB = Length2{};
     std::vector<BodyConstraint> bodies;
     EXPECT_THROW(SolvePosition(jd, bodies, ConstraintSolverConf{}), std::out_of_range);
 
+    const auto posA = Position{Length2{-5_m, 0_m}, 0_deg};
+    const auto posB = Position{Length2{+5_m, 0_m}, 0_deg};
+    jd.groundAnchorA = posA.linear + Length2{0_m, 8_m};
+    jd.groundAnchorB = posB.linear + Length2{0_m, 8_m};
     jd.bodyA = BodyID(0u);
-    jd.bodyB = BodyID(0u);
-    bodies.push_back(BodyConstraint{});
-    EXPECT_NO_THROW(SolvePosition(jd, bodies, ConstraintSolverConf{}));
-    EXPECT_EQ(bodies[0].GetPosition(), Position());
-
     jd.bodyB = BodyID(1u);
-    bodies.push_back(BodyConstraint{});
-    EXPECT_NO_THROW(SolvePosition(jd, bodies, ConstraintSolverConf{}));
-    EXPECT_EQ(bodies[0].GetPosition(), Position());
-    EXPECT_EQ(bodies[1].GetPosition(), Position());
-    EXPECT_EQ(bodies[0].GetVelocity(), Velocity());
-    EXPECT_EQ(bodies[1].GetVelocity(), Velocity());
+    bodies.push_back(BodyConstraint{Real(1)/4_kg, InvRotInertia{}, Length2{}, posA, Velocity{}});
+    bodies.push_back(BodyConstraint{Real(1)/4_kg, InvRotInertia{}, Length2{}, posB, Velocity{}});
+
+    auto solved = false;
+    jd.ratio = Real(1);
+    EXPECT_NO_THROW(solved = SolvePosition(jd, bodies, ConstraintSolverConf{}));
+    EXPECT_FALSE(solved);
+    EXPECT_EQ(GetX(bodies[0].GetPosition().linear), GetX(posA.linear));
+    EXPECT_EQ(GetY(bodies[0].GetPosition().linear), GetY(posA.linear) + 8_m);
+    EXPECT_EQ(bodies[0].GetPosition().angular, posA.angular);
+    EXPECT_EQ(GetX(bodies[1].GetPosition().linear), GetX(posB.linear));
+    EXPECT_EQ(GetY(bodies[1].GetPosition().linear), GetY(posB.linear) + 8_m);
+    EXPECT_EQ(bodies[1].GetPosition().angular, posB.angular);
+
+    jd.ratio = Real(1.2);
+    EXPECT_NO_THROW(solved = SolvePosition(jd, bodies, ConstraintSolverConf{}));
+    EXPECT_TRUE(solved);
+    EXPECT_EQ(GetX(bodies[0].GetPosition().linear), GetX(posA.linear));
+    EXPECT_EQ(GetY(bodies[0].GetPosition().linear), GetY(posA.linear) + 8_m);
+    EXPECT_EQ(bodies[0].GetPosition().angular, posA.angular);
+    EXPECT_EQ(GetX(bodies[1].GetPosition().linear), GetX(posB.linear));
+    EXPECT_EQ(GetY(bodies[1].GetPosition().linear), GetY(posB.linear) + 8_m);
+    EXPECT_EQ(bodies[1].GetPosition().angular, posB.angular);
 }

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -336,6 +336,26 @@ TEST(PulleyJointConf, InitVelocityColdStartResetsImpulse)
     EXPECT_EQ(jd.impulse, 0_Ns);
 }
 
+TEST(PulleyJointConf, InitVelocitySetsMass)
+{
+    auto stepConf = StepConf{};
+    auto jd = PulleyJointConf{};
+    jd.bodyA = BodyID(0u);
+    jd.bodyB = BodyID(1u);
+    std::vector<BodyConstraint> bodies;
+    bodies.push_back(BodyConstraint{
+        Real(1)/4_kg, InvRotInertia{}, Length2{}, Position{}, Velocity{}
+    });
+    bodies.push_back(BodyConstraint{
+        Real(1)/4_kg, InvRotInertia{}, Length2{}, Position{}, Velocity{}
+    });
+    stepConf.dtRatio = Real(1);
+    stepConf.doWarmStart = false;
+    ASSERT_EQ(jd.mass, 0_kg);
+    EXPECT_NO_THROW(InitVelocity(jd, bodies, stepConf, ConstraintSolverConf{}));
+    EXPECT_EQ(jd.mass, 2_kg);
+}
+
 TEST(PulleyJointConf, SolveVelocity)
 {
     auto jd = PulleyJointConf{};

--- a/UnitTests/Version.cpp
+++ b/UnitTests/Version.cpp
@@ -25,7 +25,7 @@ using namespace playrho;
 
 TEST(Version, GetVersion)
 {
-    const auto version = Version{0, 11, 0};
+    const auto version = Version{0, 11, 1};
     EXPECT_EQ(GetVersion().major, version.major);
     EXPECT_EQ(GetVersion().minor, version.minor);
     EXPECT_EQ(GetVersion().revision, version.revision);


### PR DESCRIPTION
#### Description - What's this PR do?
- Fixes #365.
- Fixes an unreported issue with the Entity Editor in the Testbed where iterations couldn't be set separately for regular phase and TOI phase.
- Updates version to 0.11.1.

#### Related Issues
- Issue #365: Pulley joints don't appear to work anymore.

