### PR TITLE
Updates 20230929

### DIFF
--- a/Library/include/playrho/Matrix.hpp
+++ b/Library/include/playrho/Matrix.hpp
@@ -26,7 +26,7 @@
 /// @brief Definition of the @c Matrix alias and closely related code.
 
 #include <playrho/Vector.hpp>
-#include <playrho/Vector2.hpp>
+#include <playrho/Vector2.hpp> // for Vec2
 #include <playrho/Templates.hpp>
 #include <playrho/Real.hpp>
 #include <playrho/Units.hpp>
@@ -40,6 +40,8 @@ namespace playrho {
 /// @see Vector, MatrixTraitsGroup, IsVectorV
 template <typename T, std::size_t M, std::size_t N>
 using Matrix = Vector<Vector<T, N>, M>;
+
+namespace detail {
 
 /// @defgroup MatrixTraitsGroup Matrix Traits
 /// @brief Collection of trait classes for matrices.
@@ -70,10 +72,6 @@ struct IsMatrix: std::false_type {};
 template <typename T, std::size_t M, std::size_t N>
 struct IsMatrix<Vector<Vector<T, N>, M>>: std::true_type {};
 
-/// @brief Determines whether the given type is a <code>Matrix</code> type.
-template <class T>
-inline constexpr bool IsMatrixV = IsMatrix<T>::value;
-
 /// @brief Trait class for checking if type is a square matrix type.
 /// @details Trait class for determining whether the given type is a matrix having an equal
 ///   number of rows and columns.
@@ -99,11 +97,17 @@ struct IsSquareMatrix: std::false_type {};
 template <typename T, std::size_t M>
 struct IsSquareMatrix<Vector<Vector<T, M>, M>>: std::true_type {};
 
+/// @}
+
+} // namespace detail
+
+/// @brief Determines whether the given type is a <code>Matrix</code> type.
+template <class T>
+inline constexpr bool IsMatrixV = detail::IsMatrix<T>::value;
+
 /// @brief Determines whether the given type is a **square** <code>Matrix</code> type.
 template <class T>
-inline constexpr bool IsSquareMatrixV = IsSquareMatrix<T>::value;
-
-/// @}
+inline constexpr bool IsSquareMatrixV = detail::IsSquareMatrix<T>::value;
 
 /// @brief Gets the identity matrix of the template type and size.
 /// @see https://en.wikipedia.org/wiki/Identity_matrix

--- a/Library/include/playrho/Vector.hpp
+++ b/Library/include/playrho/Vector.hpp
@@ -218,6 +218,8 @@ struct Vector
     value_type elements[N? N: 1]; // Never zero to avoid needing C++ extension capability.
 };
 
+namespace detail {
+
 /// @defgroup VectorTraitsGroup Vector Traits
 /// @brief Collection of trait classes for Vector.
 /// @{
@@ -244,11 +246,13 @@ struct IsVector: std::false_type {};
 template <typename T, std::size_t N>
 struct IsVector<Vector<T, N>>: std::true_type {};
 
+/// @}
+
+} // namespace detail
+
 /// @brief Determines whether the given type is a <code>Vector</code> type.
 template <class T>
-inline constexpr bool IsVectorV = IsVector<T>::value;
-
-/// @}
+inline constexpr bool IsVectorV = detail::IsVector<T>::value;
 
 /// @brief Equality operator.
 /// @relatedalso Vector

--- a/Library/include/playrho/d2/Joint.hpp
+++ b/Library/include/playrho/d2/Joint.hpp
@@ -470,6 +470,8 @@ private:
 
 // Traits...
 
+namespace detail {
+
 /// @brief An "is valid joint type" trait.
 /// @note This is the general false template type.
 template <typename T, class = void>
@@ -496,10 +498,12 @@ struct IsValidJointType<
         decltype(Joint{std::declval<T>()})>> : std::true_type {
 };
 
+} // namespace detail
+
 /// @brief Boolean value for whether the specified type is a valid joint type.
 /// @see Joint.
 template <class T>
-inline constexpr bool IsValidJointTypeV = IsValidJointType<T>::value;
+inline constexpr bool IsValidJointTypeV = detail::IsValidJointType<T>::value;
 
 // Free functions...
 

