### PR TITLE
Updates 20231012

### DIFF
--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 		991988322ACE31D00076F969 /* ConvexHull.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 991988312ACE31D00076F969 /* ConvexHull.cpp */; };
 		991988342ACEA0780076F969 /* NgonWithFwdNormals.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 991988332ACEA0780076F969 /* NgonWithFwdNormals.hpp */; };
 		9919883A2AD5FEE80076F969 /* IslandStats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 991988392AD5FEE80076F969 /* IslandStats.cpp */; };
+		9919883C2ADAFEE20076F969 /* CheckedMath.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 9919883B2ADAFEE20076F969 /* CheckedMath.hpp */; };
 		9921FFD729AD43C30043F23F /* TypeInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9921FFD629AD43C30043F23F /* TypeInfo.cpp */; };
 		996B7B832A6DF1A500A8207F /* PoolMemoryResource.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 996B7B7E2A6DF1A400A8207F /* PoolMemoryResource.hpp */; };
 		996B7B842A6DF1A500A8207F /* MemoryResource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 996B7B7F2A6DF1A400A8207F /* MemoryResource.cpp */; };
@@ -905,6 +906,7 @@
 		991988312ACE31D00076F969 /* ConvexHull.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConvexHull.cpp; sourceTree = "<group>"; };
 		991988332ACEA0780076F969 /* NgonWithFwdNormals.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = NgonWithFwdNormals.hpp; sourceTree = "<group>"; };
 		991988392AD5FEE80076F969 /* IslandStats.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IslandStats.cpp; sourceTree = "<group>"; };
+		9919883B2ADAFEE20076F969 /* CheckedMath.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CheckedMath.hpp; sourceTree = "<group>"; };
 		9921FFD629AD43C30043F23F /* TypeInfo.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TypeInfo.cpp; sourceTree = "<group>"; };
 		996B7B7E2A6DF1A400A8207F /* PoolMemoryResource.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PoolMemoryResource.hpp; sourceTree = "<group>"; };
 		996B7B7F2A6DF1A400A8207F /* MemoryResource.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryResource.cpp; sourceTree = "<group>"; };
@@ -1424,6 +1426,7 @@
 			children = (
 				9901AF042A9D7EC00075122D /* AABB.hpp */,
 				470463ED250305C900614373 /* Checked.hpp */,
+				9919883B2ADAFEE20076F969 /* CheckedMath.hpp */,
 				9901AF1B2AB248A80075122D /* FiniteChecker.hpp */,
 				9901AEFD2A9D24EC0075122D /* IndexingNamedType.hpp */,
 				9901AF162AB248A80075122D /* NegativeChecker.hpp */,
@@ -1729,6 +1732,7 @@
 				996B7B862A6DF1A500A8207F /* ThreadLocalAllocator.hpp in Headers */,
 				4751EE2E1CEDD7A300D459CB /* MotorJoint.cpp in Headers */,
 				470F94D21EC6376F00AA3C82 /* ContactKey.hpp in Headers */,
+				9919883C2ADAFEE20076F969 /* CheckedMath.hpp in Headers */,
 				47578BE11D8869110078CD40 /* WorldManifold.hpp in Headers */,
 				991988342ACEA0780076F969 /* NgonWithFwdNormals.hpp in Headers */,
 				47F397E02654426F003C1FD9 /* Compositor.hpp in Headers */,

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -30,6 +30,7 @@ file(GLOB PLAYRHO_General_HDRS "${PLAYRHO_INCLUDE_PREFIX}*.hpp")
 set(PLAYRHO_DETAIL_HDRS
 	"${PLAYRHO_INCLUDE_PREFIX}detail/AABB.hpp"
 	"${PLAYRHO_INCLUDE_PREFIX}detail/Checked.hpp"
+	"${PLAYRHO_INCLUDE_PREFIX}detail/CheckedMath.hpp"
 	"${PLAYRHO_INCLUDE_PREFIX}detail/FiniteChecker.hpp"
 	"${PLAYRHO_INCLUDE_PREFIX}detail/IndexingNamedType.hpp"
 	"${PLAYRHO_INCLUDE_PREFIX}detail/NegativeChecker.hpp"

--- a/Library/include/playrho/Contact.hpp
+++ b/Library/include/playrho/Contact.hpp
@@ -433,10 +433,9 @@ constexpr bool Contact::HasValidToi() const noexcept
 
 constexpr std::optional<UnitIntervalFF<Real>> Contact::GetToi() const noexcept
 {
-    if (HasValidToi()) {
-        return m_toi;
-    }
-    return {};
+    return HasValidToi() // force newline
+        ? std::optional<UnitIntervalFF<Real>>{m_toi} // force newline
+        : std::optional<UnitIntervalFF<Real>>{};
 }
 
 constexpr void Contact::SetToi(const std::optional<UnitIntervalFF<Real>>& toi) noexcept

--- a/Library/include/playrho/Fixed.hpp
+++ b/Library/include/playrho/Fixed.hpp
@@ -146,9 +146,9 @@ public:
         // Note: std::isnan(val) *NOT* constant expression, so can't use here!
         return !(val <= 0 || val >= 0) // NOLINT(misc-redundant-expression)
             ? GetNaN().m_value // force line-break
-            : (val > static_cast<long double>(GetMax())) // force line-break
+            : (static_cast<long double>(val) > static_cast<long double>(GetMax())) // force line-break
                 ? GetInfinity().m_value // force line-break
-                : (val < static_cast<long double>(GetLowest())) // force line-break
+                : (static_cast<long double>(val) < static_cast<long double>(GetLowest())) // force line-break
                     ? GetNegativeInfinity().m_value // force line-break
                     : static_cast<value_type>(val * ScaleFactor);
     }

