### PR TITLE
Updates noexcept 20230308

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,7 @@
 #   run-clang-tidy -p PlayRhoBuild -header-filter='.*' PlayRho/PlayRho
 
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,bugprone-*,concurrency-*,misc-*,modernize-*,performance-*,portability-*,readability-*,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-no-malloc,-cppcoreguidelines-owning-memory,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-avoid-c-arrays,-llvmlibc-*,-readability-implicit-bool-conversion,-readability-named-parameter,-readability-identifier-length,-readability-uppercase-literal-suffix,-readability-container-size-empty,-fuchsia-overloaded-operator,-hicpp-no-array-decay'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,concurrency-*,portability-*,bugprone-exception-escape,readability-inconsistent-declaration-parameter-name,misc-redundant-expression'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -395,6 +395,7 @@
 		80BB8A76141C3F7600F1753A /* libPlayRho.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 80FF01D2141C3D980059E59D /* libPlayRho.a */; };
 		80BB8A7B141C3FA700F1753A /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 80BB8A7A141C3FA700F1753A /* OpenGL.framework */; };
 		9921FFD729AD43C30043F23F /* TypeInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9921FFD629AD43C30043F23F /* TypeInfo.cpp */; };
+		99CF862F29B9087700D9D112 /* BaseShapeConf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99CF862E29B9087700D9D112 /* BaseShapeConf.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -864,6 +865,7 @@
 		80CD7722143AF3230086DB87 /* ConvexHull.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConvexHull.cpp; sourceTree = "<group>"; };
 		80FF01D2141C3D980059E59D /* libPlayRho.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPlayRho.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9921FFD629AD43C30043F23F /* TypeInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TypeInfo.cpp; sourceTree = "<group>"; };
+		99CF862E29B9087700D9D112 /* BaseShapeConf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BaseShapeConf.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -922,6 +924,7 @@
 				47CF984F1E0088ED0077F5F2 /* Angle.cpp */,
 				470ADAAB25546D2700EEE99D /* ArrayAllocator.cpp */,
 				4734B21B1DC1121900F15E29 /* ArrayList.cpp */,
+				99CF862E29B9087700D9D112 /* BaseShapeConf.cpp */,
 				475A94531D930503000CA9A8 /* BlockAllocator.cpp */,
 				476FBF52253FB96E0057D5F3 /* Body.cpp */,
 				476FBF4E253FAD690057D5F3 /* BodyConf.cpp */,
@@ -1208,6 +1211,7 @@
 				80BB8957141C3E5900F1753A /* World.hpp */,
 				4764089625226D7C0090F711 /* WorldBody.cpp */,
 				4764088C252268A30090F711 /* WorldBody.hpp */,
+				47440F0A1EDA365400AB3F51 /* WorldConf.hpp */,
 				4764089B25226E170090F711 /* WorldContact.cpp */,
 				476408912522698E0090F711 /* WorldContact.hpp */,
 				4764089825226E170090F711 /* WorldJoint.cpp */,
@@ -1216,7 +1220,6 @@
 				4764088F2522698E0090F711 /* WorldMisc.hpp */,
 				4795B64B262DF06800FB3EC6 /* WorldShape.cpp */,
 				4795B64A262DF06800FB3EC6 /* WorldShape.hpp */,
-				47440F0A1EDA365400AB3F51 /* WorldConf.hpp */,
 				47640861250807720090F711 /* WorldImpl.cpp */,
 				47640860250807720090F711 /* WorldImpl.hpp */,
 				47640880251F0F9B0090F711 /* WorldImplBody.cpp */,
@@ -1757,6 +1760,7 @@
 				4731DE4D1DE90D8200E7F931 /* MassData.cpp in Sources */,
 				474FDB531E72643D00F401AF /* forward_list.cpp in Sources */,
 				473971AA1D9F0E4E00F7137F /* ContactSolver.cpp in Sources */,
+				99CF862F29B9087700D9D112 /* BaseShapeConf.cpp in Sources */,
 				475A94541D930503000CA9A8 /* BlockAllocator.cpp in Sources */,
 				47B58F601F5B791500354C34 /* FlagGuard.cpp in Sources */,
 				4731DDFC1DC8FBEE00E7F931 /* Island.cpp in Sources */,
