### PR TITLE
Some cleanups to address UB sanitizer & clang-tidy

### DIFF
--- a/PlayRho/Common/FlagGuard.hpp
+++ b/PlayRho/Common/FlagGuard.hpp
@@ -64,8 +64,11 @@ namespace playrho {
         FlagGuard() = delete;
         
     private:
-        T& m_flag; ///< Flag.
-        T m_value; ///< Value.
+        /// @brief Flag.
+        T& m_flag; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
+
+        /// @brief Value.
+        T m_value;
     };
 
 } // namespace playrho

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -258,7 +258,8 @@ using IsReverseIterable = typename detail::IsReverseIterableImpl<T>;
 /// @see https://stackoverflow.com/a/28139075/7410358
 template <typename T>
 struct ReversionWrapper {
-    T& iterable; ///< Reference to underlying iterable.
+    /// @brief Reference to underlying iterable.
+    T& iterable; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 };
 
 /// @brief Begin function for getting a reversed order iterator.

--- a/PlayRho/Common/Version.cpp
+++ b/PlayRho/Common/Version.cpp
@@ -38,7 +38,7 @@ Version GetVersion() noexcept
     return Version{PLAYRHO_VERSION_MAJOR, PLAYRHO_VERSION_MINOR, PLAYRHO_VERSION_PATCH};
 }
 
-std::string GetBuildDetails() noexcept
+std::string GetBuildDetails()
 {
     std::stringstream stream;
     stream << "asserts=";

--- a/PlayRho/Common/Version.hpp
+++ b/PlayRho/Common/Version.hpp
@@ -113,7 +113,7 @@ constexpr auto operator>=(const Version& lhs, const Version& rhs) noexcept
 Version GetVersion() noexcept;
 
 /// @brief Gets the build details of the library.
-std::string GetBuildDetails() noexcept;
+std::string GetBuildDetails();
 
 } // namespace playrho
 

--- a/PlayRho/Dynamics/Joints/JointConf.hpp
+++ b/PlayRho/Dynamics/Joints/JointConf.hpp
@@ -24,6 +24,7 @@
 
 #include <PlayRho/Dynamics/BodyID.hpp>
 
+#include <cstddef> // for std::max_align_t
 #include <cstdint>
 
 namespace playrho {
@@ -61,15 +62,28 @@ constexpr bool GetCollideConnected(const JointConf& object) noexcept
     return object.collideConnected;
 }
 
+#ifdef _MSC_VER
+#pragma warning( push )
+#endif
+
+// Disable MSVC from warning "structure was padded due to alignment specifier".
+// The possibly additional space usage is preferable to U.B. from returning
+// possibly misaligned references.
+#ifdef _MSC_VER
+#pragma warning( disable : 4324 )
+#endif
+
 /// @brief Joint builder definition structure.
 /// @details This is a builder structure of chainable methods for building a shape
 ///   configuration.
+/// @note Alignment requirement specified to ensure proper alignment of references
+///   returned for method chaining.
 /// @note This is a templated nested value class for initializing joints that
 ///   uses the Curiously Recurring Template Pattern (CRTP) to provide method chaining
 ///   via static polymorphism.
 /// @see https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 template <class T>
-struct JointBuilder : JointConf {
+struct alignas(std::max_align_t) JointBuilder : JointConf {
     /// @brief Value type.
     using value_type = T;
 
@@ -97,6 +111,10 @@ struct JointBuilder : JointConf {
         return static_cast<reference>(*this);
     }
 };
+
+#ifdef _MSC_VER
+#pragma warning( pop )
+#endif
 
 class Joint;
 

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -44,7 +44,7 @@ TEST(DistanceJointConf, ByteSize)
     // builds and to report actual size rather than just reporting that expected size is wrong.
     switch (sizeof(Real)) {
     case 4:
-        EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(76));
+        EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(80));
         break;
     case 8:
         EXPECT_EQ(sizeof(DistanceJointConf), std::size_t(144));

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -37,26 +37,6 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(FrictionJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(80));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(152));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(FrictionJointConf), std::size_t(304));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(FrictionJointConf, DefaultConstruction)
 {
     FrictionJointConf def{};

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -42,26 +42,6 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(GearJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(GearJointConf), std::size_t(116));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(GearJointConf), std::size_t(224));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(GearJointConf), std::size_t(432));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(GearJointConf, DefaultConstruction)
 {
     auto conf = GearJointConf{};

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -43,7 +43,7 @@ TEST(MotorJointConf, ByteSize)
     // builds and to report actual size rather than just reporting that expected size is wrong.
     switch (sizeof(Real)) {
     case 4:
-        EXPECT_EQ(sizeof(MotorJointConf), std::size_t(92));
+        EXPECT_EQ(sizeof(MotorJointConf), std::size_t(96));
         break;
     case 8:
         EXPECT_EQ(sizeof(MotorJointConf), std::size_t(176));

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -35,26 +35,6 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(PrismaticJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(160));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(312));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(PrismaticJointConf), std::size_t(624));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(PrismaticJointConf, Construction)
 {
     auto world = World{};

--- a/UnitTests/PulleyJoint.cpp
+++ b/UnitTests/PulleyJoint.cpp
@@ -137,26 +137,6 @@ TEST(PulleyJointConf, UseRatio)
     EXPECT_EQ(PulleyJointConf{}.UseRatio(value).ratio, value);
 }
 
-TEST(PulleyJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(92));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(176));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(PulleyJointConf), std::size_t(352));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(PulleyJoint, Construction)
 {
     PulleyJointConf def;

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -40,26 +40,6 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(RevoluteJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(128));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(248));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(RevoluteJointConf), std::size_t(496));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(RevoluteJointConf, DefaultConstruction)
 {
     const auto jd = RevoluteJointConf{};

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -39,26 +39,6 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(RopeJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(RopeJointConf), std::size_t(68));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(RopeJointConf), std::size_t(128));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(RopeJointConf), std::size_t(256));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(RopeJointConf, DefaultConstruction)
 {
     RopeJointConf def{};

--- a/UnitTests/TargetJoint.cpp
+++ b/UnitTests/TargetJoint.cpp
@@ -82,26 +82,6 @@ TEST(TargetJointConf, UseDampingRatio)
     EXPECT_EQ(TargetJointConf{}.UseDampingRatio(value).dampingRatio, value);
 }
 
-TEST(TargetJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(TargetJointConf), std::size_t(80));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(TargetJointConf), std::size_t(152));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(TargetJointConf), std::size_t(304));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 #if 0
 TEST(TargetJoint, IsOkay)
 {

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -44,26 +44,6 @@ TEST(WeldJoint, Traits)
     EXPECT_FALSE((IsAddable<WeldJointConf, WeldJointConf>::value));
 }
 
-TEST(WeldJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(WeldJointConf), std::size_t(108));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(WeldJointConf), std::size_t(208));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(WeldJointConf), std::size_t(416));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(WeldJointConf, DefaultConstruction)
 {
     WeldJointConf def{};

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -39,26 +39,6 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(WheelJointConf, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(WheelJointConf), std::size_t(124));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(WheelJointConf), std::size_t(240));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(WheelJointConf), std::size_t(480));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(WheelJointConf, DefaultConstruction)
 {
     WheelJointConf def{};


### PR DESCRIPTION
#### Description - What's this PR do?
- Specify joint conf alignment.
- Stips `noexcept` from `GetBuildDetails` function which shouldn't have been marked that way.
- Address some warnings against reference data members detected by clang-tidy.

#### Impacts/Risks of These Changes?
Code's less likely to fatally exit & clang-tidy will have less to complain about.