--- a/Library/include/playrho/d2/Shape.hpp
+++ b/Library/include/playrho/d2/Shape.hpp
@@ -42,9 +42,6 @@
 #include <playrho/d2/MassData.hpp>
 #include <playrho/d2/Math.hpp>
 
-// Set this to 1 to use std::unique_ptr or to 0 to use std::shared_ptr.
-#define SHAPE_USES_UNIQUE_PTR 1
-
 namespace playrho {
 namespace d2 {
 
@@ -465,16 +462,11 @@ public:
     /// @post <code>has_value()</code> returns false.
     Shape() noexcept = default;
 
-#if SHAPE_USES_UNIQUE_PTR
     /// @brief Copy constructor.
     Shape(const Shape& other) : m_self{other.m_self ? other.m_self->Clone_() : nullptr}
     {
         // Intentionally empty.
     }
-#else
-    /// @brief Copy constructor.
-    Shape(const Shape& other) = default;
-#endif
 
     /// @brief Move constructor.
     Shape(Shape&& other) noexcept = default;
@@ -490,29 +482,17 @@ public:
     /// @throws std::bad_alloc if there's a failure allocating storage.
     template <typename T, typename Tp = DecayedTypeIfNotSame<T, Shape>,
               typename = std::enable_if_t<std::is_constructible_v<Tp, T>>>
-    explicit Shape(T&& arg) : m_self
-    {
-#if SHAPE_USES_UNIQUE_PTR
-        std::make_unique<Model<Tp>>(std::forward<T>(arg))
-#else
-        std::make_shared<Model<Tp>>(std::forward<T>(arg))
-#endif
-    }
+    explicit Shape(T&& arg) : m_self{std::make_unique<Model<Tp>>(std::forward<T>(arg))}
     {
         // Intentionally empty.
     }
 
-#if SHAPE_USES_UNIQUE_PTR
     /// @brief Copy assignment.
     Shape& operator=(const Shape& other)
     {
         m_self = other.m_self ? other.m_self->Clone_() : nullptr;
         return *this;
     }
-#else
-    /// @brief Copy assignment operator.
-    Shape& operator=(const Shape& other) = default;
-#endif
 
     /// @brief Move assignment operator.
     Shape& operator=(Shape&& other) = default;
@@ -929,11 +909,7 @@ private:
         data_type data; ///< Data.
     };
 
-#if SHAPE_USES_UNIQUE_PTR
     std::unique_ptr<const Concept> m_self; ///< Self pointer.
-#else
-    std::shared_ptr<const Concept> m_self; ///< Self pointer.
-#endif
 };
 
 // Related free functions...

--- a/Library/include/playrho/d2/Shape.hpp
+++ b/Library/include/playrho/d2/Shape.hpp
@@ -52,6 +52,8 @@ class Shape;
 
 // Traits...
 