@@ -2029,6 +2033,7 @@
 			buildSettings = {
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
 					/usr/local/boost_1_75_0,
 					/usr/local/include,
 					/opt/homebrew/opt/googletest/include,
@@ -2049,6 +2054,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
 					/usr/local/boost_1_75_0,
 					/usr/local/include,
 					/opt/homebrew/opt/googletest/include,
@@ -2068,6 +2074,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
 					/usr/local/include,
 					/usr/local/boost_1_75_0,
 					../..,
@@ -2089,6 +2096,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
 					/usr/local/include,
 					/usr/local/boost_1_75_0,
 					../..,
@@ -2106,6 +2114,11 @@
 		80BB8912141C3E2700F1753A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
+					/usr/local/boost_1_75_0,
+					../..,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -2113,6 +2126,11 @@
 		80BB8913141C3E2700F1753A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
+					/usr/local/boost_1_75_0,
+					../..,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -2125,6 +2143,7 @@
 					../../Testbed/Framework/imgui,
 					../../Testbed/Framework/imgui/examples/libs/gl3w/,
 					../..,
+					/opt/homebrew/opt/boost/include,
 					/usr/local/include,
 					/usr/local/boost_1_75_0,
 					/opt/homebrew/opt/glfw/include,
@@ -2152,6 +2171,7 @@
 					../../Testbed/Framework/imgui,
 					../../Testbed/Framework/imgui/examples/libs/gl3w/,
 					../..,
+					/opt/homebrew/opt/boost/include,
 					/usr/local/include,
 					/usr/local/boost_1_75_0,
 					/opt/homebrew/opt/glfw/include,
@@ -2337,6 +2357,11 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
+					/usr/local/boost_1_75_0,
+					../..,
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-Wall",
 					"-Wextra",
@@ -2356,6 +2381,11 @@
 				DEPLOYMENT_POSTPROCESSING = YES;
 				EXECUTABLE_PREFIX = lib;
 				GCC_PREPROCESSOR_DEFINITIONS = "NDEBUG=1";
+				HEADER_SEARCH_PATHS = (
+					/opt/homebrew/opt/boost/include,
+					/usr/local/boost_1_75_0,
+					../..,
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-Wall",
 					"-Wextra",

--- a/PlayRho/Collision/AABB.cpp
+++ b/PlayRho/Collision/AABB.cpp
@@ -56,7 +56,7 @@ AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xfm0,
     return GetFattenedAABB(result, proxy.GetVertexRadius());
 }
 
-AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept
+AABB ComputeAABB(const Shape& shape, const Transformation& xf)
 {
     auto sum = AABB{};
     const auto childCount = GetChildCount(shape);
@@ -82,7 +82,7 @@ AABB ComputeAABB(const World& world, BodyID id)
 }
 
 AABB ComputeIntersectingAABB(const World& world, BodyID bA, ShapeID sA, ChildCounter iA, BodyID bB,
-                             ShapeID sB, ChildCounter iB) noexcept
+                             ShapeID sB, ChildCounter iB)
 {
     const auto xA = GetTransformation(world, bA);
     const auto xB = GetTransformation(world, bB);

--- a/PlayRho/Collision/AABB.hpp
+++ b/PlayRho/Collision/AABB.hpp
@@ -425,7 +425,7 @@ AABB ComputeAABB(const DistanceProxy& proxy, const Transformation& xfm0,
 
 /// @brief Computes the AABB for the given shape with the given transformation.
 /// @relatedalso Shape
-AABB ComputeAABB(const Shape& shape, const Transformation& xf) noexcept;
+AABB ComputeAABB(const Shape& shape, const Transformation& xf);
 
 /// @brief Computes the AABB for the identified shape relative to the identified body
 ///   within the given world.
@@ -442,7 +442,7 @@ AABB ComputeAABB(const World& world, BodyID id);
 ///   shape B of body B.
 /// @relatedalso World
 AABB ComputeIntersectingAABB(const World& world, BodyID bA, ShapeID sA, ChildCounter iA, BodyID bB,
-                             ShapeID sB, ChildCounter iB) noexcept;
+                             ShapeID sB, ChildCounter iB);
 
 /// @brief Computes the intersecting AABB for the given contact.
 /// @relatedalso World

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -63,7 +63,7 @@ public:
     DistanceProxy() = default;
 
     /// @brief Copy constructor.
-    DistanceProxy(const DistanceProxy& copy) noexcept
+    DistanceProxy(const DistanceProxy& copy) noexcept // NOLINT(modernize-use-equals-default)
         :
 #ifndef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
           m_vertices{copy.m_vertices},

--- a/PlayRho/Collision/DynamicTreeData.hpp
+++ b/PlayRho/Collision/DynamicTreeData.hpp
@@ -91,9 +91,6 @@ union DynamicTreeVariantData {
     /// @brief Branch specific data.
     DynamicTreeBranchData branch;
 
-    /// @brief Default constructor.
-    DynamicTreeVariantData() noexcept {}
-
     /// @brief Initializing constructor.
     constexpr DynamicTreeVariantData(DynamicTreeUnusedData value) noexcept : unused{value} {}
 

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -38,16 +38,22 @@ namespace detail {
 template <std::size_t N>
 struct MassData
 {
+    /// @brief Default mass.
+    static constexpr auto DefaultMass = NonNegative<Mass>{0_kg};
+
+    /// @brief Default rotational inertia (I).
+    static constexpr auto DefaultI = NonNegative<RotInertia>{0 * 1_m2 * 1_kg / SquareRadian};
+
     /// @brief Position of the shape's centroid relative to the shape's origin.
     Vector<Length, N> center = Vector<Length, N>{};
-    
+
     /// @brief Mass of the shape in kilograms.
-    NonNegative<Mass> mass = NonNegative<Mass>{0_kg};
-    
+    NonNegative<Mass> mass = DefaultMass;
+
     /// @brief Rotational inertia, a.k.a. moment of inertia.
     /// @details This is the rotational inertia of the shape about the local origin.
     /// @see https://en.wikipedia.org/wiki/Moment_of_inertia
-    NonNegative<RotInertia> I = NonNegative<RotInertia>{0 * 1_m2 * 1_kg / SquareRadian};
+    NonNegative<RotInertia> I = DefaultI;
 };
 
 // Free functions...

--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -58,8 +58,6 @@ void ResetNormals(std::vector<UnitVec>& normals, const std::vector<Length2>& ver
 
 } // anonymous namespace
 
-ChainShapeConf::ChainShapeConf() = default;
-
 ChainShapeConf& ChainShapeConf::Set(std::vector<Length2> vertices)
 {
     const auto count = size(vertices);
@@ -72,14 +70,14 @@ ChainShapeConf& ChainShapeConf::Set(std::vector<Length2> vertices)
     return *this;
 }
 
-ChainShapeConf& ChainShapeConf::Translate(const Length2& value) noexcept
+ChainShapeConf& ChainShapeConf::Translate(const Length2& value)
 {
     std::for_each(begin(m_vertices), end(m_vertices), [=](Length2& v) { v = v + value; });
     ResetNormals(m_normals, m_vertices);
     return *this;
 }
 
-ChainShapeConf& ChainShapeConf::Scale(const Vec2& value) noexcept
+ChainShapeConf& ChainShapeConf::Scale(const Vec2& value)
 {
     std::for_each(begin(m_vertices), end(m_vertices), [=](Length2& v) {
         v = Length2{GetX(value) * GetX(v), GetY(value) * GetY(v)};
@@ -88,7 +86,7 @@ ChainShapeConf& ChainShapeConf::Scale(const Vec2& value) noexcept
     return *this;
 }
 
-ChainShapeConf& ChainShapeConf::Rotate(const UnitVec& value) noexcept
+ChainShapeConf& ChainShapeConf::Rotate(const UnitVec& value)
 {
     std::for_each(begin(m_vertices), end(m_vertices),
                   [=](Length2& v) { v = ::playrho::d2::Rotate(v, value); });
@@ -111,7 +109,7 @@ ChainShapeConf& ChainShapeConf::Add(Length2 vertex)
     return *this;
 }
 
-MassData ChainShapeConf::GetMassData() const noexcept
+MassData ChainShapeConf::GetMassData() const
 {
     const auto density = this->density;
     if (density > 0_kgpm2) {

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -63,18 +63,30 @@ public:
     }
 
     /// @brief Sets the configuration up for representing a chain of vertices as given.
-    ChainShapeConf& Set(std::vector<Length2> arg);
+    /// @note This function provides the strong exception guarantee. The state of this instance
+    ///   won't change if this function throws any exception.
+    /// @throws InvalidArgument if the number of vertices given is greater than <code>MaxChildCount</code>.
+    /// @post <code>GetVertices()</code> returns the vertices given.
+    /// @post <code>GetVertexCount()</code> returns the number of vertices given.
+    /// @post <code>GetVertex(i)</code> returns the vertex <code>vertices[i]</code> for all valid indices.
+    ChainShapeConf& Set(std::vector<Length2> vertices);
 
     /// @brief Adds the given vertex.
     ChainShapeConf& Add(Length2 vertex);
 
     /// @brief Translates the vertices by the given amount.
+    /// @note This function provides the strong exception guarantee. The state of this instance
+    ///   won't change if this function throws any exception.
     ChainShapeConf& Translate(const Length2& value);
 
     /// @brief Scales the vertices by the given amount.
+    /// @note This function provides the strong exception guarantee. The state of this instance
+    ///   won't change if this function throws any exception.
     ChainShapeConf& Scale(const Vec2& value);
 
     /// @brief Rotates the vertices by the given amount.
+    /// @note This function provides the strong exception guarantee. The state of this instance
+    ///   won't change if this function throws any exception.
     ChainShapeConf& Rotate(const UnitVec& value);
 
     /// @brief Gets the "child" shape count.

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -50,14 +50,17 @@ namespace d2 {
 class ChainShapeConf : public ShapeBuilder<ChainShapeConf>
 {
 public:
+    /// @brief Default vertex radius.
+    static constexpr auto DefaultVertexRadius = NonNegative<Length>{DefaultLinearSlop * Real{2}};
+
     /// @brief Gets the default vertex radius.
+    /// @note This is just a backward compatibility interface for getting the default vertex radius.
+    ///    The new way is to use <code>DefaultVertexRadius</code> directly.
+    /// @return <code>DefaultVertexRadius</code>.
     static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
-        return NonNegative<Length>{DefaultLinearSlop * Real{2}};
+        return DefaultVertexRadius;
     }
-
-    /// @brief Default constructor.
-    ChainShapeConf();
 
     /// @brief Sets the configuration up for representing a chain of vertices as given.
     ChainShapeConf& Set(std::vector<Length2> arg);
@@ -66,13 +69,13 @@ public:
     ChainShapeConf& Add(Length2 vertex);
 
     /// @brief Translates the vertices by the given amount.
-    ChainShapeConf& Translate(const Length2& value) noexcept;
+    ChainShapeConf& Translate(const Length2& value);
 
     /// @brief Scales the vertices by the given amount.
-    ChainShapeConf& Scale(const Vec2& value) noexcept;
+    ChainShapeConf& Scale(const Vec2& value);
 
     /// @brief Rotates the vertices by the given amount.
-    ChainShapeConf& Rotate(const UnitVec& value) noexcept;
+    ChainShapeConf& Rotate(const UnitVec& value);
 
     /// @brief Gets the "child" shape count.
     ChildCounter GetChildCount() const noexcept
@@ -86,7 +89,7 @@ public:
     DistanceProxy GetChild(ChildCounter index) const;
 
     /// @brief Gets the mass data.
-    MassData GetMassData() const noexcept;
+    MassData GetMassData() const;
 
     /// @brief Uses the given vertex radius.
     ChainShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
@@ -172,7 +175,7 @@ inline DistanceProxy GetChild(const ChainShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the mass data for a given chain shape configuration.
-inline MassData GetMassData(const ChainShapeConf& arg) noexcept
+inline MassData GetMassData(const ChainShapeConf& arg)
 {
     return arg.GetMassData();
 }
@@ -191,43 +194,43 @@ inline ChildCounter GetNextIndex(const ChainShapeConf& shape, ChildCounter index
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg)
+inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg) noexcept
 {
     return arg.vertexRadius;
 }
 
 /// @brief Gets the vertex radius of the given shape configuration.
-inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCounter)
+inline NonNegative<Length> GetVertexRadius(const ChainShapeConf& arg, ChildCounter) noexcept
 {
     return GetVertexRadius(arg);
 }
 
 /// @brief Sets the vertex radius of the shape.
-inline void SetVertexRadius(ChainShapeConf& arg, NonNegative<Length> value)
+inline void SetVertexRadius(ChainShapeConf& arg, NonNegative<Length> value) noexcept
 {
     arg.vertexRadius = value;
 }
 
 /// @brief Sets the vertex radius of the shape for the given index.
-inline void SetVertexRadius(ChainShapeConf& arg, ChildCounter, NonNegative<Length> value)
+inline void SetVertexRadius(ChainShapeConf& arg, ChildCounter, NonNegative<Length> value) noexcept
 {
     SetVertexRadius(arg, value);
 }
 
 /// @brief Translates the given shape's vertices by the given amount.
-inline void Translate(ChainShapeConf& arg, const Length2& value) noexcept
+inline void Translate(ChainShapeConf& arg, const Length2& value)
 {
     arg.Translate(value);
 }
 
 /// @brief Scales the given shape's vertices by the given amount.
-inline void Scale(ChainShapeConf& arg, const Vec2& value) noexcept
+inline void Scale(ChainShapeConf& arg, const Vec2& value)
 {
     arg.Scale(value);
 }
 
 /// @brief Rotates the given shape's vertices by the given amount.
-inline void Rotate(ChainShapeConf& arg, const UnitVec& value) noexcept
+inline void Rotate(ChainShapeConf& arg, const UnitVec& value)
 {
     arg.Rotate(value);
 }

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -41,13 +41,19 @@ namespace d2 {
 /// @ingroup PartsGroup
 ///
 struct DiskShapeConf : ShapeBuilder<DiskShapeConf> {
+    /// @brief Default radius.
+    static constexpr auto DefaultRadius = NonNegative<Length>{DefaultLinearSlop * 2};
+
     /// @brief Gets the default radius.
+    /// @note This is just a backward compatibility interface for getting the default radius.
+    ///    The new way is to use <code>DefaultRadius</code> directly.
+    /// @return <code>DefaultRadius</code>.
     static constexpr NonNegative<Length> GetDefaultRadius() noexcept
     {
-        return NonNegative<Length>{DefaultLinearSlop * 2};
+        return DefaultRadius;
     }
 
-    constexpr DiskShapeConf() = default;
+    constexpr DiskShapeConf() noexcept = default;
 
     /// @brief Initializing constructor.
     constexpr DiskShapeConf(NonNegative<Length> r) : vertexRadius{r}
@@ -169,7 +175,7 @@ inline void SetVertexRadius(DiskShapeConf& arg, ChildCounter, NonNegative<Length
 }
 
 /// @brief Gets the mass data of the given disk shape configuration.
-inline MassData GetMassData(const DiskShapeConf& arg) noexcept
+inline MassData GetMassData(const DiskShapeConf& arg)
 {
     return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.location);
 }

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -43,10 +43,16 @@ namespace d2 {
 class EdgeShapeConf : public ShapeBuilder<EdgeShapeConf>
 {
 public:
+    /// @brief Default vertex radius.
+    static constexpr auto DefaultVertexRadius = NonNegative<Length>{DefaultLinearSlop * Real{2}};
+
     /// @brief Gets the default vertex radius.
+    /// @note This is just a backward compatibility interface for getting the default vertex radius.
+    ///    The new way is to use <code>DefaultVertexRadius</code> directly.
+    /// @return <code>DefaultVertexRadius</code>.
     static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
-        return NonNegative<Length>{DefaultLinearSlop * Real{2}};
+        return DefaultVertexRadius;
     }
 
     /// @brief Gets the default configuration.
@@ -55,7 +61,7 @@ public:
         return EdgeShapeConf{};
     }
 
-    EdgeShapeConf() = default;
+    EdgeShapeConf() noexcept = default;
 
     /// @brief Initializing constructor.
     EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf = GetDefaultConf()) noexcept;
@@ -175,7 +181,7 @@ inline void SetVertexRadius(EdgeShapeConf& arg, ChildCounter, NonNegative<Length
 }
 
 /// @brief Gets the mass data for the given shape configuration.
-inline MassData GetMassData(const EdgeShapeConf& arg) noexcept
+inline MassData GetMassData(const EdgeShapeConf& arg)
 {
     return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.GetVertexA(),
                                     arg.GetVertexB());

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -34,7 +34,7 @@ static_assert(IsValidShapeType<MultiShapeConf>::value);
 /// Computes the mass properties of this shape using its dimensions and density.
 /// The inertia tensor is computed about the local origin.
 /// @return Mass data for this shape.
-MassData GetMassData(const MultiShapeConf& arg) noexcept
+MassData GetMassData(const MultiShapeConf& arg)
 {
     auto mass = 0_kg;
     const auto origin = Length2{};
@@ -79,7 +79,7 @@ ConvexHull ConvexHull::Get(const VertexSet& pointSet, NonNegative<Length> vertex
     return ConvexHull{vertices, normals, vertexRadius};
 }
 
-ConvexHull& ConvexHull::Translate(const Length2& value) noexcept
+ConvexHull& ConvexHull::Translate(const Length2& value)
 {
     auto newPoints = VertexSet{};
     for (const auto& v : vertices) {
@@ -89,7 +89,7 @@ ConvexHull& ConvexHull::Translate(const Length2& value) noexcept
     return *this;
 }
 
-ConvexHull& ConvexHull::Scale(const Vec2& value) noexcept
+ConvexHull& ConvexHull::Scale(const Vec2& value)
 {
     auto newPoints = VertexSet{};
     for (const auto& v : vertices) {
@@ -99,7 +99,7 @@ ConvexHull& ConvexHull::Scale(const Vec2& value) noexcept
     return *this;
 }
 
-ConvexHull& ConvexHull::Rotate(const UnitVec& value) noexcept
+ConvexHull& ConvexHull::Rotate(const UnitVec& value)
 {
     auto newPoints = VertexSet{};
     for (const auto& v : vertices) {
@@ -110,27 +110,27 @@ ConvexHull& ConvexHull::Rotate(const UnitVec& value) noexcept
 }
 
 MultiShapeConf& MultiShapeConf::AddConvexHull(const VertexSet& pointSet,
-                                              NonNegative<Length> vertexRadius) noexcept
+                                              NonNegative<Length> vertexRadius)
 {
     children.emplace_back(ConvexHull::Get(pointSet, vertexRadius));
     return *this;
 }
 
-MultiShapeConf& MultiShapeConf::Translate(const Length2& value) noexcept
+MultiShapeConf& MultiShapeConf::Translate(const Length2& value)
 {
     std::for_each(begin(children), end(children),
                   [&value](ConvexHull& child) { child.Translate(value); });
     return *this;
 }
 
-MultiShapeConf& MultiShapeConf::Scale(const Vec2& value) noexcept
+MultiShapeConf& MultiShapeConf::Scale(const Vec2& value)
 {
     std::for_each(begin(children), end(children),
                   [&value](ConvexHull& child) { child.Scale(value); });
     return *this;
 }
 
-MultiShapeConf& MultiShapeConf::Rotate(const UnitVec& value) noexcept
+MultiShapeConf& MultiShapeConf::Rotate(const UnitVec& value)
 {
     std::for_each(begin(children), end(children),
                   [&value](ConvexHull& child) { child.Rotate(value); });

--- a/PlayRho/Collision/Shapes/MultiShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.hpp
@@ -65,13 +65,13 @@ public:
     }
 
     /// @brief Translates all the vertices by the given amount.
-    ConvexHull& Translate(const Length2& value) noexcept;
+    ConvexHull& Translate(const Length2& value);
 
     /// @brief Scales all the vertices by the given amount.
-    ConvexHull& Scale(const Vec2& value) noexcept;
+    ConvexHull& Scale(const Vec2& value);
 
     /// @brief Rotates all the vertices by the given amount.
-    ConvexHull& Rotate(const UnitVec& value) noexcept;
+    ConvexHull& Rotate(const UnitVec& value);
 
     /// @brief Equality operator.
     friend bool operator==(const ConvexHull& lhs, const ConvexHull& rhs) noexcept
@@ -121,21 +121,22 @@ private:
 /// @details Composes zero or more convex shapes into what can be a concave shape.
 /// @ingroup PartsGroup
 struct MultiShapeConf : public ShapeBuilder<MultiShapeConf> {
+    /// @brief Default vertex radius.
+    static constexpr auto DefaultVertexRadius = NonNegative<Length>{DefaultLinearSlop * 2};
+
     /// @brief Gets the default vertex radius for the <code>MultiShapeConf</code>.
+    /// @note This is just a backward compatibility interface for getting the default vertex radius.
+    ///    The new way is to use <code>DefaultVertexRadius</code> directly.
+    /// @return <code>DefaultVertexRadius</code>.
     static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
-        return NonNegative<Length>{DefaultLinearSlop * 2};
+        return DefaultVertexRadius;
     }
 
     /// @brief Gets the default configuration for a <code>MultiShapeConf</code>.
     static inline MultiShapeConf GetDefaultConf() noexcept
     {
         return MultiShapeConf{};
-    }
-
-    inline MultiShapeConf() : ShapeBuilder{ShapeConf{}}
-    {
-        // Intentionally empty.
     }
 
     /// Creates a convex hull from the given set of local points.
@@ -145,16 +146,16 @@ struct MultiShapeConf : public ShapeBuilder<MultiShapeConf> {
     ///   may lead to poor stacking behavior.
     MultiShapeConf&
     AddConvexHull(const VertexSet& pointSet,
-                  NonNegative<Length> vertexRadius = GetDefaultVertexRadius()) noexcept;
+                  NonNegative<Length> vertexRadius = GetDefaultVertexRadius());
 
     /// @brief Translates all the vertices by the given amount.
-    MultiShapeConf& Translate(const Length2& value) noexcept;
+    MultiShapeConf& Translate(const Length2& value);
 
     /// @brief Scales all the vertices by the given amount.
-    MultiShapeConf& Scale(const Vec2& value) noexcept;
+    MultiShapeConf& Scale(const Vec2& value);
 
     /// @brief Rotates all the vertices by the given amount.
-    MultiShapeConf& Rotate(const UnitVec& value) noexcept;
+    MultiShapeConf& Rotate(const UnitVec& value);
 
     std::vector<ConvexHull> children; ///< Children.
 };
@@ -191,7 +192,7 @@ inline DistanceProxy GetChild(const MultiShapeConf& arg, ChildCounter index)
 }
 
 /// @brief Gets the mass data for the given shape configuration.
-MassData GetMassData(const MultiShapeConf& arg) noexcept;
+MassData GetMassData(const MultiShapeConf& arg);
 
 /// @brief Gets the vertex radius of the given shape configuration.
 inline NonNegative<Length> GetVertexRadius(const MultiShapeConf& arg, ChildCounter index)
@@ -212,19 +213,19 @@ inline void SetVertexRadius(MultiShapeConf& arg, ChildCounter index, NonNegative
 }
 
 /// @brief Translates the given shape configuration's vertices by the given amount.
-inline void Translate(MultiShapeConf& arg, const Length2& value) noexcept
+inline void Translate(MultiShapeConf& arg, const Length2& value)
 {
     arg.Translate(value);
 }
 
 /// @brief Scales the given shape configuration's vertices by the given amount.
-inline void Scale(MultiShapeConf& arg, const Vec2& value) noexcept
+inline void Scale(MultiShapeConf& arg, const Vec2& value)
 {
     arg.Scale(value);
 }
 
 /// @brief Rotates the given shape configuration's vertices by the given amount.
-inline void Rotate(MultiShapeConf& arg, const UnitVec& value) noexcept
+inline void Rotate(MultiShapeConf& arg, const UnitVec& value)
 {
     arg.Rotate(value);
 }

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -29,22 +29,22 @@ namespace d2 {
 
 static_assert(IsValidShapeType<PolygonShapeConf>::value);
 
-PolygonShapeConf::PolygonShapeConf() = default;
+PolygonShapeConf::PolygonShapeConf() noexcept = default;
 
-PolygonShapeConf::PolygonShapeConf(Length hx, Length hy, const PolygonShapeConf& conf) noexcept
+PolygonShapeConf::PolygonShapeConf(Length hx, Length hy, const PolygonShapeConf& conf)
     : ShapeBuilder{conf}
 {
     SetAsBox(hx, hy);
 }
 
 PolygonShapeConf::PolygonShapeConf(Span<const Length2> points,
-                                   const PolygonShapeConf& conf) noexcept
+                                   const PolygonShapeConf& conf)
     : ShapeBuilder{conf}
 {
     Set(points);
 }
 
-PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy) noexcept
+PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy)
 {
     m_centroid = Length2{};
 
@@ -71,13 +71,13 @@ PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy) noexcept
 }
 
 /// @brief Uses the given vertices.
-PolygonShapeConf& PolygonShapeConf::UseVertices(const std::vector<Length2>& verts) noexcept
+PolygonShapeConf& PolygonShapeConf::UseVertices(const std::vector<Length2>& verts)
 {
     return Set(Span<const Length2>(data(verts), size(verts)));
 }
 
 PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy, Length2 center,
-                                             Angle angle) noexcept
+                                             Angle angle)
 {
     SetAsBox(hx, hy);
     Transform(Transformation{center, UnitVec::Get(angle)});
@@ -94,7 +94,7 @@ PolygonShapeConf& PolygonShapeConf::Transform(Transformation xfm) noexcept
     return *this;
 }
 
-PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m) noexcept
+PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m)
 {
     auto newPoints = VertexSet{};
     for (const auto& v : m_vertices) {
@@ -103,7 +103,7 @@ PolygonShapeConf& PolygonShapeConf::Transform(const Mat22& m) noexcept
     return Set(newPoints);
 }
 
-PolygonShapeConf& PolygonShapeConf::Translate(const Length2& value) noexcept
+PolygonShapeConf& PolygonShapeConf::Translate(const Length2& value)
 {
     auto newPoints = VertexSet{};
     for (const auto& v : m_vertices) {
@@ -112,7 +112,7 @@ PolygonShapeConf& PolygonShapeConf::Translate(const Length2& value) noexcept
     return Set(newPoints);
 }
 
-PolygonShapeConf& PolygonShapeConf::Scale(const Vec2& value) noexcept
+PolygonShapeConf& PolygonShapeConf::Scale(const Vec2& value)
 {
     auto newPoints = VertexSet{};
     for (const auto& v : m_vertices) {
@@ -121,7 +121,7 @@ PolygonShapeConf& PolygonShapeConf::Scale(const Vec2& value) noexcept
     return Set(newPoints);
 }
 
-PolygonShapeConf& PolygonShapeConf::Rotate(const UnitVec& value) noexcept
+PolygonShapeConf& PolygonShapeConf::Rotate(const UnitVec& value)
 {
     auto newPoints = VertexSet{};
     for (const auto& v : m_vertices) {
@@ -130,7 +130,7 @@ PolygonShapeConf& PolygonShapeConf::Rotate(const UnitVec& value) noexcept
     return Set(newPoints);
 }
 
-PolygonShapeConf& PolygonShapeConf::Set(Span<const Length2> points) noexcept
+PolygonShapeConf& PolygonShapeConf::Set(Span<const Length2> points)
 {
     // Perform welding and copy vertices into local buffer.
     auto point_set = VertexSet(Square(DefaultLinearSlop));
@@ -140,7 +140,7 @@ PolygonShapeConf& PolygonShapeConf::Set(Span<const Length2> points) noexcept
     return Set(point_set);
 }
 
-PolygonShapeConf& PolygonShapeConf::Set(const VertexSet& points) noexcept
+PolygonShapeConf& PolygonShapeConf::Set(const VertexSet& points)
 {
     m_vertices = GetConvexHullAsVector(points);
     assert(size(m_vertices) < std::numeric_limits<VertexCounter>::max());

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -100,7 +100,7 @@ public:
     /// @warning Points may be re-ordered, even if they form a convex polygon
     /// @warning Collinear points are handled but not removed. Collinear points
     ///   may lead to poor stacking behavior.
-    PolygonShapeConf& Set(Span<const Length2> verts);
+    PolygonShapeConf& Set(Span<const Length2> points);
 
     /// @brief Sets the vertices to a convex hull of the given ones.
     /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -45,10 +45,16 @@ namespace d2 {
 class PolygonShapeConf : public ShapeBuilder<PolygonShapeConf>
 {
 public:
+    /// @brief Default vertex radius.
+    static constexpr auto DefaultVertexRadius = NonNegative<Length>{DefaultLinearSlop * 2};
+
     /// @brief Gets the default vertex radius for the <code>PolygonShapeConf</code>.
+    /// @note This is just a backward compatibility interface for getting the default vertex radius.
+    ///    The new way is to use <code>DefaultVertexRadius</code> directly.
+    /// @return <code>DefaultVertexRadius</code>.
     static constexpr NonNegative<Length> GetDefaultVertexRadius() noexcept
     {
-        return NonNegative<Length>{DefaultLinearSlop * 2};
+        return DefaultVertexRadius;
     }
 
     /// @brief Gets the default configuration for a <code>PolygonShapeConf</code>.
@@ -57,7 +63,7 @@ public:
         return PolygonShapeConf{};
     }
 
-    PolygonShapeConf();
+    PolygonShapeConf() noexcept;
 
     /// @brief Initializing constructor for a 4-sided box polygon.
     /// @param hx Half of the width.
@@ -65,7 +71,7 @@ public:
     /// @param conf Additional configuration information.
     /// @see SetAsBox.
     PolygonShapeConf(Length hx, Length hy,
-                     const PolygonShapeConf& conf = GetDefaultConf()) noexcept;
+                     const PolygonShapeConf& conf = GetDefaultConf());
 
     /// @brief Creates a convex hull from the given array of local points.
     /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
@@ -73,51 +79,51 @@ public:
     /// @warning collinear points are handled but not removed. Collinear points
     /// may lead to poor stacking behavior.
     explicit PolygonShapeConf(Span<const Length2> points,
-                              const PolygonShapeConf& conf = GetDefaultConf()) noexcept;
+                              const PolygonShapeConf& conf = GetDefaultConf());
 
     /// @brief Uses the given vertex radius.
     PolygonShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
 
     /// @brief Uses the given vertices.
-    PolygonShapeConf& UseVertices(const std::vector<Length2>& verts) noexcept;
+    PolygonShapeConf& UseVertices(const std::vector<Length2>& verts);
 
     /// @brief Sets the vertices to represent an axis-aligned box centered on the local origin.
     /// @param hx the half-width.
     /// @param hy the half-height.
-    PolygonShapeConf& SetAsBox(Length hx, Length hy) noexcept;
+    PolygonShapeConf& SetAsBox(Length hx, Length hy);
 
     /// @brief Sets the vertices for the described box.
-    PolygonShapeConf& SetAsBox(Length hx, Length hy, Length2 center, Angle angle) noexcept;
+    PolygonShapeConf& SetAsBox(Length hx, Length hy, Length2 center, Angle angle);
 
     /// @brief Sets the vertices to a convex hull of the given ones.
     /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
     /// @warning Points may be re-ordered, even if they form a convex polygon
     /// @warning Collinear points are handled but not removed. Collinear points
     ///   may lead to poor stacking behavior.
-    PolygonShapeConf& Set(Span<const Length2> verts) noexcept;
+    PolygonShapeConf& Set(Span<const Length2> verts);
 
     /// @brief Sets the vertices to a convex hull of the given ones.
     /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
     /// @warning Points may be re-ordered, even if they form a convex polygon
     /// @warning Collinear points are handled but not removed. Collinear points
     ///   may lead to poor stacking behavior.
-    PolygonShapeConf& Set(const VertexSet& points) noexcept;
+    PolygonShapeConf& Set(const VertexSet& points);
 
     /// @brief Transforms the vertices by the given transformation.
     PolygonShapeConf& Transform(Transformation xfm) noexcept;
 
     /// @brief Transforms the vertices by the given transformation matrix.
     /// @see https://en.wikipedia.org/wiki/Transformation_matrix
-    PolygonShapeConf& Transform(const Mat22& m) noexcept;
+    PolygonShapeConf& Transform(const Mat22& m);
 
     /// @brief Translates all the vertices by the given amount.
-    PolygonShapeConf& Translate(const Length2& value) noexcept;
+    PolygonShapeConf& Translate(const Length2& value);
 
     /// @brief Scales all the vertices by the given amount.
-    PolygonShapeConf& Scale(const Vec2& value) noexcept;
+    PolygonShapeConf& Scale(const Vec2& value);
 
     /// @brief Rotates all the vertices by the given amount.
-    PolygonShapeConf& Rotate(const UnitVec& value) noexcept;
+    PolygonShapeConf& Rotate(const UnitVec& value);
 
     /// @brief Equality operator.
     friend bool operator==(const PolygonShapeConf& lhs, const PolygonShapeConf& rhs) noexcept
@@ -264,7 +270,7 @@ inline void SetVertexRadius(PolygonShapeConf& arg, ChildCounter, NonNegative<Len
 
 /// @brief Gets the mass data for the given shape configuration.
 /// @relatedalso PolygonShapeConf
-inline MassData GetMassData(const PolygonShapeConf& arg) noexcept
+inline MassData GetMassData(const PolygonShapeConf& arg)
 {
     return playrho::d2::GetMassData(arg.vertexRadius, arg.density, arg.GetVertices());
 }
@@ -279,25 +285,25 @@ Length2 GetEdge(const PolygonShapeConf& shape, VertexCounter index);
 ///   transformation matrix.
 /// @see https://en.wikipedia.org/wiki/Transformation_matrix
 /// @relatedalso PolygonShapeConf
-inline void Transform(PolygonShapeConf& arg, const Mat22& m) noexcept
+inline void Transform(PolygonShapeConf& arg, const Mat22& m)
 {
     arg.Transform(m);
 }
 
 /// @brief Translates the given shape configuration's vertices by the given amount.
-inline void Translate(PolygonShapeConf& arg, const Length2& value) noexcept
+inline void Translate(PolygonShapeConf& arg, const Length2& value)
 {
     arg.Translate(value);
 }
 
 /// @brief Scales the given shape configuration's vertices by the given amount.
-inline void Scale(PolygonShapeConf& arg, const Vec2& value) noexcept
+inline void Scale(PolygonShapeConf& arg, const Vec2& value)
 {
     arg.Scale(value);
 }
 
 /// @brief Rotates the given shape configuration's vertices by the given amount.
-inline void Rotate(PolygonShapeConf& arg, const UnitVec& value) noexcept
+inline void Rotate(PolygonShapeConf& arg, const UnitVec& value)
 {
     arg.Rotate(value);
 }

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -259,7 +259,7 @@ DistanceProxy GetChild(const Shape& shape, ChildCounter index);
 
 /// @brief Gets the mass properties of this shape using its dimensions and density.
 /// @return Mass data for this shape.
-MassData GetMassData(const Shape& shape) noexcept;
+MassData GetMassData(const Shape& shape);
 
 /// @brief Gets the coefficient of friction.
 /// @return Value of 0 or higher.
@@ -400,6 +400,9 @@ bool operator!=(const Shape& lhs, const Shape& rhs) noexcept;
 class Shape
 {
 public:
+    /// @brief Default density of a default-constructed, or otherwise value-less, shape.
+    static constexpr auto DefaultDensity = NonNegative<AreaDensity>{0_kgpm2};
+
     /// @brief Default constructor.
     /// @post <code>has_value()</code> returns false.
     Shape() noexcept = default;
@@ -496,7 +499,7 @@ public:
         return shape.m_self->GetChild_(index);
     }
 
-    friend MassData GetMassData(const Shape& shape) noexcept
+    friend MassData GetMassData(const Shape& shape)
     {
         return shape.m_self ? shape.m_self->GetMassData_() : MassData{};
     }
@@ -548,7 +551,7 @@ public:
 
     friend NonNegative<AreaDensity> GetDensity(const Shape& shape) noexcept
     {
-        return shape.m_self ? shape.m_self->GetDensity_() : NonNegative<AreaDensity>{0_kgpm2};
+        return shape.m_self ? shape.m_self->GetDensity_() : DefaultDensity;
     }
 
     friend void SetDensity(Shape& shape, NonNegative<AreaDensity> value)
@@ -658,7 +661,7 @@ private:
         virtual DistanceProxy GetChild_(ChildCounter index) const = 0;
 
         /// @brief Gets the mass data.
-        virtual MassData GetMassData_() const noexcept = 0;
+        virtual MassData GetMassData_() const = 0;
 
         /// @brief Gets the vertex radius.
         /// @param idx Child index to get vertex radius for.
@@ -765,7 +768,7 @@ private:
             return GetChild(data, index);
         }
 
-        MassData GetMassData_() const noexcept override
+        MassData GetMassData_() const override
         {
             return GetMassData(data);
         }

--- a/PlayRho/Collision/Shapes/ShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ShapeConf.hpp
@@ -24,6 +24,7 @@
 
 #include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/Finite.hpp>
+#include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Settings.hpp>
 #include <PlayRho/Dynamics/Filter.hpp>
 
@@ -33,6 +34,22 @@ namespace d2 {
 /// @brief Base configuration for initializing shapes.
 /// @note This is a nested base value class for initializing shapes.
 struct BaseShapeConf {
+
+    /// @brief Default friction value.
+    static constexpr auto DefaultFriction = NonNegative<Real>{Real{2} / Real{10}};
+
+    /// @brief Default restitution value.
+    static inline const auto DefaultRestitution = Finite<Real>{0};
+
+    /// @brief Default density value.
+    static constexpr auto DefaultDensity = NonNegative<AreaDensity>{0_kgpm2};
+
+    /// @brief Default filter value.
+    static constexpr auto DefaultFilter = Filter{};
+
+    /// @brief Default is-sensor value.
+    static constexpr auto DefaultIsSensor = false;
+
     /// @brief Friction coefficient.
     ///
     /// @note This must be a value between 0 and +infinity. It is safer however to
@@ -41,27 +58,27 @@ struct BaseShapeConf {
     /// @note The square-root of the product of this value multiplied by a touching
     ///   fixture's friction becomes the friction coefficient for the contact.
     ///
-    NonNegative<Real> friction = NonNegative<Real>{Real{2} / Real{10}};
+    NonNegative<Real> friction = DefaultFriction;
 
     /// @brief Restitution (elasticity) of the associated shape.
     ///
     /// @note This should be a valid finite value.
     /// @note This is usually in the range [0,1].
     ///
-    Finite<Real> restitution = Finite<Real>{0};
+    Finite<Real> restitution = DefaultRestitution;
 
     /// @brief Area density of the associated shape.
     ///
     /// @note This must be a non-negative value.
     /// @note Use 0 to indicate that the shape's associated mass should be 0.
     ///
-    NonNegative<AreaDensity> density = NonNegative<AreaDensity>{0_kgpm2};
+    NonNegative<AreaDensity> density = DefaultDensity;
 
     /// Filtering data for contacts.
-    Filter filter;
+    Filter filter = DefaultFilter;
 
     /// A sensor shape collects contact information but never generates a collision response.
-    bool isSensor = false;
+    bool isSensor = DefaultIsSensor;
 };
 
 /// @brief Builder configuration structure.
@@ -74,15 +91,6 @@ struct BaseShapeConf {
 template <typename ConcreteConf>
 struct ShapeBuilder : BaseShapeConf {
     // Note: don't use 'using ShapeConf::ShapeConf' here as it doesn't work in this context!
-
-    /// @brief Default constructor.
-    constexpr ShapeBuilder() = default;
-
-    /// @brief Initializing constructor.
-    constexpr explicit ShapeBuilder(const BaseShapeConf& value) noexcept : BaseShapeConf{value}
-    {
-        // Intentionally empty.
-    }
 
     /// @brief Uses the given friction.
     constexpr ConcreteConf& UseFriction(NonNegative<Real> value) noexcept;

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -57,12 +57,9 @@ public:
     /// @brief Constant pointer type.
     using const_pointer = const value_type*;
 
-    constexpr ArrayList() noexcept
-    {
-        // Intentionally empty.
-        // Note that defaulting this method instead of writing it out here,
-        // causes issues with gcc.
-    }
+    /// @brief Default constructor.
+    /// @note Some older versions of gcc have issues with this being defaulted.
+    constexpr ArrayList() noexcept = default;
 
     template <std::size_t COPY_MAXSIZE, typename COPY_SIZE_TYPE,
               typename = std::enable_if_t<COPY_MAXSIZE <= MAXSIZE>>

--- a/PlayRho/Common/Finite.hpp
+++ b/PlayRho/Common/Finite.hpp
@@ -22,12 +22,9 @@
 #define PLAYRHO_COMMON_FINITE_HPP
 
 #include <PlayRho/Common/CheckedValue.hpp>
-
-#include <cmath>
+#include <PlayRho/Common/Math.hpp> // for playrho::isfinite
 
 namespace playrho {
-
-using std::isfinite;
 
 /// @brief Finite constrained value checker.
 template <typename T>
@@ -44,7 +41,7 @@ struct FiniteChecker {
 
     /// @brief Value checking functor.
     /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(isfinite(v), T{v})
+    auto operator()(const T& v) -> decltype(isfinite(v), T{v})
     {
         if (!isfinite(v)) {
             throw exception_type("value not finite");

--- a/PlayRho/Common/Fixed.hpp
+++ b/PlayRho/Common/Fixed.hpp
@@ -116,10 +116,13 @@ public:
     {
         static_assert(std::is_floating_point<T>::value, "floating point value required");
         // Note: std::isnan(val) *NOT* constant expression, so can't use here!
-        return !(val <= 0 || val >= 0)? GetNaN().m_value:
-            (val > static_cast<long double>(GetMax()))? GetInfinity().m_value:
-            (val < static_cast<long double>(GetLowest()))? GetNegativeInfinity().m_value:
-            static_cast<value_type>(val * ScaleFactor);
+        return !(val <= 0 || val >= 0) // NOLINT(misc-redundant-expression)
+            ? GetNaN().m_value // force line-break
+            : (val > static_cast<long double>(GetMax())) // force line-break
+                ? GetInfinity().m_value // force line-break
+                : (val < static_cast<long double>(GetLowest())) // force line-break
+                    ? GetNegativeInfinity().m_value // force line-break
+                    : static_cast<value_type>(val * ScaleFactor);
     }
 
     /// @brief Gets the value from a signed integral value.

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -318,7 +318,8 @@ constexpr auto GetMagnitudeSquared(const T& value) noexcept
 /// @brief Gets the magnitude of the given value.
 /// @note Works for any type for which <code>GetMagnitudeSquared</code> also works.
 template <typename T>
-inline auto GetMagnitude(const T& value) -> decltype(sqrt(GetMagnitudeSquared(value)))
+inline auto GetMagnitude(const T& value) noexcept(noexcept(sqrt(GetMagnitudeSquared(value))))
+    -> decltype(sqrt(GetMagnitudeSquared(value)))
 {
     return sqrt(GetMagnitudeSquared(value));
 }

--- a/PlayRho/Common/Settings.hpp
+++ b/PlayRho/Common/Settings.hpp
@@ -36,6 +36,7 @@
 
 #include <PlayRho/Common/Templates.hpp>
 #include <PlayRho/Common/RealConstants.hpp>
+#include <PlayRho/Common/Positive.hpp>
 #include <PlayRho/Common/Units.hpp>
 #include <PlayRho/Common/Wider.hpp>
 
@@ -134,10 +135,10 @@ constexpr auto InvalidVertex = static_cast<VertexCounter>(-1);
 constexpr auto DefaultLinearSlop = detail::Defaults<Real>::GetLinearSlop();
 
 /// @brief Default minimum vertex radius.
-constexpr auto DefaultMinVertexRadius = DefaultLinearSlop * Real{2};
+constexpr auto DefaultMinVertexRadius = Positive<Length>{DefaultLinearSlop * Real{2}};
 
 /// @brief Default maximum vertex radius.
-constexpr auto DefaultMaxVertexRadius = detail::Defaults<Real>::GetMaxVertexRadius();
+constexpr auto DefaultMaxVertexRadius = Positive<Length>{detail::Defaults<Real>::GetMaxVertexRadius()};
 
 /// @brief Default AABB extension amount.
 constexpr auto DefaultAabbExtension = DefaultLinearSlop * Real{20};

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -136,7 +136,7 @@ constexpr bool IsValid(const T& value) noexcept
     // So for all T, for which isnan() is implemented, this should work
     // correctly and quite usefully!
     //
-    return value == value;
+    return value == value; // NOLINT(misc-redundant-expression)
 }
 
 // GetInvalid template specializations.

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -86,7 +86,7 @@ Body::FlagsType Body::GetFlags(const BodyConf& bd) noexcept
     return flags;
 }
 
-Body::Body(const BodyConf& bd) noexcept
+Body::Body(const BodyConf& bd)
     : m_xf{::playrho::d2::GetTransformation(bd)},
       m_sweep{Position{bd.location, bd.angle}},
       m_flags{GetFlags(bd)},

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -100,6 +100,12 @@ public:
         e_massDataDirtyFlag = FlagsType(0x0200u),
     };
 
+    /// @brief Default linear damping.
+    static constexpr auto DefaultLinearDamping = NonNegative<Frequency>{};
+
+    /// @brief Default angular damping.
+    static constexpr auto DefaultAngularDamping = NonNegative<Frequency>{};
+
     /// @brief Gets the flags for the given value.
     static FlagsType GetFlags(BodyType type) noexcept;
 
@@ -130,7 +136,7 @@ public:
     /// @see GetLinearDamping, GetAngularDamping, GetInvMass, GetTransformation, GetVelocity,
     ///   GetAcceleration.
     /// @see World::CreateBody.
-    explicit Body(const BodyConf& bd = GetDefaultBodyConf()) noexcept;
+    explicit Body(const BodyConf& bd = GetDefaultBodyConf());
 
     /// @brief Gets the body transform for the body's origin.
     /// @details This gets the translation/location and rotation/direction of the body relative to
@@ -207,7 +213,7 @@ public:
 
     /// @brief Gets the linear damping of the body.
     /// @see SetLinearDamping.
-    Frequency GetLinearDamping() const noexcept;
+    NonNegative<Frequency> GetLinearDamping() const noexcept;
 
     /// @brief Sets the linear damping of the body.
     /// @see GetLinearDamping.
@@ -215,7 +221,7 @@ public:
 
     /// @brief Gets the angular damping of the body.
     /// @see SetAngularDamping.
-    Frequency GetAngularDamping() const noexcept;
+    NonNegative<Frequency> GetAngularDamping() const noexcept;
 
     /// @brief Sets the angular damping of the body.
     /// @see GetAngularDamping.
@@ -382,7 +388,7 @@ public:
 
     /// @brief Gets the identifiers of the shapes attached to this body.
     /// @see SetShapes, Attach, Detach.
-    std::vector<ShapeID> GetShapes() const noexcept;
+    const std::vector<ShapeID>& GetShapes() const noexcept;
 
     /// @brief Sets the identifiers of the shapes attached to this body.
     /// @note This also sets the mass-data-dirty flag.
@@ -400,6 +406,7 @@ public:
     bool Detach(ShapeID shapeId);
 
 private:
+
     //
     // Member variables. Try to keep total size small.
     //
@@ -444,8 +451,8 @@ private:
     /// @note 4-bytes.
     InvRotInertia m_invRotI = 0;
 
-    NonNegative<Frequency> m_linearDamping{}; ///< Linear damping. 4-bytes.
-    NonNegative<Frequency> m_angularDamping{}; ///< Angular damping. 4-bytes.
+    NonNegative<Frequency> m_linearDamping{DefaultLinearDamping}; ///< Linear damping. 4-bytes.
+    NonNegative<Frequency> m_angularDamping{DefaultAngularDamping}; ///< Angular damping. 4-bytes.
 
     /// Under-active time.
     /// @details A body under-active for enough time should have their awake flag unset.
@@ -490,7 +497,7 @@ inline void Body::SetInvMassData(NonNegative<InvMass> invMass,
     UnsetMassDataDirty();
 }
 
-inline Frequency Body::GetLinearDamping() const noexcept
+inline NonNegative<Frequency> Body::GetLinearDamping() const noexcept
 {
     return m_linearDamping;
 }
@@ -500,7 +507,7 @@ inline void Body::SetLinearDamping(NonNegative<Frequency> linearDamping) noexcep
     m_linearDamping = linearDamping;
 }
 
-inline Frequency Body::GetAngularDamping() const noexcept
+inline NonNegative<Frequency> Body::GetAngularDamping() const noexcept
 {
     return m_angularDamping;
 }
@@ -655,7 +662,7 @@ inline void Body::Advance0(Real value) noexcept
     assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
 }
 
-inline std::vector<ShapeID> Body::GetShapes() const noexcept
+inline const std::vector<ShapeID>& Body::GetShapes() const noexcept
 {
     return m_shapes;
 }
@@ -1030,7 +1037,7 @@ inline InvRotInertia GetInvRotInertia(const Body& body) noexcept
 /// @brief Gets the linear damping of the body.
 /// @see SetLinearDamping(Body& body, NonNegative<Frequency> value).
 /// @relatedalso Body
-inline Frequency GetLinearDamping(const Body& body) noexcept
+inline NonNegative<Frequency> GetLinearDamping(const Body& body) noexcept
 {
     return body.GetLinearDamping();
 }
@@ -1046,7 +1053,7 @@ inline void SetLinearDamping(Body& body, NonNegative<Frequency> value) noexcept
 /// @brief Gets the angular damping of the body.
 /// @see SetAngularDamping(Body& body, NonNegative<Frequency> value).
 /// @relatedalso Body
-inline Frequency GetAngularDamping(const Body& body) noexcept
+inline NonNegative<Frequency> GetAngularDamping(const Body& body) noexcept
 {
     return body.GetAngularDamping();
 }
@@ -1369,7 +1376,7 @@ void ApplyAngularImpulse(Body& body, AngularMomentum impulse) noexcept;
 
 /// @brief Gets the identifiers of the shapes attached to the body.
 /// @relatedalso Body
-inline std::vector<ShapeID> GetShapes(const Body& body) noexcept
+inline const std::vector<ShapeID>& GetShapes(const Body& body) noexcept
 {
     return body.GetShapes();
 }

--- a/PlayRho/Dynamics/BodyConf.hpp
+++ b/PlayRho/Dynamics/BodyConf.hpp
@@ -50,6 +50,51 @@ class Body;
 /// @see World, Body.
 ///
 struct BodyConf {
+    /// @brief Default body type.
+    static constexpr auto DefaultBodyType = BodyType::Static;
+
+    /// @brief Default location.
+    static constexpr auto DefaultLocation = Length2{};
+
+    /// @brief Default angle.
+    static constexpr auto DefaultAngle = 0_deg;
+
+    /// @brief Default linear velocity.
+    static constexpr auto DefaultLinearVelocity = LinearVelocity2{};
+
+    /// @brief Default angular velocity.
+    static constexpr auto DefaultAngularVelocity = 0_rpm;
+
+    /// @brief Default linear acceleration.
+    static constexpr auto DefaultLinearAcceleration = LinearAcceleration2{};
+
+    /// @brief Default angular acceleration.
+    static constexpr auto DefaultAngularAcceleration = AngularAcceleration{0 * RadianPerSquareSecond};
+
+    /// @brief Default linear damping.
+    static constexpr auto DefaultLinearDamping = NonNegative<Frequency>{0_Hz};
+
+    /// @brief Default angular damping.
+    static constexpr auto DefaultAngularDamping = NonNegative<Frequency>{0_Hz};
+
+    /// @brief Default under active time.
+    static constexpr auto DefaultUnderActiveTime = 0_s;
+
+    /// @brief Default allow sleep.
+    static constexpr auto DefaultAllowSleep = true;
+
+    /// @brief Default awake value.
+    static constexpr auto DefaultAwake = true;
+
+    /// @brief Default fixed rotation value.
+    static constexpr auto DefaultFixedRotation = false;
+
+    /// @brief Default bullet value.
+    static constexpr auto DefaultBullet = false;
+
+    /// @brief Default enabled value.
+    static constexpr auto DefaultEnabled = true;
+
     // Builder-styled methods...
 
     /// @brief Use the given type.
@@ -113,43 +158,43 @@ struct BodyConf {
 
     /// @brief Type of the body: static, kinematic, or dynamic.
     /// @note If a dynamic body would have zero mass, the mass is set to one.
-    BodyType type = BodyType::Static;
+    BodyType type = DefaultBodyType;
 
     /// The world location of the body. Avoid creating bodies at the origin
     /// since this can lead to many overlapping shapes.
-    Length2 location = Length2{};
+    Length2 location = DefaultLocation;
 
     /// The world angle of the body.
-    Angle angle = 0_deg;
+    Angle angle = DefaultAngle;
 
     /// The linear velocity of the body's origin in world co-ordinates (in m/s).
-    LinearVelocity2 linearVelocity = LinearVelocity2{};
+    LinearVelocity2 linearVelocity = DefaultLinearVelocity;
 
     /// The angular velocity of the body.
-    AngularVelocity angularVelocity = 0_rpm;
+    AngularVelocity angularVelocity = DefaultAngularVelocity;
 
     /// Initial linear acceleration of the body.
     /// @note Usually this should be 0.
-    LinearAcceleration2 linearAcceleration = LinearAcceleration2{};
+    LinearAcceleration2 linearAcceleration = DefaultLinearAcceleration;
 
     /// Initial angular acceleration of the body.
     /// @note Usually this should be 0.
-    AngularAcceleration angularAcceleration = AngularAcceleration{0 * RadianPerSquareSecond};
+    AngularAcceleration angularAcceleration = DefaultAngularAcceleration;
 
     /// Linear damping is use to reduce the linear velocity. The damping parameter
     /// can be larger than 1 but the damping effect becomes sensitive to the
     /// time step when the damping parameter is large.
-    NonNegative<Frequency> linearDamping = NonNegative<Frequency>{0_Hz};
+    NonNegative<Frequency> linearDamping = DefaultLinearDamping;
 
     /// Angular damping is use to reduce the angular velocity. The damping parameter
     /// can be larger than 1 but the damping effect becomes sensitive to the
     /// time step when the damping parameter is large.
-    NonNegative<Frequency> angularDamping = NonNegative<Frequency>{0_Hz};
+    NonNegative<Frequency> angularDamping = DefaultAngularDamping;
 
     /// Under-active time.
     /// @details Set this to the value retrieved from <code>Body::GetUnderActiveTime</code>
     ///   or leave it as 0.
-    Time underActiveTime = 0_s;
+    Time underActiveTime = DefaultUnderActiveTime;
 
     /// Identifier of shape that will be associated with the body on its creation.
     /// @note This can often be faster than later using an <code>Attach</code> function.
@@ -157,22 +202,22 @@ struct BodyConf {
 
     /// Set this flag to false if this body should never fall asleep. Note that
     /// this increases CPU usage.
-    bool allowSleep = true;
+    bool allowSleep = DefaultAllowSleep;
 
     /// Is the body awake or sleeping?
-    bool awake = true;
+    bool awake = DefaultAwake;
 
     /// Should this body be prevented from rotating? Useful for characters.
-    bool fixedRotation = false;
+    bool fixedRotation = DefaultFixedRotation;
 
     /// Is this a fast moving body that should be prevented from tunneling through
     /// other moving bodies? Note that all bodies are prevented from tunneling through
     /// kinematic and static bodies. This setting is only considered on dynamic bodies.
     /// @note Use this flag sparingly since it increases processing time.
-    bool bullet = false;
+    bool bullet = DefaultBullet;
 
     /// Whether or not the body is enabled.
-    bool enabled = true;
+    bool enabled = DefaultEnabled;
 };
 
 constexpr BodyConf& BodyConf::UseType(BodyType t) noexcept

--- a/PlayRho/Dynamics/Contacts/ContactKey.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactKey.hpp
@@ -36,10 +36,8 @@ namespace playrho {
 class ContactKey
 {
 public:
-    constexpr ContactKey() noexcept
-    {
-        // Intentionally empty
-    }
+    /// @brief Default constructor.
+    constexpr ContactKey() noexcept = default;
 
     /// @brief Initializing constructor.
     constexpr ContactKey(ContactCounter fp1, ContactCounter fp2) noexcept

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
@@ -54,10 +54,7 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf> {
     using super = JointBuilder<DistanceJointConf>;
 
     /// @brief Default constructor.
-    constexpr DistanceJointConf() = default;
-
-    /// @brief Copy constructor.
-    DistanceJointConf(const DistanceJointConf& copy) = default;
+    constexpr DistanceJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, and length using the world anchors.

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
@@ -51,7 +51,7 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf> {
     using super = JointBuilder<FrictionJointConf>;
 
     /// @brief Default constructor.
-    constexpr FrictionJointConf() = default;
+    constexpr FrictionJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, axis, and reference angle using the world

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
@@ -54,9 +54,13 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf> {
     constexpr FrictionJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
-    /// @details Initialize the bodies, anchors, axis, and reference angle using the world
-    ///   anchor and world axis.
-    FrictionJointConf(BodyID bodyA, BodyID bodyB, Length2 laA = Length2{},
+    /// @details Initialize the bodies and local anchors.
+    /// @post <code>bodyA</code> will hold the value of <code>bA</code>.
+    /// @post <code>bodyB</code> will hold the value of <code>bB</code>.
+    /// @post <code>localAnchorA</code> will hold the value of <code>laA</code>.
+    /// @post <code>localAnchorB</code> will hold the value of <code>laB</code>.
+    /// @post All other member variables will be zero initialized.
+    FrictionJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{},
                       Length2 laB = Length2{}) noexcept;
 
     /// @brief Uses the given maximum force value.

--- a/PlayRho/Dynamics/Joints/GearJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/GearJointConf.hpp
@@ -74,7 +74,7 @@ struct GearJointConf : public JointBuilder<GearJointConf> {
     using TypeData = std::variant<std::monostate, PrismaticData, RevoluteData>;
 
     /// @brief Default constructor.
-    constexpr GearJointConf() = default;
+    constexpr GearJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
     GearJointConf(BodyID bA, BodyID bB, BodyID bC, BodyID bD) noexcept;

--- a/PlayRho/Dynamics/Joints/MotorJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.hpp
@@ -50,8 +50,14 @@ struct MotorJointConf : public JointBuilder<MotorJointConf> {
     /// @brief Super type.
     using super = JointBuilder<MotorJointConf>;
 
+    /// @brief Default max force.
+    static constexpr auto DefaultMaxForce = NonNegative<Force>(1_N);
+
+    /// @brief Default max torque.
+    static constexpr auto DefaultMaxTorque = NonNegative<Torque>(1_Nm);
+
     /// @brief Default constructor.
-    constexpr MotorJointConf() = default;
+    constexpr MotorJointConf() noexcept = default;
 
     /// @brief Initialize the bodies and offsets using the current transforms.
     MotorJointConf(BodyID bA, BodyID bB, Length2 lo = Length2{}, Angle ao = 0_deg) noexcept;
@@ -101,10 +107,10 @@ struct MotorJointConf : public JointBuilder<MotorJointConf> {
     AngularMomentum angularImpulse{}; ///< Angular impulse.
 
     /// @brief Maximum motor force.
-    NonNegative<Force> maxForce = NonNegative<Force>(1_N);
+    NonNegative<Force> maxForce = DefaultMaxForce;
 
     /// @brief Maximum motor torque.
-    NonNegative<Torque> maxTorque = NonNegative<Torque>(1_Nm);
+    NonNegative<Torque> maxTorque = DefaultMaxTorque;
 
     /// @brief Position correction factor in the range [0,1].
     Real correctionFactor = Real(0.3);

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
@@ -59,10 +59,7 @@ struct PrismaticJointConf : public JointBuilder<PrismaticJointConf> {
     using super = JointBuilder<PrismaticJointConf>;
 
     /// @brief Default constructor.
-    constexpr PrismaticJointConf() = default;
-
-    /// @brief Copy constructor.
-    PrismaticJointConf(const PrismaticJointConf& copy) = default;
+    constexpr PrismaticJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, axis, and reference angle using the world

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
@@ -55,13 +55,13 @@ static_assert(std::is_nothrow_destructible<PulleyJointConf>::value,
 // K = J * invM * JT
 //   = invMass1 + invI1 * cross(r1, u1)^2 + ratio^2 * (invMass2 + invI2 * cross(r2, u2)^2)
 
-PulleyJointConf::PulleyJointConf(BodyID bA, BodyID bB, Length2 groundA, Length2 groundB,
-                                 Length2 anchorA, Length2 anchorB, Length lA, Length lB)
+PulleyJointConf::PulleyJointConf(BodyID bA, BodyID bB, Length2 gaA, Length2 gaB,
+                                 Length2 laA, Length2 laB, Length lA, Length lB)
     : super{super{}.UseBodyA(bA).UseBodyB(bB).UseCollideConnected(true)},
-      groundAnchorA{groundA},
-      groundAnchorB{groundB},
-      localAnchorA{anchorA},
-      localAnchorB{anchorB},
+      groundAnchorA{gaA},
+      groundAnchorB{gaB},
+      localAnchorA{laA},
+      localAnchorB{laB},
       lengthA{lA},
       lengthB{lB}
 {

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
@@ -72,9 +72,17 @@ struct PulleyJointConf : public JointBuilder<PulleyJointConf> {
     PulleyJointConf() noexcept : super{super{}.UseCollideConnected(true)} {}
 
     /// Initialize the bodies, anchors, lengths, max lengths, and ratio using the world anchors.
-    PulleyJointConf(BodyID bodyA, BodyID bodyB, Length2 groundAnchorA = DefaultGroundAnchorA,
-                    Length2 groundAnchorB = DefaultGroundAnchorB,
-                    Length2 anchorA = DefaultLocalAnchorA, Length2 anchorB = DefaultLocalAnchorB,
+    /// @post <code>bodyA</code> will have the value of <code>bA</code>.
+    /// @post <code>bodyB</code> will have the value of <code>bB</code>.
+    /// @post <code>groundAnchorA</code> will have the value of <code>gaA</code>.
+    /// @post <code>groundAnchorB</code> will have the value of <code>gaB</code>.
+    /// @post <code>localAnchorA</code> will have the value of <code>laA</code>.
+    /// @post <code>localAnchorB</code> will have the value of <code>laB</code>.
+    /// @post <code>lengthA</code> will have the value of <code>lA</code>.
+    /// @post <code>lengthB</code> will have the value of <code>lB</code>.
+    PulleyJointConf(BodyID bA, BodyID bB, Length2 gaA = DefaultGroundAnchorA,
+                    Length2 gaB = DefaultGroundAnchorB,
+                    Length2 laA = DefaultLocalAnchorA, Length2 laB = DefaultLocalAnchorB,
                     Length lA = 0_m, Length lB = 0_m);
 
     /// @brief Uses the given ratio value.

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
@@ -66,7 +66,7 @@ struct RevoluteJointConf : public JointBuilder<RevoluteJointConf> {
     using super = JointBuilder<RevoluteJointConf>;
 
     /// @brief Default constructor.
-    constexpr RevoluteJointConf() = default;
+    constexpr RevoluteJointConf() noexcept = default;
 
     /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
     RevoluteJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{}, Length2 laB = Length2{},

--- a/PlayRho/Dynamics/Joints/RopeJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.hpp
@@ -59,7 +59,7 @@ struct RopeJointConf : public JointBuilder<RopeJointConf> {
     using super = JointBuilder<RopeJointConf>;
 
     /// @brief Default constructor.
-    constexpr RopeJointConf() = default;
+    constexpr RopeJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
     constexpr RopeJointConf(BodyID bodyA, BodyID bodyB) noexcept

--- a/PlayRho/Dynamics/Joints/TargetJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.hpp
@@ -49,11 +49,17 @@ struct TargetJointConf : public JointBuilder<TargetJointConf> {
     /// @brief Super type.
     using super = JointBuilder<TargetJointConf>;
 
+    /// @brief Default frequency.
+    static constexpr auto DefaultFrequency = NonNegative<Frequency>(5_Hz);
+
+    /// @brief Default damping ratio.
+    static constexpr auto DefaultDampingRatio = NonNegative<Real>(0.7f);
+
     /// @brief Default constructor.
-    constexpr TargetJointConf() = default;
+    constexpr TargetJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
-    constexpr TargetJointConf(BodyID b) noexcept : super{super{}.UseBodyB(b)}
+    constexpr TargetJointConf(BodyID b) noexcept: super{super{}.UseBodyB(b)}
     {
         // Intentionally empty.
     }
@@ -115,10 +121,10 @@ struct TargetJointConf : public JointBuilder<TargetJointConf> {
     /// Frequency.
     /// @details The has to do with the response speed.
     /// @note This value may not be negative.
-    NonNegative<Frequency> frequency = NonNegative<Frequency>(5_Hz);
+    NonNegative<Frequency> frequency = DefaultFrequency;
 
     /// The damping ratio. 0 = no damping, 1 = critical damping.
-    NonNegative<Real> dampingRatio = NonNegative<Real>(0.7f);
+    NonNegative<Real> dampingRatio = DefaultDampingRatio;
 
     InvMass gamma = InvMass{0}; ///< Gamma.
 

--- a/PlayRho/Dynamics/Joints/WeldJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.hpp
@@ -53,7 +53,7 @@ struct WeldJointConf : public JointBuilder<WeldJointConf> {
     using super = JointBuilder<WeldJointConf>;
 
     /// @brief Default constructor.
-    constexpr WeldJointConf() = default;
+    constexpr WeldJointConf() noexcept = default;
 
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, and reference angle using a world

--- a/PlayRho/Dynamics/Joints/WeldJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.hpp
@@ -58,12 +58,17 @@ struct WeldJointConf : public JointBuilder<WeldJointConf> {
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, and reference angle using a world
     ///   anchor point.
-    /// @param bodyA Identifier of body A.
+    /// @param bA Identifier of body A.
+    /// @param bB Identifier of body B.
     /// @param laA Local anchor A location in world coordinates.
-    /// @param bodyB Identifier of body B.
     /// @param laB Local anchor B location in world coordinates.
     /// @param ra Reference angle.
-    WeldJointConf(BodyID bodyA, BodyID bodyB, Length2 laA = Length2{}, Length2 laB = Length2{},
+    /// @post <code>bodyA</code> will have the value of <code>bA</code>.
+    /// @post <code>bodyB</code> will have the value of <code>bB</code>.
+    /// @post <code>localAnchorA</code> will have the value of <code>laA</code>.
+    /// @post <code>localAnchorB</code> will have the value of <code>laB</code>.
+    /// @post <code>referenceAngle</code> will have the value of <code>ra</code>.
+    WeldJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{}, Length2 laB = Length2{},
                   Angle ra = 0_deg) noexcept;
 
     /// @brief Uses the given frequency value.

--- a/PlayRho/Dynamics/Joints/WheelJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.hpp
@@ -56,8 +56,11 @@ struct WheelJointConf : public JointBuilder<WheelJointConf> {
     /// @brief Super type.
     using super = JointBuilder<WheelJointConf>;
 
+    /// @brief Default frequency.
+    static constexpr auto DefaultFrequency = NonNegative<Frequency>{2_Hz};
+
     /// @brief Default constructor.
-    constexpr WheelJointConf() = default;
+    constexpr WheelJointConf() noexcept = default;
 
     /// Initialize the bodies, anchors, axis, and reference angle using the world
     /// anchor and world axis.
@@ -121,7 +124,7 @@ struct WheelJointConf : public JointBuilder<WheelJointConf> {
     AngularVelocity motorSpeed = 0_rpm;
 
     /// Suspension frequency, zero indicates no suspension
-    NonNegative<Frequency> frequency = 2_Hz;
+    NonNegative<Frequency> frequency = DefaultFrequency;
 
     /// Suspension damping ratio, one indicates critical damping
     Real dampingRatio = 0.7f;

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -148,12 +148,12 @@ ContactCounter World::GetContactRange() const noexcept
     return ::playrho::d2::GetContactRange(*m_impl);
 }
 
-World::Bodies World::GetBodies() const noexcept
+const World::Bodies& World::GetBodies() const noexcept
 {
     return ::playrho::d2::GetBodies(*m_impl);
 }
 
-World::Bodies World::GetBodiesForProxies() const noexcept
+const World::Bodies& World::GetBodiesForProxies() const noexcept
 {
     return ::playrho::d2::GetBodiesForProxies(*m_impl);
 }
@@ -178,22 +178,22 @@ void World::Destroy(BodyID id)
     ::playrho::d2::Destroy(*m_impl, id);
 }
 
-World::Shapes World::GetShapes(BodyID id) const
+const World::Shapes& World::GetShapes(BodyID id) const
 {
     return ::playrho::d2::GetShapes(*m_impl, id);
 }
 
-World::BodyJoints World::GetJoints(BodyID id) const
+const World::BodyJoints& World::GetJoints(BodyID id) const
 {
     return ::playrho::d2::GetJoints(*m_impl, id);
 }
 
-World::Contacts World::GetContacts(BodyID id) const
+const World::Contacts& World::GetContacts(BodyID id) const
 {
     return ::playrho::d2::GetContacts(*m_impl, id);
 }
 
-World::Joints World::GetJoints() const noexcept
+const World::Joints& World::GetJoints() const noexcept
 {
     return ::playrho::d2::GetJoints(*m_impl);
 }
@@ -243,7 +243,7 @@ void World::Destroy(ShapeID id)
     ::playrho::d2::Destroy(*m_impl, id);
 }
 
-World::Contacts World::GetContacts() const noexcept
+const World::Contacts& World::GetContacts() const noexcept
 {
     return ::playrho::d2::GetContacts(*m_impl);
 }

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -325,14 +325,14 @@ public:
     ///   <code>CreateBody(const BodyConf&)</code> method that haven't yet been destroyed.
     /// @return An iterable of body identifiers.
     /// @see CreateBody(const BodyConf&).
-    Bodies GetBodies() const noexcept;
+    const Bodies& GetBodies() const noexcept;
 
     /// @brief Gets the bodies-for-proxies range for this world.
     /// @details Provides insight on what bodies have been queued for proxy processing
     ///   during the next call to the world step method.
     /// @see Step.
     /// @todo Remove this function from this class - access from implementation instead.
-    Bodies GetBodiesForProxies() const noexcept;
+    const Bodies& GetBodiesForProxies() const noexcept;
 
     /// @brief Creates a rigid body that's a copy of the given one.
     /// @warning This function should not be used while the world is locked &mdash; as it is
@@ -381,19 +381,19 @@ public:
     /// @brief Gets the range of joints attached to the identified body.
     /// @throws std::out_of_range If given an invalid body identifier.
     /// @see CreateJoint, GetBodyRange.
-    BodyJoints GetJoints(BodyID id) const;
+    const BodyJoints& GetJoints(BodyID id) const;
 
     /// @brief Gets the container of contacts attached to the identified body.
     /// @warning This collection changes during the time step and you may
     ///   miss some collisions if you don't use <code>ContactListener</code>.
     /// @throws std::out_of_range If given an invalid body identifier.
     /// @see GetBodyRange.
-    Contacts GetContacts(BodyID id) const;
+    const Contacts& GetContacts(BodyID id) const;
 
     /// @brief Gets the identities of the shapes associated with the identified body.
     /// @throws std::out_of_range If given an invalid body identifier.
     /// @see GetBodyRange, CreateBody, SetBody.
-    Shapes GetShapes(BodyID id) const;
+    const Shapes& GetShapes(BodyID id) const;
 
     /// @}
 
@@ -412,7 +412,7 @@ public:
     ///   <code>CreateJoint</code> method that haven't yet been destroyed.
     /// @return World joints sized-range.
     /// @see CreateJoint.
-    Joints GetJoints() const noexcept;
+    const Joints& GetJoints() const noexcept;
 
     /// @brief Creates a joint to constrain one or more bodies.
     /// @warning This function is locked during callbacks.
@@ -501,7 +501,7 @@ public:
     /// @warning contacts are created and destroyed in the middle of a time step.
     /// Use <code>ContactListener</code> to avoid missing contacts.
     /// @return World contacts sized-range.
-    Contacts GetContacts() const noexcept;
+    const Contacts& GetContacts() const noexcept;
 
     /// @brief Gets the identified contact.
     /// @throws std::out_of_range If given an invalid contact identifier.

--- a/PlayRho/Dynamics/WorldBody.cpp
+++ b/PlayRho/Dynamics/WorldBody.cpp
@@ -45,12 +45,12 @@ BodyCounter GetBodyRange(const World& world) noexcept
     return world.GetBodyRange();
 }
 
-std::vector<BodyID> GetBodies(const World& world) noexcept
+const std::vector<BodyID>& GetBodies(const World& world) noexcept
 {
     return world.GetBodies();
 }
 
-std::vector<BodyID> GetBodiesForProxies(const World& world) noexcept
+const std::vector<BodyID>& GetBodiesForProxies(const World& world) noexcept
 {
     return world.GetBodiesForProxies();
 }
@@ -119,7 +119,7 @@ bool Detach(World& world, BodyID id, bool resetMassData)
     return anyDetached;
 }
 
-std::vector<ShapeID> GetShapes(const World& world, BodyID id)
+const std::vector<ShapeID>& GetShapes(const World& world, BodyID id)
 {
     return world.GetShapes(id);
 }
@@ -412,7 +412,7 @@ void SetMassData(World& world, BodyID id, const MassData& massData)
     world.SetBody(id, body);
 }
 
-std::vector<std::pair<BodyID, JointID>> GetJoints(const World& world, BodyID id)
+const std::vector<std::pair<BodyID, JointID>>& GetJoints(const World& world, BodyID id)
 {
     return world.GetJoints(id);
 }
@@ -482,7 +482,7 @@ void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> value)
     world.SetBody(id, body);
 }
 
-std::vector<KeyedContactPtr> GetContacts(const World& world, BodyID id)
+const std::vector<KeyedContactPtr>& GetContacts(const World& world, BodyID id)
 {
     return world.GetContacts(id);
 }
@@ -558,19 +558,19 @@ void SetTorque(World& world, BodyID id, Torque torque)
     SetAcceleration(world, id, linAccel, angAccel);
 }
 
-BodyCounter GetAwakeCount(const World& world) noexcept
+BodyCounter GetAwakeCount(const World& world)
 {
-    const auto bodies = world.GetBodies();
+    const auto& bodies = world.GetBodies();
     return static_cast<BodyCounter>(count_if(cbegin(bodies), cend(bodies),
                                              [&](const auto &b) {
         return IsAwake(world, b); }));
 }
 
-BodyCounter Awaken(World& world) noexcept
+BodyCounter Awaken(World& world)
 {
     // Can't use count_if since body gets modified.
     auto awoken = BodyCounter{0};
-    const auto bodies = world.GetBodies();
+    const auto& bodies = world.GetBodies();
     for_each(begin(bodies), end(bodies), [&world,&awoken](const auto &b) {
         if (::playrho::d2::Awaken(world, b))
         {
@@ -580,25 +580,25 @@ BodyCounter Awaken(World& world) noexcept
     return awoken;
 }
 
-void SetAccelerations(World& world, Acceleration acceleration) noexcept
+void SetAccelerations(World& world, Acceleration acceleration)
 {
-    const auto bodies = world.GetBodies();
+    const auto& bodies = world.GetBodies();
     for_each(begin(bodies), end(bodies), [&world, acceleration](const auto &b) {
         SetAcceleration(world, b, acceleration);
     });
 }
 
-void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept
+void SetAccelerations(World& world, LinearAcceleration2 acceleration)
 {
-    const auto bodies = world.GetBodies();
+    const auto& bodies = world.GetBodies();
     for_each(begin(bodies), end(bodies), [&world, acceleration](const auto &b) {
         SetAcceleration(world, b, acceleration);
     });
 }
 
-BodyID FindClosestBody(const World& world, Length2 location) noexcept
+BodyID FindClosestBody(const World& world, Length2 location)
 {
-    const auto bodies = world.GetBodies();
+    const auto& bodies = world.GetBodies();
     auto found = InvalidBodyID;
     auto minLengthSquared = std::numeric_limits<Area>::infinity();
     for (const auto& body: bodies)

--- a/PlayRho/Dynamics/WorldBody.cpp
+++ b/PlayRho/Dynamics/WorldBody.cpp
@@ -190,9 +190,9 @@ void SetAngle(World& world, BodyID id, Angle value)
     SetBody(world, id, body);
 }
 
-void RotateAboutWorldPoint(World& world, BodyID body, Angle amount, Length2 worldPoint)
+void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, Length2 worldPoint)
 {
-    const auto xfm = GetTransformation(world, body);
+    const auto xfm = GetTransformation(world, id);
     const auto p = xfm.p - worldPoint;
     const auto c = cos(amount);
     const auto s = sin(amount);
@@ -200,22 +200,22 @@ void RotateAboutWorldPoint(World& world, BodyID body, Angle amount, Length2 worl
     const auto y = GetX(p) * s + GetY(p) * c;
     const auto pos = Length2{x, y} + worldPoint;
     const auto angle = GetAngle(xfm.q) + amount;
-    SetTransform(world, body, pos, angle);
+    SetTransform(world, id, pos, angle);
 }
 
-void RotateAboutLocalPoint(World& world, BodyID body, Angle amount, Length2 localPoint)
+void RotateAboutLocalPoint(World& world, BodyID id, Angle amount, Length2 localPoint)
 {
-    RotateAboutWorldPoint(world, body, amount, GetWorldPoint(world, body, localPoint));
+    RotateAboutWorldPoint(world, id, amount, GetWorldPoint(world, id, localPoint));
 }
 
-Acceleration CalcGravitationalAcceleration(const World& world, BodyID body)
+Acceleration CalcGravitationalAcceleration(const World& world, BodyID id)
 {
-    const auto m1 = GetMass(world, body);
+    const auto m1 = GetMass(world, id);
     if (isnormal(m1)) {
         auto sumForce = Force2{};
-        const auto loc1 = GetLocation(world, body);
+        const auto loc1 = GetLocation(world, id);
         for (const auto& b2: world.GetBodies()) {
-            if (b2 == body) {
+            if (b2 == id) {
                 continue;
             }
             const auto m2 = GetMass(world, b2);
@@ -463,10 +463,10 @@ Frequency GetLinearDamping(const World& world, BodyID id)
     return GetLinearDamping(GetBody(world, id));
 }
 
-void SetLinearDamping(World& world, BodyID id, NonNegative<Frequency> value)
+void SetLinearDamping(World& world, BodyID id, NonNegative<Frequency> linearDamping)
 {
     auto body = GetBody(world, id);
-    SetLinearDamping(body, value);
+    SetLinearDamping(body, linearDamping);
     world.SetBody(id, body);
 }
 
@@ -475,10 +475,10 @@ Frequency GetAngularDamping(const World& world, BodyID id)
     return GetAngularDamping(GetBody(world, id));
 }
 
-void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> value)
+void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> angularDamping)
 {
     auto body = GetBody(world, id);
-    SetAngularDamping(body, value);
+    SetAngularDamping(body, angularDamping);
     world.SetBody(id, body);
 }
 

--- a/PlayRho/Dynamics/WorldBody.hpp
+++ b/PlayRho/Dynamics/WorldBody.hpp
@@ -254,7 +254,7 @@ void SetAcceleration(World& world, BodyID id, Acceleration value);
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @see GetTransformation(const World& world, BodyID id).
 /// @relatedalso World
-void SetTransformation(World& world, BodyID id, Transformation xfm);
+void SetTransformation(World& world, BodyID id, Transformation value);
 
 /// @brief Sets the position of the body's origin and rotation.
 /// @details This instantly adjusts the body to be at the new position and new orientation.
@@ -390,14 +390,14 @@ inline UnitVec GetLocalVector(const World& world, BodyID body, const UnitVec uv)
 
 /// @brief Gets a local point relative to the body's origin given a world point.
 /// @param world The world in which the identified body exists.
-/// @param body Identifier of body that the returned point should be relative to.
+/// @param id Identifier of body that the returned point should be relative to.
 /// @param worldPoint point in world coordinates.
 /// @return the corresponding local point relative to the body's origin.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-inline Length2 GetLocalPoint(const World& world, BodyID body, const Length2 worldPoint)
+inline Length2 GetLocalPoint(const World& world, BodyID id, const Length2 worldPoint)
 {
-    return InverseTransform(worldPoint, GetTransformation(world, body));
+    return InverseTransform(worldPoint, GetTransformation(world, id));
 }
 
 /// @brief Gets the angle of the identified body.
@@ -414,9 +414,9 @@ inline Position GetPosition(const World& world, BodyID id)
 
 /// @brief Convenience function for getting a world vector of the identified body.
 /// @relatedalso World
-inline UnitVec GetWorldVector(const World& world, BodyID body, UnitVec localVector)
+inline UnitVec GetWorldVector(const World& world, BodyID id, UnitVec localVector)
 {
-    return Rotate(localVector, GetTransformation(world, body).q);
+    return Rotate(localVector, GetTransformation(world, id).q);
 }
 
 /// @brief Gets the velocity of the identified body.

--- a/PlayRho/Dynamics/WorldBody.hpp
+++ b/PlayRho/Dynamics/WorldBody.hpp
@@ -72,11 +72,11 @@ BodyCounter GetBodyRange(const World& world) noexcept;
 
 /// @brief Gets the bodies of the specified world.
 /// @relatedalso World
-std::vector<BodyID> GetBodies(const World& world) noexcept;
+const std::vector<BodyID>& GetBodies(const World& world) noexcept;
 
 /// @brief Gets the bodies-for-proxies range for the given world.
 /// @relatedalso World
-std::vector<BodyID> GetBodiesForProxies(const World& world) noexcept;
+const std::vector<BodyID>& GetBodiesForProxies(const World& world) noexcept;
 
 /// @brief Creates a rigid body within the world that's a copy of the given one.
 /// @warning This function should not be used while the world is locked &mdash; as it is
@@ -172,7 +172,7 @@ bool Detach(World& world, BodyID id, bool resetMassData = true);
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @see Attach, Detach.
 /// @relatedalso World
-std::vector<ShapeID> GetShapes(const World& world, BodyID id);
+const std::vector<ShapeID>& GetShapes(const World& world, BodyID id);
 
 /// @brief Gets the count of shapes associated with the identified body.
 /// @throws std::out_of_range If given an invalid body identifier.
@@ -680,7 +680,7 @@ inline void ResetMassData(World& world, BodyID id)
 /// @brief Gets the range of all joints attached to the identified body.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-std::vector<std::pair<BodyID, JointID>> GetJoints(const World& world, BodyID id);
+const std::vector<std::pair<BodyID, JointID>>& GetJoints(const World& world, BodyID id);
 
 /// @brief Is identified body "speedable".
 /// @details Is the body able to have a non-zero speed associated with it.
@@ -744,7 +744,7 @@ void SetSleepingAllowed(World& world, BodyID, bool value);
 ///   miss some collisions if you don't use <code>ContactListener</code>.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-std::vector<KeyedContactPtr> GetContacts(const World& world, BodyID id);
+const std::vector<KeyedContactPtr>& GetContacts(const World& world, BodyID id);
 
 /// @brief Gets the centripetal force necessary to put the body into an orbit having
 ///    the given radius.
@@ -851,17 +851,17 @@ void SetAngularDamping(World& world, BodyID id, NonNegative<Frequency> angularDa
 
 /// @brief Gets the count of awake bodies in the given world.
 /// @relatedalso World
-BodyCounter GetAwakeCount(const World& world) noexcept;
+BodyCounter GetAwakeCount(const World& world);
 
 /// @brief Awakens all of the bodies in the given world.
 /// @details Calls all of the world's bodies' <code>SetAwake</code> method.
 /// @return Sum total of calls to bodies' <code>SetAwake</code> method that returned true.
 /// @relatedalso World
-BodyCounter Awaken(World& world) noexcept;
+BodyCounter Awaken(World& world);
 
 /// @brief Finds body in given world that's closest to the given location.
 /// @relatedalso World
-BodyID FindClosestBody(const World& world, Length2 location) noexcept;
+BodyID FindClosestBody(const World& world, Length2 location);
 
 /// @brief Gets the body count in the given world.
 /// @return 0 or higher.
@@ -875,19 +875,19 @@ inline BodyCounter GetBodyCount(const World& world) noexcept
 /// @brief Sets the accelerations of all the world's bodies to the given value.
 /// @throws WrongState if this function is called while the world is locked.
 /// @relatedalso World
-void SetAccelerations(World& world, Acceleration acceleration) noexcept;
+void SetAccelerations(World& world, Acceleration acceleration);
 
 /// @brief Sets the accelerations of all the world's bodies to the given value.
 /// @note This will leave the angular acceleration alone.
 /// @throws WrongState if this function is called while the world is locked.
 /// @relatedalso World
-void SetAccelerations(World& world, LinearAcceleration2 acceleration) noexcept;
+void SetAccelerations(World& world, LinearAcceleration2 acceleration);
 
 /// @brief Clears forces.
 /// @details Manually clear the force buffer on all bodies.
 /// @throws WrongState if this function is called while the world is locked.
 /// @relatedalso World
-inline void ClearForces(World& world) noexcept
+inline void ClearForces(World& world)
 {
     SetAccelerations(world, Acceleration{});
 }

--- a/PlayRho/Dynamics/WorldConf.hpp
+++ b/PlayRho/Dynamics/WorldConf.hpp
@@ -24,7 +24,7 @@
 /// @file
 /// Declarations of the WorldConf class.
 
-#include <PlayRho/Common/Positive.hpp>
+#include <PlayRho/Common/Settings.hpp>
 
 namespace playrho {
 namespace d2 {

--- a/PlayRho/Dynamics/WorldContact.cpp
+++ b/PlayRho/Dynamics/WorldContact.cpp
@@ -135,17 +135,17 @@ Real GetRestitution(const World& world, ContactID id)
     return GetRestitution(GetContact(world, id));
 }
 
-void SetFriction(World& world, ContactID id, Real value)
+void SetFriction(World& world, ContactID id, Real friction)
 {
     auto contact = GetContact(world, id);
-    SetFriction(contact, value);
+    SetFriction(contact, friction);
     SetContact(world, id, contact);
 }
 
-void SetRestitution(World& world, ContactID id, Real value)
+void SetRestitution(World& world, ContactID id, Real restitution)
 {
     auto contact = GetContact(world, id);
-    SetRestitution(contact, value);
+    SetRestitution(contact, restitution);
     SetContact(world, id, contact);
 }
 

--- a/PlayRho/Dynamics/WorldContact.cpp
+++ b/PlayRho/Dynamics/WorldContact.cpp
@@ -38,7 +38,7 @@ ContactCounter GetContactRange(const World& world) noexcept
     return world.GetContactRange();
 }
 
-std::vector<KeyedContactPtr> GetContacts(const World& world) noexcept
+const std::vector<KeyedContactPtr>& GetContacts(const World& world) noexcept
 {
     return world.GetContacts();
 }
@@ -202,9 +202,9 @@ WorldManifold GetWorldManifold(const World& world, ContactID id)
     return GetWorldManifold(world, GetContact(world, id), GetManifold(world, id));
 }
 
-ContactCounter GetTouchingCount(const World& world) noexcept
+ContactCounter GetTouchingCount(const World& world)
 {
-    const auto contacts = world.GetContacts();
+    const auto& contacts = world.GetContacts();
     return static_cast<ContactCounter>(count_if(cbegin(contacts), cend(contacts),
                                                 [&](const auto &c) {
         return IsTouching(world, std::get<ContactID>(c));

--- a/PlayRho/Dynamics/WorldContact.hpp
+++ b/PlayRho/Dynamics/WorldContact.hpp
@@ -68,7 +68,7 @@ ContactCounter GetContactRange(const World& world) noexcept;
 
 /// @brief Gets the contacts recognized within the given world.
 /// @relatedalso World
-std::vector<KeyedContactPtr> GetContacts(const World& world) noexcept;
+const std::vector<KeyedContactPtr>& GetContacts(const World& world) noexcept;
 
 /// @brief Gets the identified contact.
 /// @throws std::out_of_range If given an invalid contact identifier.
@@ -264,7 +264,7 @@ void UnsetEnabled(World& world, ContactID id);
 
 /// @brief Gets the touching count for the given world.
 /// @relatedalso World
-ContactCounter GetTouchingCount(const World& world) noexcept;
+ContactCounter GetTouchingCount(const World& world);
 
 /// @brief Convenience function for setting/unsetting the enabled status of the identified
 ///   contact based on the value parameter.

--- a/PlayRho/Dynamics/WorldImpl.hpp
+++ b/PlayRho/Dynamics/WorldImpl.hpp
@@ -424,11 +424,11 @@ public:
     /// @note This may cause the connected bodies to begin colliding.
     /// @post The destroyed joint will no longer be present in the range returned from the
     ///   <code>GetJoints()</code> method.
-    /// @param joint Joint to destroy that had been created by this world.
+    /// @param id Identifier of joint to destroy that had been created by this world.
     /// @throws WrongState if this function is called while the world is locked.
     /// @see CreateJoint(const Joint&), GetJoints.
     /// @see PhysicalEntities.
-    void Destroy(JointID joint);
+    void Destroy(JointID id);
 
     /// @brief Gets whether the given identifier is to a joint that's been destroyed.
     /// @note Complexity is at most O(n) where n is the number of elements free.
@@ -672,7 +672,7 @@ private:
     void Remove(BodyID id);
 
     /// @brief Updates associated bodies and contacts for specified joint's addition.
-    void Add(JointID j, bool flagForFiltering = false);
+    void Add(JointID id, bool flagForFiltering = false);
 
     /// @brief Updates associated bodies and contacts for specified joint's removal.
     void Remove(JointID id);

--- a/PlayRho/Dynamics/WorldImpl.hpp
+++ b/PlayRho/Dynamics/WorldImpl.hpp
@@ -276,7 +276,7 @@ public:
     /// @details Provides insight on what fixtures have been queued for proxy processing
     ///   during the next call to the world step method.
     /// @see Step.
-    std::vector<std::pair<BodyID, ShapeID>> GetFixturesForProxies() const noexcept;
+    const std::vector<std::pair<BodyID, ShapeID>>& GetFixturesForProxies() const noexcept;
 
     /// @brief Determines whether this world has new fixtures.
     bool HasNewFixtures() const noexcept;
@@ -299,13 +299,13 @@ public:
     /// @return Body range that can be iterated over using its begin and end methods
     ///   or using ranged-based for-loops.
     /// @see CreateBody(const Body&).
-    Bodies GetBodies() const noexcept;
+    const Bodies& GetBodies() const noexcept;
 
     /// @brief Gets the bodies-for-proxies range for this world.
     /// @details Provides insight on what bodies have been queued for proxy processing
     ///   during the next call to the world step method.
     /// @see Step.
-    Bodies GetBodiesForProxies() const noexcept;
+    const Bodies& GetBodiesForProxies() const noexcept;
 
     /// @brief Creates a rigid body that's a copy of the given one.
     /// @warning This function should not be used while the world is locked &mdash; as it is
@@ -365,10 +365,10 @@ public:
 
     /// @brief Gets the contacts associated with the identified body.
     /// @throws std::out_of_range if given an invalid id.
-    Contacts GetContacts(BodyID id) const;
+    const Contacts& GetContacts(BodyID id) const;
 
     /// @throws std::out_of_range if given an invalid id.
-    BodyJoints GetJoints(BodyID id) const;
+    const BodyJoints& GetJoints(BodyID id) const;
 
     /// @}
 
@@ -387,7 +387,7 @@ public:
     ///   <code>CreateJoint(const Joint&)</code> method that haven't yet been destroyed.
     /// @return World joints sized-range.
     /// @see CreateJoint(const Joint&).
-    Joints GetJoints() const noexcept;
+    const Joints& GetJoints() const noexcept;
 
     /// @brief Creates a joint to constrain one or more bodies.
     /// @warning This function is locked during callbacks.
@@ -490,7 +490,7 @@ public:
     /// @warning contacts are created and destroyed in the middle of a time step.
     /// Use <code>ContactListener</code> to avoid missing contacts.
     /// @return World contacts sized-range.
-    Contacts GetContacts() const noexcept;
+    const Contacts& GetContacts() const noexcept;
 
     /// @brief Gets the identified contact.
     /// @throws std::out_of_range If given an invalid contact identifier.
@@ -669,13 +669,13 @@ private:
                                                 const StepConf& conf);
 
     /// @brief Removes the given body from this world.
-    void Remove(BodyID id) noexcept;
+    void Remove(BodyID id);
 
     /// @brief Updates associated bodies and contacts for specified joint's addition.
     void Add(JointID j, bool flagForFiltering = false);
 
     /// @brief Updates associated bodies and contacts for specified joint's removal.
-    void Remove(JointID id) noexcept;
+    void Remove(JointID id);
 
     /// @brief Sets the step complete state.
     /// @post <code>IsStepComplete()</code> will return the value set.
@@ -884,27 +884,27 @@ inline void WorldImpl::AddProxies(const Proxies& proxies)
     m_proxiesForContacts.insert(end(m_proxiesForContacts), begin(proxies), end(proxies));
 }
 
-inline WorldImpl::Bodies WorldImpl::GetBodies() const noexcept
+inline const WorldImpl::Bodies& WorldImpl::GetBodies() const noexcept
 {
     return m_bodies;
 }
 
-inline WorldImpl::Bodies WorldImpl::GetBodiesForProxies() const noexcept
+inline const WorldImpl::Bodies& WorldImpl::GetBodiesForProxies() const noexcept
 {
     return m_bodiesForSync;
 }
 
-inline std::vector<std::pair<BodyID, ShapeID>> WorldImpl::GetFixturesForProxies() const noexcept
+inline const std::vector<std::pair<BodyID, ShapeID>>& WorldImpl::GetFixturesForProxies() const noexcept
 {
     return m_fixturesForProxies;
 }
 
-inline WorldImpl::Joints WorldImpl::GetJoints() const noexcept
+inline const WorldImpl::Joints& WorldImpl::GetJoints() const noexcept
 {
     return m_joints;
 }
 
-inline WorldImpl::Contacts WorldImpl::GetContacts() const noexcept
+inline const WorldImpl::Contacts& WorldImpl::GetContacts() const noexcept
 {
     return m_contacts;
 }

--- a/PlayRho/Dynamics/WorldImplBody.cpp
+++ b/PlayRho/Dynamics/WorldImplBody.cpp
@@ -58,7 +58,7 @@ void Destroy(WorldImpl& world, BodyID id)
     world.Destroy(id);
 }
 
-std::vector<std::pair<BodyID, JointID>> GetJoints(const WorldImpl& world, BodyID id)
+const std::vector<std::pair<BodyID, JointID>>& GetJoints(const WorldImpl& world, BodyID id)
 {
     return world.GetJoints(id);
 }
@@ -80,12 +80,12 @@ bool Detach(WorldImpl& world, BodyID id, ShapeID shapeID)
     return false;
 }
 
-std::vector<ShapeID> GetShapes(const WorldImpl& world, BodyID id)
+const std::vector<ShapeID>& GetShapes(const WorldImpl& world, BodyID id)
 {
     return world.GetBody(id).GetShapes();
 }
 
-std::vector<KeyedContactPtr> GetContacts(const WorldImpl& world, BodyID id)
+const std::vector<KeyedContactPtr>& GetContacts(const WorldImpl& world, BodyID id)
 {
     return world.GetContacts(id);
 }

--- a/PlayRho/Dynamics/WorldImplBody.hpp
+++ b/PlayRho/Dynamics/WorldImplBody.hpp
@@ -79,7 +79,7 @@ void Destroy(WorldImpl& world, BodyID id);
 /// @brief Gets the range of all joints attached to this body.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso WorldImpl
-std::vector<std::pair<BodyID, JointID>> GetJoints(const WorldImpl& world, BodyID id);
+const std::vector<std::pair<BodyID, JointID>>& GetJoints(const WorldImpl& world, BodyID id);
 
 /// @brief Associates a validly identified shape with the validly identified body.
 /// @throws std::out_of_range If given an invalid body or shape identifier.
@@ -98,14 +98,14 @@ bool Detach(WorldImpl& world, BodyID id, ShapeID shapeID);
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @throws WrongState if this method is called while the world is locked.
 /// @relatedalso WorldImpl
-std::vector<ShapeID> GetShapes(const WorldImpl& world, BodyID id);
+const std::vector<ShapeID>& GetShapes(const WorldImpl& world, BodyID id);
 
 /// @brief Gets the container of all contacts attached to this body.
 /// @warning This collection changes during the time step and you may
 ///   miss some collisions if you don't use <code>ContactListener</code>.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso WorldImpl
-std::vector<KeyedContactPtr> GetContacts(const WorldImpl& world, BodyID id);
+const std::vector<KeyedContactPtr>& GetContacts(const WorldImpl& world, BodyID id);
 
 } // namespace d2
 } // namespace playrho

--- a/PlayRho/Dynamics/WorldImplMisc.cpp
+++ b/PlayRho/Dynamics/WorldImplMisc.cpp
@@ -97,22 +97,22 @@ void ShiftOrigin(WorldImpl& world, Length2 newOrigin)
     world.ShiftOrigin(newOrigin);
 }
 
-std::vector<BodyID> GetBodies(const WorldImpl& world) noexcept
+const std::vector<BodyID>& GetBodies(const WorldImpl& world) noexcept
 {
     return world.GetBodies();
 }
 
-std::vector<BodyID> GetBodiesForProxies(const WorldImpl& world) noexcept
+const std::vector<BodyID>& GetBodiesForProxies(const WorldImpl& world) noexcept
 {
     return world.GetBodiesForProxies();
 }
 
-std::vector<JointID> GetJoints(const WorldImpl& world) noexcept
+const std::vector<JointID>& GetJoints(const WorldImpl& world) noexcept
 {
     return world.GetJoints();
 }
 
-std::vector<KeyedContactPtr> GetContacts(const WorldImpl& world) noexcept
+const std::vector<KeyedContactPtr>& GetContacts(const WorldImpl& world) noexcept
 {
     return world.GetContacts();
 }
@@ -157,7 +157,7 @@ const DynamicTree& GetTree(const WorldImpl& world) noexcept
     return world.GetTree();
 }
 
-std::vector<std::pair<BodyID, ShapeID>> GetFixturesForProxies(const WorldImpl& world) noexcept
+const std::vector<std::pair<BodyID, ShapeID>>& GetFixturesForProxies(const WorldImpl& world) noexcept
 {
     return world.GetFixturesForProxies();
 }

--- a/PlayRho/Dynamics/WorldImplMisc.hpp
+++ b/PlayRho/Dynamics/WorldImplMisc.hpp
@@ -109,29 +109,29 @@ void ShiftOrigin(WorldImpl& world, Length2 newOrigin);
 
 /// @brief Gets the bodies of the specified world.
 /// @relatedalso WorldImpl
-std::vector<BodyID> GetBodies(const WorldImpl& world) noexcept;
+const std::vector<BodyID>& GetBodies(const WorldImpl& world) noexcept;
 
 /// @brief Gets the bodies-for-proxies range for this world.
 /// @details Provides insight on what bodies have been queued for proxy processing
 ///   during the next call to the world step method.
 /// @see WorldImpl::Step.
 /// @relatedalso WorldImpl
-std::vector<BodyID> GetBodiesForProxies(const WorldImpl& world) noexcept;
+const std::vector<BodyID>& GetBodiesForProxies(const WorldImpl& world) noexcept;
 
 /// @brief Gets the fixtures-for-proxies range for this world.
 /// @details Provides insight on what fixtures have been queued for proxy processing
 ///   during the next call to the world step method.
 /// @see Step.
 /// @relatedalso WorldImpl
-std::vector<std::pair<BodyID, ShapeID>> GetFixturesForProxies(const WorldImpl& world) noexcept;
+const std::vector<std::pair<BodyID, ShapeID>>& GetFixturesForProxies(const WorldImpl& world) noexcept;
 
 /// @brief Gets the joints of the specified world.
 /// @relatedalso WorldImpl
-std::vector<JointID> GetJoints(const WorldImpl& world) noexcept;
+const std::vector<JointID>& GetJoints(const WorldImpl& world) noexcept;
 
 /// @brief Gets the contacts of the specified world.
 /// @relatedalso WorldImpl
-std::vector<KeyedContactPtr> GetContacts(const WorldImpl& world) noexcept;
+const std::vector<KeyedContactPtr>& GetContacts(const WorldImpl& world) noexcept;
 
 /// @brief Is the world locked (in the middle of a time step).
 /// @relatedalso WorldImpl

--- a/PlayRho/Dynamics/WorldJoint.cpp
+++ b/PlayRho/Dynamics/WorldJoint.cpp
@@ -36,7 +36,7 @@ JointCounter GetJointRange(const World& world) noexcept
     return world.GetJointRange();
 }
 
-std::vector<JointID> GetJoints(const World& world) noexcept
+const std::vector<JointID>& GetJoints(const World& world) noexcept
 {
     return world.GetJoints();
 }

--- a/PlayRho/Dynamics/WorldJoint.hpp
+++ b/PlayRho/Dynamics/WorldJoint.hpp
@@ -61,7 +61,7 @@ JointCounter GetJointRange(const World& world) noexcept;
 
 /// @brief Gets the joints of the specified world.
 /// @relatedalso World
-std::vector<JointID> GetJoints(const World& world) noexcept;
+const std::vector<JointID>& GetJoints(const World& world) noexcept;
 
 /// @brief Creates a new joint within the given world.
 /// @throws WrongState if this method is called while the world is locked.

--- a/PlayRho/Dynamics/WorldShape.cpp
+++ b/PlayRho/Dynamics/WorldShape.cpp
@@ -61,10 +61,10 @@ TypeID GetType(const World& world, ShapeID id)
     return GetType(GetShape(world, id));
 }
 
-ShapeCounter GetAssociationCount(const World& world) noexcept
+ShapeCounter GetAssociationCount(const World& world)
 {
     auto sum = ShapeCounter{0};
-    const auto bodies = world.GetBodies();
+    const auto& bodies = world.GetBodies();
     for_each(begin(bodies), end(bodies), [&world,&sum](const auto &b) {
         sum += static_cast<ShapeCounter>(size(world.GetShapes(b)));
     });

--- a/PlayRho/Dynamics/WorldShape.cpp
+++ b/PlayRho/Dynamics/WorldShape.cpp
@@ -96,10 +96,10 @@ void SetRestitution(World& world, ShapeID id, Real value)
     SetShape(world, id, object);
 }
 
-void SetFilterData(World& world, ShapeID id, const Filter& value)
+void SetFilterData(World& world, ShapeID id, const Filter& filter)
 {
     auto object = GetShape(world, id);
-    SetFilter(object, value);
+    SetFilter(object, filter);
     SetShape(world, id, object);
 }
 

--- a/PlayRho/Dynamics/WorldShape.hpp
+++ b/PlayRho/Dynamics/WorldShape.hpp
@@ -106,7 +106,7 @@ TypeID GetType(const World& world, ShapeID id);
 
 /// @brief Gets the count of body-shape associations in the given world.
 /// @relatedalso World
-ShapeCounter GetAssociationCount(const World& world) noexcept;
+ShapeCounter GetAssociationCount(const World& world);
 
 /// @brief Gets the count of uniquely identified shapes that are in use -
 ///   i.e. that are attached to bodies.

--- a/UnitTests/AABB.cpp
+++ b/UnitTests/AABB.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Acceleration.cpp
+++ b/UnitTests/Acceleration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Angle.cpp
+++ b/UnitTests/Angle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/ArrayAllocator.cpp
+++ b/UnitTests/ArrayAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/ArrayList.cpp
+++ b/UnitTests/ArrayList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/BaseShapeConf.cpp
+++ b/UnitTests/BaseShapeConf.cpp
@@ -30,10 +30,11 @@ using namespace playrho::d2;
 TEST(BaseShapeConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<BaseShapeConf>);
-    EXPECT_TRUE(std::is_nothrow_default_constructible_v<BaseShapeConf>);
-
     EXPECT_TRUE(std::is_copy_constructible_v<BaseShapeConf>);
+#ifndef USE_BOOST_UNITS
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<BaseShapeConf>);
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<BaseShapeConf>);
+#endif
 }
 
 TEST(BaseShapeConf, DefaultConstruction)

--- a/UnitTests/BaseShapeConf.cpp
+++ b/UnitTests/BaseShapeConf.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "UnitTests.hpp"
+
+#include <PlayRho/Collision/Shapes/ShapeConf.hpp>
+
+#include <type_traits>
+
+using namespace playrho;
+using namespace playrho::d2;
+
+TEST(BaseShapeConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<BaseShapeConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<BaseShapeConf>);
+
+    EXPECT_TRUE(std::is_copy_constructible_v<BaseShapeConf>);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<BaseShapeConf>);
+}
+
+TEST(BaseShapeConf, DefaultConstruction)
+{
+    EXPECT_EQ(BaseShapeConf().friction, BaseShapeConf::DefaultFriction);
+    EXPECT_EQ(BaseShapeConf().restitution, BaseShapeConf::DefaultRestitution);
+    EXPECT_EQ(BaseShapeConf().density, BaseShapeConf::DefaultDensity);
+    EXPECT_EQ(BaseShapeConf().filter, BaseShapeConf::DefaultFilter);
+    EXPECT_EQ(BaseShapeConf().isSensor, BaseShapeConf::DefaultIsSensor);
+}

--- a/UnitTests/BlockAllocator.cpp
+++ b/UnitTests/BlockAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -69,6 +69,8 @@ TEST(Body, DefaultConstruction)
     EXPECT_TRUE(Body().IsEnabled());
     EXPECT_FALSE(Body().IsAwake());
     EXPECT_FALSE(Body().IsSpeedable());
+    EXPECT_EQ(Body().GetLinearDamping(), Body::DefaultLinearDamping);
+    EXPECT_EQ(Body().GetAngularDamping(), Body::DefaultAngularDamping);
 }
 
 TEST(Body, GetFlagsForBodyType)

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/BodyConf.cpp
+++ b/UnitTests/BodyConf.cpp
@@ -47,10 +47,11 @@ TEST(BodyConf, ByteSize)
 TEST(BodyConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<BodyConf>);
-    EXPECT_TRUE(std::is_nothrow_default_constructible_v<BodyConf>);
-
     EXPECT_TRUE(std::is_copy_constructible_v<BodyConf>);
+#ifndef USE_BOOST_UNITS
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<BodyConf>);
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<BodyConf>);
+#endif
 }
 
 TEST(BodyConf, DefaultConstruction)

--- a/UnitTests/BodyConf.cpp
+++ b/UnitTests/BodyConf.cpp
@@ -44,6 +44,36 @@ TEST(BodyConf, ByteSize)
     }
 }
 
+TEST(BodyConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<BodyConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<BodyConf>);
+
+    EXPECT_TRUE(std::is_copy_constructible_v<BodyConf>);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<BodyConf>);
+}
+
+TEST(BodyConf, DefaultConstruction)
+{
+    EXPECT_EQ(BodyConf().type, BodyConf::DefaultBodyType);
+    EXPECT_EQ(BodyConf().location, BodyConf::DefaultLocation);
+    EXPECT_EQ(BodyConf().angle, BodyConf::DefaultAngle);
+    EXPECT_EQ(BodyConf().linearVelocity, BodyConf::DefaultLinearVelocity);
+    EXPECT_EQ(BodyConf().angularVelocity, BodyConf::DefaultAngularVelocity);
+    EXPECT_EQ(BodyConf().linearAcceleration, BodyConf::DefaultLinearAcceleration);
+    EXPECT_EQ(BodyConf().angularAcceleration, BodyConf::DefaultAngularAcceleration);
+    EXPECT_EQ(BodyConf().linearDamping, BodyConf::DefaultLinearDamping);
+    EXPECT_EQ(BodyConf().angularDamping, BodyConf::DefaultAngularDamping);
+    EXPECT_EQ(BodyConf().underActiveTime, BodyConf::DefaultUnderActiveTime);
+    EXPECT_EQ(BodyConf().type, BodyType::Static);
+    EXPECT_EQ(BodyConf().shape, InvalidShapeID);
+    EXPECT_EQ(BodyConf().allowSleep, BodyConf::DefaultAllowSleep);
+    EXPECT_EQ(BodyConf().awake, BodyConf::DefaultAwake);
+    EXPECT_EQ(BodyConf().fixedRotation, BodyConf::DefaultFixedRotation);
+    EXPECT_EQ(BodyConf().bullet, BodyConf::DefaultBullet);
+    EXPECT_EQ(BodyConf().enabled, BodyConf::DefaultEnabled);
+}
+
 TEST(BodyConf, UseType)
 {
     EXPECT_EQ(BodyConf{}.UseType(BodyType::Static).type, BodyType::Static);

--- a/UnitTests/BodyConf.cpp
+++ b/UnitTests/BodyConf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/BodyConstraint.cpp
+++ b/UnitTests/BodyConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/BodyID.cpp
+++ b/UnitTests/BodyID.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/BodyType.cpp
+++ b/UnitTests/BodyType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -70,7 +70,9 @@ TEST(ChainShapeConf, IsValidShapeType)
 TEST(ChainShapeConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<ChainShapeConf>);
+#ifndef USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<ChainShapeConf>);
+#endif
 }
 
 TEST(ChainShapeConf, DefaultConstruction)
@@ -300,7 +302,13 @@ TEST(ChainShapeConf, FourVertex)
     auto conf = ChainShapeConf{};
     conf.density = density;
     conf.vertexRadius = vertexRadius;
-    conf.Set(std::vector<Length2>(begin(locations), end(locations)));
+    const auto locationsVector = std::vector<Length2>(begin(locations), end(locations));
+    conf.Set(locationsVector);
+    EXPECT_EQ(conf.GetVertices(), locationsVector);
+    EXPECT_EQ(conf.GetVertexCount(), locations.size());
+    for (auto i = ChildCounter{0}; i < locations.size(); ++i) {
+        EXPECT_EQ(locations[i], conf.GetVertex(i));
+    }
     auto foo = ChainShapeConf{conf};
     EXPECT_EQ(GetChildCount(foo), ChildCounter{4});
     EXPECT_EQ(foo.GetVertexCount(), ChildCounter{5});

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -67,6 +67,12 @@ TEST(ChainShapeConf, IsValidShapeType)
     EXPECT_TRUE(IsValidShapeType<ChainShapeConf>::value);
 }
 
+TEST(ChainShapeConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<ChainShapeConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<ChainShapeConf>);
+}
+
 TEST(ChainShapeConf, DefaultConstruction)
 {
     const auto foo = ChainShapeConf{};
@@ -82,6 +88,7 @@ TEST(ChainShapeConf, DefaultConstruction)
         EXPECT_EQ(GetVertexRadius(foo, i), ChainShapeConf::GetDefaultVertexRadius());
     }
     EXPECT_THROW(GetChild(foo, GetChildCount(foo)), InvalidArgument);
+    EXPECT_EQ(ChainShapeConf::DefaultVertexRadius, ChainShapeConf::GetDefaultVertexRadius());
     EXPECT_EQ(GetVertexRadius(foo, GetChildCount(foo)), ChainShapeConf::GetDefaultVertexRadius());
     EXPECT_EQ(GetDensity(foo), defaultConf.density);
     EXPECT_EQ(GetFriction(foo), defaultConf.friction);

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/CheckedValue.cpp
+++ b/UnitTests/CheckedValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Compositor.cpp
+++ b/UnitTests/Compositor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/ContactFeature.cpp
+++ b/UnitTests/ContactFeature.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/ContactImpulsesList.cpp
+++ b/UnitTests/ContactImpulsesList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/ContactSolver.cpp
+++ b/UnitTests/ContactSolver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/DiskShape.cpp
+++ b/UnitTests/DiskShape.cpp
@@ -58,6 +58,7 @@ TEST(DiskShapeConf, DefaultConstruction)
 
     EXPECT_EQ(GetTypeID(foo), GetTypeID<DiskShapeConf>());
     EXPECT_EQ(GetChildCount(foo), ChildCounter{1});
+    EXPECT_EQ(DiskShapeConf::GetDefaultRadius(), DiskShapeConf::DefaultRadius);
     EXPECT_EQ(foo.GetRadius(), DiskShapeConf::GetDefaultRadius());
     EXPECT_EQ(GetX(foo.GetLocation()), 0_m);
     EXPECT_EQ(GetY(foo.GetLocation()), 0_m);

--- a/UnitTests/Distance.cpp
+++ b/UnitTests/Distance.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -56,6 +56,14 @@ TEST(DistanceJointConf, ByteSize)
     }
 }
 
+TEST(DistanceJointConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<DistanceJointConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<DistanceJointConf>);
+    EXPECT_TRUE(std::is_copy_constructible_v<DistanceJointConf>);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<DistanceJointConf>);
+}
+
 TEST(DistanceJointConf, DefaultConstruction)
 {
     auto def = DistanceJointConf{};

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -59,9 +59,12 @@ TEST(DistanceJointConf, ByteSize)
 TEST(DistanceJointConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<DistanceJointConf>);
-    EXPECT_TRUE(std::is_nothrow_default_constructible_v<DistanceJointConf>);
     EXPECT_TRUE(std::is_copy_constructible_v<DistanceJointConf>);
+
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<DistanceJointConf>);
+#ifndef USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<DistanceJointConf>);
+#endif
 }
 
 TEST(DistanceJointConf, DefaultConstruction)

