### PR TITLE
Second try at pushing Doxygen API updates to gh-pages via CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         mv ${{env.TARGET_BRANCH_NAME}} ${{env.TARGET_BRANCH_NAME}}.old
         mkdir -p ${{env.TARGET_BRANCH_NAME}}
-        cp -R ${{github.workspace}}/build/Documentation/API/html/ ${{env.TARGET_BRANCH_NAME}}
+        rsync -a ${{github.workspace}}/build/Documentation/API/html/ ${{env.TARGET_BRANCH_NAME}}
 
     - name: Git Config Add Commit
       if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
#### Description - What's this PR do?
`cp` not same as `cp` between all two Unix. So maybe `rsync` more consistent. So trailing `/` honored.