### PR TITLE
Updates 202310071

### DIFF
--- a/Benchmark/CMakeLists.txt
+++ b/Benchmark/CMakeLists.txt
@@ -20,9 +20,8 @@ set(BENCHMARK_INSTALL_DOCS OFF CACHE BOOL "Enable installation of docs.")
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googlebench/src")
 	add_subdirectory(googlebench)
 else()
-	message(STATUS "googlebench submodule source code not found. Perhaps not git recurivse clone?")
 	include(FetchContent)
-	message(STATUS "Attempting to download googlebench source code.")
+	message(STATUS "Attempting to fetch googlebench source code.")
 	FetchContent_Declare(
 		googlebench
 		GIT_REPOSITORY https://github.com/google/benchmark.git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,18 +35,43 @@ Follow the above links for each component you want to build to read about the pr
 and to ensure that they are installed.
 
 All of the components minimally require the following:
+
 - A command line shell/window like `bash`. For Windows, see https://learn.microsoft.com/en-us/windows/terminal/.
-- **git**: If you don't already have Git installed, it can be obtained from: https://git-scm.com/downloads.
 - **A C++17 compiler suite**: That could be Microsoft's Visual C++, GNU's GCC, or LLVM's Clang. On Microsoft Windows platforms, you can get a complete C++17 compiler suite by getting Microsoft's Visual Studio from https://www.visualstudio.com/downloads/.
-- **CMake**: If you don't have version 3.16.3 or higher of CMake installed on your system, the latest releases of CMake can be obtained from https://cmake.org/.
+- **git**: If you don't already have Git installed, it can be obtained from: https://git-scm.com/downloads.
+- **CMake**: If you don't have version 3.16.3 or higher of CMake installed on your system, the latest releases of CMake can be obtained from https://cmake.org/. Note that it's possible to skip this prerequisite, but it's not recommended nor as well supported.
 
 ## Steps
 
-All of these steps should be run from the same working directory.
+All of these steps assume they're run from the same working directory.
 
-### Download The Repository
+### Get Access
 
-If you haven't already downloaded the repository, run:
+If you don't already have access to the source code, use **one** of the following methods to get it.
+
+#### Download ZIP
+
+If you only want to build the source code and aren't interested in its development, you can just download a ZIP file of the latest code:
+
+1. Download [master.zip](https://github.com/louis-langholtz/PlayRho/archive/refs/heads/master.zip).
+2. Unzip it, if not done automatically for you by your download application.
+3. Rename the unzipped directory to `PlayRho`.
+
+#### Git Clone
+
+If you might be interested in helping development of this project or prefer using `git`:
+
+```sh
+git clone https://github.com/louis-langholtz/PlayRho.git
+```
+
+This should work fine for building the base library component.
+This should also work fine now for the application components, so long as you use CMake in the following steps.
+
+#### Recursive Git Clone
+
+Alternatively, like if you want to try building without CMake via Xcode for example, do a recursive clone:
+
 ```sh
 git clone --recurse-submodules https://github.com/louis-langholtz/PlayRho.git
 ```

--- a/Library/include/playrho/d2/WorldConf.hpp
+++ b/Library/include/playrho/d2/WorldConf.hpp
@@ -55,6 +55,9 @@ struct WorldConf {
     /// @brief Default initial proxy capacity.
     static constexpr auto DefaultProxyCapacity = ContactCounter(1024);
 
+    /// @brief Default initial reserve buffers capacity.
+    static constexpr auto DefaultReserveBuffers = std::uint8_t(1u);
+
     /// @brief Default initial reserve body stack capacity.
     static constexpr auto DefaultReserveBodyStack = BodyCounter(16384u);
 
@@ -62,10 +65,13 @@ struct WorldConf {
     static constexpr auto DefaultReserveBodyConstraints = BodyCounter(1024u);
 
     /// @brief Default initial reserve distance constraints capacity.
-    static constexpr auto DefaultReserveDistanceConstraints = DefaultReserveBodyConstraints * 4u;
+    static constexpr auto DefaultReserveDistanceConstraints = ContactCounter{DefaultReserveBodyConstraints * 4u};
 
     /// @brief Default initial reserve contact keys capacity.
     static constexpr auto DefaultReserveContactKeys = ContactCounter(1024u);
+
+    /// @brief Default do-stats value.
+    static constexpr auto DefaultDoStats = false;
 
     /// @brief Uses the given min vertex radius value.
     constexpr WorldConf& UseUpstream(pmr::memory_resource *value) noexcept;
@@ -107,17 +113,29 @@ struct WorldConf {
     /// @brief Initial proxy capacity.
     ContactCounter proxyCapacity = DefaultProxyCapacity;
 
-    /// @brief Reserve body stack capacity.
+    /// @brief Initial reserve contact keys capacity in #-of-elements.
+    /// @note This is used as the reserve buffer #-of-elements for finding contacts. The number of
+    ///   contact keys has an **upper bound** of the square of the number of bodies in the world.
+    ContactCounter reserveContactKeys = DefaultReserveContactKeys;
+
+    /// @brief Initial reserve distance constraints capacity in #-of-elements.
+    /// @note This is used for reserving #-of-elements capacity for position and velocity
+    ///   constraints. It's tied to the number of contacts in the world.
+    ContactCounter reserveDistanceConstraints = DefaultReserveDistanceConstraints;
+
+    /// @brief Initial reserve body stack capacity in #-of-elements.
+    /// @note Max body stack #-of-elements capacity has **upper bound** of # of bodies in world.
     BodyCounter reserveBodyStack = DefaultReserveBodyStack;
 
-    /// @brief Reserve body constraints capacity.
+    /// @brief Initial reserve body constraints capacity in #-of-elements.
+    /// @note This is tied to the number of bodies in the world.
     BodyCounter reserveBodyConstraints = DefaultReserveBodyConstraints;
 
-    /// @brief Reserve distance constraints capacity.
-    BodyCounter reserveDistanceConstraints = DefaultReserveDistanceConstraints;
+    /// @brief Initial reserve buffers capacity in #-of-elements.
+    std::uint8_t reserveBuffers = DefaultReserveBuffers;
 
-    /// @brief Reserve contact keys capacity.
-    ContactCounter reserveContactKeys = DefaultReserveContactKeys;
+    /// @brief Whether to collect resource statistics or not.
+    bool doStats = DefaultDoStats;
 };
 
 constexpr WorldConf& WorldConf::UseUpstream(pmr::memory_resource *value) noexcept

--- a/Library/include/playrho/pmr/PoolMemoryResource.hpp
+++ b/Library/include/playrho/pmr/PoolMemoryResource.hpp
@@ -54,22 +54,22 @@ struct PoolMemoryOptions
 
     /// @brief Whether buffers are releasable when unused and a bigger space is needed.
     bool releasable{true};
-
-    /// @brief Operator equals support.
-    friend bool operator==(const PoolMemoryOptions& lhs, const PoolMemoryOptions& rhs) noexcept
-    {
-        return (lhs.reserveBuffers == rhs.reserveBuffers) // force line-break
-            && (lhs.reserveBytes == rhs.reserveBytes) // force line-break
-            && (lhs.limitBuffers == rhs.limitBuffers) // force line-break
-            && (lhs.releasable == rhs.releasable);
-    }
-
-    /// @brief Operator not-equals support.
-    friend bool operator!=(const PoolMemoryOptions& lhs, const PoolMemoryOptions& rhs) noexcept
-    {
-        return !(lhs == rhs);
-    }
 };
+
+/// @brief Operator equals support.
+constexpr bool operator==(const PoolMemoryOptions& lhs, const PoolMemoryOptions& rhs) noexcept
+{
+    return (lhs.reserveBuffers == rhs.reserveBuffers) // force line-break
+        && (lhs.reserveBytes == rhs.reserveBytes) // force line-break
+        && (lhs.limitBuffers == rhs.limitBuffers) // force line-break
+        && (lhs.releasable == rhs.releasable);
+}
+
+/// @brief Operator not-equals support.
+constexpr bool operator!=(const PoolMemoryOptions& lhs, const PoolMemoryOptions& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
 
 /// @brief Pool memory resource.
 /// @note This is a memory pooling implementation of a <code>memory_resource</code>.

--- a/Testbed/CMakeLists.txt
+++ b/Testbed/CMakeLists.txt
@@ -35,9 +35,8 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/Framework/imgui/imgui.h")
 	endforeach()
 	list(APPEND IMGUI_INCLUDE_DIRS "Framework/imgui" "Framework/imgui/examples/libs/gl3w")
 else()
-	message(STATUS "ImGui submodule source code not found. Not git recurivse clone?")
 	include(FetchContent)
-	message(STATUS "Attempting to download ImGui source code.")
+	message(STATUS "Attempting to fetch ImGui source code.")
 	FetchContent_Declare(
 		imgui
 		GIT_REPOSITORY https://github.com/ocornut/imgui.git

--- a/UnitTests/CMakeLists.txt
+++ b/UnitTests/CMakeLists.txt
@@ -41,9 +41,8 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/googletest/googletest")
 	add_subdirectory(googletest EXCLUDE_FROM_ALL)
 else()
-	message(STATUS "googletest submodule source code not found. Not git recurivse clone?")
 	include(FetchContent)
-	message(STATUS "Attempting to download googletest source code.")
+	message(STATUS "Attempting to fetch googletest source code.")
 	FetchContent_Declare(
 		googletest
 		GIT_REPOSITORY https://github.com/google/googletest.git

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -29,35 +29,36 @@
 #include <playrho/to_underlying.hpp>
 #include <playrho/WrongState.hpp>
 
-#include <playrho/d2/World.hpp>
+#include <playrho/d2/AabbTreeWorld.hpp>
 #include <playrho/d2/Body.hpp>
+#include <playrho/d2/BodyConf.hpp>
+#include <playrho/d2/ContactImpulsesList.hpp>
+#include <playrho/d2/DiskShapeConf.hpp>
+#include <playrho/d2/DistanceJointConf.hpp>
+#include <playrho/d2/DynamicTree.hpp> // for GetTree
+#include <playrho/d2/EdgeShapeConf.hpp>
+#include <playrho/d2/FrictionJointConf.hpp>
+#include <playrho/d2/GearJointConf.hpp>
+#include <playrho/d2/Joint.hpp>
+#include <playrho/d2/Manifold.hpp>
+#include <playrho/d2/MotorJointConf.hpp>
+#include <playrho/d2/PolygonShapeConf.hpp>
+#include <playrho/d2/PointStates.hpp>
+#include <playrho/d2/RayCastInput.hpp>
+#include <playrho/d2/RayCastOutput.hpp>
+#include <playrho/d2/RopeJointConf.hpp>
+#include <playrho/d2/RevoluteJointConf.hpp>
+#include <playrho/d2/PrismaticJointConf.hpp>
+#include <playrho/d2/PulleyJointConf.hpp>
+#include <playrho/d2/TargetJointConf.hpp>
+#include <playrho/d2/WheelJointConf.hpp>
+#include <playrho/d2/WeldJointConf.hpp>
+#include <playrho/d2/World.hpp>
 #include <playrho/d2/WorldBody.hpp>
 #include <playrho/d2/WorldShape.hpp>
 #include <playrho/d2/WorldMisc.hpp>
 #include <playrho/d2/WorldJoint.hpp>
 #include <playrho/d2/WorldContact.hpp>
-#include <playrho/d2/BodyConf.hpp>
-#include <playrho/d2/ContactImpulsesList.hpp>
-#include <playrho/d2/DiskShapeConf.hpp>
-#include <playrho/d2/PolygonShapeConf.hpp>
-#include <playrho/d2/EdgeShapeConf.hpp>
-#include <playrho/d2/PointStates.hpp>
-#include <playrho/d2/DynamicTree.hpp> // for GetTree
-#include <playrho/d2/RayCastInput.hpp>
-#include <playrho/d2/RayCastOutput.hpp>
-#include <playrho/d2/Manifold.hpp>
-#include <playrho/d2/Joint.hpp>
-#include <playrho/d2/TargetJointConf.hpp>
-#include <playrho/d2/RopeJointConf.hpp>
-#include <playrho/d2/RevoluteJointConf.hpp>
-#include <playrho/d2/PrismaticJointConf.hpp>
-#include <playrho/d2/DistanceJointConf.hpp>
-#include <playrho/d2/PulleyJointConf.hpp>
-#include <playrho/d2/WeldJointConf.hpp>
-#include <playrho/d2/FrictionJointConf.hpp>
-#include <playrho/d2/MotorJointConf.hpp>
-#include <playrho/d2/WheelJointConf.hpp>
-#include <playrho/d2/GearJointConf.hpp>
 
 using namespace playrho;
 using namespace playrho::d2;
@@ -434,6 +435,26 @@ TEST(World, MoveAssignment)
         other = std::move(world);
         EXPECT_EQ(GetBodies(other).size(), 2u);
         EXPECT_EQ(GetJoints(other).size(), 3u);
+    }
+}
+
+TEST(World, GetType)
+{
+    EXPECT_NE(GetType(World{}), GetTypeID<void>());
+    EXPECT_EQ(GetType(World{}), GetTypeID<AabbTreeWorld>());
+}
+
+TEST(World, TypeCast)
+{
+    {
+        auto world = World{};
+        EXPECT_EQ(TypeCast<int>(&world), nullptr);
+        EXPECT_THROW(TypeCast<int>(world), std::bad_cast);
+    }
+    {
+        const auto world = World{};
+        EXPECT_EQ(TypeCast<const int>(&world), nullptr);
+        EXPECT_THROW(TypeCast<int>(world), std::bad_cast);
     }
 }
 

--- a/UnitTests/WorldConf.cpp
+++ b/UnitTests/WorldConf.cpp
@@ -37,6 +37,8 @@ TEST(WorldConf, DefaultConstruction)
     EXPECT_EQ(worldConf.reserveBodyConstraints, WorldConf::DefaultReserveBodyConstraints);
     EXPECT_EQ(worldConf.reserveDistanceConstraints, WorldConf::DefaultReserveDistanceConstraints);
     EXPECT_EQ(worldConf.reserveContactKeys, WorldConf::DefaultReserveContactKeys);
+    EXPECT_EQ(worldConf.reserveBuffers, WorldConf::DefaultReserveBuffers);
+    EXPECT_EQ(worldConf.doStats, WorldConf::DefaultDoStats);
 }
 
 TEST(WorldConf, UseUpstream)


### PR DESCRIPTION
#### Description - What's this PR do?
- Adds option to enable/disable resource stats collection to `WorldConf`.
- Adds a `pmr::StatsResource` data member to `AabbTreeWorld` to support stats collection.
- Adds `GetType` & `TypeCast` support to `World` - like `Joint` has.
- Updates `INSTALL.md` for new CMake `FetchContent` support that was previously added to application `CMakeLists.txt` files.