--- a/UnitTests/DistanceProxy.cpp
+++ b/UnitTests/DistanceProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Dump.cpp
+++ b/UnitTests/Dump.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/DynamicMemory.cpp
+++ b/UnitTests/DynamicMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -168,13 +168,7 @@ TEST(DynamicTreeLeafData, Traits)
 
 TEST(DynamicTreeVariantData, Traits)
 {
-    EXPECT_TRUE(std::is_default_constructible<DynamicTreeVariantData>::value);
-    EXPECT_TRUE(std::is_nothrow_default_constructible<DynamicTreeVariantData>::value);
-    //EXPECT_TRUE(std::is_trivially_default_constructible<DynamicTreeVariantData>::value);
-
-    EXPECT_TRUE(std::is_nothrow_constructible<DynamicTreeVariantData>::value);
-    EXPECT_TRUE(std::is_constructible<DynamicTreeVariantData>::value);
-    //EXPECT_TRUE(std::is_trivially_constructible<DynamicTreeVariantData>::value);
+    EXPECT_FALSE(std::is_default_constructible<DynamicTreeVariantData>::value);
 
     EXPECT_TRUE(std::is_copy_constructible<DynamicTreeVariantData>::value);
     EXPECT_TRUE(std::is_nothrow_copy_constructible<DynamicTreeVariantData>::value);

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -51,6 +51,15 @@ TEST(EdgeShapeConf, IsValidShapeType)
     EXPECT_TRUE(IsValidShapeType<EdgeShapeConf>::value);
 }
 