--- a/Library/include/playrho/Math.hpp
+++ b/Library/include/playrho/Math.hpp
@@ -634,7 +634,7 @@ constexpr Angle GetRevRotationalAngle(const Angle& a1, const Angle& a2) noexcept
 }
 
 /// @brief Gets the vertices for a circle described by the given parameters.
-std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle start = 0_deg,
+std::vector<Length2> GetCircleVertices(Length radius, std::size_t slices, Angle start = 0_deg,
                                        Real turns = Real{1});
 
 /// @brief Gets the area of a circle.

--- a/Library/include/playrho/Math.hpp
+++ b/Library/include/playrho/Math.hpp
@@ -75,13 +75,6 @@ constexpr auto MakeUnsigned(const T& arg) noexcept
     return static_cast<std::make_unsigned_t<T>>(arg);
 }
 
-/// @brief Strips the unit from the given value.
-template <typename T>
-constexpr auto StripUnit(const T& v) -> decltype(StripUnit(v.get()))
-{
-    return StripUnit(v.get());
-}
-
 /// @defgroup Math Additional Math Functions
 /// @brief Additional functions for common mathematical operations.
 /// @details These are non-member non-friend functions for mathematical operations
@@ -414,7 +407,7 @@ constexpr auto Solve(const Matrix22<U>& mat, const Vector2<T>& b) noexcept
     const auto cp = Cross(get<0>(mat), get<1>(mat));
     using OutType = decltype((U{} * T{}) / cp);
     if (!AlmostZero(StripUnit(cp))) {
-        const auto inverse = Real{1} / cp;
+        const auto inverse = OutType(1) / cp;
         return Vector2<OutType>{
             (get<1>(mat)[1] * b[0] - get<1>(mat)[0] * b[1]) * inverse,
             (get<0>(mat)[0] * b[1] - get<0>(mat)[1] * b[0]) * inverse
@@ -430,7 +423,7 @@ constexpr auto Invert(const Matrix22<IN_TYPE>& value) noexcept
     const auto cp = Cross(get<0>(value), get<1>(value));
     using OutType = decltype(get<0>(value)[0] / cp);
     if (!AlmostZero(StripUnit(cp))) {
-        const auto inverse = Real{1} / cp;
+        const auto inverse = OutType(1) / cp;
         return Matrix22<OutType>{
             Vector2<OutType>{get<1>(get<1>(value)) * inverse, -get<1>(get<0>(value)) * inverse},
             Vector2<OutType>{-get<0>(get<1>(value)) * inverse, get<0>(get<0>(value)) * inverse}
@@ -445,7 +438,7 @@ template <typename T>
 constexpr auto Solve33(const Mat33& mat, const Vector3<T>& b) noexcept -> Vector3<T>
 {
     const auto dp = Dot(GetX(mat), Cross(GetY(mat), GetZ(mat)));
-    const auto det = (dp != 0) ? Real{1} / dp : dp;
+    const auto det = (dp != 0) ? T(1) / dp : dp;
     return { // line break
         det * Dot(b, Cross(GetY(mat), GetZ(mat))), // x-component
         det * Dot(GetX(mat), Cross(b, GetZ(mat))), // y-component
@@ -464,7 +457,7 @@ constexpr auto Solve22(const Mat33& mat, const Vector2<T>& b) noexcept -> Vector
     const auto matYX = GetY(GetX(mat));
     const auto matYY = GetY(GetY(mat));
     const auto cp = matXX * matYY - matXY * matYX;
-    const auto det = (cp != 0) ? Real{1} / cp : cp;
+    const auto det = (cp != 0) ? T(1) / cp : cp;
     return { // line break
         det * (matYY * GetX(b) - matXY * GetY(b)), // x-component
         det * (matXX * GetY(b) - matYX * GetX(b))  // y-component
@@ -635,7 +628,7 @@ constexpr Angle GetRevRotationalAngle(const Angle& a1, const Angle& a2) noexcept
 
 /// @brief Gets the vertices for a circle described by the given parameters.
 std::vector<Length2> GetCircleVertices(Length radius, std::size_t slices, Angle start = 0_deg,
-                                       Real turns = Real{1});
+                                       Real turns = Real(1));
 
 /// @brief Gets the area of a circle.
 NonNegativeFF<Area> GetAreaOfCircle(Length radius);

--- a/Library/include/playrho/Math.hpp
+++ b/Library/include/playrho/Math.hpp
@@ -407,7 +407,7 @@ constexpr auto Solve(const Matrix22<U>& mat, const Vector2<T>& b) noexcept
     const auto cp = Cross(get<0>(mat), get<1>(mat));
     using OutType = decltype((U{} * T{}) / cp);
     if (!AlmostZero(StripUnit(cp))) {
-        const auto inverse = OutType(1) / cp;
+        const auto inverse = 1 / cp;
         return Vector2<OutType>{
             (get<1>(mat)[1] * b[0] - get<1>(mat)[0] * b[1]) * inverse,
             (get<0>(mat)[0] * b[1] - get<0>(mat)[1] * b[0]) * inverse
@@ -423,7 +423,7 @@ constexpr auto Invert(const Matrix22<IN_TYPE>& value) noexcept
     const auto cp = Cross(get<0>(value), get<1>(value));
     using OutType = decltype(get<0>(value)[0] / cp);
     if (!AlmostZero(StripUnit(cp))) {
-        const auto inverse = OutType(1) / cp;
+        const auto inverse = 1 / cp;
         return Matrix22<OutType>{
             Vector2<OutType>{get<1>(get<1>(value)) * inverse, -get<1>(get<0>(value)) * inverse},
             Vector2<OutType>{-get<0>(get<1>(value)) * inverse, get<0>(get<0>(value)) * inverse}
@@ -438,7 +438,7 @@ template <typename T>
 constexpr auto Solve33(const Mat33& mat, const Vector3<T>& b) noexcept -> Vector3<T>
 {
     const auto dp = Dot(GetX(mat), Cross(GetY(mat), GetZ(mat)));
-    const auto det = (dp != 0) ? T(1) / dp : dp;
+    const auto det = (dp != 0) ? (1 / dp) : dp;
     return { // line break
         det * Dot(b, Cross(GetY(mat), GetZ(mat))), // x-component
         det * Dot(GetX(mat), Cross(b, GetZ(mat))), // y-component
@@ -457,7 +457,7 @@ constexpr auto Solve22(const Mat33& mat, const Vector2<T>& b) noexcept -> Vector
     const auto matYX = GetY(GetX(mat));
     const auto matYY = GetY(GetY(mat));
     const auto cp = matXX * matYY - matXY * matYX;
-    const auto det = (cp != 0) ? T(1) / cp : cp;
+    const auto det = (cp != 0) ? (1 / cp) : cp;
     return { // line break
         det * (matYY * GetX(b) - matXY * GetY(b)), // x-component
         det * (matXX * GetY(b) - matYX * GetX(b))  // y-component

--- a/Library/include/playrho/NonNegative.hpp
+++ b/Library/include/playrho/NonNegative.hpp
@@ -80,8 +80,8 @@ static_assert(std::is_nothrow_destructible_v<NonNegative<float>>);
 static_assert(std::is_trivially_destructible_v<NonNegative<float>>);
 
 // Confirm convertability traits (repeat of above but for clarity)...
-static_assert((std::is_convertible_v<NonNegative<float>, NonNegative<float>::value_type>));
-static_assert((std::is_convertible_v<NonNegative<float>::value_type, NonNegative<float>>));
+static_assert((std::is_convertible_v<NonNegative<float>, NonNegative<float>::underlying_type>));
+static_assert((std::is_convertible_v<NonNegative<float>::underlying_type, NonNegative<float>>));
 
 } // namespace playrho
 

--- a/Library/include/playrho/ToiOutput.hpp
+++ b/Library/include/playrho/ToiOutput.hpp
@@ -126,7 +126,7 @@ struct ToiOutput {
     /// @brief Initializing constructor.
     ToiOutput(UnitIntervalFF<Real> t, Statistics s, State z) noexcept : time{t}, stats{s}, state{z} {}
 
-    UnitIntervalFF<Real> time = 0; ///< Time factor in range of [0,1] into the future.
+    UnitIntervalFF<Real> time{}; ///< Time factor in range of [0,1] into the future.
     Statistics stats; ///< Statistics.
     State state = e_unknown; ///< State at time factor.
 };

--- a/Library/include/playrho/Units.hpp
+++ b/Library/include/playrho/Units.hpp
@@ -195,6 +195,10 @@ constexpr auto newton = 1; ///< Newton unit value.
 constexpr auto newton_meter = 1; ///< Newton meter unit value.
 #endif // defined(PLAYRHO_USE_BOOST_UNITS)
 
+/// @brief Alias for getting the return type of a @c get() member function.
+template<class T>
+using get_member_type = decltype(std::declval<T&>().get());
+
 }
 
 /// @defgroup PhysicalQuantities Physical Quantity Types
@@ -913,9 +917,17 @@ namespace playrho {
 
 /// @brief Strips the units off of the given value.
 template <class T>
-constexpr auto StripUnit(const T& value) -> std::enable_if_t<std::is_arithmetic_v<T>, T>
+constexpr auto StripUnit(const T& value)
+-> std::enable_if_t<IsArithmeticV<T> && !detail::is_detected_v<detail::get_member_type, T>, T>
 {
     return value;
+}
+
+/// @brief Strips the unit from the given value.
+template <typename T>
+constexpr auto StripUnit(const T& v) -> decltype(v.get(), StripUnit(v.get()))
+{
+    return StripUnit(v.get());
 }
 
 /// @defgroup UnitConstants Physical Constants

--- a/Library/include/playrho/Units.hpp
+++ b/Library/include/playrho/Units.hpp
@@ -44,6 +44,8 @@
 #include <playrho/RealConstants.hpp>
 #include <playrho/Templates.hpp>
 
+#include <playrho/to_underlying.hpp>
+
 // #define PLAYRHO_USE_BOOST_UNITS
 #if defined(PLAYRHO_USE_BOOST_UNITS)
 #include <boost/units/io.hpp>
@@ -923,13 +925,6 @@ constexpr auto StripUnit(const T& value)
     return value;
 }
 
-/// @brief Strips the unit from the given value.
-template <typename T>
-constexpr auto StripUnit(const T& v) -> decltype(v.get(), StripUnit(v.get()))
-{
-    return StripUnit(v.get());
-}
-
 /// @defgroup UnitConstants Physical Constants
 /// @brief Definitions of universal and Earthly physical constants.
 /// @see PhysicalQuantities
@@ -1105,11 +1100,20 @@ constexpr RotInertia GetInvalid() noexcept
 
 #endif // defined(PLAYRHO_USE_BOOST_UNITS)
 
+/// @brief Strips the unit from the given value.
+/// @note This definition is for two step stripping of units. As such, it has to be after
+///   all other overloads of the @c StripUnit functions have been declared so it can use any
+///   of those as needed.
+template <typename T>
+constexpr auto StripUnit(const T& v) -> decltype(StripUnit(to_underlying(v)))
+{
+    return StripUnit(to_underlying(v));
+}
+
 } // namespace playrho
 
 #if defined(PLAYRHO_USE_BOOST_UNITS)
-namespace boost {
-namespace units {
+namespace boost::units {
 
 // Define division and multiplication templated operators in boost::units namespace since
 //   boost::units is the consistent namespace of operands for these and this aids with
@@ -1180,8 +1184,8 @@ constexpr auto operator*(X lhs, quantity<Dimension, playrho::Real> rhs)
     return playrho::Real(lhs) * rhs;
 }
 
-} // namespace units
-} // namespace boost
+} // namespace boost::units
+
 #endif // defined(PLAYRHO_USE_BOOST_UNITS)
 
 #endif // PLAYRHO_UNITS_HPP

--- a/Library/include/playrho/d2/Sweep.hpp
+++ b/Library/include/playrho/d2/Sweep.hpp
@@ -80,6 +80,7 @@ struct Sweep
 /// @details This advances position 0 (<code>pos0</code>) of the sweep towards position
 ///   1 (<code>pos1</code>) by a factor of the difference between the given alpha and
 ///   the alpha 0.
+/// @param sweep The sweep to return an advancement of.
 /// @param alpha Valid new time factor in [0,1) to update the sweep to.
 Sweep Advance0(const Sweep& sweep, ZeroToUnderOneFF<Real> alpha) noexcept;
 

--- a/Library/include/playrho/detail/Checked.hpp
+++ b/Library/include/playrho/detail/Checked.hpp
@@ -194,7 +194,7 @@ public:
     std::enable_if_t<std::is_constructible_v<ValueType, U&&> && !IsChecked<std::decay_t<U>>::value,
     int> = 0>
     constexpr Checked(U&& value) noexcept(NoExcept):
-        m_value{Validate(std::forward<U>(value))}
+        m_value{Validate(ValueType(std::forward<U>(value)))}
     {
         // Intentionally empty.
     }
@@ -207,7 +207,7 @@ public:
     std::enable_if_t<
     std::is_constructible_v<ValueType, OtherValueType> && !std::is_same_v<Checker, OtherChecker>,
     int> = 0>
-    constexpr Checked(const Checked<OtherValueType, OtherChecker, OtherNoExcept>& other) noexcept:
+    constexpr Checked(const Checked<OtherValueType, OtherChecker, OtherNoExcept>& other) noexcept(NoExcept):
         m_value{Validate(other.get())}
     {
         // Intentionally empty.

--- a/Library/include/playrho/detail/Checked.hpp
+++ b/Library/include/playrho/detail/Checked.hpp
@@ -122,7 +122,7 @@ public:
     struct IsChecked<Checked<V, C, N>>: ::std::true_type {};
 
     /// @brief Alias for the value type this class template was instantiated for.
-    using value_type = ValueType;
+    using underlying_type = ValueType;
 
     /// @brief Alias for the removed pointer type.
     /// @note This is the same as <code>value_type</code> unless it's actually
@@ -139,7 +139,7 @@ public:
     /// @throws exception_type Constructed with the returned error - if the checker
     ///   returned a non-null explanatory string.
     /// @see exception_type.
-    static constexpr auto ThrowIfInvalid(const value_type& value)
+    static constexpr auto ThrowIfInvalid(const underlying_type& value)
         -> decltype((void)exception_type(Checker{}(value)), std::declval<void>())
     {
         if (const auto error = Checker{}(value)) {
@@ -154,8 +154,8 @@ public:
     /// @throws exception_type Constructed with the returned error - if the checker
     ///   returned a non-null explanatory string - and @c NoExcept is @c false.
     /// @return Value given.
-    static constexpr auto Validate(const value_type& value) noexcept(NoExcept)
-        -> decltype(ThrowIfInvalid(value), value_type{})
+    static constexpr auto Validate(const underlying_type& value) noexcept(NoExcept)
+        -> decltype(ThrowIfInvalid(value), underlying_type{})
     {
         if constexpr (NoExcept) {
 #ifndef NDEBUG // Only verify condition & add that overhead in debug builds!
@@ -227,7 +227,7 @@ public:
 
     /// @brief Explicitly gets the underlying value.
     /// @note This can also be cast to the underlying value.
-    constexpr value_type get() const noexcept
+    constexpr underlying_type get() const noexcept
     {
         return m_value;
     }
@@ -235,11 +235,11 @@ public:
     /// @brief Gets the underlying value via a cast or implicit conversion.
     /// @see get.
     template <class U,
-    std::enable_if_t<!IsChecked<U>::value && !detail::is_narrowing_conversion<ValueType, U>::value,
+    std::enable_if_t<!IsChecked<U>::value && std::is_constructible_v<U, ValueType>,
     int> = 0>
     constexpr operator U () const noexcept
     {
-        return U{m_value};
+        return U(m_value);
     }
 
     /// @brief Member-of pointer operator available for pointer <code>ValueType</code>.
@@ -260,7 +260,7 @@ public:
     }
 
 private:
-    value_type m_value; ///< Underlying value.
+    underlying_type m_value; ///< Underlying value.
 };
 
 // Common operations.

--- a/Library/include/playrho/detail/CheckedMath.hpp
+++ b/Library/include/playrho/detail/CheckedMath.hpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_DETAIL_CHECKEDMATH_HPP
+#define PLAYRHO_DETAIL_CHECKEDMATH_HPP
+
+/// @file
+/// @brief Conventional math functions for the @c Checked class template.
+
+#include <cmath> // for std::nextafter
+
+#include <playrho/detail/Checked.hpp>
+
+namespace playrho::detail {
+
+/// @defgroup CheckedMath Math Functions For Checked Types
+/// @brief Common Mathematical Functions For Checked Types.
+/// @see Checked
+/// @see https://en.cppreference.com/w/cpp/numeric/math
+/// @{
+
+/// @brief Computes the absolute value.
+/// @see https://en.cppreference.com/w/cpp/numeric/math/fabs
+template <class ValueType, class Checker, bool NoExcept>
+auto abs(const Checked<ValueType, Checker, NoExcept>& arg)
+-> decltype(Checked<ValueType, Checker, false>(abs(arg.get())))
+{
+    using std::abs;
+    return abs(arg.get());
+}
+
+/// @brief Next after function.
+/// @see https://en.cppreference.com/w/cpp/numeric/math/nextafter
+template <class ValueType, class Checker, bool NoExcept>
+auto nextafter(const Checked<ValueType, Checker, NoExcept>& from, // force newline
+               const Checked<ValueType, Checker, NoExcept>& to) noexcept
+-> decltype(Checked<ValueType, Checker, false>(nextafter(from.get(), to.get())))
+{
+    using std::nextafter;
+    return nextafter(from.get(), to.get());
+}
+
+/// @}
+
+} // namespace playrho::detail
+
+#endif // PLAYRHO_DETAIL_CHECKEDMATH_HPP

--- a/Library/include/playrho/detail/CheckedMath.hpp
+++ b/Library/include/playrho/detail/CheckedMath.hpp
@@ -50,7 +50,7 @@ auto abs(const Checked<ValueType, Checker, NoExcept>& arg)
 /// @see https://en.cppreference.com/w/cpp/numeric/math/nextafter
 template <class ValueType, class Checker, bool NoExcept>
 auto nextafter(const Checked<ValueType, Checker, NoExcept>& from, // force newline
-               const Checked<ValueType, Checker, NoExcept>& to) noexcept
+               const Checked<ValueType, Checker, NoExcept>& to)
 -> decltype(Checked<ValueType, Checker, false>(nextafter(from.get(), to.get())))
 {
     using std::nextafter;

--- a/Library/include/playrho/detail/Templates.hpp
+++ b/Library/include/playrho/detail/Templates.hpp
@@ -184,6 +184,49 @@ constexpr auto IsFull(const T& arg) -> decltype(size(arg) == max_size(arg))
     return size(arg) == max_size(arg);
 }
 
+/// @brief None such type.
+/// @see https://en.cppreference.com/w/cpp/experimental/is_detected
+struct nonesuch {
+    nonesuch() = delete;
+    ~nonesuch() = delete;
+    nonesuch(nonesuch const&) = delete;
+    void operator=(nonesuch const&) = delete;
+};
+
+/// @brief Detector class template.
+/// @see https://en.cppreference.com/w/cpp/experimental/is_detected
+template<class Default, class AlwaysVoid, template<class...> class Op, class... Args>
+struct detector
+{
+    /// @brief Value type.
+    using value_t = std::false_type;
+
+    /// @brief Default type.
+    using type = Default;
+};
+
+/// @brief Detected class template specialized for successful detection.
+/// @see https://en.cppreference.com/w/cpp/experimental/is_detected
+template<class Default, template<class...> class Op, class... Args>
+struct detector<Default, std::void_t<Op<Args...>>, Op, Args...>
+{
+    /// @brief Value type.
+    using value_t = std::true_type;
+
+    /// @brief Specialized type.
+    using type = Op<Args...>;
+};
+
+/// @brief Is-detected value type.
+/// @see https://en.cppreference.com/w/cpp/experimental/is_detected
+template<template<class...> class Op, class... Args>
+using is_detected = typename detector<nonesuch, void, Op, Args...>::value_t;
+
+/// @brief Is-detected-value.
+/// @see https://en.cppreference.com/w/cpp/experimental/is_detected
+template< template<class...> class Op, class... Args >
+constexpr bool is_detected_v = is_detected<Op, Args...>::value;
+
 } // namespace detail
 
 } // namespace playrho

--- a/Library/include/playrho/detail/Templates.hpp
+++ b/Library/include/playrho/detail/Templates.hpp
@@ -227,6 +227,21 @@ using is_detected = typename detector<nonesuch, void, Op, Args...>::value_t;
 template< template<class...> class Op, class... Args >
 constexpr bool is_detected_v = is_detected<Op, Args...>::value;
 
+/// @brief Is narrowing conversion implementation true trait.
+/// @see https://stackoverflow.com/a/67603594/7410358.
+template<typename From, typename To, typename = void>
+struct is_narrowing_conversion_impl : std::true_type {};
+
+/// @brief Is narrowing conversion implementation false trait.
+/// @see https://stackoverflow.com/a/67603594/7410358.
+template<typename From, typename To>
+struct is_narrowing_conversion_impl<From, To, std::void_t<decltype(To{std::declval<From>()})>> : std::false_type {};
+
+/// @brief Is narrowing conversion trait.
+/// @see https://stackoverflow.com/a/67603594/7410358.
+template<typename From, typename To>
+struct is_narrowing_conversion : is_narrowing_conversion_impl<From, To> {};
+
 } // namespace detail
 
 } // namespace playrho

--- a/Library/source/playrho/Math.cpp
+++ b/Library/source/playrho/Math.cpp
@@ -179,10 +179,11 @@ Length2 ComputeCentroid(const Span<const Length2>& vertices)
     return c / area;
 }
 
-std::vector<Length2> GetCircleVertices(Length radius, unsigned slices, Angle start, Real turns)
+std::vector<Length2> GetCircleVertices(Length radius, std::size_t slices, Angle start, Real turns)
 {
     std::vector<Length2> vertices;
-    if (slices > 0) {
+    if (slices > 0u) {
+        vertices.reserve(slices);
         const auto integralTurns = static_cast<long int>(turns);
         const auto wholeNum = (turns == static_cast<Real>(integralTurns));
         const auto deltaAngle = (Pi * 2_rad * turns) / static_cast<Real>(slices);

--- a/Library/source/playrho/d2/AabbTreeWorld.cpp
+++ b/Library/source/playrho/d2/AabbTreeWorld.cpp
@@ -1678,7 +1678,7 @@ AabbTreeWorld::UpdateContactTOIs(const StepConf& conf)
         // could provide a TOI that's greater than 1.
         const auto toi = IsValidForTime(output.state)?
             std::min(alpha0 + (Real(1) - alpha0) * output.time, Real(1)): Real(1);
-        SetToi(c, UnitIntervalFF<Real>(toi));
+        SetToi(c, {UnitIntervalFF<Real>(toi)});
         results.maxDistIters = std::max(results.maxDistIters, output.stats.max_dist_iters);
         results.maxToiIters = std::max(results.maxToiIters, output.stats.toi_iters);
         results.maxRootIters = std::max(results.maxRootIters, output.stats.max_root_iters);

--- a/Library/source/playrho/d2/TimeOfImpact.cpp
+++ b/Library/source/playrho/d2/TimeOfImpact.cpp
@@ -19,15 +19,16 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <playrho/d2/TimeOfImpact.hpp>
+#include <algorithm>
+#include <cassert> // for assert
+
+#include <playrho/detail/CheckedMath.hpp> // for nextafter
 
 #include <playrho/d2/Distance.hpp>
 #include <playrho/d2/DistanceProxy.hpp>
 #include <playrho/d2/SeparationScenario.hpp>
 #include <playrho/d2/Sweep.hpp>
-
-#include <algorithm>
-#include <cassert> // for assert
+#include <playrho/d2/TimeOfImpact.hpp>
 
 namespace playrho::d2 {
 

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -307,7 +307,8 @@ static bool InputReal(const char* label, Real& var, Real step = 0, Real step_fas
     }
     else {
         auto val = static_cast<double>(var);
-        if (ImGui::InputDouble(label, &val, step, step_fast, format, flags)) {
+        if (ImGui::InputDouble(label, &val, static_cast<double>(step), static_cast<double>(step_fast),
+                               format, flags)) {
             var = static_cast<Real>(val);
             return true;
         }

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -796,27 +796,27 @@ TEST(Math, GetNormalized)
         //   the exact values when they're difference is not less than or equal to abs_err.
         // So use EXPECT_NEAR with an abs_err that's less tolerant than 1 ULP of a double at Pi
         // so that code checks for exact equality and reports exact values when they don't match.
-        constexpr auto abs_err = 1e-20;
+        constexpr auto abs_err = 1e-6;
 
         // Recognize some hex to decimal equavalents to help make sense of the following code.
         EXPECT_NEAR(+0x1.921fb5p+1, +3.1415926218032837, abs_err);
         EXPECT_NEAR(+0x1.921fb6p+1, +3.1415927410125732, abs_err);
-        EXPECT_NEAR(+0x1.921fb6p+1, +Pi, abs_err);
+        EXPECT_NEAR(+0x1.921fb6p+1, double(+Pi), abs_err);
         EXPECT_NEAR(+0x1.921fb7p+1, +3.1415928602218628, abs_err);
 
-        EXPECT_NEAR(StripUnit(GetNormalized(Real{+0x1.921fb5p+1f} * 1_rad)),
-                    Real{+0x1.921fb5p+1f}, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real{+0x1.921fb6p+1f} * 1_rad)),
-                    Real{-0x1.921fb6p+1f}, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real{+0x1.921fb7p+1f} * 1_rad)),
-                    Real{-0x1.921fb5p+1f}, abs_err);
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb5p+1f) * 1_rad))),
+                    +0x1.921fb5p+1, abs_err);
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb6p+1f) * 1_rad))),
+                    -0x1.921fb6p+1, abs_err);
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb7p+1f) * 1_rad))),
+                    -0x1.921fb5p+1, abs_err);
 
