### PR TITLE
Updates 20230404

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,20 @@
 #   run-clang-tidy -p PlayRhoBuild -header-filter='.*' PlayRho/PlayRho
 
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,concurrency-*,portability-*,readability-*,misc-*,performance-*,modernize-use-nullptr,modernize-unary-static-assert,modernize-use-emplace,modernize-use-using,modernize-return-braced-init-list,cppcoreguidelines-avoid-capture-default-when-capturing-this,cppcoreguidelines-avoid-non-const-global-variables,cppcoreguidelines-narrowing-conversions,cppcoreguidelines-prefer-member-initializer,cppcoreguidelines-pro-type-const-cast,cppcoreguidelines-pro-type-cstyle-cast,cppcoreguidelines-slicing,cppcoreguidelines-virtual-class-destructor,cppcoreguidelines-pro-type-member-init,bugprone-*,-bugprone-implicit-widening-of-multiplication-result,-bugprone-branch-clone,-bugprone-easily-swappable-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,-readability-uppercase-literal-suffix,-readability-identifier-length,-readability-named-parameter,-readability-implicit-bool-conversion,-readability-qualified-auto'
+Checks: 'bugprone-*,
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-use-nullptr,modernize-unary-static-assert,modernize-use-emplace,modernize-use-using,modernize-return-braced-init-list,
+  performance-*,
+  portability-*,
+  readability-*,
+  -bugprone-implicit-widening-of-multiplication-result,-bugprone-branch-clone,-bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-avoid-c-arrays,-cppcoreguidelines-non-private-member-variables-in-classes,-cppcoreguidelines-special-member-functions,-cppcoreguidelines-macro-usage,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-reinterpret-cast,
+  -misc-non-private-member-variables-in-classes,-misc-no-recursion,
+  -readability-uppercase-literal-suffix,-readability-identifier-length,-readability-named-parameter,-readability-implicit-bool-conversion,-readability-qualified-auto'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,6 +24,8 @@ HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           'Angle;AngularAcceleration;AngularVelocity;Area;AreaDensity;Force;Frequency;InvMass;InvRotInertia;Length;LinearVelocity;Mass;Momentum;NonNegative;Positive;RotInertia;Time;Torque;'
   - key:             llvm-else-after-return.WarnOnConditionVariables
     value:           'false'
   - key:             modernize-loop-convert.MinConfidence

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,9 @@ option(PLAYRHO_BUILD_BENCHMARK "Build PlayRho Benchmark console application." OF
 option(PLAYRHO_BUILD_TESTBED "Build PlayRho Testbed GUI application." OFF)
 option(PLAYRHO_ENABLE_COVERAGE "Enable code coverage generation." OFF)
 
+option(PLAYRHO_ENABLE_BOOST_UNITS "Enable use of Boost units (experimental)." OFF)
+mark_as_advanced(FORCE PLAYRHO_ENABLE_BOOST_UNITS)
+
 set(LIB_INSTALL_DIR lib${LIB_SUFFIX})
 
 # Tell Microsoft Visual C (MSVC) to enable unwind semantics since it doesn't by default.

--- a/Documentation/PhysicalUnits.md
+++ b/Documentation/PhysicalUnits.md
@@ -20,11 +20,11 @@ To build with Boost units support:
   3. Add the path to that directory to your build system's list of include paths.
      If using the example directory, then you'd add `/usr/local/boost_1_75_0` to your
      build system's include paths.
-  4. Go into your PlayRho project setup and add "USE_BOOST_UNITS" as a
+  4. Go into your PlayRho project setup and add "PLAYRHO_USE_BOOST_UNITS" as a
      C pre-processor define so that the file
      [`PlayRho/Common/Units.hpp`](../PlayRho/Common/Units.hpp) can see that it's defined.
      This could be achieved just by uncommenting the line that appears like:
-     `// #define USE_BOOST_UNITS`.
+     `// #define PLAYRHO_USE_BOOST_UNITS`.
   5. Rebuild the PlayRho library and any applications. If you've used the
      physical units interface correctly everywhere, you should get no units
      related warnings or errors.

--- a/PlayRho/CMakeLists.txt
+++ b/PlayRho/CMakeLists.txt
@@ -89,6 +89,12 @@ target_include_directories(PlayRho PUBLIC
 	"$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
+if (PLAYRHO_ENABLE_BOOST_UNITS)
+	find_package(Boost REQUIRED)
+	target_include_directories(PlayRho SYSTEM PUBLIC ${Boost_INCLUDE_DIR})
+	target_compile_definitions(PlayRho PUBLIC -DPLAYRHO_USE_BOOST_UNITS)
+endif()
+
 # These are used to create visual studio folders.
 source_group(Collision FILES ${PLAYRHO_Collision_SRCS} ${PLAYRHO_Collision_HDRS})
 source_group(Collision\\Shapes FILES ${PLAYRHO_Shapes_SRCS} ${PLAYRHO_Shapes_HDRS})

--- a/PlayRho/Collision/Collision.cpp
+++ b/PlayRho/Collision/Collision.cpp
@@ -35,9 +35,7 @@ PointStates GetPointStates(const Manifold& manifold1, const Manifold& manifold2)
     for (auto i = decltype(manifold1.GetPointCount()){0}; i < manifold1.GetPointCount(); ++i)
     {
         const auto cf = manifold1.GetContactFeature(i);
-
         retval.state1[i] = PointState::RemoveState;
-
         for (auto j = decltype(manifold2.GetPointCount()){0}; j < manifold2.GetPointCount(); ++j)
         {
             if (manifold2.GetContactFeature(j) == cf)
@@ -52,9 +50,7 @@ PointStates GetPointStates(const Manifold& manifold1, const Manifold& manifold2)
     for (auto i = decltype(manifold2.GetPointCount()){0}; i < manifold2.GetPointCount(); ++i)
     {
         const auto cf = manifold2.GetContactFeature(i);
-
         retval.state2[i] = PointState::AddState;
-
         for (auto j = decltype(manifold1.GetPointCount()){0}; j < manifold1.GetPointCount(); ++j)
         {
             if (manifold1.GetContactFeature(j) == cf)

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -113,7 +113,7 @@ std::vector<Length2> GetConvexHullAsVector(Span<const Length2> vertices)
     return result;
 }
 
-bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept
+bool TestPoint(const DistanceProxy& proxy, const Length2& point) noexcept
 {
     const auto count = proxy.GetVertexCount();
     const auto vr = proxy.GetVertexRadius();

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -168,7 +168,7 @@ public:
     {
         assert(index != InvalidVertex);
         assert(index < m_count);
-        return *(m_vertices + index);
+        return *(m_vertices + index); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     }
 
     /// @brief Gets the normal for the given index.
@@ -176,7 +176,7 @@ public:
     {
         assert(index != InvalidVertex);
         assert(index < m_count);
-        return *(m_normals + index);
+        return *(m_normals + index); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     }
 
 private:

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -99,7 +99,7 @@ public:
     /// @warning Behavior is undefined if the normals aren't normals for adjacent vertices.
     /// @warning Behavior is undefined if any normal is not unique.
     ///
-    DistanceProxy(const NonNegative<Length> vertexRadius, const VertexCounter count,
+    DistanceProxy(const NonNegative<Length>& vertexRadius, const VertexCounter count,
                   const Length2* vertices, const UnitVec* normals) noexcept
         :
 #ifndef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
@@ -246,7 +246,7 @@ inline VertexCounter GetSupportIndex(const DistanceProxy& proxy, T dir) noexcept
 /// @return <code>true</code> if point is contained in the proxy, <code>false</code> otherwise.
 /// @relatedalso DistanceProxy
 /// @ingroup TestPointGroup
-bool TestPoint(const DistanceProxy& proxy, Length2 point) noexcept;
+bool TestPoint(const DistanceProxy& proxy, const Length2& point) noexcept;
 
 /// @brief Finds the lowest right most vertex in the given collection.
 std::size_t FindLowestRightMostVertex(Span<const Length2> vertices);

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -224,7 +224,7 @@ DynamicTree::Size UpdateUpwardFrom(DynamicTree::TreeNode nodes[], DynamicTree::S
 /// @details Finds the index of the "lowest cost" node using a surface area heuristic
 ///   (S.A.H.) for two dimensions.
 /// @warning Behavior is undefined if the given index is invalid or for an unused node.
-DynamicTree::Size FindLowestCostNode(const DynamicTree::TreeNode nodes[], AABB leafAABB,
+DynamicTree::Size FindLowestCostNode(const DynamicTree::TreeNode nodes[], const AABB& leafAABB,
                                      DynamicTree::Size index) noexcept
 {
     assert(IsValid(leafAABB));
@@ -637,7 +637,7 @@ void DynamicTree::RebuildBottomUp()
     Free(nodes);
 }
 
-void DynamicTree::ShiftOrigin(Length2 newOrigin) noexcept
+void DynamicTree::ShiftOrigin(const Length2& newOrigin) noexcept
 {
     // Build array of leaves. Free the rest.
     for (auto i = decltype(m_nodeCapacity){0}; i < m_nodeCapacity; ++i) {

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -497,7 +497,7 @@ inline const DynamicTree::TreeNode& DynamicTree::GetNode(Size index) const noexc
 {
     assert(index != GetInvalidSize());
     assert(index < m_nodeCapacity);
-    return m_nodes[index];
+    return *(m_nodes + index); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 }
 
 inline DynamicTree::Height DynamicTree::GetHeight(Size index) const noexcept

--- a/PlayRho/Collision/DynamicTree.hpp
+++ b/PlayRho/Collision/DynamicTree.hpp
@@ -230,7 +230,7 @@ public:
     /// @note Useful for large worlds.
     /// @note The shift formula is: <code>position -= newOrigin</code>.
     /// @param newOrigin the new origin with respect to the old origin.
-    void ShiftOrigin(Length2 newOrigin) noexcept;
+    void ShiftOrigin(const Length2& newOrigin) noexcept;
 
     /// @brief Gets the current node capacity of this tree.
     /// @see Reserve.
@@ -338,7 +338,7 @@ public:
     }
 
     /// @brief Initializing constructor.
-    constexpr TreeNode(const DynamicTreeLeafData& value, AABB aabb,
+    constexpr TreeNode(const DynamicTreeLeafData& value, const AABB& aabb,
                        Size other = DynamicTree::GetInvalidSize()) noexcept
         : m_aabb{aabb}, m_variant{value}, m_height{0}, m_other{other}
     {
@@ -346,7 +346,7 @@ public:
     }
 
     /// @brief Initializing constructor.
-    constexpr TreeNode(const DynamicTreeBranchData& value, AABB aabb, Height height,
+    constexpr TreeNode(const DynamicTreeBranchData& value, const AABB& aabb, Height height,
                        Size other = DynamicTree::GetInvalidSize()) noexcept
         : m_aabb{aabb}, m_variant{value}, m_height{height}, m_other{other}
     {
@@ -386,7 +386,7 @@ public:
 
     /// @brief Sets the node's AABB.
     /// @warning Behavior is undefined if called on a free/unused node!
-    constexpr void SetAABB(AABB value) noexcept
+    constexpr void SetAABB(const AABB& value) noexcept
     {
         assert(!IsUnused(m_height));
         m_aabb = value;

--- a/PlayRho/Collision/Manifold.cpp
+++ b/PlayRho/Collision/Manifold.cpp
@@ -57,7 +57,7 @@ inline index_type GetEdgeIndex(VertexCounter i1, VertexCounter i2, VertexCounter
 
 using VertexCounterPair = std::pair<VertexCounter, VertexCounter>;
 
-VertexCounterPair GetMostAntiParallelEdge(UnitVec shape0_rel_n0, const Transformation& xf0,
+VertexCounterPair GetMostAntiParallelEdge(const UnitVec& shape0_rel_n0, const Transformation& xf0,
                                           const DistanceProxy& shape1, const Transformation& xf1,
                                           const VertexCounter2 indices1) noexcept
 {
@@ -78,9 +78,9 @@ VertexCounterPair GetMostAntiParallelEdge(UnitVec shape0_rel_n0, const Transform
                : std::make_pair(secondIdx, firstIdx);
 }
 
-ClipList GetClipPoints(Length2 shape0_abs_v0, Length2 shape0_abs_v1, VertexCounterPair shape0_e,
-                       UnitVec shape0_abs_e0_dir, Length2 shape1_abs_v0, Length2 shape1_abs_v1,
-                       VertexCounterPair shape1_e)
+ClipList GetClipPoints(const Length2& shape0_abs_v0, const Length2& shape0_abs_v1, VertexCounterPair shape0_e,
+                       const UnitVec& shape0_abs_e0_dir, const Length2& shape1_abs_v0,
+                       const Length2& shape1_abs_v1, VertexCounterPair shape1_e)
 {
     // Gets the two vertices in world coordinates and their face-vertex contact features
     // of the incident edge of shape1
@@ -260,7 +260,7 @@ Manifold GetManifold(bool flipped, // NOLINT(readability-function-cognitive-comp
 }
 
 Manifold GetManifold(bool flipped, Length totalRadius, const DistanceProxy& shape,
-                     const Transformation& sxf, Length2 point, const Transformation& xfm)
+                     const Transformation& sxf, const Length2& point, const Transformation& xfm)
 {
     const auto vertexCount = shape.GetVertexCount();
     assert(vertexCount > 0);
@@ -344,8 +344,9 @@ Manifold GetManifold(bool flipped, Length totalRadius, const DistanceProxy& shap
                                  ContactFeature::e_vertex, 0, point);
 }
 
-Manifold GetManifold(const Length2& locationA, const Transformation& xfA, Length2 locationB,
-                     const Transformation& xfB, Length totalRadius) noexcept
+Manifold GetManifold(const Length2& locationA, const Transformation& xfA, // force line-break
+                     const Length2& locationB, const Transformation& xfB, // force line-break
+                     Length totalRadius) noexcept
 {
     const auto pA = Transform(locationA, xfA);
     const auto pB = Transform(locationB, xfB);
@@ -362,7 +363,7 @@ Manifold GetManifold(const Length2& locationA, const Transformation& xfA, Length
 
 Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA, //
                        const DistanceProxy& shapeB, const Transformation& xfB, //
-                       Manifold::Conf conf)
+                       const Manifold::Conf& conf)
 {
     // Assumes called after detecting AABB overlap.
     // Find edge normal of max separation on A - return if separating axis is found

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -163,7 +163,7 @@ public:
     /// @param iA Index of vertex from shape A representing the local center of "circle" A.
     /// @param vB Local center of "circle" B.
     /// @param iB Index of vertex from shape B representing the local center of "circle" B.
-    static inline Manifold GetForCircles(Length2 vA, CfIndex iA, Length2 vB, CfIndex iB) noexcept
+    static inline Manifold GetForCircles(const Length2& vA, CfIndex iA, const Length2& vB, CfIndex iB) noexcept
     {
         return Manifold{e_circles,
                         GetInvalid<UnitVec>(),
@@ -177,7 +177,7 @@ public:
     /// Gets a face A typed manifold.
     /// @param normalA Local normal of the face from polygon A.
     /// @param faceA Any point in local coordinates on the face whose normal was provided.
-    static inline Manifold GetForFaceA(UnitVec normalA, Length2 faceA) noexcept
+    static inline Manifold GetForFaceA(const UnitVec& normalA, const Length2& faceA) noexcept
     {
         return Manifold{e_faceA, normalA, faceA, 0, {{}}};
     }
@@ -186,7 +186,7 @@ public:
     /// @param ln Normal on polygon A.
     /// @param lp Center of face A.
     /// @param mp1 Manifold point 1 (of 1).
-    static inline Manifold GetForFaceA(UnitVec ln, Length2 lp, const Point& mp1) noexcept
+    static inline Manifold GetForFaceA(const UnitVec& ln, const Length2& lp, const Point& mp1) noexcept
     {
         // assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB ==
         // ContactFeature::e_face);
@@ -198,7 +198,7 @@ public:
     /// @param lp Center of face A.
     /// @param mp1 Manifold point 1 (of 2).
     /// @param mp2 Manifold point 2 (of 2).
-    static inline Manifold GetForFaceA(UnitVec ln, Length2 lp, const Point& mp1,
+    static inline Manifold GetForFaceA(const UnitVec& ln, const Length2& lp, const Point& mp1,
                                        const Point& mp2) noexcept
     {
         // assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB ==
@@ -213,7 +213,7 @@ public:
     /// Gets a face B typed manifold.
     /// @param ln Normal on polygon B.
     /// @param lp Center of face B.
-    static inline Manifold GetForFaceB(UnitVec ln, Length2 lp) noexcept
+    static inline Manifold GetForFaceB(const UnitVec& ln, const Length2& lp) noexcept
     {
         return Manifold{e_faceB, ln, lp, 0, {{}}};
     }
@@ -222,7 +222,7 @@ public:
     /// @param ln Normal on polygon B.
     /// @param lp Center of face B.
     /// @param mp1 Manifold point 1.
-    static inline Manifold GetForFaceB(UnitVec ln, Length2 lp, const Point& mp1) noexcept
+    static inline Manifold GetForFaceB(const UnitVec& ln, const Length2& lp, const Point& mp1) noexcept
     {
         // assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB ==
         // ContactFeature::e_face);
@@ -234,7 +234,7 @@ public:
     /// @param lp Center of face B.
     /// @param mp1 Manifold point 1 (of 2).
     /// @param mp2 Manifold point 2 (of 2).
-    static inline Manifold GetForFaceB(UnitVec ln, Length2 lp, const Point& mp1,
+    static inline Manifold GetForFaceB(const UnitVec& ln, const Length2& lp, const Point& mp1,
                                        const Point& mp2) noexcept
     {
         // assert(mp1.contactFeature.typeA == ContactFeature::e_face || mp1.contactFeature.typeB ==
@@ -245,7 +245,7 @@ public:
     }
 
     /// @brief Gets the face A manifold for the given data.
-    static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa) noexcept
+    static inline Manifold GetForFaceA(const UnitVec& na, CfIndex ia, const Length2& pa) noexcept
     {
         return Manifold{
             e_faceA,
@@ -259,7 +259,7 @@ public:
     }
 
     /// @brief Gets the face B manifold for the given data.
-    static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb) noexcept
+    static inline Manifold GetForFaceB(const UnitVec& nb, CfIndex ib, const Length2& pb) noexcept
     {
         return Manifold{
             e_faceB,
@@ -273,8 +273,8 @@ public:
     }
 
     /// @brief Gets the face A manifold for the given data.
-    static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa, CfType tb0, CfIndex ib0,
-                                       Length2 pb0) noexcept
+    static inline Manifold GetForFaceA(const UnitVec& na, CfIndex ia, const Length2& pa, CfType tb0, CfIndex ib0,
+                                       const Length2& pb0) noexcept
     {
         return Manifold{e_faceA,
                         na,
@@ -285,8 +285,8 @@ public:
     }
 
     /// @brief Gets the face B manifold for the given data.
-    static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb, CfType ta0, CfIndex ia0,
-                                       Length2 pa0) noexcept
+    static inline Manifold GetForFaceB(const UnitVec& nb, CfIndex ib, const Length2& pb, CfType ta0, CfIndex ia0,
+                                       const Length2& pa0) noexcept
     {
         return Manifold{e_faceB,
                         nb,
@@ -297,8 +297,8 @@ public:
     }
 
     /// @brief Gets the face A manifold for the given data.
-    static inline Manifold GetForFaceA(UnitVec na, CfIndex ia, Length2 pa, CfType tb0, CfIndex ib0,
-                                       Length2 pb0, CfType tb1, CfIndex ib1, Length2 pb1) noexcept
+    static inline Manifold GetForFaceA(const UnitVec& na, CfIndex ia, const Length2& pa, CfType tb0, CfIndex ib0,
+                                       const Length2& pb0, CfType tb1, CfIndex ib1, const Length2& pb1) noexcept
     {
         return Manifold{e_faceA,
                         na,
@@ -309,8 +309,8 @@ public:
     }
 
     /// @brief Gets the face B manifold for the given data.
-    static inline Manifold GetForFaceB(UnitVec nb, CfIndex ib, Length2 pb, CfType ta0, CfIndex ia0,
-                                       Length2 pa0, CfType ta1, CfIndex ia1, Length2 pa1) noexcept
+    static inline Manifold GetForFaceB(const UnitVec& nb, CfIndex ib, const Length2& pb, CfType ta0, CfIndex ia0,
+                                       const Length2& pa0, CfType ta1, CfIndex ia1, const Length2& pa1) noexcept
     {
         return Manifold{e_faceB,
                         nb,
@@ -374,7 +374,7 @@ public:
     /// @brief Sets the contact impulses for the given index.
     /// @details Sets the contact impulses for the given index where the first impulse
     ///   is the "normal impulse" and the second impulse is the "tangent impulse".
-    void SetContactImpulses(size_type index, Momentum2 value) noexcept
+    void SetContactImpulses(size_type index, const Momentum2& value) noexcept
     {
         assert(index < m_pointCount);
         m_points[index].normalImpulse = get<0>(value);
@@ -405,7 +405,7 @@ public:
     void AddPoint(const Point& mp) noexcept;
 
     /// @brief Adds a new point with the given data.
-    void AddPoint(CfType type, CfIndex index, Length2 point) noexcept;
+    void AddPoint(CfType type, CfIndex index, const Length2& point) noexcept;
 
     /// @brief Gets the local normal for a face-type manifold.
     /// @note Only valid for face-A or face-B type manifolds.
@@ -466,7 +466,7 @@ private:
     /// @param lp Local point.
     /// @param n number of points defined in array.
     /// @param mpa Manifold point array.
-    constexpr Manifold(Type t, UnitVec ln, Length2 lp, size_type n, const PointArray& mpa) noexcept;
+    constexpr Manifold(Type t, const UnitVec& ln, const Length2& lp, size_type n, const PointArray& mpa) noexcept;
 
     Type m_type = e_unset; ///< Type of collision this manifold is associated with (1-byte).
     size_type m_pointCount = 0; ///< Number of defined manifold points (1-byte).
@@ -514,7 +514,7 @@ constexpr Manifold::Conf GetDefaultManifoldConf() noexcept
 /// @relatedalso Manifold::Conf
 Manifold::Conf GetManifoldConf(const StepConf& conf) noexcept;
 
-constexpr Manifold::Manifold(Type t, UnitVec ln, Length2 lp, size_type n,
+constexpr Manifold::Manifold(Type t, const UnitVec& ln, const Length2& lp, size_type n,
                              const PointArray& mpa) noexcept
     : m_type{t}, m_pointCount{n}, m_localNormal{ln}, m_localPoint{lp}, m_points{mpa}
 {
@@ -541,7 +541,7 @@ inline void Manifold::AddPoint(const Point& mp) noexcept
     ++m_pointCount;
 }
 
-inline void Manifold::AddPoint(CfType type, CfIndex index, Length2 point) noexcept
+inline void Manifold::AddPoint(CfType type, CfIndex index, const Length2& point) noexcept
 {
     assert(m_pointCount < MaxManifoldPoints);
     switch (m_type) {
@@ -609,11 +609,12 @@ Manifold GetManifold(bool flipped, const DistanceProxy& shape0, const Transforma
 /// @pre The given distance proxy <code>GetVertexCount()</code> must be one or greater.
 /// @warning Behavior is undefined if the given distance proxy <code>GetVertexCount()</code> is less than one.
 Manifold GetManifold(bool flipped, Length totalRadius, const DistanceProxy& shape,
-                     const Transformation& sxf, Length2 point, const Transformation& xfm);
+                     const Transformation& sxf, const Length2& point, const Transformation& xfm);
 
 /// @brief Gets a point-to-point based manifold.
-Manifold GetManifold(const Length2& locationA, const Transformation& xfA, Length2 locationB,
-                     const Transformation& xfB, Length totalRadius) noexcept;
+Manifold GetManifold(const Length2& locationA, const Transformation& xfA, // force line-break
+                     const Length2& locationB, const Transformation& xfB, // force line-break
+                     Length totalRadius) noexcept;
 
 /// @brief Calculates the relevant collision manifold.
 ///
@@ -625,7 +626,7 @@ Manifold GetManifold(const Length2& locationA, const Transformation& xfA, Length
 ///
 Manifold CollideShapes(const DistanceProxy& shapeA, const Transformation& xfA,
                        const DistanceProxy& shapeB, const Transformation& xfB,
-                       Manifold::Conf conf = GetDefaultManifoldConf());
+                       const Manifold::Conf& conf = GetDefaultManifoldConf());
 #if 0
 Manifold CollideCached(const DistanceProxy& shapeA, const Transformation& xfA,
                        const DistanceProxy& shapeB, const Transformation& xfB,
@@ -639,7 +640,7 @@ Manifold GetManifold(const DistanceProxy& proxyA, const Transformation& transfor
 
 #if 0
 Length2 GetLocalPoint(const DistanceProxy& proxy, ContactFeature::Type type,
-                       ContactFeature::Index index);
+                      ContactFeature::Index index);
 #endif
 
 /// @brief Gets a unique name for the given manifold type.

--- a/PlayRho/Collision/Manifold.hpp
+++ b/PlayRho/Collision/Manifold.hpp
@@ -448,13 +448,15 @@ private:
         /// @brief Array indexing operator.
         constexpr Point& operator[](std::size_t i)
         {
-            return elements[i];
+            assert(i < MaxManifoldPoints);
+            return elements[i]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
         }
 
         /// @brief Array indexing operator.
         constexpr const Point& operator[](std::size_t i) const
         {
-            return elements[i];
+            assert(i < MaxManifoldPoints);
+            return elements[i]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
         }
     };
 

--- a/PlayRho/Collision/MassData.cpp
+++ b/PlayRho/Collision/MassData.cpp
@@ -30,7 +30,7 @@
 namespace playrho {
 namespace d2 {
 
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location)
+MassData GetMassData(Length r, NonNegative<AreaDensity> density, const Length2& location)
 {
     // Uses parallel axis theorem, perpendicular axis theorem, and the second moment of area.
     // See: https://en.wikipedia.org/wiki/Second_moment_of_area
@@ -53,7 +53,8 @@ MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 locatio
     return MassData{location, mass, I};
 }
 
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1)
+MassData GetMassData(Length r, NonNegative<AreaDensity> density, // force line-break
+                     const Length2& v0, const Length2& v1)
 {
     const auto r_squared = Area{r * r};
     const auto circle_area = r_squared * Pi;
@@ -131,7 +132,7 @@ MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
     
     auto center = Length2{};
     auto area = 0_m2;
-    auto I = SecondMomentOfArea{0};
+    auto I = SecondMomentOfArea{};
     
     // s is the reference point for forming triangles.
     // It's location doesn't change the result (except for rounding error).

--- a/PlayRho/Collision/MassData.hpp
+++ b/PlayRho/Collision/MassData.hpp
@@ -87,7 +87,7 @@ using MassData = ::playrho::detail::MassData<2>;
 /// @param density Areal density of mass.
 /// @param location Location of the center of the shape.
 ///
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 location);
+MassData GetMassData(Length r, NonNegative<AreaDensity> density, const Length2& location);
 
 /// @brief Computes the mass data for a linear shape.
 ///
@@ -96,7 +96,8 @@ MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 locatio
 /// @param v0 Location of vertex zero.
 /// @param v1 Location of vertex one.
 ///
-MassData GetMassData(Length r, NonNegative<AreaDensity> density, Length2 v0, Length2 v1);
+MassData GetMassData(Length r, NonNegative<AreaDensity> density, // force line-break
+                     const Length2& v0, const Length2& v1);
 
 /// @brief Gets the mass data for the given collection of vertices with the given
 ///    properties.

--- a/PlayRho/Collision/RayCastOutput.cpp
+++ b/PlayRho/Collision/RayCastOutput.cpp
@@ -36,7 +36,7 @@
 namespace playrho {
 namespace d2 {
 
-RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept
+RayCastOutput RayCast(Length radius, const Length2& location, const RayCastInput& input) noexcept
 {
     // Collision Detection in Interactive 3D Environments by Gino van den Bergen
     // From Section 3.1.2
@@ -85,9 +85,9 @@ RayCastOutput RayCast( // NOLINT(readability-function-cognitive-complexity)
     const auto pDelta = input.p2 - input.p1;
     for (auto i = decltype(max_size(pDelta)){0}; i < max_size(pDelta); ++i)
     {
-        const auto p1i = p1[i];
-        const auto pdi = pDelta[i];
-        const auto range = aabb.ranges[i];
+        const auto& p1i = p1[i];
+        const auto& pdi = pDelta[i];
+        const auto& range = aabb.ranges[i];
 
         if (AlmostZero(pdi))
         {

--- a/PlayRho/Collision/RayCastOutput.hpp
+++ b/PlayRho/Collision/RayCastOutput.hpp
@@ -78,7 +78,7 @@ using DynamicTreeRayCastCB = std::function<Real(BodyID body,
 using ShapeRayCastCB = std::function<RayCastOpcode(BodyID body,
                                                    ShapeID shape,
                                                    ChildCounter child,
-                                                   Length2 point,
+                                                   const Length2& point,
                                                    UnitVec normal)>;
 
 /// @defgroup RayCastGroup Ray Casting Functions
@@ -90,7 +90,7 @@ using ShapeRayCastCB = std::function<RayCastOpcode(BodyID body,
 /// @param radius Radius of the circle.
 /// @param location Location in world coordinates of the circle.
 /// @param input Ray-cast input parameters.
-RayCastOutput RayCast(Length radius, Length2 location, const RayCastInput& input) noexcept;
+RayCastOutput RayCast(Length radius, const Length2& location, const RayCastInput& input) noexcept;
 
 /// @brief Cast a ray against the given AABB.
 /// @param aabb Axis Aligned Bounding Box.

--- a/PlayRho/Collision/ShapeSeparation.cpp
+++ b/PlayRho/Collision/ShapeSeparation.cpp
@@ -36,7 +36,7 @@ namespace {
 /// @param vertices Vertices from second convex shape.
 /// @return Minimum separation and index or indices of the vertex or edge respectively
 ///   for which that's found.
-LengthIndices GetMinSeparationInfo(Length2 origin, UnitVec direction, Span<const Length2> vertices)
+LengthIndices GetMinSeparationInfo(const Length2& origin, const UnitVec& direction, Span<const Length2> vertices)
 {
     // Search for vertices most anti-parallel to directional normal from origin.
     // See: https://en.wikipedia.org/wiki/Antiparallel_(mathematics)#Antiparallel_vectors
@@ -63,8 +63,8 @@ LengthIndices GetMinSeparationInfo(Length2 origin, UnitVec direction, Span<const
 
 } // anonymous namespace
 
-SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
-                                   const DistanceProxy& proxy2, Transformation xf2)
+SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, const Transformation& xf1,
+                                   const DistanceProxy& proxy2, const Transformation& xf2)
 {
     // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
     auto separation = -std::numeric_limits<Length>::infinity();
@@ -103,8 +103,8 @@ SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation x
     return SeparationInfo{separation, firstIndex, secondIndices};
 }
 
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2)
+SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, const Transformation& xf1,
+                                const DistanceProxy& proxy2, const Transformation& xf2)
 {
     // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
     auto separation = -std::numeric_limits<Length>::infinity();
@@ -127,8 +127,9 @@ SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
     return SeparationInfo{separation, firstIndex, secondIndices};
 }
 
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2, Length stop)
+SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, const Transformation& xf1,
+                                const DistanceProxy& proxy2, const Transformation& xf2,
+                                Length stop)
 {
     // Find the max separation between proxy1 and proxy2 using edge normals from proxy1.
     auto separation = -std::numeric_limits<Length>::infinity();

--- a/PlayRho/Collision/ShapeSeparation.hpp
+++ b/PlayRho/Collision/ShapeSeparation.hpp
@@ -38,8 +38,8 @@ class DistanceProxy;
 ///   distance from each other in the direction of that normal), and the maximal distance.
 /// @relatedalso DistanceProxy
 /// @see Distance.
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2);
+SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, const Transformation& xf1,
+                                const DistanceProxy& proxy2, const Transformation& xf2);
 
 /// @brief Gets the max separation information.
 /// @return Index of the vertex and normal from <code>proxy1</code>,
@@ -47,8 +47,9 @@ SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
 ///   distance from each other in the direction of that normal), and the maximal distance.
 /// @relatedalso DistanceProxy
 /// @see Distance.
-SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
-                                const DistanceProxy& proxy2, Transformation xf2, Length stop);
+SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, const Transformation& xf1,
+                                const DistanceProxy& proxy2, const Transformation& xf2,
+                                Length stop);
 
 /// @brief Gets the max separation information for the first four vertices of the two
 ///   given shapes.
@@ -59,8 +60,8 @@ SeparationInfo GetMaxSeparation(const DistanceProxy& proxy1, Transformation xf1,
 ///   distance from each other in the direction of that normal), and the maximal distance.
 /// @relatedalso DistanceProxy
 /// @see Distance.
-SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, Transformation xf1,
-                                   const DistanceProxy& proxy2, Transformation xf2);
+SeparationInfo GetMaxSeparation4x4(const DistanceProxy& proxy1, const Transformation& xf1,
+                                   const DistanceProxy& proxy2, const Transformation& xf2);
 
 /// @brief Gets the max separation information.
 /// @return Index of the vertex and normal from <code>proxy1</code>,

--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -100,7 +100,7 @@ ChainShapeConf& ChainShapeConf::Rotate(const UnitVec& value)
     return *this;
 }
 
-ChainShapeConf& ChainShapeConf::Add(Length2 vertex)
+ChainShapeConf& ChainShapeConf::Add(const Length2& vertex)
 {
     if (!empty(m_vertices)) {
         auto vprev = m_vertices.back();
@@ -123,7 +123,7 @@ MassData ChainShapeConf::GetMassData() const
         if (vertexCount > 1) {
             // XXX: This overcounts for the overlapping circle shape.
             auto mass = 0_kg;
-            auto I = RotInertia{0};
+            auto I = RotInertia{};
             auto area = 0_m2;
             auto center = Length2{};
             auto vprev = GetVertex(0);
@@ -166,7 +166,7 @@ DistanceProxy ChainShapeConf::GetChild(ChildCounter index) const
 
 // Free functions...
 
-ChainShapeConf GetChainShapeConf(Length2 dimensions)
+ChainShapeConf GetChainShapeConf(const Length2& dimensions)
 {
     auto conf = ChainShapeConf{};
 

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -72,7 +72,7 @@ public:
     ChainShapeConf& Set(std::vector<Length2> vertices);
 
     /// @brief Adds the given vertex.
-    ChainShapeConf& Add(Length2 vertex);
+    ChainShapeConf& Add(const Length2& vertex);
 
     /// @brief Translates the vertices by the given amount.
     /// @note This function provides the strong exception guarantee. The state of this instance
@@ -249,7 +249,7 @@ inline void Rotate(ChainShapeConf& arg, const UnitVec& value)
 
 /// @brief Gets an enclosing chain shape configuration for an axis aligned rectangle of the
 ///    given dimensions (width and height).
-ChainShapeConf GetChainShapeConf(Length2 dimensions);
+ChainShapeConf GetChainShapeConf(const Length2& dimensions);
 
 /// @brief Gets an enclosing chain shape configuration for an axis aligned square of the
 ///    given dimension.

--- a/PlayRho/Collision/Shapes/Compositor.hpp
+++ b/PlayRho/Collision/Shapes/Compositor.hpp
@@ -52,12 +52,12 @@ struct Discriminator : Base {
 /// @note This class is not intended for standalone use.
 /// @see Compositor.
 template <class Set1, class Set2, class Set3, class Set4, class Set5, class Set6>
-struct PolicySelector : Discriminator<Set1, 1>, // NOLINT(readability-magic-numbers)
-                        Discriminator<Set2, 2>, // NOLINT(readability-magic-numbers)
-                        Discriminator<Set3, 3>, // NOLINT(readability-magic-numbers)
-                        Discriminator<Set4, 4>, // NOLINT(readability-magic-numbers)
-                        Discriminator<Set5, 5>, // NOLINT(readability-magic-numbers)
-                        Discriminator<Set6, 6>  // NOLINT(readability-magic-numbers)
+struct PolicySelector : Discriminator<Set1, 1>, // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+                        Discriminator<Set2, 2>, // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+                        Discriminator<Set3, 3>, // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+                        Discriminator<Set4, 4>, // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+                        Discriminator<Set5, 5>, // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+                        Discriminator<Set6, 6>  // NOLINT(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 {
 };
 

--- a/PlayRho/Collision/Shapes/Compositor.hpp
+++ b/PlayRho/Collision/Shapes/Compositor.hpp
@@ -217,7 +217,7 @@ public:
     DynamicRectangle() = default;
 
     /// @brief Initializing constructor.
-    DynamicRectangle(Length width, Length height, Length2 offset = Length2{})
+    DynamicRectangle(Length width, Length height, const Length2& offset = Length2{})
         : vertices{Length2{+width / 2, -height / 2} + offset, //
                    Length2{+width / 2, +height / 2} + offset, //
                    Length2{-width / 2, +height / 2} + offset, //
@@ -236,7 +236,7 @@ public:
 
     /// @brief Sets the dimensions of this rectangle.
     /// @see GetDimensions.
-    void SetDimensions(Length2 val)
+    void SetDimensions(const Length2& val)
     {
         const auto offset = GetOffset();
         vertices = {Length2{+GetX(val) / 2, -GetY(val) / 2} + offset, //
@@ -255,7 +255,7 @@ public:
 
     /// @brief Sets the x and y offset of this rectangle.
     /// @see GetOffset.
-    void SetOffset(Length2 val)
+    void SetOffset(const Length2& val)
     {
         const auto dims = GetDimensions();
         vertices = {Length2{+GetX(dims) / 2, -GetY(dims) / 2} + val, //
@@ -315,13 +315,13 @@ public:
     }
 
     /// @brief Translates the vertices of this geometry.
-    void Translate(Length2 value)
+    void Translate(const Length2& value)
     {
         SetOffset(GetOffset() + value);
     }
 
     /// @brief Scales the vertices of this geometry.
-    void Scale(Vec2 value)
+    void Scale(const Vec2& value)
     {
         const auto dims = GetDimensions();
         SetDimensions(Length2{GetX(dims) * GetX(value), GetY(dims) * GetY(value)});

--- a/PlayRho/Collision/Shapes/DiskShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/DiskShapeConf.hpp
@@ -62,7 +62,7 @@ struct DiskShapeConf : ShapeBuilder<DiskShapeConf> {
     }
 
     /// @brief Uses the given value as the location.
-    constexpr DiskShapeConf& UseLocation(Length2 value) noexcept
+    constexpr DiskShapeConf& UseLocation(const Length2& value) noexcept
     {
         location = value;
         return *this;
@@ -76,14 +76,14 @@ struct DiskShapeConf : ShapeBuilder<DiskShapeConf> {
     }
 
     /// @brief Translates the location by the given amount.
-    constexpr DiskShapeConf& Translate(Length2 value) noexcept
+    constexpr DiskShapeConf& Translate(const Length2& value) noexcept
     {
         location += value;
         return *this;
     }
 
     /// @brief Scales the location by the given amount.
-    constexpr DiskShapeConf& Scale(Vec2 value) noexcept
+    constexpr DiskShapeConf& Scale(const Vec2& value) noexcept
     {
         location = Length2{GetX(location) * GetX(value), GetY(location) * GetY(value)};
         return *this;

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.cpp
@@ -28,7 +28,8 @@ namespace d2 {
 
 static_assert(IsValidShapeType<EdgeShapeConf>::value);
 
-EdgeShapeConf::EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf) noexcept
+EdgeShapeConf::EdgeShapeConf(const Length2& vA, const Length2& vB, // force line-break
+                             const EdgeShapeConf& conf) noexcept
     : ShapeBuilder{conf}, vertexRadius{conf.vertexRadius}, m_vertices{vA, vB}
 {
     const auto normal = GetUnitVector(GetFwdPerpendicular(vB - vA));
@@ -36,7 +37,7 @@ EdgeShapeConf::EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf) 
     m_normals[1] = -normal;
 }
 
-EdgeShapeConf& EdgeShapeConf::Set(Length2 vA, Length2 vB) noexcept
+EdgeShapeConf& EdgeShapeConf::Set(const Length2& vA, const Length2& vB) noexcept
 {
     m_vertices[0] = vA;
     m_vertices[1] = vB;

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -64,10 +64,11 @@ public:
     EdgeShapeConf() noexcept = default;
 
     /// @brief Initializing constructor.
-    EdgeShapeConf(Length2 vA, Length2 vB, const EdgeShapeConf& conf = GetDefaultConf()) noexcept;
+    EdgeShapeConf(const Length2& vA, const Length2& vB, // force line-break
+                  const EdgeShapeConf& conf = GetDefaultConf()) noexcept;
 
     /// @brief Sets both vertices in one call.
-    EdgeShapeConf& Set(Length2 vA, Length2 vB) noexcept;
+    EdgeShapeConf& Set(const Length2& vA, const Length2& vB) noexcept;
 
     /// @brief Uses the given vertex radius.
     EdgeShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;

--- a/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/EdgeShapeConf.hpp
@@ -96,7 +96,10 @@ public:
     /// @brief Gets the "child" shape.
     DistanceProxy GetChild() const noexcept
     {
-        return DistanceProxy{vertexRadius, 2, m_vertices, m_normals};
+        return DistanceProxy{vertexRadius, 2, // force line-break
+            static_cast<const Length2*>(m_vertices), // explicitly decay array into pointer
+            static_cast<const UnitVec*>(m_normals) // explicitly decay array into pointer
+        };
     }
 
     /// @brief Vertex radius.

--- a/PlayRho/Collision/Shapes/MultiShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/MultiShapeConf.cpp
@@ -39,7 +39,7 @@ MassData GetMassData(const MultiShapeConf& arg)
     auto mass = 0_kg;
     const auto origin = Length2{};
     auto weightedCenter = origin * Kilogram;
-    auto I = RotInertia{0};
+    auto I = RotInertia{};
     const auto density = arg.density;
 
     std::for_each(begin(arg.children), end(arg.children), [&](const ConvexHull& ch) {

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -70,7 +70,7 @@ PolygonShapeConf& PolygonShapeConf::UseVertices(const std::vector<Length2>& vert
     return Set(Span<const Length2>(data(verts), size(verts)));
 }
 
-PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy, Length2 center,
+PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy, const Length2& center,
                                              Angle angle)
 {
     SetAsBox(hx, hy);
@@ -78,7 +78,7 @@ PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy, Length2 cente
     return *this;
 }
 
-PolygonShapeConf& PolygonShapeConf::Transform(Transformation xfm) noexcept
+PolygonShapeConf& PolygonShapeConf::Transform(const Transformation& xfm) noexcept
 {
     for (auto i = decltype(GetVertexCount()){0}; i < GetVertexCount(); ++i) {
         m_vertices[i] = playrho::d2::Transform(m_vertices[i], xfm);
@@ -187,7 +187,7 @@ bool Validate(const Span<const Length2>& verts)
     for (auto i = decltype(count){0}; i < count; ++i) {
         const auto i1 = i;
         const auto i2 = GetModuloNext(i1, count);
-        const auto p = verts[i1];
+        const auto& p = verts[i1];
         const auto e = verts[i2] - p;
         for (auto j = decltype(count){0}; j < count; ++j) {
             if ((j == i1) || (j == i2)) {

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -93,7 +93,7 @@ public:
     PolygonShapeConf& SetAsBox(Length hx, Length hy);
 
     /// @brief Sets the vertices for the described box.
-    PolygonShapeConf& SetAsBox(Length hx, Length hy, Length2 center, Angle angle);
+    PolygonShapeConf& SetAsBox(Length hx, Length hy, const Length2& center, Angle angle);
 
     /// @brief Sets the vertices to a convex hull of the given ones.
     /// @note The size of the span must be in the range [1, <code>MaxShapeVertices</code>].
@@ -110,7 +110,7 @@ public:
     PolygonShapeConf& Set(const VertexSet& points);
 
     /// @brief Transforms the vertices by the given transformation.
-    PolygonShapeConf& Transform(Transformation xfm) noexcept;
+    PolygonShapeConf& Transform(const Transformation& xfm) noexcept;
 
     /// @brief Transforms the vertices by the given transformation matrix.
     /// @see https://en.wikipedia.org/wiki/Transformation_matrix

--- a/PlayRho/Collision/Shapes/Shape.cpp
+++ b/PlayRho/Collision/Shapes/Shape.cpp
@@ -29,7 +29,7 @@ namespace d2 {
 // construction nor copy/move assignment.
 static_assert(!IsValidShapeType<Shape>::value);
 
-bool TestPoint(const Shape& shape, Length2 point) noexcept
+bool TestPoint(const Shape& shape, const Length2& point) noexcept
 {
     const auto childCount = GetChildCount(shape);
     for (auto i = decltype(childCount){0}; i < childCount; ++i) {

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -212,8 +212,8 @@ SetFilter(T& o, Filter value)
 
 /// @brief Fallback translate function that throws unless the given value has no effect.
 template <class T>
-std::enable_if_t<IsValidShapeType<T>::value && !HasTranslate<T>::value, void>
-Translate(T&, Length2 value)
+auto Translate(T&, const Length2& value)
+    -> std::enable_if_t<IsValidShapeType<T>::value && !HasTranslate<T>::value, void>
 {
     if (Length2{} != value) {
         throw InvalidArgument("Translate non-zero amount not supported");
@@ -222,7 +222,8 @@ Translate(T&, Length2 value)
 
 /// @brief Fallback scale function that throws unless the given value has no effect.
 template <class T>
-std::enable_if_t<IsValidShapeType<T>::value && !HasScale<T>::value, void> Scale(T&, Vec2 value)
+auto Scale(T&, const Vec2& value)
+    -> std::enable_if_t<IsValidShapeType<T>::value && !HasScale<T>::value, void>
 {
     if (Vec2{Real(1), Real(1)} != value) {
         throw InvalidArgument("Scale non-identity amount not supported");
@@ -231,8 +232,8 @@ std::enable_if_t<IsValidShapeType<T>::value && !HasScale<T>::value, void> Scale(
 
 /// @brief Fallback rotate function that throws unless the given value has no effect.
 template <class T>
-std::enable_if_t<IsValidShapeType<T>::value && !HasRotate<T>::value, void> Rotate(T&,
-                                                                                  UnitVec value)
+auto Rotate(T&, const UnitVec& value)
+    -> std::enable_if_t<IsValidShapeType<T>::value && !HasRotate<T>::value, void>
 {
     if (UnitVec::GetRight() != value) {
         throw InvalidArgument("Rotate non-zero amount not supported");
@@ -887,7 +888,7 @@ private:
 ///   <code>false</code> otherwise.
 /// @relatedalso Shape
 /// @ingroup TestPointGroup
-bool TestPoint(const Shape& shape, Length2 point) noexcept;
+bool TestPoint(const Shape& shape, const Length2& point) noexcept;
 
 /// @brief Gets the vertex count for the specified child of the given shape.
 /// @relatedalso Shape

--- a/PlayRho/Collision/Shapes/Shape.hpp
+++ b/PlayRho/Collision/Shapes/Shape.hpp
@@ -644,8 +644,8 @@ public:
 
 private:
     /// @brief Internal configuration concept.
-    /// @note Provides the interface for runtime value polymorphism.
-    struct Concept {
+    /// @details Provides an internal pure virtual interface for the runtime value polymorphism.
+    struct Concept { // NOLINT(cppcoreguidelines-special-member-functions)
         virtual ~Concept() = default;
 
         /// @brief Clones this concept and returns a pointer to a mutable copy.

--- a/PlayRho/Collision/SimplexEdge.hpp
+++ b/PlayRho/Collision/SimplexEdge.hpp
@@ -46,8 +46,8 @@ public:
     /// @param iA Index of point A within the shape that it comes from.
     /// @param pB Point B in world coordinates.
     /// @param iB Index of point B within the shape that it comes from.
-    constexpr SimplexEdge(Length2 pA, VertexCounter iA,
-                          Length2 pB, VertexCounter iB) noexcept;
+    constexpr SimplexEdge(const Length2& pA, VertexCounter iA, // force line-break
+                          const Length2& pB, VertexCounter iB) noexcept;
     
     /// @brief Gets point A (in world coordinates).
     constexpr auto GetPointA() const noexcept { return m_wA; }
@@ -70,8 +70,8 @@ private:
     IndexPair m_indexPair{}; ///< Index pair. @details Indices of points A and B. 2-bytes.
 };
 
-constexpr SimplexEdge::SimplexEdge(Length2 pA, VertexCounter iA,
-                                                  Length2 pB, VertexCounter iB) noexcept:
+constexpr SimplexEdge::SimplexEdge(const Length2& pA, VertexCounter iA, // force line-break
+                                   const Length2& pB, VertexCounter iB) noexcept:
     m_wA{pA}, m_wB{pB}, m_indexPair{iA, iB}
 {
     // Intentionally empty.

--- a/PlayRho/Collision/WorldManifold.cpp
+++ b/PlayRho/Collision/WorldManifold.cpp
@@ -32,8 +32,8 @@ namespace d2 {
 namespace {
 
 inline WorldManifold GetForCircles(const Manifold& manifold,
-                                   const Transformation xfA, const Length radiusA,
-                                   const Transformation xfB, const Length radiusB)
+                                   const Transformation& xfA, const Length radiusA,
+                                   const Transformation& xfB, const Length radiusB)
 {
     assert(manifold.GetPointCount() == 1);
 
@@ -49,8 +49,8 @@ inline WorldManifold GetForCircles(const Manifold& manifold,
 }
 
 inline WorldManifold GetForFaceA(const Manifold& manifold,
-                                 const Transformation xfA, const Length radiusA,
-                                 const Transformation xfB, const Length radiusB)
+                                 const Transformation& xfA, const Length radiusA,
+                                 const Transformation& xfB, const Length radiusB)
 {
     const auto normal = Rotate(manifold.GetLocalNormal(), xfA.q);
     const auto planePoint = Transform(manifold.GetLocalPoint(), xfA);
@@ -76,8 +76,8 @@ inline WorldManifold GetForFaceA(const Manifold& manifold,
 }
 
 inline WorldManifold GetForFaceB(const Manifold& manifold,
-                                 const Transformation xfA, const Length radiusA,
-                                 const Transformation xfB, const Length radiusB)
+                                 const Transformation& xfA, const Length radiusA,
+                                 const Transformation& xfB, const Length radiusB)
 {
     const auto normal = Rotate(manifold.GetLocalNormal(), xfB.q);
     const auto planePoint = Transform(manifold.GetLocalPoint(), xfB);
@@ -106,8 +106,8 @@ inline WorldManifold GetForFaceB(const Manifold& manifold,
 } // anonymous namespace
 
 WorldManifold GetWorldManifold(const Manifold& manifold,
-                               Transformation xfA, Length radiusA,
-                               Transformation xfB, Length radiusB)
+                               const Transformation& xfA, Length radiusA,
+                               const Transformation& xfB, Length radiusB)
 {
     const auto type = manifold.GetType();
 

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -139,7 +139,7 @@ public:
     Length2 GetPoint(size_type index) const noexcept
     {
         assert(index < MaxManifoldPoints);
-        return m_points[index];
+        return m_points[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
     /// Gets the amount of separation at the given indexed point.
@@ -155,7 +155,7 @@ public:
     Length GetSeparation(size_type index) const noexcept
     {
         assert(index < MaxManifoldPoints);
-        return m_separations[index];
+        return m_separations[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
     /// @brief Gets the given index contact impulses.
@@ -163,7 +163,7 @@ public:
     Momentum2 GetImpulses(size_type index) const noexcept
     {
         assert(index < MaxManifoldPoints);
-        return m_impulses[index];
+        return m_impulses[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
 };
 

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -80,7 +80,7 @@ public:
     WorldManifold() = default;
     
     /// @brief Initializing constructor.
-    constexpr explicit WorldManifold(UnitVec normal) noexcept:
+    constexpr explicit WorldManifold(const UnitVec& normal) noexcept:
         m_normal{normal}
     {
         assert(IsValid(normal));
@@ -88,7 +88,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr explicit WorldManifold(UnitVec normal, PointData ps0) noexcept:
+    constexpr explicit WorldManifold(const UnitVec& normal, const PointData& ps0) noexcept:
         m_normal{normal},
         m_points{ps0.location, GetInvalid<Length2>()},
         m_impulses{ps0.impulse, Momentum2{}},
@@ -99,7 +99,7 @@ public:
     }
     
     /// @brief Initializing constructor.
-    constexpr explicit WorldManifold(UnitVec normal, PointData ps0, PointData ps1) noexcept:
+    constexpr explicit WorldManifold(const UnitVec& normal, const PointData& ps0, const PointData& ps1) noexcept:
         m_normal{normal},
         m_points{ps0.location, ps1.location},
         m_impulses{ps0.impulse, ps1.impulse},
@@ -186,8 +186,8 @@ public:
 /// @relatedalso Manifold
 ///
 WorldManifold GetWorldManifold(const Manifold& manifold,
-                               Transformation xfA, Length radiusA,
-                               Transformation xfB, Length radiusB);
+                               const Transformation& xfA, Length radiusA,
+                               const Transformation& xfB, Length radiusB);
 
 /// Gets the world manifold for the given data.
 ///

--- a/PlayRho/Common/ArrayList.hpp
+++ b/PlayRho/Common/ArrayList.hpp
@@ -57,6 +57,12 @@ public:
     /// @brief Constant pointer type.
     using const_pointer = const value_type*;
 
+    /// @brief Iterator type.
+    using iterator = value_type*;
+
+    /// @brief Constant iterator type.
+    using const_iterator = const value_type*;
+
     /// @brief Default constructor.
     /// @note Some older versions of gcc have issues with this being defaulted.
     constexpr ArrayList() noexcept = default;
@@ -103,7 +109,7 @@ public:
     constexpr void push_back(const value_type& value) noexcept
     {
         assert(m_size < MAXSIZE);
-        m_elements[m_size] = value;
+        m_elements[m_size] = value; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
         ++m_size;
     }
 
@@ -136,13 +142,13 @@ public:
     reference operator[](size_type index) noexcept
     {
         assert(index < MAXSIZE);
-        return m_elements[index];
+        return m_elements[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
 
     constexpr const_reference operator[](size_type index) const noexcept
     {
         assert(index < MAXSIZE);
-        return m_elements[index];
+        return m_elements[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
 
     /// Gets the size of this collection.
@@ -161,27 +167,34 @@ public:
         return MAXSIZE;
     }
 
-    auto data() const noexcept
+    pointer data() noexcept
     {
         return m_elements.data();
     }
 
-    pointer begin() noexcept
+    const_pointer data() const noexcept
     {
         return m_elements.data();
-    }
-    pointer end() noexcept
-    {
-        return m_elements.data() + m_size;
     }
 
-    const_pointer begin() const noexcept
+    iterator begin() noexcept
     {
-        return m_elements.data();
+        return data();
     }
-    const_pointer end() const noexcept
+
+    iterator end() noexcept
     {
-        return m_elements.data() + m_size;
+        return data() + size();
+    }
+
+    const_iterator begin() const noexcept
+    {
+        return data();
+    }
+
+    const_iterator end() const noexcept
+    {
+        return data() + size();
     }
 
 private:

--- a/PlayRho/Common/BlockAllocator.cpp
+++ b/PlayRho/Common/BlockAllocator.cpp
@@ -218,14 +218,12 @@ void BlockAllocator::Free(void* p, size_type n)
 
 void BlockAllocator::Clear()
 {
-    for (auto i = decltype(m_chunkCount){0}; i < m_chunkCount; ++i)
-    {
+    for (auto i = decltype(m_chunkCount){0}; i < m_chunkCount; ++i) {
         playrho::Free(m_chunks[i].blocks);
     }
-
     m_chunkCount = 0;
     std::memset(m_chunks, 0, m_chunkSpace * sizeof(Chunk));
-    std::memset(m_freeLists, 0, sizeof(m_freeLists));
+    std::memset(data(m_freeLists), 0, sizeof(m_freeLists));
 }
 
 } // namespace playrho

--- a/PlayRho/Common/DynamicMemory.cpp
+++ b/PlayRho/Common/DynamicMemory.cpp
@@ -29,7 +29,7 @@ namespace playrho {
     void* Alloc(std::size_t size)
     {
         if (size) {
-            const auto memory = std::malloc(size);
+            const auto memory = std::malloc(size); // NOLINT(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
             if (!memory) {
                 throw std::bad_alloc{};
             }
@@ -41,7 +41,7 @@ namespace playrho {
     void* Realloc(void* ptr, std::size_t size)
     {
         if (size) {
-            const auto memory = std::realloc(ptr, size);
+            const auto memory = std::realloc(ptr, size); // NOLINT(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
              if (!memory) {
                  throw std::bad_alloc{};
              }
@@ -53,7 +53,7 @@ namespace playrho {
     
     void Free(void* mem)
     {
-        std::free(mem);
+        std::free(mem); // NOLINT(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory)
     }
 
 } // namespace playrho

--- a/PlayRho/Common/GrowableStack.hpp
+++ b/PlayRho/Common/GrowableStack.hpp
@@ -23,6 +23,8 @@
 #define PLAYRHO_COMMON_GROWABLESTACK_HPP
 
 #include <PlayRho/Common/DynamicMemory.hpp>
+#include <PlayRho/Common/Templates.hpp>
+
 #include <cstring>
 
 namespace playrho {
@@ -61,7 +63,7 @@ public:
 
     ~GrowableStack() noexcept
     {
-        if (m_stack != m_array)
+        if (m_stack != data(m_array))
         {
             Free(m_stack);
             m_stack = nullptr;
@@ -81,7 +83,7 @@ public:
             m_capacity *= GetBufferGrowthRate();
             m_stack = AllocArray<T>(m_capacity);
             std::memcpy(m_stack, old, m_count * sizeof(T));
-            if (old != m_array)
+            if (old != data(m_array))
             {
                 Free(old);
             }
@@ -127,7 +129,7 @@ public:
 
 private:
     ElementType m_array[N] = {}; ///< Array data.
-    ElementType* m_stack = m_array; ///< Pointer to array of data.
+    ElementType* m_stack = data(m_array); ///< Pointer to array of data.
     CountType m_count = 0; ///< Count of elements.
     CountType m_capacity = N; ///< Capacity for storing elements.
 };

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -37,7 +37,7 @@ constexpr auto cfloor(T v) noexcept
 /// @brief Constant expression enhanced floor function.
 /// @note Unlike <code>std::floor</code>, this function is only defined for finite values.
 /// @see https://en.cppreference.com/w/cpp/numeric/math/floor
-#if defined(USE_BOOST_UNITS)
+#if defined(PLAYRHO_USE_BOOST_UNITS)
 template <class Unit>
 constexpr auto cfloor(const boost::units::quantity<Unit, Real>& v) noexcept
 {

--- a/PlayRho/Common/Math.cpp
+++ b/PlayRho/Common/Math.cpp
@@ -172,12 +172,11 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices)
 
     for (auto i = decltype(size(vertices)){0}; i < size(vertices); ++i) {
         // Triangle vertices.
-        const auto p1 = pRef;
-        const auto p2 = vertices[i];
-        const auto p3 = vertices[GetModuloNext(i, size(vertices))];
+        const auto& p2 = vertices[i];
+        const auto& p3 = vertices[GetModuloNext(i, size(vertices))];
 
-        const auto e1 = p2 - p1;
-        const auto e2 = p3 - p1;
+        const auto e1 = p2 - pRef;
+        const auto e2 = p3 - pRef;
 
         constexpr auto RealInverseOfTwo = Real{1} / Real{2};
         const auto triangleArea = Area{Cross(e1, e2) * RealInverseOfTwo};
@@ -185,7 +184,7 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices)
 
         // Area weighted centroid
         constexpr auto RealInverseOfThree = Real{1} / Real{3};
-        const auto aveP = (p1 + p2 + p3) * RealInverseOfThree;
+        const auto aveP = (pRef + p2 + p3) * RealInverseOfThree;
         c += triangleArea * aveP;
     }
 
@@ -237,9 +236,9 @@ NonNegative<Area> GetAreaOfPolygon(const Span<const Length2>& vertices)
     auto sum = 0_m2;
     const auto count = size(vertices);
     for (auto i = decltype(count){0}; i < count; ++i) {
-        const auto last_v = vertices[GetModuloPrev(i, count)];
-        const auto this_v = vertices[i];
-        const auto next_v = vertices[GetModuloNext(i, count)];
+        const auto& last_v = vertices[GetModuloPrev(i, count)];
+        const auto& this_v = vertices[i];
+        const auto& next_v = vertices[GetModuloNext(i, count)];
         sum += GetX(this_v) * (GetY(next_v) - GetY(last_v));
     }
 
@@ -263,8 +262,8 @@ SecondMomentOfArea GetPolarMoment(const Span<const Length2>& vertices)
     auto sum_y = SquareMeter * SquareMeter * 0;
     const auto count = size(vertices);
     for (auto i = decltype(count){0}; i < count; ++i) {
-        const auto this_v = vertices[i];
-        const auto next_v = vertices[GetModuloNext(i, count)];
+        const auto& this_v = vertices[i];
+        const auto& next_v = vertices[GetModuloNext(i, count)];
         const auto fact_b = Cross(this_v, next_v);
         sum_x += [&]() {
             const auto fact_a =

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -66,42 +66,42 @@ using std::trunc;
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-constexpr auto& GetX(T& value)
+constexpr auto GetX(T& value) -> decltype(get<0>(value))
 {
     return get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-constexpr auto& GetY(T& value)
+constexpr auto GetY(T& value) -> decltype(get<1>(value))
 {
     return get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-constexpr auto& GetZ(T& value)
+constexpr auto GetZ(T& value) -> decltype(get<2>(value))
 {
     return get<2>(value);
 }
 
 /// @brief Gets the "X" element of the given value - i.e. the first element.
 template <typename T>
-constexpr auto GetX(const T& value)
+constexpr auto GetX(const T& value) -> decltype(get<0>(value))
 {
     return get<0>(value);
 }
 
 /// @brief Gets the "Y" element of the given value - i.e. the second element.
 template <typename T>
-constexpr auto GetY(const T& value)
+constexpr auto GetY(const T& value) -> decltype(get<1>(value))
 {
     return get<1>(value);
 }
 
 /// @brief Gets the "Z" element of the given value - i.e. the third element.
 template <typename T>
-constexpr auto GetZ(const T& value)
+constexpr auto GetZ(const T& value) -> decltype(get<2>(value))
 {
     return get<2>(value);
 }
@@ -113,8 +113,8 @@ constexpr auto GetZ(const T& value)
 ///   to the value in the type that's the unsigned type equivalent of the input value.
 ///   <code>std::make_unsigned</code> merely provides the unsigned **type** equivalent.
 template <typename T>
-constexpr std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
-MakeUnsigned(const T& arg) noexcept
+constexpr auto MakeUnsigned(const T& arg) noexcept
+    -> std::enable_if_t<std::is_signed<T>::value, std::make_unsigned_t<T>>
 {
     return static_cast<std::make_unsigned_t<T>>(arg);
 }
@@ -135,16 +135,17 @@ constexpr auto StripUnit(const T& v) -> decltype(StripUnit(v.get()))
 /// @brief Secant method.
 /// @see https://en.wikipedia.org/wiki/Secant_method
 template <typename T, typename U>
-constexpr U Secant(T target, U a1, T s1, U a2, T s2) noexcept
+constexpr auto Secant(const T& target, const U& a1, const T& s1, const U& a2, const T& s2)
+    -> decltype(a1 + (target - s1) * (a2 - a1) / (s2 - s1))
 {
-    static_assert(IsArithmetic<T>::value && IsArithmetic<U>::value, "Arithmetic types required.");
     return a1 + (target - s1) * (a2 - a1) / (s2 - s1);
 }
 
 /// @brief Bisection method.
 /// @see https://en.wikipedia.org/wiki/Bisection_method
 template <typename T>
-constexpr T Bisect(T a1, T a2) noexcept
+constexpr auto Bisect(const T& a1, const T& a2)
+    -> decltype((a1 + a2) / 2)
 {
     return (a1 + a2) / 2;
 }
@@ -152,10 +153,9 @@ constexpr T Bisect(T a1, T a2) noexcept
 /// @brief Is-odd.
 /// @details Determines whether the given integral value is odd (as opposed to being even).
 template <typename T>
-constexpr bool IsOdd(T val) noexcept
+constexpr auto IsOdd(const T& val) -> decltype((val % 2) != T{})
 {
-    static_assert(std::is_integral<T>::value, "Integral type required.");
-    return val % 2;
+    return (val % 2) != T{};
 }
 
 /// @brief Squares the given value.
@@ -198,7 +198,7 @@ constexpr auto DefaultRoundOffPrecission = unsigned{100000};
 
 /// @brief Computes the rounded value of the given value.
 template <typename T>
-auto RoundOff(T value, unsigned precision = DefaultRoundOffPrecission) ->
+auto RoundOff(const T& value, unsigned precision = DefaultRoundOffPrecission) ->
     decltype(round(value * static_cast<T>(precision)) / static_cast<T>(precision))
 {
     const auto factor = static_cast<T>(precision);
@@ -215,7 +215,7 @@ inline auto RoundOff(const Vec2& value, std::uint32_t precision = DefaultRoundOf
 /// @brief Absolute value function for vectors.
 /// @relatedalso Vector
 template <typename T, std::size_t N>
-constexpr Vector<T, N> abs(const Vector<T, N>& v) noexcept
+constexpr auto abs(const Vector<T, N>& v) noexcept -> decltype(abs(T{}), Vector<T, N>{})
 {
     auto result = Vector<T, N>{};
     for (auto i = decltype(N){0}; i < N; ++i) {
@@ -235,15 +235,15 @@ inline d2::UnitVec abs(const d2::UnitVec& v) noexcept
 /// odd results like a divide by zero trap occurring.
 /// @return <code>true</code> if the given value is almost zero, <code>false</code> otherwise.
 template <typename T>
-constexpr auto AlmostZero(T value) -> decltype(abs(value) < std::numeric_limits<T>::min())
+constexpr auto AlmostZero(const T& value) -> decltype(abs(value) < std::numeric_limits<T>::min())
 {
     return abs(value) < std::numeric_limits<T>::min();
 }
 
 /// @brief Determines whether the given two values are "almost equal".
 template <typename T>
-constexpr std::enable_if_t<std::is_floating_point<T>::value, bool> AlmostEqual(T x, T y,
-                                                                               int ulp = 2)
+constexpr auto AlmostEqual(const T& x, const T& y, int ulp = 2)
+    -> std::enable_if_t<std::is_floating_point<T>::value, bool>
 {
     // From http://en.cppreference.com/w/cpp/types/numeric_limits/epsilon :
     //   "the machine epsilon has to be scaled to the magnitude of the values used
@@ -664,7 +664,7 @@ Angle GetShortestDelta(Angle a0, Angle a1) noexcept;
 
 /// @brief Gets the forward/clockwise rotational angle to go from angle 1 to angle 2.
 /// @return Angular rotation in the clockwise direction to go from angle 1 to angle 2.
-constexpr Angle GetFwdRotationalAngle(const Angle a1, const Angle a2) noexcept
+constexpr Angle GetFwdRotationalAngle(const Angle& a1, const Angle& a2) noexcept
 {
     constexpr auto FullCircleAngle = 360_deg;
     return (a1 < a2) ? (a2 - a1) - FullCircleAngle : a2 - a1;
@@ -672,7 +672,7 @@ constexpr Angle GetFwdRotationalAngle(const Angle a1, const Angle a2) noexcept
 
 /// @brief Gets the reverse (counter) clockwise rotational angle to go from angle 1 to angle 2.
 /// @return Angular rotation in the counter clockwise direction to go from angle 1 to angle 2.
-constexpr Angle GetRevRotationalAngle(const Angle a1, const Angle a2) noexcept
+constexpr Angle GetRevRotationalAngle(const Angle& a1, const Angle& a2) noexcept
 {
     constexpr auto FullCircleAngle = 360_deg;
     return (a1 > a2) ? FullCircleAngle - (a1 - a2) : a2 - a1;
@@ -791,7 +791,7 @@ constexpr auto InverseRotate(const Vector2<T>& vector, const UnitVec& angle) noe
 /// @return value divided by its length if length not almost zero otherwise invalid value.
 /// @see AlmostEqual.
 template <class T>
-inline UnitVec GetUnitVector(const Vector2<T>& value, UnitVec fallback = UnitVec::GetDefaultFallback())
+inline UnitVec GetUnitVector(const Vector2<T>& value, const UnitVec& fallback = UnitVec::GetDefaultFallback())
 {
     return std::get<0>(UnitVec::Get(StripUnit(GetX(value)), StripUnit(GetY(value)), fallback));
 }
@@ -940,8 +940,8 @@ LinearVelocity2 GetContactRelVelocity(const Velocity& velA, const Length2& relA,
                                       const Length2& relB) noexcept;
 
 /// @brief Gets whether the given velocity is "under active" based on the given tolerances.
-inline bool IsUnderActive(const Velocity& velocity, const LinearVelocity linSleepTol,
-                          const AngularVelocity angSleepTol) noexcept
+inline bool IsUnderActive(const Velocity& velocity, const LinearVelocity& linSleepTol,
+                          const AngularVelocity& angSleepTol) noexcept
 {
     const auto linVelSquared = GetMagnitudeSquared(velocity.linear);
     const auto angVelSquared = Square(velocity.angular);
@@ -949,7 +949,7 @@ inline bool IsUnderActive(const Velocity& velocity, const LinearVelocity linSlee
 }
 
 /// @brief Gets the "effective" inverse mass.
-inline InvMass GetEffectiveInvMass(const InvRotInertia invRotI, const Length2& p, const UnitVec& q)
+inline InvMass GetEffectiveInvMass(const InvRotInertia& invRotI, const Length2& p, const UnitVec& q)
 {
     // InvRotInertia is L^-2 M^-1 QP^2. Therefore (L^-2 M^-1 QP^2) * (L^2 / QP^2) gives M^-1.
     return invRotI * Square(Length{Cross(p, q)} / Radian);

--- a/PlayRho/Common/NonNegative.hpp
+++ b/PlayRho/Common/NonNegative.hpp
@@ -32,16 +32,16 @@ struct NonNegativeChecker {
     using exception_type = std::invalid_argument;
 
     /// @brief Valid value supplying functor.
-    constexpr auto operator()() noexcept -> decltype(static_cast<T>(0))
+    constexpr auto operator()() noexcept -> decltype(T{})
     {
-        return static_cast<T>(0);
+        return T{};
     }
 
     /// @brief Value checking functor.
     /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(!(v >= static_cast<T>(0)), T{v})
+    constexpr auto operator()(const T& v) -> decltype(!(v >= T{}), T{v})
     {
-        if (!(v >= static_cast<T>(0))) {
+        if (!(v >= T{})) {
             throw exception_type("value not greater than nor equal to zero");
         }
         return v;

--- a/PlayRho/Common/Positive.hpp
+++ b/PlayRho/Common/Positive.hpp
@@ -33,9 +33,9 @@ struct PositiveChecker {
 
     /// @brief Value checking functor.
     /// @throws exception_type if given value is not valid.
-    constexpr auto operator()(const T& v) -> decltype(!(v > static_cast<T>(0)), T{v})
+    constexpr auto operator()(const T& v) -> decltype(!(v > T{}), T{v})
     {
-        if (!(v > static_cast<T>(0))) {
+        if (!(v > T{})) {
             throw exception_type("value not greater than zero");
         }
         return v;

--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -57,9 +57,6 @@ public:
 
     Span() = default;
 
-    /// @brief Copy constructor.
-    Span(const Span& copy) = default;
-
     /// @brief Initializing constructor.
     constexpr Span(pointer array, size_type size) noexcept : m_array{array}, m_size{size} {}
 

--- a/PlayRho/Common/StackAllocator.cpp
+++ b/PlayRho/Common/StackAllocator.cpp
@@ -61,8 +61,7 @@ void* StackAllocator::Allocate(size_type size)
 
     if (m_entryCount < m_max_entries)
     {
-        auto entry = m_entries + m_entryCount;
-        
+        const auto entry = m_entries + m_entryCount; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         const auto available = m_size - m_index;
         if (size > (available / sizeof(std::max_align_t)) * sizeof(std::max_align_t))
         {
@@ -71,19 +70,17 @@ void* StackAllocator::Allocate(size_type size)
         }
         else
         {
-            auto ptr = static_cast<void*>(m_data + m_index);
+            auto ptr = static_cast<void*>(m_data + m_index); // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
             auto space = available;
             entry->data = std::align(alignment_size(size), size, ptr, space);
             entry->usedMalloc = false;
             size += (available - space);
             m_index += size;
         }
-
         entry->size = size;
         m_allocation += size;
         m_maxAllocation = std::max(m_maxAllocation, m_allocation);
         ++m_entryCount;
-
         return entry->data;
     }
     return nullptr;
@@ -94,7 +91,7 @@ void StackAllocator::Free(void* p) noexcept
     if (p)
     {
         assert(m_entryCount > 0);
-        const auto entry = m_entries + m_entryCount - 1;
+        const auto entry = m_entries + m_entryCount - 1; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         assert(p == entry->data);
         if (entry->usedMalloc)
         {

--- a/PlayRho/Common/Sweep.hpp
+++ b/PlayRho/Common/Sweep.hpp
@@ -45,7 +45,7 @@ public:
     Sweep() = default;
 
     /// @brief Initializing constructor.
-    constexpr Sweep(const Position p0, const Position p1, const Length2 lc = Length2{0_m, 0_m},
+    constexpr Sweep(const Position& p0, const Position& p1, const Length2& lc = Length2{0_m, 0_m},
                     Real a0 = 0) noexcept
         : pos0{p0}, pos1{p1}, localCenter{lc}, alpha0{a0}
     {
@@ -54,7 +54,7 @@ public:
     }
 
     /// @brief Initializing constructor.
-    constexpr explicit Sweep(const Position p, const Length2 lc = Length2{0_m, 0_m})
+    constexpr explicit Sweep(const Position& p, const Length2& lc = Length2{0_m, 0_m})
         : Sweep{p, p, lc, 0}
     {
         // Intentionally empty.
@@ -132,7 +132,7 @@ constexpr bool operator!=(const Sweep& lhs, const Sweep& rhs)
 
 /// @brief Convenience function for setting the sweep's local center.
 /// @relatedalso Sweep
-inline void SetLocalCenter(Sweep& sweep, Length2 value) noexcept
+inline void SetLocalCenter(Sweep& sweep, const Length2& value) noexcept
 {
     sweep = Sweep{sweep.pos0, sweep.pos1, value, sweep.GetAlpha0()};
 }

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -465,7 +465,7 @@ private:
     static constexpr std::false_type check(...);
 
     /// @brief Type alias for given template parameters.
-    using type = decltype(check<Type>(nullptr));
+    using type = decltype(check<Type>(nullptr)); // NOLINT(cppcoreguidelines-pro-type-vararg)
 
 public:
     /// Whether or not the given type has the specified functor.

--- a/PlayRho/Common/TypeInfo.hpp
+++ b/PlayRho/Common/TypeInfo.hpp
@@ -54,14 +54,16 @@ std::string TypeNameAsString()
     // enum class Fruit {APPLE, PEAR};
     // std::cout << Name<Fruit>() << '\n';
     // produces: std::string Name() [T = Fruit]
-    return std::regex_replace(__PRETTY_FUNCTION__, std::regex(".*T = (.*)\\].*"), "$1");
+    return std::regex_replace(__PRETTY_FUNCTION__, // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                              std::regex(".*T = (.*)\\].*"), "$1");
 #elif defined(__GNUC__)
     // Use __PRETTY_FUNCTION__. **Note that despite its appearance, this is an identifier; it's not a macro**!
     // template <typename T> string Name() { return string{__PRETTY_FUNCTION__}; }
     // enum class Fruit {APPLE, PEAR};
     // std::cout << Name<Fruit>() << '\n';
     // produces: std::string Name() [with T = Fruit; std::string = std::__cxx11::basic_string<char>]
-    return std::regex_replace(__PRETTY_FUNCTION__, std::regex(".*T = (.*);.*"), "$1");
+    return std::regex_replace(__PRETTY_FUNCTION__, // NOLINT(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+                              std::regex(".*T = (.*);.*"), "$1");
 #elif defined(__FUNCSIG__)
     // Assume this is Microsoft Visual C++ or compatible compiler and format.
     // enum class Fruit {APPLE, PEAR};

--- a/PlayRho/Common/UnitVec.hpp
+++ b/PlayRho/Common/UnitVec.hpp
@@ -124,7 +124,7 @@ public:
     /// @brief Gets the unit vector & magnitude from the given parameters.
     template <typename T>
     static PolarCoord<T> Get(const T x, const T y,
-                             const UnitVec fallback = GetDefaultFallback()) noexcept
+                             const UnitVec& fallback = GetDefaultFallback()) noexcept
     {
         // Try the faster way first...
         const auto magnitudeSquared = x * x + y * y;
@@ -144,7 +144,7 @@ public:
         }
         
         // Give up and return the fallback value.
-        return std::make_pair(fallback, T{0});
+        return std::make_pair(fallback, T{});
     }
 
     /// @brief Gets the given angled unit vector.
@@ -252,7 +252,7 @@ public:
     ///
     /// @return Result of rotating this unit vector by the given amount.
     ///
-    constexpr UnitVec Rotate(UnitVec amount) const noexcept
+    constexpr UnitVec Rotate(const UnitVec& amount) const noexcept
     {
         return UnitVec{GetX() * amount.GetX() - GetY() * amount.GetY(),
                         GetY() * amount.GetX() + GetX() * amount.GetY()};
@@ -306,20 +306,20 @@ private:
 // Free functions...
 
 /// @brief Gets the "X-axis".
-constexpr UnitVec GetXAxis(UnitVec rot) noexcept { return rot; }
+constexpr UnitVec GetXAxis(const UnitVec& rot) noexcept { return rot; }
 
 /// @brief Gets the "Y-axis".
 /// @note This is the reverse perpendicular vector of the given unit vector.
-constexpr UnitVec GetYAxis(UnitVec rot) noexcept { return rot.GetRevPerpendicular(); }
+constexpr UnitVec GetYAxis(const UnitVec& rot) noexcept { return rot.GetRevPerpendicular(); }
 
 /// @brief Equality operator.
-constexpr bool operator==(const UnitVec a, const UnitVec b) noexcept
+constexpr bool operator==(const UnitVec& a, const UnitVec& b) noexcept
 {
     return (a.GetX() == b.GetX()) && (a.GetY() == b.GetY());
 }
 
 /// @brief Inequality operator.
-constexpr bool operator!=(const UnitVec a, const UnitVec b) noexcept
+constexpr bool operator!=(const UnitVec& a, const UnitVec& b) noexcept
 {
     return (a.GetX() != b.GetX()) || (a.GetY() != b.GetY());
 }
@@ -330,7 +330,7 @@ constexpr bool operator!=(const UnitVec a, const UnitVec b) noexcept
 /// @param vector Vector to return a counter-clockwise perpendicular equivalent for.
 /// @return A counter-clockwise 90-degree rotation of the given vector.
 /// @see GetFwdPerpendicular.
-constexpr UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
+constexpr UnitVec GetRevPerpendicular(const UnitVec& vector) noexcept
 {
     return vector.GetRevPerpendicular();
 }
@@ -340,7 +340,7 @@ constexpr UnitVec GetRevPerpendicular(const UnitVec vector) noexcept
 /// @param vector Vector to return a clockwise perpendicular equivalent for.
 /// @return A clockwise 90-degree rotation of the given vector.
 /// @see GetRevPerpendicular.
-constexpr UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
+constexpr UnitVec GetFwdPerpendicular(const UnitVec& vector) noexcept
 {
     return vector.GetFwdPerpendicular();
 }
@@ -348,20 +348,20 @@ constexpr UnitVec GetFwdPerpendicular(const UnitVec vector) noexcept
 /// @brief Rotates a unit vector by the angle expressed by the second unit vector.
 /// @return Unit vector for the angle that's the sum of the two angles expressed by
 ///   the input unit vectors.
-constexpr UnitVec Rotate(const UnitVec vector, const UnitVec& angle) noexcept
+constexpr UnitVec Rotate(const UnitVec& vector, const UnitVec& angle) noexcept
 {
     return vector.Rotate(angle);
 }
 
 /// @brief Inverse rotates a vector.
-constexpr UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noexcept
+constexpr UnitVec InverseRotate(const UnitVec& vector, const UnitVec& angle) noexcept
 {
     return vector.Rotate(angle.FlipY());
 }
 
 /// @brief Gets the specified element of the given collection.
 template <std::size_t I>
-constexpr UnitVec::value_type get(UnitVec v) noexcept
+constexpr UnitVec::value_type get(const UnitVec& v) noexcept
 {
     static_assert(I < UnitVec::size(), "Index out of bounds in playrho::get<> (playrho::UnitVec)");
     switch (I)
@@ -373,14 +373,14 @@ constexpr UnitVec::value_type get(UnitVec v) noexcept
 
 /// @brief Gets element 0 of the given collection.
 template <>
-constexpr UnitVec::value_type get<0>(UnitVec v) noexcept
+constexpr UnitVec::value_type get<0>(const UnitVec& v) noexcept
 {
     return v.GetX();
 }
 
 /// @brief Gets element 1 of the given collection.
 template <>
-constexpr UnitVec::value_type get<1>(UnitVec v) noexcept
+constexpr UnitVec::value_type get<1>(const UnitVec& v) noexcept
 {
     return v.GetY();
 }

--- a/PlayRho/Common/UnitVec.hpp
+++ b/PlayRho/Common/UnitVec.hpp
@@ -66,7 +66,7 @@ public:
     
     /// @brief Constant reverse iterator type.
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-    
+
     /// @brief Gets the right-ward oriented unit vector.
     /// @note This is the value for the 0/4 turned (0 angled) unit vector.
     /// @note This is the reverse perpendicular unit vector of the bottom oriented vector.
@@ -92,7 +92,7 @@ public:
     static constexpr UnitVec GetBottom() noexcept { return UnitVec{0, -1}; }
 
     /// @brief Gets the non-oriented unit vector.
-    static constexpr UnitVec GetZero() noexcept { return UnitVec{0, 0}; }
+    static constexpr UnitVec GetZero() noexcept { return UnitVec{}; }
 
     /// @brief Gets the 45 degree unit vector.
     /// @details This is the unit vector in the positive X and Y quadrant where X == Y.
@@ -158,20 +158,20 @@ public:
     constexpr UnitVec() noexcept = default;
     
     /// @brief Gets the max size.
-    static constexpr size_type max_size() noexcept { return size_type{2}; }
+    static constexpr size_type max_size() noexcept { return N; }
     
     /// @brief Gets the size.
-    static constexpr size_type size() noexcept { return size_type{2}; }
+    static constexpr size_type size() noexcept { return N; }
     
     /// @brief Whether empty.
     /// @note Always false for N > 0.
     static constexpr bool empty() noexcept { return false; }
     
     /// @brief Gets a "begin" iterator.
-    const_iterator begin() const noexcept { return const_iterator(m_elems); }
+    const_iterator begin() const noexcept { return const_iterator(data()); }
     
     /// @brief Gets an "end" iterator.
-    const_iterator end() const noexcept { return const_iterator(m_elems + 2); }
+    const_iterator end() const noexcept { return const_iterator(data() + N); }
     
     /// @brief Gets a "begin" iterator.
     const_iterator cbegin() const noexcept { return begin(); }
@@ -182,13 +182,13 @@ public:
     /// @brief Gets a reverse "begin" iterator.
     const_reverse_iterator crbegin() const noexcept
     {
-        return const_reverse_iterator{m_elems + 2};
+        return const_reverse_iterator{data() + N};
     }
     
     /// @brief Gets a reverse "end" iterator.
     const_reverse_iterator crend() const noexcept
     {
-        return const_reverse_iterator{m_elems};
+        return const_reverse_iterator{data()};
     }
     
     /// @brief Gets a reverse "begin" iterator.
@@ -209,7 +209,7 @@ public:
     constexpr const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
-        return m_elems[pos];
+        return m_elems[pos]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
     /// @brief Gets a constant reference to the requested element.
@@ -220,13 +220,14 @@ public:
         {
             throw InvalidArgument("Vector::at: position >= size()");
         }
-        return m_elems[pos];
+        return m_elems[pos]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
     /// @brief Direct access to data.
     constexpr const_pointer data() const noexcept
     {
-        return m_elems;
+        // Cast to be more explicit about wanting to decay array into pointer...
+        return static_cast<const_pointer>(m_elems);
     }
     
     /// @brief Gets the "X" value.
@@ -290,14 +291,16 @@ public:
     }
 
 private:
-    
+    /// @brief Dimensionality of this type.
+    static constexpr auto N = std::size_t{2};
+
     /// @brief Initializing constructor.
     constexpr UnitVec(value_type x, value_type y) noexcept : m_elems{x, y}
     {
         // Intentionally empty.
     }
 
-    value_type m_elems[2] = { value_type{0}, value_type{0} }; ///< Element values.
+    value_type m_elems[N] = {}; ///< Element values.
 };
 
 // Free functions...
@@ -360,7 +363,7 @@ constexpr UnitVec InverseRotate(const UnitVec vector, const UnitVec& angle) noex
 template <std::size_t I>
 constexpr UnitVec::value_type get(UnitVec v) noexcept
 {
-    static_assert(I < 2, "Index out of bounds in playrho::get<> (playrho::UnitVec)");
+    static_assert(I < UnitVec::size(), "Index out of bounds in playrho::get<> (playrho::UnitVec)");
     switch (I)
     {
         case 0: return v.GetX();
@@ -405,7 +408,7 @@ namespace std {
 
 /// @brief Tuple size info for <code>playrho::d2::UnitVec</code>.
 template<>
-class tuple_size< playrho::d2::UnitVec >: public std::integral_constant<std::size_t, 2> {};
+class tuple_size< playrho::d2::UnitVec >: public std::integral_constant<std::size_t, playrho::d2::UnitVec::size()> {};
 
 /// @brief Tuple element type info for <code>playrho::d2::UnitVec</code>.
 template<std::size_t I>

--- a/PlayRho/Common/Units.hpp
+++ b/PlayRho/Common/Units.hpp
@@ -43,8 +43,8 @@
 #include <type_traits>
 #include <cmath>
 
-// #define USE_BOOST_UNITS
-#if defined(USE_BOOST_UNITS)
+// #define PLAYRHO_USE_BOOST_UNITS
+#if defined(PLAYRHO_USE_BOOST_UNITS)
 #include <boost/units/io.hpp>
 #include <boost/units/limits.hpp>
 #include <boost/units/cmath.hpp>
@@ -53,7 +53,6 @@
 #include <boost/units/systems/si/velocity.hpp>
 #include <boost/units/systems/si/acceleration.hpp>
 #include <boost/units/systems/si/frequency.hpp>
-#include <boost/units/systems/si/velocity.hpp>
 #include <boost/units/systems/si/mass.hpp>
 #include <boost/units/systems/si/momentum.hpp>
 #include <boost/units/systems/si/area.hpp>
@@ -108,16 +107,7 @@ using inverse_moment_of_inertia =
 
 } // namespace playrho::units::si
 
-#endif // defined(USE_BOOST_UNITS)
-
-// Define quantity and unit related macros to abstract away C-preprocessor definitions
-#if defined(USE_BOOST_UNITS)
-#define PLAYRHO_QUANTITY(BoostDimension) boost::units::quantity<BoostDimension, Real>
-#define PLAYRHO_UNIT(Quantity, BoostUnit) Quantity((BoostUnit)*Real(1))
-#else // defined(USE_BOOST_UNITS)
-#define PLAYRHO_QUANTITY(BoostDimension) Real
-#define PLAYRHO_UNIT(Quantity, BoostUnit) Real(1)
-#endif // defined(USE_BOOST_UNITS)
+#endif // defined(PLAYRHO_USE_BOOST_UNITS)
 
 namespace playrho {
 
@@ -131,6 +121,78 @@ constexpr auto MinutesPerHour = 60;
 
 /// @brief Hours per day.
 constexpr auto HoursPerDay = 24;
+
+// Setup quantity types...
+#if defined(PLAYRHO_USE_BOOST_UNITS)
+using time = boost::units::quantity<boost::units::si::time, Real>;
+using frequency = boost::units::quantity<boost::units::si::frequency, Real>;
+using length = boost::units::quantity<boost::units::si::length, Real>;
+using velocity = boost::units::quantity<boost::units::si::velocity, Real>;
+using acceleration = boost::units::quantity<boost::units::si::acceleration, Real>;
+using mass = boost::units::quantity<boost::units::si::mass, Real>;
+using inverse_mass = boost::units::quantity<playrho::units::si::inverse_mass, Real>;
+using area = boost::units::quantity<boost::units::si::area, Real>;
+using surface_density = boost::units::quantity<boost::units::si::surface_density, Real>;
+using plane_angle = boost::units::quantity<boost::units::si::plane_angle, Real>;
+using angular_velocity = boost::units::quantity<boost::units::si::angular_velocity, Real>;
+using angular_acceleration = boost::units::quantity<boost::units::si::angular_acceleration, Real>;
+using force = boost::units::quantity<boost::units::si::force, Real>;
+using torque = boost::units::quantity<boost::units::si::torque, Real>;
+using second_moment_of_area = boost::units::quantity<playrho::units::si::second_moment_of_area, Real>;
+using moment_of_inertia = boost::units::quantity<boost::units::si::moment_of_inertia, Real>;
+using inverse_moment_of_inertia = boost::units::quantity<playrho::units::si::inverse_moment_of_inertia, Real>;
+using momentum = boost::units::quantity<boost::units::si::momentum, Real>;
+using angular_momentum = boost::units::quantity<boost::units::si::angular_momentum, Real>;
+#else // !defined(PLAYRHO_USE_BOOST_UNITS)
+using time = Real;
+using frequency = Real;
+using length = Real;
+using velocity = Real;
+using acceleration = Real;
+using mass = Real;
+using inverse_mass = Real;
+using area = Real;
+using surface_density = Real;
+using plane_angle = Real;
+using angular_velocity = Real;
+using angular_acceleration = Real;
+using force = Real;
+using torque = Real;
+using second_moment_of_area = Real;
+using moment_of_inertia = Real;
+using inverse_moment_of_inertia = Real;
+using momentum = Real;
+using angular_momentum = Real;
+#endif // defined(PLAYRHO_USE_BOOST_UNITS)
+
+// Setup unit types...
+#if defined(PLAYRHO_USE_BOOST_UNITS)
+constexpr auto second = 1 * boost::units::si::second;
+constexpr auto hertz = 1 * boost::units::si::hertz;
+constexpr auto meter = 1 * boost::units::si::meter;
+constexpr auto meter_per_second = 1 * boost::units::si::meter_per_second;
+constexpr auto meter_per_second_squared = 1 * boost::units::si::meter_per_second_squared;
+constexpr auto kilogram = 1 * boost::units::si::kilogram;
+constexpr auto square_meter = 1 * boost::units::si::square_meter;
+constexpr auto kilogram_per_square_meter = 1 * boost::units::si::kilogram_per_square_meter;
+constexpr auto radian = 1 * boost::units::si::radian;
+constexpr auto radian_per_second = 1 * boost::units::si::radian_per_second;
+constexpr auto newton = 1 * boost::units::si::newton;
+constexpr auto newton_meter = 1 * boost::units::si::newton_meter;
+#else // !defined(PLAYRHO_USE_BOOST_UNITS)
+constexpr auto second = 1;
+constexpr auto hertz = 1;
+constexpr auto meter = 1;
+constexpr auto meter_per_second = 1;
+constexpr auto meter_per_second_squared = 1;
+constexpr auto kilogram = 1;
+constexpr auto square_meter = 1;
+constexpr auto kilogram_per_square_meter = 1;
+constexpr auto radian = 1;
+constexpr auto radian_per_second = 1;
+constexpr auto newton = 1;
+constexpr auto newton_meter = 1;
+#endif // defined(PLAYRHO_USE_BOOST_UNITS)
 
 }
 
@@ -150,7 +212,7 @@ constexpr auto HoursPerDay = 24;
 /// @note The SI unit of time is the second.
 /// @see Second.
 /// @see https://en.wikipedia.org/wiki/Time_in_physics
-using Time = PLAYRHO_QUANTITY(boost::units::si::time);
+using Time = detail::time;
 
 /// @brief Frequency quantity.
 /// @details This is the type alias for the frequency quantity. It's a derived quantity
@@ -160,7 +222,7 @@ using Time = PLAYRHO_QUANTITY(boost::units::si::time);
 /// @see Time.
 /// @see Hertz.
 /// @see https://en.wikipedia.org/wiki/Frequency
-using Frequency = PLAYRHO_QUANTITY(boost::units::si::frequency);
+using Frequency = detail::frequency;
 
 /// @brief Length quantity.
 /// @details This is the type alias for the length base quantity.
@@ -168,7 +230,7 @@ using Frequency = PLAYRHO_QUANTITY(boost::units::si::frequency);
 /// @note The SI unit of length is the meter.
 /// @see Meter.
 /// @see https://en.wikipedia.org/wiki/Length
-using Length = PLAYRHO_QUANTITY(boost::units::si::length);
+using Length = detail::length;
 
 /// @brief Linear velocity quantity.
 /// @details This is the type alias for the linear velocity derived quantity.
@@ -177,7 +239,7 @@ using Length = PLAYRHO_QUANTITY(boost::units::si::length);
 /// @see Length, Time.
 /// @see MeterPerSecond.
 /// @see https://en.wikipedia.org/wiki/Speed
-using LinearVelocity = PLAYRHO_QUANTITY(boost::units::si::velocity);
+using LinearVelocity = detail::velocity;
 
 /// @brief Linear acceleration quantity.
 /// @details This is the type alias for the linear acceleration derived quantity.
@@ -186,7 +248,7 @@ using LinearVelocity = PLAYRHO_QUANTITY(boost::units::si::velocity);
 /// @see Length, Time, LinearVelocity.
 /// @see MeterPerSquareSecond.
 /// @see https://en.wikipedia.org/wiki/Acceleration
-using LinearAcceleration = PLAYRHO_QUANTITY(boost::units::si::acceleration);
+using LinearAcceleration = detail::acceleration;
 
 /// @brief Mass quantity.
 /// @details This is the type alias for the mass base quantity.
@@ -194,14 +256,14 @@ using LinearAcceleration = PLAYRHO_QUANTITY(boost::units::si::acceleration);
 /// @note The SI unit of mass is the kilogram.
 /// @see Kilogram.
 /// @see https://en.wikipedia.org/wiki/Mass
-using Mass = PLAYRHO_QUANTITY(boost::units::si::mass);
+using Mass = detail::mass;
 
 /// @brief Inverse mass quantity.
 /// @details This is the type alias for the inverse mass quantity. It's a derived quantity
 ///   that's the inverse of mass.
 /// @note This quantity's dimension is: inverse mass (<code>M^-1</code>).
 /// @see Mass.
-using InvMass = PLAYRHO_QUANTITY(playrho::units::si::inverse_mass);
+using InvMass = detail::inverse_mass;
 
 /// @brief Area quantity.
 /// @details This is the type alias for the area quantity. It's a derived quantity.
@@ -210,7 +272,7 @@ using InvMass = PLAYRHO_QUANTITY(playrho::units::si::inverse_mass);
 /// @see Length.
 /// @see SquareMeter.
 /// @see https://en.wikipedia.org/wiki/Area
-using Area = PLAYRHO_QUANTITY(boost::units::si::area);
+using Area = detail::area;
 
 /// @brief Area (surface) density quantity.
 /// @details This is the type alias for the area density quantity. It's a derived quantity.
@@ -219,13 +281,13 @@ using Area = PLAYRHO_QUANTITY(boost::units::si::area);
 /// @see Mass, Area.
 /// @see KilogramPerSquareMeter.
 /// @see https://en.wikipedia.org/wiki/Area_density
-using AreaDensity = PLAYRHO_QUANTITY(boost::units::si::surface_density);
+using AreaDensity = detail::surface_density;
 
 /// @brief Angle quantity.
 /// @details This is the type alias for the plane angle base quantity.
 /// @note This quantity's dimension is: plane angle (<code>QP</code>).
 /// @see Radian, Degree.
-using Angle = PLAYRHO_QUANTITY(boost::units::si::plane_angle);
+using Angle = detail::plane_angle;
 
 /// @brief Angular velocity quantity.
 /// @details This is the type alias for the plane angular velocity quantity. It's a
@@ -235,7 +297,7 @@ using Angle = PLAYRHO_QUANTITY(boost::units::si::plane_angle);
 /// @see Angle, Time.
 /// @see RadianPerSecond, DegreePerSecond.
 /// @see https://en.wikipedia.org/wiki/Angular_velocity
-using AngularVelocity = PLAYRHO_QUANTITY(boost::units::si::angular_velocity);
+using AngularVelocity = detail::angular_velocity;
 
 /// @brief Angular acceleration quantity.
 /// @details This is the type alias for the angular acceleration quantity. It's a
@@ -245,7 +307,7 @@ using AngularVelocity = PLAYRHO_QUANTITY(boost::units::si::angular_velocity);
 /// @see Angle, Time, AngularVelocity.
 /// @see RadianPerSquareSecond, DegreePerSquareSecond.
 /// @see https://en.wikipedia.org/wiki/Angular_acceleration
-using AngularAcceleration = PLAYRHO_QUANTITY(boost::units::si::angular_acceleration);
+using AngularAcceleration = detail::angular_acceleration;
 
 /// @brief Force quantity.
 /// @details This is the type alias for the force quantity. It's a derived quantity.
@@ -254,7 +316,7 @@ using AngularAcceleration = PLAYRHO_QUANTITY(boost::units::si::angular_accelerat
 /// @see Length, Mass, Time.
 /// @see Newton.
 /// @see https://en.wikipedia.org/wiki/Force
-using Force = PLAYRHO_QUANTITY(boost::units::si::force);
+using Force = detail::force;
 
 /// @brief Torque quantity.
 /// @details This is the type alias for the torque quantity. It's a derived quantity
@@ -265,7 +327,7 @@ using Force = PLAYRHO_QUANTITY(boost::units::si::force);
 /// @see Length, Mass, Time, Angle.
 /// @see NewtonMeter.
 /// @see https://en.wikipedia.org/wiki/Torque
-using Torque = PLAYRHO_QUANTITY(boost::units::si::torque);
+using Torque = detail::torque;
 
 /// @brief Second moment of area quantity.
 /// @details This is the type alias for the second moment of area quantity. It's a
@@ -273,7 +335,7 @@ using Torque = PLAYRHO_QUANTITY(boost::units::si::torque);
 /// @note This quantity's dimensions are: length-squared-squared (<code>L^4</code>).
 /// @see Length.
 /// @see https://en.wikipedia.org/wiki/Second_moment_of_area
-using SecondMomentOfArea = PLAYRHO_QUANTITY(playrho::units::si::second_moment_of_area);
+using SecondMomentOfArea = detail::second_moment_of_area;
 
 /// @brief Rotational inertia quantity.
 /// @details This is the type alias for the rotational inertia quantity. It's a
@@ -284,7 +346,7 @@ using SecondMomentOfArea = PLAYRHO_QUANTITY(playrho::units::si::second_moment_of
 ///   (<code>kg * m^2</code>).
 /// @see Length, Mass, Angle, InvRotInertia.
 /// @see https://en.wikipedia.org/wiki/Moment_of_inertia
-using RotInertia = PLAYRHO_QUANTITY(boost::units::si::moment_of_inertia);
+using RotInertia = detail::moment_of_inertia;
 
 /// @brief Inverse rotational inertia quantity.
 /// @details This is the type alias for the inverse rotational inertia quantity. It's
@@ -292,7 +354,7 @@ using RotInertia = PLAYRHO_QUANTITY(boost::units::si::moment_of_inertia);
 /// @note This quantity's dimensions are: angle-squared per length-squared per mass
 ///    (<code>L^-2 M^-1 QP^2</code>).
 /// @see Length, Mass, Angle, RotInertia.
-using InvRotInertia = PLAYRHO_QUANTITY(playrho::units::si::inverse_moment_of_inertia);
+using InvRotInertia = detail::inverse_moment_of_inertia;
 
 /// @brief Momentum quantity.
 /// @details This is the type alias for the momentum quantity. It's a derived quantity.
@@ -303,7 +365,7 @@ using InvRotInertia = PLAYRHO_QUANTITY(playrho::units::si::inverse_moment_of_ine
 /// @see Length, Mass, Time.
 /// @see NewtonSecond.
 /// @see https://en.wikipedia.org/wiki/Momentum
-using Momentum = PLAYRHO_QUANTITY(boost::units::si::momentum);
+using Momentum = detail::momentum;
 
 /// @brief Angular momentum quantity.
 /// @details This is the type alias for the angular momentum quantity. It's a derived
@@ -314,7 +376,7 @@ using Momentum = PLAYRHO_QUANTITY(boost::units::si::momentum);
 /// @see Length, Mass, Time, Angle, Momentum.
 /// @see NewtonMeterSecond.
 /// @see https://en.wikipedia.org/wiki/Angular_momentum
-using AngularMomentum = PLAYRHO_QUANTITY(boost::units::si::angular_momentum);
+using AngularMomentum = detail::angular_momentum;
 
 /// @}
 
@@ -330,7 +392,7 @@ using AngularMomentum = PLAYRHO_QUANTITY(boost::units::si::angular_momentum);
 /// @note This is the SI base unit of time.
 /// @see Time.
 /// @see https://en.wikipedia.org/wiki/Second
-constexpr auto Second = PLAYRHO_UNIT(Time, boost::units::si::second);
+constexpr auto Second = Time(detail::second);
 
 /// @brief Square second unit.
 /// @see Second
@@ -340,46 +402,44 @@ constexpr auto SquareSecond = Second * Second;
 /// @details Represents the hertz unit of frequency (Hz).
 /// @see Frequency.
 /// @see https://en.wikipedia.org/wiki/Hertz
-constexpr auto Hertz = PLAYRHO_UNIT(Frequency, boost::units::si::hertz);
+constexpr auto Hertz = Frequency(detail::hertz);
 
 /// @brief Meter unit of Length.
 /// @details A unit of the length quantity.
 /// @note This is the SI base unit of length.
 /// @see Length.
 /// @see https://en.wikipedia.org/wiki/Metre
-constexpr auto Meter = PLAYRHO_UNIT(Length, boost::units::si::meter);
+constexpr auto Meter = Length(detail::meter);
 
 /// @brief Meter per second unit of linear velocity.
 /// @see LinearVelocity.
-constexpr auto MeterPerSecond = PLAYRHO_UNIT(LinearVelocity, boost::units::si::meter_per_second);
+constexpr auto MeterPerSecond = LinearVelocity(detail::meter_per_second);
 
 /// @brief Meter per square second unit of linear acceleration.
 /// @see LinearAcceleration.
-constexpr auto MeterPerSquareSecond =
-    PLAYRHO_UNIT(LinearAcceleration, boost::units::si::meter_per_second_squared);
+constexpr auto MeterPerSquareSecond = LinearAcceleration(detail::meter_per_second_squared);
 
 /// @brief Kilogram unit of mass.
 /// @note This is the SI base unit of mass.
 /// @see Mass.
 /// @see https://en.wikipedia.org/wiki/Kilogram
-constexpr auto Kilogram = PLAYRHO_UNIT(Mass, boost::units::si::kilogram);
+constexpr auto Kilogram = Mass(detail::kilogram);
 
 /// @brief Square meter unit of area.
 /// @see Area.
-constexpr auto SquareMeter = PLAYRHO_UNIT(Area, boost::units::si::square_meter);
+constexpr auto SquareMeter = Area(detail::square_meter);
 
 /// @brief Cubic meter unit of volume.
 constexpr auto CubicMeter = Meter * Meter * Meter;
 
 /// @brief Kilogram per square meter unit of area density.
 /// @see AreaDensity.
-constexpr auto KilogramPerSquareMeter =
-    PLAYRHO_UNIT(AreaDensity, boost::units::si::kilogram_per_square_meter);
+constexpr auto KilogramPerSquareMeter = AreaDensity(detail::kilogram_per_square_meter);
 
 /// @brief Radian unit of angle.
 /// @see Angle.
 /// @see Degree.
-constexpr auto Radian = PLAYRHO_UNIT(Angle, boost::units::si::radian);
+constexpr auto Radian = Angle(detail::radian);
 
 /// @brief Degree unit of angle quantity.
 /// @see Angle.
@@ -394,7 +454,7 @@ constexpr auto SquareRadian = Radian * Radian;
 /// @brief Radian per second unit of angular velocity.
 /// @see AngularVelocity.
 /// @see Radian, Second.
-constexpr auto RadianPerSecond = PLAYRHO_UNIT(AngularVelocity, boost::units::si::radian_per_second);
+constexpr auto RadianPerSecond = AngularVelocity(detail::radian_per_second);
 
 /// @brief Degree per second unit of angular velocity.
 /// @see AngularVelocity.
@@ -413,12 +473,12 @@ constexpr auto DegreePerSquareSecond = Degree / (Second * Second);
 
 /// @brief Newton unit of force.
 /// @see Force.
-constexpr auto Newton = PLAYRHO_UNIT(Force, boost::units::si::newton);
+constexpr auto Newton = Force(detail::newton);
 
 /// @brief Newton meter unit of torque.
 /// @see Torque.
 /// @see Newton, Meter.
-constexpr auto NewtonMeter = PLAYRHO_UNIT(Torque, boost::units::si::newton_meter);
+constexpr auto NewtonMeter = Torque(detail::newton_meter);
 
 /// @brief Newton second unit of momentum.
 /// @see Momentum.
@@ -878,7 +938,7 @@ constexpr auto BigG = Real{6.67408e-11f} * CubicMeter / (Kilogram * SquareSecond
 
 /// @}
 
-#if defined(USE_BOOST_UNITS)
+#if defined(PLAYRHO_USE_BOOST_UNITS)
 using boost::units::cos;
 using boost::units::isfinite;
 using boost::units::isnormal;
@@ -1029,11 +1089,11 @@ constexpr RotInertia GetInvalid() noexcept
     return GetInvalid<Real>() * SquareMeter * Kilogram / SquareRadian;
 }
 
-#endif // defined(USE_BOOST_UNITS)
+#endif // defined(PLAYRHO_USE_BOOST_UNITS)
 
 } // namespace playrho
 
-#if defined(USE_BOOST_UNITS)
+#if defined(PLAYRHO_USE_BOOST_UNITS)
 namespace boost {
 namespace units {
 
@@ -1108,9 +1168,6 @@ constexpr auto operator*(X lhs, quantity<Dimension, playrho::Real> rhs)
 
 } // namespace units
 } // namespace boost
-#endif // defined(USE_BOOST_UNITS)
-
-#undef PLAYRHO_QUANTITY
-#undef PLAYRHO_UNIT
+#endif // defined(PLAYRHO_USE_BOOST_UNITS)
 
 #endif // PLAYRHO_COMMON_UNITS_HPP

--- a/PlayRho/Common/Vector.hpp
+++ b/PlayRho/Common/Vector.hpp
@@ -105,16 +105,16 @@ struct Vector
     static constexpr bool empty() noexcept { return N == 0; }
     
     /// @brief Gets a "begin" iterator.
-    iterator begin() noexcept { return iterator(elements); }
+    iterator begin() noexcept { return iterator(data()); }
 
     /// @brief Gets an "end" iterator.
-    iterator end() noexcept { return iterator(elements + N); }
+    iterator end() noexcept { return iterator(data() + N); }
     
     /// @brief Gets a "begin" iterator.
-    const_iterator begin() const noexcept { return const_iterator(elements); }
+    const_iterator begin() const noexcept { return const_iterator(data()); }
     
     /// @brief Gets an "end" iterator.
-    const_iterator end() const noexcept { return const_iterator(elements + N); }
+    const_iterator end() const noexcept { return const_iterator(data() + N); }
     
     /// @brief Gets a "begin" iterator.
     const_iterator cbegin() const noexcept { return begin(); }
@@ -123,21 +123,21 @@ struct Vector
     const_iterator cend() const noexcept { return end(); }
 
     /// @brief Gets a reverse "begin" iterator.
-    reverse_iterator rbegin() noexcept { return reverse_iterator{elements + N}; }
+    reverse_iterator rbegin() noexcept { return reverse_iterator{data() + N}; }
 
     /// @brief Gets a reverse "end" iterator.
-    reverse_iterator rend() noexcept { return reverse_iterator{elements}; }
+    reverse_iterator rend() noexcept { return reverse_iterator{data()}; }
     
     /// @brief Gets a reverse "begin" iterator.
     const_reverse_iterator crbegin() const noexcept
     {
-        return const_reverse_iterator{elements + N};
+        return const_reverse_iterator{data() + N};
     }
     
     /// @brief Gets a reverse "end" iterator.
     const_reverse_iterator crend() const noexcept
     {
-        return const_reverse_iterator{elements};
+        return const_reverse_iterator{data()};
     }
 
     /// @brief Gets a reverse "begin" iterator.
@@ -158,7 +158,7 @@ struct Vector
     constexpr reference operator[](size_type pos) noexcept
     {
         assert(pos < size());
-        return elements[pos];
+        return elements[pos]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
     /// @brief Gets a constant reference to the requested element.
@@ -167,7 +167,7 @@ struct Vector
     constexpr const_reference operator[](size_type pos) const noexcept
     {
         assert(pos < size());
-        return elements[pos];
+        return elements[pos]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
     /// @brief Gets a reference to the requested element.
@@ -195,13 +195,15 @@ struct Vector
     /// @brief Direct access to data.
     constexpr pointer data() noexcept
     {
-        return elements;
+        // Cast to be more explicit about wanting to decay array into pointer...
+        return static_cast<pointer>(elements);
     }
     
     /// @brief Direct access to data.
     constexpr const_pointer data() const noexcept
     {
-        return elements;
+        // Cast to be more explicit about wanting to decay array into pointer...
+        return static_cast<const_pointer>(elements);
     }
     
     /// @brief Elements.

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -113,7 +113,7 @@ constexpr Momentum2 GetInvalid() noexcept
     return Momentum2{GetInvalid<Momentum>(), GetInvalid<Momentum>()};
 }
 
-constexpr Vec2 GetVec2(const Length2 value)
+constexpr Vec2 GetVec2(const Length2& value)
 {
     return Vec2{
         get<0>(value) / Meter,
@@ -121,7 +121,7 @@ constexpr Vec2 GetVec2(const Length2 value)
     };
 }
 
-constexpr Vec2 GetVec2(const LinearVelocity2 value)
+constexpr Vec2 GetVec2(const LinearVelocity2& value)
 {
     return Vec2{
         get<0>(value) / MeterPerSecond,
@@ -129,7 +129,7 @@ constexpr Vec2 GetVec2(const LinearVelocity2 value)
     };
 }
 
-constexpr Vec2 GetVec2(const Momentum2 value)
+constexpr Vec2 GetVec2(const Momentum2& value)
 {
     return Vec2{
         get<0>(value) / (Kilogram * MeterPerSecond),
@@ -137,7 +137,7 @@ constexpr Vec2 GetVec2(const Momentum2 value)
     };
 }
 
-constexpr Vec2 GetVec2(const Force2 value)
+constexpr Vec2 GetVec2(const Force2& value)
 {
     return Vec2{
         get<0>(value) / Newton,
@@ -147,12 +147,11 @@ constexpr Vec2 GetVec2(const Force2 value)
 #endif
 
 namespace d2 {
-    
-    /// @brief Earthly gravity in 2-dimensions.
-    /// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
-    /// @see EarthlyLinearAcceleration
-    constexpr auto EarthlyGravity = LinearAcceleration2{
-        0_mps2, EarthlyLinearAcceleration};
+
+/// @brief Earthly gravity in 2-dimensions.
+/// @details Linear acceleration in 2-dimensions of an earthly object due to Earth's mass.
+/// @see EarthlyLinearAcceleration
+constexpr auto EarthlyGravity = LinearAcceleration2{0_mps2, EarthlyLinearAcceleration};
 
 } // namespace d2
 } // namespace playrho

--- a/PlayRho/Common/Vector2.hpp
+++ b/PlayRho/Common/Vector2.hpp
@@ -84,7 +84,7 @@ constexpr bool IsValid(const Vector2<TYPE>& value) noexcept
     return IsValid(get<0>(value)) && IsValid(get<1>(value));
 }
 
-#ifdef USE_BOOST_UNITS
+#ifdef PLAYRHO_USE_BOOST_UNITS
 /// @brief Gets an invalid value for the Length2 type.
 template <>
 constexpr Length2 GetInvalid() noexcept

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -58,7 +58,7 @@ public:
     Area GetMinSeparationSquared() const noexcept { return m_minSepSquared; }
 
     /// @brief Adds the given vertex into the set if allowed.
-    bool add(Length2 value)
+    bool add(const Length2& value)
     {
         if (find(value) != end())
         {
@@ -91,12 +91,12 @@ public:
 
     /// Finds contained point whose delta with the given point has a squared length less
     /// than or equal to this set's minimum length squared value.
-    const_pointer find(Length2 value) const
+    const_pointer find(const Length2& value) const
     {
         // squaring anything smaller than the sqrt(std::numeric_limits<Vec2::data_type>::min())
         // won't be reversible.
         // i.e. won't obey the property that square(sqrt(a)) == a and sqrt(square(a)) == a.
-        return std::find_if(begin(), end(), [&](Length2 elem) {
+        return std::find_if(begin(), end(), [&](const Length2& elem) {
             // length squared must be large enough to have a reasonable enough unit vector.
             return GetMagnitudeSquared(value - elem) <= m_minSepSquared;
         });

--- a/PlayRho/Dynamics/Body.cpp
+++ b/PlayRho/Dynamics/Body.cpp
@@ -90,7 +90,7 @@ Body::Body(const BodyConf& bd)
     : m_xf{::playrho::d2::GetTransformation(bd)},
       m_sweep{Position{bd.location, bd.angle}},
       m_flags{GetFlags(bd)},
-      m_invMass{(bd.type == playrho::BodyType::Dynamic) ? InvMass{Real{1} / Kilogram} : InvMass{0}},
+      m_invMass{(bd.type == playrho::BodyType::Dynamic) ? InvMass{Real{1} / Kilogram} : InvMass{}},
       m_linearDamping{bd.linearDamping},
       m_angularDamping{bd.angularDamping},
       m_shapes{(bd.shape == InvalidShapeID) ? std::vector<ShapeID>{}
@@ -144,7 +144,7 @@ void Body::SetType(BodyType value) noexcept
         SetInvMassData(InvMass{}, InvRotInertia{});
         break;
     }
-    m_underActiveTime = 0;
+    m_underActiveTime = 0_s;
 }
 
 void Body::SetSleepingAllowed(bool flag) noexcept
@@ -173,7 +173,7 @@ void Body::UnsetAwake() noexcept
 {
     if (!IsSpeedable() || IsSleepingAllowed()) {
         UnsetAwakeFlag();
-        m_underActiveTime = 0;
+        m_underActiveTime = 0_s;
         m_linearVelocity = LinearVelocity2{};
         m_angularVelocity = 0_rpm;
     }
@@ -191,14 +191,14 @@ void Body::SetVelocity(const Velocity& velocity) noexcept
     JustSetVelocity(velocity);
 }
 
-void Body::JustSetVelocity(Velocity value) noexcept
+void Body::JustSetVelocity(const Velocity& value) noexcept
 {
     assert(IsSpeedable() || (value == Velocity{}));
     m_linearVelocity = value.linear;
     m_angularVelocity = value.angular;
 }
 
-void Body::SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angular) noexcept
+void Body::SetAcceleration(const LinearAcceleration2& linear, AngularAcceleration angular) noexcept
 {
     assert(IsValid(linear));
     assert(IsValid(angular));
@@ -209,7 +209,7 @@ void Body::SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angul
     }
 
     if (!IsAccelerable()) {
-        if ((linear != LinearAcceleration2{}) || (angular != AngularAcceleration{0})) {
+        if ((linear != LinearAcceleration2{}) || (angular != AngularAcceleration{})) {
             // non-accelerable bodies can only be set to zero acceleration, bail...
             return;
         }
@@ -266,7 +266,7 @@ void SetTransformation(Body& body, const Transformation& value) noexcept
     SetSweep(body, Sweep{Position{value.p, GetAngle(value.q)}, GetSweep(body).GetLocalCenter()});
 }
 
-void SetLocation(Body& body, Length2 value)
+void SetLocation(Body& body, const Length2& value)
 {
     SetTransformation(body, Transformation{value, GetTransformation(body).q});
 }
@@ -302,7 +302,7 @@ Velocity GetVelocity(const Body& body, Time h) noexcept
     return velocity;
 }
 
-void ApplyLinearImpulse(Body& body, Momentum2 impulse, Length2 point) noexcept
+void ApplyLinearImpulse(Body& body, const Momentum2& impulse, const Length2& point) noexcept
 {
     auto velocity = body.GetVelocity();
     velocity.linear += body.GetInvMass() * impulse;

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -96,7 +96,7 @@ public:
         /// forces). Bodies with this set are "accelerable" - dynamic bodies.
         e_accelerationFlag = FlagsType(0x0100u),
 
-        /// @brief Mass Data Dirty Flag.
+        /// @brief Mass data dirty flag.
         e_massDataDirtyFlag = FlagsType(0x0200u),
     };
 

--- a/PlayRho/Dynamics/Body.hpp
+++ b/PlayRho/Dynamics/Body.hpp
@@ -168,7 +168,7 @@ public:
     /// Sets the body's velocity.
     /// @note This sets what <code>GetVelocity()</code> returns.
     /// @see GetVelocity.
-    void JustSetVelocity(Velocity value) noexcept;
+    void JustSetVelocity(const Velocity& value) noexcept;
 
     /// @brief Sets the linear and rotational accelerations on this body.
     /// @note This has no effect on non-accelerable bodies.
@@ -176,7 +176,7 @@ public:
     /// @param linear Linear acceleration.
     /// @param angular Angular acceleration.
     /// @see GetLinearAcceleration, GetAngularAcceleration.
-    void SetAcceleration(LinearAcceleration2 linear, AngularAcceleration angular) noexcept;
+    void SetAcceleration(const LinearAcceleration2& linear, AngularAcceleration angular) noexcept;
 
     /// @brief Gets this body's linear acceleration.
     /// @see SetAcceleration.
@@ -427,29 +427,29 @@ private:
 
     /// @brief Linear velocity.
     /// @note 8-bytes.
-    LinearVelocity2 m_linearVelocity = LinearVelocity2{};
+    LinearVelocity2 m_linearVelocity = {};
 
     /// @brief Linear acceleration.
     /// @note 8-bytes.
-    LinearAcceleration2 m_linearAcceleration = LinearAcceleration2{};
+    LinearAcceleration2 m_linearAcceleration = {};
 
     /// @brief Angular velocity.
     /// @note 4-bytes.
-    AngularVelocity m_angularVelocity = AngularVelocity{};
+    AngularVelocity m_angularVelocity = 0_rpm;
 
     /// @brief Angular acceleration.
     /// @note 4-bytes.
-    AngularAcceleration m_angularAcceleration = AngularAcceleration{0};
+    AngularAcceleration m_angularAcceleration = {};
 
     /// Inverse mass of the body.
     /// @details A non-negative value. Zero for non linearly-accelerable bodies.
     /// @note 4-bytes.
-    InvMass m_invMass = 0;
+    InvMass m_invMass = {};
 
     /// Inverse rotational inertia about the center of mass.
     /// @details A non-negative value. Zero for non rotationally-accelerable bodies.
     /// @note 4-bytes.
-    InvRotInertia m_invRotI = 0;
+    InvRotInertia m_invRotI = {};
 
     NonNegative<Frequency> m_linearDamping{DefaultLinearDamping}; ///< Linear damping. 4-bytes.
     NonNegative<Frequency> m_angularDamping{DefaultAngularDamping}; ///< Angular damping. 4-bytes.
@@ -458,7 +458,7 @@ private:
     /// @details A body under-active for enough time should have their awake flag unset.
     ///   I.e. if a body is under-active for long enough, it should go to sleep.
     /// @note 4-bytes.
-    Time m_underActiveTime = 0;
+    Time m_underActiveTime = 0_s;
 
     /// @brief Identifiers of shapes attached/associated with this body.
     std::vector<ShapeID> m_shapes;
@@ -856,7 +856,7 @@ inline Length2 GetLocation(const Body& body) noexcept
 ///   if value is invalid.
 /// @see GetLocation(const Body& body).
 /// @relatedalso Body
-void SetLocation(Body& body, Length2 value);
+void SetLocation(Body& body, const Length2& value);
 
 /// @brief Gets the body's sweep.
 /// @see SetSweep(Body& body, const Sweep& value).
@@ -890,14 +890,14 @@ inline Position GetPosition1(const Body& body) noexcept
 
 /// @brief Sets the "position 0" Position information for the given body.
 /// @relatedalso Body
-inline void SetPosition0(Body& body, Position value) noexcept
+inline void SetPosition0(Body& body, const Position& value) noexcept
 {
     body.SetPosition0(value);
 }
 
 /// @brief Sets the "position 1" Position information for the given body.
 /// @relatedalso Body
-inline void SetPosition1(Body& body, Position value) noexcept
+inline void SetPosition1(Body& body, const Position& value) noexcept
 {
     body.SetPosition1(value);
 }
@@ -1082,7 +1082,7 @@ inline Acceleration GetAcceleration(const Body& body) noexcept
 /// @param value Acceleration value to set.
 /// @see GetAcceleration(const Body& body).
 /// @relatedalso Body
-inline void SetAcceleration(Body& body, Acceleration value) noexcept
+inline void SetAcceleration(Body& body, const Acceleration& value) noexcept
 {
     body.SetAcceleration(value.linear, value.angular);
 }
@@ -1172,7 +1172,7 @@ inline void SetRotInertia(Body& body, RotInertia value) noexcept
 /// @param angular Angular acceleration.
 /// @see GetAcceleration(const Body& body).
 /// @relatedalso Body
-inline void SetAcceleration(Body& body, LinearAcceleration2 linear,
+inline void SetAcceleration(Body& body, const LinearAcceleration2& linear,
                             AngularAcceleration angular) noexcept
 {
     body.SetAcceleration(linear, angular);
@@ -1181,7 +1181,7 @@ inline void SetAcceleration(Body& body, LinearAcceleration2 linear,
 /// @brief Sets the given linear acceleration of the given body.
 /// @see GetAcceleration(const Body& body).
 /// @relatedalso Body
-inline void SetAcceleration(Body& body, LinearAcceleration2 value) noexcept
+inline void SetAcceleration(Body& body, const LinearAcceleration2& value) noexcept
 {
     body.SetAcceleration(value, body.GetAngularAcceleration());
 }
@@ -1247,7 +1247,7 @@ inline AngularVelocity GetAngularVelocity(const Body& body) noexcept
 /// @param value the new linear velocity of the center of mass.
 /// @see GetLinearVelocity(const Body& body).
 /// @relatedalso Body
-inline void SetVelocity(Body& body, LinearVelocity2 value) noexcept
+inline void SetVelocity(Body& body, const LinearVelocity2& value) noexcept
 {
     body.SetVelocity(Velocity{value, GetAngularVelocity(body)});
 }
@@ -1267,7 +1267,7 @@ inline void SetVelocity(Body& body, AngularVelocity value) noexcept
 /// @param localPoint a point measured relative the the body's origin.
 /// @return the same point expressed in world coordinates.
 /// @relatedalso Body
-inline Length2 GetWorldPoint(const Body& body, const Length2 localPoint) noexcept
+inline Length2 GetWorldPoint(const Body& body, const Length2& localPoint) noexcept
 {
     return Transform(localPoint, body.GetTransformation());
 }
@@ -1277,14 +1277,14 @@ inline Length2 GetWorldPoint(const Body& body, const Length2 localPoint) noexcep
 /// @param localVector a vector fixed in the body.
 /// @return the same vector expressed in world coordinates.
 /// @relatedalso Body
-inline Length2 GetWorldVector(const Body& body, const Length2 localVector) noexcept
+inline Length2 GetWorldVector(const Body& body, const Length2& localVector) noexcept
 {
     return Rotate(localVector, body.GetTransformation().q);
 }
 
 /// @brief Gets the world vector for the given local vector from the given body's transformation.
 /// @relatedalso Body
-inline UnitVec GetWorldVector(const Body& body, const UnitVec localVector) noexcept
+inline UnitVec GetWorldVector(const Body& body, const UnitVec& localVector) noexcept
 {
     return Rotate(localVector, body.GetTransformation().q);
 }
@@ -1294,7 +1294,7 @@ inline UnitVec GetWorldVector(const Body& body, const UnitVec localVector) noexc
 /// @param worldPoint point in world coordinates.
 /// @return the corresponding local point relative to the body's origin.
 /// @relatedalso Body
-inline Length2 GetLocalPoint(const Body& body, const Length2 worldPoint) noexcept
+inline Length2 GetLocalPoint(const Body& body, const Length2& worldPoint) noexcept
 {
     return InverseTransform(worldPoint, body.GetTransformation());
 }
@@ -1304,7 +1304,7 @@ inline Length2 GetLocalPoint(const Body& body, const Length2 worldPoint) noexcep
 /// @param uv Unit vector in world orientation.
 /// @return the corresponding local vector.
 /// @relatedalso Body
-inline UnitVec GetLocalVector(const Body& body, const UnitVec uv) noexcept
+inline UnitVec GetLocalVector(const Body& body, const UnitVec& uv) noexcept
 {
     return InverseRotate(uv, body.GetTransformation().q);
 }
@@ -1315,7 +1315,7 @@ inline UnitVec GetLocalVector(const Body& body, const UnitVec uv) noexcept
 /// @return the world velocity of a point.
 /// @relatedalso Body
 inline LinearVelocity2 GetLinearVelocityFromWorldPoint(const Body& body,
-                                                       const Length2 worldPoint) noexcept
+                                                       const Length2& worldPoint) noexcept
 {
     const auto velocity = body.GetVelocity();
     const auto worldCtr = GetWorldCenter(body);
@@ -1330,7 +1330,7 @@ inline LinearVelocity2 GetLinearVelocityFromWorldPoint(const Body& body,
 /// @return the world velocity of a point.
 /// @relatedalso Body
 inline LinearVelocity2 GetLinearVelocityFromLocalPoint(const Body& body,
-                                                       const Length2 localPoint) noexcept
+                                                       const Length2& localPoint) noexcept
 {
     return GetLinearVelocityFromWorldPoint(body, GetWorldPoint(body, localPoint));
 }
@@ -1366,7 +1366,7 @@ Velocity GetVelocity(const Body& body, Time h) noexcept;
 /// @param impulse the world impulse vector.
 /// @param point the world position of the point of application.
 /// @relatedalso Body
-void ApplyLinearImpulse(Body& body, Momentum2 impulse, Length2 point) noexcept;
+void ApplyLinearImpulse(Body& body, const Momentum2& impulse, const Length2& point) noexcept;
 
 /// @brief Applies an angular impulse.
 /// @param body Body to apply the angular impulse to.

--- a/PlayRho/Dynamics/BodyConf.hpp
+++ b/PlayRho/Dynamics/BodyConf.hpp
@@ -104,25 +104,25 @@ struct BodyConf {
     constexpr BodyConf& Use(BodyType t) noexcept;
 
     /// @brief Use the given location.
-    constexpr BodyConf& UseLocation(Length2 l) noexcept;
+    constexpr BodyConf& UseLocation(const Length2& l) noexcept;
 
     /// @brief Use the given angle.
     constexpr BodyConf& UseAngle(Angle a) noexcept;
 
     /// @brief Use the given linear velocity.
-    constexpr BodyConf& UseLinearVelocity(LinearVelocity2 v) noexcept;
+    constexpr BodyConf& UseLinearVelocity(const LinearVelocity2& v) noexcept;
 
     /// @brief Use the given angular velocity.
     constexpr BodyConf& UseAngularVelocity(AngularVelocity v) noexcept;
 
     /// @brief Use the given position for the linear and angular positions.
-    constexpr BodyConf& Use(Position v) noexcept;
+    constexpr BodyConf& Use(const Position& v) noexcept;
 
     /// @brief Use the given velocity for the linear and angular velocities.
-    constexpr BodyConf& Use(Velocity v) noexcept;
+    constexpr BodyConf& Use(const Velocity& v) noexcept;
 
     /// @brief Use the given linear acceleration.
-    constexpr BodyConf& UseLinearAcceleration(LinearAcceleration2 v) noexcept;
+    constexpr BodyConf& UseLinearAcceleration(const LinearAcceleration2& v) noexcept;
 
     /// @brief Use the given angular acceleration.
     constexpr BodyConf& UseAngularAcceleration(AngularAcceleration v) noexcept;
@@ -231,7 +231,7 @@ constexpr BodyConf& BodyConf::Use(BodyType t) noexcept
     return *this;
 }
 
-constexpr BodyConf& BodyConf::UseLocation(Length2 l) noexcept
+constexpr BodyConf& BodyConf::UseLocation(const Length2& l) noexcept
 {
     location = l;
     return *this;
@@ -243,27 +243,27 @@ constexpr BodyConf& BodyConf::UseAngle(Angle a) noexcept
     return *this;
 }
 
-constexpr BodyConf& BodyConf::Use(Position v) noexcept
+constexpr BodyConf& BodyConf::Use(const Position& v) noexcept
 {
     location = v.linear;
     angle = v.angular;
     return *this;
 }
 
-constexpr BodyConf& BodyConf::Use(Velocity v) noexcept
+constexpr BodyConf& BodyConf::Use(const Velocity& v) noexcept
 {
     linearVelocity = v.linear;
     angularVelocity = v.angular;
     return *this;
 }
 
-constexpr BodyConf& BodyConf::UseLinearVelocity(LinearVelocity2 v) noexcept
+constexpr BodyConf& BodyConf::UseLinearVelocity(const LinearVelocity2& v) noexcept
 {
     linearVelocity = v;
     return *this;
 }
 
-constexpr BodyConf& BodyConf::UseLinearAcceleration(LinearAcceleration2 v) noexcept
+constexpr BodyConf& BodyConf::UseLinearAcceleration(const LinearAcceleration2& v) noexcept
 {
     linearAcceleration = v;
     return *this;

--- a/PlayRho/Dynamics/ContactImpulsesList.hpp
+++ b/PlayRho/Dynamics/ContactImpulsesList.hpp
@@ -22,7 +22,9 @@
 #define PLAYRHO_DYNAMICS_CONTACTIMPULSESLIST_HPP
 
 #include <PlayRho/Common/Settings.hpp>
+
 #include <algorithm>
+#include <cassert>
 
 namespace playrho {
 namespace d2 {
@@ -45,17 +47,25 @@ public:
     Counter GetCount() const noexcept { return count; }
     
     /// @brief Gets the given indexed entry normal.
-    Momentum GetEntryNormal(Counter index) const noexcept { return normalImpulses[index]; }
-    
+    Momentum GetEntryNormal(Counter index) const noexcept
+    {
+        assert(index < MaxManifoldPoints);
+        return normalImpulses[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+    }
+
     /// @brief Gets the given indexed entry tangent.
-    Momentum GetEntryTanget(Counter index) const noexcept { return tangentImpulses[index]; }
-    
+    Momentum GetEntryTanget(Counter index) const noexcept
+    {
+        assert(index < MaxManifoldPoints);
+        return tangentImpulses[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+    }
+
     /// @brief Adds an entry of the given data.
     void AddEntry(Momentum normal, Momentum tangent) noexcept
     {
         assert(count < MaxManifoldPoints);
-        normalImpulses[count] = normal;
-        tangentImpulses[count] = tangent;
+        normalImpulses[count] = normal; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
+        tangentImpulses[count] = tangent; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
         ++count;
     }
     

--- a/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/BodyConstraint.hpp
@@ -43,8 +43,8 @@ public:
 
     /// @brief Initializing constructor.
     constexpr
-    BodyConstraint(InvMass invMass, InvRotInertia invRotI, Length2 localCenter,
-                     Position position, Velocity velocity) noexcept:
+    BodyConstraint(InvMass invMass, InvRotInertia invRotI, const Length2& localCenter,
+                   const Position& position, const Velocity& velocity) noexcept:
         m_position{position},
         m_velocity{velocity},
         m_localCenter{localCenter},
@@ -54,8 +54,8 @@ public:
         assert(IsValid(position));
         assert(IsValid(velocity));
         assert(IsValid(localCenter));
-        assert(invMass >= InvMass{0});
-        assert(invRotI >= InvRotInertia{0});
+        assert(invMass >= InvMass{});
+        assert(invRotI >= InvRotInertia{});
     }
 
     /// @brief Gets the inverse mass of this body representation.
@@ -78,12 +78,12 @@ public:
     /// @brief Sets the position of the body.
     /// @param value A valid position value to set for the represented body.
     /// @warning Behavior is undefined if the given value is not valid.
-    BodyConstraint& SetPosition(Position value) noexcept;
+    BodyConstraint& SetPosition(const Position& value) noexcept;
 
     /// @brief Sets the velocity of the body.
     /// @param value A valid velocity value to set for the represented body.
     /// @warning Behavior is undefined if the given value is not valid.
-    BodyConstraint& SetVelocity(Velocity value) noexcept;
+    BodyConstraint& SetVelocity(const Velocity& value) noexcept;
 
 private:
     Position m_position; ///< Position data of body.
@@ -121,14 +121,14 @@ inline Velocity BodyConstraint::GetVelocity() const noexcept
     return m_velocity;
 }
 
-inline BodyConstraint& BodyConstraint::SetPosition(Position value) noexcept
+inline BodyConstraint& BodyConstraint::SetPosition(const Position& value) noexcept
 {
     assert(IsValid(value));
     m_position = value;
     return *this;
 }
 
-inline BodyConstraint& BodyConstraint::SetVelocity(Velocity value) noexcept
+inline BodyConstraint& BodyConstraint::SetVelocity(const Velocity& value) noexcept
 {
     assert(IsValid(value));
     m_velocity = value;
@@ -137,7 +137,7 @@ inline BodyConstraint& BodyConstraint::SetVelocity(Velocity value) noexcept
 
 /// @brief Gets the <code>BodyConstraint</code> based on the given parameters.
 inline BodyConstraint GetBodyConstraint(const Body& body, Time time,
-                                        MovementConf conf) noexcept
+                                        const MovementConf& conf) noexcept
 {
     return BodyConstraint{
         GetInvMass(body),

--- a/PlayRho/Dynamics/Contacts/Contact.hpp
+++ b/PlayRho/Dynamics/Contacts/Contact.hpp
@@ -326,7 +326,7 @@ private:
 
     /// Tangent speed.
     /// @note Field is 4-bytes (with 4-byte Real).
-    LinearVelocity m_tangentSpeed = 0;
+    LinearVelocity m_tangentSpeed = 0_mps;
 
     /// Time of impact.
     /// @note This is a unit interval of time (a value between 0 and 1).

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -66,7 +66,7 @@ struct ImpulseChange
     UnitVec direction; ///< Direction.
 };
 
-VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impulses,
+VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2& impulses,
                               const std::vector<BodyConstraint>& bodies)
 {
     assert(IsValid(impulses));
@@ -97,7 +97,7 @@ VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2 impu
     };
 }
 
-Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2 newImpulses,
+Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2& newImpulses,
                           std::vector<BodyConstraint>& bodies)
 {
     const auto delta_v = GetVelocityDelta(vc, newImpulses - GetNormalImpulses(vc), bodies);
@@ -111,7 +111,7 @@ Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2 newImpulses,
 
 std::optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
                                               std::vector<BodyConstraint>& bodies,
-                                              const LinearVelocity2 b_prime)
+                                              const LinearVelocity2& b_prime)
 {
     //
     // Case 1: vn = 0
@@ -151,7 +151,7 @@ std::optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
 
 std::optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc,
                                               std::vector<BodyConstraint>& bodies,
-                                              const LinearVelocity2 b_prime)
+                                              const LinearVelocity2& b_prime)
 {
     //
     // Case 2: vn1 = 0 and x2 = 0
@@ -188,7 +188,7 @@ std::optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc,
 
 std::optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc,
                                               std::vector<BodyConstraint>& bodies,
-                                              const LinearVelocity2 b_prime)
+                                              const LinearVelocity2& b_prime)
 {
     //
     // Case 3: vn2 = 0 and x1 = 0
@@ -225,7 +225,7 @@ std::optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc,
 
 std::optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc,
                                               std::vector<BodyConstraint>& bodies,
-                                              const LinearVelocity2 b_prime)
+                                              const LinearVelocity2& b_prime)
 {
     //
     // Case 4: x1 = 0 and x2 = 0
@@ -330,7 +330,7 @@ inline Momentum BlockSolveNormalConstraint(VelocityConstraint& vc,
     }
     
     // No solution, give up. This is hit sometimes, but it doesn't seem to matter.
-    return 0;
+    return 0_Ns;
 }
 
 inline Momentum SeqSolveNormalConstraint(VelocityConstraint& vc,
@@ -503,23 +503,23 @@ d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
     const auto bodyA = &bodies[to_underlying(pc.GetBodyA())];
     const auto bodyB = &bodies[to_underlying(pc.GetBodyB())];
     
-    const auto invMassA = moveA? bodyA->GetInvMass(): InvMass{0};
-    const auto invRotInertiaA = moveA? bodyA->GetInvRotInertia(): InvRotInertia{0};
+    const auto invMassA = moveA? bodyA->GetInvMass(): InvMass{};
+    const auto invRotInertiaA = moveA? bodyA->GetInvRotInertia(): InvRotInertia{};
     const auto localCenterA = bodyA->GetLocalCenter();
     
-    const auto invMassB = moveB? bodyB->GetInvMass(): InvMass{0};
-    const auto invRotInertiaB = moveB? bodyB->GetInvRotInertia(): InvRotInertia{0};
+    const auto invMassB = moveB? bodyB->GetInvMass(): InvMass{};
+    const auto invRotInertiaB = moveB? bodyB->GetInvRotInertia(): InvRotInertia{};
     const auto localCenterB = bodyB->GetLocalCenter();
     
     // Compute inverse mass total.
     // This must be > 0 unless doing TOI solving and neither bodies were the bodies specified.
     const auto invMassTotal = invMassA + invMassB;
-    assert(invMassTotal >= InvMass{0});
+    assert(invMassTotal >= InvMass{});
     
     const auto totalRadius = pc.GetTotalRadius();
     
-    const auto solver_fn = [&](const d2::PositionSolverManifold psm,
-                               const Length2 pA, const Length2 pB) {
+    const auto solver_fn = [&](const d2::PositionSolverManifold& psm,
+                               const Length2& pA, const Length2& pB) {
         const auto separation = psm.m_separation - totalRadius;
         // Positive separation means shapes not overlapping and not touching.
         // Zero separation means shapes are touching.
@@ -532,7 +532,7 @@ d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
         const auto K = invMassTotal + GetEffectiveInvMass(invRotInertiaA, rA, psm.m_normal) +
             GetEffectiveInvMass(invRotInertiaB, rB, psm.m_normal);
         
-        assert(K >= InvMass{0});
+        assert(K >= InvMass{});
         
         // Prevent large corrections & don't push separation above -conf.linearSlop.
         const auto C = -std::clamp(conf.resolutionRate * (separation + conf.linearSlop),

--- a/PlayRho/Dynamics/Contacts/ContactSolver.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.hpp
@@ -46,7 +46,7 @@ struct PositionSolution
 };
 
 /// @brief Addition operator.
-inline PositionSolution operator+ (PositionSolution lhs, PositionSolution rhs)
+inline PositionSolution operator+ (const PositionSolution& lhs, const PositionSolution& rhs)
 {
     return PositionSolution{
         lhs.pos_a + rhs.pos_a,
@@ -56,7 +56,7 @@ inline PositionSolution operator+ (PositionSolution lhs, PositionSolution rhs)
 }
 
 /// @brief Subtraction operator.
-inline PositionSolution operator- (PositionSolution lhs, PositionSolution rhs)
+inline PositionSolution operator- (const PositionSolution& lhs, const PositionSolution& rhs)
 {
     return PositionSolution{
         lhs.pos_a - rhs.pos_a,

--- a/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
+++ b/PlayRho/Dynamics/Contacts/PositionSolverManifold.cpp
@@ -33,8 +33,8 @@ namespace {
 /// @param plp Point's local point. Location of shape B in local coordinates.
 /// @note The returned separation is the magnitude of the positional difference of the two points.
 ///   This is always a non-negative amount.
-inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2 lp,
-                                            const Transformation& xfB, Length2 plp)
+inline PositionSolverManifold GetForCircles(const Transformation& xfA, const Length2& lp,
+                                            const Transformation& xfB, const Length2& plp)
 {
     const auto pointA = Transform(lp, xfA);
     const auto pointB = Transform(plp, xfB);
@@ -54,8 +54,8 @@ inline PositionSolverManifold GetForCircles(const Transformation& xfA, Length2 l
 /// @param plp Point's local point. Location for shape B in local coordinates.
 /// @return Separation is the dot-product of the positional difference between the two points in
 ///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2 lp, UnitVec ln,
-                                          const Transformation& xfB, Length2 plp)
+inline PositionSolverManifold GetForFaceA(const Transformation& xfA, const Length2& lp, const UnitVec& ln,
+                                          const Transformation& xfB, const Length2& plp)
 {
     const auto planePoint = Transform(lp, xfA);
     const auto normal = Rotate(ln, xfA.q);
@@ -73,8 +73,8 @@ inline PositionSolverManifold GetForFaceA(const Transformation& xfA, Length2 lp,
 /// @param plp Point's local point. Location for shape A in local coordinates.
 /// @return Separation is the dot-product of the positional difference between the two points in
 ///   the direction of the world normal.
-inline PositionSolverManifold GetForFaceB(const Transformation& xfB, Length2 lp, UnitVec ln,
-                                          const Transformation& xfA, Length2 plp)
+inline PositionSolverManifold GetForFaceB(const Transformation& xfB, const Length2& lp, const UnitVec& ln,
+                                          const Transformation& xfA, const Length2& plp)
 {
     const auto planePoint = Transform(lp, xfB);
     const auto normal = Rotate(ln, xfB.q);

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
@@ -56,7 +56,7 @@ inline InvMass3 ComputeK(const VelocityConstraint& vc, const std::vector<BodyCon
     const auto invMassB = bodyB->GetInvMass();
     
     const auto invMass = invMassA + invMassB;
-    assert(invMass > InvMass{0});
+    assert(invMass > InvMass{});
     
     const auto invRotMassA0 = InvMass{(invRotInertiaA * Square(rnA0)) / SquareRadian};
     const auto invRotMassA1 = InvMass{(invRotInertiaA * Square(rnA1)) / SquareRadian};
@@ -130,8 +130,8 @@ VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
 
 VelocityConstraint::Point
 VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                             Length2 relA, Length2 relB, const std::vector<BodyConstraint>& bodies,
-                             Conf conf) const noexcept
+                             const Length2& relA, const Length2& relB, const std::vector<BodyConstraint>& bodies,
+                             const Conf& conf) const noexcept
 {
     assert(IsValid(normalImpulse));
     assert(IsValid(tangentImpulse));
@@ -167,21 +167,22 @@ VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
         const auto invRotMassA = invRotInertiaA * Square(Cross(relA, GetNormal())) / SquareRadian;
         const auto invRotMassB = invRotInertiaB * Square(Cross(relB, GetNormal())) / SquareRadian;
         const auto value = invMass + invRotMassA + invRotMassB;
-        return (value != InvMass{0})? Real{1} / value : 0_kg;
+        return (value != InvMass{})? Real{1} / value : 0_kg;
     }();
     point.tangentMass = [&]() {
         const auto invRotMassA = invRotInertiaA * Square(Cross(relA, GetTangent())) / SquareRadian;
         const auto invRotMassB = invRotInertiaB * Square(Cross(relB, GetTangent())) / SquareRadian;
         const auto value = invMass + invRotMassA + invRotMassB;
-        return (value != InvMass{0})? Real{1} / value : 0_kg;
+        return (value != InvMass{})? Real{1} / value : 0_kg;
     }();
 
     return point;
 }
 
 void VelocityConstraint::AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                                  Length2 relA, Length2 relB, const std::vector<BodyConstraint>& bodies,
-                                  Conf conf)
+                                  const Length2& relA, const Length2& relB,
+                                  const std::vector<BodyConstraint>& bodies,
+                                  const Conf& conf)
 {
     assert(m_pointCount < MaxManifoldPoints);
     m_points[m_pointCount] = GetPoint(normalImpulse * conf.dtRatio, tangentImpulse * conf.dtRatio,

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -237,16 +237,16 @@ private:
     ///   <code>MaxManifoldPoints</code> points.
     /// @see GetPointCount().
     void AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                  Length2 relA, Length2 relB, const std::vector<BodyConstraint>& bodies,
-                  Conf conf);
+                  const Length2& relA, const Length2& relB, const std::vector<BodyConstraint>& bodies,
+                  const Conf& conf);
     
     /// Removes the last point added.
     void RemovePoint() noexcept;
     
     /// @brief Gets a point instance for the given parameters.
     Point GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                   Length2 relA, Length2 relB, const std::vector<BodyConstraint>& bodies,
-                   Conf conf) const noexcept;
+                   const Length2& relA, const Length2& relB, const std::vector<BodyConstraint>& bodies,
+                   const Conf& conf) const noexcept;
     
     /// Accesses the point identified by the given index.
     /// @warning Behavior is undefined if given index is not less than
@@ -460,14 +460,14 @@ inline void SetTangentImpulseAtPoint(VelocityConstraint& vc, VelocityConstraint:
 }
 
 /// @brief Sets the normal impulses of the given velocity constraint.
-inline void SetNormalImpulses(VelocityConstraint& vc, const Momentum2 impulses)
+inline void SetNormalImpulses(VelocityConstraint& vc, const Momentum2& impulses)
 {
     SetNormalImpulseAtPoint(vc, 0, impulses[0]);
     SetNormalImpulseAtPoint(vc, 1, impulses[1]);
 }
 
 /// @brief Sets the tangent impulses of the given velocity constraint.
-inline void SetTangentImpulses(VelocityConstraint& vc, const Momentum2 impulses)
+inline void SetTangentImpulses(VelocityConstraint& vc, const Momentum2& impulses)
 {
     SetTangentImpulseAtPoint(vc, 0, impulses[0]);
     SetTangentImpulseAtPoint(vc, 1, impulses[1]);

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -225,7 +225,7 @@ public:
     const Point& GetPointAt(size_type index) const
     {
         assert(index < MaxManifoldPoints);
-        return m_points[index];
+        return m_points[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
 private:
@@ -259,7 +259,7 @@ private:
     Point& PointAt(size_type index)
     {
         assert(index < MaxManifoldPoints);
-        return m_points[index];
+        return m_points[index]; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     }
     
     Point m_points[MaxManifoldPoints]; ///< Velocity constraint points array (at least 72-bytes).
@@ -297,7 +297,7 @@ private:
 inline void VelocityConstraint::RemovePoint() noexcept
 {
     assert(m_pointCount > 0);
-    m_points[m_pointCount - 1] = Point{};
+    m_points[m_pointCount - 1] = Point{}; // NOLINT(cppcoreguidelines-pro-bounds-constant-array-index)
     --m_pointCount;
 }
 

--- a/PlayRho/Dynamics/IslandStats.hpp
+++ b/PlayRho/Dynamics/IslandStats.hpp
@@ -30,7 +30,7 @@ namespace playrho {
 struct IslandStats
 {
     Length minSeparation = std::numeric_limits<Length>::infinity(); ///< Minimum separation.
-    Momentum maxIncImpulse = 0; ///< Maximum incremental impulse.
+    Momentum maxIncImpulse = 0_Ns; ///< Maximum incremental impulse.
     BodyCounter bodiesSlept = 0; ///< Bodies slept.
     ContactCounter contactsUpdated = 0; ///< Contacts updated.
     ContactCounter contactsSkipped = 0; ///< Contacts skipped.

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
@@ -58,7 +58,9 @@ struct DistanceJointConf : public JointBuilder<DistanceJointConf> {
 
     /// @brief Initializing constructor.
     /// @details Initialize the bodies, anchors, and length using the world anchors.
-    DistanceJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{}, Length2 laB = Length2{},
+    DistanceJointConf(BodyID bA, BodyID bB, // force line-break
+                      const Length2& laA = Length2{}, // force line-break
+                      const Length2& laB = Length2{}, // force line-break
                       Length l = 1_m) noexcept;
 
     /// @brief Uses the given length.
@@ -153,8 +155,9 @@ DistanceJointConf GetDistanceJointConf(const Joint& joint);
 
 /// @brief Gets the configuration for the given parameters.
 /// @relatedalso World
-DistanceJointConf GetDistanceJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchorA = Length2{}, Length2 anchorB = Length2{});
+DistanceJointConf GetDistanceJointConf(const World& world, BodyID bodyA, BodyID bodyB, // force line-break
+                                       const Length2& anchorA = Length2{}, // force line-break
+                                       const Length2& anchorB = Length2{});
 
 /// @brief Gets the current linear reaction for the given configuration.
 /// @relatedalso DistanceJointConf
@@ -167,7 +170,7 @@ constexpr Momentum2 GetLinearReaction(const DistanceJointConf& object) noexcept
 /// @relatedalso DistanceJointConf
 constexpr AngularMomentum GetAngularReaction(const DistanceJointConf&) noexcept
 {
-    return AngularMomentum{0};
+    return AngularMomentum{};
 }
 
 /// @brief Shifts the origin notion of the given configuration.

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.cpp
@@ -55,7 +55,8 @@ static_assert(std::is_nothrow_destructible<FrictionJointConf>::value,
 // J = [0 0 -1 0 0 1]
 // K = invI1 + invI2
 
-FrictionJointConf::FrictionJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB) noexcept
+FrictionJointConf::FrictionJointConf(BodyID bA, BodyID bB, // force line-break
+                                     const Length2& laA, const Length2& laB) noexcept
     : super{super{}.UseBodyA(bA).UseBodyB(bB)}, localAnchorA{laA}, localAnchorB{laB}
 {
     // Intentionally empty.
@@ -67,7 +68,7 @@ FrictionJointConf GetFrictionJointConf(const Joint& joint)
 }
 
 FrictionJointConf GetFrictionJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchor)
+                                       const Length2& anchor)
 {
     return FrictionJointConf{bodyA, bodyB, GetLocalPoint(world, bodyA, anchor),
                              GetLocalPoint(world, bodyB, anchor)};
@@ -127,7 +128,7 @@ void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies
 
     const auto invRotInertia = invRotInertiaA + invRotInertiaB;
     object.angularMass =
-        (invRotInertia > InvRotInertia{0}) ? RotInertia{Real{1} / invRotInertia} : RotInertia{0};
+        (invRotInertia > InvRotInertia{}) ? RotInertia{Real{1} / invRotInertia} : RotInertia{};
 
     if (step.doWarmStart) {
         // Scale impulses to support a variable time step.
@@ -146,7 +147,7 @@ void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies
     }
     else {
         object.linearImpulse = Momentum2{};
-        object.angularImpulse = AngularMomentum{0};
+        object.angularImpulse = AngularMomentum{};
     }
 
     bodyConstraintA.SetVelocity(velA);
@@ -186,7 +187,7 @@ bool SolveVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodie
                                            -maxAngularImpulse, maxAngularImpulse);
         const auto incAngularImpulse = object.angularImpulse - oldAngularImpulse;
 
-        if (incAngularImpulse != AngularMomentum{0}) {
+        if (incAngularImpulse != AngularMomentum{}) {
             solved = false;
         }
 

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
@@ -60,8 +60,9 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf> {
     /// @post <code>localAnchorA</code> will hold the value of <code>laA</code>.
     /// @post <code>localAnchorB</code> will hold the value of <code>laB</code>.
     /// @post All other member variables will be zero initialized.
-    FrictionJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{},
-                      Length2 laB = Length2{}) noexcept;
+    FrictionJointConf(BodyID bA, BodyID bB, // force line-break
+                      const Length2& laA = Length2{}, // force line-break
+                      const Length2& laB = Length2{}) noexcept;
 
     /// @brief Uses the given maximum force value.
     constexpr auto& UseMaxForce(NonNegative<Force> v) noexcept
@@ -91,7 +92,7 @@ struct FrictionJointConf : public JointBuilder<FrictionJointConf> {
 
     // Solver shared data - data saved & updated over multiple InitVelocityConstraints calls.
     Momentum2 linearImpulse = Momentum2{}; ///< Linear impulse.
-    AngularMomentum angularImpulse = AngularMomentum{0}; ///< Angular impulse.
+    AngularMomentum angularImpulse = AngularMomentum{}; ///< Angular impulse.
 
     // Solver temp
     Length2 rA = {}; ///< Relative A.
@@ -133,7 +134,7 @@ FrictionJointConf GetFrictionJointConf(const Joint& joint);
 /// @brief Gets the confguration for the given parameters.
 /// @relatedalso World
 FrictionJointConf GetFrictionJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchor);
+                                       const Length2& anchor);
 
 /// @brief Gets the current linear reaction for the given configuration.
 /// @relatedalso FrictionJointConf

--- a/PlayRho/Dynamics/Joints/GearJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/GearJointConf.hpp
@@ -203,7 +203,7 @@ constexpr AngularMomentum GetAngularReaction(const GearJointConf& object)
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso GearJointConf
-constexpr bool ShiftOrigin(GearJointConf&, Length2) noexcept
+constexpr bool ShiftOrigin(GearJointConf&, const Length2&) noexcept
 {
     return false;
 }

--- a/PlayRho/Dynamics/Joints/Joint.cpp
+++ b/PlayRho/Dynamics/Joints/Joint.cpp
@@ -465,7 +465,7 @@ Length2 GetTarget(const Joint& object)
     throw std::invalid_argument("GetTarget not supported by joint type");
 }
 
-void SetTarget(Joint& object, Length2 value)
+void SetTarget(Joint& object, const Length2& value)
 {
     const auto type = GetType(object);
     if (type == GetTypeID<TargetJointConf>()) {
@@ -599,7 +599,7 @@ Length2 GetLinearOffset(const Joint& object)
     throw std::invalid_argument("GetLinearOffset not supported by joint type!");
 }
 
-void SetLinearOffset(Joint& object, Length2 value)
+void SetLinearOffset(Joint& object, const Length2& value)
 {
     const auto type = GetType(object);
     if (type == GetTypeID<MotorJointConf>()) {

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -89,7 +89,7 @@ bool GetCollideConnected(const Joint& object) noexcept;
 
 /// @brief Shifts the origin for any points stored in world coordinates.
 /// @return <code>true</code> if shift done, <code>false</code> otherwise.
-bool ShiftOrigin(Joint& object, Length2 value) noexcept;
+bool ShiftOrigin(Joint& object, const Length2& value) noexcept;
 
 /// @brief Initializes velocity constraint data based on the given solver data.
 /// @note This MUST be called prior to calling <code>SolveVelocity</code>.
@@ -291,7 +291,7 @@ public:
         return object.m_self ? object.m_self->GetCollideConnected_() : false;
     }
 
-    friend bool ShiftOrigin(Joint& object, Length2 value) noexcept
+    friend bool ShiftOrigin(Joint& object, const Length2& value) noexcept
     {
         return object.m_self ? object.m_self->ShiftOrigin_(value) : false;
     }
@@ -352,7 +352,7 @@ private:
         virtual bool GetCollideConnected_() const noexcept = 0;
 
         /// @brief Call to notify joint of a shift in the world origin.
-        virtual bool ShiftOrigin_(Length2 value) noexcept = 0;
+        virtual bool ShiftOrigin_(const Length2& value) noexcept = 0;
 
         /// @brief Initializes the velocities for this joint.
         virtual void InitVelocity_(BodyConstraintsMap& bodies, const playrho::StepConf& step,
@@ -436,7 +436,7 @@ private:
         }
 
         /// @copydoc Concept::ShiftOrigin_
-        bool ShiftOrigin_(Length2 value) noexcept override
+        bool ShiftOrigin_(const Length2& value) noexcept override
         {
             return ShiftOrigin(data, value);
         }
@@ -693,7 +693,7 @@ Length2 GetTarget(const Joint& object);
 /// @brief Sets the given joint's target property if it has one.
 /// @throws std::invalid_argument If not supported for the given joint's type.
 /// @relatedalso Joint
-void SetTarget(Joint& object, Length2 value);
+void SetTarget(Joint& object, const Length2& value);
 
 /// Gets the lower linear joint limit.
 /// @throws std::invalid_argument If not supported for the given joint's type.
@@ -753,7 +753,7 @@ Length2 GetLinearOffset(const Joint& object);
 /// @brief Sets the linear offset property of the specified joint if its type has one.
 /// @throws std::invalid_argument If not supported for the given joint's type.
 /// @relatedalso Joint
-void SetLinearOffset(Joint& object, Length2 value);
+void SetLinearOffset(Joint& object, const Length2& value);
 
 /// @brief Gets the angular offset property of the specified joint if its type has one.
 /// @throws std::invalid_argument If not supported for the given joint's type.

--- a/PlayRho/Dynamics/Joints/Joint.hpp
+++ b/PlayRho/Dynamics/Joints/Joint.hpp
@@ -319,7 +319,7 @@ public:
 private:
     /// @brief Internal configuration concept.
     /// @note Provides the interface for runtime value polymorphism.
-    struct Concept {
+    struct Concept { // NOLINT(cppcoreguidelines-special-member-functions)
         /// @brief Explicitly declared virtual destructor.
         virtual ~Concept() = default;
 

--- a/PlayRho/Dynamics/Joints/MotorJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.cpp
@@ -58,7 +58,8 @@ static_assert(std::is_nothrow_destructible<MotorJointConf>::value,
 // J = [0 0 -1 0 0 1]
 // K = invI1 + invI2
 
-MotorJointConf::MotorJointConf(BodyID bA, BodyID bB, Length2 lo, Angle ao) noexcept
+MotorJointConf::MotorJointConf(BodyID bA, BodyID bB, // force line-break
+                               const Length2& lo, Angle ao) noexcept
     : super{super{}.UseBodyA(bA).UseBodyB(bB)}, linearOffset{lo}, angularOffset{ao}
 {
     // Intentionally empty.
@@ -128,7 +129,7 @@ void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies, c
 
     const auto invRotInertia = invRotInertiaA + invRotInertiaB;
     object.angularMass =
-        (invRotInertia > InvRotInertia{0}) ? RotInertia{Real{1} / invRotInertia} : RotInertia{0};
+        (invRotInertia > InvRotInertia{}) ? RotInertia{Real{1} / invRotInertia} : RotInertia{};
 
     object.linearError = (posB.linear + object.rB) - (posA.linear + object.rA);
     object.angularError = (posB.angular - posA.angular) - object.angularOffset;
@@ -149,7 +150,7 @@ void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies, c
     }
     else {
         object.linearImpulse = Momentum2{};
-        object.angularImpulse = AngularMomentum{0};
+        object.angularImpulse = AngularMomentum{};
     }
 
     bodyConstraintA.SetVelocity(velA);
@@ -192,7 +193,7 @@ bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
         object.angularImpulse = newAngularImpulse;
         const auto incAngularImpulse = newAngularImpulse - oldAngularImpulse;
 
-        if (incAngularImpulse != AngularMomentum{0}) {
+        if (incAngularImpulse != AngularMomentum{}) {
             solved = false;
         }
         velA.angular -= invRotInertiaA * incAngularImpulse;

--- a/PlayRho/Dynamics/Joints/MotorJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.hpp
@@ -63,10 +63,11 @@ struct MotorJointConf : public JointBuilder<MotorJointConf> {
     constexpr MotorJointConf() noexcept = default;
 
     /// @brief Initialize the bodies and offsets using the current transforms.
-    MotorJointConf(BodyID bA, BodyID bB, Length2 lo = Length2{}, Angle ao = 0_deg) noexcept;
+    MotorJointConf(BodyID bA, BodyID bB, // force line-break
+                   const Length2& lo = Length2{}, Angle ao = 0_deg) noexcept;
 
     /// @brief Uses the given linear offset value.
-    constexpr auto& UseLinearOffset(Length2 v) noexcept
+    constexpr auto& UseLinearOffset(const Length2& v) noexcept
     {
         linearOffset = v;
         return *this;
@@ -178,7 +179,7 @@ constexpr auto GetLocalAnchorB(const MotorJointConf&) noexcept
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso MotorJointConf
-constexpr auto ShiftOrigin(MotorJointConf&, Length2) noexcept
+constexpr auto ShiftOrigin(MotorJointConf&, const Length2&) noexcept
 {
     return false;
 }
@@ -269,7 +270,7 @@ constexpr auto GetLinearOffset(const MotorJointConf& object) noexcept
 
 /// @brief Free function for setting the linear offset value of the given configuration.
 /// @relatedalso MotorJointConf
-constexpr auto SetLinearOffset(MotorJointConf& object, Length2 value) noexcept
+constexpr auto SetLinearOffset(MotorJointConf& object, const Length2& value) noexcept
 {
     object.UseLinearOffset(value);
 }

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.cpp
@@ -111,8 +111,9 @@ static_assert(std::is_nothrow_destructible<PrismaticJointConf>::value,
 // Now compute impulse to be applied:
 // df = f2 - f1
 
-PrismaticJointConf::PrismaticJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB,
-                                       UnitVec axisA, Angle angle) noexcept
+PrismaticJointConf::PrismaticJointConf(BodyID bA, BodyID bB, // force line-break
+                                       const Length2& laA, const Length2& laB, // force line-break
+                                       const UnitVec& axisA, Angle angle) noexcept
     : super{super{}.UseBodyA(bA).UseBodyB(bB)},
       localAnchorA{laA},
       localAnchorB{laB},
@@ -187,7 +188,7 @@ void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodie
     const auto invRotMassA = InvMass{invRotInertiaA * Square(object.a1) / SquareRadian};
     const auto invRotMassB = InvMass{invRotInertiaB * Square(object.a2) / SquareRadian};
     const auto totalInvMass = invMassA + invMassB + invRotMassA + invRotMassB;
-    object.motorMass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
+    object.motorMass = (totalInvMass > InvMass{}) ? Real{1} / totalInvMass : 0_kg;
 
     // Prismatic constraint.
     {
@@ -209,7 +210,7 @@ void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodie
         const auto totalInvRotInertia = invRotInertiaA + invRotInertiaB;
 
         const auto k22 =
-            (totalInvRotInertia == InvRotInertia{0}) ? Real{1} : StripUnit(totalInvRotInertia);
+            (totalInvRotInertia == InvRotInertia{}) ? Real{1} : StripUnit(totalInvRotInertia);
         const auto k23 = (invRotInertiaA * object.a1 + invRotInertiaB * object.a2) * Meter *
                          Kilogram / SquareRadian;
         const auto k33 = StripUnit(totalInvMass);
@@ -248,7 +249,7 @@ void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodie
     }
 
     if (!object.enableMotor) {
-        object.motorImpulse = 0;
+        object.motorImpulse = 0_Ns;
     }
 
     if (step.doWarmStart) {
@@ -276,7 +277,7 @@ void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodie
     }
     else {
         object.impulse = Vec3{};
-        object.motorImpulse = 0;
+        object.motorImpulse = 0_Ns;
     }
 
     bodyConstraintA.SetVelocity(velA);

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
@@ -64,8 +64,9 @@ struct PrismaticJointConf : public JointBuilder<PrismaticJointConf> {
     /// @brief Initializing constructor.
     /// @details Initializes the bodies, anchors, axis, and reference angle using the world
     ///   anchor and unit world axis.
-    PrismaticJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{}, Length2 laB = Length2{},
-                       UnitVec axisA = UnitVec::GetRight(), Angle angle = 0_deg) noexcept;
+    PrismaticJointConf(BodyID bA, BodyID bB, // force line-break
+                       const Length2& laA = Length2{}, const Length2& laB = Length2{},
+                       const UnitVec& axisA = UnitVec::GetRight(), Angle angle = 0_deg) noexcept;
 
     /// @brief Uses the given enable limit state value.
     constexpr auto& UseEnableLimit(bool v) noexcept
@@ -126,7 +127,7 @@ struct PrismaticJointConf : public JointBuilder<PrismaticJointConf> {
 
     Vec3 impulse = Vec3{}; ///< Impulse.
 
-    Momentum motorImpulse = 0; ///< Motor impulse.
+    Momentum motorImpulse = 0_Ns; ///< Motor impulse.
 
     /// Enable/disable the joint limit.
     bool enableLimit = false;
@@ -233,7 +234,7 @@ constexpr void SetLinearLimits(PrismaticJointConf& conf, Length lower, Length up
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso PrismaticJointConf
-constexpr auto ShiftOrigin(PrismaticJointConf&, Length2) noexcept
+constexpr auto ShiftOrigin(PrismaticJointConf&, const Length2&) noexcept
 {
     return false;
 }

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
@@ -55,8 +55,10 @@ static_assert(std::is_nothrow_destructible<PulleyJointConf>::value,
 // K = J * invM * JT
 //   = invMass1 + invI1 * cross(r1, u1)^2 + ratio^2 * (invMass2 + invI2 * cross(r2, u2)^2)
 
-PulleyJointConf::PulleyJointConf(BodyID bA, BodyID bB, Length2 gaA, Length2 gaB,
-                                 Length2 laA, Length2 laB, Length lA, Length lB)
+PulleyJointConf::PulleyJointConf(BodyID bA, BodyID bB, // force line-break
+                                 const Length2& gaA, const Length2& gaB, // force line-break
+                                 const Length2& laA, const Length2& laB, // force line-break
+                                 Length lA, Length lB)
     : super{super{}.UseBodyA(bA).UseBodyB(bB).UseCollideConnected(true)},
       groundAnchorA{gaA},
       groundAnchorB{gaB},
@@ -73,8 +75,9 @@ PulleyJointConf GetPulleyJointConf(const Joint& joint)
     return TypeCast<PulleyJointConf>(joint);
 }
 
-PulleyJointConf GetPulleyJointConf(const World& world, BodyID bA, BodyID bB, Length2 groundA,
-                                   Length2 groundB, Length2 anchorA, Length2 anchorB)
+PulleyJointConf GetPulleyJointConf(const World& world, BodyID bA, BodyID bB, // force line-break
+                                   const Length2& groundA, const Length2& groundB, // force line-break
+                                   const Length2& anchorA, const Length2& anchorB)
 {
     return PulleyJointConf{bA,
                            bB,
@@ -128,7 +131,7 @@ void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
 
     const auto totalInvMass = totInvMassA + object.ratio * object.ratio * totInvMassB;
 
-    object.mass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
+    object.mass = (totalInvMass > InvMass{}) ? Real{1} / totalInvMass : 0_kg;
 
     if (step.doWarmStart) {
         // Scale impulses to support variable time steps.
@@ -228,7 +231,7 @@ bool SolvePosition(const PulleyJointConf& object, std::vector<BodyConstraint>& b
     const auto totalInvMassB = invMassB + invRotInertiaB * Square(ruB) / SquareRadian;
 
     const auto totalInvMass = totalInvMassA + Square(object.ratio) * totalInvMassB;
-    const auto mass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
+    const auto mass = (totalInvMass > InvMass{}) ? Real{1} / totalInvMass : 0_kg;
 
     const auto srcLengthRatio = object.lengthA + object.ratio * object.lengthB; // constant C0
     const auto dstLengthRatio = lengthA + object.ratio * lengthB;
@@ -249,7 +252,7 @@ bool SolvePosition(const PulleyJointConf& object, std::vector<BodyConstraint>& b
     return linearError < conf.linearSlop;
 }
 
-bool ShiftOrigin(PulleyJointConf& object, Length2 newOrigin) noexcept
+bool ShiftOrigin(PulleyJointConf& object, const Length2& newOrigin) noexcept
 {
     object.groundAnchorA -= newOrigin;
     object.groundAnchorB -= newOrigin;

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
@@ -80,9 +80,11 @@ struct PulleyJointConf : public JointBuilder<PulleyJointConf> {
     /// @post <code>localAnchorB</code> will have the value of <code>laB</code>.
     /// @post <code>lengthA</code> will have the value of <code>lA</code>.
     /// @post <code>lengthB</code> will have the value of <code>lB</code>.
-    PulleyJointConf(BodyID bA, BodyID bB, Length2 gaA = DefaultGroundAnchorA,
-                    Length2 gaB = DefaultGroundAnchorB,
-                    Length2 laA = DefaultLocalAnchorA, Length2 laB = DefaultLocalAnchorB,
+    PulleyJointConf(BodyID bA, BodyID bB, // force line-break
+                    const Length2& gaA = DefaultGroundAnchorA,
+                    const Length2& gaB = DefaultGroundAnchorB,
+                    const Length2& laA = DefaultLocalAnchorA,
+                    const Length2& laB = DefaultLocalAnchorB,
                     Length lA = 0_m, Length lB = 0_m);
 
     /// @brief Uses the given ratio value.
@@ -159,8 +161,9 @@ PulleyJointConf GetPulleyJointConf(const Joint& joint);
 
 /// @brief Gets the configuration for the given parameters.
 /// @relatedalso World
-PulleyJointConf GetPulleyJointConf(const World& world, BodyID bA, BodyID bB, Length2 groundA,
-                                   Length2 groundB, Length2 anchorA, Length2 anchorB);
+PulleyJointConf GetPulleyJointConf(const World& world, BodyID bA, BodyID bB, // force line-break
+                                   const Length2& groundA, const Length2& groundB,
+                                   const Length2& anchorA, const Length2& anchorB);
 
 /// @brief Gets the current linear reaction of the given configuration.
 /// @relatedalso PulleyJointConf
@@ -173,12 +176,12 @@ constexpr Momentum2 GetLinearReaction(const PulleyJointConf& object) noexcept
 /// @relatedalso PulleyJointConf
 constexpr AngularMomentum GetAngularReaction(const PulleyJointConf&) noexcept
 {
-    return AngularMomentum{0};
+    return AngularMomentum{};
 }
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso PulleyJointConf
-bool ShiftOrigin(PulleyJointConf& object, Length2 newOrigin) noexcept;
+bool ShiftOrigin(PulleyJointConf& object, const Length2& newOrigin) noexcept;
 
 /// @brief Initializes velocity constraint data based on the given solver data.
 /// @note This MUST be called prior to calling <code>SolveVelocity</code>.

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.cpp
@@ -32,8 +32,8 @@ namespace d2 {
 
 namespace {
 
-Mat33 GetMat33(InvMass invMassA, Length2 rA, InvRotInertia invRotInertiaA, InvMass invMassB,
-               Length2 rB, InvRotInertia invRotInertiaB)
+Mat33 GetMat33(InvMass invMassA, const Length2& rA, InvRotInertia invRotInertiaA, InvMass invMassB,
+               const Length2& rB, InvRotInertia invRotInertiaB)
 {
     const auto totInvI = invRotInertiaA + invRotInertiaB;
 
@@ -89,7 +89,8 @@ static_assert(std::is_nothrow_destructible<RevoluteJointConf>::value,
 // J = [0 0 -1 0 0 1]
 // K = invI1 + invI2
 
-RevoluteJointConf::RevoluteJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB,
+RevoluteJointConf::RevoluteJointConf(BodyID bA, BodyID bB, // force line-break
+                                     const Length2& laA, const Length2& laB,
                                      Angle ra) noexcept
     : super{super{}.UseBodyA(bA).UseBodyB(bB)},
       localAnchorA{laA},
@@ -105,7 +106,7 @@ RevoluteJointConf GetRevoluteJointConf(const Joint& joint)
 }
 
 RevoluteJointConf GetRevoluteJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchor)
+                                       const Length2& anchor)
 {
     return RevoluteJointConf{bodyA, bodyB, GetLocalPoint(world, bodyA, anchor),
                              GetLocalPoint(world, bodyB, anchor),
@@ -159,15 +160,15 @@ void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies
     //     [          -r1y*iA-r2y*iB,           r1x*iA+r2x*iB,                   iA+iB]
 
     const auto totInvI = invRotInertiaA + invRotInertiaB;
-    const auto fixedRotation = (totInvI == InvRotInertia{0});
+    const auto fixedRotation = (totInvI == InvRotInertia{});
 
     object.mass =
         GetMat33(invMassA, object.rA, invRotInertiaA, invMassB, object.rB, invRotInertiaB);
     object.angularMass =
-        (totInvI > InvRotInertia{0}) ? RotInertia{Real{1} / totInvI} : RotInertia{0};
+        (totInvI > InvRotInertia{}) ? RotInertia{Real{1} / totInvI} : RotInertia{};
 
     if (!object.enableMotor || fixedRotation) {
-        object.angularMotorImpulse = 0;
+        object.angularMotorImpulse = {};
     }
 
     if (object.enableLimit && !fixedRotation) {
@@ -217,7 +218,7 @@ void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies
     }
     else {
         object.impulse = Vec3{};
-        object.angularMotorImpulse = 0;
+        object.angularMotorImpulse = {};
     }
 
     bodyConstraintA.SetVelocity(velA);
@@ -244,7 +245,7 @@ bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodie
     const auto invMassB = bodyConstraintB.GetInvMass();
     const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
 
-    const auto fixedRotation = (invRotInertiaA + invRotInertiaB == InvRotInertia{0});
+    const auto fixedRotation = (invRotInertiaA + invRotInertiaB == InvRotInertia{});
 
     // Solve motor constraint.
     if (object.enableMotor && (object.limitState != LimitState::e_equalLimits) && !fixedRotation) {
@@ -359,7 +360,7 @@ bool SolvePosition(const RevoluteJointConf& object, std::vector<BodyConstraint>&
     auto posB = bodyConstraintB.GetPosition();
     const auto invRotInertiaB = bodyConstraintB.GetInvRotInertia();
 
-    const auto fixedRotation = ((invRotInertiaA + invRotInertiaB) == InvRotInertia{0});
+    const auto fixedRotation = ((invRotInertiaA + invRotInertiaB) == InvRotInertia{});
 
     // Solve angular limit constraint.
     auto angularError = 0_rad;

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
@@ -69,7 +69,8 @@ struct RevoluteJointConf : public JointBuilder<RevoluteJointConf> {
     constexpr RevoluteJointConf() noexcept = default;
 
     /// @brief Initialize the bodies, anchors, and reference angle using a world anchor point.
-    RevoluteJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{}, Length2 laB = Length2{},
+    RevoluteJointConf(BodyID bA, BodyID bB, // force line-break
+                      const Length2& laA = Length2{}, const Length2& laB = Length2{},
                       Angle ra = 0_deg) noexcept;
 
     /// @brief Uses the given enable limit state value.
@@ -149,7 +150,7 @@ struct RevoluteJointConf : public JointBuilder<RevoluteJointConf> {
     AngularVelocity motorSpeed = 0_rpm;
 
     /// @brief Maximum motor torque used to achieve the desired motor speed.
-    Torque maxMotorTorque = 0;
+    Torque maxMotorTorque = 0_Nm;
 
     Length2 rA = {}; ///< Rotated delta of body A's local center from local anchor A.
     Length2 rB = {}; ///< Rotated delta of body B's local center from local anchor B.
@@ -189,7 +190,7 @@ RevoluteJointConf GetRevoluteJointConf(const Joint& joint);
 /// @brief Gets the configuration for the given parameters.
 /// @relatedalso World
 RevoluteJointConf GetRevoluteJointConf(const World& world, BodyID bodyA, BodyID bodyB,
-                                       Length2 anchor);
+                                       const Length2& anchor);
 
 /// @brief Gets the current angle of the given configuration in the given world.
 /// @relatedalso World
@@ -201,7 +202,7 @@ AngularVelocity GetAngularVelocity(const World& world, const RevoluteJointConf& 
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso RevoluteJointConf
-constexpr auto ShiftOrigin(RevoluteJointConf&, Length2) noexcept
+constexpr auto ShiftOrigin(RevoluteJointConf&, const Length2&) noexcept
 {
     return false;
 }

--- a/PlayRho/Dynamics/Joints/RopeJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.cpp
@@ -96,7 +96,7 @@ void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, co
     else {
         object.u = UnitVec::GetZero();
         object.mass = 0_kg;
-        object.impulse = 0;
+        object.impulse = 0_Ns;
         return;
     }
 
@@ -107,7 +107,7 @@ void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, co
     const auto invRotMassB = InvMass{invRotInertiaB * Square(crB)};
     const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
 
-    object.mass = (invMass != InvMass{0}) ? Real{1} / invMass : 0_kg;
+    object.mass = (invMass != InvMass{}) ? Real{1} / invMass : 0_kg;
 
     if (step.doWarmStart) {
         // Scale the impulse to support a variable time step.
@@ -123,7 +123,7 @@ void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, co
         velB += Velocity{invMassB * P, invRotInertiaB * LB};
     }
     else {
-        object.impulse = 0;
+        object.impulse = 0_Ns;
     }
 
     bodyConstraintA.SetVelocity(velA);

--- a/PlayRho/Dynamics/Joints/RopeJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.hpp
@@ -84,7 +84,7 @@ struct RopeJointConf : public JointBuilder<RopeJointConf> {
     /// The maximum length of the rope.
     Length maxLength = 0_m;
 
-    Length length = 0; ///< Length.
+    Length length = 0_m; ///< Length.
     Momentum impulse = 0_Ns; ///< Impulse.
 
     // Solver temp
@@ -130,12 +130,12 @@ constexpr Momentum2 GetLinearReaction(const RopeJointConf& object) noexcept
 /// @relatedalso RopeJointConf
 constexpr AngularMomentum GetAngularReaction(const RopeJointConf&) noexcept
 {
-    return AngularMomentum{0};
+    return AngularMomentum{};
 }
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso RopeJointConf
-constexpr auto ShiftOrigin(RopeJointConf&, Length2) noexcept
+constexpr auto ShiftOrigin(RopeJointConf&, const Length2&) noexcept
 {
     return false;
 }

--- a/PlayRho/Dynamics/Joints/TargetJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.cpp
@@ -115,7 +115,7 @@ void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
     const auto tmp = d + h * k; // M T^-1
     assert(IsValid(Real{tmp * Second / Kilogram}));
     const auto invGamma = Mass{h * tmp}; // M T^-1 * T is simply M.
-    object.gamma = (invGamma != 0_kg) ? Real{1} / invGamma : InvMass{0};
+    object.gamma = (invGamma != 0_kg) ? Real{1} / invGamma : InvMass{};
     const auto beta = Frequency{h * k * object.gamma}; // T * M T^-2 * M^-1 is T^-1
 
     // Compute the effective mass matrix.

--- a/PlayRho/Dynamics/Joints/TargetJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.hpp
@@ -65,7 +65,7 @@ struct TargetJointConf : public JointBuilder<TargetJointConf> {
     }
 
     /// @brief Use value for target.
-    constexpr auto& UseTarget(Length2 v) noexcept
+    constexpr auto& UseTarget(const Length2& v) noexcept
     {
         target = v;
         return *this;
@@ -76,7 +76,7 @@ struct TargetJointConf : public JointBuilder<TargetJointConf> {
     ///   <code>bodyB != InvalidBodyID
     ///     ? GetLocalPoint(GetBody(world, bodyB), target)
     ///     : GetInvalid<Length2>()</code>.
-    constexpr auto& UseAnchor(Length2 v) noexcept
+    constexpr auto& UseAnchor(const Length2& v) noexcept
     {
         localAnchorB = v;
         return *this;
@@ -126,7 +126,7 @@ struct TargetJointConf : public JointBuilder<TargetJointConf> {
     /// The damping ratio. 0 = no damping, 1 = critical damping.
     NonNegative<Real> dampingRatio = DefaultDampingRatio;
 
-    InvMass gamma = InvMass{0}; ///< Gamma.
+    InvMass gamma = InvMass{}; ///< Gamma.
 
     Momentum2 impulse = Momentum2{}; ///< Impulse.
 
@@ -179,12 +179,12 @@ constexpr Momentum2 GetLinearReaction(const TargetJointConf& object)
 /// @relatedalso TargetJointConf
 constexpr AngularMomentum GetAngularReaction(const TargetJointConf&)
 {
-    return AngularMomentum{0};
+    return AngularMomentum{};
 }
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso TargetJointConf
-constexpr bool ShiftOrigin(TargetJointConf& object, Length2 newOrigin)
+constexpr bool ShiftOrigin(TargetJointConf& object, const Length2& newOrigin)
 {
     object.target -= newOrigin;
     return true;
@@ -238,7 +238,7 @@ bool SolvePosition(const TargetJointConf& object, std::vector<BodyConstraint>& b
 
 /// @brief Free function for setting the target value of the given configuration.
 /// @relatedalso TargetJointConf
-constexpr void SetTarget(TargetJointConf& object, Length2 value) noexcept
+constexpr void SetTarget(TargetJointConf& object, const Length2& value) noexcept
 {
     object.UseTarget(value);
 }

--- a/PlayRho/Dynamics/Joints/WeldJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.hpp
@@ -68,7 +68,8 @@ struct WeldJointConf : public JointBuilder<WeldJointConf> {
     /// @post <code>localAnchorA</code> will have the value of <code>laA</code>.
     /// @post <code>localAnchorB</code> will have the value of <code>laB</code>.
     /// @post <code>referenceAngle</code> will have the value of <code>ra</code>.
-    WeldJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{}, Length2 laB = Length2{},
+    WeldJointConf(BodyID bA, BodyID bB, // force line-break
+                  const Length2& laA = Length2{}, const Length2& laB = Length2{},
                   Angle ra = 0_deg) noexcept;
 
     /// @brief Uses the given frequency value.
@@ -161,7 +162,7 @@ constexpr AngularMomentum GetAngularReaction(const WeldJointConf& object) noexce
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso WeldJointConf
-constexpr auto ShiftOrigin(WeldJointConf&, Length2) noexcept
+constexpr auto ShiftOrigin(WeldJointConf&, const Length2&) noexcept
 {
     return false;
 }

--- a/PlayRho/Dynamics/Joints/WheelJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.cpp
@@ -59,8 +59,9 @@ static_assert(std::is_nothrow_destructible<WheelJointConf>::value,
 // Cdot = wB - wA
 // J = [0 0 -1 0 0 1]
 
-WheelJointConf::WheelJointConf(BodyID bA, BodyID bB, Length2 laA, Length2 laB,
-                               UnitVec axis) noexcept
+WheelJointConf::WheelJointConf(BodyID bA, BodyID bB, // force line-break
+                               const Length2& laA, const Length2& laB,
+                               const UnitVec& axis) noexcept
     : super{super{}.UseBodyA(bA).UseBodyB(bB)},
       localAnchorA{laA},
       localAnchorB{laB},
@@ -75,8 +76,8 @@ WheelJointConf GetWheelJointConf(const Joint& joint)
     return TypeCast<WheelJointConf>(joint);
 }
 
-WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB, Length2 anchor,
-                                 UnitVec axis)
+WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB, // force line-break
+                                 const Length2& anchor, const UnitVec& axis)
 {
     return WheelJointConf{bodyA, bodyB, GetLocalPoint(world, bodyA, anchor),
                           GetLocalPoint(world, bodyB, anchor), GetLocalVector(world, bodyA, axis)};
@@ -125,13 +126,13 @@ void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, c
         const auto invRotMassB = invRotInertiaB * Square(object.sBy) / SquareRadian;
         const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
 
-        object.mass = (invMass > InvMass{0}) ? Real{1} / invMass : 0;
+        object.mass = (invMass > InvMass{}) ? Real{1} / invMass : 0_kg;
     }
 
     // Spring constraint
     object.springMass = 0_kg;
-    object.bias = 0;
-    object.gamma = 0;
+    object.bias = 0_mps;
+    object.gamma = {};
     if (object.frequency > 0_Hz) {
         object.ax = Rotate(object.localXAxisA, qA);
         object.sAx = Cross(dd + rA, object.ax);
@@ -141,7 +142,7 @@ void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, c
         const auto invRotMassB = invRotInertiaB * Square(object.sBx) / SquareRadian;
         const auto invMass = invMassA + invMassB + invRotMassA + invRotMassB;
 
-        if (invMass > InvMass{0}) {
+        if (invMass > InvMass{}) {
             object.springMass = Real{1} / invMass;
 
             const auto C = Length{Dot(dd, object.ax)};
@@ -159,16 +160,15 @@ void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, c
             const auto h = step.deltaTime;
 
             const auto invGamma = Mass{h * (d + h * k)};
-            object.gamma = (invGamma > 0_kg) ? Real{1} / invGamma : 0;
+            object.gamma = (invGamma > 0_kg) ? Real{1} / invGamma : InvMass{};
             object.bias = LinearVelocity{C * h * k * object.gamma};
 
             const auto totalInvMass = invMass + object.gamma;
-            object.springMass = (totalInvMass > InvMass{0}) ? Real{1} / totalInvMass : 0_kg;
+            object.springMass = (totalInvMass > InvMass{}) ? Real{1} / totalInvMass : 0_kg;
         }
     }
     else {
-        object.springImpulse = 0;
-
+        object.springImpulse = 0_Ns;
         object.ax = UnitVec::GetZero();
         object.sAx = 0_m;
         object.sBx = 0_m;
@@ -178,11 +178,11 @@ void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, c
     if (object.enableMotor) {
         const auto invRotInertia = invRotInertiaA + invRotInertiaB;
         object.angularMass =
-            (invRotInertia > InvRotInertia{0}) ? Real{1} / invRotInertia : RotInertia{0};
+            (invRotInertia > InvRotInertia{}) ? Real{1} / invRotInertia : RotInertia{};
     }
     else {
-        object.angularMass = RotInertia{0};
-        object.angularImpulse = 0;
+        object.angularMass = RotInertia{};
+        object.angularImpulse = AngularMomentum{};
     }
 
     if (step.doWarmStart) {
@@ -206,9 +206,9 @@ void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, c
         velB += Velocity{invMassB * P, invRotInertiaB * LB};
     }
     else {
-        object.impulse = 0;
-        object.springImpulse = 0;
-        object.angularImpulse = 0;
+        object.impulse = 0_Ns;
+        object.springImpulse = 0_Ns;
+        object.angularImpulse = AngularMomentum{};
     }
 
     bodyConstraintA.SetVelocity(velA);
@@ -329,7 +329,7 @@ bool SolvePosition(const WheelJointConf& object, std::vector<BodyConstraint>& bo
 
     const auto k = InvMass{invMassA + invMassB + invRotMassA + invRotMassB};
 
-    const auto impulse = (k != InvMass{0}) ? -(C / k) : 0 * Kilogram * Meter;
+    const auto impulse = (k != InvMass{}) ? -(C / k) : 0 * Kilogram * Meter;
 
     const auto P = impulse * ay;
     const auto LA = impulse * sAy / Radian;

--- a/PlayRho/Dynamics/Joints/WheelJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.hpp
@@ -67,8 +67,9 @@ struct WheelJointConf : public JointBuilder<WheelJointConf> {
 
     /// Initialize the bodies, anchors, axis, and reference angle using the world
     /// anchor and world axis.
-    WheelJointConf(BodyID bA, BodyID bB, Length2 laA = Length2{}, Length2 laB = Length2{},
-                   UnitVec axis = UnitVec::GetRight()) noexcept;
+    WheelJointConf(BodyID bA, BodyID bB, // force line-break
+                   const Length2& laA = Length2{}, const Length2& laB = Length2{},
+                   const UnitVec& axis = UnitVec::GetRight()) noexcept;
 
     /// @brief Uses the given enable motor state value.
     constexpr auto& UseEnableMotor(bool v) noexcept
@@ -121,7 +122,7 @@ struct WheelJointConf : public JointBuilder<WheelJointConf> {
     bool enableMotor = false;
 
     /// The maximum motor torque.
-    Torque maxMotorTorque = Torque{0};
+    Torque maxMotorTorque = Torque{};
 
     /// The desired angular motor speed.
     AngularVelocity motorSpeed = 0_rpm;
@@ -132,9 +133,9 @@ struct WheelJointConf : public JointBuilder<WheelJointConf> {
     /// Suspension damping ratio, one indicates critical damping
     Real dampingRatio = DefaultDampingRatio;
 
-    Momentum impulse = 0; ///< Impulse.
-    AngularMomentum angularImpulse = 0; ///< Angular impulse.
-    Momentum springImpulse = 0; ///< Spring impulse.
+    Momentum impulse = 0_Ns; ///< Impulse.
+    AngularMomentum angularImpulse = {}; ///< Angular impulse.
+    Momentum springImpulse = 0_Ns; ///< Spring impulse.
 
     UnitVec ax; ///< Solver A X directional.
     UnitVec ay; ///< Solver A Y directional.
@@ -145,11 +146,11 @@ struct WheelJointConf : public JointBuilder<WheelJointConf> {
     Length sBy = 0_m; ///< Solver B y location.
 
     Mass mass = 0_kg; ///< Mass.
-    RotInertia angularMass = RotInertia{0}; ///< Motor mass.
+    RotInertia angularMass = RotInertia{}; ///< Motor mass.
     Mass springMass = 0_kg; ///< Spring mass.
 
     LinearVelocity bias = 0_mps; ///< Bias.
-    InvMass gamma = InvMass{0}; ///< Gamma.
+    InvMass gamma = InvMass{}; ///< Gamma.
 };
 
 /// @brief Equality operator.
@@ -197,8 +198,8 @@ WheelJointConf GetWheelJointConf(const Joint& joint);
 
 /// @brief Gets the definition data for the given parameters.
 /// @relatedalso World
-WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB, Length2 anchor,
-                                 UnitVec axis = UnitVec::GetRight());
+WheelJointConf GetWheelJointConf(const World& world, BodyID bodyA, BodyID bodyB, // force line-break
+                                 const Length2& anchor, const UnitVec& axis = UnitVec::GetRight());
 
 /// @brief Gets the angular velocity for the given configuration within the specified world.
 /// @relatedalso World
@@ -213,7 +214,7 @@ constexpr Momentum2 GetLinearReaction(const WheelJointConf& object)
 
 /// @brief Shifts the origin notion of the given configuration.
 /// @relatedalso WheelJointConf
-constexpr auto ShiftOrigin(WheelJointConf&, Length2)
+constexpr auto ShiftOrigin(WheelJointConf&, const Length2&)
 {
     return false;
 }

--- a/PlayRho/Dynamics/StepConf.hpp
+++ b/PlayRho/Dynamics/StepConf.hpp
@@ -69,7 +69,7 @@ struct StepConf {
     static constexpr auto DefaultRegResolutionRate = Real{2} / 10; // aka 0.2.;
 
     /// @brief Default regular min separation.
-    static constexpr auto DefaultRegMinSeparation = -DefaultLinearSlop * Real{3};
+    static constexpr auto DefaultRegMinSeparation = -playrho::DefaultLinearSlop * Real{3};
 
     /// @brief Default regular min momentum.
     static constexpr auto DefaultRegMinMomentum = Momentum{playrho::DefaultRegMinMomentum};
@@ -78,7 +78,7 @@ struct StepConf {
     static constexpr auto DefaultToiResolutionRate = Real{75} / 100; // aka .75
 
     /// @brief Default time of impact (TOI) min separation.
-    static constexpr auto DefaultToiMinSeparation = -DefaultLinearSlop * Real(1.5f);
+    static constexpr auto DefaultToiMinSeparation = -playrho::DefaultLinearSlop * Real(1.5f);
 
     /// @brief Default time of impact (TOI) min momemtum.
     static constexpr auto DefaultToiMinMomentum = Momentum{playrho::DefaultToiMinMomentum};
@@ -388,10 +388,6 @@ struct StepConf {
 // Basic requirements...
 static_assert(std::is_default_constructible_v<StepConf>);
 static_assert(std::is_copy_constructible_v<StepConf>);
-
-// Special expectations...
-static_assert(std::is_nothrow_default_constructible_v<StepConf>);
-static_assert(std::is_nothrow_copy_constructible_v<StepConf>);
 
 /// @brief Gets the maximum regular linear correction from the given value.
 /// @relatedalso StepConf

--- a/PlayRho/Dynamics/StepStats.hpp
+++ b/PlayRho/Dynamics/StepStats.hpp
@@ -50,7 +50,7 @@ struct RegStepStats {
     Length minSeparation = std::numeric_limits<Length>::infinity();
 
     /// @brief Max incremental impulse.
-    Momentum maxIncImpulse = 0;
+    Momentum maxIncImpulse = 0_Ns;
 
     BodyCounter islandsFound = 0; ///< Islands found count.
     BodyCounter islandsSolved = 0; ///< Islands solved count.
@@ -73,7 +73,7 @@ struct ToiStepStats {
     Length minSeparation = std::numeric_limits<Length>::infinity();
 
     /// @brief Max incremental impulse.
-    Momentum maxIncImpulse = 0;
+    Momentum maxIncImpulse = 0_Ns;
 
     counter_type islandsFound = 0; ///< Islands found count.
     counter_type islandsSolved = 0; ///< Islands solved count.

--- a/PlayRho/Dynamics/World.cpp
+++ b/PlayRho/Dynamics/World.cpp
@@ -115,7 +115,7 @@ bool World::IsLocked() const noexcept
     return m_impl && ::playrho::d2::IsLocked(*m_impl);
 }
 
-void World::ShiftOrigin(Length2 newOrigin)
+void World::ShiftOrigin(const Length2& newOrigin)
 {
     ::playrho::d2::ShiftOrigin(*m_impl, newOrigin);
 }

--- a/PlayRho/Dynamics/World.hpp
+++ b/PlayRho/Dynamics/World.hpp
@@ -292,7 +292,7 @@ public:
     ///   have been translated per the shift amount and direction.
     /// @param newOrigin the new origin with respect to the old origin
     /// @throws WrongState if this method is called while the world is locked.
-    void ShiftOrigin(Length2 newOrigin);
+    void ShiftOrigin(const Length2& newOrigin);
 
     /// @brief Gets the minimum vertex radius that shapes in this world can be.
     /// @see GetMaxVertexRadius.

--- a/PlayRho/Dynamics/WorldBody.cpp
+++ b/PlayRho/Dynamics/WorldBody.cpp
@@ -135,14 +135,14 @@ Acceleration GetAcceleration(const World& world, BodyID id)
 }
 
 void SetAcceleration(World& world, BodyID id,
-                     LinearAcceleration2 linear, AngularAcceleration angular)
+                     const LinearAcceleration2& linear, AngularAcceleration angular)
 {
     auto body = GetBody(world, id);
     SetAcceleration(body, linear, angular);
     SetBody(world, id, body);
 }
 
-void SetAcceleration(World& world, BodyID id, LinearAcceleration2 value)
+void SetAcceleration(World& world, BodyID id, const LinearAcceleration2& value)
 {
     auto body = GetBody(world, id);
     SetAcceleration(body, value);
@@ -156,21 +156,21 @@ void SetAcceleration(World& world, BodyID id, AngularAcceleration value)
     SetBody(world, id, body);
 }
 
-void SetAcceleration(World& world, BodyID id, Acceleration value)
+void SetAcceleration(World& world, BodyID id, const Acceleration& value)
 {
     auto body = GetBody(world, id);
     SetAcceleration(body, value);
     SetBody(world, id, body);
 }
 
-void SetTransformation(World& world, BodyID id, Transformation value)
+void SetTransformation(World& world, BodyID id, const Transformation& value)
 {
     auto body = GetBody(world, id);
     SetTransformation(body, value);
     SetBody(world, id, body);
 }
 
-void SetLocation(World& world, BodyID id, Length2 value)
+void SetLocation(World& world, BodyID id, const Length2& value)
 {
     auto body = GetBody(world, id);
     SetLocation(body, value);
@@ -184,7 +184,7 @@ void SetAngle(World& world, BodyID id, Angle value)
     SetBody(world, id, body);
 }
 
-void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, Length2 worldPoint)
+void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, const Length2& worldPoint)
 {
     const auto xfm = GetTransformation(world, id);
     const auto p = xfm.p - worldPoint;
@@ -197,7 +197,7 @@ void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, Length2 worldP
     SetTransform(world, id, pos, angle);
 }
 
-void RotateAboutLocalPoint(World& world, BodyID id, Angle amount, Length2 localPoint)
+void RotateAboutLocalPoint(World& world, BodyID id, Angle amount, const Length2& localPoint)
 {
     RotateAboutWorldPoint(world, id, amount, GetWorldPoint(world, id, localPoint));
 }
@@ -383,11 +383,11 @@ void SetMassData(World& world, BodyID id, const MassData& massData)
     const auto mass = (massData.mass > 0_kg)? Mass{massData.mass}: 1_kg;
     const auto invMass = Real{1} / mass;
     auto invRotInertia = Real(0) / (1_m2 * 1_kg / SquareRadian);
-    if ((massData.I > RotInertia{0}) && (!body.IsFixedRotation())) {
+    if ((massData.I > RotInertia{}) && (!body.IsFixedRotation())) {
         const auto lengthSquared = GetMagnitudeSquared(massData.center);
         // L^2 M QP^-2
         const auto I = RotInertia{massData.I} - RotInertia{(mass * lengthSquared) / SquareRadian};
-        assert(I > RotInertia{0});
+        assert(I > RotInertia{});
         invRotInertia = Real{1} / I;
     }
     body.SetInvMassData(invMass, invRotInertia);
@@ -481,7 +481,7 @@ const std::vector<KeyedContactPtr>& GetContacts(const World& world, BodyID id)
     return world.GetContacts(id);
 }
 
-Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis)
+Force2 GetCentripetalForce(const World& world, BodyID id, const Length2& axis)
 {
     // For background on centripetal force, see:
     //   https://en.wikipedia.org/wiki/Centripetal_force
@@ -497,7 +497,7 @@ Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis)
     return Force2{dir * mass * Square(magnitudeOfVelocity) * invRadius};
 }
 
-void ApplyForce(World& world, BodyID id, Force2 force, Length2 point)
+void ApplyForce(World& world, BodyID id, const Force2& force, const Length2& point)
 {
     // Torque is L^2 M T^-2 QP^-1.
     const auto& body = GetBody(world, id);
@@ -520,7 +520,7 @@ void ApplyTorque(World& world, BodyID id, Torque torque)
     SetAcceleration(world, id, linAccel, angAccel);
 }
 
-void ApplyLinearImpulse(World& world, BodyID id, Momentum2 impulse, Length2 point)
+void ApplyLinearImpulse(World& world, BodyID id, const Momentum2& impulse, const Length2& point)
 {
     auto body = GetBody(world, id);
     ApplyLinearImpulse(body, impulse, point);
@@ -534,7 +534,7 @@ void ApplyAngularImpulse(World& world, BodyID id, AngularMomentum impulse)
     SetBody(world, id, body);
 }
 
-void SetForce(World& world, BodyID id, Force2 force, Length2 point)
+void SetForce(World& world, BodyID id, const Force2& force, const Length2& point)
 {
     const auto linAccel = LinearAcceleration2{force * GetInvMass(world, id)};
     const auto invRotI = GetInvRotInertia(world, id);
@@ -574,7 +574,7 @@ BodyCounter Awaken(World& world)
     return awoken;
 }
 
-void SetAccelerations(World& world, Acceleration acceleration)
+void SetAccelerations(World& world, const Acceleration& acceleration)
 {
     const auto& bodies = world.GetBodies();
     for_each(begin(bodies), end(bodies), [&world, acceleration](const auto &b) {
@@ -582,7 +582,7 @@ void SetAccelerations(World& world, Acceleration acceleration)
     });
 }
 
-void SetAccelerations(World& world, LinearAcceleration2 acceleration)
+void SetAccelerations(World& world, const LinearAcceleration2& acceleration)
 {
     const auto& bodies = world.GetBodies();
     for_each(begin(bodies), end(bodies), [&world, acceleration](const auto &b) {
@@ -590,7 +590,7 @@ void SetAccelerations(World& world, LinearAcceleration2 acceleration)
     });
 }
 
-BodyID FindClosestBody(const World& world, Length2 location)
+BodyID FindClosestBody(const World& world, const Length2& location)
 {
     const auto& bodies = world.GetBodies();
     auto found = InvalidBodyID;

--- a/PlayRho/Dynamics/WorldBody.hpp
+++ b/PlayRho/Dynamics/WorldBody.hpp
@@ -214,7 +214,7 @@ Acceleration GetAcceleration(const World& world, BodyID id);
 /// @see GetAcceleration(const World& world, BodyID id).
 /// @relatedalso World
 void SetAcceleration(World& world, BodyID id,
-                     LinearAcceleration2 linear, AngularAcceleration angular);
+                     const LinearAcceleration2& linear, AngularAcceleration angular);
 
 /// @brief Sets the linear accelerations on the body.
 /// @note This has no effect on non-accelerable bodies.
@@ -223,7 +223,7 @@ void SetAcceleration(World& world, BodyID id,
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @see GetAcceleration(const World& world, BodyID id).
 /// @relatedalso World
-void SetAcceleration(World& world, BodyID id, LinearAcceleration2 value);
+void SetAcceleration(World& world, BodyID id, const LinearAcceleration2& value);
 
 /// @brief Sets the rotational accelerations on the body.
 /// @note This has no effect on non-accelerable bodies.
@@ -244,7 +244,7 @@ void SetAcceleration(World& world, BodyID id, AngularAcceleration value);
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @see GetAcceleration(const World& world, BodyID id).
 /// @relatedalso World
-void SetAcceleration(World& world, BodyID id, Acceleration value);
+void SetAcceleration(World& world, BodyID id, const Acceleration& value);
 
 /// @brief Sets the transformation of the body.
 /// @details This instantly adjusts the body to be at the new transformation.
@@ -254,7 +254,7 @@ void SetAcceleration(World& world, BodyID id, Acceleration value);
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @see GetTransformation(const World& world, BodyID id).
 /// @relatedalso World
-void SetTransformation(World& world, BodyID id, Transformation value);
+void SetTransformation(World& world, BodyID id, const Transformation& value);
 
 /// @brief Sets the position of the body's origin and rotation.
 /// @details This instantly adjusts the body to be at the new position and new orientation.
@@ -268,7 +268,7 @@ void SetTransformation(World& world, BodyID id, Transformation value);
 /// @throws WrongState if this function is called while the world is locked.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-inline void SetTransform(World& world, BodyID id, Length2 location, Angle angle)
+inline void SetTransform(World& world, BodyID id, const Length2& location, Angle angle)
 {
     SetTransformation(world, id, Transformation{location, UnitVec::Get(angle)});
 }
@@ -284,7 +284,7 @@ inline void SetTransform(World& world, BodyID id, Length2 location, Angle angle)
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @see GetLocation(const World& world, BodyID id).
 /// @relatedalso World
-void SetLocation(World& world, BodyID id, Length2 value);
+void SetLocation(World& world, BodyID id, const Length2& value);
 
 /// @brief Sets the body's angular orientation.
 /// @details This instantly adjusts the body to be at the new angular orientation.
@@ -309,7 +309,7 @@ void SetAngle(World& world, BodyID id, Angle value);
 /// @throws WrongState if this function is called while the world is locked.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, Length2 worldPoint);
+void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, const Length2& worldPoint);
 
 /// @brief Rotates a body a given amount around a point in body local coordinates.
 /// @details This changes both the linear and angular positions of the body.
@@ -323,7 +323,7 @@ void RotateAboutWorldPoint(World& world, BodyID id, Angle amount, Length2 worldP
 /// @throws WrongState if this function is called while the world is locked.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-void RotateAboutLocalPoint(World& world, BodyID id, Angle amount, Length2 localPoint);
+void RotateAboutLocalPoint(World& world, BodyID id, Angle amount, const Length2& localPoint);
 
 /// @brief Calculates the gravitationally associated acceleration for the given body within its world.
 /// @return Zero acceleration if given body is has no mass, else the acceleration of
@@ -375,7 +375,7 @@ inline Length2 GetLocation(const World& world, BodyID id)
 /// @return the same point expressed in world coordinates.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-inline Length2 GetWorldPoint(const World& world, BodyID id, const Length2 localPoint)
+inline Length2 GetWorldPoint(const World& world, BodyID id, const Length2& localPoint)
 {
     return Transform(localPoint, GetTransformation(world, id));
 }
@@ -383,7 +383,7 @@ inline Length2 GetWorldPoint(const World& world, BodyID id, const Length2 localP
 /// @brief Convenience function for getting the local vector of the identified body.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-inline UnitVec GetLocalVector(const World& world, BodyID body, const UnitVec uv)
+inline UnitVec GetLocalVector(const World& world, BodyID body, const UnitVec& uv)
 {
     return InverseRotate(uv, GetTransformation(world, body).q);
 }
@@ -395,7 +395,7 @@ inline UnitVec GetLocalVector(const World& world, BodyID body, const UnitVec uv)
 /// @return the corresponding local point relative to the body's origin.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-inline Length2 GetLocalPoint(const World& world, BodyID id, const Length2 worldPoint)
+inline Length2 GetLocalPoint(const World& world, BodyID id, const Length2& worldPoint)
 {
     return InverseTransform(worldPoint, GetTransformation(world, id));
 }
@@ -414,7 +414,7 @@ inline Position GetPosition(const World& world, BodyID id)
 
 /// @brief Convenience function for getting a world vector of the identified body.
 /// @relatedalso World
-inline UnitVec GetWorldVector(const World& world, BodyID id, UnitVec localVector)
+inline UnitVec GetWorldVector(const World& world, BodyID id, const UnitVec& localVector)
 {
     return Rotate(localVector, GetTransformation(world, id).q);
 }
@@ -576,7 +576,7 @@ InvRotInertia GetInvRotInertia(const World& world, BodyID id);
 inline Mass GetMass(const World& world, BodyID id)
 {
     const auto invMass = GetInvMass(world, id);
-    return (invMass != InvMass{0})? Mass{Real{1} / invMass}: 0_kg;
+    return (invMass != InvMass{})? Mass{Real{1} / invMass}: 0_kg;
 }
 
 /// @brief Gets the rotational inertia of the body.
@@ -723,7 +723,7 @@ const std::vector<KeyedContactPtr>& GetContacts(const World& world, BodyID id);
 ///    the given radius.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis);
+Force2 GetCentripetalForce(const World& world, BodyID id, const Length2& axis);
 
 /// @brief Applies a force to the center of mass of the given body.
 /// @note Non-zero forces wakes up the body.
@@ -733,7 +733,7 @@ Force2 GetCentripetalForce(const World& world, BodyID id, Length2 axis);
 /// @throws WrongState if this function is called while the world is locked.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-inline void ApplyForceToCenter(World& world, BodyID id, Force2 force)
+inline void ApplyForceToCenter(World& world, BodyID id, const Force2& force)
 {
     const auto linAccel = GetLinearAcceleration(world, id) + force * GetInvMass(world, id);
     const auto angAccel = GetAngularAcceleration(world, id);
@@ -751,7 +751,7 @@ inline void ApplyForceToCenter(World& world, BodyID id, Force2 force)
 /// @throws WrongState if this function is called while the world is locked.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-void ApplyForce(World& world, BodyID id, Force2 force, Length2 point);
+void ApplyForce(World& world, BodyID id, const Force2& force, const Length2& point);
 
 /// @brief Applies a torque.
 /// @note This affects the angular velocity without affecting the linear velocity of the
@@ -777,7 +777,7 @@ void ApplyTorque(World& world, BodyID id, Torque torque);
 /// @throws WrongState if this function is called while the world is locked.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-void ApplyLinearImpulse(World& world, BodyID id, Momentum2 impulse, Length2 point);
+void ApplyLinearImpulse(World& world, BodyID id, const Momentum2& impulse, const Length2& point);
 
 /// @brief Applies an angular impulse.
 /// @param world The world in which the identified body exists.
@@ -792,7 +792,7 @@ void ApplyAngularImpulse(World& world, BodyID id, AngularMomentum impulse);
 /// @throws WrongState if this function is called while the world is locked.
 /// @throws std::out_of_range If given an invalid body identifier.
 /// @relatedalso World
-void SetForce(World& world, BodyID id, Force2 force, Length2 point);
+void SetForce(World& world, BodyID id, const Force2& force, const Length2& point);
 
 /// @brief Sets the given amount of torque to the given body.
 /// @throws WrongState if this function is called while the world is locked.
@@ -834,7 +834,7 @@ BodyCounter Awaken(World& world);
 
 /// @brief Finds body in given world that's closest to the given location.
 /// @relatedalso World
-BodyID FindClosestBody(const World& world, Length2 location);
+BodyID FindClosestBody(const World& world, const Length2& location);
 
 /// @brief Gets the body count in the given world.
 /// @return 0 or higher.
@@ -848,13 +848,13 @@ inline BodyCounter GetBodyCount(const World& world) noexcept
 /// @brief Sets the accelerations of all the world's bodies to the given value.
 /// @throws WrongState if this function is called while the world is locked.
 /// @relatedalso World
-void SetAccelerations(World& world, Acceleration acceleration);
+void SetAccelerations(World& world, const Acceleration& acceleration);
 
 /// @brief Sets the accelerations of all the world's bodies to the given value.
 /// @note This will leave the angular acceleration alone.
 /// @throws WrongState if this function is called while the world is locked.
 /// @relatedalso World
-void SetAccelerations(World& world, LinearAcceleration2 acceleration);
+void SetAccelerations(World& world, const LinearAcceleration2& acceleration);
 
 /// @brief Clears forces.
 /// @details Manually clear the force buffer on all bodies.

--- a/PlayRho/Dynamics/WorldImpl.cpp
+++ b/PlayRho/Dynamics/WorldImpl.cpp
@@ -120,8 +120,8 @@ struct WorldImpl::ContactUpdateConf
 
 namespace {
 
-constexpr char idIsDestroyedMsg[] = "ID is destroyed";
-constexpr char worldIsLockedMsg[] = "world is locked";
+constexpr auto idIsDestroyedMsg = "ID is destroyed";
+constexpr auto worldIsLockedMsg = "world is locked";
 
 inline void IntegratePositions(const Island::Bodies& bodies, BodyConstraints& constraints, Time h)
 {

--- a/PlayRho/Dynamics/WorldImpl.cpp
+++ b/PlayRho/Dynamics/WorldImpl.cpp
@@ -222,7 +222,7 @@ void WarmStartVelocities(const VelocityConstraints& velConstraints,
 }
 
 void GetBodyConstraints(std::vector<BodyConstraint>& constraints, const Island::Bodies& bodies,
-                        const ObjectPool<Body>& bodyBuffer, Time h, MovementConf conf)
+                        const ObjectPool<Body>& bodyBuffer, Time h, const MovementConf& conf)
 {
     assert(size(constraints) == size(bodyBuffer));
     for (const auto& id: bodies) {
@@ -2027,7 +2027,7 @@ StepStats WorldImpl::Step(const StepConf& conf)
     return stepStats;
 }
 
-void WorldImpl::ShiftOrigin(Length2 newOrigin)
+void WorldImpl::ShiftOrigin(const Length2& newOrigin)
 {
     if (IsLocked()) {
         throw WrongState(worldIsLockedMsg);

--- a/PlayRho/Dynamics/WorldImpl.hpp
+++ b/PlayRho/Dynamics/WorldImpl.hpp
@@ -234,7 +234,7 @@ public:
     ///   have been translated per the shift amount and direction.
     /// @param newOrigin the new origin with respect to the old origin
     /// @throws WrongState if this function is called while the world is locked.
-    void ShiftOrigin(Length2 newOrigin);
+    void ShiftOrigin(const Length2& newOrigin);
 
     /// @brief Gets the minimum vertex radius that shapes in this world can be.
     Length GetMinVertexRadius() const noexcept;
@@ -820,7 +820,7 @@ private:
     /// @details Used to compute time step ratio to support a variable time step.
     /// @note 4-bytes large.
     /// @see Step.
-    Frequency m_inv_dt0 = 0;
+    Frequency m_inv_dt0 = 0_Hz;
     
     /// @brief Minimum vertex radius.
     Positive<Length> m_minVertexRadius;

--- a/PlayRho/Dynamics/WorldImplMisc.cpp
+++ b/PlayRho/Dynamics/WorldImplMisc.cpp
@@ -94,7 +94,7 @@ StepStats Step(WorldImpl& world, const StepConf& conf)
     return world.Step(conf);
 }
 
-void ShiftOrigin(WorldImpl& world, Length2 newOrigin)
+void ShiftOrigin(WorldImpl& world, const Length2& newOrigin)
 {
     world.ShiftOrigin(newOrigin);
 }

--- a/PlayRho/Dynamics/WorldImplMisc.hpp
+++ b/PlayRho/Dynamics/WorldImplMisc.hpp
@@ -105,7 +105,7 @@ StepStats Step(WorldImpl& world, const StepConf& conf);
 /// @param newOrigin the new origin with respect to the old origin
 /// @throws WrongState if this method is called while the world is locked.
 /// @relatedalso WorldImpl
-void ShiftOrigin(WorldImpl& world, Length2 newOrigin);
+void ShiftOrigin(WorldImpl& world, const Length2& newOrigin);
 
 /// @brief Gets the bodies of the specified world.
 /// @relatedalso WorldImpl

--- a/PlayRho/Dynamics/WorldJoint.cpp
+++ b/PlayRho/Dynamics/WorldJoint.cpp
@@ -266,7 +266,7 @@ Length2 GetLinearOffset(const World& world, JointID id)
     return GetLinearOffset(GetJoint(world, id));
 }
 
-void SetLinearOffset(World& world, JointID id, Length2 value)
+void SetLinearOffset(World& world, JointID id, const Length2& value)
 {
     auto joint = GetJoint(world, id);
     SetLinearOffset(joint, value);
@@ -310,7 +310,7 @@ Length2 GetTarget(const World& world, JointID id)
     return GetTarget(GetJoint(world, id));
 }
 
-void SetTarget(World& world, JointID id, Length2 value)
+void SetTarget(World& world, JointID id, const Length2& value)
 {
     auto joint = GetJoint(world, id);
     SetTarget(joint, value);
@@ -334,7 +334,7 @@ void SetAngularLimits(World& world, JointID id, Angle lower, Angle upper)
     SetJoint(world, id, joint);
 }
 
-bool ShiftOrigin(World& world, JointID id, Length2 value)
+bool ShiftOrigin(World& world, JointID id, const Length2& value)
 {
     auto joint = GetJoint(world, id);
     const auto shifted = ShiftOrigin(joint, value);

--- a/PlayRho/Dynamics/WorldJoint.hpp
+++ b/PlayRho/Dynamics/WorldJoint.hpp
@@ -303,7 +303,7 @@ Length2 GetLinearOffset(const World& world, JointID id);
 /// @brief Sets the target linear offset, in frame A.
 /// @throws std::out_of_range If given an invalid joint identifier.
 /// @relatedalso World
-void SetLinearOffset(World& world, JointID id, Length2 value);
+void SetLinearOffset(World& world, JointID id, const Length2& value);
 
 /// @brief Gets the target angular offset.
 /// @throws std::out_of_range If given an invalid joint identifier.
@@ -345,7 +345,7 @@ Length2 GetTarget(const World& world, JointID id);
 /// @throws WrongState if this method is called while the world is locked.
 /// @throws std::out_of_range If given an invalid joint identifier.
 /// @relatedalso World
-void SetTarget(World& world, JointID id, Length2 value);
+void SetTarget(World& world, JointID id, const Length2& value);
 
 /// Get the lower joint limit.
 /// @throws std::out_of_range If given an invalid joint identifier.
@@ -368,7 +368,7 @@ void SetAngularLimits(World& world, JointID id, Angle lower, Angle upper);
 /// @throws WrongState if this method is called while the world is locked.
 /// @throws std::out_of_range If given an invalid joint identifier.
 /// @relatedalso World
-bool ShiftOrigin(World& world, JointID id, Length2 value);
+bool ShiftOrigin(World& world, JointID id, const Length2& value);
 
 /// @brief Gets the damping ratio associated with the identified joint if it has one.
 /// @throws std::out_of_range If given an invalid joint identifier.

--- a/PlayRho/Dynamics/WorldMisc.cpp
+++ b/PlayRho/Dynamics/WorldMisc.cpp
@@ -121,7 +121,7 @@ const DynamicTree& GetTree(const World& world) noexcept
     return world.GetTree();
 }
 
-void ShiftOrigin(World& world, Length2 newOrigin)
+void ShiftOrigin(World& world, const Length2& newOrigin)
 {
     world.ShiftOrigin(newOrigin);
 }

--- a/PlayRho/Dynamics/WorldMisc.hpp
+++ b/PlayRho/Dynamics/WorldMisc.hpp
@@ -156,7 +156,7 @@ Length GetMaxVertexRadius(const World& world) noexcept;
 /// @param newOrigin the new origin with respect to the old origin
 /// @throws WrongState if this method is called while the world is locked.
 /// @relatedalso World
-void ShiftOrigin(World& world, Length2 newOrigin);
+void ShiftOrigin(World& world, const Length2& newOrigin);
 
 } // namespace d2
 } // namespace playrho

--- a/PlayRho/Dynamics/WorldShape.cpp
+++ b/PlayRho/Dynamics/WorldShape.cpp
@@ -141,7 +141,7 @@ void Rotate(World& world, ShapeID id, const UnitVec& value)
 MassData ComputeMassData(const World& world, const std::vector<ShapeID>& ids)
 {
     auto mass = 0_kg;
-    auto I = RotInertia{0};
+    auto I = RotInertia{};
     auto weightedCenter = Length2{};
     for (const auto& shapeId: ids) {
         const auto& shape = GetShape(world, shapeId);
@@ -156,7 +156,7 @@ MassData ComputeMassData(const World& world, const std::vector<ShapeID>& ids)
     return MassData{center, mass, I};
 }
 
-bool TestPoint(const World& world, BodyID bodyId, ShapeID shapeId, Length2 p)
+bool TestPoint(const World& world, BodyID bodyId, ShapeID shapeId, const Length2& p)
 {
     return TestPoint(GetShape(world, shapeId), InverseTransform(p, GetTransformation(world, bodyId)));
 }

--- a/PlayRho/Dynamics/WorldShape.hpp
+++ b/PlayRho/Dynamics/WorldShape.hpp
@@ -238,7 +238,7 @@ MassData ComputeMassData(const World& world, const std::vector<ShapeID>& ids);
 /// @throws std::out_of_range If given an invalid body or shape identifier.
 /// @relatedalso World
 /// @ingroup TestPointGroup
-bool TestPoint(const World& world, BodyID bodyId, ShapeID shapeId, Length2 p);
+bool TestPoint(const World& world, BodyID bodyId, ShapeID shapeId, const Length2& p);
 
 /// @brief Gets the default friction amount for the given shapes.
 /// @relatedalso Shape

--- a/UnitTests/BaseShapeConf.cpp
+++ b/UnitTests/BaseShapeConf.cpp
@@ -31,7 +31,7 @@ TEST(BaseShapeConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<BaseShapeConf>);
     EXPECT_TRUE(std::is_copy_constructible_v<BaseShapeConf>);
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<BaseShapeConf>);
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<BaseShapeConf>);
 #endif

--- a/UnitTests/BodyConf.cpp
+++ b/UnitTests/BodyConf.cpp
@@ -48,7 +48,7 @@ TEST(BodyConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<BodyConf>);
     EXPECT_TRUE(std::is_copy_constructible_v<BodyConf>);
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<BodyConf>);
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<BodyConf>);
 #endif

--- a/UnitTests/ChainShape.cpp
+++ b/UnitTests/ChainShape.cpp
@@ -70,7 +70,7 @@ TEST(ChainShapeConf, IsValidShapeType)
 TEST(ChainShapeConf, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible_v<ChainShapeConf>);
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<ChainShapeConf>);
 #endif
 }

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -688,7 +688,7 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction1)
         case 4:
             EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_4x4), VertexCounter{0}); // v0 of shape0
             EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_4x4), VertexCounter{3}); // v3 of shape1
-#if defined(__clang_major__) && (__clang_major__ >= 14)
+#if defined(__clang_major__) && (__clang_major__ >= 14) && !defined(PLAYRHO_USE_BOOST_UNITS)
             EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_NxN), VertexCounter{1}); // v0 of shape0
             EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_nos), VertexCounter{1}); // v0 of shape0
             EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_NxN), VertexCounter{0}); // v3 of shape1

--- a/UnitTests/CollideShapes.cpp
+++ b/UnitTests/CollideShapes.cpp
@@ -687,11 +687,18 @@ TEST(CollideShapes, GetMaxSeparationFreeFunction1)
     {
         case 4:
             EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_4x4), VertexCounter{0}); // v0 of shape0
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_4x4), VertexCounter{3}); // v3 of shape1
+#if defined(__clang_major__) && (__clang_major__ >= 14)
+            EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_NxN), VertexCounter{1}); // v0 of shape0
+            EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_nos), VertexCounter{1}); // v0 of shape0
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_NxN), VertexCounter{0}); // v3 of shape1
+            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_nos), VertexCounter{0}); // v3 of shape1
+#else
             EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_NxN), VertexCounter{0}); // v0 of shape0
             EXPECT_EQ(GetFirstShapeVertexIdx( maxSep01_nos), VertexCounter{0}); // v0 of shape0
-            EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_4x4), VertexCounter{3}); // v3 of shape1
             EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_NxN), VertexCounter{3}); // v3 of shape1
             EXPECT_EQ(GetSecondShapeVertexIdx<0>(maxSep01_nos), VertexCounter{3}); // v3 of shape1
+#endif
             break;
         case 8:
             EXPECT_EQ(GetFirstShapeVertexIdx(maxSep01_4x4), VertexCounter{1}); // v1 of shape0

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -64,7 +64,7 @@ TEST(DistanceJointConf, Traits)
     EXPECT_TRUE(std::is_copy_constructible_v<DistanceJointConf>);
 
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<DistanceJointConf>);
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<DistanceJointConf>);
 #endif
 }

--- a/UnitTests/DynamicTree.cpp
+++ b/UnitTests/DynamicTree.cpp
@@ -87,7 +87,7 @@ TEST(DynamicTreeNode, Traits)
     EXPECT_FALSE(std::is_trivially_constructible<DynamicTree::TreeNode>::value);
     
     EXPECT_TRUE(std::is_copy_constructible<DynamicTree::TreeNode>::value);
-#ifdef USE_BOOST_UNITS
+#ifdef PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_nothrow_copy_constructible<DynamicTree::TreeNode>::value);
     EXPECT_FALSE(std::is_trivially_copy_constructible<DynamicTree::TreeNode>::value);
 #else
@@ -96,7 +96,7 @@ TEST(DynamicTreeNode, Traits)
 #endif
     
     EXPECT_TRUE(std::is_copy_assignable<DynamicTree::TreeNode>::value);
-#ifdef USE_BOOST_UNITS
+#ifdef PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_nothrow_copy_assignable<DynamicTree::TreeNode>::value);
     EXPECT_FALSE(std::is_trivially_copy_assignable<DynamicTree::TreeNode>::value);
 #else

--- a/UnitTests/MassData.cpp
+++ b/UnitTests/MassData.cpp
@@ -53,7 +53,7 @@ TEST(MassData, Traits)
     EXPECT_FALSE(IsIterable<MassData>::value);
 
     EXPECT_TRUE(std::is_default_constructible_v<MassData>);
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<MassData>); // may be compiler dependent
 #endif
     
@@ -68,7 +68,7 @@ TEST(MassData, Traits)
     // EXPECT_TRUE(std::is_nothrow_constructible<MassData>::value); // gcc 6.3
     
     EXPECT_TRUE(std::is_copy_constructible<MassData>::value);
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_copy_constructible<MassData>::value); // may be compiler dependent
 #endif
 

--- a/UnitTests/MultiShape.cpp
+++ b/UnitTests/MultiShape.cpp
@@ -69,7 +69,7 @@ TEST(MultiShapeConf, Traits)
     EXPECT_TRUE(std::is_default_constructible_v<MultiShapeConf>);
     EXPECT_TRUE(std::is_copy_constructible_v<MultiShapeConf>);
 
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<MultiShapeConf>);
 #endif
 }

--- a/UnitTests/StepStats.cpp
+++ b/UnitTests/StepStats.cpp
@@ -73,23 +73,23 @@ TEST(StepStats, ByteSize)
 TEST(StepStats, Traits)
 {
     EXPECT_TRUE(std::is_default_constructible<StepStats>::value);
-#ifdef USE_BOOST_UNITS
+#ifdef PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_nothrow_default_constructible<StepStats>::value);
 #else
     EXPECT_TRUE(std::is_nothrow_default_constructible<StepStats>::value);
-#endif // USE_BOOST_UNITS
+#endif // PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_trivially_default_constructible<StepStats>::value);
     
     EXPECT_TRUE(std::is_constructible<StepStats>::value);
-#ifdef USE_BOOST_UNITS
+#ifdef PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_nothrow_constructible<StepStats>::value);
 #else
     EXPECT_TRUE(std::is_nothrow_constructible<StepStats>::value);
-#endif // USE_BOOST_UNITS
+#endif // PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_trivially_constructible<StepStats>::value);
 
     EXPECT_TRUE(std::is_copy_constructible<StepStats>::value);
-#ifdef USE_BOOST_UNITS
+#ifdef PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_nothrow_copy_constructible<StepStats>::value);
     EXPECT_FALSE(std::is_trivially_copy_constructible<StepStats>::value);
 #else
@@ -98,7 +98,7 @@ TEST(StepStats, Traits)
 #endif
     
     EXPECT_TRUE(std::is_copy_assignable<StepStats>::value);
-#ifdef USE_BOOST_UNITS
+#ifdef PLAYRHO_USE_BOOST_UNITS
     EXPECT_FALSE(std::is_nothrow_copy_assignable<StepStats>::value);
     EXPECT_FALSE(std::is_trivially_copy_assignable<StepStats>::value);
 #else

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -42,7 +42,7 @@ TEST(TargetJointConf, Traits)
     EXPECT_TRUE(std::is_nothrow_default_constructible_v<TargetJointConf>);
     EXPECT_TRUE(std::is_copy_constructible_v<TargetJointConf>);
     EXPECT_TRUE(std::is_copy_assignable_v<TargetJointConf>);
-#ifndef USE_BOOST_UNITS
+#ifndef PLAYRHO_USE_BOOST_UNITS
     EXPECT_TRUE(std::is_nothrow_copy_constructible_v<TargetJointConf>);
     EXPECT_TRUE(std::is_nothrow_copy_assignable_v<TargetJointConf>);
 #endif

--- a/UnitTests/TimeOfImpact.cpp
+++ b/UnitTests/TimeOfImpact.cpp
@@ -1059,37 +1059,11 @@ TEST(TimeOfImpact, NextAfter)
     EXPECT_EQ(output.state, ToiOutput::e_nextAfter);
     EXPECT_NEAR(static_cast<double>(output.time), 0.99750623441396513, 0.0001);
     EXPECT_EQ(output.stats.max_dist_iters, 1);
-    if (std::is_same<Real, float>::value)
-    {
-        EXPECT_EQ(output.stats.max_root_iters, 8);
-    }
-    else if (std::is_same<Real, double>::value)
-    {
-        EXPECT_EQ(output.stats.max_root_iters, 8);
-    }
-    else if (std::is_same<Real, long double>::value)
-    {
-        EXPECT_EQ(output.stats.max_root_iters, 6);
-    }
+    EXPECT_EQ(output.stats.max_root_iters, 8);
     EXPECT_EQ(output.stats.toi_iters, 1);
     EXPECT_EQ(output.stats.sum_dist_iters, 1);
     EXPECT_EQ(output.stats.sum_finder_iters, 0);
-    if (std::is_same<Real, float>::value)
-    {
-        EXPECT_EQ(output.stats.sum_root_iters, 8);
-    }
-    else if (std::is_same<Real, double>::value)
-    {
-        EXPECT_EQ(output.stats.sum_root_iters, 8);
-    }
-    else if (std::is_same<Real, long double>::value)
-    {
-        EXPECT_EQ(output.stats.sum_root_iters, 6);
-    }
-    else
-    {
-        EXPECT_EQ(output.stats.sum_root_iters, 0);
-    }
+    EXPECT_EQ(output.stats.sum_root_iters, 8);
 }
 
 TEST(TimeOfImpact, TargetDepthExceedsTotalRadius)

--- a/UnitTests/UnitVec.cpp
+++ b/UnitTests/UnitVec.cpp
@@ -42,6 +42,19 @@ TEST(UnitVec, ByteSize)
     }
 }
 
+TEST(UnitVec, DefaultConstruction)
+{
+    constexpr auto ExpectedDimensions = 2u;
+    EXPECT_EQ(UnitVec::size(), ExpectedDimensions);
+    EXPECT_EQ(UnitVec().GetX(), UnitVec::value_type());
+    EXPECT_EQ(UnitVec().GetY(), UnitVec::value_type());
+    const auto uv = UnitVec();
+    for (const auto& e: uv) {
+        EXPECT_EQ(e, UnitVec::value_type());
+    }
+    EXPECT_EQ(UnitVec(), UnitVec::GetZero());
+}
+
 TEST(UnitVec, RightIsRevPerpOfBottom)
 {
     EXPECT_EQ(UnitVec::GetRight(), UnitVec::GetBottom().GetRevPerpendicular());

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1571,7 +1571,7 @@ TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
         
         EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.location));
         EXPECT_GT(GetY(GetLocation(world, body)), GetY(pos));
-        EXPECT_EQ(GetY(GetLocation(world, body)), GetY(pos) + ((GetY(vel) + GetY(EarthlyGravity) * time_inc) * time_inc));
+        EXPECT_FLOAT_EQ(GetY(GetLocation(world, body)), GetY(pos) + ((GetY(vel) + GetY(EarthlyGravity) * time_inc) * time_inc));
         pos = GetLocation(world, body);
         
         EXPECT_EQ(GetX(GetLinearVelocity(world, body)), 0_mps);
@@ -2949,18 +2949,30 @@ TEST(World_Longer, TilesComesToRest)
     switch (sizeof(Real))
     {
         case 4u:
+#if defined(__clang_major__) && (__clang_major__ >= 14)
+            EXPECT_EQ(numSteps, 1804ul);
+            EXPECT_EQ(sumRegPosIters, 36527ul);
+            EXPECT_EQ(sumRegVelIters, 46979ul);
+            EXPECT_EQ(sumToiPosIters, 43806ul);
+            EXPECT_EQ(sumToiVelIters, 112175ul);
+#else
             EXPECT_EQ(numSteps, 1799ul);
             EXPECT_EQ(sumRegPosIters, 36512ul);
             EXPECT_EQ(sumRegVelIters, 46940ul);
             EXPECT_EQ(sumToiPosIters, 44021ul);
             EXPECT_EQ(sumToiVelIters, 113137ul);
+#endif
             break;
         case 8u:
             EXPECT_EQ(numSteps, 1828ul);
             EXPECT_EQ(sumRegPosIters, 36540ul);
             EXPECT_EQ(sumRegVelIters, 47173ul);
             EXPECT_EQ(sumToiPosIters, 44005ul);
+#if defined(__clang_major__) && (__clang_major__ >= 14)
+            EXPECT_EQ(sumToiVelIters, 114308ul);
+#else
             EXPECT_EQ(sumToiVelIters, 114196ul);
+#endif
             break;
     }
 #else

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1571,7 +1571,8 @@ TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
         
         EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.location));
         EXPECT_GT(GetY(GetLocation(world, body)), GetY(pos));
-        EXPECT_FLOAT_EQ(GetY(GetLocation(world, body)), GetY(pos) + ((GetY(vel) + GetY(EarthlyGravity) * time_inc) * time_inc));
+        EXPECT_FLOAT_EQ(Real(GetY(GetLocation(world, body)) / 1_m),
+                        Real((GetY(pos) + ((GetY(vel) + GetY(EarthlyGravity) * time_inc) * time_inc)) / 1_m));
         pos = GetLocation(world, body);
         
         EXPECT_EQ(GetX(GetLinearVelocity(world, body)), 0_mps);
@@ -2775,7 +2776,11 @@ TEST(World_Longer, TilesComesToRest)
         EXPECT_LE(totalBodiesSlept, 670u);
         EXPECT_TRUE(firstStepWithZeroMoved);
         if (firstStepWithZeroMoved) {
+#if defined(PLAYRHO_USE_BOOST_UNITS)
+            EXPECT_GE(*firstStepWithZeroMoved, 1797u);
+#else
             EXPECT_GE(*firstStepWithZeroMoved, 1798u);
+#endif
             EXPECT_LE(*firstStepWithZeroMoved, 1812u);
         }
 #else // unrecognized arch; just check results are within range of others
@@ -2829,7 +2834,7 @@ TEST(World_Longer, TilesComesToRest)
 
     EXPECT_EQ(awakeCount, 0u);
     if (awakeCount == 0u) {
-#ifdef _WIN32 // todo: update macro use, probably more to do with arch than OS!
+#if defined(_WIN32) // todo: update macro use, probably more to do with arch than OS!
         EXPECT_EQ(lastStats.reg.proxiesMoved, 1u);
 #else
         EXPECT_EQ(lastStats.reg.proxiesMoved, 0u);
@@ -2950,11 +2955,19 @@ TEST(World_Longer, TilesComesToRest)
     {
         case 4u:
 #if defined(__clang_major__) && (__clang_major__ >= 14)
+#if defined(PLAYRHO_USE_BOOST_UNITS)
+            EXPECT_EQ(numSteps, 1800ul);
+            EXPECT_EQ(sumRegPosIters, 36516ul);
+            EXPECT_EQ(sumRegVelIters, 46948ul);
+            EXPECT_EQ(sumToiPosIters, 44022ul);
+            EXPECT_EQ(sumToiVelIters, 113284ul);
+#else
             EXPECT_EQ(numSteps, 1804ul);
             EXPECT_EQ(sumRegPosIters, 36527ul);
             EXPECT_EQ(sumRegVelIters, 46979ul);
             EXPECT_EQ(sumToiPosIters, 43806ul);
             EXPECT_EQ(sumToiVelIters, 112175ul);
+#endif
 #else
             EXPECT_EQ(numSteps, 1799ul);
             EXPECT_EQ(sumRegPosIters, 36512ul);
@@ -2968,7 +2981,7 @@ TEST(World_Longer, TilesComesToRest)
             EXPECT_EQ(sumRegPosIters, 36540ul);
             EXPECT_EQ(sumRegVelIters, 47173ul);
             EXPECT_EQ(sumToiPosIters, 44005ul);
-#if defined(__clang_major__) && (__clang_major__ >= 14)
+#if defined(__clang_major__) && (__clang_major__ >= 14) && !defined(PLAYRHO_USE_BOOST_UNITS)
             EXPECT_EQ(sumToiVelIters, 114308ul);
 #else
             EXPECT_EQ(sumToiVelIters, 114196ul);

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -2834,7 +2834,7 @@ TEST(World_Longer, TilesComesToRest)
 
     EXPECT_EQ(awakeCount, 0u);
     if (awakeCount == 0u) {
-#if defined(_WIN32) // todo: update macro use, probably more to do with arch than OS!
+#if defined(_WIN32) || defined(PLAYRHO_USE_BOOST_UNITS) // odd
         EXPECT_EQ(lastStats.reg.proxiesMoved, 1u);
 #else
         EXPECT_EQ(lastStats.reg.proxiesMoved, 0u);


### PR DESCRIPTION
#### Description - What's this PR do?

Primarily, improves experience with enabling Boost units:

- Integrates use of Boost units with CMake.
- Increases clang-tidy compliance when built with Boost units enabled.
- Increases clang-tidy checks being done.
- Updates parameter passing to more consistently pass multi-member and multi-element classes by `const` reference. This seems a reasonable compromise to appeasing more clang-tidy parameter passing checks both with and without boost units enabled.