+TEST(EdgeShapeConf, DefaultConstruction)
+{
+    EXPECT_EQ(EdgeShapeConf::GetDefaultVertexRadius(), EdgeShapeConf::DefaultVertexRadius);
+    const auto foo = EdgeShapeConf{};
+    EXPECT_EQ(foo.vertexRadius, EdgeShapeConf::GetDefaultVertexRadius());
+    EXPECT_EQ((Length2{}), foo.GetVertexA());
+    EXPECT_EQ((Length2{}), foo.GetVertexB());
+}
+
 TEST(EdgeShapeConf, GetInvalidChildThrows)
 {
     const auto foo = EdgeShapeConf{};

--- a/UnitTests/EdgeShape.cpp
+++ b/UnitTests/EdgeShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Epsilon.cpp
+++ b/UnitTests/Epsilon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Filter.cpp
+++ b/UnitTests/Filter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Fixed.cpp
+++ b/UnitTests/Fixed.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/FlagGuard.cpp
+++ b/UnitTests/FlagGuard.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -71,6 +71,27 @@ TEST(FrictionJointConf, DefaultConstruction)
 
 TEST(FrictionJointConf, InitializingConstructor)
 {
+    const auto laA = Length2{-1_m, 0_m};
+    const auto laB = Length2{+1_m, 0_m};
+    const auto bA = BodyID(0);
+    const auto bB = BodyID(1);
+    const auto def = FrictionJointConf(bA, bB, laA, laB);
+    EXPECT_EQ(def.bodyA, bA);
+    EXPECT_EQ(def.bodyB, bB);
+    EXPECT_EQ(def.localAnchorA, laA);
+    EXPECT_EQ(def.localAnchorB, laB);
+    EXPECT_EQ(def.maxForce, NonNegative<Force>());
+    EXPECT_EQ(def.maxTorque, NonNegative<Torque>());
+    EXPECT_EQ(def.linearImpulse, Momentum2());
+    EXPECT_EQ(def.angularImpulse, AngularMomentum());
+    EXPECT_EQ(def.rA, Length2());
+    EXPECT_EQ(def.rB, Length2());
+    EXPECT_EQ(def.linearMass, Mass22());
+    EXPECT_EQ(def.angularMass, RotInertia());
+}
+
+TEST(FrictionJointConf, GetFrictionJointConf)
+{
     World world{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/GrowableStack.cpp
+++ b/UnitTests/GrowableStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/IndexPair.cpp
+++ b/UnitTests/IndexPair.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Interval.cpp
+++ b/UnitTests/Interval.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Island.cpp
+++ b/UnitTests/Island.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Joint.cpp
+++ b/UnitTests/Joint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Joint.cpp
+++ b/UnitTests/Joint.cpp
@@ -309,6 +309,15 @@ static_assert(!IsValidJointType<sans_all::JointTester>::value);
 
 } // namespace test
 
+TEST(JointConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<JointConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<JointConf>);
+
+    EXPECT_TRUE(std::is_copy_constructible_v<JointConf>);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<JointConf>);
+}
+
 TEST(JointBuilder, Construction)
 {
     EXPECT_EQ(JointBuilder<JointConf>{}.bodyA, InvalidBodyID);

--- a/UnitTests/Manifold.cpp
+++ b/UnitTests/Manifold.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -53,8 +53,9 @@ TEST(MassData, Traits)
     EXPECT_FALSE(IsIterable<MassData>::value);
 
     EXPECT_TRUE(std::is_default_constructible_v<MassData>);
+#ifndef USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<MassData>); // may be compiler dependent
-    EXPECT_FALSE(std::is_trivially_default_constructible_v<MassData>);
+#endif
     
     EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass, RotInertia>::value));
     EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass>::value));
