### PR TITLE
fix target name in build shared

### DIFF
--- a/PlayRho/CMakeLists.txt
+++ b/PlayRho/CMakeLists.txt
@@ -90,7 +90,7 @@ if(PLAYRHO_BUILD_SHARED)
 		${PLAYRHO_Rope_SRCS}
 		${PLAYRHO_Rope_HDRS}
 	)
-	target_compile_features(PlayRho PUBLIC cxx_std_17)
+	target_compile_features(PlayRho_shared PUBLIC cxx_std_17)
 	set_target_properties(PlayRho_shared PROPERTIES
 		OUTPUT_NAME "PlayRho"
 		CLEAN_DIRECT_OUTPUT 1


### PR DESCRIPTION
#### Description - What's this PR do?
I can't build playrho shared build only.
It seems to be caused by CMakeLists.txt bug.

#### Impacts/Risks of These Changes?
Nothing at all.

#### Where should a reviewer start?
Only 1 line.

#### How should this be tested?
I build Playrho locally with `PLAYRHO_BUILD_SHARED=ON PLAYRHO_BUILD_STATIC=OFF`.

#### Any background context you want to provide?
I am trying to create conan recipe for PlayRho.
https://github.com/conan-io/conan-center-index/pull/11728

This bug prevents conan-center-index's CI test of PlayRho.

#### Related Issues

#### Related Pull Requests

#### Screenshots (if appropriate)
