### PR TITLE
Fix for issue #442: avoids insecure sprintf functions

### DIFF
--- a/Testbed/Framework/DebugDraw.cpp
+++ b/Testbed/Framework/DebugDraw.cpp
@@ -725,7 +725,7 @@ void DebugDraw::DrawString(const Length2& pw, TextAlign align, const char *strin
     char buffer[512];
     va_list arg;
     va_start(arg, string);
-    vsprintf(buffer, string, arg);
+    std::vsnprintf(buffer, sizeof(buffer), string, arg);
     va_end(arg);
     
     const auto textSize = ImGui::CalcTextSize(buffer);

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -3539,8 +3539,8 @@ int main()
     const auto buildDetails = GetBuildDetails();
     
     char title[64];
-    std::sprintf(title, "PlayRho Testbed Version %d.%d.%d",
-                 buildVersion.major, buildVersion.minor, buildVersion.revision);
+    std::snprintf(title, sizeof(title), "PlayRho Testbed Version %d.%d.%d",
+                  buildVersion.major, buildVersion.minor, buildVersion.revision);
 
     SetupGlfwWindowHints();
 

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -1271,13 +1271,13 @@ void Test::Step(const Settings& settings, Drawer& drawer, UiState& ui)
                                 ImGuiWindowFlags_NoCollapse);
         char buffer[40];
         
-        std::sprintf(buffer, "Max of %u", m_stats.m_maxTouching);
+        std::snprintf(buffer, sizeof(buffer), "Max of %u", m_stats.m_maxTouching);
         ImGui::PlotHistogram("# Touching", DequeValuesGetter<std::size_t>::Func,
                              &m_numTouchingPerStep, static_cast<int>(size(m_numTouchingPerStep)),
                              0, buffer, 0.0f, static_cast<float>(m_stats.m_maxContacts),
                              ImVec2(600, 100));
 
-        std::sprintf(buffer, "Max of %u", m_stats.m_maxContacts);
+        std::snprintf(buffer, sizeof(buffer), "Max of %u", m_stats.m_maxContacts);
         ImGui::PlotHistogram("# Contacts", DequeValuesGetter<std::size_t>::Func,
                              &m_numContactsPerStep, static_cast<int>(size(m_numContactsPerStep)),
                              0, buffer, 0.0f, static_cast<float>(m_stats.m_maxContacts),


### PR DESCRIPTION
#### Description - What's this PR do?
Avoids insecure `*sprintf` functions.

#### Related Issues
- Issue #442.