@@ -65,11 +66,12 @@ TEST(MassData, Traits)
     EXPECT_TRUE((std::is_constructible<MassData>::value));
     // EXPECT_FALSE(std::is_nothrow_constructible<MassData>::value); // clang 3.7 and 4.0
     // EXPECT_TRUE(std::is_nothrow_constructible<MassData>::value); // gcc 6.3
-    EXPECT_FALSE((std::is_trivially_constructible<MassData, Length2, Mass, RotInertia>::value));
     
     EXPECT_TRUE(std::is_copy_constructible<MassData>::value);
+#ifndef USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_copy_constructible<MassData>::value); // may be compiler dependent
-    
+#endif
+
     EXPECT_TRUE(std::is_copy_assignable<MassData>::value);
     // EXPECT_TRUE(std::is_nothrow_copy_assignable<MassData>::value); // with clang-4.0 gcc 6.3
     // EXPECT_FALSE(std::is_nothrow_copy_assignable<MassData>::value); // with clang-3.7

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -52,10 +52,9 @@ TEST(MassData, Traits)
 {
     EXPECT_FALSE(IsIterable<MassData>::value);
 
-    EXPECT_TRUE(std::is_default_constructible<MassData>::value);
-    // EXPECT_FALSE(std::is_nothrow_default_constructible<MassData>::value); // clang-3.7 and 4.0
-    // EXPECT_TRUE(std::is_nothrow_default_constructible<MassData>::value); // gcc 6.3
-    EXPECT_FALSE(std::is_trivially_default_constructible<MassData>::value);
+    EXPECT_TRUE(std::is_default_constructible_v<MassData>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<MassData>); // may be compiler dependent
+    EXPECT_FALSE(std::is_trivially_default_constructible_v<MassData>);
     
     EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass, RotInertia>::value));
     EXPECT_FALSE((std::is_constructible<MassData, Length2, Mass>::value));
