### PR TITLE
Moves ToSigned out from playrho::d2 and properly into playrho

### DIFF
--- a/PlayRho/Common/Math.hpp
+++ b/PlayRho/Common/Math.hpp
@@ -656,6 +656,13 @@ constexpr auto GetModuloPrev(const T value, const T count) noexcept -> T
     return (value ? value : count) - 1;
 }
 
+/// @brief Converts the given value to its closest signed equivalent.
+template< class T >
+constexpr auto ToSigned(const T& value) -> decltype(static_cast<std::make_signed_t<T>>(value))
+{
+    return static_cast<std::make_signed_t<T>>(value);
+}
+
 /// @brief Gets the shortest angular distance to go from angle 0 to angle 1.
 /// @details This gets the angle to rotate angle 0 by, in order to get to angle 1, with the
 ///   least amount of rotation.
@@ -971,13 +978,6 @@ constexpr auto GetReflectionMatrix(const UnitVec& axis)
         }
     }
     return result;
-}
-
-/// @brief Converts the given value to its closest signed equivalent.
-template< class T >
-constexpr auto ToSigned(const T& value) -> decltype(static_cast<std::make_signed_t<T>>(value))
-{
-    return static_cast<std::make_signed_t<T>>(value);
 }
 
 } // namespace d2


### PR DESCRIPTION
#### Description - What's this PR do?
Moves `ToSigned` from `playrho::d2` up to `playrho`.

#### Related Issues
- Issue #490.
