### PR TITLE
Enables warnings by default for all compiles of the PlayRho library

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -2288,7 +2288,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "c++17";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_CODE_COVERAGE = NO;
-				CLANG_USE_OPTIMIZATION_PROFILE = YES;
+				CLANG_USE_OPTIMIZATION_PROFILE = NO;
 				CLANG_WARN_ASSIGN_ENUM = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -2357,7 +2357,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN__EXIT_TIME_DESTRUCTORS = YES;
+				CLANG_WARN__EXIT_TIME_DESTRUCTORS = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEPLOYMENT_LOCATION = YES;
@@ -2372,12 +2372,13 @@
 					/usr/local/boost_1_75_0,
 					../..,
 				);
-				OTHER_CPLUSPLUSFLAGS = (
+				OTHER_CPLUSPLUSFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRIP_INSTALLED_PRODUCT = NO;
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Debug;
 		};
@@ -2385,7 +2386,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN__EXIT_TIME_DESTRUCTORS = YES;
+				CLANG_WARN__EXIT_TIME_DESTRUCTORS = NO;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEPLOYMENT_LOCATION = YES;
 				DEPLOYMENT_POSTPROCESSING = YES;
@@ -2396,11 +2397,12 @@
 					/usr/local/boost_1_75_0,
 					../..,
 				);
-				OTHER_CPLUSPLUSFLAGS = (
+				OTHER_CPLUSPLUSFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = (
 					"-Wall",
 					"-Wextra",
 				);
-				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
 		};

--- a/PlayRho/CMakeLists.txt
+++ b/PlayRho/CMakeLists.txt
@@ -95,6 +95,13 @@ if (PLAYRHO_ENABLE_BOOST_UNITS)
 	target_compile_definitions(PlayRho PUBLIC -DPLAYRHO_USE_BOOST_UNITS)
 endif()
 
+# Enable additional warnings to help ensure library code compiles clean
+# For GNU, see https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+target_compile_options(PlayRho PRIVATE
+	$<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+	$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Wundef -Wcast-align -Wconversion -Werror>
+)
+
 # These are used to create visual studio folders.
 source_group(Collision FILES ${PLAYRHO_Collision_SRCS} ${PLAYRHO_Collision_HDRS})
 source_group(Collision\\Shapes FILES ${PLAYRHO_Shapes_SRCS} ${PLAYRHO_Shapes_HDRS})

--- a/PlayRho/Collision/Distance.cpp
+++ b/PlayRho/Collision/Distance.cpp
@@ -124,8 +124,10 @@ DistanceOutput Distance(const DistanceProxy& proxyA, const Transformation& trans
     }
 
     if (empty(simplexEdges)) {
-        simplexEdges.push_back(GetSimplexEdge(proxyA, transformA, 0, proxyB, transformB, 0));
-        savedIndices = IndexPair3{{IndexPair{0, 0}, InvalidIndexPair, InvalidIndexPair}};
+        static constexpr auto idxA = static_cast<VertexCounter>(0u);
+        static constexpr auto idxB = static_cast<VertexCounter>(0u);
+        simplexEdges.push_back(GetSimplexEdge(proxyA, transformA, idxA, proxyB, transformB, idxB));
+        savedIndices = IndexPair3{{IndexPair{idxA, idxB}, InvalidIndexPair, InvalidIndexPair}};
     }
 
     auto simplex = Simplex{};

--- a/PlayRho/Collision/DistanceProxy.cpp
+++ b/PlayRho/Collision/DistanceProxy.cpp
@@ -133,8 +133,8 @@ bool TestPoint(const DistanceProxy& proxy, const Length2& point) noexcept
     }
     
     auto maxDot = -MaxFloat * Meter;