@@ -69,10 +68,7 @@ TEST(MassData, Traits)
     EXPECT_FALSE((std::is_trivially_constructible<MassData, Length2, Mass, RotInertia>::value));
     
     EXPECT_TRUE(std::is_copy_constructible<MassData>::value);
-    // EXPECT_TRUE(std::is_nothrow_copy_constructible<MassData>::value); // with clang-4.0 gcc 6.3
-    // EXPECT_FALSE(std::is_nothrow_copy_constructible<MassData>::value); // with clang-3.7
-    // EXPECT_TRUE(std::is_trivially_copy_constructible<MassData>::value); // with clang-4.0
-    // EXPECT_FALSE(std::is_trivially_copy_constructible<MassData>::value); // with clang-3.7
+    EXPECT_TRUE(std::is_nothrow_copy_constructible<MassData>::value); // may be compiler dependent
     
     EXPECT_TRUE(std::is_copy_assignable<MassData>::value);
     // EXPECT_TRUE(std::is_nothrow_copy_assignable<MassData>::value); // with clang-4.0 gcc 6.3

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Mat22.cpp
+++ b/UnitTests/Mat22.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Mat33.cpp
+++ b/UnitTests/Mat33.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -65,6 +65,8 @@ TEST(MotorJointConf, DefaultConstruction)
 
     EXPECT_EQ(def.linearOffset, (Length2{}));
     EXPECT_EQ(def.angularOffset, 0_deg);
