### PR TITLE
Removes no longer needed functions Data+Size & makes Span more std::span

### DIFF
--- a/PlayRho/Common/Span.hpp
+++ b/PlayRho/Common/Span.hpp
@@ -55,7 +55,7 @@ public:
     /// @brief Size type.
     using size_type = std::size_t;
 
-    Span() = default;
+    constexpr Span() noexcept = default;
 
     /// @brief Initializing constructor.
     constexpr Span(pointer array, size_type size) noexcept : m_array{array}, m_size{size} {}
@@ -68,7 +68,8 @@ public:
 
     /// @brief Initializing constructor.
     template <typename U, typename = std::enable_if_t<!std::is_array<U>::value>>
-    constexpr Span(U& value) noexcept : m_array{detail::Data(value)}, m_size{detail::Size(value)}
+    constexpr Span(U&& value) noexcept
+        : m_array{::playrho::data(std::forward<U>(value))}, m_size{::playrho::size(std::forward<U>(value))}
     {
     }
 
@@ -79,38 +80,19 @@ public:
     }
 
     /// @brief Gets the "begin" iterator value.
-    pointer begin() const noexcept
-    {
-        return m_array;
-    }
-
-    /// @brief Gets the "begin" iterator value.
-    const_pointer cbegin() const noexcept
+    constexpr pointer begin() const noexcept
     {
         return m_array;
     }
 
     /// @brief Gets the "end" iterator value.
-    pointer end() const noexcept
-    {
-        return m_array + m_size;
-    }
-
-    /// @brief Gets the "end" iterator value.
-    const_pointer cend() const noexcept
+    constexpr pointer end() const noexcept
     {
         return m_array + m_size;
     }
 
     /// @brief Accesses the indexed element.
-    data_type& operator[](size_type index) noexcept
-    {
-        assert(index < m_size);
-        return m_array[index];
-    }
-
-    /// @brief Accesses the indexed element.
-    const data_type& operator[](size_type index) const noexcept
+    constexpr data_type& operator[](size_type index) const noexcept
     {
         assert(index < m_size);
         return m_array[index];
@@ -123,7 +105,7 @@ public:
     }
 
     /// @brief Direct access to data.
-    pointer data() const noexcept
+    constexpr pointer data() const noexcept
     {
         return m_array;
     }

--- a/PlayRho/Common/Templates.hpp
+++ b/PlayRho/Common/Templates.hpp
@@ -85,24 +85,6 @@ constexpr auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
     return size(arg) == max_size(arg);
 }
 
-/// @brief Internal helper template function to avoid confusion for use within classes
-///   that define their own <code>data()</code> method.
-template <typename T>
-static auto Data(T& v)
-{
-    using ::playrho::data;
-    return data(v);
-}
-
-/// @brief Internal helper template function to avoid confusion for use within classes
-///   that define their own <code>size()</code> method.
-template <typename T>
-static auto Size(T& v)
-{
-    using ::playrho::size;
-    return size(v);
-}
-
 } // namespace detail
 
 /// @brief "Not used" annotator.

--- a/PlayRho/Common/VertexSet.hpp
+++ b/PlayRho/Common/VertexSet.hpp
@@ -77,11 +77,11 @@ public:
     /// @brief Gets the current size of this set.
     std::size_t size() const noexcept
     {
-        return ::playrho::detail::Size(m_elements);
+        return ::playrho::size(m_elements);
     }
     
     /// @brief Gets the pointer to the data buffer.
-    const_pointer data() const { return ::playrho::detail::Data(m_elements); }
+    const_pointer data() const { return ::playrho::data(m_elements); }
     
     /// @brief Gets the "begin" iterator value.
     const_pointer begin() const { return data(); }


### PR DESCRIPTION
#### Description - What's this PR do?
- Removes no longer needed functions `Data` + `Size`.
- Makes `Span` more `std::span` like.