-        EXPECT_NEAR(StripUnit(GetNormalized(Real{-0x1.921fb5p+1f} * 1_rad)),
-                    Real{-0x1.921fb5p+1f}, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real{-0x1.921fb6p+1f} * 1_rad)),
-                    Real{-0x1.921fb6p+1f}, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real{-0x1.921fb7p+1f} * 1_rad)),
-                    Real{+0x1.921fb5p+1f}, abs_err);
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb5p+1f) * 1_rad))),
+                    -0x1.921fb5p+1, abs_err);
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb6p+1f) * 1_rad))),
+                    -0x1.921fb6p+1, abs_err);
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb7p+1f) * 1_rad))),
+                    +0x1.921fb5p+1, abs_err);
     }
     else if constexpr (std::is_same_v<Real, double>) {
         // Pick an absolute error allowable...
@@ -845,7 +845,7 @@ TEST(Math, GetNormalized)
 
         // Check that GetNormalized(-Pi) == -Pi
         EXPECT_NEAR(static_cast<double>(Real{GetNormalized(-Pi * 1_rad)/1_rad}),
-                    -Pi, abs_err);
+                    double(-Pi), abs_err);
 
         // Check that GetNormalized(-Pi) == GetNormalized(+Pi)...
         EXPECT_NEAR(static_cast<double>(Real{GetNormalized(+Pi * 1_rad)/1_rad}),
@@ -853,41 +853,41 @@ TEST(Math, GetNormalized)
                     abs_err);
 
         // Turning counter-clockwise, check before, during, and after positive Pi...
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d13p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d13p+1) * 1_rad))),
                     +0x1.921fb54442d13p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d14p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d14p+1) * 1_rad))),
                     +0x1.921fb54442d14p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d15p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d15p+1) * 1_rad))),
                     +0x1.921fb54442d15p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d16p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d16p+1) * 1_rad))),
                     +0x1.921fb54442d16p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d17p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d17p+1) * 1_rad))),
                     +0x1.921fb54442d17p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d18p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d18p+1) * 1_rad))),
                     -0x1.921fb54442d18p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d19p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d19p+1) * 1_rad))),
                     -0x1.921fb54442d17p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d1ap+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d1ap+1) * 1_rad))),
                     -0x1.921fb54442d16p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d1bp+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d1bp+1) * 1_rad))),
                     -0x1.921fb54442d15p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(+0x1.921fb54442d1cp+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(+0x1.921fb54442d1cp+1) * 1_rad))),
                     -0x1.921fb54442d14p+1, abs_err);
 
         // Turning clockwise, check before, during, and after negative Pi...
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(-0x1.921fb54442d16p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb54442d16p+1) * 1_rad))),
                     -0x1.921fb54442d16p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(-0x1.921fb54442d17p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb54442d17p+1) * 1_rad))),
                     -0x1.921fb54442d17p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(-0x1.921fb54442d18p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb54442d18p+1) * 1_rad))),
                     -0x1.921fb54442d18p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(-0x1.921fb54442d19p+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb54442d19p+1) * 1_rad))),
                     +0x1.921fb54442d17p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(-0x1.921fb54442d1ap+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb54442d1ap+1) * 1_rad))),
                     +0x1.921fb54442d16p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(-0x1.921fb54442d1bp+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb54442d1bp+1) * 1_rad))),
                     +0x1.921fb54442d15p+1, abs_err);
