### PR TITLE
Switches to pass by Span instead of owning containers...

### DIFF
--- a/PlayRho/Collision/Shapes/ChainShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/ChainShapeConf.cpp
@@ -19,8 +19,9 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
+#include <PlayRho/Common/Span.hpp>
 
+#include <PlayRho/Collision/Shapes/ChainShapeConf.hpp>
 #include <PlayRho/Collision/AABB.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
 
@@ -34,7 +35,7 @@ static_assert(IsValidShapeType<ChainShapeConf>::value);
 
 namespace {
 
-std::vector<UnitVec> ComputeNormals(const std::vector<Length2>& vertices)
+std::vector<UnitVec> ComputeNormals(const Span<const Length2>& vertices)
 {
     std::vector<UnitVec> normals;
     if (size(vertices) > std::size_t{1}) {

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.cpp
@@ -65,9 +65,9 @@ PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy)
 }
 
 /// @brief Uses the given vertices.
-PolygonShapeConf& PolygonShapeConf::UseVertices(const std::vector<Length2>& verts)
+PolygonShapeConf& PolygonShapeConf::UseVertices(const Span<const Length2>& verts)
 {
-    return Set(Span<const Length2>(data(verts), size(verts)));
+    return Set(verts);
 }
 
 PolygonShapeConf& PolygonShapeConf::SetAsBox(Length hx, Length hy, const Length2& center,

--- a/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
+++ b/PlayRho/Collision/Shapes/PolygonShapeConf.hpp
@@ -23,6 +23,7 @@
 #define PLAYRHO_COLLISION_SHAPES_POLYGONSHAPECONF_HPP
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 #include <PlayRho/Collision/Shapes/ShapeConf.hpp>
 #include <PlayRho/Collision/DistanceProxy.hpp>
 #include <PlayRho/Collision/MassData.hpp>
@@ -85,7 +86,7 @@ public:
     PolygonShapeConf& UseVertexRadius(NonNegative<Length> value) noexcept;
 
     /// @brief Uses the given vertices.
-    PolygonShapeConf& UseVertices(const std::vector<Length2>& verts);
+    PolygonShapeConf& UseVertices(const Span<const Length2>& verts);
 
     /// @brief Sets the vertices to represent an axis-aligned box centered on the local origin.
     /// @param hx the half-width.

--- a/PlayRho/Dynamics/Contacts/ContactSolver.cpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.cpp
@@ -19,11 +19,10 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
-
-#include <PlayRho/Dynamics/Contacts/ConstraintSolverConf.hpp>
 #include <PlayRho/Collision/Collision.hpp>
 #include <PlayRho/Collision/WorldManifold.hpp>
+#include <PlayRho/Dynamics/Contacts/ContactSolver.hpp>
+#include <PlayRho/Dynamics/Contacts/ConstraintSolverConf.hpp>
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 #include <PlayRho/Dynamics/Contacts/PositionSolverManifold.hpp>
 #include <PlayRho/Dynamics/Contacts/VelocityConstraint.hpp>
@@ -67,7 +66,7 @@ struct ImpulseChange
 };
 
 VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2& impulses,
-                              const std::vector<BodyConstraint>& bodies)
+                              const Span<const BodyConstraint>& bodies)
 {
     assert(IsValid(impulses));
 
@@ -98,7 +97,7 @@ VelocityPair GetVelocityDelta(const VelocityConstraint& vc, const Momentum2& imp
 }
 
 Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2& newImpulses,
-                          std::vector<BodyConstraint>& bodies)
+                          const Span<BodyConstraint>& bodies)
 {
     const auto delta_v = GetVelocityDelta(vc, newImpulses - GetNormalImpulses(vc), bodies);
     const auto bodyA = &bodies[to_underlying(vc.GetBodyA())];
@@ -110,7 +109,7 @@ Momentum BlockSolveUpdate(VelocityConstraint& vc, const Momentum2& newImpulses,
 }
 
 std::optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
-                                              std::vector<BodyConstraint>& bodies,
+                                              const Span<BodyConstraint>& bodies,
                                               const LinearVelocity2& b_prime)
 {
     //
@@ -150,7 +149,7 @@ std::optional<Momentum> BlockSolveNormalCase1(VelocityConstraint& vc,
 }
 
 std::optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc,
-                                              std::vector<BodyConstraint>& bodies,
+                                              const Span<BodyConstraint>& bodies,
                                               const LinearVelocity2& b_prime)
 {
     //
@@ -187,7 +186,7 @@ std::optional<Momentum> BlockSolveNormalCase2(VelocityConstraint& vc,
 }
 
 std::optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc,
-                                              std::vector<BodyConstraint>& bodies,
+                                              const Span<BodyConstraint>& bodies,
                                               const LinearVelocity2& b_prime)
 {
     //
@@ -224,7 +223,7 @@ std::optional<Momentum> BlockSolveNormalCase3(VelocityConstraint& vc,
 }
 
 std::optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc,
-                                              std::vector<BodyConstraint>& bodies,
+                                              const Span<BodyConstraint>& bodies,
                                               const LinearVelocity2& b_prime)
 {
     //
@@ -242,7 +241,7 @@ std::optional<Momentum> BlockSolveNormalCase4(VelocityConstraint& vc,
 }
 
 inline Momentum BlockSolveNormalConstraint(VelocityConstraint& vc,
-                                           std::vector<BodyConstraint>& bodies)
+                                           const Span<BodyConstraint>& bodies)
 {
     assert(vc.GetPointCount() == 2);
 
@@ -334,7 +333,7 @@ inline Momentum BlockSolveNormalConstraint(VelocityConstraint& vc,
 }
 
 inline Momentum SeqSolveNormalConstraint(VelocityConstraint& vc,
-                                         std::vector<BodyConstraint>& bodies)
+                                         const Span<BodyConstraint>& bodies)
 {
     auto maxIncImpulse = 0_Ns;
     
@@ -392,7 +391,7 @@ inline Momentum SeqSolveNormalConstraint(VelocityConstraint& vc,
 }
 
 inline Momentum SolveTangentConstraint(VelocityConstraint& vc,
-                                       std::vector<BodyConstraint>& bodies)
+                                       const Span<BodyConstraint>& bodies)
 {
     auto maxIncImpulse = 0_Ns;
     
@@ -453,7 +452,7 @@ inline Momentum SolveTangentConstraint(VelocityConstraint& vc,
 }
 
 inline Momentum SolveNormalConstraint(VelocityConstraint& vc,
-                                      std::vector<BodyConstraint>& bodies)
+                                      const Span<BodyConstraint>& bodies)
 {
 #if 1
     // Note: Block solving reduces World.TilesComesToRest iteration counts and is faster.
@@ -477,8 +476,7 @@ inline Momentum SolveNormalConstraint(VelocityConstraint& vc,
 
 namespace GaussSeidel {
 
-Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc,
-                                 std::vector<d2::BodyConstraint>& bodies)
+Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc, const Span<d2::BodyConstraint>& bodies)
 {
     auto maxIncImpulse = 0_Ns;
     
@@ -493,7 +491,7 @@ Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc,
 
 d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
                                              bool moveA, bool moveB,
-                                             const std::vector<d2::BodyConstraint>& bodies,
+                                             const Span<d2::BodyConstraint>& bodies,
                                              const ConstraintSolverConf& conf)
 {
     assert(IsValid(conf.resolutionRate));

--- a/PlayRho/Dynamics/Contacts/ContactSolver.hpp
+++ b/PlayRho/Dynamics/Contacts/ContactSolver.hpp
@@ -23,6 +23,7 @@
 #define PLAYRHO_DYNAMICS_CONTACTS_CONTACTSOLVER_HPP
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 #include <vector>
 
@@ -85,7 +86,7 @@ namespace GaussSeidel {
 ///   valid point relative positions, and valid velocity biases.
 ///
 Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc,
-                                 std::vector<d2::BodyConstraint>& bodies);
+                                 const Span<d2::BodyConstraint>& bodies);
 
 /// Solves the given position constraint.
 /// @details
@@ -96,7 +97,7 @@ Momentum SolveVelocityConstraint(d2::VelocityConstraint& vc,
 ///   (prior to "solving").
 d2::PositionSolution SolvePositionConstraint(const d2::PositionConstraint& pc,
                                              bool moveA, bool moveB,
-                                             const std::vector<d2::BodyConstraint>& bodies,
+                                             const Span<d2::BodyConstraint>& bodies,
                                              const ConstraintSolverConf& conf);
 
 } // namespace GaussSidel

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.cpp
@@ -31,7 +31,7 @@ namespace d2 {
 
 namespace {
 
-inline InvMass3 ComputeK(const VelocityConstraint& vc, const std::vector<BodyConstraint>& bodies) noexcept
+inline InvMass3 ComputeK(const VelocityConstraint& vc, const Span<const BodyConstraint>& bodies) noexcept
 {
     assert(vc.GetPointCount() == 2);
 
@@ -79,7 +79,7 @@ VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
                                        const WorldManifold& worldManifold,
                                        BodyID bA,
                                        BodyID bB,
-                                       const std::vector<BodyConstraint>& bodies,
+                                       const Span<const BodyConstraint>& bodies,
                                        const Conf& conf):
     m_bodyA{bA}, m_bodyB{bB},
     m_normal{worldManifold.GetNormal()},
@@ -130,7 +130,8 @@ VelocityConstraint::VelocityConstraint(Real friction, Real restitution,
 
 VelocityConstraint::Point
 VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                             const Length2& relA, const Length2& relB, const std::vector<BodyConstraint>& bodies,
+                             const Length2& relA, const Length2& relB,
+                             const Span<const BodyConstraint>& bodies,
                              const Conf& conf) const noexcept
 {
     assert(IsValid(normalImpulse));
@@ -181,7 +182,7 @@ VelocityConstraint::GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
 
 void VelocityConstraint::AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
                                   const Length2& relA, const Length2& relB,
-                                  const std::vector<BodyConstraint>& bodies,
+                                  const Span<const BodyConstraint>& bodies,
                                   const Conf& conf)
 {
     assert(m_pointCount < MaxManifoldPoints);

--- a/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
+++ b/PlayRho/Dynamics/Contacts/VelocityConstraint.hpp
@@ -23,6 +23,8 @@
 #define PLAYRHO_DYNAMICS_CONTACTS_VELOCITYCONSTRAINT_HPP
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
+
 #include <PlayRho/Dynamics/Contacts/BodyConstraint.hpp>
 
 namespace playrho {
@@ -80,7 +82,7 @@ public:
                        const WorldManifold& worldManifold,
                        BodyID bA,
                        BodyID bB,
-                       const std::vector<BodyConstraint>& bodies,
+                       const Span<const BodyConstraint>& bodies,
                        const Conf& conf = GetDefaultConf());
     
     /// Gets the normal of the contact in world coordinates.
@@ -237,7 +239,7 @@ private:
     ///   <code>MaxManifoldPoints</code> points.
     /// @see GetPointCount().
     void AddPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                  const Length2& relA, const Length2& relB, const std::vector<BodyConstraint>& bodies,
+                  const Length2& relA, const Length2& relB, const Span<const BodyConstraint>& bodies,
                   const Conf& conf);
     
     /// Removes the last point added.
@@ -245,7 +247,7 @@ private:
     
     /// @brief Gets a point instance for the given parameters.
     Point GetPoint(Momentum normalImpulse, Momentum tangentImpulse,
-                   const Length2& relA, const Length2& relB, const std::vector<BodyConstraint>& bodies,
+                   const Length2& relA, const Length2& relB, const Span<const BodyConstraint>& bodies,
                    const Conf& conf) const noexcept;
     
     /// Accesses the point identified by the given index.

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.cpp
@@ -78,7 +78,7 @@ DistanceJointConf GetDistanceJointConf(const World& world, BodyID bodyA, BodyID 
                              GetLocalPoint(world, bodyB, anchorB), GetMagnitude(anchorB - anchorA)};
 }
 
-void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(DistanceJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -166,7 +166,7 @@ void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf&)
+bool SolveVelocity(DistanceJointConf& object, const Span<BodyConstraint>& bodies, const StepConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
         return true;
@@ -200,7 +200,7 @@ bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodie
     return impulse == 0_Ns;
 }
 
-bool SolvePosition(const DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const DistanceJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {

--- a/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/DistanceJointConf.hpp
@@ -25,6 +25,7 @@
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 #include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -191,7 +192,7 @@ constexpr bool ShiftOrigin(DistanceJointConf&, Length2) noexcept
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso DistanceJointConf
-void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(DistanceJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -205,7 +206,7 @@ void InitVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso DistanceJointConf
-bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(DistanceJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -217,7 +218,7 @@ bool SolveVelocity(DistanceJointConf& object, std::vector<BodyConstraint>& bodie
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso DistanceJointConf
-bool SolvePosition(const DistanceJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const DistanceJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for setting the frequency value of the given configuration.

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.cpp
@@ -74,7 +74,7 @@ FrictionJointConf GetFrictionJointConf(const World& world, BodyID bodyA, BodyID 
                              GetLocalPoint(world, bodyB, anchor)};
 }
 
-void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(FrictionJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -154,7 +154,7 @@ void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(FrictionJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -231,7 +231,7 @@ bool SolveVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodie
     return solved;
 }
 
-bool SolvePosition(const FrictionJointConf&, std::vector<BodyConstraint>&,
+bool SolvePosition(const FrictionJointConf&, const Span<BodyConstraint>&,
                    const ConstraintSolverConf&)
 {
     return true;

--- a/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/FrictionJointConf.hpp
@@ -23,9 +23,9 @@
 #define PLAYRHO_DYNAMICS_JOINTS_FRICTIONJOINTCONF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
-
 #include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -168,7 +168,7 @@ constexpr bool ShiftOrigin(FrictionJointConf&, Length2) noexcept
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso FrictionJointConf
-void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(FrictionJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -182,14 +182,14 @@ void InitVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso FrictionJointConf
-bool SolveVelocity(FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(FrictionJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
 /// @note This is a no-op and always returns <code>true</code>.
 /// @return <code>true</code>.
 /// @relatedalso FrictionJointConf
-bool SolvePosition(const FrictionJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const FrictionJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for getting the max force value of the given configuration.

--- a/PlayRho/Dynamics/Joints/GearJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/GearJointConf.cpp
@@ -168,7 +168,7 @@ GearJointConf GetGearJointConf(const World& world, JointID id1, JointID id2, Rea
     return def;
 }
 
-void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(GearJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf&)
 {
     if ((object.bodyA == InvalidBodyID) || (object.bodyB == InvalidBodyID) || //
@@ -262,7 +262,7 @@ void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies, co
     bodyConstraintD.SetVelocity(velD);
 }
 
-bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf&)
+bool SolveVelocity(GearJointConf& object, const Span<BodyConstraint>& bodies, const StepConf&)
 {
     if ((object.bodyA == InvalidBodyID) || (object.bodyB == InvalidBodyID) || //
         (object.bodyC == InvalidBodyID) || (object.bodyD == InvalidBodyID)) {
@@ -299,7 +299,7 @@ bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies, c
     return impulse == 0_Ns;
 }
 
-bool SolvePosition(const GearJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const GearJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((object.bodyA == InvalidBodyID) || (object.bodyB == InvalidBodyID) || //

--- a/PlayRho/Dynamics/Joints/GearJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/GearJointConf.hpp
@@ -23,9 +23,9 @@
 #define PLAYRHO_DYNAMICS_JOINTS_GEARJOINTCONF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
-
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Dynamics/Joints/JointID.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 #include <variant>
 
@@ -219,7 +219,7 @@ constexpr bool ShiftOrigin(GearJointConf&, const Length2&) noexcept
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso GearJointConf
-void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(GearJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -233,7 +233,7 @@ void InitVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies, co
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso GearJointConf
-bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(GearJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -245,7 +245,7 @@ bool SolveVelocity(GearJointConf& object, std::vector<BodyConstraint>& bodies,
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso GearJointConf
-bool SolvePosition(const GearJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const GearJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for getting the ratio value of the given configuration.

--- a/PlayRho/Dynamics/Joints/Joint.cpp
+++ b/PlayRho/Dynamics/Joints/Joint.cpp
@@ -54,9 +54,13 @@ static_assert(std::is_nothrow_destructible<Joint>::value, "Joint must be nothrow
 
 // Free functions...
 
-BodyConstraint& At(std::vector<BodyConstraint>& container, BodyID key)
+BodyConstraint& At(const Span<BodyConstraint>& container, BodyID key)
 {
-    return container.at(to_underlying(key));
+    const auto index = to_underlying(key);
+    if (index >= container.size()) {
+        throw std::out_of_range{"invalid index"};
+    }
+    return container[index];
 }
 
 Length2 GetLocalAnchorA(const Joint& object)

--- a/PlayRho/Dynamics/Joints/MotorJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.cpp
@@ -76,7 +76,7 @@ MotorJointConf GetMotorJointConf(const World& world, BodyID bA, BodyID bB)
                           GetAngle(world, bB) - GetAngle(world, bA)};
 }
 
-void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(MotorJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -157,7 +157,7 @@ void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies, c
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(MotorJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -238,7 +238,7 @@ bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
     return solved;
 }
 
-bool SolvePosition(const MotorJointConf&, std::vector<BodyConstraint>&, const ConstraintSolverConf&)
+bool SolvePosition(const MotorJointConf&, const Span<BodyConstraint>&, const ConstraintSolverConf&)
 {
     return true;
 }

--- a/PlayRho/Dynamics/Joints/MotorJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/MotorJointConf.hpp
@@ -23,9 +23,9 @@
 #define PLAYRHO_DYNAMICS_JOINTS_MOTORJOINTCONF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
-
 #include <PlayRho/Common/NonNegative.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -195,7 +195,7 @@ constexpr auto ShiftOrigin(MotorJointConf&, const Length2&) noexcept
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso MotorJointConf
-void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(MotorJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -209,14 +209,14 @@ void InitVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies, c
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso MotorJointConf
-bool SolveVelocity(MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(MotorJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
 /// @note This is a no-op and always returns <code>true</code>.
 /// @return <code>true</code>.
 /// @relatedalso MotorJointConf
-bool SolvePosition(const MotorJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const MotorJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for getting the maximum force value of the given configuration.

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.cpp
@@ -152,7 +152,7 @@ AngularMomentum GetAngularReaction(const PrismaticJointConf& conf)
     return GetY(conf.impulse) * SquareMeter * Kilogram / (Second * Radian);
 }
 
-void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(PrismaticJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -284,7 +284,7 @@ void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodie
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(PrismaticJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -406,7 +406,7 @@ bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodi
 // We could take the active state from the velocity solver. However, the joint might push past the
 // limit when the velocity solver indicates the limit is inactive.
 //
-bool SolvePosition(const PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const PrismaticJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {

--- a/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PrismaticJointConf.hpp
@@ -23,9 +23,9 @@
 #define PLAYRHO_DYNAMICS_JOINTS_PRISMATICJOINTCONF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
-
 #include <PlayRho/Dynamics/Joints/LimitState.hpp>
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -258,7 +258,7 @@ AngularMomentum GetAngularReaction(const PrismaticJointConf& conf);
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocityConstraints.
 /// @relatedalso PrismaticJointConf
-void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(PrismaticJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -272,7 +272,7 @@ void InitVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodie
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso PrismaticJointConf
-bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(PrismaticJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -284,7 +284,7 @@ bool SolveVelocity(PrismaticJointConf& object, std::vector<BodyConstraint>& bodi
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso PrismaticJointConf
-bool SolvePosition(const PrismaticJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const PrismaticJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for setting the maximum motor torque value of the given configuration.

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.cpp
@@ -89,7 +89,7 @@ PulleyJointConf GetPulleyJointConf(const World& world, BodyID bA, BodyID bB, // 
                            GetMagnitude(anchorB - groundB)};
 }
 
-void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(PulleyJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -152,7 +152,7 @@ void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf&)
+bool SolveVelocity(PulleyJointConf& object, const Span<BodyConstraint>& bodies, const StepConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
         return true;
@@ -189,7 +189,7 @@ bool SolveVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
     return impulse == 0_Ns;
 }
 
-bool SolvePosition(const PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const PulleyJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {

--- a/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/PulleyJointConf.hpp
@@ -23,8 +23,8 @@
 #define PLAYRHO_DYNAMICS_JOINTS_PULLEYJOINTCONF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
-
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -194,7 +194,7 @@ bool ShiftOrigin(PulleyJointConf& object, const Length2& newOrigin) noexcept;
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso PulleyJointConf
-void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(PulleyJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -208,7 +208,7 @@ void InitVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso PulleyJointConf
-bool SolveVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(PulleyJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -220,7 +220,7 @@ bool SolveVelocity(PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso PulleyJointConf
-bool SolvePosition(const PulleyJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const PulleyJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for getting the length A value of the given configuration.

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.cpp
@@ -124,7 +124,7 @@ AngularVelocity GetAngularVelocity(const World& world, const RevoluteJointConf& 
     return GetVelocity(world, GetBodyB(conf)).angular - GetVelocity(world, GetBodyA(conf)).angular;
 }
 
-void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(RevoluteJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -225,7 +225,7 @@ void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(RevoluteJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -344,7 +344,7 @@ bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodie
     return true;
 }
 
-bool SolvePosition(const RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const RevoluteJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {

--- a/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RevoluteJointConf.hpp
@@ -23,9 +23,9 @@
 #define PLAYRHO_DYNAMICS_JOINTS_REVOLUTEJOINTCONF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
-
 #include <PlayRho/Common/Math.hpp>
 #include <PlayRho/Dynamics/Joints/LimitState.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -247,7 +247,7 @@ constexpr AngularMomentum GetAngularReaction(const RevoluteJointConf& conf) noex
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocityConstraints.
 /// @relatedalso RevoluteJointConf
-void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(RevoluteJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -261,7 +261,7 @@ void InitVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso RevoluteJointConf
-bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(RevoluteJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -273,7 +273,7 @@ bool SolveVelocity(RevoluteJointConf& object, std::vector<BodyConstraint>& bodie
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso RevoluteJointConf
-bool SolvePosition(const RevoluteJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const RevoluteJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for setting the angular limits of the given configuration.

--- a/PlayRho/Dynamics/Joints/RopeJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.cpp
@@ -56,7 +56,7 @@ RopeJointConf GetRopeJointConf(const Joint& joint)
 // K = J * invM * JT
 //   = invMassA + invIA * cross(rA, u)^2 + invMassB + invIB * cross(rB, u)^2
 
-void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(RopeJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -130,7 +130,7 @@ void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, co
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step)
+bool SolveVelocity(RopeJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
         return true;
@@ -171,7 +171,7 @@ bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, c
     return localImpulse == 0_Ns;
 }
 
-bool SolvePosition(const RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const RopeJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {

--- a/PlayRho/Dynamics/Joints/RopeJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/RopeJointConf.hpp
@@ -23,8 +23,8 @@
 #define PLAYRHO_DYNAMICS_JOINTS_ROPEJOINTCONF_HPP
 
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
-
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 #include <PlayRho/Dynamics/Joints/LimitState.hpp>
 
 namespace playrho {
@@ -151,7 +151,7 @@ constexpr auto ShiftOrigin(RopeJointConf&, const Length2&) noexcept
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso RopeJointConf
-void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(RopeJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -165,7 +165,7 @@ void InitVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies, co
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso RopeJointConf
-bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(RopeJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -177,7 +177,7 @@ bool SolveVelocity(RopeJointConf& object, std::vector<BodyConstraint>& bodies,
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso RopeJointConf
-bool SolvePosition(const RopeJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const RopeJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for getting the maximum length value of the given configuration.

--- a/PlayRho/Dynamics/Joints/TargetJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.cpp
@@ -81,7 +81,7 @@ Mass22 GetEffectiveMassMatrix(const TargetJointConf& object, const BodyConstrain
 // Identity used:
 // w k % (rx i + ry j) = w * (-ry i + rx j)
 
-void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(TargetJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf&)
 {
     if (GetBodyB(object) == InvalidBodyID) {
@@ -145,7 +145,7 @@ void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(TargetJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step)
 {
     if (GetBodyB(object) == InvalidBodyID) {
@@ -180,7 +180,7 @@ bool SolveVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
     return incImpulse == Momentum2{0_Ns, 0_Ns};
 }
 
-bool SolvePosition(const TargetJointConf&, std::vector<BodyConstraint>&,
+bool SolvePosition(const TargetJointConf&, const Span<BodyConstraint>&,
                    const ConstraintSolverConf&)
 {
     return true;

--- a/PlayRho/Dynamics/Joints/TargetJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/TargetJointConf.hpp
@@ -25,6 +25,7 @@
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -212,7 +213,7 @@ Mass22 GetEffectiveMassMatrix(const TargetJointConf& object, const BodyConstrain
 ///  <code>InvalidBodyID</code> and does not index within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso TargetJointConf
-void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+void InitVelocity(TargetJointConf& object, const Span<BodyConstraint>& bodies,
                   const StepConf& step, const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -226,14 +227,14 @@ void InitVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso TargetJointConf
-bool SolveVelocity(TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(TargetJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
 /// @note This is a no-op and always returns <code>true</code>.
 /// @return <code>true</code>.
 /// @relatedalso TargetJointConf
-bool SolvePosition(const TargetJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const TargetJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for setting the target value of the given configuration.

--- a/PlayRho/Dynamics/Joints/WeldJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.cpp
@@ -111,7 +111,7 @@ WeldJointConf GetWeldJointConf(const World& world, BodyID bodyA, BodyID bodyB, c
                          GetAngle(world, bodyB) - GetAngle(world, bodyA)};
 }
 
-void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(WeldJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -213,7 +213,7 @@ void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies, co
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf&)
+bool SolveVelocity(WeldJointConf& object, const Span<BodyConstraint>& bodies, const StepConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
         return true;
@@ -299,7 +299,7 @@ bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies, c
     return true;
 }
 
-bool SolvePosition(const WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const WeldJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {

--- a/PlayRho/Dynamics/Joints/WeldJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WeldJointConf.hpp
@@ -25,6 +25,7 @@
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -178,7 +179,7 @@ constexpr auto ShiftOrigin(WeldJointConf&, const Length2&) noexcept
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso WeldJointConf
-void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(WeldJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -192,7 +193,7 @@ void InitVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies, co
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso WeldJointConf
-bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(WeldJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -204,7 +205,7 @@ bool SolveVelocity(WeldJointConf& object, std::vector<BodyConstraint>& bodies,
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso WeldJointConf
-bool SolvePosition(const WeldJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const WeldJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Free function for setting the frequency of the given configuration.

--- a/PlayRho/Dynamics/Joints/WheelJointConf.cpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.cpp
@@ -88,7 +88,7 @@ AngularVelocity GetAngularVelocity(const World& world, const WheelJointConf& con
     return GetVelocity(world, GetBodyB(conf)).angular - GetVelocity(world, GetBodyA(conf)).angular;
 }
 
-void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(WheelJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf&)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -215,7 +215,7 @@ void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, c
     bodyConstraintB.SetVelocity(velB);
 }
 
-bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(WheelJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {
@@ -292,7 +292,7 @@ bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
     return true;
 }
 
-bool SolvePosition(const WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const WheelJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf)
 {
     if ((GetBodyA(object) == InvalidBodyID) || (GetBodyB(object) == InvalidBodyID)) {

--- a/PlayRho/Dynamics/Joints/WheelJointConf.hpp
+++ b/PlayRho/Dynamics/Joints/WheelJointConf.hpp
@@ -25,6 +25,7 @@
 #include <PlayRho/Dynamics/Joints/JointConf.hpp>
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 namespace playrho {
 
@@ -230,7 +231,7 @@ constexpr auto ShiftOrigin(WheelJointConf&, const Length2&)
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @see SolveVelocity.
 /// @relatedalso WheelJointConf
-void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, const StepConf& step,
+void InitVelocity(WheelJointConf& object, const Span<BodyConstraint>& bodies, const StepConf& step,
                   const ConstraintSolverConf& conf);
 
 /// @brief Solves velocity constraint.
@@ -244,7 +245,7 @@ void InitVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies, c
 /// @see InitVelocity.
 /// @return <code>true</code> if velocity is "solved", <code>false</code> otherwise.
 /// @relatedalso WheelJointConf
-bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolveVelocity(WheelJointConf& object, const Span<BodyConstraint>& bodies,
                    const StepConf& step);
 
 /// @brief Solves the position constraint.
@@ -256,7 +257,7 @@ bool SolveVelocity(WheelJointConf& object, std::vector<BodyConstraint>& bodies,
 ///  <code>InvalidBodyID</code> and are not  indices within range of the given <code>bodies</code> container.
 /// @return <code>true</code> if the position errors are within tolerance.
 /// @relatedalso WheelJointConf
-bool SolvePosition(const WheelJointConf& object, std::vector<BodyConstraint>& bodies,
+bool SolvePosition(const WheelJointConf& object, const Span<BodyConstraint>& bodies,
                    const ConstraintSolverConf& conf);
 
 /// @brief Sets the maximum motor torque for the given configuration.

--- a/PlayRho/Dynamics/WorldImpl.cpp
+++ b/PlayRho/Dynamics/WorldImpl.cpp
@@ -57,6 +57,7 @@
 #include <PlayRho/Common/LengthError.hpp>
 #include <PlayRho/Common/DynamicMemory.hpp>
 #include <PlayRho/Common/FlagGuard.hpp>
+#include <PlayRho/Common/Span.hpp>
 #include <PlayRho/Common/WrongState.hpp>
 
 #include <algorithm>
@@ -142,7 +143,7 @@ inline void IntegratePositions(const Island::Bodies& bodies, BodyConstraints& co
 /// @param listener Listener to call.
 /// @param constraints Array of m_contactCount contact velocity constraint elements.
 inline void Report(const WorldImpl::ImpulsesContactListener& listener,
-                   const std::vector<ContactID>& contacts,
+                   const Span<const ContactID>& contacts,
                    const VelocityConstraints& constraints,
                    StepConf::iteration_type solved)
 {
@@ -176,7 +177,7 @@ inline void AssignImpulses(Manifold& var, const VelocityConstraint& vc)
 
 /// @brief Calculates the "warm start" velocity deltas for the given velocity constraint.
 VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc,
-                                         const std::vector<BodyConstraint>& bodies)
+                                         const Span<const BodyConstraint>& bodies)
 {
     auto vp = VelocityPair{Velocity{LinearVelocity2{}, 0_rpm}, Velocity{LinearVelocity2{}, 0_rpm}};
 
@@ -210,7 +211,7 @@ VelocityPair CalcWarmStartVelocityDeltas(const VelocityConstraint& vc,
 }
 
 void WarmStartVelocities(const VelocityConstraints& velConstraints,
-                         std::vector<BodyConstraint>& bodies)
+                         const Span<BodyConstraint>& bodies)
 {
     for_each(cbegin(velConstraints), cend(velConstraints), [&](const VelocityConstraint& vc) {
         const auto vp = CalcWarmStartVelocityDeltas(vc, bodies);
@@ -221,7 +222,7 @@ void WarmStartVelocities(const VelocityConstraints& velConstraints,
     });
 }
 
-void GetBodyConstraints(std::vector<BodyConstraint>& constraints, const Island::Bodies& bodies,
+void GetBodyConstraints(const Span<BodyConstraint>& constraints, const Island::Bodies& bodies,
                         const ObjectPool<Body>& bodyBuffer, Time h, const MovementConf& conf)
 {
     assert(size(constraints) == size(bodyBuffer));
@@ -395,7 +396,7 @@ inline bool IsValidForTime(ToiOutput::State state) noexcept
 }
 
 bool FlagForFiltering(ObjectPool<Contact>& contactBuffer, BodyID bodyA,
-                      const std::vector<KeyedContactPtr>& contactsBodyB,
+                      const Span<const KeyedContactPtr>& contactsBodyB,
                       BodyID bodyB) noexcept
 {
     auto anyFlagged = false;
@@ -470,7 +471,7 @@ void ResetBodiesForSolveTOI(WorldImpl::Bodies& bodies, ObjectPool<Body>& buffer)
 
 /// @brief Reset contacts for solve TOI.
 void ResetBodyContactsForSolveTOI(ObjectPool<Contact>& buffer,
-                                  const std::vector<KeyedContactPtr>& contacts) noexcept
+                                  const Span<const KeyedContactPtr>& contacts) noexcept
 {
     // Invalidate all contact TOIs on this displaced body.
     for_each(cbegin(contacts), cend(contacts), [&buffer](const auto& ci) {
@@ -491,7 +492,7 @@ void ResetContactsForSolveTOI(ObjectPool<Contact>& buffer,
 
 /// @brief Destroys all of the given fixture's proxies.
 void DestroyProxies(DynamicTree& tree,
-                    const std::vector<DynamicTree::Size>& fixtureProxies,
+                    const Span<const DynamicTree::Size>& fixtureProxies,
                     std::vector<DynamicTree::Size>& proxies) noexcept
 {
     const auto childCount = size(fixtureProxies);
@@ -647,7 +648,7 @@ void ResizeAndReset(std::vector<T>& vector, typename std::vector<T>::size_type n
 
 /// @brief Removes <em>unspeedables</em> from the is <em>is-in-island</em> state.
 WorldImpl::Bodies::size_type
-RemoveUnspeedablesFromIslanded(const std::vector<BodyID>& bodies,
+RemoveUnspeedablesFromIslanded(const Span<const BodyID>& bodies,
                                           const ObjectPool<Body>& buffer,
                                           std::vector<bool>& islanded)
 {

--- a/PlayRho/Dynamics/WorldShape.cpp
+++ b/PlayRho/Dynamics/WorldShape.cpp
@@ -138,7 +138,7 @@ void Rotate(World& world, ShapeID id, const UnitVec& value)
     SetShape(world, id, object);
 }
 
-MassData ComputeMassData(const World& world, const std::vector<ShapeID>& ids)
+MassData ComputeMassData(const World& world, const Span<const ShapeID>& ids)
 {
     auto mass = 0_kg;
     auto I = RotInertia{};

--- a/PlayRho/Dynamics/WorldShape.hpp
+++ b/PlayRho/Dynamics/WorldShape.hpp
@@ -38,6 +38,7 @@
 /// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
 
 #include <PlayRho/Common/Math.hpp>
+#include <PlayRho/Common/Span.hpp>
 
 #include <PlayRho/Collision/MassData.hpp>
 #include <PlayRho/Collision/Shapes/Shape.hpp>
@@ -228,7 +229,7 @@ inline MassData GetMassData(const World& world, ShapeID id)
 /// @return accumulated mass data for all shapes identified.
 /// @throws std::out_of_range If given an invalid shape identifier.
 /// @relatedalso World
-MassData ComputeMassData(const World& world, const std::vector<ShapeID>& ids);
+MassData ComputeMassData(const World& world, const Span<const ShapeID>& ids);
 
 /// @brief Tests a point for containment in a shape associated with a body.
 /// @param world The world that the given shape ID exists within.

--- a/UnitTests/Joint.cpp
+++ b/UnitTests/Joint.cpp
@@ -55,18 +55,18 @@ using namespace playrho::d2;
         return false;                                                                              \
     }
 #define DEFINE_INITVELOCITY                                                                        \
-    [[maybe_unused]] void InitVelocity(JointTester&, std::vector<BodyConstraint>&,                 \
+    [[maybe_unused]] void InitVelocity(JointTester&, const Span<BodyConstraint>&,                  \
                                        const StepConf&, const ConstraintSolverConf&)               \
     {                                                                                              \
     }
 #define DEFINE_SOLVEVELOCITY                                                                       \
-    [[maybe_unused]] bool SolveVelocity(JointTester&, std::vector<BodyConstraint>&,                \
+    [[maybe_unused]] bool SolveVelocity(JointTester&, const Span<BodyConstraint>&,                 \
                                         const StepConf&)                                           \
     {                                                                                              \
         return true;                                                                               \
     }
 #define DEFINE_SOLVEPOSITION                                                                       \
-    [[maybe_unused]] bool SolvePosition(const JointTester&, std::vector<BodyConstraint>&,          \
+    [[maybe_unused]] bool SolvePosition(const JointTester&, const Span<BodyConstraint>&,           \
                                         const ConstraintSolverConf&)                               \
     {                                                                                              \
         return true;                                                                               \

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -286,7 +286,7 @@ TEST(PrismaticJointConf, WithDynamicCirclesAndLimitEnabled)
         ASSERT_EQ(GetLinearUpperLimit(conf), 0_m);
     }
 
-    Step(world, 1_s);
+    EXPECT_NO_THROW(Step(world, 1_s));
     EXPECT_NEAR(double(Real{GetX(GetLocation(world, b1)) / Meter}), -1.0, 0.001);
     EXPECT_NEAR(double(Real{GetY(GetLocation(world, b1)) / Meter}), 0.0, 0.001);
     EXPECT_NEAR(double(Real{GetX(GetLocation(world, b2)) / Meter}), +1.0, 0.01);

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -356,7 +356,7 @@ TEST(WheelJointConf, InitVelocity)
 {
     auto conf = WheelJointConf{};
     std::vector<BodyConstraint> bodies;
-    EXPECT_NO_THROW(InitVelocity(conf, bodies, StepConf{}, ConstraintSolverConf{}));
+    EXPECT_NO_THROW(InitVelocity(conf, Span<BodyConstraint>(bodies), StepConf{}, ConstraintSolverConf{}));
     conf.bodyA = BodyID(0);
     conf.bodyB = BodyID(0);
     EXPECT_THROW(InitVelocity(conf, bodies, StepConf{}, ConstraintSolverConf{}), std::out_of_range);


### PR DESCRIPTION
#### Description - What's this PR do?
Decrease coupling with owning container types like std::vector and makes it easier to change to another type like a vector with a custom allocator.