-    auto maxIdx = static_cast<decltype(count)>(-1);
-    for (auto i = decltype(count){0}; i < count; ++i)
+    auto maxIdx = decltype(proxy.GetVertexCount())(-1);
+    for (auto i = decltype(proxy.GetVertexCount())(0); i < count; ++i)
     {
         const auto vi = proxy.GetVertex(i);
         const auto delta = point - vi;

--- a/PlayRho/Collision/DistanceProxy.hpp
+++ b/PlayRho/Collision/DistanceProxy.hpp
@@ -110,9 +110,8 @@ public:
           m_vertexRadius{vertexRadius}
     {
         assert(vertexRadius >= 0_m);
-        assert(count >= 0);
-        assert(count < 1 || vertices);
-        assert(count < 2 || normals);
+        assert(count < 1u || vertices);
+        assert(count < 2u || normals);
 #ifdef IMPLEMENT_DISTANCEPROXY_WITH_BUFFERS
         if (vertices) {
             std::copy(vertices, vertices + count, m_vertices);

--- a/PlayRho/Collision/DynamicTree.cpp
+++ b/PlayRho/Collision/DynamicTree.cpp
@@ -83,6 +83,7 @@ DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i
     // assert(index < GetNodeCapacity());
     assert(DynamicTree::IsBranch(nodes[i].GetHeight()));
 
+    /* note: gcc doesn't like multiline comments within double-slash
     //          o
     //          |
     //          i
@@ -90,6 +91,7 @@ DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i
     //      *-c1  c2-*
     //     /   |  |   \
     // c1c1 c1c2  c2c1 c2c2
+    **/
     const auto oldNodeI = nodes[i];
     const auto o = oldNodeI.GetOther();
     const auto c1 = oldNodeI.AsBranch().child1;
@@ -106,6 +108,7 @@ DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i
         const auto c2c1Node = nodes[c2c1];
         const auto c2c2Node = nodes[c2c2];
 
+        /* note: gcc doesn't like multiline comments within double-slash
         // From:
         //          *i*
         //         /   \
@@ -123,6 +126,7 @@ DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i
         //
         // Rotate left and pick the taller of c2c1 or c2c2 or the better fitting to move to the new
         // i node.
+        **/
         const auto ms = MakeMoveStay(c2c1Node, c2c1, c2c2Node, c2c2, c1Node.GetAABB());
         const auto newNodeI = MakeNode(c1, c1Node.GetAABB(), c1Height, ms.first,
                                        nodes[ms.first].GetAABB(), nodes[ms.first].GetHeight(), c2);
@@ -153,6 +157,7 @@ DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i
         const auto c1c1Node = nodes[c1c1];
         const auto c1c2Node = nodes[c1c2];
 
+        /* note: gcc doesn't like multiline comments within double-slash
         // From:
         //          *i*
         //         /   \
@@ -170,6 +175,7 @@ DynamicTree::Size RebalanceAt(DynamicTree::TreeNode nodes[], DynamicTree::Size i
         //
         // Rotate right and pick the taller of c1c1 or c1c2 or the better fitting to move to the new
         // i node.
+        **/
         const auto ms = MakeMoveStay(c1c1Node, c1c1, c1c2Node, c1c2, c2Node.GetAABB());
         const auto newNodeI =
             MakeNode(ms.first, nodes[ms.first].GetAABB(), nodes[ms.first].GetHeight(), c2,

--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -117,7 +117,6 @@ ChainShapeConf& ChainShapeConf::Add(const Length2& vertex)
 
 MassData ChainShapeConf::GetMassData() const
 {
-    const auto density = this->density;
     if (density > 0_kgpm2) {
         const auto vertexCount = GetVertexCount();
         if (vertexCount > 1) {

--- a/PlayRho/Collision/Shapes/ChainShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.hpp
@@ -115,14 +115,14 @@ public:
     /// @brief Gets a vertex by index.
     Length2 GetVertex(ChildCounter index) const
     {
-        assert((0 <= index) && (index < GetVertexCount()));
+        assert(index < GetVertexCount());
         return m_vertices[index];
     }
 
     /// @brief Gets the normal at the given index.
     UnitVec GetNormal(ChildCounter index) const
     {
-        assert((0 <= index) && (index < GetVertexCount()));
+        assert(index < GetVertexCount());
         return m_normals[index];
     }
 

--- a/PlayRho/Collision/Shapes/Compositor.hpp
+++ b/PlayRho/Collision/Shapes/Compositor.hpp
@@ -872,7 +872,8 @@ bool operator==(const Compositor<P11, P12, P13, P14, P15, P16>& lhs,
     if (lhsCount != rhsCount) {
         return false;
     }
-    for (auto i = static_cast<decltype(lhsCount)>(0); i < lhsCount; ++i) {
+    using IndexType = std::remove_cv_t<decltype(lhsCount)>;
+    for (auto i = static_cast<IndexType>(0); i < lhsCount; ++i) {
         if (GetChild(lhs, i) != GetChild(rhs, i)) {
             return false;
         }

--- a/PlayRho/Collision/WorldManifold.hpp
+++ b/PlayRho/Collision/WorldManifold.hpp
@@ -118,7 +118,7 @@ public:
     ///
     size_type GetPointCount() const noexcept
     {
-        return (IsValid(m_separations[0])? 1: 0) + (IsValid(m_separations[1])? 1: 0);
+        return static_cast<size_type>((IsValid(m_separations[0])? 1u: 0u) + (IsValid(m_separations[1])? 1u: 0u));
     }
     
     /// Gets the normal of the contact.

--- a/PlayRho/Common/CheckedValue.hpp
+++ b/PlayRho/Common/CheckedValue.hpp
@@ -333,9 +333,9 @@ constexpr auto operator!= (const Other& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator<= (const CheckedValue<ValueType, CheckerType>& lhs,
                            const Other& rhs)
--> decltype(ValueType(lhs) <= rhs)
+-> decltype(ValueType(lhs) <= ValueType(rhs))
 {
-    return ValueType(lhs) <= rhs;
+    return ValueType(lhs) <= ValueType(rhs);
 }
 
 /// @brief Constrained value less-than or equal-to operator.
@@ -346,9 +346,9 @@ constexpr auto operator<= (const CheckedValue<ValueType, CheckerType>& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator<= (const Other& lhs,
                            const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs <= ValueType(rhs))
+-> decltype(ValueType(lhs) <= ValueType(rhs))
 {
-    return lhs <= ValueType(rhs);
+    return ValueType(lhs) <= ValueType(rhs);
 }
 
 /// @brief Constrained value greater-than or equal-to operator.
@@ -359,9 +359,9 @@ constexpr auto operator<= (const Other& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator>= (const CheckedValue<ValueType, CheckerType>& lhs,
                            const Other& rhs)
--> decltype(ValueType(lhs) >= rhs)
+-> decltype(ValueType(lhs) >= ValueType(rhs))
 {
-    return ValueType(lhs) >= rhs;
+    return ValueType(lhs) >= ValueType(rhs);
 }
 
 /// @brief Constrained value greater-than or equal-to operator.
@@ -372,9 +372,9 @@ constexpr auto operator>= (const CheckedValue<ValueType, CheckerType>& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator>= (const Other& lhs,
                            const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs >= ValueType(rhs))
+-> decltype(ValueType(lhs) >= ValueType(rhs))
 {
-    return lhs >= ValueType(rhs);
+    return ValueType(lhs) >= ValueType(rhs);
 }
 
 
@@ -386,9 +386,9 @@ constexpr auto operator>= (const Other& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator< (const CheckedValue<ValueType, CheckerType>& lhs,
                           const Other& rhs)
--> decltype(ValueType(lhs) < rhs)
+-> decltype(ValueType(lhs) < ValueType(rhs))
 {
-    return ValueType(lhs) < rhs;
+    return ValueType(lhs) < ValueType(rhs);
 }
 
 /// @brief Constrained value less-than operator.
@@ -399,9 +399,9 @@ constexpr auto operator< (const CheckedValue<ValueType, CheckerType>& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator< (const Other& lhs,
                           const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs < ValueType(rhs))
+-> decltype(ValueType(lhs) < ValueType(rhs))
 {
-    return lhs < ValueType(rhs);
+    return ValueType(lhs) < ValueType(rhs);
 }
 
 /// @brief Constrained value greater-than operator.
@@ -412,9 +412,9 @@ constexpr auto operator< (const Other& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator> (const CheckedValue<ValueType, CheckerType>& lhs,
                           const Other& rhs)
--> decltype(ValueType(lhs) > rhs)
+-> decltype(ValueType(lhs) > ValueType(rhs))
 {
-    return ValueType(lhs) > rhs;
+    return ValueType(lhs) > ValueType(rhs);
 }
 
 /// @brief Constrained value greater-than ooperator.
@@ -425,9 +425,9 @@ constexpr auto operator> (const CheckedValue<ValueType, CheckerType>& lhs,
 template <typename ValueType, typename CheckerType, typename Other>
 constexpr auto operator> (const Other& lhs,
                           const CheckedValue<ValueType, CheckerType>& rhs)
--> decltype(lhs > ValueType(rhs))
+-> decltype(ValueType(lhs) > ValueType(rhs))
 {
-    return lhs > ValueType(rhs);
+    return ValueType(lhs) > ValueType(rhs);
 }
 
 /// @brief Constrained value multiplication operator.

--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -639,10 +639,11 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices);
 /// @pre The given value is less than the given count.
 /// @warning Behavior is undefined if the given value is not less than the given count.
 template <typename T>
-constexpr auto GetModuloNext(const T value, const T count) noexcept -> T
+constexpr auto GetModuloNext(T value, T count) noexcept -> decltype(++value, T(value % count))
 {
     assert(value < count);
-    return (value + 1) % count; // NOLINT(clang-analyzer-core.DivideZero)
+    ++value;
+    return T(value % count); // NOLINT(clang-analyzer-core.DivideZero)
 }
 
 /// @brief Gets the modulo previous value.

--- a/PlayRho/Common/StackAllocator.hpp
+++ b/PlayRho/Common/StackAllocator.hpp
@@ -150,10 +150,10 @@ private:
         bool usedMalloc; ///< Whether <code>malloc</code> was used.
     };
     
-    char* const m_data; ///< Data.
-    AllocationRecord* const m_entries; ///< Entries.
-    size_type const m_size; ///< Size.
-    size_type const m_max_entries; ///< Max entries.
+    char* m_data; ///< Data.
+    AllocationRecord* m_entries; ///< Entries.
+    size_type m_size; ///< Size.
+    size_type m_max_entries; ///< Max entries.
     
     size_type m_index = 0; ///< Index.
     size_type m_allocation = 0; ///< Allocation.

--- a/PlayRho/Dynamics/WorldImpl.cpp
+++ b/PlayRho/Dynamics/WorldImpl.cpp
@@ -80,7 +80,7 @@
 // Enable this macro to enable sorting ID lists like m_contacts. This results in more linearly
 // accessed memory. Benchmarking hasn't found a significant performance improvement however but
 // it does seem to decrease performance in smaller simulations.
-//#define DO_SORT_ID_LISTS
+#define DO_SORT_ID_LISTS 0
 
 using std::for_each;
 using std::remove;
@@ -1246,13 +1246,13 @@ void WorldImpl::AddToIsland(Island& island, BodyStack& stack,
         assert(newNumContacts >= oldNumContacts);
         const auto netNumContacts = newNumContacts - oldNumContacts;
         assert(remNumContacts >= netNumContacts);
-        remNumContacts -= netNumContacts;
-        
+        remNumContacts -= static_cast<ContactCounter>(netNumContacts);
+
         const auto numJoints = size(island.joints);
         // Adds appropriate joints of current body and appropriate 'other' bodies of those joint.
         AddJointsToIsland(island, stack, m_bodyJoints[to_underlying(bodyID)]);
 
-        remNumJoints -= size(island.joints) - numJoints;
+        remNumJoints -= static_cast<JointCounter>(size(island.joints) - numJoints);
     }
 }
 
@@ -1335,8 +1335,8 @@ RegStepStats WorldImpl::SolveReg(const StepConf& conf)
                 AddToIsland(island, b, remNumBodies, remNumContacts, remNumJoints);
                 stats.maxIslandBodies = std::max(stats.maxIslandBodies,
                                                  static_cast<BodyCounter>(size(island.bodies)));
-                remNumBodies += RemoveUnspeedablesFromIslanded(island.bodies, m_bodyBuffer,
-                                                               m_islandedBodies);
+                const auto numRemoved = RemoveUnspeedablesFromIslanded(island.bodies, m_bodyBuffer, m_islandedBodies);
+                remNumBodies += static_cast<BodyCounter>(numRemoved);
 #if defined(DO_THREADED)
                 // Updates bodies' sweep.pos0 to current sweep.pos1 and bodies' sweep.pos1 to new positions
                 futures.push_back(std::async(std::launch::async, &WorldImpl::SolveRegIslandViaGS,

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -1339,3 +1339,14 @@ TEST(Math, ToSigned)
     EXPECT_EQ(ToSigned(42u), 42);
     EXPECT_EQ(ToSigned(static_cast<std::uint8_t>(255u)), -1);
 }
+
+TEST(Math, GetModuloNext)
+{
+    EXPECT_EQ(GetModuloNext(std::uint8_t(0u), std::uint8_t(1u)), std::uint8_t(0u));
+    EXPECT_EQ(GetModuloNext(std::uint8_t(0u), std::uint8_t(2u)), std::uint8_t(1u));
+    EXPECT_EQ(GetModuloNext(std::uint8_t(254u), std::uint8_t(255u)), std::uint8_t(0u));
+    EXPECT_EQ(GetModuloNext(std::int8_t(0), std::int8_t(1)), std::int8_t(0));
+    EXPECT_EQ(GetModuloNext(std::int8_t(0), std::int8_t(2)), std::int8_t(1));
+    EXPECT_EQ(GetModuloNext(std::int8_t(1), std::int8_t(2)), std::int8_t(0));
+    EXPECT_EQ(GetModuloNext(std::int8_t(126), std::int8_t(127)), std::int8_t(0));
+}


### PR DESCRIPTION
#### Description - What's this PR do?
I had these enabled in my development environments but had forgotten to add these to CMake. Thanks go to GitHub user "titofra" for pointing out that these were missing from CMake in their PR, #484.

#### Impacts/Risks of These Changes?

Cleaner builds - in terms of compiler reported warnings/errors - by users including the PlayRho library.

#### Where should a reviewer start?

The compile logs of the CI workflows.

#### How should this be tested?

Noticing that no warnings/errors are reported - after possibly addressing any that may now show up.

#### Related Pull Requests
- #484.