-        EXPECT_NEAR(StripUnit(GetNormalized(Real(-0x1.921fb54442d1cp+1) * 1_rad)),
+        EXPECT_NEAR(double(StripUnit(GetNormalized(Real(-0x1.921fb54442d1cp+1) * 1_rad))),
                     +0x1.921fb54442d14p+1, abs_err);
     }
 

--- a/UnitTests/Math.cpp
+++ b/UnitTests/Math.cpp
@@ -24,6 +24,7 @@
 #include <type_traits>
 #include <chrono>
 #include <cmath>
+#include <new> // for std::bad_alloc
 
 #include <playrho/ConstraintSolverConf.hpp>
 
@@ -1159,6 +1160,13 @@ TEST(Math, LengthFasterThanHypot)
     
     EXPECT_LT(elapsed_secs_length.count(), elapsed_secs_hypot.count());
     EXPECT_NEAR(totalLength, totalHypot, totalLength / 10.0);
+}
+
+TEST(Math, GetCircleVerticesMaxSizeSlices)
+{
+    auto vertices = std::vector<Length2>{};
+    EXPECT_THROW(vertices = GetCircleVertices(10_m, vertices.max_size()), std::bad_alloc);
+    EXPECT_NE(size(vertices), vertices.max_size());
 }
 
 TEST(Math, GetCircleVertices)

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -2626,7 +2626,7 @@ TEST(World, CollidingDynamicBodies)
     const auto time_contacting = elapsed_time;
 
     EXPECT_TRUE(listener.touching);
