### PR TITLE
Changes for exports/DLLs

### DIFF
--- a/.github/workflows/linux-debug.yml
+++ b/.github/workflows/linux-debug.yml
@@ -30,10 +30,18 @@ jobs:
         sudo apt install lcov
 
     - name: Configure
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # Configure CMake in a 'build' subdirectory.
+      # `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DPLAYRHO_BUILD_HELLOWORLD=ON -DPLAYRHO_BUILD_UNIT_TESTS=ON -DPLAYRHO_BUILD_TESTBED=ON -DPLAYRHO_BUILD_BENCHMARK=ON -DPLAYRHO_REAL_TYPE=${{matrix.real_type}} -DPLAYRHO_ENABLE_COVERAGE=ON
+      run: >
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DPLAYRHO_BUILD_HELLOWORLD=ON
+        -DPLAYRHO_BUILD_UNIT_TESTS=ON
+        -DPLAYRHO_BUILD_TESTBED=ON
+        -DPLAYRHO_BUILD_BENCHMARK=ON
+        -DPLAYRHO_REAL_TYPE=${{matrix.real_type}}
+        -DPLAYRHO_ENABLE_COVERAGE=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,11 @@ jobs:
       matrix:
         build_type: [Release]
         real_type: [float, double]
+        include:
+          - real_type: float
+            linkage: 'shared'
+          - real_type: double
+            linkage: 'static'
 
     steps:
     - uses: actions/checkout@v3
@@ -29,10 +34,18 @@ jobs:
         sudo apt install libglfw3-dev libglew2.2 libglew-dev
 
     - name: Configure
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # Configure CMake in a 'build' subdirectory.
+      # `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DPLAYRHO_BUILD_HELLOWORLD=ON -DPLAYRHO_BUILD_UNIT_TESTS=ON -DPLAYRHO_BUILD_TESTBED=ON -DPLAYRHO_BUILD_BENCHMARK=ON -DPLAYRHO_REAL_TYPE=${{matrix.real_type}}
+      run: >
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DPLAYRHO_BUILD_HELLOWORLD=ON
+        -DPLAYRHO_BUILD_UNIT_TESTS=ON
+        -DPLAYRHO_BUILD_TESTBED=ON
+        -DPLAYRHO_BUILD_BENCHMARK=ON
+        -DPLAYRHO_REAL_TYPE=${{matrix.real_type}}
+        -DBUILD_SHARED_LIBS=${{matrix.linkage == 'shared'}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,6 +15,11 @@ jobs:
     strategy:
       matrix:
         build_type: [Debug, Release]
+        include:
+          - build_type: Debug
+            linkage: 'shared'
+          - build_type: Release
+            linkage: 'static'
 
     steps:
     - uses: actions/checkout@v3
@@ -27,10 +32,17 @@ jobs:
         brew install pkg-config glfw
 
     - name: Configure
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # Configure CMake in a 'build' subdirectory.
+      # `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: |
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DPLAYRHO_BUILD_HELLOWORLD=ON -DPLAYRHO_BUILD_UNIT_TESTS=ON -DPLAYRHO_BUILD_TESTBED=ON -DPLAYRHO_BUILD_BENCHMARK=ON
+      run: >
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DPLAYRHO_BUILD_HELLOWORLD=ON
+        -DPLAYRHO_BUILD_UNIT_TESTS=ON
+        -DPLAYRHO_BUILD_TESTBED=ON
+        -DPLAYRHO_BUILD_BENCHMARK=ON
+        -DBUILD_SHARED_LIBS=${{matrix.linkage == 'shared'}}
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,32 +16,42 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         platform: [Win32, x64]
+        include:
+          - platform: Win32
+            triplet: x86-windows-static
+            genplat: WIN32
+          - platform: x64
+            triplet: x64-windows-static
+            genplat: x64
+          - build_type: Debug
+            linkage: 'shared'
+          - build_type: Release
+            linkage: 'static'
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - name: Install Prerequisites & Configure
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+    - name: Install Prerequisites
       run: |
-        $triplet = ""
-        $genplat = ""
-        switch ("${{matrix.platform}}")
-        {
-          "Win32" {
-            $triplet = "x86-windows-static"
-            $genplat = "WIN32"
-          }
-          "x64"   {
-            $triplet = "x64-windows-static"
-            $genplat = "x64"
-          }
-        }
-        vcpkg install --triplet=$triplet glew glfw3
-        echo "genplat=${genplat}, triplet=${triplet}"
-        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DPLAYRHO_BUILD_HELLOWORLD=ON -DPLAYRHO_BUILD_UNIT_TESTS=ON -DPLAYRHO_BUILD_TESTBED=ON -DPLAYRHO_BUILD_BENCHMARK=ON -DCMAKE_GENERATOR_PLATFORM="${genplat}" -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET="${triplet}"
+        vcpkg install --triplet=${{matrix.triplet}} glew glfw3
+
+    - name: Configure
+      # Configure CMake in a 'build' subdirectory.
+      # `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{github.workspace}}/build
+        -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
+        -DPLAYRHO_BUILD_HELLOWORLD=ON
+        -DPLAYRHO_BUILD_UNIT_TESTS=ON
+        -DPLAYRHO_BUILD_TESTBED=ON
+        -DPLAYRHO_BUILD_BENCHMARK=ON
+        -DCMAKE_GENERATOR_PLATFORM=${{matrix.genplat}}
+        -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
+        -DVCPKG_TARGET_TRIPLET=${{matrix.triplet}}
+        -DBUILD_SHARED_LIBS=${{matrix.linkage == 'shared'}}
 
     - name: Build
       # Build your program with the given configuration

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -322,6 +322,7 @@
 		80BB8A75141C3F4C00F1753A /* libPlayRho.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80FF01D2141C3D980059E59D /* libPlayRho.a */; };
 		80BB8A76141C3F7600F1753A /* libPlayRho.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80FF01D2141C3D980059E59D /* libPlayRho.a */; };
 		80BB8A7B141C3FA700F1753A /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80BB8A7A141C3FA700F1753A /* OpenGL.framework */; };