+namespace detail {
+
 /// @brief An "is valid shape type" trait.
 /// @note This is the general false template type.
 template <typename T, class = void>
@@ -87,11 +89,6 @@ struct IsValidShapeType<
     : std::true_type {
 };
 
-/// @brief Boolean value for whether the specified type is a valid shape type.
-/// @see Shape.
-template <class T>
-inline constexpr bool IsValidShapeTypeV = IsValidShapeType<T>::value;
-
 template <class T, class = void>
 struct HasSetFriction : std::false_type {
 };
@@ -102,10 +99,6 @@ struct HasSetFriction<T,
     : std::true_type {
 };
 
-/// @brief Helper variable template on whether <code>SetFriction(T&, Real)</code> is found.
-template <class T>
-inline constexpr bool HasSetFrictionV = HasSetFriction<T>::value;
-
 template <class T, class = void>
 struct HasSetSensor : std::false_type {
 };
@@ -114,10 +107,6 @@ template <class T>
 struct HasSetSensor<T, std::void_t<decltype(SetSensor(std::declval<T&>(), std::declval<bool>()))>>
     : std::true_type {
 };
-
-/// @brief Helper variable template on whether <code>SetSensor(T&, bool)</code> is found.
-template <class T>
-inline constexpr bool HasSetSensorV = HasSetSensor<T>::value;
 
 template <class T, class = void>
 struct HasSetDensity : std::false_type {
@@ -129,10 +118,6 @@ struct HasSetDensity<T, std::void_t<decltype(SetDensity(std::declval<T&>(),
     : std::true_type {
 };
 
-/// @brief Helper variable template on whether <code>SetDensity(T&, NonNegative<AreaDensity>)</code> is found.
-template <class T>
-inline constexpr bool HasSetDensityV = HasSetDensity<T>::value;
-
 template <class T, class = void>
 struct HasSetRestitution : std::false_type {
 };
@@ -143,10 +128,6 @@ struct HasSetRestitution<
     : std::true_type {
 };
 
-/// @brief Helper variable template on whether <code>SetRestitution(T&, Real)</code> is found.
-template <class T>
-inline constexpr bool HasSetRestitutionV = HasSetRestitution<T>::value;
-
 template <class T, class = void>
 struct HasSetFilter : std::false_type {
 };
@@ -155,10 +136,6 @@ template <class T>
 struct HasSetFilter<T, std::void_t<decltype(SetFilter(std::declval<T&>(), std::declval<Filter>()))>>
     : std::true_type {
 };
-
-/// @brief Helper variable template on whether <code>SetFilter(T&, Filter)</code> is found.
-template <class T>
-inline constexpr bool HasSetFilterV = HasSetFilter<T>::value;
 
 template <class T, class = void>
 struct HasTranslate : std::false_type {
@@ -170,10 +147,6 @@ struct HasTranslate<T,
     : std::true_type {
 };
 
-/// @brief Helper variable template on whether <code>Translate(T&, Length2)</code> is found.
-template <class T>
-inline constexpr bool HasTranslateV = HasTranslate<T>::value;
-
 template <class T, class = void>
 struct HasScale : std::false_type {
 };
@@ -182,10 +155,6 @@ template <class T>
 struct HasScale<T, std::void_t<decltype(Scale(std::declval<T&>(), std::declval<Vec2>()))>>
     : std::true_type {
 };
-
-/// @brief Helper variable template on whether <code>Scale(T&, Vec2)</code> is found.
-template <class T>
-inline constexpr bool HasScaleV = HasScale<T>::value;
 
 /// @brief Type trait for not finding a <code>Rotate(T&, Angle)</code> function.
 /// @details A @c UnaryTypeTrait providing the member constant @c value equal to @c false for
@@ -206,9 +175,44 @@ struct HasRotate<T, std::void_t<decltype(Rotate(std::declval<T&>(), std::declval
     : std::true_type {
 };
 
+}
+
+/// @brief Boolean value for whether the specified type is a valid shape type.
+/// @see Shape.
+template <class T>
+inline constexpr bool IsValidShapeTypeV = detail::IsValidShapeType<T>::value;
+
+/// @brief Helper variable template on whether <code>SetFriction(T&, Real)</code> is found.
+template <class T>
+inline constexpr bool HasSetFrictionV = detail::HasSetFriction<T>::value;
+
+/// @brief Helper variable template on whether <code>SetSensor(T&, bool)</code> is found.
+template <class T>
+inline constexpr bool HasSetSensorV = detail::HasSetSensor<T>::value;
+
+/// @brief Helper variable template on whether <code>SetDensity(T&, NonNegative<AreaDensity>)</code> is found.
+template <class T>
+inline constexpr bool HasSetDensityV = detail::HasSetDensity<T>::value;
+
+/// @brief Helper variable template on whether <code>SetRestitution(T&, Real)</code> is found.
+template <class T>
+inline constexpr bool HasSetRestitutionV = detail::HasSetRestitution<T>::value;
+
+/// @brief Helper variable template on whether <code>SetFilter(T&, Filter)</code> is found.
+template <class T>
+inline constexpr bool HasSetFilterV = detail::HasSetFilter<T>::value;
+
+/// @brief Helper variable template on whether <code>Translate(T&, Length2)</code> is found.
+template <class T>
+inline constexpr bool HasTranslateV = detail::HasTranslate<T>::value;
+
+/// @brief Helper variable template on whether <code>Scale(T&, Vec2)</code> is found.
+template <class T>
+inline constexpr bool HasScaleV = detail::HasScale<T>::value;
+
 /// @brief Helper variable template on whether <code>Rotate(T&, Angle)</code> is found.
 template <class T>
-inline constexpr bool HasRotateV = HasRotate<T>::value;
+inline constexpr bool HasRotateV = detail::HasRotate<T>::value;
 
 /// @brief Fallback friction setter that throws unless given the same value as current.
 template <class T>

--- a/Library/include/playrho/detail/underlying_type.hpp
+++ b/Library/include/playrho/detail/underlying_type.hpp
@@ -52,7 +52,7 @@ struct underlying_type<T, std::enable_if_t<std::is_enum_v<T>>>
 
 /// Underlying-type template class for <code>detail::IndexingNamedType</code> types.
 template <class T>
-struct underlying_type<T, std::enable_if_t<detail::has_underlying_type_member<T>::value>>
+struct underlying_type<T, std::enable_if_t<has_underlying_type_member<T>::value>>
 {
     /// @brief Type alias of the underlying type.
     using type = typename T::underlying_type;

--- a/Library/source/playrho/d2/AabbTreeWorld.cpp
+++ b/Library/source/playrho/d2/AabbTreeWorld.cpp
@@ -842,7 +842,7 @@ void Clear(AabbTreeWorld& world) noexcept
     if (const auto listener = world.m_listeners.shapeDestruction) {
         for (auto&& shape: world.m_shapeBuffer) {
             if (shape != Shape{}) {
-                using underlying_type = detail::underlying_type_t<ShapeID>;
+                using underlying_type = ::playrho::detail::underlying_type_t<ShapeID>;
                 const auto index = &shape - world.m_shapeBuffer.data();
                 try {
                     listener(static_cast<ShapeID>(static_cast<underlying_type>(index)));

--- a/UnitTests/Shape.cpp
+++ b/UnitTests/Shape.cpp
@@ -40,11 +40,7 @@ TEST(Shape, ByteSize)
 {
     // Check size at test runtime instead of compile-time via static_assert to avoid stopping
     // builds and to report actual size rather than just reporting that expected size is wrong.
-#if SHAPE_USES_UNIQUE_PTR
     EXPECT_EQ(sizeof(Shape), sizeof(std::unique_ptr<int>));
-#else
-    EXPECT_EQ(sizeof(Shape), sizeof(std::shared_ptr<int>));
-#endif
 }
 
 TEST(Shape, Traits)
@@ -67,11 +63,7 @@ TEST(Shape, Traits)
     EXPECT_FALSE((std::is_trivially_constructible_v<Shape, X, X>));
 
     EXPECT_TRUE(std::is_copy_constructible_v<Shape>);
-#if SHAPE_USES_UNIQUE_PTR
     EXPECT_FALSE(std::is_nothrow_copy_constructible_v<Shape>);
-#else
-    EXPECT_TRUE(std::is_nothrow_copy_constructible_v<Shape>);
-#endif
     EXPECT_FALSE(std::is_trivially_copy_constructible_v<Shape>);
 
     EXPECT_TRUE(std::is_move_constructible_v<Shape>);
@@ -79,11 +71,7 @@ TEST(Shape, Traits)
     EXPECT_FALSE(std::is_trivially_move_constructible_v<Shape>);
 
     EXPECT_TRUE(std::is_copy_assignable_v<Shape>);
-#if SHAPE_USES_UNIQUE_PTR
     EXPECT_FALSE(std::is_nothrow_copy_assignable_v<Shape>);
-#else
-    EXPECT_TRUE(std::is_nothrow_copy_assignable_v<Shape>);
-#endif
     EXPECT_FALSE(std::is_trivially_copy_assignable_v<Shape>);
 
     EXPECT_TRUE(std::is_move_assignable_v<Shape>);


### PR DESCRIPTION
#### Description - What's this PR do?
- Moves more details under `detail` sub-namespace.
- Removes `SHAPE_USES_UNIQUE_PTR` macro in favor of using `unique_ptr` all the time.