-    EXPECT_NEAR(double(time_contacting / 1_s), double(time_collision / 1_s), 0.02);
+    EXPECT_NEAR(double(Real(time_contacting / 1_s)), double(Real(time_collision / 1_s)), 0.02);
     EXPECT_EQ(GetY(GetLocation(world, body_a)), 0_m);
     EXPECT_EQ(GetY(GetLocation(world, body_b)), 0_m);
 
@@ -2658,7 +2658,7 @@ TEST(World, CollidingDynamicBodies)
     }
     EXPECT_FALSE(listener.touching);
 
-    EXPECT_TRUE(AlmostEqual(double(elapsed_time / 1_s), double((time_contacting + time_inc) / 1_s)));
+    EXPECT_TRUE(AlmostEqual(double(Real(elapsed_time / 1_s)), double(Real((time_contacting + time_inc) / 1_s))));
 
     // collision should be fully resolved now...
     EXPECT_LT(GetX(GetLocation(world, body_a)), -1_m);

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -756,9 +756,9 @@ TEST(World, GetSetAngle)
     ASSERT_EQ(GetAngle(world, body), 0_deg);
     ASSERT_EQ(GetAngularVelocity(world, body), 0_rpm);
     EXPECT_NO_THROW(SetAngle(world, body, Pi * 0.5_rad));