+    EXPECT_EQ(def.maxForce, MotorJointConf::DefaultMaxForce);
+    EXPECT_EQ(def.maxTorque, MotorJointConf::DefaultMaxTorque);
     EXPECT_EQ(def.maxForce, 1_N);
     EXPECT_EQ(def.maxTorque, 1_Nm);
     EXPECT_EQ(def.correctionFactor, Real(0.3));

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -67,8 +67,11 @@ TEST(MultiShapeConf, IsValidShapeType)
 TEST(MultiShapeConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<MultiShapeConf>);
-    EXPECT_TRUE(std::is_nothrow_default_constructible_v<MultiShapeConf>);
     EXPECT_TRUE(std::is_copy_constructible_v<MultiShapeConf>);
+
+#ifndef USE_BOOST_UNITS
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<MultiShapeConf>);
+#endif
 }
 
 TEST(MultiShapeConf, DefaultConstruction)

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -25,6 +25,7 @@
 #include <PlayRho/Common/VertexSet.hpp>
 
 #include <array>
+#include <type_traits>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -63,12 +64,19 @@ TEST(MultiShapeConf, IsValidShapeType)
     EXPECT_TRUE(IsValidShapeType<MultiShapeConf>::value);
 }
 
+TEST(MultiShapeConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<MultiShapeConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<MultiShapeConf>);
+    EXPECT_TRUE(std::is_copy_constructible_v<MultiShapeConf>);
+}
+
 TEST(MultiShapeConf, DefaultConstruction)
 {
     const auto foo = MultiShapeConf{};
     const auto defaultMassData = MassData{};
     const auto defaultConf = MultiShapeConf{};
-    
+    EXPECT_EQ(MultiShapeConf::DefaultVertexRadius, MultiShapeConf::GetDefaultVertexRadius());
     EXPECT_EQ(GetTypeID(foo), GetTypeID<MultiShapeConf>());
     EXPECT_EQ(GetChildCount(foo), ChildCounter{0});
     EXPECT_EQ(GetMassData(foo), defaultMassData);
@@ -209,7 +217,7 @@ TEST(MultiShapeConf, SetVertexRadius)
     vs.add(v2);
     foo.AddConvexHull(vs);
     ASSERT_EQ(foo.children.size(), std::size_t(1));
-    ASSERT_EQ(foo.children.at(0).GetVertexRadius(), DefaultLinearSlop * Real(2));
+    ASSERT_EQ(foo.children.at(0).GetVertexRadius(), MultiShapeConf::DefaultVertexRadius);
     auto copy = foo;
     ASSERT_EQ(copy, foo);
     const auto amount = 2_m;

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -60,8 +60,16 @@ TEST(PolygonShapeConf, IsValidShapeType)
     EXPECT_TRUE(IsValidShapeType<PolygonShapeConf>::value);
 }
 