+		9921FFD729AD43C30043F23F /* TypeInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9921FFD629AD43C30043F23F /* TypeInfo.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -780,6 +781,7 @@
 		80BB8A7A141C3FA700F1753A /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = System/Library/Frameworks/OpenGL.framework; sourceTree = SDKROOT; };
 		80CD7722143AF3230086DB87 /* ConvexHull.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = ConvexHull.hpp; sourceTree = "<group>"; };
 		80FF01D2141C3D980059E59D /* libPlayRho.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPlayRho.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		9921FFD629AD43C30043F23F /* TypeInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TypeInfo.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -903,6 +905,7 @@
 				47327E741E9F1E2A0048FCD8 /* TargetJoint.cpp */,
 				474BC4031D41278800447DCD /* TimeOfImpact.cpp */,
 				474BC4041D41278800447DCD /* Transformation.cpp */,
+				9921FFD629AD43C30043F23F /* TypeInfo.cpp */,
 				47C96C501FA24BC100A6C587 /* Units.cpp */,
 				47928F5A2009E83500A5DD5B /* UnitTests.hpp */,
 				470F94DD1ECB94D600AA3C82 /* UnitVec.cpp */,
@@ -1648,6 +1651,7 @@
 				470F9B521EF8E2C5007EF7B6 /* RayCastOutput.cpp in Sources */,
 				472724251E310C7600C64921 /* float.cpp in Sources */,
 				474BC4321D413DC200447DCD /* IndexPair.cpp in Sources */,
+				9921FFD729AD43C30043F23F /* TypeInfo.cpp in Sources */,
 				47ED555124F05F26005A3586 /* DynamicMemory.cpp in Sources */,
 				47928F371E66539000EE6E9E /* FrictionJoint.cpp in Sources */,
 				474BC4331D413DC200447DCD /* main.cpp in Sources */,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,9 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
 endif()
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+
 # The PlayRho library.
 add_subdirectory(PlayRho)
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,10 +17,10 @@ See the documentation for each component to learn more about that component and 
 
 ## Supported Platforms
 