-    EXPECT_NEAR(double(StripUnit(GetAngle(world, body))), Pi * 0.5, 0.00001);
+    EXPECT_NEAR(double(StripUnit(GetAngle(world, body))), double(Pi) * 0.5, 0.00001);
     EXPECT_NO_THROW(SetAngle(world, body, Pi * 2.1_rad));
-    EXPECT_NEAR(double(StripUnit(GetAngle(world, body))), Pi * 2.1, 0.00001);
+    EXPECT_NEAR(double(StripUnit(GetAngle(world, body))), double(Pi) * 2.1, 0.00001);
     EXPECT_NO_THROW(SetAngle(world, body, Pi * 0_rad));
     EXPECT_NO_THROW(SetVelocity(world, body, 60_rpm));
     for (auto i = 0; i < 105; ++i) {


### PR DESCRIPTION
#### Description - What's this PR do?
- Updates `Checked` type to support any `is_constructible_v` type conversion instead of only non-narrowing conversions.
- Adds direct support for some cmath functions (`abs` and `nextafter`) as `CheckedMath.hpp`.
- Removes implicit conversion from `Fixed.hpp` in an if-statement.
- Updates `FixedMath.hpp` to keep detail functions at top and adds some new math function support from `cmath` (`isinf` and `floor`).
- Updates `GetCircleVertices` from taking `unsigned` number of slices to taking `std::size_t`.
- Updates `GetCircleVertices` to reserve space before pushing elements to avoid having to relocate memory for larger numbers of slices.
- Adds new template helpers.