+TEST(PolygonShapeConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<PolygonShapeConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<PolygonShapeConf>);
+    EXPECT_TRUE(std::is_copy_constructible_v<PolygonShapeConf>);
+}
+
 TEST(PolygonShapeConf, DefaultConstruction)
 {
+    EXPECT_EQ(PolygonShapeConf::GetDefaultVertexRadius(), PolygonShapeConf::DefaultVertexRadius);
     const auto shape = PolygonShapeConf{};
     EXPECT_EQ(shape.GetVertexCount(), 0);
     EXPECT_EQ(GetChildCount(shape), ChildCounter(1));

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Position.cpp
+++ b/UnitTests/Position.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/PositionConstraint.cpp
+++ b/UnitTests/PositionConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/PositionSolverManifold.cpp
+++ b/UnitTests/PositionSolverManifold.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/RayCastOutput.cpp
+++ b/UnitTests/RayCastOutput.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Real.cpp
+++ b/UnitTests/Real.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/SeparationScenario.cpp
+++ b/UnitTests/SeparationScenario.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -100,12 +100,13 @@ TEST(Shape, Traits)
 
 TEST(Shape, DefaultConstruction)
 {
+    EXPECT_EQ(Shape::DefaultDensity, (NonNegative<AreaDensity>{0_kgpm2}));
     const auto s = Shape{};
     EXPECT_FALSE(s.has_value());
     EXPECT_EQ(GetMassData(s), MassData());
     EXPECT_EQ(GetFriction(s), Real(0));
     EXPECT_EQ(GetRestitution(s), Real(0));
-    EXPECT_EQ(GetDensity(s), 0_kgpm2);
+    EXPECT_EQ(GetDensity(s), Shape::DefaultDensity);
     EXPECT_THROW(GetVertexRadius(s, 0), InvalidArgument);
     EXPECT_EQ(GetChildCount(s), ChildCounter(0));
     EXPECT_THROW(GetChild(s, 0), InvalidArgument);

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Simplex.cpp
+++ b/UnitTests/Simplex.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/SimplexEdge.cpp
+++ b/UnitTests/SimplexEdge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/StackAllocator.cpp
+++ b/UnitTests/StackAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/StepConf.cpp
+++ b/UnitTests/StepConf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/StepStats.cpp
+++ b/UnitTests/StepStats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Sweep.cpp
+++ b/UnitTests/Sweep.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -41,9 +41,11 @@ TEST(TargetJointConf, Traits)
     EXPECT_TRUE(std::is_default_constructible_v<TargetJointConf>);
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<TargetJointConf>);
     EXPECT_TRUE(std::is_copy_constructible_v<TargetJointConf>);
-    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<TargetJointConf>);
     EXPECT_TRUE(std::is_copy_assignable_v<TargetJointConf>);
+#ifndef USE_BOOST_UNITS
+    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<TargetJointConf>);
     EXPECT_TRUE(std::is_nothrow_copy_assignable_v<TargetJointConf>);
+#endif
 }
 
 TEST(TargetJointConf, DefaultConstruction)

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -31,9 +31,26 @@
 #include <PlayRho/Dynamics/WorldBody.hpp>
 
 #include <stdexcept>
+#include <type_traits>
 
 using namespace playrho;
 using namespace playrho::d2;
+
+TEST(TargetJointConf, Traits)
+{
+    EXPECT_TRUE(std::is_default_constructible_v<TargetJointConf>);
+    EXPECT_TRUE(std::is_nothrow_default_constructible_v<TargetJointConf>);
+    EXPECT_TRUE(std::is_copy_constructible_v<TargetJointConf>);
+    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<TargetJointConf>);
+    EXPECT_TRUE(std::is_copy_assignable_v<TargetJointConf>);
+    EXPECT_TRUE(std::is_nothrow_copy_assignable_v<TargetJointConf>);
+}
+
+TEST(TargetJointConf, DefaultConstruction)
+{
+    EXPECT_EQ(TargetJointConf().frequency, TargetJointConf::DefaultFrequency);
+    EXPECT_EQ(TargetJointConf().dampingRatio, TargetJointConf::DefaultDampingRatio);
+}
 
 TEST(TargetJointConf, UseTarget)
 {

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Transformation.cpp
+++ b/UnitTests/Transformation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/UnitTests.hpp
+++ b/UnitTests/UnitTests.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/UnitVec.cpp
+++ b/UnitTests/UnitVec.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Units.cpp
+++ b/UnitTests/Units.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Vec2.cpp
+++ b/UnitTests/Vec2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Vec3.cpp
+++ b/UnitTests/Vec3.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Vector.cpp
+++ b/UnitTests/Vector.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Velocity.cpp
+++ b/UnitTests/Velocity.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/VelocityConstraint.cpp
+++ b/UnitTests/VelocityConstraint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/Version.cpp
+++ b/UnitTests/Version.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/VertexSet.cpp
+++ b/UnitTests/VertexSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -77,6 +77,26 @@ TEST(WeldJointConf, DefaultConstruction)
     EXPECT_EQ(def.dampingRatio, Real(0));
 }
 
+TEST(WeldJointConf, InitalizingConstruction)
+{
+    const auto bA = BodyID(1);
+    const auto bB = BodyID(2);
+    const auto laA = Length2(-4.2_m, 3.8_m);
+    const auto laB = Length2(5.1_m, 4_m);
+    const auto ra = 90_deg;
+    const auto def = WeldJointConf{bA, bB, laA, laB, ra};
+
+    EXPECT_EQ(def.bodyA, bA);
+    EXPECT_EQ(def.bodyB, bB);
+    EXPECT_EQ(def.collideConnected, false);
+
+    EXPECT_EQ(def.localAnchorA, laA);
+    EXPECT_EQ(def.localAnchorB, laB);
+    EXPECT_EQ(def.referenceAngle, ra);
+    EXPECT_EQ(def.frequency, 0_Hz);
+    EXPECT_EQ(def.dampingRatio, Real(0));
+}
+
 TEST(WeldJoint, Construction)
 {
     WeldJointConf def;

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -72,6 +72,7 @@ TEST(WheelJointConf, DefaultConstruction)
     EXPECT_FALSE(def.enableMotor);
     EXPECT_EQ(def.maxMotorTorque, Torque(0));
     EXPECT_EQ(def.motorSpeed, 0_rpm);
+    EXPECT_EQ(def.frequency, WheelJointConf::DefaultFrequency);
     EXPECT_EQ(def.frequency, 2_Hz);
     EXPECT_EQ(def.dampingRatio, Real(0.7f));
 }

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WorldBody.cpp
+++ b/UnitTests/WorldBody.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WorldContact.cpp
+++ b/UnitTests/WorldContact.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WorldFixture.cpp
+++ b/UnitTests/WorldFixture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WorldImpl.cpp
+++ b/UnitTests/WorldImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WorldJoint.cpp
+++ b/UnitTests/WorldJoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WorldManifold.cpp
+++ b/UnitTests/WorldManifold.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/WorldShape.cpp
+++ b/UnitTests/WorldShape.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/double.cpp
+++ b/UnitTests/double.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/float.cpp
+++ b/UnitTests/float.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/forward_list.cpp
+++ b/UnitTests/forward_list.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/functional.cpp
+++ b/UnitTests/functional.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages

--- a/UnitTests/main.cpp
+++ b/UnitTests/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
  *
  * This software is provided 'as-is', without any express or implied
  * warranty. In no event will the authors be held liable for any damages


### PR DESCRIPTION
#### Description - What's this PR do?
- Decreases clang-tidy checks for now.
- Addresses misc-redundant-expression warnings over library code.
- Addresses readability-inconsistent-declaration-parameter-name warnings over library code.
- Fixes unit test expectations on traits when USE_BOOST_UNITS defined
- Addresses modernize-use-equals-default warnings over library code
- Fixes noexcept usage per feedback from clang-tidy bugprone-exception-escap
- Fixes Finite to not be constexpr since std::isfinite is not
- Adds support for boost alternatively under /opt/homebrew
- Updates UnitTests code copyrights