-All components are known to build and work on the following target platforms as confirmed through this project's continuous integration setup:
+All components are known to build, and the library to validate, on the following target platforms (as confirmed through this project's continuous integration setup):
 - [macOS 11 (Release & Debug)](.github/workflows/macos.yml).
-- [Ubuntu linux (Release)](.github/workflows/linux.yml).
-- [Ubuntu linux (Debug)](.github/workflows/linux-debug.yml).
+- [Ubuntu Linux (Release)](.github/workflows/linux.yml).
+- [Ubuntu Linux (Debug)](.github/workflows/linux-debug.yml).
 - [Windows "2019" (Win32, x64 for Release & Debug)](.github/workflows/windows.yml).
 
 While the library itself should be buildable on any platform having a C++17 or higher standards compliant compiler,
@@ -53,9 +53,9 @@ git clone --recurse-submodules https://github.com/louis-langholtz/PlayRho.git
 
 ### Configure
 
-This step sets up what is to be built and installed in future steps.
-This step depends on the components to be built and possibly the platform they are built on.
-Follow the above links for each component you want to build to read about the configuration arguments needed for that component and possibly for the target platform.
+This step sets up things for future steps, like what components are to be built, how they are to be built, and where they are to be installed.
+This step depends heavily on the components chosen, how you want them built, and possibly the platform they are built on.
+Follow the above links for each component you're interested in to read about the configuration arguments needed for that component and possibly for the target platform.
 
 For example, to only build the library component using the CMake default generator and compiler environment, run the following:
 
@@ -64,11 +64,23 @@ cmake -S PlayRho -B PlayRhoBuild
 ```
 
 Alternatively, add the configuration arguments needed for each desired component and your platform.
-Then run the following where `$ConfigOptions` is the accumalated configuration options for the components you want:
+Then run the following where `$ConfigOptions` is the accumulated configuration options for the components you want:
 
 ```sh
 cmake -S PlayRho -B PlayRhoBuild $ConfigOptions
 ```
+
+#### Additional Options
+
+For a listing of non-advanced configuration options, run:
+```sh
+cmake -LH -S PlayRho -B PlayRhoBuild
+```
+
+For example:
+- To build everything to use double precision floating point arithmetic (instead of single precision), add `-DPLAYRHO_REAL_TYPE=double`.
+- To build everything using shared linkage (instead of static linkage), add `-DBUILD_SHARED_LIBS=ON`.
+- To set the installation prefix, add an argument like `-DCMAKE_INSTALL_PREFIX=/opt/PlayRho`.
 
 ### Build
 
@@ -101,14 +113,3 @@ These steps assume that:
 - You want to install these components into CMake's standard system paths.
 - The necessary prerequisites for the components have already been installed.
 
-Various other options are also available.
-
-For example, add the following argument to set the installation prefix:
-```sh
--DCMAKE_INSTALL_PREFIX=/opt/PlayRho
-```
-
-Or, to list the available non-advanced options:
-```sh
-cmake -LH -S PlayRho -B PlayRhoBuild
-```

--- a/PlayRho/CMakeLists.txt
+++ b/PlayRho/CMakeLists.txt
@@ -67,11 +67,19 @@ set(libsrc
 )
 
 if(PLAYRHO_BUILD_SHARED)
+	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 	add_library(PlayRho SHARED ${libsrc})
 else()
 	add_library(PlayRho STATIC ${libsrc})
 endif()
 add_library(PlayRho::PlayRho ALIAS PlayRho)
+
+include(GenerateExportHeader)
+generate_export_header(PlayRho EXPORT_FILE_NAME Export.h)
+if (NOT PLAYRHO_BUILD_SHARED)
+	target_compile_definitions(PlayRho PUBLIC -DPLAYRHO_STATIC_DEFINE)
+endif()
+
 target_compile_features(PlayRho PUBLIC cxx_std_17)
 set_target_properties(PlayRho PROPERTIES
 	OUTPUT_NAME "PlayRho"

--- a/PlayRho/Common/TypeInfo.hpp
+++ b/PlayRho/Common/TypeInfo.hpp
@@ -21,11 +21,46 @@
 #ifndef PLAYRHO_COMMON_TYPEID_HPP
 #define PLAYRHO_COMMON_TYPEID_HPP
 
-#include <PlayRho/Common/IndexingNamedType.hpp>
-#include <PlayRho/Common/Templates.hpp> // for GetInvalid, IsValid
+#include <PlayRho/Common/Templates.hpp>
+
+#include <functional> // for std::reference_wrapper
+#include <regex>
+#include <string>
+#include <typeindex>
+#include <typeinfo>
 
 namespace playrho {
 namespace detail {
+
+template <typename T>
+std::string TypeNameAsString()
+{
+    // Ideally return string unique to the type T...
+#if defined(__clang__)
+    // Use __PRETTY_FUNCTION__. **Note that despite its appearance, this is an identifier; it's not a macro**!
+    // template <typename T> string Name() { return string{__PRETTY_FUNCTION__}; }
+    // enum class Fruit {APPLE, PEAR};
+    // std::cout << Name<Fruit>() << '\n';
+    // produces: std::string Name() [T = Fruit]
+    return std::regex_replace(__PRETTY_FUNCTION__, std::regex(".*T = (.*)\\].*"), "$1");
+#elif defined(__GNUC__)
+    // Use __PRETTY_FUNCTION__. **Note that despite its appearance, this is an identifier; it's not a macro**!
+    // template <typename T> string Name() { return string{__PRETTY_FUNCTION__}; }
+    // enum class Fruit {APPLE, PEAR};
+    // std::cout << Name<Fruit>() << '\n';
+    // produces: std::string Name() [with T = Fruit; std::string = std::__cxx11::basic_string<char>]
+    return std::regex_replace(__PRETTY_FUNCTION__, std::regex(".*T = (.*);.*"), "$1");
+#elif defined(__FUNCSIG__)
+    // Assume this is Microsoft Visual C++ or compatible compiler and format.
+    // enum class Fruit {APPLE, PEAR};
+    // std::cout << Name<Fruit>() << '\n';
+    // produces:
+    // class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > __cdecl Name<enum Fruit>(void)
+    return std::regex_replace(__FUNCSIG__, std::regex(".* __cdecl [^<]+<(.*)>\\(void\\)"), "$1");
+#else
+    return {}; // not unique but maybe still helpful at avoiding compiler issues
+#endif
+}
 
 /// @brief Gets a null-terminated byte string identifying this function.
 /// @note Intended for use by <code>TypeInfo</code> to set the value of its
@@ -34,16 +69,10 @@ namespace detail {
 ///    when whole program is turned on. Such an issue is documented in Issue #370.
 /// @see https://github.com/louis-langholtz/PlayRho/issues/370
 template <typename T>
-static constexpr const char* GetNameForTypeInfo() noexcept
+static const char* GetNameForTypeInfo() noexcept
 {
-    // Ideally return string unique to the type T...
-#if defined(_MSC_VER)
-    return __FUNCSIG__;
-#elif defined(__GNUC__)
-    return __PRETTY_FUNCTION__;
-#else
-    return __func__; // not unique but maybe still helpful at avoiding compiler issues
-#endif
+    static const std::string buffer = TypeNameAsString<T>();
+    return buffer.c_str();
 }
 
 } // namespace detail
@@ -60,79 +89,114 @@ struct TypeInfo
     ///   template's type <code>T</code> prevents issue #370. Credit for this technique
     ///   goes to Li Jin (github user pigpigyyy).
     /// @see https://github.com/louis-langholtz/PlayRho/issues/370
-    static constexpr const char* name = detail::GetNameForTypeInfo<T>();
+    static inline const char* name = detail::GetNameForTypeInfo<T>();
 };
 
-/// @brief Type info specialization for <code>float</code>.
-template <>
-struct TypeInfo<float>
-{
-    /// @brief Provides name of the type as a null-terminated string.
-    static constexpr const char* name = "float";
-};
+class TypeID;
 
-/// @brief Type info specialization for <code>double</code>.
-template <>
-struct TypeInfo<double>
-{
-    /// @brief Provides name of the type as a null-terminated string.
-    static constexpr const char* name = "double";
-};
+/// @brief Gets the type ID for the function's template parameter type with its name demangled.
+template <typename T>
+TypeID GetTypeID() noexcept;
 
-/// @brief Type info specialization for <code>long double</code>.
-template <>
-struct TypeInfo<long double>
-{
-    /// @brief Provides name of the type as a null-terminated string.
-    static constexpr const char* name = "long double";
-};
+/// @brief Gets the type ID for the function parameter type with its name demangled.
+template <typename T>
+TypeID GetTypeID(const T&) noexcept;
 
 /// @brief Type identifier.
-using TypeID = detail::IndexingNamedType<const char * const *, struct TypeIdentifier>;
-
-/// @brief Invalid type ID value.
-constexpr auto InvalidTypeID =
-    static_cast<TypeID>(static_cast<TypeID::underlying_type>(nullptr));
-
-/// @brief Gets an invalid value for the TypeID type.
-template <>
-constexpr TypeID GetInvalid() noexcept
+/// @note This provides value semantics like being copyable, assignable, and equality comparable.
+class TypeID
 {
-    return InvalidTypeID;
-}
+public:
+    /// Default constructor.
+    /// @post A type identifier equivalent to the value returned by <code>GetTypeID<void>()</code>.
+    TypeID() noexcept = default;
 
-/// @brief Determines if the given value is valid.
-template <>
-constexpr bool IsValid(const TypeID& value) noexcept
-{
-    return value != GetInvalid<TypeID>();
-}
+    /// Gets demangled name of the type this was generated for as a a non-null, null terminated string buffer.
+    constexpr const char* GetName() const noexcept
+    {
+        return m_name;
+    }
 
-/// @brief Gets the type ID for the template parameter type.
+    /// Equality operator support via "hidden friend" function.
+    inline friend bool operator==(const TypeID& lhs, const TypeID& rhs) noexcept
+    {
+        return lhs.m_info.get() == rhs.m_info.get();
+    }
+
+    /// Inequality operator support via "hidden friend" function.
+    inline friend bool operator!=(const TypeID& lhs, const TypeID& rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
+    /// Less-than operator support via "hidden friend" function.
+    /// @note The ordering of type IDs is unspecified. This is provided anyway to support things like associative containers.
+    inline friend bool operator<(const TypeID& lhs, const TypeID& rhs) noexcept
+    {
+        return std::type_index{lhs.m_info.get()} < std::type_index{rhs.m_info.get()};
+    }
+
+    /// Less-than-or-equal operator support via "hidden friend" function.
+    /// @note The ordering of type IDs is unspecified. This is provided anyway to support things like associative containers.
+    inline friend bool operator<=(const TypeID& lhs, const TypeID& rhs) noexcept
+    {
+        return std::type_index{lhs.m_info.get()} <= std::type_index{rhs.m_info.get()};
+    }
+
+    /// Greater-than operator support via "hidden friend" function.
+    /// @note The ordering of type IDs is unspecified. This is provided anyway to support things like associative containers.
+    inline friend bool operator>(const TypeID& lhs, const TypeID& rhs) noexcept
+    {
+        return std::type_index{lhs.m_info.get()} > std::type_index{rhs.m_info.get()};
+    }
+
+    /// Greater-than-or-equal operator support via "hidden friend" function.
+    /// @note The ordering of type IDs is unspecified. This is provided anyway to support things like associative containers.
+    inline friend bool operator>=(const TypeID& lhs, const TypeID& rhs) noexcept
+    {
+        return std::type_index{lhs.m_info.get()} >= std::type_index{rhs.m_info.get()};
+    }
+
+    template <typename T>
+    friend TypeID GetTypeID() noexcept;
+
+    template <typename T>
+    friend TypeID GetTypeID(const T&) noexcept;
+
+private:
+    explicit TypeID(const std::type_info& info, const char* name) noexcept:
+        m_info{info}, m_name{name}
+    {
+        // Intentionally empty.
+    }
+
+    std::reference_wrapper<const std::type_info> m_info{typeid(void)};
+    const char* m_name{TypeInfo<void>::name};
+};
+
 template <typename T>
-constexpr TypeID GetTypeID()
+TypeID GetTypeID() noexcept
 {
-    return TypeID{&TypeInfo<std::decay_t<T>>::name};
+    return TypeID{typeid(std::decay_t<T>), TypeInfo<std::decay_t<T>>::name};
 }
 
-/// @brief Gets the type ID for the function parameter type.
 template <typename T>
-constexpr TypeID GetTypeID(T)
+TypeID GetTypeID(const T&) noexcept
 {
-    return TypeID{&TypeInfo<std::decay_t<T>>::name};
+    return TypeID{typeid(std::decay_t<T>), TypeInfo<std::decay_t<T>>::name};
 }
 
 /// @brief Gets the name associated with the given type ID.
-constexpr const char* GetName(TypeID id) noexcept
+inline const char* GetName(const TypeID& id) noexcept
 {
-    return *to_underlying(id);
+    return id.GetName();
 }
 
 /// @brief Gets the name associated with the given template parameter type.
 template <typename T>
 constexpr const char* GetTypeName() noexcept
 {
-    return TypeInfo<T>::name;
+    return GetTypeID<std::decay_t<T>>().GetName();
 }
 
 } // namespace playrho

--- a/PlayRho/Dynamics/Joints/GearJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/GearJointConf.hpp
@@ -224,14 +224,14 @@ constexpr auto GetConstant(const GearJointConf& object) noexcept
 
 /// @brief Free function for getting joint 1 type value of the given configuration.
 /// @relatedalso GearJointConf
-constexpr auto GetType1(const GearJointConf& object) noexcept
+inline auto GetType1(const GearJointConf& object) noexcept
 {
     return object.type1;
 }
 
 /// @brief Free function for getting joint 2 type value of the given configuration.
 /// @relatedalso GearJointConf
-constexpr auto GetType2(const GearJointConf& object) noexcept
+inline auto GetType2(const GearJointConf& object) noexcept
 {
     return object.type2;
 }

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -25,6 +25,7 @@
 #define PLAYRHO_DYNAMICS_JOINTS_JOINT_HPP
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/TypeInfo.hpp> // for GetTypeID
 #include <PlayRho/Dynamics/Joints/LimitState.hpp>
 #include <PlayRho/Dynamics/BodyID.hpp>
 

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -20,7 +20,7 @@ add_compile_definitions(PLAYRHO_VERSION_MINOR=${PlayRho_VERSION_MINOR})
 add_compile_definitions(PLAYRHO_VERSION_PATCH=${PlayRho_VERSION_PATCH})
 
 # Hides options.
-mark_as_advanced(FORCE BUILD_GMOCK BUILD_GTEST BUILD_SHARED_LIBS)
+mark_as_advanced(FORCE BUILD_GMOCK BUILD_GTEST)
 mark_as_advanced(FORCE INSTALL_GMOCK INSTALL_GTEST)
 mark_as_advanced(FORCE gmock_build_tests)
 mark_as_advanced(FORCE gtest_build_samples gtest_build_tests gtest_disable_pthreads gtest_hide_internal_symbols)
@@ -30,16 +30,18 @@ mark_as_advanced(FORCE CMAKE_DEBUG_POSTFIX)
 set(BUILD_GMOCK ON)
 set(INSTALL_GTEST OFF CACHE BOOL "Enable installation of googletest.")
 set(INSTALL_GMOCK OFF CACHE BOOL "Enable installation of googlemock.")
+set(gtest_hide_internal_symbols ON CACHE BOOL "")
 
 if (MSVC)
   if (PLAYRHO_BUILD_SHARED)
-    message(STATUS "UnitTests: Adding definition for linking with googletest as shared library.")
-    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY)
+    #message(STATUS "UnitTests: Adding definition for linking with googletest as shared library.")
+    #add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY)
   else()
-    message(STATUS "UnitTests: Setting option value for linking googletest with static library.")
-    set(gtest_force_shared_crt ON CACHE BOOL "Required setting for linking googletest with static library." FORCE)
+    #message(STATUS "UnitTests: Setting option value for linking googletest with static library.")
   endif()
 endif()
+# Prevent overriding the parent project's compiler/linker settings on Windows
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Add subdirectory to build.
 # For cmd details, see: https://cmake.org/cmake/help/v3.1/command/add_subdirectory.html
@@ -65,7 +67,7 @@ endif()
 
 # Link a target to given libraries.
 # See details at: https://cmake.org/cmake/help/v3.1/command/target_link_libraries.html
-target_link_libraries(UnitTests PlayRho gtest)
+target_link_libraries(UnitTests PlayRho GTest::gtest)
 
 # link with coverage library
 if(${PLAYRHO_ENABLE_COVERAGE})
@@ -75,9 +77,6 @@ if(${PLAYRHO_ENABLE_COVERAGE})
         target_link_libraries(UnitTests -fprofile-arcs -ftest-coverage)
     endif()
 endif()
-
-# Adds UnitTests to be run when like "make test" is executed.
-add_test(UnitTests UnitTests)
 
 include(GoogleTest)
 gtest_discover_tests(UnitTests)

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -46,16 +46,16 @@ TEST(GearJointConf, ByteSize)
     case 4:
 #if defined(_WIN32)
 #if defined(_WIN64)
-        EXPECT_EQ(sizeof(GearJointConf), std::size_t(136));
+        EXPECT_EQ(sizeof(GearJointConf), std::size_t(152));
 #else
-        EXPECT_EQ(sizeof(GearJointConf), std::size_t(124));
+        EXPECT_EQ(sizeof(GearJointConf), std::size_t(132));
 #endif
 #else
-        EXPECT_EQ(sizeof(GearJointConf), std::size_t(136));
+        EXPECT_EQ(sizeof(GearJointConf), std::size_t(152));
 #endif
         break;
     case 8:
-        EXPECT_EQ(sizeof(GearJointConf), std::size_t(240));
+        EXPECT_EQ(sizeof(GearJointConf), std::size_t(256));
         break;
     case 16:
         EXPECT_EQ(sizeof(GearJointConf), std::size_t(448));

--- a/UnitTests/TypeInfo.cpp
+++ b/UnitTests/TypeInfo.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "UnitTests.hpp"
+
+#include <PlayRho/Common/TypeInfo.hpp>
+
+#include <cstring>
+
+using namespace playrho;
+
+TEST(TypeInfo, DefaultConstruction)
+{
+    EXPECT_EQ(TypeID(), GetTypeID<void>());
+    EXPECT_TRUE(std::strcmp(TypeID().GetName(), GetTypeID<void>().GetName()) == 0);
+    EXPECT_NE(TypeID(), GetTypeID<int>());
+}
+
+TEST(TypeInfo, Equality)
+{
+    EXPECT_TRUE(TypeID() == GetTypeID<void>());
+    EXPECT_FALSE(TypeID() == GetTypeID<int>());
+    EXPECT_TRUE(GetTypeID<float>() == GetTypeID<float>());
+    EXPECT_FALSE(GetTypeID<float>() == GetTypeID<int>());
+}
+
+TEST(TypeInfo, InEquality)
+{
+    EXPECT_FALSE(TypeID() != GetTypeID<void>());
+    EXPECT_TRUE(TypeID() != GetTypeID<int>());
+    EXPECT_FALSE(GetTypeID<float>() != GetTypeID<float>());
+    EXPECT_TRUE(GetTypeID<float>() != GetTypeID<int>());
+}
+
+TEST(TypeInfo, Comparisons)
+{
+    EXPECT_FALSE(GetTypeID<float>() < GetTypeID<float>());
+    EXPECT_TRUE(GetTypeID<float>() <= GetTypeID<float>());
+    EXPECT_FALSE(GetTypeID<float>() > GetTypeID<float>());
+    EXPECT_TRUE(GetTypeID<float>() >= GetTypeID<float>());
+    EXPECT_TRUE((GetTypeID<float>() < GetTypeID<int>()) || (GetTypeID<float>() > GetTypeID<int>()));
+}


### PR DESCRIPTION
#### Description - What's this PR do?

Changes for exports/DLLs

- Updates workflow yml syntax.
- Explicitly sets gtest_hide_internal_symbols.
- Fixes TypeInfo to better support Windows shared linkage while still supporting the other platforms.
- Updates INSTALL.md.

(cherry picked from commit e081983316024880a7d12787a1be37d286bacb57)
