### PR TITLE
Updates 20231218

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -67,6 +67,7 @@
 #include <playrho/d2/DynamicTree.hpp>
 #include <playrho/d2/Joint.hpp>
 #include <playrho/d2/Manifold.hpp>
+#include <playrho/d2/Position.hpp>
 #include <playrho/d2/ShapeSeparation.hpp>
 #include <playrho/d2/World.hpp>
 #include <playrho/d2/WorldBody.hpp> // for GetAwakeCount
@@ -1669,8 +1670,8 @@ static playrho::d2::Position GetPositionFloorNormal(playrho::d2::Position pos0, 
     const auto da = pos1.angular - pos0.angular;
     const auto na =
         pos0.angular + (da - twoPi * floor((da + playrho::Pi * playrho::Radian) * rTwoPi)) * beta;
-    return {pos0.linear + (pos1.linear - pos0.linear) * beta,
-            na - twoPi * floor((na + playrho::Pi * playrho::Radian) * rTwoPi)};
+    return playrho::d2::Position{pos0.linear + (pos1.linear - pos0.linear) * beta,
+                                 na - twoPi * floor((na + playrho::Pi * playrho::Radian) * rTwoPi)};
 }
 
 static void GetPositionNaively(benchmark::State& state)

--- a/Library/include/playrho/d2/Body.hpp
+++ b/Library/include/playrho/d2/Body.hpp
@@ -129,8 +129,8 @@ public:
     /// @brief Initializing constructor.
     /// @note To create a body within a world, use <code>World::CreateBody</code>.
     /// @param bd Configuration data for the body to construct.
-    /// @post The internal <code>m_flags</code> state will be set to the value of
-    ///  <code>GetFlags(const BodyConf&)</code> given @a bd.
+    /// @post <code>GetFlags()</code> will return the value of
+    ///  <code>GetFlags(const BodyConf&)</code> given by @a bd.
     /// @post <code>GetLinearDamping()</code> will return the value of @a bd.linearDamping.
     /// @post <code>GetAngularDamping()</code> will return the value of @a bd.angularDamping.
     /// @post <code>GetInvMass()</code> will return <code>Real(0)/Kilogram</code> if
@@ -145,8 +145,8 @@ public:
     ///   <code>SetAcceleration(LinearAcceleration2, AngularAcceleration)</code> had been called
     ///   with the values of @a bd.linearAcceleration and @a bd.angularAcceleration.
     /// @see GetFlags(const BodyConf&).
-    /// @see GetLinearDamping, GetAngularDamping, GetInvMass, GetTransformation, GetVelocity,
-    ///   GetAcceleration.
+    /// @see GetFlags, GetLinearDamping, GetAngularDamping, GetInvMass, GetTransformation,
+    ///   GetVelocity, GetAcceleration.
     /// @see World::CreateBody.
     explicit Body(const BodyConf& bd = GetDefaultBodyConf());
 
@@ -166,6 +166,9 @@ public:
     /// @brief Gets the body's sweep.
     /// @see SetSweep.
     const Sweep& GetSweep() const noexcept;
+
+    /// @brief Gets the body's flag state.
+    FlagsType GetFlags() const noexcept;
 
     /// @brief Gets the velocity.
     /// @see SetVelocity, JustSetVelocity.
@@ -251,6 +254,7 @@ public:
 
     /// @brief Sets the type of this body.
     /// @post <code>GetType()</code> returns type set.
+    /// @post <code>GetFlags()</code> returns a value reflective of the type set.
     /// @post <code>GetUnderActiveTime()</code> returns 0.
     /// @post <code>IsAwake()</code> returns true for <code>BodyType::Dynamic</code> or
     ///   <code>BodyType::Kinematic</code>, and returns false for <code>BodyType::Static</code>.
@@ -478,6 +482,11 @@ inline const Sweep& Body::GetSweep() const noexcept
     return m_sweep;
 }
 
+inline Body::FlagsType Body::GetFlags() const noexcept
+{
+    return m_flags;
+}
+
 inline Velocity Body::GetVelocity() const noexcept
 {
     return Velocity{m_linearVelocity, m_angularVelocity};
@@ -523,7 +532,7 @@ inline void Body::SetAngularDamping(NonNegative<Frequency> angularDamping) noexc
 
 inline bool Body::IsImpenetrable() const noexcept
 {
-    return (m_flags & e_impenetrableFlag) != 0;
+    return (GetFlags() & e_impenetrableFlag) != 0;
 }
 
 inline void Body::SetImpenetrable() noexcept
@@ -551,7 +560,7 @@ inline void Body::UnsetAwakeFlag() noexcept
 
 inline bool Body::IsAwake() const noexcept
 {
-    return (m_flags & e_awakeFlag) != 0;
+    return (GetFlags() & e_awakeFlag) != 0;
 }
 
 inline Time Body::GetUnderActiveTime() const noexcept
@@ -568,27 +577,27 @@ inline void Body::SetUnderActiveTime(Time value) noexcept
 
 inline bool Body::IsEnabled() const noexcept
 {
-    return (m_flags & e_enabledFlag) != 0;
+    return (GetFlags() & e_enabledFlag) != 0;
 }
 
 inline bool Body::IsFixedRotation() const noexcept
 {
-    return (m_flags & e_fixedRotationFlag) != 0;
+    return (GetFlags() & e_fixedRotationFlag) != 0;
 }
 
 inline bool Body::IsSpeedable() const noexcept
 {
-    return (m_flags & e_velocityFlag) != 0;
+    return (GetFlags() & e_velocityFlag) != 0;
 }
 
 inline bool Body::IsAccelerable() const noexcept
 {
-    return (m_flags & e_accelerationFlag) != 0;
+    return (GetFlags() & e_accelerationFlag) != 0;
 }
 
 inline bool Body::IsSleepingAllowed() const noexcept
 {
-    return (m_flags & e_autoSleepFlag) != 0;
+    return (GetFlags() & e_autoSleepFlag) != 0;
 }
 
 inline LinearAcceleration2 Body::GetLinearAcceleration() const noexcept
@@ -603,7 +612,7 @@ inline AngularAcceleration Body::GetAngularAcceleration() const noexcept
 
 inline bool Body::IsMassDataDirty() const noexcept
 {
-    return (m_flags & e_massDataDirtyFlag) != 0;
+    return (GetFlags() & e_massDataDirtyFlag) != 0;
 }
 
 inline void Body::SetEnabled() noexcept
@@ -860,6 +869,13 @@ inline const Sweep& GetSweep(const Body& body) noexcept
 inline void SetSweep(Body& body, const Sweep& value) noexcept
 {
     body.SetSweep(value);
+}
+
+/// @brief Gets the body's flag state.
+/// @relatedalso Body
+inline Body::FlagsType GetFlags(const Body& body) noexcept
+{
+    return body.GetFlags();
 }
 
 /// @brief Gets the "position 0" Position information for the given body.

--- a/Library/include/playrho/d2/Body.hpp
+++ b/Library/include/playrho/d2/Body.hpp
@@ -104,8 +104,8 @@ public:
         e_velocityFlag = FlagsType(0x0080u),
 
         /// @brief Acceleration flag.
-        /// @details Set this to enable changes in velocity due to physical properties (like
-        /// forces). Bodies with this set are "accelerable" - dynamic bodies.
+        /// @details Set this to enable changes in velocity due to physical properties
+        ///   (like forces). Bodies with this set are "accelerable" - dynamic bodies.
         e_accelerationFlag = FlagsType(0x0100u),
 
         /// @brief Mass data dirty flag.
@@ -131,19 +131,22 @@ public:
     /// @param bd Configuration data for the body to construct.
     /// @post <code>GetFlags()</code> will return the value of
     ///  <code>GetFlags(const BodyConf&)</code> given by @a bd.
-    /// @post <code>GetLinearDamping()</code> will return the value of @a bd.linearDamping.
-    /// @post <code>GetAngularDamping()</code> will return the value of @a bd.angularDamping.
-    /// @post <code>GetInvMass()</code> will return <code>Real(0)/Kilogram</code> if
-    ///   <code>bd.type != BodyType::Dynamic</code>, otherwise it will return
-    ///   <code>Real(1)/Kilogram</code>.
+    /// @post <code>GetLinearDamping()</code> returns value of @a bd.linearDamping.
+    /// @post <code>GetAngularDamping()</code> returns value of @a bd.angularDamping.
+    /// @post <code>GetInvMass()</code> returns <code>Real(0)/Kilogram</code> if
+    ///   <code>bd.type != BodyType::Dynamic</code>, otherwise it returns value of
+    ///   @a bd.invMass.
+    /// @post <code>GetInvRotI()</code> returns <code>InvRotInertia{}</code> if
+    ///   <code>bd.type != BodyType::Dynamic</code>, otherwise it returns value of
+    ///   @a bd.invRotI.
     /// @post <code>GetTransformation()</code> will return the value of
     ///   <code>::playrho::d2::GetTransformation(const BodyConf&)</code> given @a bd.
     /// @post <code>GetVelocity()</code> will return the value as if
     ///   <code>SetVelocity(const Velocity&)</code> had been called with the values of
     ///   @a bd.linearVelocity and @a bd.angularVelocity as the velocity.
     /// @post <code>GetAcceleration()</code> will return the value as if
-    ///   <code>SetAcceleration(LinearAcceleration2, AngularAcceleration)</code> had been called
-    ///   with the values of @a bd.linearAcceleration and @a bd.angularAcceleration.
+    ///   <code>SetAcceleration(LinearAcceleration2, AngularAcceleration)</code> had been
+    ///   called with values of @a bd.linearAcceleration and @a bd.angularAcceleration.
     /// @see GetFlags(const BodyConf&).
     /// @see GetFlags, GetLinearDamping, GetAngularDamping, GetInvMass, GetTransformation,
     ///   GetVelocity, GetAcceleration.
@@ -151,14 +154,15 @@ public:
     explicit Body(const BodyConf& bd = GetDefaultBodyConf());
 
     /// @brief Gets the body transform for the body's origin.
-    /// @details This gets the translation/location and rotation/direction of the body relative to
-    ///   its world. The location and direction of the body after stepping the world's physics
-    ///   simulations is dependent on a number of factors:
+    /// @details This gets the translation/location and rotation/direction of the body
+    ///   relative to its world. The location and direction of the body after stepping
+    ///   the world's physics simulations is dependent on a number of factors:
     ///   1. Location and direction at the last time step.
     ///   2. Forces and torques acting on the body (applied force, applied impulse, etc.).
     ///   3. The mass and rotational inertia of the body.
     ///   4. Damping of the body.
-    ///   5. Restitutioen and friction values of body's shape parts when experiencing collisions.
+    ///   5. Restitutioen and friction values of body's shape parts when experiencing
+    ///      collisions.
     /// @return the world transform of the body's origin.
     /// @see SetSweep.
     const Transformation& GetTransformation() const noexcept;
@@ -422,7 +426,7 @@ private:
 
     /// Inverse rotational inertia about the center of mass.
     /// @details A non-negative value. Zero for non rotationally-accelerable bodies.
-    NonNegativeFF<InvRotInertia> m_invRotI = {};
+    NonNegativeFF<InvRotInertia> m_invRotI;
 
     NonNegative<Frequency> m_linearDamping{DefaultLinearDamping}; ///< Linear damping.
     NonNegative<Frequency> m_angularDamping{DefaultAngularDamping}; ///< Angular damping.

--- a/Library/include/playrho/d2/Body.hpp
+++ b/Library/include/playrho/d2/Body.hpp
@@ -176,19 +176,20 @@ public:
 
     /// @brief Sets the body's velocity (linear and angular velocity).
     /// @param value Value of the velocity to set.
-    /// @post If @p velocity is non-zero and <code>IsSpeedable()</code> is true,
-    ///   <code>IsAwake()</code> returns true and <code>GetUnderActiveTime()</code> returns 0.
-    /// @post If @p velocity is zero or <code>IsSpeedable()</code> is true,
+    /// @post If @p velocity is non-zero and <code>IsSpeedable(const Body&)</code> is true,
+    ///   <code>IsAwake(const Body&)</code> returns true and
+    ///   <code>GetUnderActiveTime()</code> returns 0.
+    /// @post If @p velocity is zero or <code>IsSpeedable(const Body&)</code> is true,
     ///   <code>GetVelocity()</code> returns the @p value set.
-    /// @see IsAwake, IsSpeedable, GetUnderActiveTime, GetVelocity.
+    /// @see IsAwake(const Body&), IsSpeedable(const Body&), GetUnderActiveTime, GetVelocity.
     void SetVelocity(const Velocity& value) noexcept;
 
     /// Sets the body's velocity.
     /// @note This sets what <code>GetVelocity()</code> returns.
     /// @param value Value of the velocity to set.
-    /// @pre <code>IsSpeedable()</code> is true or given velocity is zero.
+    /// @pre <code>IsSpeedable(const Body&)</code> is true or given velocity is zero.
     /// @post <code>GetVelocity()</code> returns the @p value set.
-    /// @see GetVelocity, IsSpeedable.
+    /// @see GetVelocity, IsSpeedable(const Body&).
     void JustSetVelocity(const Velocity& value) noexcept;
 
     /// @brief Sets the linear and rotational accelerations on this body.
@@ -228,8 +229,8 @@ public:
     NonNegativeFF<InvRotInertia> GetInvRotInertia() const noexcept;
 
     /// @brief Sets the inverse mass data and clears the mass-data-dirty flag.
-    /// @post <code>IsMassDataDirty()</code> returns false.
-    /// @see GetInvMass, GetInvRotInertia, IsMassDataDirty.
+    /// @post <code>IsMassDataDirty(const Body&)</code> returns false.
+    /// @see GetInvMass, GetInvRotInertia, IsMassDataDirty(const Body&).
     void SetInvMassData(NonNegative<InvMass> invMass, NonNegative<InvRotInertia> invRotI) noexcept;
 
     /// @brief Gets the linear damping of the body.
@@ -256,77 +257,50 @@ public:
     /// @post <code>GetType()</code> returns type set.
     /// @post <code>GetFlags()</code> returns a value reflective of the type set.
     /// @post <code>GetUnderActiveTime()</code> returns 0.
-    /// @post <code>IsAwake()</code> returns true for <code>BodyType::Dynamic</code> or
+    /// @post <code>IsAwake(const Body&)</code> returns true for <code>BodyType::Dynamic</code> or
     ///   <code>BodyType::Kinematic</code>, and returns false for <code>BodyType::Static</code>.
     /// @see GetType.
     void SetType(BodyType value) noexcept;
 
-    /// @brief Is "speedable".
-    /// @details Is this body able to have a non-zero speed associated with it.
-    ///   Kinematic and Dynamic bodies are speedable. Static bodies are not.
-    /// @see GetType, SetType.
-    bool IsSpeedable() const noexcept;
-
-    /// @brief Is "accelerable".
-    /// @details Indicates whether this body is accelerable, i.e. whether it is effected by
-    ///   forces. Only Dynamic bodies are accelerable.
-    /// @return true if the body is accelerable, false otherwise.
-    /// @see GetType, SetType.
-    bool IsAccelerable() const noexcept;
-
-    /// @brief Is this body treated like a bullet for continuous collision detection?
-    /// @see SetImpenetrable, UnsetImpenetrable.
-    bool IsImpenetrable() const noexcept;
-
     /// @brief Sets the impenetrable status of this body.
     /// @details Sets that this body should be treated like a bullet for continuous collision
     ///   detection.
-    /// @post <code>IsImpenetrable()</code> returns true.
-    /// @see IsImpenetrable.
+    /// @post <code>IsImpenetrable(const Body& body)</code> returns true.
+    /// @see IsImpenetrable(const Body& body).
     void SetImpenetrable() noexcept;
 
     /// @brief Unsets the impenetrable status of this body.
     /// @details Unsets that this body should be treated like a bullet for continuous collision
     ///   detection.
-    /// @post <code>IsImpenetrable()</code> returns false.
-    /// @see IsImpenetrable.
+    /// @post <code>IsImpenetrable(const Body& body)</code> returns false.
+    /// @see IsImpenetrable(const Body& body).
     void UnsetImpenetrable() noexcept;
-
-    /// @brief Gets whether or not this body allowed to sleep.
-    /// @see SetSleepingAllowed.
-    bool IsSleepingAllowed() const noexcept;
 
     /// @brief Sets whether or not this body is allowed to sleep.
     /// @details Use to enable/disable sleeping on this body. If you disable sleeping, the
     /// body will be woken.
-    /// @see IsSleepingAllowed.
+    /// @see IsSleepingAllowed(const Body&).
     void SetSleepingAllowed(bool flag) noexcept;
-
-    /// @brief Gets the awake/asleep state of this body.
-    /// @warning Being awake may or may not imply being speedable.
-    /// @return true if the body is awake.
-    /// @see SetAwake.
-    bool IsAwake() const noexcept;
 
     /// @brief Awakens this body.
     /// @details Sets this body to awake and resets its under-active time if it's a "speedable"
     ///   body. This function has no effect otherwise.
-    /// @post If this body is a "speedable" body, then this body's <code>IsAwake</code> function
+    /// @post If this body is a "speedable" body, then the <code>IsAwake(const Body&)</code> function
     ///   returns true.
     /// @post If this body is a "speedable" body, then this body's <code>GetUnderActiveTime</code>
     ///   function returns zero.
-    /// @see IsAwake.
+    /// @see IsAwake(const Body&).
     void SetAwake() noexcept;
 
     /// @brief Sets this body to asleep if sleeping is allowed.
     /// @details If this body is allowed to sleep, this: sets the sleep state of the body to
     ///   asleep, resets this body's under active time, and resets this body's velocity (linear
     ///   and angular).
-    /// @post This body's <code>IsAwake</code> function returns false.
+    /// @post The <code>IsAwake(const Body&)</code> function returns false.
     /// @post This body's <code>GetUnderActiveTime</code> function returns zero.
     /// @post This body's <code>GetVelocity</code> function returns zero linear and zero angular
     ///   speed.
-    /// @see IsAwake.
+    /// @see IsAwake(const Body&).
     void UnsetAwake() noexcept;
 
     /// @brief Gets this body's under-active time value.
@@ -342,40 +316,30 @@ public:
     /// @see GetUnderActiveTime.
     void SetUnderActiveTime(Time value) noexcept;
 
-    /// @brief Does this body have fixed rotation?
-    /// @see SetFixedRotation.
-    bool IsFixedRotation() const noexcept;
-
     /// @brief Sets this body to have fixed rotation.
     /// @note This causes the mass to be reset.
-    /// @see IsFixedRotation.
+    /// @see IsFixedRotation(const Body&).
     void SetFixedRotation(bool flag);
 
     /// @brief Sets the body's awake flag.
     /// @details This is done unconditionally.
     /// @note This should **not** be called unless the body is "speedable".
-    /// @pre <code>IsSpeedable()</code> is true.
+    /// @pre <code>IsSpeedable(const Body&)</code> is true.
     /// @see UnsetAwakeFlag.
     void SetAwakeFlag() noexcept;
 
     /// @brief Unsets the body's awake flag.
-    /// @pre Either <code>!IsSpeedable()</code> or <code>IsSleepingAllowed()</code>.
+    /// @pre Either <code>!IsSpeedable(const Body&)</code> or
+    ///   <code>IsSleepingAllowed(const Body&)</code>.
     /// @see SetAwakeFlag.
     void UnsetAwakeFlag() noexcept;
 
-    /// @brief Gets whether the mass data for this body is "dirty".
-    bool IsMassDataDirty() const noexcept;
-
-    /// @brief Gets the enabled/disabled state of the body.
-    /// @see SetEnabled, UnsetEnabled.
-    bool IsEnabled() const noexcept;
-
     /// @brief Sets the enabled state.
-    /// @see IsEnabled.
+    /// @see IsEnabled(const Body&).
     void SetEnabled() noexcept;
 
     /// @brief Unsets the enabled flag.
-    /// @see IsEnabled.
+    /// @see IsEnabled(const Body&).
     void UnsetEnabled() noexcept;
 
     /// @brief Sets the sweep value of the given body.
@@ -405,23 +369,23 @@ public:
 
     /// @brief Sets the identifiers of the shapes attached to this body.
     /// @post <code>GetShapes()</code> returns the value given.
-    /// @post <code>IsMassDataDirty()</code> returns true.
+    /// @post <code>IsMassDataDirty(const Body&)</code> returns true.
     /// @see GetShapes, Attach, Detach.
     void SetShapes(std::vector<ShapeID> value);
 
     /// @brief Adds the given shape identifier to the identifiers associated with this body.
     /// @param shapeId Identifier of the shape to attach.
     /// @pre @p shapeId is not @c InvalidShapeID .
-    /// @post <code>IsMassDataDirty()</code> returns true.
+    /// @post <code>IsMassDataDirty(const Body&)</code> returns true.
     /// @post <code>GetShapes()</code> returned container contains the given identifier.
-    /// @see Detach, GetShapes, SetShapes, IsMassDataDirty.
+    /// @see Detach, GetShapes, SetShapes, IsMassDataDirty(const Body&).
     Body& Attach(ShapeID shapeId);
 
     /// @brief Removes the given shape identifier from the identifiers associated with this body.
     /// @note This also sets the mass-data-dirty flag. Call <code>SetInvMassData</code> to clear it.
     /// @param shapeId Identifier of the shape to detach.
     /// @return true if identified shape was detached, false otherwise.
-    /// @post <code>IsMassDataDirty()</code> returns true if this function returned true.
+    /// @post <code>IsMassDataDirty(const Body&)</code> returns true if this function returned true.
     /// @post <code>GetShapes()</code> returned container contains one less of the identifier.
     /// @see GetShapes, SetShapes, Attach, SetInvMassData.
     bool Detach(ShapeID shapeId);
@@ -530,11 +494,6 @@ inline void Body::SetAngularDamping(NonNegative<Frequency> angularDamping) noexc
     m_angularDamping = angularDamping;
 }
 
-inline bool Body::IsImpenetrable() const noexcept
-{
-    return (GetFlags() & e_impenetrableFlag) != 0;
-}
-
 inline void Body::SetImpenetrable() noexcept
 {
     m_flags |= e_impenetrableFlag;
@@ -548,19 +507,15 @@ inline void Body::UnsetImpenetrable() noexcept
 inline void Body::SetAwakeFlag() noexcept
 {
     // Protect the body's invariant that only "speedable" bodies can be awake.
-    assert(IsSpeedable());
+    assert((m_flags & Body::e_velocityFlag) != 0);
     m_flags |= e_awakeFlag;
 }
 
 inline void Body::UnsetAwakeFlag() noexcept
 {
-    assert(!IsSpeedable() || IsSleepingAllowed());
+    assert(((m_flags & e_velocityFlag) == 0) ||
+           ((m_flags & e_autoSleepFlag) != 0));
     m_flags &= ~e_awakeFlag;
-}
-
-inline bool Body::IsAwake() const noexcept
-{
-    return (GetFlags() & e_awakeFlag) != 0;
 }
 
 inline Time Body::GetUnderActiveTime() const noexcept
@@ -570,34 +525,9 @@ inline Time Body::GetUnderActiveTime() const noexcept
 
 inline void Body::SetUnderActiveTime(Time value) noexcept
 {
-    if ((value == 0_s) || IsAccelerable()) {
+    if ((value == 0_s) || ((m_flags & e_accelerationFlag) != 0)) {
         m_underActiveTime = value;
     }
-}
-
-inline bool Body::IsEnabled() const noexcept
-{
-    return (GetFlags() & e_enabledFlag) != 0;
-}
-
-inline bool Body::IsFixedRotation() const noexcept
-{
-    return (GetFlags() & e_fixedRotationFlag) != 0;
-}
-
-inline bool Body::IsSpeedable() const noexcept
-{
-    return (GetFlags() & e_velocityFlag) != 0;
-}
-
-inline bool Body::IsAccelerable() const noexcept
-{
-    return (GetFlags() & e_accelerationFlag) != 0;
-}
-
-inline bool Body::IsSleepingAllowed() const noexcept
-{
-    return (GetFlags() & e_autoSleepFlag) != 0;
 }
 
 inline LinearAcceleration2 Body::GetLinearAcceleration() const noexcept
@@ -608,11 +538,6 @@ inline LinearAcceleration2 Body::GetLinearAcceleration() const noexcept
 inline AngularAcceleration Body::GetAngularAcceleration() const noexcept
 {
     return m_angularAcceleration;
-}
-
-inline bool Body::IsMassDataDirty() const noexcept
-{
-    return (GetFlags() & e_massDataDirtyFlag) != 0;
 }
 
 inline void Body::SetEnabled() noexcept
@@ -627,20 +552,20 @@ inline void Body::UnsetEnabled() noexcept
 
 inline void Body::SetSweep(const Sweep& value) noexcept
 {
-    assert(IsSpeedable() || value.pos0 == value.pos1);
+    assert(((m_flags & Body::e_velocityFlag) != 0) || value.pos0 == value.pos1);
     m_sweep = value;
     m_xf = GetTransform1(value);
 }
 
 inline void Body::SetPosition0(const Position& value) noexcept
 {
-    assert(IsSpeedable() || m_sweep.pos0 == value);
+    assert(((m_flags & Body::e_velocityFlag) != 0) || m_sweep.pos0 == value);
     m_sweep.pos0 = value;
 }
 
 inline void Body::SetPosition1(const Position& value) noexcept
 {
-    assert(IsSpeedable() || m_sweep.pos1 == value);
+    assert(((m_flags & Body::e_velocityFlag) != 0) || m_sweep.pos1 == value);
     m_sweep.pos1 = value;
     m_xf = ::playrho::d2::GetTransformation(value, m_sweep.localCenter);
 }
@@ -654,10 +579,10 @@ inline void Body::Advance0(ZeroToUnderOneFF<Real> value) noexcept
 {
     // Note: Static bodies must **never** have different sweep position values.
     // Confirm bodies don't have different sweep positions to begin with...
-    assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
+    assert(((m_flags & Body::e_velocityFlag) != 0) || m_sweep.pos1 == m_sweep.pos0);
     m_sweep = ::playrho::d2::Advance0(m_sweep, value);
     // Confirm bodies don't have different sweep positions to end with...
-    assert(IsSpeedable() || m_sweep.pos1 == m_sweep.pos0);
+    assert(((m_flags & Body::e_velocityFlag) != 0) || m_sweep.pos1 == m_sweep.pos0);
 }
 
 inline const std::vector<ShapeID>& Body::GetShapes() const noexcept
@@ -689,23 +614,31 @@ inline void SetType(Body& body, BodyType value) noexcept
     body.SetType(value);
 }
 
+/// @brief Gets the body's flag state.
+/// @relatedalso Body
+inline Body::FlagsType GetFlags(const Body& body) noexcept
+{
+    return body.GetFlags();
+}
+
 /// @brief Is "speedable".
 /// @details Is this body able to have a non-zero speed associated with it.
 /// Kinematic and Dynamic bodies are speedable. Static bodies are not.
 /// @relatedalso Body
 inline bool IsSpeedable(const Body& body) noexcept
 {
-    return body.IsSpeedable();
+    return (body.GetFlags() & Body::e_velocityFlag) != 0;
 }
 
 /// @brief Is "accelerable".
 /// @details Indicates whether this body is accelerable, i.e. whether it is effected by
 ///   forces. Only Dynamic bodies are accelerable.
 /// @return true if the body is accelerable, false otherwise.
+/// @see GetType(const Body& body), SetType(Body& body, BodyType value).
 /// @relatedalso Body
 inline bool IsAccelerable(const Body& body) noexcept
 {
-    return body.IsAccelerable();
+    return (body.GetFlags() & Body::e_accelerationFlag) != 0;
 }
 
 /// @brief Is this body treated like a bullet for continuous collision detection?
@@ -713,7 +646,7 @@ inline bool IsAccelerable(const Body& body) noexcept
 /// @relatedalso Body
 inline bool IsImpenetrable(const Body& body) noexcept
 {
-    return body.IsImpenetrable();
+    return (body.GetFlags() & Body::e_impenetrableFlag) != 0;
 }
 
 /// @brief Sets the impenetrable status of this body.
@@ -741,7 +674,7 @@ inline void UnsetImpenetrable(Body& body) noexcept
 /// @relatedalso Body
 inline bool IsSleepingAllowed(const Body& body) noexcept
 {
-    return body.IsSleepingAllowed();
+    return (body.GetFlags() & Body::e_autoSleepFlag) != 0;
 }
 
 /// You can disable sleeping on this body. If you disable sleeping, the
@@ -758,7 +691,7 @@ inline void SetSleepingAllowed(Body& body, bool value) noexcept
 /// @relatedalso Body
 inline bool IsEnabled(const Body& body) noexcept
 {
-    return body.IsEnabled();
+    return (body.GetFlags() & Body::e_enabledFlag) != 0;
 }
 
 /// @brief Sets the enabled state.
@@ -797,13 +730,13 @@ inline void SetEnabled(Body& body, bool value) noexcept
 /// @relatedalso Body
 inline bool IsAwake(const Body& body) noexcept
 {
-    return body.IsAwake();
+    return (body.GetFlags() & Body::e_awakeFlag) != 0;
 }
 
 /// @brief Awakens this body.
 /// @details Sets this body to awake and resets its under-active time if it's a "speedable"
 ///   body. This function has no effect otherwise.
-/// @post If this body is a "speedable" body, then this body's <code>IsAwake</code> function
+/// @post If this body is a "speedable" body, then <code>IsAwake(const Body&)</code> function
 ///   returns true.
 /// @post If this body is a "speedable" body, then this body's <code>GetUnderActiveTime</code>
 ///   function returns zero.
@@ -818,7 +751,7 @@ inline void SetAwake(Body& body) noexcept
 /// @details If this body is allowed to sleep, this: sets the sleep state of the body to
 /// asleep, resets this body's under active time, and resets this body's velocity (linear
 /// and angular).
-/// @post This body's <code>IsAwake</code> function returns false.
+/// @post <code>IsAwake(const Body&)</code> function returns false.
 /// @post This body's <code>GetUnderActiveTime</code> function returns zero.
 /// @post This body's <code>GetVelocity</code> function returns zero linear and zero angular
 ///   speed.
@@ -869,13 +802,6 @@ inline const Sweep& GetSweep(const Body& body) noexcept
 inline void SetSweep(Body& body, const Sweep& value) noexcept
 {
     body.SetSweep(value);
-}
-
-/// @brief Gets the body's flag state.
-/// @relatedalso Body
-inline Body::FlagsType GetFlags(const Body& body) noexcept
-{
-    return body.GetFlags();
 }
 
 /// @brief Gets the "position 0" Position information for the given body.
@@ -993,7 +919,7 @@ inline Time GetUnderActiveTime(const Body& body) noexcept
 /// @relatedalso Body
 inline bool IsFixedRotation(const Body& body) noexcept
 {
-    return body.IsFixedRotation();
+    return (body.GetFlags() & Body::e_fixedRotationFlag) != 0;
 }
 
 /// @brief Sets this body to have fixed rotation.
@@ -1009,7 +935,7 @@ inline void SetFixedRotation(Body& body, bool value)
 /// @relatedalso Body
 inline bool IsMassDataDirty(const Body& body) noexcept
 {
-    return body.IsMassDataDirty();
+    return (body.GetFlags() & Body::e_massDataDirtyFlag) != 0;
 }
 
 /// @brief Gets the inverse total mass of the body.
@@ -1111,7 +1037,7 @@ inline AngularAcceleration GetAngularAcceleration(const Body& body) noexcept
 /// @relatedalso Body
 inline bool Awaken(Body& body) noexcept
 {
-    if (!body.IsAwake() && body.IsSpeedable()) {
+    if (!IsAwake(body) && IsSpeedable(body)) {
         body.SetAwake();
         return true;
     }
@@ -1123,7 +1049,7 @@ inline bool Awaken(Body& body) noexcept
 /// @relatedalso Body
 inline bool Unawaken(Body& body) noexcept
 {
-    if (body.IsAwake() && body.IsSleepingAllowed()) {
+    if (IsAwake(body) && IsSleepingAllowed(body)) {
         body.UnsetAwake();
         return true;
     }

--- a/Library/include/playrho/d2/BodyConf.hpp
+++ b/Library/include/playrho/d2/BodyConf.hpp
@@ -23,7 +23,7 @@
 #define PLAYRHO_D2_BODYCONF_HPP
 
 /// @file
-/// @brief Declarations of @c BodyConf class and free functions associated with it.
+/// @brief Declarations of @c BodyConf class & free functions associated with it.
 
 #include <cstdlib> // for std::size_t
 #include <type_traits> // for std::is_default_constructible_v
@@ -31,6 +31,7 @@
 #include <playrho/ArrayList.hpp>
 #include <playrho/BodyType.hpp>
 #include <playrho/NonNegative.hpp>
+#include <playrho/Real.hpp>
 #include <playrho/ShapeID.hpp>
 #include <playrho/Span.hpp>
 #include <playrho/Units.hpp>
@@ -46,8 +47,8 @@ namespace playrho::d2 {
 class Body;
 
 /// @brief Configuration for a body.
-/// @details A body configuration holds all the data needed to construct a rigid body.
-///   You can safely re-use body configurations.
+/// @details A body configuration holds all the data needed to construct a rigid
+///   body. You can safely re-use body configurations.
 /// @note Value class meant for passing in for <code>Body</code> construction.
 /// @see World, Body.
 struct BodyConf {
@@ -56,6 +57,14 @@ struct BodyConf {
 
     /// @brief Default sweep.
     static constexpr auto DefaultSweep = Sweep{};
+
+    /// @brief Default inverse mass.
+    static constexpr auto DefaultInvMass =
+        NonNegativeFF<InvMass>{Real(1) / Kilogram};
+
+    /// @brief Default inverse rotational inertia.
+    static constexpr auto DefaultInvRotI =
+        NonNegativeFF<InvRotInertia>{};
 
     /// @brief Default linear velocity.
     static constexpr auto DefaultLinearVelocity = LinearVelocity2{};
@@ -67,13 +76,14 @@ struct BodyConf {
     static constexpr auto DefaultLinearAcceleration = LinearAcceleration2{};
 
     /// @brief Default angular acceleration.
-    static constexpr auto DefaultAngularAcceleration = AngularAcceleration{0 * RadianPerSquareSecond};
+    static constexpr auto DefaultAngularAcceleration =
+        AngularAcceleration{0 * RadianPerSquareSecond};
 
     /// @brief Default linear damping.
-    static constexpr auto DefaultLinearDamping = NonNegative<Frequency>{0_Hz};
+    static constexpr auto DefaultLinearDamping = NonNegativeFF<Frequency>{0_Hz};
 
     /// @brief Default angular damping.
-    static constexpr auto DefaultAngularDamping = NonNegative<Frequency>{0_Hz};
+    static constexpr auto DefaultAngularDamping = NonNegativeFF<Frequency>{0_Hz};
 
     /// @brief Default under active time.
     static constexpr auto DefaultUnderActiveTime = 0_s;
@@ -106,6 +116,12 @@ struct BodyConf {
 
     /// @brief Use the given sweep.
     constexpr BodyConf& Use(const Sweep& v) noexcept;
+
+    /// @brief Use the given inverse mass.
+    constexpr BodyConf& UseInvMass(const NonNegative<InvMass>& v) noexcept;
+
+    /// @brief Use the given inverse rotational inertia.
+    constexpr BodyConf& UseInvRotI(const NonNegative<InvRotInertia>& v) noexcept;
 
     /// @brief Use the given location.
     constexpr BodyConf& UseLocation(const Length2& l) noexcept;
@@ -178,7 +194,15 @@ struct BodyConf {
     /// @note Avoid creating bodies at the origin since this can lead to many overlapping shapes.
     Sweep sweep = DefaultSweep;
 
-    /// The linear velocity of the body's origin in world co-ordinates (in m/s).
+    /// @brief Inverse mass for the body.
+    /// @note Only applies if type is dynamic.
+    NonNegative<InvMass> invMass = DefaultInvMass;
+
+    /// @brief Inverse rotational inertia for the body.
+    /// @note Only applies if type is dynamic.
+    NonNegative<InvRotInertia> invRotI = DefaultInvRotI;
+
+    /// The linear velocity of the body's origin in world co-ordinates.
     LinearVelocity2 linearVelocity = DefaultLinearVelocity;
 
     /// The angular velocity of the body.
@@ -244,6 +268,18 @@ constexpr BodyConf& BodyConf::Use(BodyType t) noexcept
 constexpr BodyConf& BodyConf::Use(const Sweep& v) noexcept
 {
     sweep = v;
+    return *this;
+}
+
+constexpr BodyConf& BodyConf::UseInvMass(const NonNegative<InvMass>& v) noexcept
+{
+    invMass = v;
+    return *this;
+}
+
+constexpr BodyConf& BodyConf::UseInvRotI(const NonNegative<InvRotInertia>& v) noexcept
+{
+    invRotI = v;
     return *this;
 }
 
@@ -398,6 +434,8 @@ constexpr bool operator==(const BodyConf& lhs, const BodyConf& rhs) noexcept
 {
     return lhs.type == rhs.type && //
            lhs.sweep == rhs.sweep && //
+           lhs.invMass == rhs.invMass && //
+           lhs.invRotI == rhs.invRotI && //
            lhs.linearVelocity == rhs.linearVelocity && //
            lhs.angularVelocity == rhs.angularVelocity && //
            lhs.linearAcceleration == rhs.linearAcceleration && //

--- a/Library/include/playrho/d2/BodyConf.hpp
+++ b/Library/include/playrho/d2/BodyConf.hpp
@@ -103,6 +103,9 @@ struct BodyConf {
     /// @brief Default enabled value.
     static constexpr auto DefaultEnabled = true;
 
+    /// @brief Default mass data dirty value.
+    static constexpr auto DefaultMassDataDirty = true;
+
     /// @brief Max associable shapes.
     static constexpr auto MaxShapes = std::size_t(128);
 
@@ -183,6 +186,9 @@ struct BodyConf {
     /// @brief Use the given enabled state.
     constexpr BodyConf& UseEnabled(bool value) noexcept;
 
+    /// @brief Use the given mass data dirty state.
+    constexpr BodyConf& UseMassDataDirty(bool v) noexcept;
+
     // Public member variables...
 
     /// @brief Type of the body: static, kinematic, or dynamic.
@@ -252,6 +258,9 @@ struct BodyConf {
 
     /// Whether or not the body is enabled.
     bool enabled = DefaultEnabled;
+
+    /// @brief Whether mass data is "dirty".
+    bool massDataDirty = DefaultMassDataDirty;
 };
 
 constexpr BodyConf& BodyConf::UseType(BodyType t) noexcept
@@ -271,13 +280,15 @@ constexpr BodyConf& BodyConf::Use(const Sweep& v) noexcept
     return *this;
 }
 
-constexpr BodyConf& BodyConf::UseInvMass(const NonNegative<InvMass>& v) noexcept
+constexpr BodyConf& BodyConf::UseInvMass(
+    const NonNegative<InvMass>& v) noexcept
 {
     invMass = v;
     return *this;
 }
 
-constexpr BodyConf& BodyConf::UseInvRotI(const NonNegative<InvRotInertia>& v) noexcept
+constexpr BodyConf& BodyConf::UseInvRotI(
+    const NonNegative<InvRotInertia>& v) noexcept
 {
     invRotI = v;
     return *this;
@@ -392,6 +403,12 @@ constexpr BodyConf& BodyConf::UseEnabled(bool value) noexcept
     return *this;
 }
 
+constexpr BodyConf& BodyConf::UseMassDataDirty(bool v) noexcept
+{
+    massDataDirty = v;
+    return *this;
+}
+
 // Asserts some basic traits...
 static_assert(std::is_default_constructible_v<BodyConf>);
 static_assert(std::is_copy_constructible_v<BodyConf>);
@@ -448,7 +465,8 @@ constexpr bool operator==(const BodyConf& lhs, const BodyConf& rhs) noexcept
            lhs.awake == rhs.awake && //
            lhs.fixedRotation == rhs.fixedRotation && //
            lhs.bullet == rhs.bullet && //
-           lhs.enabled == rhs.enabled;
+           lhs.enabled == rhs.enabled && //
+           lhs.massDataDirty == rhs.massDataDirty;
 }
 
 /// @brief Operator not-equals.

--- a/Library/include/playrho/d2/EdgeShapeConf.hpp
+++ b/Library/include/playrho/d2/EdgeShapeConf.hpp
@@ -26,15 +26,22 @@
 /// @brief Definition of the @c EdgeShapeConf class and closely related code.
 
 #include <array>
-#include <utility> // for std::index_sequence
 
-#include <playrho/TypeInfo.hpp>
+#include <playrho/InvalidArgument.hpp>
+#include <playrho/NonNegative.hpp>
+#include <playrho/Real.hpp>
+#include <playrho/Settings.hpp>
+#include <playrho/Units.hpp>
+#include <playrho/Vector2.hpp> // for Length2
+
+#include <playrho/detail/Templates.hpp>
+#include <playrho/detail/TypeInfo.hpp>
 
 #include <playrho/d2/DistanceProxy.hpp>
 #include <playrho/d2/MassData.hpp>
-#include <playrho/d2/Math.hpp>
 #include <playrho/d2/NgonWithFwdNormals.hpp>
 #include <playrho/d2/ShapeConf.hpp>
+#include <playrho/d2/UnitVec.hpp>
 
 namespace playrho::d2 {
 

--- a/Library/include/playrho/d2/JointConf.hpp
+++ b/Library/include/playrho/d2/JointConf.hpp
@@ -26,12 +26,11 @@
 /// @brief Definition of the @c JointConf class and closely related code.
 
 #include <cstddef> // for std::max_align_t
-#include <cstdint>
 
 #include <playrho/BodyID.hpp>
+#include <playrho/Units.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho::d2 {
 
 /// @brief Base joint definition class.
 /// @details Joint definitions are used to construct joints.
@@ -337,7 +336,6 @@ constexpr auto GetAngularMotorImpulse(const T& conf) noexcept
     return conf.angularMotorImpulse;
 }
 
-} // namespace d2
-} // namespace playrho
+} // namespace playrho::d2
 
 #endif // PLAYRHO_D2_JOINTCONF_HPP

--- a/Library/include/playrho/d2/MassData.hpp
+++ b/Library/include/playrho/d2/MassData.hpp
@@ -33,10 +33,7 @@
 #include <playrho/Vector.hpp>
 #include <playrho/Vector2.hpp>
 
-#include <playrho/d2/Math.hpp>
-
-namespace playrho {
-namespace detail {
+namespace playrho::detail {
 
 /// @brief Mass data.
 /// @details This holds the mass data computed for a shape.
@@ -79,28 +76,24 @@ constexpr bool operator!= (MassData<N> lhs, MassData<N> rhs)
     return !(lhs == rhs);
 }
 
-} // namespace detail
+} // namespace playrho::detail
 
-namespace d2 {
+namespace playrho::d2 {
 
 /// @brief Mass data alias for 2-D objects.
 using MassData = ::playrho::detail::MassData<2>;
 
 /// @brief Computes the mass data for a circular shape.
-///
 /// @param r Radius of the circular shape.
 /// @param density Areal density of mass.
 /// @param location Location of the center of the shape.
-///
 MassData GetMassData(Length r, NonNegative<AreaDensity> density, const Length2& location);
 
 /// @brief Computes the mass data for a linear shape.
-///
 /// @param r Radius of the vertices of the linear shape.
 /// @param density Areal density of mass.
 /// @param v0 Location of vertex zero.
 /// @param v1 Location of vertex one.
-///
 MassData GetMassData(Length r, NonNegative<AreaDensity> density, // force line-break
                      const Length2& v0, const Length2& v1);
 
@@ -109,7 +102,6 @@ MassData GetMassData(Length r, NonNegative<AreaDensity> density, // force line-b
 MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
                      Span<const Length2> vertices);
 
-} // namespace d2
-} // namespace playrho
+} // namespace playrho::d2
 
 #endif // PLAYRHO_D2_MASSDATA_HPP

--- a/Library/include/playrho/d2/PolygonShapeConf.hpp
+++ b/Library/include/playrho/d2/PolygonShapeConf.hpp
@@ -25,17 +25,27 @@
 /// @file
 /// @brief Definition of the @c PolygonShapeConf class and closely related code.
 
+#include <cassert> // for assert
 #include <type_traits>
 #include <vector>
 
+#include <playrho/InvalidArgument.hpp>
+#include <playrho/Matrix.hpp> // for Mat22
+#include <playrho/NonNegative.hpp>
+#include <playrho/Settings.hpp>
 #include <playrho/Span.hpp>
-#include <playrho/TypeInfo.hpp>
+#include <playrho/Units.hpp>
+#include <playrho/Vector2.hpp>
+
+#include <playrho/detail/Templates.hpp>
+#include <playrho/detail/TypeInfo.hpp>
 
 #include <playrho/d2/DistanceProxy.hpp>
 #include <playrho/d2/MassData.hpp>
-#include <playrho/d2/Math.hpp>
 #include <playrho/d2/NgonWithFwdNormals.hpp>
 #include <playrho/d2/ShapeConf.hpp>
+#include <playrho/d2/Transformation.hpp>
+#include <playrho/d2/UnitVec.hpp>
 #include <playrho/d2/VertexSet.hpp>
 
 namespace playrho::d2 {
@@ -201,6 +211,11 @@ struct PolygonShapeConf : public ShapeBuilder<PolygonShapeConf>
     /// @brief N-gon data.
     NgonWithFwdNormals<> ngon;
 };
+
+// Assert some expected traits...
+static_assert(std::is_default_constructible_v<PolygonShapeConf>);
+static_assert(std::is_nothrow_default_constructible_v<PolygonShapeConf>);
+static_assert(std::is_copy_constructible_v<PolygonShapeConf>);
 
 inline PolygonShapeConf& PolygonShapeConf::UseVertexRadius(NonNegative<Length> value) noexcept
 {

--- a/Library/include/playrho/d2/Position.hpp
+++ b/Library/include/playrho/d2/Position.hpp
@@ -54,8 +54,8 @@ struct Position {
 
 // Assert some expected traits...
 static_assert(std::is_nothrow_default_constructible_v<Position>);
-static_assert(std::is_nothrow_copy_constructible_v<Position>);
-static_assert(std::is_nothrow_move_constructible_v<Position>);
+static_assert(std::is_copy_constructible_v<Position>);
+static_assert(std::is_move_constructible_v<Position>);
 static_assert(std::is_nothrow_destructible_v<Position>);
 
 /// @brief Equality operator.

--- a/Library/include/playrho/d2/Position.hpp
+++ b/Library/include/playrho/d2/Position.hpp
@@ -25,21 +25,38 @@
 /// @file
 /// @brief Definition of the @c Position class and closely related code.
 
+#include <type_traits>
+
 #include <playrho/Real.hpp>
 #include <playrho/Templates.hpp>
 #include <playrho/Units.hpp>
 #include <playrho/Vector2.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho::d2 {
 
 /// @brief 2-D positional data structure.
 /// @details A 2-element length and angle pair suitable for representing a linear and
 ///   angular position in 2-D.
 struct Position {
-    Length2 linear; ///< Linear position.
-    Angle angular; ///< Angular position.
+    /// @brief Default constructor.
+    constexpr Position() noexcept = default;
+
+    /// @brief Initializing constructor.
+    constexpr explicit Position(Length2 l, Angle a = 0_deg) noexcept:
+          linear{l}, angular{a}
+    {
+        // Intentionally empty.
+    }
+
+    Length2 linear{}; ///< Linear position.
+    Angle angular{}; ///< Angular position.
 };
+
+// Assert some expected traits...
+static_assert(std::is_nothrow_default_constructible_v<Position>);
+static_assert(std::is_nothrow_copy_constructible_v<Position>);
+static_assert(std::is_nothrow_move_constructible_v<Position>);
+static_assert(std::is_nothrow_destructible_v<Position>);
 
 /// @brief Equality operator.
 /// @relatedalso Position
@@ -114,7 +131,9 @@ constexpr Position operator*(const Real scalar, const Position& pos)
     return Position{pos.linear * scalar, pos.angular * scalar};
 }
 
-} // namespace d2
+} // namespace playrho::d2
+
+namespace playrho {
 
 /// @brief Determines if the given value is valid.
 /// @relatedalso d2::Position

--- a/Library/include/playrho/d2/ShapeConf.hpp
+++ b/Library/include/playrho/d2/ShapeConf.hpp
@@ -28,7 +28,7 @@
 #include <playrho/Filter.hpp>
 #include <playrho/Finite.hpp>
 #include <playrho/NonNegative.hpp>
-#include <playrho/Settings.hpp>
+#include <playrho/Real.hpp>
 #include <playrho/Units.hpp>
 
 namespace playrho::d2 {
@@ -53,27 +53,21 @@ struct BaseShapeConf {
     static constexpr auto DefaultIsSensor = false;
 
     /// @brief Friction coefficient.
-    ///
     /// @note This must be a value between 0 and +infinity. It is safer however to
     ///   keep the value below the square root of the max value of a Real.
     /// @note This is usually in the range [0,1].
     /// @note The square-root of the product of this value multiplied by a touching
     ///   fixture's friction becomes the friction coefficient for the contact.
-    ///
     NonNegative<Real> friction = DefaultFriction;
 
     /// @brief Restitution (elasticity) of the associated shape.
-    ///
     /// @note This should be a valid finite value.
     /// @note This is usually in the range [0,1].
-    ///
     Finite<Real> restitution = DefaultRestitution;
 
     /// @brief Area density of the associated shape.
-    ///
     /// @note This must be a non-negative value.
     /// @note Use 0 to indicate that the shape's associated mass should be 0.
-    ///
     NonNegative<AreaDensity> density = DefaultDensity;
 
     /// Filtering data for contacts.

--- a/Library/include/playrho/d2/Sweep.hpp
+++ b/Library/include/playrho/d2/Sweep.hpp
@@ -25,7 +25,9 @@
 /// @file
 /// @brief Definition of the @c Sweep class and closely related code.
 
-#include <playrho/Settings.hpp>
+#include <playrho/Real.hpp>
+#include <playrho/Templates.hpp> // for IsValid
+#include <playrho/Units.hpp>
 #include <playrho/Vector2.hpp>
 #include <playrho/ZeroToUnderOne.hpp>
 

--- a/Library/include/playrho/d2/WorldBody.hpp
+++ b/Library/include/playrho/d2/WorldBody.hpp
@@ -38,18 +38,23 @@
 /// @see World, BodyID.
 /// @see https://en.wikipedia.org/wiki/Create,_read,_update_and_delete.
 
-#include <iterator>
-#include <vector>
-#include <functional>
-
 #include <playrho/BodyID.hpp>
-#include <playrho/JointID.hpp>
-#include <playrho/KeyedContactID.hpp>
+#include <playrho/BodyType.hpp>
+#include <playrho/Math.hpp>
+#include <playrho/NonNegative.hpp>
+#include <playrho/Real.hpp>
+#include <playrho/Settings.hpp>
 #include <playrho/ShapeID.hpp>
+#include <playrho/Units.hpp>
+#include <playrho/Vector2.hpp> // for Length2
 
-#include <playrho/d2/Body.hpp>
+#include <playrho/d2/Acceleration.hpp>
 #include <playrho/d2/MassData.hpp>
 #include <playrho/d2/Math.hpp>
+#include <playrho/d2/Position.hpp>
+#include <playrho/d2/Transformation.hpp>
+#include <playrho/d2/UnitVec.hpp>
+#include <playrho/d2/Velocity.hpp>
 
 namespace playrho::d2 {
 

--- a/Library/source/playrho/d2/Body.cpp
+++ b/Library/source/playrho/d2/Body.cpp
@@ -104,15 +104,14 @@ Body::FlagsType Body::GetFlags(const BodyConf& bd) noexcept
 
 Body::Body(const BodyConf& bd)
     : m_xf{::playrho::d2::GetTransformation(bd)},
-      m_sweep{Position{bd.location, bd.angle}},
+      m_sweep{bd.sweep},
       m_flags{GetFlags(bd)},
       m_invMass{(bd.type == playrho::BodyType::Dynamic) ? InvMass{Real{1} / Kilogram} : InvMass{}},
       m_linearDamping{bd.linearDamping},
       m_angularDamping{bd.angularDamping},
       m_shapes(bd.shapes.begin(), bd.shapes.end())
 {
-    assert(IsValid(bd.location));
-    assert(IsValid(bd.angle));
+    assert(IsValid(bd.sweep));
     assert(IsValid(bd.linearVelocity));
     assert(IsValid(bd.angularVelocity));
     assert(IsValid(m_xf));

--- a/Library/source/playrho/d2/Body.cpp
+++ b/Library/source/playrho/d2/Body.cpp
@@ -340,7 +340,7 @@ bool operator==(const Body& lhs, const Body& rhs)
 {
     return GetTransformation(lhs) == GetTransformation(rhs) && //
            GetSweep(lhs) == GetSweep(rhs) && //
-           GetType(lhs) == GetType(rhs) && //
+           GetFlags(lhs) == GetFlags(rhs) && //
            GetVelocity(lhs) == GetVelocity(rhs) && //
            GetAcceleration(lhs) == GetAcceleration(rhs) && //
            GetInvMass(lhs) == GetInvMass(rhs) && //

--- a/Library/source/playrho/d2/Body.cpp
+++ b/Library/source/playrho/d2/Body.cpp
@@ -100,6 +100,12 @@ Body::FlagsType Body::GetFlags(const BodyConf& bd) noexcept
     if (bd.enabled) {
         flags |= e_enabledFlag;
     }
+    if (bd.massDataDirty &&
+        (!bd.shapes.empty() ||
+         (bd.invMass != BodyConf::DefaultInvMass) ||
+         (bd.invRotI != BodyConf::DefaultInvRotI))) {
+        flags |= e_massDataDirtyFlag;
+    }
     return flags;
 }
 

--- a/Library/source/playrho/d2/Body.cpp
+++ b/Library/source/playrho/d2/Body.cpp
@@ -26,6 +26,7 @@
 
 #include <playrho/BodyType.hpp>
 #include <playrho/Math.hpp>
+#include <playrho/NonNegative.hpp>
 #include <playrho/Real.hpp>
 #include <playrho/ShapeID.hpp>
 #include <playrho/Templates.hpp>
@@ -106,7 +107,10 @@ Body::Body(const BodyConf& bd)
     : m_xf{::playrho::d2::GetTransformation(bd)},
       m_sweep{bd.sweep},
       m_flags{GetFlags(bd)},
-      m_invMass{(bd.type == playrho::BodyType::Dynamic) ? InvMass{Real{1} / Kilogram} : InvMass{}},
+      m_invMass{(bd.type == playrho::BodyType::Dynamic)
+                    ? bd.invMass : NonNegative<InvMass>{}},
+      m_invRotI{(bd.type == playrho::BodyType::Dynamic)
+                    ? bd.invRotI : NonNegative<InvRotInertia>{}},
       m_linearDamping{bd.linearDamping},
       m_angularDamping{bd.angularDamping},
       m_shapes(bd.shapes.begin(), bd.shapes.end())

--- a/Library/source/playrho/d2/BodyConf.cpp
+++ b/Library/source/playrho/d2/BodyConf.cpp
@@ -31,6 +31,8 @@ BodyConf GetBodyConf(const Body& body)
     auto def = BodyConf{};
     def.type = GetType(body);
     def.sweep = GetSweep(body);
+    def.invMass = GetInvMass(body);
+    def.invRotI = GetInvRotInertia(body);
     def.linearVelocity = GetLinearVelocity(body);
     def.angularVelocity = GetAngularVelocity(body);
     def.linearAcceleration = GetLinearAcceleration(body);

--- a/Library/source/playrho/d2/BodyConf.cpp
+++ b/Library/source/playrho/d2/BodyConf.cpp
@@ -46,6 +46,7 @@ BodyConf GetBodyConf(const Body& body)
     def.fixedRotation = IsFixedRotation(body);
     def.bullet = IsAccelerable(body) && IsImpenetrable(body);
     def.enabled = IsEnabled(body);
+    def.massDataDirty = IsMassDataDirty(body);
     return def;
 }
 

--- a/Library/source/playrho/d2/BodyConf.cpp
+++ b/Library/source/playrho/d2/BodyConf.cpp
@@ -30,8 +30,7 @@ BodyConf GetBodyConf(const Body& body)
 {
     auto def = BodyConf{};
     def.type = GetType(body);
-    def.location = GetLocation(body);
-    def.angle = GetAngle(body);
+    def.sweep = GetSweep(body);
     def.linearVelocity = GetLinearVelocity(body);
     def.angularVelocity = GetAngularVelocity(body);
     def.linearAcceleration = GetLinearAcceleration(body);
@@ -50,7 +49,7 @@ BodyConf GetBodyConf(const Body& body)
 
 Transformation GetTransformation(const BodyConf& conf) noexcept
 {
-    return {conf.location, UnitVec::Get(conf.angle)};
+    return {conf.sweep.pos0.linear, UnitVec::Get(conf.sweep.pos0.angular)};
 }
 
 } // namespace playrho::d2

--- a/Library/source/playrho/d2/JointConf.cpp
+++ b/Library/source/playrho/d2/JointConf.cpp
@@ -19,11 +19,12 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#include <type_traits> // for std::is_default_constructible_v
+
 #include <playrho/d2/JointConf.hpp>
 #include <playrho/d2/Joint.hpp>
 
-namespace playrho {
-namespace d2 {
+namespace playrho::d2 {
 
 static_assert(std::is_default_constructible_v<JointConf>,
               "JointConf should be default constructible!");
@@ -44,5 +45,4 @@ void Set(JointConf& def, const Joint& joint) noexcept
     def.collideConnected = GetCollideConnected(joint);
 }
 
-} // namespace d2
-} // namespace playrho
+} // namespace playrho::d2

--- a/Library/source/playrho/d2/MassData.cpp
+++ b/Library/source/playrho/d2/MassData.cpp
@@ -19,16 +19,24 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#include <cassert>
+
+#include <playrho/Math.hpp>
+#include <playrho/NonNegative.hpp>
+#include <playrho/Real.hpp>
+#include <playrho/RealConstants.hpp>
+#include <playrho/Span.hpp>
+#include <playrho/Units.hpp>
+#include <playrho/Vector.hpp>
+#include <playrho/Vector2.hpp>
+
+#include <playrho/detail/Templates.hpp>
+
 #include <playrho/d2/MassData.hpp>
+#include <playrho/d2/Math.hpp>
+#include <playrho/d2/UnitVec.hpp>
 
-#include <playrho/d2/Shape.hpp>
-#include <playrho/d2/EdgeShapeConf.hpp>
-#include <playrho/d2/PolygonShapeConf.hpp>
-#include <playrho/d2/ChainShapeConf.hpp>
-#include <playrho/d2/DiskShapeConf.hpp>
-
-namespace playrho {
-namespace d2 {
+namespace playrho::d2 {
 
 MassData GetMassData(Length r, NonNegative<AreaDensity> density, const Length2& location)
 {
@@ -182,5 +190,4 @@ MassData GetMassData(Length vertexRadius, NonNegative<AreaDensity> density,
     return MassData{massDataCenter, mass, massDataI};
 }
 
-} // namespace d2
-} // namespace playrho
+} // namespace playrho::d2

--- a/Library/source/playrho/d2/Sweep.cpp
+++ b/Library/source/playrho/d2/Sweep.cpp
@@ -19,6 +19,9 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#include <playrho/Real.hpp>
+#include <playrho/ZeroToUnderOne.hpp>
+
 #include <playrho/d2/Math.hpp> // for GetPosition
 #include <playrho/d2/Sweep.hpp>
 

--- a/Library/source/playrho/d2/WorldBody.cpp
+++ b/Library/source/playrho/d2/WorldBody.cpp
@@ -366,9 +366,9 @@ void ResetMassData(World& world, BodyID id)
 void SetMassData(World& world, BodyID id, const MassData& massData)
 {
     auto body = GetBody(world, id);
-    if (!body.IsAccelerable()) {
+    if (!IsAccelerable(body)) {
         body.SetInvMassData(InvMass{}, InvRotInertia{});
-        if (!body.IsSpeedable()) {
+        if (!IsSpeedable(body)) {
             body.SetSweep(Sweep{Position{GetLocation(body), GetAngle(body)}});
         }
         SetBody(world, id, body);
@@ -377,7 +377,7 @@ void SetMassData(World& world, BodyID id, const MassData& massData)
     const auto mass = (massData.mass > 0_kg)? Mass{massData.mass}: 1_kg;
     const auto invMass = Real{1} / mass;
     auto invRotInertia = Real(0) / (1_m2 * 1_kg / SquareRadian);
-    if ((massData.I > RotInertia{}) && (!body.IsFixedRotation())) {
+    if ((massData.I > RotInertia{}) && (!IsFixedRotation(body))) {
         const auto lengthSquared = GetMagnitudeSquared(massData.center);
         // L^2 M QP^-2
         const auto I = RotInertia{massData.I} - RotInertia{(mass * lengthSquared) / SquareRadian};

--- a/Library/source/playrho/d2/WorldBody.cpp
+++ b/Library/source/playrho/d2/WorldBody.cpp
@@ -20,13 +20,31 @@
  */
 
 #include <algorithm>
-#include <functional>
-#include <memory>
+#include <cassert>
+#include <limits>
 
 #include <playrho/to_underlying.hpp>
+#include <playrho/BodyID.hpp>
+#include <playrho/BodyType.hpp>
+#include <playrho/Math.hpp>
+#include <playrho/NonNegative.hpp>
+#include <playrho/Real.hpp>
+#include <playrho/Settings.hpp>
+#include <playrho/ShapeID.hpp>
+#include <playrho/Units.hpp>
+#include <playrho/Vector.hpp> // for GetX, GetY
+#include <playrho/Vector2.hpp> // for Length2
 
+#include <playrho/detail/Templates.hpp>
+
+#include <playrho/d2/Acceleration.hpp>
 #include <playrho/d2/Body.hpp>
+#include <playrho/d2/MassData.hpp>
 #include <playrho/d2/Math.hpp>
+#include <playrho/d2/Position.hpp>
+#include <playrho/d2/Sweep.hpp>
+#include <playrho/d2/Transformation.hpp>
+#include <playrho/d2/Velocity.hpp>
 #include <playrho/d2/WorldBody.hpp>
 #include <playrho/d2/WorldShape.hpp>
 #include <playrho/d2/World.hpp>

--- a/Testbed/Tests/ApplyForce.cpp
+++ b/Testbed/Tests/ApplyForce.cpp
@@ -98,14 +98,13 @@ public:
             conf.density = 2_kgpm2;
             const auto poly2 = PolygonShapeConf(vertices, conf);
 
-            auto bd = BodyConf{};
-            bd.type = BodyType::Dynamic;
-            bd.angularDamping = 2_Hz;
-            bd.linearDamping = 0.5_Hz;
-            bd.location = Length2{0_m, 2_m};
-            bd.angle = Pi * 1_rad;
-            bd.allowSleep = false;
-            m_body = CreateBody(GetWorld(), bd);
+            m_body = CreateBody(GetWorld(), BodyConf{}
+                                                .Use(BodyType::Dynamic)
+                                                .UseAngularDamping(2_Hz)
+                                                .UseLinearDamping(0.5_Hz)
+                                                .UseLocation(Length2{0_m, 2_m})
+                                                .UseAngle(Pi * 1_rad)
+                                                .UseAllowSleep(false));
             Attach(GetWorld(), m_body, CreateShape(GetWorld(), poly1));
             Attach(GetWorld(), m_body, CreateShape(GetWorld(), poly2));
         }

--- a/Testbed/Tests/BasicSliderCrank.cpp
+++ b/Testbed/Tests/BasicSliderCrank.cpp
@@ -39,7 +39,7 @@ public:
         {
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-8.0f, 20.0f) * 1_m;
+            bd.UseLocation(Vec2(-8.0f, 20.0f) * 1_m);
             bd.linearAcceleration = GetGravity();
             const auto body = CreateBody(GetWorld(), bd);
             auto conf = PolygonShapeConf{};
@@ -55,7 +55,7 @@ public:
         {
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(4.0f, 20.0f) * 1_m;
+            bd.UseLocation(Vec2(4.0f, 20.0f) * 1_m);
             bd.linearAcceleration = GetGravity();
             const auto body = CreateBody(GetWorld(), bd);
             auto conf = PolygonShapeConf{};
@@ -72,7 +72,7 @@ public:
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
             bd.fixedRotation = true;
-            bd.location = Vec2(12.0f, 20.0f) * 1_m;
+            bd.UseLocation(Vec2(12.0f, 20.0f) * 1_m);
             bd.linearAcceleration = GetGravity();
             const auto body = CreateBody(GetWorld(), bd);
             const auto conf = PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(3_m, 3_m);

--- a/Testbed/Tests/Breakable.cpp
+++ b/Testbed/Tests/Breakable.cpp
@@ -59,8 +59,7 @@ public:
             BodyConf bd;
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
-            bd.location = Length2{0_m, 40_m};
-            bd.angle = Pi * 0.25_rad;
+            bd.Use(Position{Length2{0_m, 40_m}, Pi * 0.25_rad});
             m_body1 = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), m_body1, m_shape1);
             Attach(GetWorld(), m_body1, m_shape2);
@@ -99,8 +98,8 @@ public:
         BodyConf bd;
         bd.type = BodyType::Dynamic;
         bd.linearAcceleration = GetGravity();
-        bd.location = GetLocation(GetWorld(), m_body1);
-        bd.angle = GetAngle(GetWorld(), m_body1);
+        bd.UseLocation(GetLocation(GetWorld(), m_body1));
+        bd.UseAngle(GetAngle(GetWorld(), m_body1));
 
         const auto body2 = CreateBody(GetWorld(), bd);
         Attach(GetWorld(), body2, m_shape2);

--- a/Testbed/Tests/BulletTest.cpp
+++ b/Testbed/Tests/BulletTest.cpp
@@ -31,9 +31,7 @@ public:
     BulletTest()
     {
         {
-            BodyConf bd;
-            bd.location = Length2{};
-            const auto body = CreateBody(GetWorld(), bd);
+            const auto body = CreateBody(GetWorld(), BodyConf{}.UseLocation(Length2{}));
             Attach(GetWorld(), body,
                    CreateShape(GetWorld(),
                                EdgeShapeConf{Vec2(-10.0f, 0.0f) * 1_m, Vec2(10.0f, 0.0f) * 1_m}));
@@ -46,7 +44,7 @@ public:
             BodyConf bd;
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(0.0f, 4.0f) * 1_m;
+            bd.UseLocation(Vec2(0.0f, 4.0f) * 1_m);
 
             auto conf = PolygonShapeConf{};
             conf.UseDensity(1_kgpm2);
@@ -60,7 +58,7 @@ public:
 
             // m_x = RandomFloat(-1.0f, 1.0f);
             m_x = 0.20352793f;
-            bd.location = Vec2(m_x, 10.0f) * 1_m;
+            bd.UseLocation(Vec2(m_x, 10.0f) * 1_m);
             bd.bullet = true;
 
             m_bullet = CreateBody(GetWorld(), bd);

--- a/Testbed/Tests/Cantilever.cpp
+++ b/Testbed/Tests/Cantilever.cpp
@@ -48,7 +48,7 @@ public:
             for (auto i = 0; i < e_count; ++i) {
                 auto bd = BodyConf{};
                 bd.type = BodyType::Dynamic;
-                bd.location = Vec2(-14.5f + 1.0f * i, 5.0f) * 1_m;
+                bd.UseLocation(Vec2(-14.5f + 1.0f * i, 5.0f) * 1_m);
                 const auto body = CreateBody(GetWorld(), bd);
                 Attach(GetWorld(), body, shape);
 
@@ -67,7 +67,7 @@ public:
             for (auto i = 0; i < 3; ++i) {
                 auto bd = BodyConf{};
                 bd.type = BodyType::Dynamic;
-                bd.location = Vec2(-14.0f + 2.0f * i, 15.0f) * 1_m;
+                bd.UseLocation(Vec2(-14.0f + 2.0f * i, 15.0f) * 1_m);
                 const auto body = CreateBody(GetWorld(), bd);
                 Attach(GetWorld(), body, shape);
 
@@ -89,7 +89,7 @@ public:
             for (auto i = 0; i < e_count; ++i) {
                 auto bd = BodyConf{};
                 bd.type = BodyType::Dynamic;
-                bd.location = Vec2(-4.5f + 1.0f * i, 5.0f) * 1_m;
+                bd.UseLocation(Vec2(-4.5f + 1.0f * i, 5.0f) * 1_m);
                 const auto body = CreateBody(GetWorld(), bd);
                 Attach(GetWorld(), body, shape);
                 if (i > 0) {
@@ -108,7 +108,7 @@ public:
             for (auto i = 0; i < e_count; ++i) {
                 auto bd = BodyConf{};
                 bd.type = BodyType::Dynamic;
-                bd.location = Vec2(5.5f + 1.0f * i, 10.0f) * 1_m;
+                bd.UseLocation(Vec2(5.5f + 1.0f * i, 10.0f) * 1_m);
                 const auto body = CreateBody(GetWorld(), bd);
                 Attach(GetWorld(), body, shape);
                 if (i > 0) {
@@ -129,7 +129,7 @@ public:
         for (auto i = 0; i < 2; ++i) {
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-8.0f + 8.0f * i, 12.0f) * 1_m;
+            bd.UseLocation(Vec2(-8.0f + 8.0f * i, 12.0f) * 1_m);
             Attach(GetWorld(), CreateBody(GetWorld(), bd), polyshape);
         }
 
@@ -139,7 +139,7 @@ public:
         for (auto i = 0; i < 2; ++i) {
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-6.0f + 6.0f * i, 10.0f) * 1_m;
+            bd.UseLocation(Vec2(-6.0f + 6.0f * i, 10.0f) * 1_m);
             Attach(GetWorld(), CreateBody(GetWorld(), bd), circleshape);
         }
 

--- a/Testbed/Tests/Car.cpp
+++ b/Testbed/Tests/Car.cpp
@@ -101,10 +101,10 @@ public:
 
         // Teeter
         {
-            auto bd = BodyConf{};
-            bd.location = Vec2(140.0f, 1.0f) * 1_m;
-            bd.type = BodyType::Dynamic;
-            const auto body = CreateBody(GetWorld(), bd);
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}
+                                             .UseLocation(Vec2(140.0f, 1.0f) * 1_m)
+                                             .Use(BodyType::Dynamic));
             Attach(GetWorld(), body,
                    CreateShape(GetWorld(),
                                PolygonShapeConf{}.UseDensity(1_kgpm2).SetAsBox(10_m, 0.25_m)));
@@ -127,9 +127,10 @@ public:
                                 1_m, 0.125_m));
             auto prevBody = ground;
             for (auto i = 0; i < N; ++i) {
-                auto bd = BodyConf{}.UseType(BodyType::Dynamic);
-                bd.location = Vec2(161 + 2 * i, -0.125f) * 1_m;
-                const auto body = CreateBody(GetWorld(), bd);
+                const auto body = CreateBody(GetWorld(),
+                                             BodyConf{}
+                                                 .UseType(BodyType::Dynamic)
+                                                 .UseLocation(Vec2(161 + 2 * i, -0.125f) * 1_m));
                 Attach(GetWorld(), body, shape);
                 CreateJoint(GetWorld(), GetRevoluteJointConf(GetWorld(), prevBody, body,
                                                              Vec2(160 + 2 * i, -0.125f) * 1_m));

--- a/Testbed/Tests/Chain.cpp
+++ b/Testbed/Tests/Chain.cpp
@@ -38,10 +38,10 @@ public:
         const auto y = 25.0f;
         auto prevBody = ground;
         for (auto i = 0; i < 30; ++i) {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(0.5f + i, y) * 1_m;
+            const auto bd = BodyConf{}
+                .Use(BodyType::Dynamic)
+                .UseLinearAcceleration(GetGravity())
+                .UseLocation(Vec2(0.5f + i, y) * 1_m);
             const auto body = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), body, shape);
             CreateJoint(GetWorld(),

--- a/Testbed/Tests/CharacterCollision.cpp
+++ b/Testbed/Tests/CharacterCollision.cpp
@@ -157,23 +157,23 @@ public:
         // Square character 1
         {
             BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.fixedRotation = false;
-            bd.allowSleep = false;
+            bd.Use(BodyType::Dynamic);
+            bd.UseFixedRotation(false);
+            bd.UseAllowSleep(false);
             const auto square = CreateShape(
                 GetWorld(),
                 PolygonShapeConf{}.UseFriction(0.0f).UseDensity(20_kgpm2).SetAsBox(0.5_m, 0.5_m));
-            bd.location = Vec2(-3.0f, 8.0f) * 1_m;
+            bd.UseLocation(Vec2(-3.0f, 8.0f) * 1_m);
             Attach(GetWorld(), CreateBody(GetWorld(), bd), square);
-            bd.location = Vec2(19.0f, 7.0f) * 1_m;
+            bd.UseLocation(Vec2(19.0f, 7.0f) * 1_m);
             Attach(GetWorld(), CreateBody(GetWorld(), bd), square);
         }
 
         // Square character 2
         {
             BodyConf bd;
-            bd.location = Vec2(-5.0f, 5.0f) * 1_m;
-            bd.type = BodyType::Dynamic;
+            bd.UseLocation(Vec2(-5.0f, 5.0f) * 1_m);
+            bd.Use(BodyType::Dynamic);
             bd.fixedRotation = true;
             bd.allowSleep = false;
 
@@ -185,10 +185,10 @@ public:
         // Hexagon character
         {
             BodyConf bd;
-            bd.location = Vec2(-5.0f, 8.0f) * 1_m;
-            bd.type = BodyType::Dynamic;
-            bd.fixedRotation = true;
-            bd.allowSleep = false;
+            bd.Use(BodyType::Dynamic);
+            bd.UseLocation(Vec2(-5.0f, 8.0f) * 1_m);
+            bd.UseFixedRotation(true);
+            bd.UseAllowSleep(false);
 
             const auto body = CreateBody(GetWorld(), bd);
 
@@ -207,10 +207,10 @@ public:
         // Disk character
         {
             BodyConf bd;
-            bd.location = Vec2(3.0f, 5.0f) * 1_m;
-            bd.type = BodyType::Dynamic;
-            bd.fixedRotation = true;
-            bd.allowSleep = false;
+            bd.Use(BodyType::Dynamic);
+            bd.UseLocation(Vec2(3.0f, 5.0f) * 1_m);
+            bd.UseFixedRotation(true);
+            bd.UseAllowSleep(false);
 
             const auto body = CreateBody(GetWorld(), bd);
             auto conf = DiskShapeConf{};
@@ -222,9 +222,9 @@ public:
         // Disk character
         {
             BodyConf bd;
-            bd.location = Vec2(-7.0f, 6.0f) * 1_m;
-            bd.type = BodyType::Dynamic;
-            bd.allowSleep = false;
+            bd.Use(BodyType::Dynamic);
+            bd.UseLocation(Vec2(-7.0f, 6.0f) * 1_m);
+            bd.UseAllowSleep(false);
 
             m_character = CreateBody(GetWorld(), bd);
 

--- a/Testbed/Tests/CollisionFiltering.cpp
+++ b/Testbed/Tests/CollisionFiltering.cpp
@@ -71,7 +71,7 @@ public:
 
         auto triangleBodyConf = BodyConf{};
         triangleBodyConf.type = BodyType::Dynamic;
-        triangleBodyConf.location = Vec2(-5.0f, 2.0f) * 1_m;
+        triangleBodyConf.UseLocation(Vec2(-5.0f, 2.0f) * 1_m);
 
         const auto body1 = CreateBody(GetWorld(), triangleBodyConf);
         Attach(GetWorld(), body1,
@@ -83,7 +83,7 @@ public:
         vertices[2] *= 2.0f;
         polygon.Set(vertices);
         triangleFilter.groupIndex = k_largeGroup;
-        triangleBodyConf.location = Vec2(-5.0f, 6.0f) * 1_m;
+        triangleBodyConf.UseLocation(Vec2(-5.0f, 6.0f) * 1_m);
         triangleBodyConf.fixedRotation = true; // look at me!
 
         const auto body2 = CreateBody(GetWorld(), triangleBodyConf);
@@ -93,7 +93,7 @@ public:
         {
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-5.0f, 10.0f) * 1_m;
+            bd.UseLocation(Vec2(-5.0f, 10.0f) * 1_m);
             const auto body = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), body,
                    CreateShape(GetWorld(),
@@ -124,7 +124,7 @@ public:
 
         auto boxBodyConf = BodyConf{};
         boxBodyConf.type = BodyType::Dynamic;
-        boxBodyConf.location = Vec2(0.0f, 2.0f) * 1_m;
+        boxBodyConf.UseLocation(Vec2(0.0f, 2.0f) * 1_m);
 
         const auto body3 = CreateBody(GetWorld(), boxBodyConf);
         Attach(GetWorld(), body3,
@@ -133,7 +133,7 @@ public:
         // Large box (recycle definitions)
         polygon.SetAsBox(2_m, 1_m);
         boxShapeFilter.groupIndex = k_largeGroup;
-        boxBodyConf.location = Vec2(0.0f, 6.0f) * 1_m;
+        boxBodyConf.UseLocation(Vec2(0.0f, 6.0f) * 1_m);
 
         const auto body4 = CreateBody(GetWorld(), boxBodyConf);
         Attach(GetWorld(), body4,
@@ -150,7 +150,7 @@ public:
 
         auto circleBodyConf = BodyConf{};
         circleBodyConf.type = BodyType::Dynamic;
-        circleBodyConf.location = Vec2(5.0f, 2.0f) * 1_m;
+        circleBodyConf.UseLocation(Vec2(5.0f, 2.0f) * 1_m);
 
         const auto body5 = CreateBody(GetWorld(), circleBodyConf);
         circleConf.vertexRadius = 1_m;
@@ -159,7 +159,7 @@ public:
 
         // Large circle
         circleShapeFilter.groupIndex = k_largeGroup;
-        circleBodyConf.location = Vec2(5.0f, 6.0f) * 1_m;
+        circleBodyConf.UseLocation(Vec2(5.0f, 6.0f) * 1_m);
 
         const auto body6 = CreateBody(GetWorld(), circleBodyConf);
         circleConf.vertexRadius = circleConf.vertexRadius * 2;

--- a/Testbed/Tests/CollisionProcessing.cpp
+++ b/Testbed/Tests/CollisionProcessing.cpp
@@ -52,8 +52,8 @@ public:
         polygon.UseDensity(1_kgpm2);
 
         BodyConf triangleBodyConf;
-        triangleBodyConf.type = BodyType::Dynamic;
-        triangleBodyConf.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
+        triangleBodyConf.Use(BodyType::Dynamic);
+        triangleBodyConf.UseLocation(Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m);
 
         const auto body1 = CreateBody(GetWorld(), triangleBodyConf);
         Attach(GetWorld(), body1, CreateShape(GetWorld(), polygon));
@@ -64,7 +64,7 @@ public:
         vertices[2] *= 2.0f;
         polygon.Set(vertices);
 
-        triangleBodyConf.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
+        triangleBodyConf.UseLocation(Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m);
 
         const auto body2 = CreateBody(GetWorld(), triangleBodyConf);
         Attach(GetWorld(), body2, CreateShape(GetWorld(), polygon));
@@ -74,14 +74,14 @@ public:
 
         BodyConf boxBodyConf;
         boxBodyConf.type = BodyType::Dynamic;
-        boxBodyConf.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
+        boxBodyConf.UseLocation(Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m);
 
         const auto body3 = CreateBody(GetWorld(), boxBodyConf);
         Attach(GetWorld(), body3, CreateShape(GetWorld(), polygon));
 
         // Large box (recycle definitions)
         polygon.SetAsBox(2_m, 1_m);
-        boxBodyConf.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
+        boxBodyConf.UseLocation(Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m);
 
         const auto body4 = CreateBody(GetWorld(), boxBodyConf);
         Attach(GetWorld(), body4, CreateShape(GetWorld(), polygon));
@@ -90,13 +90,13 @@ public:
         circleBodyConf.type = BodyType::Dynamic;
 
         // Small circle
-        circleBodyConf.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
+        circleBodyConf.UseLocation(Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m);
         const auto body5 = CreateBody(GetWorld(), circleBodyConf);
         Attach(GetWorld(), body5,
                CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(1_m).UseDensity(1_kgpm2)));
 
         // Large circle
-        circleBodyConf.location = Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m;
+        circleBodyConf.UseLocation(Vec2(RandomFloat(xLo, xHi), RandomFloat(yLo, yHi)) * 1_m);
         const auto body6 = CreateBody(GetWorld(), circleBodyConf);
         Attach(GetWorld(), body6,
                CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(2_m).UseDensity(1_kgpm2)));

--- a/Testbed/Tests/CompoundShapes.cpp
+++ b/Testbed/Tests/CompoundShapes.cpp
@@ -45,10 +45,11 @@ public:
             const auto circle2 = CreateShape(GetWorld(), conf);
             for (auto i = 0; i < 10; ++i) {
                 const auto x = RandomFloat(-0.1f, 0.1f);
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2(x + 5.0f, 1.05f + 2.5f * i) * 1_m;
-                bd.angle = 1_rad * RandomFloat(-Pi, Pi);
+                const auto bd =
+                    BodyConf{}
+                        .Use(BodyType::Dynamic)
+                        .UseLocation(Vec2(x + 5.0f, 1.05f + 2.5f * i) * 1_m)
+                        .UseAngle(1_rad * RandomFloat(-Pi, Pi));
                 const auto body = CreateBody(GetWorld(), bd);
                 Attach(GetWorld(), body, circle1);
                 Attach(GetWorld(), body, circle2);
@@ -65,10 +66,11 @@ public:
             const auto polygon2 = CreateShape(GetWorld(), conf);
             for (int i = 0; i < 10; ++i) {
                 const auto x = RandomFloat(-0.1f, 0.1f);
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2(x - 5.0f, 1.05f + 2.5f * i) * 1_m;
-                bd.angle = 1_rad * RandomFloat(-Pi, Pi);
+                const auto bd =
+                    BodyConf{}
+                        .Use(BodyType::Dynamic)
+                        .UseLocation(Vec2(x - 5.0f, 1.05f + 2.5f * i) * 1_m)
+                        .UseAngle(1_rad * RandomFloat(-Pi, Pi));
                 const auto body = CreateBody(GetWorld(), bd);
                 Attach(GetWorld(), body, polygon1);
                 Attach(GetWorld(), body, polygon2);
@@ -100,11 +102,11 @@ public:
 
             for (auto i = 0; i < 10; ++i) {
                 const auto x = RandomFloat(-0.1f, 0.1f);
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2(x, 2.05f + 2.5f * i) * 1_m;
-                bd.angle = 0_rad;
-                const auto body = CreateBody(GetWorld(), bd);
+                const auto body = CreateBody(GetWorld(),
+                                             BodyConf{}
+                                                 .Use(BodyType::Dynamic)
+                                                 .UseLocation(Vec2(x, 2.05f + 2.5f * i) * 1_m)
+                                                 .UseAngle(0_rad));
                 Attach(GetWorld(), body, triangle1);
                 Attach(GetWorld(), body, triangle2);
             }
@@ -120,11 +122,10 @@ public:
             conf.UseDensity(4_kgpm2);
             conf.SetAsBox(0.15_m, 2.7_m, Vec2(1.45f, 2.35f) * 1_m, -0.2_rad);
             const auto right = CreateShape(GetWorld(), conf);
-
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(0.0f, 2.0f) * 1_m;
-            const auto body = CreateBody(GetWorld(), bd);
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}
+                                             .Use(BodyType::Dynamic)
+                                             .UseLocation(Vec2(0.0f, 2.0f) * 1_m));
             Attach(GetWorld(), body, bottom);
             Attach(GetWorld(), body, left);
             Attach(GetWorld(), body, right);

--- a/Testbed/Tests/Confined.cpp
+++ b/Testbed/Tests/Confined.cpp
@@ -71,10 +71,10 @@ public:
         for (auto j = 0; j < e_columnCount; ++j) {
             for (auto i = 0; i < e_rowCount; ++i) {
                 BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2{-10.0f + (2.1f * j + 1.0f + 0.01f * i) * (radius / 1_m),
-                                   (2.0f * i + 1.0f) * (radius / 1_m)} *
-                              1_m;
+                bd.Use(BodyType::Dynamic);
+                bd.UseLocation(Vec2{-10.0f + (2.1f * j + 1.0f + 0.01f * i) * (radius / 1_m),
+                                    (2.0f * i + 1.0f) * (radius / 1_m)} *
+                               1_m);
                 Attach(GetWorld(), CreateBody(GetWorld(), bd), shape);
             }
         }
@@ -100,13 +100,11 @@ public:
     void CreateCircle()
     {
         const auto radius = wall_length / 10; // 2
-
-        BodyConf bd;
-        bd.type = BodyType::Dynamic;
-        bd.bullet = m_bullet_mode;
-        bd.location = Vec2{0, 20} * 1_m + GetRandomOffset();
+        auto bd = BodyConf{};
+        bd.Use(BodyType::Dynamic);
+        bd.UseBullet(m_bullet_mode);
+        bd.UseLocation(Vec2{0, 20} * 1_m + GetRandomOffset());
         // bd.allowSleep = false;
-
         auto conf = DiskShapeConf{};
         conf.density = 1_kgpm2;
         conf.restitution = 0.8f;
@@ -119,9 +117,9 @@ public:
         const auto side_length = wall_length / Real{5}; // 4
         // originally restitution was 0.8f
         BodyConf bd;
-        bd.type = BodyType::Dynamic;
-        bd.bullet = m_bullet_mode;
-        bd.location = Vec2{0, 20} * 1_m + GetRandomOffset();
+        bd.Use(BodyType::Dynamic);
+        bd.UseBullet(m_bullet_mode);
+        bd.UseLocation(Vec2{0, 20} * 1_m + GetRandomOffset());
         Attach(GetWorld(), CreateBody(GetWorld(), bd),
                CreateShape(GetWorld(),
                            PolygonShapeConf{}.UseDensity(1_kgpm2).UseRestitution(0.0f).SetAsBox(

--- a/Testbed/Tests/ContinuousTest.cpp
+++ b/Testbed/Tests/ContinuousTest.cpp
@@ -44,7 +44,7 @@ public:
         {
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(0.0f, 20.0f) * 1_m;
+            bd.UseLocation(Vec2(0.0f, 20.0f) * 1_m);
             bd.linearAcceleration = GetGravity();
             // bd.angle = 0.1f;
 

--- a/Testbed/Tests/ConveyorBelt.cpp
+++ b/Testbed/Tests/ConveyorBelt.cpp
@@ -43,9 +43,8 @@ public:
 
         // Platform
         {
-            BodyConf bd;
-            bd.location = Vec2(-5.0f, 5.0f) * 1_m;
-            const auto body = CreateBody(GetWorld(), bd);
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}.UseLocation(Vec2(-5.0f, 5.0f) * 1_m));
 
             auto conf = PolygonShapeConf{};
             conf.friction = 0.8f;
@@ -61,7 +60,7 @@ public:
             BodyConf bd;
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(-10.0f + 2.0f * i, 7.0f) * 1_m;
+            bd.UseLocation(Vec2(-10.0f + 2.0f * i, 7.0f) * 1_m);
             const auto body = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), body, boxshape);
         }

--- a/Testbed/Tests/Dominos.cpp
+++ b/Testbed/Tests/Dominos.cpp
@@ -36,9 +36,8 @@ public:
                            EdgeShapeConf(Vec2(-40.0f, 0.0f) * 1_m, Vec2(40.0f, 0.0f) * 1_m)));
 
         {
-            BodyConf bd;
-            bd.location = Vec2(-1.5f, 10.0f) * 1_m;
-            const auto ground = CreateBody(GetWorld(), bd);
+            const auto ground = CreateBody(GetWorld(),
+                                           BodyConf{}.UseLocation(Vec2(-1.5f, 10.0f) * 1_m));
             Attach(GetWorld(), ground, CreateShape(GetWorld(), PolygonShapeConf{6_m, 0.25_m}));
         }
 
@@ -59,10 +58,8 @@ public:
         {
             auto shape = PolygonShapeConf{};
             shape.SetAsBox(7.2_m, 0.25_m, Length2{}, 0.3_rad);
-
-            BodyConf bd;
-            bd.location = Vec2(1.2f, 6.0f) * 1_m;
-            const auto ground = CreateBody(GetWorld(), bd);
+            const auto ground = CreateBody(GetWorld(),
+                                           BodyConf{}.UseLocation(Vec2(1.2f, 6.0f) * 1_m));
             Attach(GetWorld(), ground, CreateShape(GetWorld(), shape));
         }
 
@@ -71,11 +68,11 @@ public:
 
         BodyID b3;
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-0.9f, 1.0f) * 1_m;
-            bd.angle = -0.15_rad;
-            b3 = CreateBody(GetWorld(), bd);
+            b3 = CreateBody(GetWorld(),
+                            BodyConf{}
+                                .Use(BodyType::Dynamic)
+                                .UseLocation(Vec2(-0.9f, 1.0f) * 1_m)
+                                .UseAngle(-0.15_rad));
             Attach(GetWorld(), b3,
                    CreateShape(GetWorld(),
                                PolygonShapeConf{}.UseDensity(10_kgpm2).SetAsBox(6_m, 0.125_m)));
@@ -87,10 +84,8 @@ public:
 
         BodyID b4;
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-10.0f, 15.0f) * 1_m;
-            b4 = CreateBody(GetWorld(), bd);
+            b4 = CreateBody(GetWorld(),
+                            BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(-10.0f, 15.0f) * 1_m));
             Attach(GetWorld(), b4,
                    CreateShape(GetWorld(),
                                PolygonShapeConf{}.UseDensity(10_kgpm2).SetAsBox(0.25_m, 0.25_m)));
@@ -102,10 +97,8 @@ public:
 
         BodyID b5;
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(6.5f, 3.0f) * 1_m;
-            b5 = CreateBody(GetWorld(), bd);
+            b5 = CreateBody(GetWorld(),
+                            BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(6.5f, 3.0f) * 1_m));
             auto conf = PolygonShapeConf{};
             conf.density = 10_kgpm2;
             conf.friction = 0.1f;
@@ -123,10 +116,8 @@ public:
 
         BodyID b6;
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(6.5f, 4.1f) * 1_m;
-            b6 = CreateBody(GetWorld(), bd);
+            b6 = CreateBody(GetWorld(),
+                            BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(6.5f, 4.1f) * 1_m));
             Attach(GetWorld(), b6,
                    CreateShape(GetWorld(), PolygonShapeConf(1_m, 0.1_m).UseDensity(30_kgpm2)));
         }
@@ -136,10 +127,8 @@ public:
 
         BodyID b7;
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(7.4f, 1.0f) * 1_m;
-            b7 = CreateBody(GetWorld(), bd);
+            b7 = CreateBody(GetWorld(),
+                            BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(7.4f, 1.0f) * 1_m));
             auto conf = PolygonShapeConf{};
             conf.density = 10_kgpm2;
             conf.SetAsBox(0.1_m, 1_m);
@@ -157,16 +146,16 @@ public:
         CreateJoint(GetWorld(), djd);
 
         {
-            const auto radius = 0.2_m;
+            const auto r = 0.2_m;
             auto conf = DiskShapeConf{};
             conf.density = 10_kgpm2;
-            conf.vertexRadius = radius;
+            conf.vertexRadius = r;
             const auto shape = CreateShape(GetWorld(), conf);
             for (auto i = 0; i < 4; ++i) {
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Length2{5.9_m + 2 * radius * static_cast<Real>(i), 2.4_m};
-                const auto body = CreateBody(GetWorld(), bd);
+                const auto body = CreateBody(GetWorld(),
+                                             BodyConf{}
+                                                 .Use(BodyType::Dynamic)
+                                                 .UseLocation(Length2{5.9_m + 2 * r * Real(i), 2.4_m}));
                 Attach(GetWorld(), body, shape);
             }
         }

--- a/Testbed/Tests/DumpShell.cpp
+++ b/Testbed/Tests/DumpShell.cpp
@@ -50,8 +50,8 @@ public:
         {
             BodyConf bd;
             bd.type = BodyType(0);
-            bd.location = Vec2(2.587699890136719e-02f, 5.515012264251709e+00f) * 1_m;
-            bd.angle = 0_rad;
+            bd.UseLocation(Vec2(2.587699890136719e-02f, 5.515012264251709e+00f) * 1_m);
+            bd.UseAngle(0_rad);
             bd.linearVelocity = Vec2(0.000000000000000e+00f, 0.000000000000000e+00f) * 1_mps;
             bd.angularVelocity = 0_rad / 1_s;
             bd.linearDamping = 0_Hz;
@@ -83,8 +83,8 @@ public:
         {
             BodyConf bd;
             bd.type = BodyType(2);
-            bd.location = Vec2(-3.122138977050781e-02f, 7.535382270812988e+00f) * 1_m;
-            bd.angle = -1.313644275069237e-02_rad;
+            bd.UseLocation(Vec2(-3.122138977050781e-02f, 7.535382270812988e+00f) * 1_m);
+            bd.UseAngle(-1.313644275069237e-02_rad);
             bd.linearVelocity = Vec2(8.230687379837036e-01f, 7.775862514972687e-02f) * 1_mps;
             bd.angularVelocity = 3.705333173274994e-02_rad / 1_s;
             bd.linearDamping = 0_Hz;
@@ -118,8 +118,8 @@ public:
         {
             BodyConf bd;
             bd.type = BodyType(2);
-            bd.location = Vec2(-7.438077926635742e-01f, 6.626811981201172e+00f) * 1_m;
-            bd.angle = -1.884713363647461e+01_rad;
+            bd.UseLocation(Vec2(-7.438077926635742e-01f, 6.626811981201172e+00f) * 1_m);
+            bd.UseAngle(-1.884713363647461e+01_rad);
             bd.linearVelocity = Vec2(1.785794943571091e-01f, 3.799796104431152e-07f) * 1_mps;
             bd.angularVelocity = -5.908820639888290e-06_rad / 1_s;
             bd.linearDamping = 0_Hz;

--- a/Testbed/Tests/EdgeShapes.cpp
+++ b/Testbed/Tests/EdgeShapes.cpp
@@ -100,29 +100,23 @@ public:
             Destroy(GetWorld(), m_bodies[m_bodyIndex]);
             m_bodies[m_bodyIndex] = InvalidBodyID;
         }
-
-        BodyConf bd;
-
         const auto x = RandomFloat(-10.0f, 10.0f);
         const auto y = RandomFloat(10.0f, 20.0f);
-        bd.location = Vec2(x, y) * 1_m;
-        bd.angle = 1_rad * RandomFloat(-Pi, Pi);
-        bd.type = BodyType::Dynamic;
-        bd.linearAcceleration = GetGravity();
-
+        auto bd = BodyConf{};
+        bd.UseLocation(Vec2(x, y) * 1_m);
+        bd.UseAngle(1_rad * RandomFloat(-Pi, Pi));
+        bd.Use(BodyType::Dynamic);
+        bd.UseLinearAcceleration(GetGravity());
         if (index == 4) {
-            bd.angularDamping = 0.02_Hz;
+            bd.UseAngularDamping(0.02_Hz);
         }
-
         m_bodies[m_bodyIndex] = CreateBody(GetWorld(), bd);
-
         if (index < 4) {
             Attach(GetWorld(), m_bodies[m_bodyIndex], m_polygons[index]);
         }
         else {
             Attach(GetWorld(), m_bodies[m_bodyIndex], m_circle);
         }
-
         m_bodyIndex = GetModuloNext(m_bodyIndex, static_cast<decltype(m_bodyIndex)>(e_maxBodies));
     }
 

--- a/Testbed/Tests/EdgeTest.cpp
+++ b/Testbed/Tests/EdgeTest.cpp
@@ -59,7 +59,7 @@ public:
         {
             BodyConf bd;
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-0.5f, 0.6f) * 1_m;
+            bd.UseLocation(Vec2(-0.5f, 0.6f) * 1_m);
             bd.allowSleep = false;
             const auto body = CreateBody(GetWorld(), bd);
 
@@ -72,7 +72,7 @@ public:
         {
             BodyConf bd;
             bd.type = BodyType::Dynamic;
-            bd.location = Vec2(1.0f, 0.6f) * 1_m;
+            bd.UseLocation(Vec2(1.0f, 0.6f) * 1_m);
             bd.allowSleep = false;
             const auto body = CreateBody(GetWorld(), bd);
 

--- a/Testbed/Tests/FifteenPuzzle.cpp
+++ b/Testbed/Tests/FifteenPuzzle.cpp
@@ -81,7 +81,7 @@ public:
         BodyConf bd;
         bd.type = BodyType::Dynamic;
         bd.bullet = true;
-        bd.location = GetCenter() + relPos + Length2{sideLength / 2, sideLength / 2};
+        bd.UseLocation(GetCenter() + relPos + Length2{sideLength / 2, sideLength / 2});
         bd.linearDamping = 20_Hz;
         const auto body = CreateBody(GetWorld(), bd);
         Attach(GetWorld(), body, CreateShape(GetWorld(), conf));

--- a/Testbed/Tests/Gears.cpp
+++ b/Testbed/Tests/Gears.cpp
@@ -40,27 +40,23 @@ public:
         const auto box =
             CreateShape(GetWorld(), PolygonShapeConf{}.SetAsBox(0.5_m, 5_m).UseDensity(5_kgpm2));
         {
-            auto bd1 = BodyConf{};
-            bd1.type = BodyType::Static;
-            bd1.location = Vec2(10.0f, 9.0f) * 1_m;
-            const auto body1 = CreateBody(GetWorld(), bd1);
+            const auto location1 = Vec2(10.0f, 9.0f) * 1_m;
+            const auto body1 = CreateBody(GetWorld(),
+                                          BodyConf{}.Use(BodyType::Static).UseLocation(location1));
 
-            auto bd2 = BodyConf{};
-            bd2.type = BodyType::Dynamic;
-            bd2.location = Vec2(10.0f, 8.0f) * 1_m;
+            const auto bd2 = BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(10.0f, 8.0f) * 1_m);
             const auto body2 = CreateBody(GetWorld(), bd2);
             Attach(GetWorld(), body2, box);
 
-            auto bd3 = BodyConf{};
-            bd3.type = BodyType::Dynamic;
-            bd3.location = Vec2(10.0f, 6.0f) * 1_m;
-            const auto body3 = CreateBody(GetWorld(), bd3);
+            const auto location3 = Vec2(10.0f, 6.0f) * 1_m;
+            const auto body3 = CreateBody(GetWorld(),
+                                          BodyConf{}.Use(BodyType::Dynamic).UseLocation(location3));
             Attach(GetWorld(), body3, Shape{circle2});
 
             auto joint1 = CreateJoint(GetWorld(),
-                                      GetRevoluteJointConf(GetWorld(), body2, body1, bd1.location));
+                                      GetRevoluteJointConf(GetWorld(), body2, body1, location1));
             auto joint2 = CreateJoint(GetWorld(),
-                                      GetRevoluteJointConf(GetWorld(), body2, body3, bd3.location));
+                                      GetRevoluteJointConf(GetWorld(), body2, body3, location3));
 
             auto jd4 = GetGearJointConf(GetWorld(), joint1, joint2);
             jd4.ratio = circle2.GetRadius() / circle1.GetRadius();
@@ -68,37 +64,34 @@ public:
         }
 
         {
-            auto bd1 = BodyConf{};
-            bd1.type = BodyType::Dynamic;
-            bd1.location = Vec2(-3.0f, 12.0f) * 1_m;
-            const auto body1 = CreateBody(GetWorld(), bd1);
+            const auto location1 = Vec2(-3.0f, 12.0f) * 1_m;
+            const auto body1 = CreateBody(GetWorld(),
+                                          BodyConf{}.Use(BodyType::Dynamic).UseLocation(location1));
             Attach(GetWorld(), body1, Shape{circle1});
 
             auto jd1 = RevoluteJointConf{};
             jd1.bodyA = ground;
             jd1.bodyB = body1;
-            jd1.localAnchorA = GetLocalPoint(GetWorld(), ground, bd1.location);
-            jd1.localAnchorB = GetLocalPoint(GetWorld(), body1, bd1.location);
+            jd1.localAnchorA = GetLocalPoint(GetWorld(), ground, location1);
+            jd1.localAnchorB = GetLocalPoint(GetWorld(), body1, location1);
             jd1.referenceAngle = GetAngle(GetWorld(), body1) - GetAngle(GetWorld(), ground);
             m_joint1 = CreateJoint(GetWorld(), jd1);
 
-            auto bd2 = BodyConf{};
-            bd2.type = BodyType::Dynamic;
-            bd2.location = Vec2(0.0f, 12.0f) * 1_m;
-            const auto body2 = CreateBody(GetWorld(), bd2);
+            const auto location2 = Vec2(0.0f, 12.0f) * 1_m;
+            const auto body2 = CreateBody(GetWorld(),
+                                          BodyConf{}.Use(BodyType::Dynamic).UseLocation(location2));
             Attach(GetWorld(), body2, Shape{circle2});
 
-            auto jd2 = GetRevoluteJointConf(GetWorld(), ground, body2, bd2.location);
+            auto jd2 = GetRevoluteJointConf(GetWorld(), ground, body2, location2);
             m_joint2 = CreateJoint(GetWorld(), jd2);
 
-            auto bd3 = BodyConf{};
-            bd3.type = BodyType::Dynamic;
-            bd3.location = Vec2(2.5f, 12.0f) * 1_m;
-            const auto body3 = CreateBody(GetWorld(), bd3);
+            const auto location3 = Vec2(2.5f, 12.0f) * 1_m;
+            const auto body3 = CreateBody(GetWorld(),
+                                          BodyConf{}.Use(BodyType::Dynamic).UseLocation(location3));
             Attach(GetWorld(), body3, box);
 
             auto jd3 =
-                GetPrismaticJointConf(GetWorld(), ground, body3, bd3.location, UnitVec::GetUp());
+                GetPrismaticJointConf(GetWorld(), ground, body3, location3, UnitVec::GetUp());
             jd3.lowerTranslation = -5_m;
             jd3.upperTranslation = 5_m;
             jd3.enableLimit = true;

--- a/Testbed/Tests/JointsTest.cpp
+++ b/Testbed/Tests/JointsTest.cpp
@@ -230,8 +230,8 @@ private:
         auto jd1 = RevoluteJointConf{};
         jd1.bodyA = containerBody;
         jd1.bodyB = body1;
-        jd1.localAnchorA = GetLocalPoint(GetWorld(), containerBody, bd1.location);
-        jd1.localAnchorB = GetLocalPoint(GetWorld(), body1, bd1.location);
+        jd1.localAnchorA = GetLocalPoint(GetWorld(), containerBody, GetLocation(bd1));
+        jd1.localAnchorB = GetLocalPoint(GetWorld(), body1, GetLocation(bd1));
         jd1.referenceAngle = GetAngle(GetWorld(), body1) - GetAngle(GetWorld(), containerBody);
         const auto joint1 = CreateJoint(GetWorld(), jd1);
 
@@ -239,7 +239,7 @@ private:
         const auto body2 = CreateBody(GetWorld(), bd2);
         Attach(GetWorld(), body2, m_diskShape);
 
-        const auto jd2 = GetRevoluteJointConf(GetWorld(), containerBody, body2, bd2.location);
+        const auto jd2 = GetRevoluteJointConf(GetWorld(), containerBody, body2, GetLocation(bd2));
         const auto joint2 = CreateJoint(GetWorld(), jd2);
 
         auto bd3 = BodyConf(DynamicBD)
@@ -248,7 +248,7 @@ private:
         const auto body3 = CreateBody(GetWorld(), bd3);
         Attach(GetWorld(), body3, m_rectShape);
 
-        auto jd3 = GetPrismaticJointConf(GetWorld(), containerBody, body3, bd3.location,
+        auto jd3 = GetPrismaticJointConf(GetWorld(), containerBody, body3, GetLocation(bd3),
                                          UnitVec::GetUp());
         jd3.upperTranslation = +0_m;
         jd3.lowerTranslation = -3.6_m;

--- a/Testbed/Tests/Mobile.cpp
+++ b/Testbed/Tests/Mobile.cpp
@@ -54,7 +54,7 @@ public:
         BodyConf bodyConf;
         bodyConf.type = BodyType::Dynamic;
         bodyConf.linearAcceleration = GetGravity();
-        bodyConf.location = GetLocation(GetWorld(), parent) + localAnchor - h;
+        bodyConf.UseLocation(GetLocation(GetWorld(), parent) + localAnchor - h);
         const auto body = CreateBody(GetWorld(), bodyConf);
         Attach(GetWorld(), body, shape);
 

--- a/Testbed/Tests/MobileBalanced.cpp
+++ b/Testbed/Tests/MobileBalanced.cpp
@@ -59,7 +59,7 @@ public:
         BodyConf bodyConf;
         bodyConf.type = BodyType::Dynamic;
         bodyConf.linearAcceleration = GetGravity();
-        bodyConf.location = p;
+        bodyConf.UseLocation(p);
         const auto body = CreateBody(GetWorld(), bodyConf);
 
         Attach(GetWorld(), body, shape);

--- a/Testbed/Tests/NewtonsCradle.cpp
+++ b/Testbed/Tests/NewtonsCradle.cpp
@@ -100,11 +100,10 @@ public:
             return;
         }
         m_frame = [&]() {
-            BodyConf bd;
-            bd.type = BodyType::Static;
-            bd.location = Length2{0, frame_height};
-            const auto body = CreateBody(GetWorld(), bd);
-
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}
+                                             .Use(BodyType::Static)
+                                             .UseLocation(Length2{0, frame_height}));
             const auto frame_width = frame_width_per_arm * static_cast<Real>(m_num_arms);
             const auto shape =
                 PolygonShapeConf{}.SetAsBox(frame_width / 2, frame_width / 24).UseDensity(20_kgpm2);
@@ -114,14 +113,12 @@ public:
 
         for (auto i = decltype(m_num_arms){0}; i < m_num_arms; ++i) {
             const auto x = (((i + Real(0.5f)) - Real(m_num_arms) / 2) * frame_width_per_arm);
-
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.linearAcceleration = GetGravity();
-            bd.bullet = m_bullet_mode;
-            bd.location = Length2{x, frame_height - (arm_length / 2)};
-
-            m_swings[i] = CreateBody(GetWorld(), bd);
+            m_swings[i] = CreateBody(GetWorld(),
+                                     BodyConf{}
+                                         .Use(BodyType::Dynamic)
+                                         .UseLinearAcceleration(GetGravity())
+                                         .UseBullet(m_bullet_mode)
+                                         .UseLocation(Length2{x, frame_height - (arm_length / 2)}));
             CreateArm(m_swings[i], arm_length);
             CreateBall(m_swings[i], Length2{0, -arm_length / 2}, ball_radius);
 
@@ -150,18 +147,15 @@ public:
     {
         if (!IsValid(m_right_side_wall)) {
             const auto frame_width = static_cast<Real>(m_num_arms) * frame_width_per_arm;
-
-            BodyConf def;
-            def.type = BodyType::Static;
-            def.location =
-                Length2{frame_width / 2 + frame_width / 24, frame_height - (arm_length / 2)};
-            const auto body = CreateBody(GetWorld(), def);
-
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}
+                                             .Use(BodyType::Static)
+                                             .UseLocation(Length2{frame_width / 2 + frame_width / 24,
+                                                                  frame_height - (arm_length / 2)}));
             const auto shape = PolygonShapeConf{}
                                    .SetAsBox(frame_width / 24, arm_length / 2 + frame_width / 24)
                                    .UseDensity(20_kgpm2);
             Attach(GetWorld(), body, CreateShape(GetWorld(), shape));
-
             m_right_side_wall = body;
         }
     }
@@ -170,13 +164,12 @@ public:
     {
         if (!IsValid(m_left_side_wall)) {
             const auto frame_width = static_cast<Real>(m_num_arms) * frame_width_per_arm;
-
-            BodyConf def;
-            def.type = BodyType::Static;
-            def.location = Length2{-(frame_width / Real{2} + frame_width / Real{24}),
-                                   frame_height - (arm_length / Real{2})};
-            const auto body = CreateBody(GetWorld(), def);
-
+            const auto location = Length2{-(frame_width / Real{2} + frame_width / Real{24}),
+                                          frame_height - (arm_length / Real{2})};
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}
+                                             .Use(BodyType::Static)
+                                             .UseLocation(location));
             const auto shape = PolygonShapeConf{}
                                    .SetAsBox(frame_width / Real{24},
                                              (arm_length / Real{2} + frame_width / Real{24}))

--- a/Testbed/Tests/OneSidedPlatform.cpp
+++ b/Testbed/Tests/OneSidedPlatform.cpp
@@ -46,9 +46,8 @@ public:
 
         // Platform
         {
-            BodyConf bd;
-            bd.location = Vec2(0.0f, 10.0f) * 1_m;
-            const auto body = CreateBody(GetWorld(), bd);
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}.UseLocation(Vec2(0.0f, 10.0f) * 1_m));
             m_platform = CreateShape(GetWorld(), PolygonShapeConf{}.SetAsBox(3_m, 0.5_m));
             Attach(GetWorld(), body, m_platform);
             m_bottom = Real(10.0f - 0.5f) * 1_m;
@@ -58,9 +57,9 @@ public:
         // Actor
         {
             BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(0.0f, 12.0f) * 1_m;
+            bd.Use(BodyType::Dynamic);
+            bd.UseLinearAcceleration(GetGravity());
+            bd.UseLocation(Vec2(0.0f, 12.0f) * 1_m);
             m_characterBodyId = CreateBody(GetWorld(), bd);
             auto conf = DiskShapeConf{};
             conf.vertexRadius = m_radius;

--- a/Testbed/Tests/Orbiter.cpp
+++ b/Testbed/Tests/Orbiter.cpp
@@ -43,22 +43,19 @@ public:
     Orbiter() : Test(GetTestConf())
     {
         SetGravity(LinearAcceleration2{});
-        {
-            auto bd = BodyConf{};
-            bd.type = BodyType::Static;
-            bd.location = m_center;
-            bd.shapes += CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(3_m));
-            CreateBody(GetWorld(), bd);
-        }
+        CreateBody(GetWorld(),
+                   BodyConf{}
+                       .Use(BodyType::Static)
+                       .UseLocation(m_center)
+                       .Use(CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(3_m))));
         {
             const auto radius = Real{12.0f};
             auto bd = BodyConf{};
-            bd.type = BodyType::Dynamic;
-            bd.location = Length2{GetX(m_center), GetY(m_center) + radius * 1_m};
-            bd.shapes +=
-                CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(0.5_m).UseDensity(1e12_kgpm2));
-            bd.linearVelocity = Vec2{Pi * radius / 2, 0} * 1_mps;
-            bd.angularVelocity = 360_deg / 1_s;
+            bd.Use(BodyType::Dynamic);
+            bd.UseLocation(Length2{GetX(m_center), GetY(m_center) + radius * 1_m});
+            bd.Use(CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(0.5_m).UseDensity(1e12_kgpm2)));
+            bd.UseLinearVelocity(Vec2{Pi * radius / 2, 0} * 1_mps);
+            bd.UseAngularVelocity(360_deg / 1_s);
             m_orbiter = CreateBody(GetWorld(), bd);
         }
         {
@@ -67,10 +64,10 @@ public:
             conf.UseVertexRadius(0.1_m);
             conf.UseDensity(1e3_kgpm2);
             auto bd = BodyConf{};
-            bd.type = BodyType::Dynamic;
-            bd.location = m_center;
-            bd.bullet = true;
-            bd.shapes += CreateShape(GetWorld(), conf);
+            bd.Use(BodyType::Dynamic);
+            bd.UseLocation(m_center);
+            bd.UseBullet(true);
+            bd.Use(CreateShape(GetWorld(), conf));
             CreateBody(GetWorld(), bd);
         }
     }

--- a/Testbed/Tests/Pinball.cpp
+++ b/Testbed/Tests/Pinball.cpp
@@ -51,14 +51,12 @@ public:
             const auto p1 = Vec2(-2.0f, 0.0f) * 1_m;
             const auto p2 = Vec2(+2.0f, 0.0f) * 1_m;
 
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.linearAcceleration = GetGravity();
+            auto bd = BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
 
-            bd.location = p1;
+            bd.UseLocation(p1);
             const auto leftFlipper = CreateBody(GetWorld(), bd);
 
-            bd.location = p2;
+            bd.UseLocation(p2);
             const auto rightFlipper = CreateBody(GetWorld(), bd);
 
             const auto box = CreateShape(
@@ -90,14 +88,11 @@ public:
 
         // Disk character
         {
-            BodyConf bd;
-            bd.location = Vec2(1.0f, 15.0f) * 1_m;
-            bd.type = BodyType::Dynamic;
-            bd.linearAcceleration = GetGravity();
-            bd.bullet = true;
-
-            m_ball = CreateBody(GetWorld(), bd);
-
+            m_ball = CreateBody(GetWorld(),
+                                BodyConf{}
+                                    .UseLocation(Vec2(1.0f, 15.0f) * 1_m)
+                                    .Use(BodyType::Dynamic)
+                                    .UseLinearAcceleration(GetGravity()).UseBullet(true));
             auto conf = DiskShapeConf{};
             conf.density = 1_kgpm2;
             conf.vertexRadius = 0.2_m;

--- a/Testbed/Tests/PolyShapes.cpp
+++ b/Testbed/Tests/PolyShapes.cpp
@@ -22,7 +22,6 @@
 #include "../Framework/Test.hpp"
 
 #include <vector>
-#include <cstring>
 
 namespace testbed {
 
@@ -96,14 +95,12 @@ public:
             m_bodies[m_bodyIndex] = InvalidBodyID;
         }
 
+        const auto x = RandomFloat(-2.0f, 2.0f);
         BodyConf bd;
         bd.type = BodyType::Dynamic;
         bd.linearAcceleration = GetGravity();
-
-        const auto x = RandomFloat(-2.0f, 2.0f);
-        bd.location = Vec2(x, 10.0f) * 1_m;
-        bd.angle = 1_rad * RandomFloat(-Pi, Pi);
-
+        bd.UseLocation(Vec2(x, 10.0f) * 1_m);
+        bd.UseAngle(1_rad * RandomFloat(-Pi, Pi));
         if (index == 4) {
             bd.angularDamping = 0.02_Hz;
         }

--- a/Testbed/Tests/Prismatic.cpp
+++ b/Testbed/Tests/Prismatic.cpp
@@ -42,8 +42,8 @@ public:
             BodyConf bd;
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(-10.0f, 10.0f) * 1_m;
-            bd.angle = 0.5_rad * Pi;
+            bd.UseLocation(Vec2(-10.0f, 10.0f) * 1_m);
+            bd.UseAngle(0.5_rad * Pi);
             bd.allowSleep = false;
             const auto body = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), body,

--- a/Testbed/Tests/Pulleys.cpp
+++ b/Testbed/Tests/Pulleys.cpp
@@ -56,11 +56,11 @@ public:
             bd.linearAcceleration = GetGravity();
 
             // bd.fixedRotation = true;
-            bd.location = Vec2(-10.0f, y) * 1_m;
+            bd.UseLocation(Vec2(-10.0f, y) * 1_m);
             const auto body1 = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), body1, shape);
 
-            bd.location = Vec2(10.0f, y) * 1_m;
+            bd.UseLocation(Vec2(10.0f, y) * 1_m);
             const auto body2 = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), body2, shape);
 

--- a/Testbed/Tests/Pyramid.cpp
+++ b/Testbed/Tests/Pyramid.cpp
@@ -43,14 +43,11 @@ public:
         const auto deltaX = Vec2(0.5625f, 1.25f);
         const auto deltaY = Vec2(1.125f, 0.0f);
         Vec2 y;
+        auto bd = BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity()).Use(shape);
         for (auto i = 0; i < e_count; ++i) {
             y = x;
             for (auto j = i; j < e_count; ++j) {
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.linearAcceleration = GetGravity();
-                bd.location = y * 1_m;
-                bd.Use(shape);
+                bd.UseLocation(y * 1_m);
                 CreateBody(GetWorld(), Body{bd});
                 y += deltaY;
             }

--- a/Testbed/Tests/RayCast.cpp
+++ b/Testbed/Tests/RayCast.cpp
@@ -109,13 +109,13 @@ public:
             Destroy(GetWorld(), m_bodies[m_bodyIndex]);
             m_bodies[m_bodyIndex] = InvalidBodyID;
         }
-        auto bd = BodyConf{};
         const auto x = RandomFloat(-10.0f, 10.0f);
         const auto y = RandomFloat(0.0f, 20.0f);
-        bd.location = Vec2(x, y) * 1_m;
-        bd.angle = 1_rad * RandomFloat(-Pi, Pi);
+        auto bd = BodyConf{};
+        bd.UseLocation(Vec2(x, y) * 1_m);
+        bd.UseAngle(1_rad * RandomFloat(-Pi, Pi));
         if (type == 4) {
-            bd.angularDamping = 0.02_Hz;
+            bd.UseAngularDamping(0.02_Hz);
         }
         m_bodies[m_bodyIndex] = CreateBody(GetWorld(), bd);
         m_userData.resize(m_bodies[m_bodyIndex].get() + 1u, -1);

--- a/Testbed/Tests/Revolute.cpp
+++ b/Testbed/Tests/Revolute.cpp
@@ -36,19 +36,16 @@ public:
                            EdgeShapeConf{Vec2(-40.0f, 0.0f) * 1_m, Vec2(40.0f, 0.0f) * 1_m}));
 
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-
-            bd.location = Vec2(-10.0f, 20.0f) * 1_m;
-            const auto body = CreateBody(GetWorld(), bd);
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}
+                                             .Use(BodyType::Dynamic)
+                                             .UseLocation(Vec2(-10.0f, 20.0f) * 1_m));
             auto circleConf = DiskShapeConf{};
             circleConf.vertexRadius = 0.5_m;
             circleConf.density = 5_kgpm2;
             Attach(GetWorld(), body, CreateShape(GetWorld(), circleConf));
-
             const auto w = 100.0f;
             SetVelocity(GetWorld(), body, Velocity{Vec2(-8.0f * w, 0.0f) * 1_mps, w * 1_rad / 1_s});
-
             auto rjd = GetRevoluteJointConf(GetWorld(), ground, body, Vec2(-10.0f, 12.0f) * 1_m);
             rjd.motorSpeed = Pi * 1_rad / 1_s;
             rjd.maxMotorTorque = 10000_Nm;
@@ -57,16 +54,12 @@ public:
             rjd.upperAngle = 0.5_rad * Pi;
             rjd.enableLimit = true;
             rjd.collideConnected = true;
-
             m_joint = CreateJoint(GetWorld(), rjd);
         }
 
         {
-            BodyConf circle_bd;
-            circle_bd.type = BodyType::Dynamic;
-            circle_bd.location = Vec2(5.0f, 30.0f) * 1_m;
-
-            m_ball = CreateBody(GetWorld(), circle_bd);
+            m_ball = CreateBody(GetWorld(),
+                                BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(5.0f, 30.0f) * 1_m));
             auto circleConf = DiskShapeConf{};
             circleConf.vertexRadius = 3_m;
             circleConf.density = 5_kgpm2;
@@ -77,11 +70,12 @@ public:
             polygon_shape.SetAsBox(10_m, 0.2_m, Vec2(-10.0f, 0.0f) * 1_m, 0_rad);
             polygon_shape.UseDensity(2_kgpm2);
 
-            BodyConf polygon_bd;
-            polygon_bd.location = Vec2(20.0f, 10.0f) * 1_m;
-            polygon_bd.type = BodyType::Dynamic;
-            polygon_bd.bullet = true;
-            const auto polygon_body = CreateBody(GetWorld(), polygon_bd);
+            const auto polygon_body =
+                CreateBody(GetWorld(),
+                           BodyConf{}
+                               .UseLocation(Vec2(20.0f, 10.0f) * 1_m)
+                               .Use(BodyType::Dynamic)
+                               .UseBullet(true));
             Attach(GetWorld(), polygon_body, CreateShape(GetWorld(), polygon_shape));
 
             auto rjd =

--- a/Testbed/Tests/RopeJoint.cpp
+++ b/Testbed/Tests/RopeJoint.cpp
@@ -68,10 +68,10 @@ public:
                 BodyConf bd;
                 bd.type = BodyType::Dynamic;
                 bd.linearAcceleration = GetGravity();
-                bd.location = Vec2(0.5f + 1.0f * i, y) * 1_m;
+                bd.UseLocation(Vec2(0.5f + 1.0f * i, y) * 1_m);
                 if (i == N - 1) {
                     shape = square;
-                    bd.location = Vec2(1.0f * i, y) * 1_m;
+                    bd.UseLocation(Vec2(1.0f * i, y) * 1_m);
                     bd.angularDamping = 0.4_Hz;
                 }
                 const auto body = CreateBody(GetWorld(), bd);

--- a/Testbed/Tests/SensorTest.cpp
+++ b/Testbed/Tests/SensorTest.cpp
@@ -55,7 +55,7 @@ public:
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(-10.0f + 3.0f * i, 20.0f) * 1_m;
+            bd.UseLocation(Vec2(-10.0f + 3.0f * i, 20.0f) * 1_m);
             m_bodies[i] = CreateBody(GetWorld(), bd);
             m_touching.resize(m_bodies[i].get() + 1);
             m_touching[m_bodies[i].get()] = false;

--- a/Testbed/Tests/ShapeEditing.cpp
+++ b/Testbed/Tests/ShapeEditing.cpp
@@ -36,22 +36,17 @@ public:
         Attach(GetWorld(), CreateBody(GetWorld()),
                CreateShape(GetWorld(),
                            EdgeShapeConf{Vec2(-40.0f, 0.0f) * 1_m, Vec2(40.0f, 0.0f) * 1_m}));
-
-        BodyConf bd;
-        bd.type = BodyType::Dynamic;
-        bd.linearAcceleration = GetGravity();
-        bd.location = Vec2(0.0f, 10.0f) * 1_m;
-        m_body = CreateBody(GetWorld(), bd);
-
+        m_body = CreateBody(GetWorld(),
+                            BodyConf{}
+                                .Use(BodyType::Dynamic)
+                                .UseLinearAcceleration(GetGravity())
+                                .UseLocation(Vec2(0.0f, 10.0f) * 1_m));
         auto shape = PolygonShapeConf{};
         shape.SetAsBox(4_m, 4_m, Length2{}, 0_deg);
         shape.UseDensity(10_kgpm2);
         Attach(GetWorld(), m_body, CreateShape(GetWorld(), shape));
-
         m_shape2 = InvalidShapeID;
-
         m_sensor = false;
-
         RegisterForKey(GLFW_KEY_C, GLFW_PRESS, 0, "Create a shape.", [&](KeyActionMods) {
             if (!IsValid(m_shape2)) {
                 auto conf = DiskShapeConf{};

--- a/Testbed/Tests/SliderCrank.cpp
+++ b/Testbed/Tests/SliderCrank.cpp
@@ -43,10 +43,10 @@ public:
 
             // Define crank.
             {
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2(0.0f, 7.0f) * 1_m;
-                const auto body = CreateBody(GetWorld(), bd);
+                const auto body = CreateBody(GetWorld(),
+                                             BodyConf{}
+                                                 .Use(BodyType::Dynamic)
+                                                 .UseLocation(Vec2(0.0f, 7.0f) * 1_m));
                 Attach(GetWorld(), body,
                        CreateShape(GetWorld(),
                                    PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(0.5_m, 2_m)));
@@ -60,10 +60,10 @@ public:
 
             // Define follower.
             {
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2(0.0f, 13.0f) * 1_m;
-                const auto body = CreateBody(GetWorld(), bd);
+                const auto body = CreateBody(GetWorld(),
+                                             BodyConf{}
+                                                 .Use(BodyType::Dynamic)
+                                                 .UseLocation(Vec2(0.0f, 13.0f) * 1_m));
                 Attach(GetWorld(), body,
                        CreateShape(GetWorld(),
                                    PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(0.5_m, 4_m)));
@@ -76,11 +76,11 @@ public:
 
             // Define piston
             {
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.fixedRotation = true;
-                bd.location = Vec2(0.0f, 17.0f) * 1_m;
-                const auto body = CreateBody(GetWorld(), bd);
+                const auto body = CreateBody(GetWorld(),
+                                             BodyConf{}
+                                                 .Use(BodyType::Dynamic)
+                                                 .UseFixedRotation(true)
+                                                 .UseLocation(Vec2(0.0f, 17.0f) * 1_m));
                 Attach(GetWorld(), body,
                        CreateShape(GetWorld(),
                                    PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(1.5_m, 1.5_m)));
@@ -95,14 +95,11 @@ public:
             }
 
             // Create a payload
-            {
-                BodyConf bd;
-                bd.type = BodyType::Dynamic;
-                bd.location = Vec2(0.0f, 23.0f) * 1_m;
-                Attach(GetWorld(), CreateBody(GetWorld(), bd),
-                       CreateShape(GetWorld(),
-                                   PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(1.5_m, 1.5_m)));
-            }
+            Attach(GetWorld(),
+                   CreateBody(GetWorld(),
+                              BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(0.0f, 23.0f) * 1_m)),
+                   CreateShape(GetWorld(),
+                               PolygonShapeConf{}.UseDensity(2_kgpm2).SetAsBox(1.5_m, 1.5_m)));
         }
         SetAccelerations(GetWorld(), GetGravity());
         RegisterForKey(GLFW_KEY_F, GLFW_PRESS, 0, "toggle friction", [&](KeyActionMods) {

--- a/Testbed/Tests/SphereStack.cpp
+++ b/Testbed/Tests/SphereStack.cpp
@@ -37,11 +37,11 @@ public:
         const auto shape =
             CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(1_m).UseDensity(1_kgpm2));
         for (auto i = 0; i < e_count; ++i) {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(0, 4.0f + 3.0f * i) * 1_m;
-            m_bodies[i] = CreateBody(GetWorld(), bd);
+            m_bodies[i] = CreateBody(GetWorld(),
+                                     BodyConf{}
+                                         .Use(BodyType::Dynamic)
+                                         .UseLinearAcceleration(GetGravity())
+                                         .UseLocation(Vec2(0, 4.0f + 3.0f * i) * 1_m));
             Attach(GetWorld(), m_bodies[i], shape);
             SetVelocity(GetWorld(), m_bodies[i], Velocity{Vec2(0.0f, -50.0f) * 1_mps, 0_rpm});
         }

--- a/Testbed/Tests/SpinningCircle.cpp
+++ b/Testbed/Tests/SpinningCircle.cpp
@@ -38,9 +38,9 @@ public:
         bodyConf.linearVelocity = LinearVelocity2{};
         bodyConf.linearDamping = 0.8_Hz;
         bodyConf.bullet = true;
-        bodyConf.location = Vec2{0, 26} * 1_m;
+        bodyConf.UseLocation(Vec2{0, 26} * 1_m);
         const auto body1 = CreateBody(GetWorld(), bodyConf);
-        bodyConf.location = Vec2{0, 14} * 1_m;
+        bodyConf.UseLocation(Vec2{0, 14} * 1_m);
         const auto body2 = CreateBody(GetWorld(), bodyConf);
         auto shapeConf = DiskShapeConf{};
         shapeConf.density = 10_kgpm2;

--- a/Testbed/Tests/TheoJansen.cpp
+++ b/Testbed/Tests/TheoJansen.cpp
@@ -58,17 +58,16 @@ public:
         poly2.UseDensity(1_kgpm2);
         poly2.UseFilter(filter);
 
-        BodyConf bd1, bd2;
-        bd1.type = BodyType::Dynamic;
-        bd2.type = BodyType::Dynamic;
-        bd1.location = m_offset;
-        bd2.location = p4 + m_offset;
-
-        bd1.angularDamping = 10_Hz;
-        bd2.angularDamping = 10_Hz;
-
-        const auto body1 = CreateBody(GetWorld(), bd1);
-        const auto body2 = CreateBody(GetWorld(), bd2);
+        const auto body1 = CreateBody(GetWorld(),
+                                      BodyConf{}
+                                          .Use(BodyType::Dynamic)
+                                          .UseLocation(m_offset)
+                                          .UseAngularDamping(10_Hz));
+        const auto body2 = CreateBody(GetWorld(),
+                                      BodyConf{}
+                                          .Use(BodyType::Dynamic)
+                                          .UseLocation(p4 + m_offset)
+                                          .UseAngularDamping(10_Hz));
 
         Attach(GetWorld(), body1, CreateShape(GetWorld(), poly1));
         Attach(GetWorld(), body2, CreateShape(GetWorld(), poly2));
@@ -126,20 +125,17 @@ public:
         circleConf.density = 1_kgpm2;
         const auto circle = CreateShape(GetWorld(), circleConf);
         for (auto i = 0; i < 40; ++i) {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = Vec2(-40.0f + 2.0f * i, 0.5f) * 1_m;
-
-            const auto body = CreateBody(GetWorld(), bd);
+            const auto body = CreateBody(GetWorld(),
+                                         BodyConf{}
+                                             .Use(BodyType::Dynamic)
+                                             .UseLocation(Vec2(-40.0f + 2.0f * i, 0.5f) * 1_m));
             Attach(GetWorld(), body, circle);
         }
 
         // Chassis
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = pivot + m_offset;
-            m_chassis = CreateBody(GetWorld(), bd);
+            m_chassis = CreateBody(GetWorld(),
+                                   BodyConf{}.Use(BodyType::Dynamic).UseLocation(pivot + m_offset));
             auto conf = PolygonShapeConf{};
             conf.density = 1_kgpm2;
             conf.filter.groupIndex = -1;
@@ -148,10 +144,8 @@ public:
         }
 
         {
-            BodyConf bd;
-            bd.type = BodyType::Dynamic;
-            bd.location = pivot + m_offset;
-            m_wheel = CreateBody(GetWorld(), bd);
+            m_wheel = CreateBody(GetWorld(),
+                                 BodyConf{}.Use(BodyType::Dynamic).UseLocation(pivot + m_offset));
             auto conf = DiskShapeConf{};
             conf.vertexRadius = 1.6_m;
             conf.density = 1_kgpm2;

--- a/Testbed/Tests/Tiles.cpp
+++ b/Testbed/Tests/Tiles.cpp
@@ -40,10 +40,7 @@ public:
 
         {
             const auto a = Real{0.5f};
-            BodyConf bd;
-            GetY(bd.location) = -a * 1_m;
-            auto ground = Body{bd};
-
+            auto ground = Body{BodyConf{}.UseLocation(Length2{0_m, -a * 1_m})};
             const auto N = 200;
             const auto M = 10;
             Vec2 position;
@@ -72,16 +69,11 @@ public:
             const auto deltaX = Vec2(0.5625f, 1.25f);
             const auto deltaY = Vec2(1.125f, 0.0f);
 
+            auto bd = BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity()).Use(shape);
             for (auto i = 0; i < e_count; ++i) {
                 y = x;
                 for (auto j = i; j < e_count; ++j) {
-                    BodyConf bd;
-                    bd.type = BodyType::Dynamic;
-                    bd.location = y * 1_m;
-                    bd.linearAcceleration = GetGravity();
-                    auto body = Body{bd};
-                    body.Attach(shape);
-                    CreateBody(GetWorld(), body);
+                    CreateBody(GetWorld(), Body{bd.UseLocation(y * 1_m)});
                     ++m_fixtureCount;
                     y += deltaY;
                 }

--- a/Testbed/Tests/VaryingFriction.cpp
+++ b/Testbed/Tests/VaryingFriction.cpp
@@ -56,7 +56,7 @@ public:
             auto bd = BodyConf{};
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(-15.0f + 4.0f * i, 28.0f) * 1_m;
+            bd.UseLocation(Vec2(-15.0f + 4.0f * i, 28.0f) * 1_m);
             const auto body = CreateBody(GetWorld(), bd);
             shape.UseFriction(friction[i]);
             Attach(GetWorld(), body, CreateShape(GetWorld(), shape));

--- a/Testbed/Tests/VaryingRestitution.cpp
+++ b/Testbed/Tests/VaryingRestitution.cpp
@@ -42,7 +42,7 @@ public:
             BodyConf bd;
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
-            bd.location = Vec2(Real(-10 + 3 * i), 20) * 1_m;
+            bd.UseLocation(Vec2(Real(-10 + 3 * i), 20) * 1_m);
             const auto body = CreateBody(GetWorld(), bd);
             shape.UseRestitution(restitution[i]);
             Attach(GetWorld(), body, CreateShape(GetWorld(), shape));

--- a/Testbed/Tests/VerticalStack.cpp
+++ b/Testbed/Tests/VerticalStack.cpp
@@ -64,12 +64,11 @@ public:
                 BodyConf bd;
                 bd.type = BodyType::Dynamic;
                 bd.linearAcceleration = GetGravity();
-
                 const auto x = 0.0f;
                 // const auto x = RandomFloat(-0.02f, 0.02f);
                 // const auto x = i % 2 == 0 ? -0.01f : 0.01f;
                 // bd.position = Vec2(xs[j] + x, (hdim - hdim/20) + (hdim * 2 - hdim / 20) * i);
-                bd.location = Vec2(xs[j] + x, (i + 1) * hdim * 4) * 1_m;
+                bd.UseLocation(Vec2(xs[j] + x, (i + 1) * hdim * 4) * 1_m);
                 Attach(GetWorld(), CreateBody(GetWorld(), bd), shape);
             }
         }
@@ -86,8 +85,7 @@ public:
                 bd.type = BodyType::Dynamic;
                 bd.linearAcceleration = GetGravity();
                 bd.bullet = true;
-                bd.location = Vec2(-31.0f, 5.0f) * 1_m;
-
+                bd.UseLocation(Vec2(-31.0f, 5.0f) * 1_m);
                 m_bullet = CreateBody(GetWorld(), bd);
                 Attach(GetWorld(), m_bullet, m_bulletshape);
                 SetVelocity(GetWorld(), m_bullet, Velocity{Vec2(400.0f, 0.0f) * 1_mps, 0_rpm});

--- a/Testbed/Tests/Web.cpp
+++ b/Testbed/Tests/Web.cpp
@@ -50,19 +50,19 @@ public:
             bd.type = BodyType::Dynamic;
             bd.linearAcceleration = GetGravity();
 
-            bd.location = Vec2(-5.0f, 5.0f) * 1_m;
+            bd.UseLocation(Vec2(-5.0f, 5.0f) * 1_m);
             m_bodies[0] = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), m_bodies[0], shape);
 
-            bd.location = Vec2(5.0f, 5.0f) * 1_m;
+            bd.UseLocation(Vec2(5.0f, 5.0f) * 1_m);
             m_bodies[1] = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), m_bodies[1], shape);
 
-            bd.location = Vec2(5.0f, 15.0f) * 1_m;
+            bd.UseLocation(Vec2(5.0f, 15.0f) * 1_m);
             m_bodies[2] = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), m_bodies[2], shape);
 
-            bd.location = Vec2(-5.0f, 15.0f) * 1_m;
+            bd.UseLocation(Vec2(-5.0f, 15.0f) * 1_m);
             m_bodies[3] = CreateBody(GetWorld(), bd);
             Attach(GetWorld(), m_bodies[3], shape);
 

--- a/Testbed/Tests/iforce2d_Trajectories.cpp
+++ b/Testbed/Tests/iforce2d_Trajectories.cpp
@@ -65,7 +65,7 @@ public:
         // another ledge which we can move with the mouse
         BodyConf kinematicBody;
         kinematicBody.type = BodyType::Kinematic;
-        kinematicBody.location = Length2{11_m, 22_m};
+        kinematicBody.UseLocation(Length2{11_m, 22_m});
         m_targetBody = CreateBody(GetWorld(), kinematicBody);
         const auto w = BallSize * 1_m;
         Length2 verts[3];
@@ -83,7 +83,7 @@ public:
         // create dynamic circle body
         BodyConf myBodyConf;
         myBodyConf.type = BodyType::Dynamic;
-        myBodyConf.location = Vec2(-15, 5) * 1_m;
+        myBodyConf.UseLocation(Vec2(-15, 5) * 1_m);
         m_launcherBody = CreateBody(GetWorld(), myBodyConf);
         Attach(GetWorld(), m_launcherBody,
                CreateShape(
@@ -102,7 +102,7 @@ public:
         CreateJoint(GetWorld(), revoluteJointConf);
 
         // create dynamic box body to fire
-        myBodyConf.location = Length2(0_m, -5_m); // will be positioned later
+        myBodyConf.UseLocation(Length2(0_m, -5_m)); // will be positioned later
         m_littleBox = CreateBody(GetWorld(), myBodyConf);
         polygonShape.SetAsBox(0.5_m, 0.5_m);
         polygonShape.UseDensity(1_kgpm2);

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -18,50 +18,12 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "UnitTests.hpp"
-
 #include <playrho/d2/Body.hpp>
+
+#include "gtest/gtest.h"
 
 using namespace playrho;
 using namespace playrho::d2;
-
-TEST(Body, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-
-    // architecture dependent...
-    switch (sizeof(Real)) {
-    case 4:
-#if defined(_WIN64)
-#if !defined(NDEBUG)
-        EXPECT_EQ(sizeof(Body), std::size_t(136));
-#else
-        EXPECT_EQ(sizeof(Body), std::size_t(128));
-#endif
-#elif defined(_WIN32)
-#if !defined(NDEBUG)
-        // Win32 debug
-        EXPECT_EQ(sizeof(Body), std::size_t(116));
-#else
-        // Win32 release
-        EXPECT_EQ(sizeof(Body), std::size_t(112));
-#endif
-#else
-        EXPECT_EQ(sizeof(Body), std::size_t(128));
-#endif
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(Body), std::size_t(224));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(Body), std::size_t(432));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
 
 TEST(Body, DefaultConstruction)
 {
@@ -228,6 +190,25 @@ TEST(Body, EqualsOperator)
         auto body2 = Body{};
         body2.SetType(BodyType::Dynamic);
         EXPECT_FALSE(body1 == body2);
+    }
+    {
+        auto bodyA = Body{};
+        auto bodyB = Body{};
+        bodyA.Attach(ShapeID(1));
+        EXPECT_FALSE(bodyA == bodyB);
+        bodyB.Attach(ShapeID(1));
+        EXPECT_TRUE(bodyA == bodyB);
+    }
+    {
+        auto bodyA = Body{};
+        bodyA.SetType(BodyType::Dynamic);
+        ASSERT_TRUE(bodyA.IsSleepingAllowed());
+        auto bodyB = Body{};
+        bodyB.SetType(BodyType::Dynamic);
+        ASSERT_TRUE(bodyA.IsSleepingAllowed());
+        bodyA.SetSleepingAllowed(false);
+        ASSERT_FALSE(bodyA.IsSleepingAllowed());
+        EXPECT_FALSE(bodyA == bodyB);
     }
 }
 

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -28,9 +28,9 @@ using namespace playrho::d2;
 TEST(Body, DefaultConstruction)
 {
     EXPECT_EQ(Body().GetType(), BodyType::Static);
-    EXPECT_TRUE(Body().IsEnabled());
-    EXPECT_FALSE(Body().IsAwake());
-    EXPECT_FALSE(Body().IsSpeedable());
+    EXPECT_TRUE(IsEnabled(Body()));
+    EXPECT_FALSE(IsAwake(Body()));
+    EXPECT_FALSE(IsSpeedable(Body()));
     EXPECT_EQ(Body().GetLinearDamping(), Body::DefaultLinearDamping);
     EXPECT_EQ(Body().GetAngularDamping(), Body::DefaultAngularDamping);
 }
@@ -202,12 +202,12 @@ TEST(Body, EqualsOperator)
     {
         auto bodyA = Body{};
         bodyA.SetType(BodyType::Dynamic);
-        ASSERT_TRUE(bodyA.IsSleepingAllowed());
+        ASSERT_TRUE(IsSleepingAllowed(bodyA));
         auto bodyB = Body{};
         bodyB.SetType(BodyType::Dynamic);
-        ASSERT_TRUE(bodyA.IsSleepingAllowed());
+        ASSERT_TRUE(IsSleepingAllowed(bodyA));
         bodyA.SetSleepingAllowed(false);
-        ASSERT_FALSE(bodyA.IsSleepingAllowed());
+        ASSERT_FALSE(IsSleepingAllowed(bodyA));
         EXPECT_FALSE(bodyA == bodyB);
     }
 }

--- a/UnitTests/BodyConf.cpp
+++ b/UnitTests/BodyConf.cpp
@@ -30,8 +30,7 @@ using namespace playrho::d2;
 TEST(BodyConf, DefaultConstruction)
 {
     EXPECT_EQ(BodyConf().type, BodyConf::DefaultBodyType);
-    EXPECT_EQ(BodyConf().location, BodyConf::DefaultLocation);
-    EXPECT_EQ(BodyConf().angle, BodyConf::DefaultAngle);
+    EXPECT_EQ(BodyConf().sweep, BodyConf::DefaultSweep);
     EXPECT_EQ(BodyConf().linearVelocity, BodyConf::DefaultLinearVelocity);
     EXPECT_EQ(BodyConf().angularVelocity, BodyConf::DefaultAngularVelocity);
     EXPECT_EQ(BodyConf().linearAcceleration, BodyConf::DefaultLinearAcceleration);
@@ -58,8 +57,7 @@ TEST(BodyConf, UseType)
 TEST(BodyConf, UsePosition)
 {
     const auto p = Position{Length2{3_m, -4_m}, 22_deg};
-    EXPECT_EQ(BodyConf{}.Use(p).location, p.linear);
-    EXPECT_EQ(BodyConf{}.Use(p).angle, p.angular);
+    EXPECT_EQ(BodyConf{}.Use(p).sweep.pos0, p);
 }
 
 TEST(BodyConf, UseVelocity)
@@ -82,8 +80,7 @@ TEST(BodyConf, UseShapes)
 static void IsSame(const BodyConf& conf, const BodyConf& conf2)
 {
     EXPECT_EQ(conf.type, conf2.type);
-    EXPECT_EQ(conf.location, conf2.location);
-    EXPECT_EQ(conf.angle, conf2.angle);
+    EXPECT_EQ(conf.sweep, conf2.sweep);
     EXPECT_EQ(conf.linearVelocity, conf2.linearVelocity);
     EXPECT_EQ(conf.angularVelocity, conf2.angularVelocity);
     EXPECT_EQ(conf.linearAcceleration, conf2.linearAcceleration);
@@ -111,8 +108,8 @@ TEST(BodyConf, GetBodyConf2)
 {
     auto conf = BodyConf{};
     conf.type = BodyType::Dynamic;
-    conf.location = Length2{2_m, 3_m};
-    conf.angle = 30_deg;
+    conf.UseLocation(Length2{2_m, 3_m});
+    conf.UseAngle(30_deg);
     conf.linearVelocity = LinearVelocity2{2_mps, 0_mps};
     conf.angularVelocity = 4_rpm;
     conf.linearAcceleration = LinearAcceleration2{2_mps2, 0_mps2};

--- a/UnitTests/BodyConf.cpp
+++ b/UnitTests/BodyConf.cpp
@@ -69,6 +69,7 @@ TEST(BodyConf, DefaultConstruction)
     EXPECT_EQ(BodyConf().fixedRotation, BodyConf::DefaultFixedRotation);
     EXPECT_EQ(BodyConf().bullet, BodyConf::DefaultBullet);
     EXPECT_EQ(BodyConf().enabled, BodyConf::DefaultEnabled);
+    EXPECT_EQ(BodyConf().massDataDirty, BodyConf::DefaultMassDataDirty);
 }
 
 TEST(BodyConf, UseType)
@@ -113,6 +114,12 @@ TEST(BodyConf, UseShapes)
     EXPECT_THROW(BodyConf{}.Use(toomany), LengthError);
 }
 
+TEST(BodyConf, UseMassDataDirty)
+{
+    EXPECT_EQ(BodyConf{}.UseMassDataDirty(true).massDataDirty, true);
+    EXPECT_EQ(BodyConf{}.UseMassDataDirty(false).massDataDirty, false);
+}
+
 TEST(BodyConf, GetBodyConf1)
 {
     auto conf = BodyConf{};
@@ -144,6 +151,7 @@ TEST(BodyConf, GetBodyConf2)
     conf.fixedRotation = true;
     conf.bullet = true;
     conf.enabled = false;
+    conf.massDataDirty = false;
     conf.invMass = InvMass{Real(1) / 2_kg};
     conf.invRotI = InvRotInertia{Real(4) * SquareRadian / (SquareMeter * 1_kg)};
     SCOPED_TRACE("checking for dynamic");

--- a/UnitTests/PolygonShape.cpp
+++ b/UnitTests/PolygonShape.cpp
@@ -18,20 +18,13 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "UnitTests.hpp"
-
 #include <playrho/d2/PolygonShapeConf.hpp>
 #include <playrho/d2/Shape.hpp>
 
+#include "gtest/gtest.h"
+
 using namespace playrho;
 using namespace playrho::d2;
-
-TEST(PolygonShapeConf, Traits)
-{
-    EXPECT_TRUE(std::is_default_constructible_v<PolygonShapeConf>);
-    EXPECT_TRUE(std::is_nothrow_default_constructible_v<PolygonShapeConf>);
-    EXPECT_TRUE(std::is_copy_constructible_v<PolygonShapeConf>);
-}
 
 TEST(PolygonShapeConf, DefaultConstruction)
 {

--- a/UnitTests/Position.cpp
+++ b/UnitTests/Position.cpp
@@ -27,26 +27,6 @@
 using namespace playrho;
 using namespace playrho::d2;
 
-TEST(Position, ByteSize)
-{
-    // Check size at test runtime instead of compile-time via static_assert to avoid stopping
-    // builds and to report actual size rather than just reporting that expected size is wrong.
-    switch (sizeof(Real)) {
-    case 4:
-        EXPECT_EQ(sizeof(Position), std::size_t(12));
-        break;
-    case 8:
-        EXPECT_EQ(sizeof(Position), std::size_t(24));
-        break;
-    case 16:
-        EXPECT_EQ(sizeof(Position), std::size_t(48));
-        break;
-    default:
-        FAIL();
-        break;
-    }
-}
-
 TEST(Position, EqualsOperator)
 {
     const auto zero = Position{};

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -1438,13 +1438,13 @@ TEST(World, StepZeroTimeDoesNothing)
     World world{};
     
     BodyConf def;
-    def.location = Length2{31.9_m, -19.24_m};
+    def.UseLocation(Length2{31.9_m, -19.24_m});
     def.type = BodyType::Dynamic;
     def.linearAcceleration = EarthlyGravity;
     
     const auto body = CreateBody(world, def);
     ASSERT_NE(body, InvalidBodyID);
-    EXPECT_EQ(GetLocation(world, body), def.location);
+    EXPECT_EQ(GetLocation(world, body), def.sweep.pos0.linear);
     EXPECT_EQ(GetX(GetLinearVelocity(world, body)), 0_mps);
     EXPECT_EQ(GetY(GetLinearVelocity(world, body)), 0_mps);
     EXPECT_EQ(GetX(GetLinearAcceleration(world, body)), Real{0.0f} * MeterPerSquareSecond);
@@ -1460,7 +1460,7 @@ TEST(World, StepZeroTimeDoesNothing)
         
         EXPECT_EQ(GetY(GetLinearAcceleration(world, body)), GetY(EarthlyGravity));
         
-        EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.location));
+        EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.sweep.pos0.linear));
         EXPECT_EQ(GetY(GetLocation(world, body)), GetY(pos));
         pos = GetLocation(world, body);
         
@@ -1478,7 +1478,7 @@ TEST(World, GravitationalBodyMovement)
 
     auto body_def = BodyConf{};
     body_def.type = BodyType::Dynamic;
-    body_def.location = p0;
+    body_def.UseLocation(p0);
     body_def.linearAcceleration = LinearAcceleration2{0, a * MeterPerSquareSecond};
 
     const auto t = .01_s;
@@ -1563,13 +1563,13 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
     auto world = World{};
     
     BodyConf def;
-    def.location = Length2{31.9_m, -19.24_m};
+    def.UseLocation(Length2{31.9_m, -19.24_m});
     def.type = BodyType::Dynamic;
     def.linearAcceleration = EarthlyGravity;
     
     const auto body = CreateBody(world, def);
     ASSERT_NE(body, InvalidBodyID);
-    EXPECT_EQ(GetLocation(world, body), def.location);
+    EXPECT_EQ(GetLocation(world, body), def.sweep.pos0.linear);
     EXPECT_EQ(GetX(GetLinearVelocity(world, body)), 0_mps);
     EXPECT_EQ(GetY(GetLinearVelocity(world, body)), 0_mps);
     EXPECT_EQ(GetX(GetLinearAcceleration(world, body)), Real{0.0f} * MeterPerSquareSecond);
@@ -1585,7 +1585,7 @@ TEST(World, BodyAccelPerSpecWithNoVelOrPosIterations)
         
         EXPECT_EQ(GetY(GetLinearAcceleration(world, body)), GetY(EarthlyGravity));
         
-        EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.location));
+        EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.sweep.pos0.linear));
         EXPECT_LT(GetY(GetLocation(world, body)), GetY(pos));
         EXPECT_EQ(GetY(GetLocation(world, body)), GetY(pos) + ((GetY(vel) + GetY(EarthlyGravity) * time_inc) * time_inc));
         pos = GetLocation(world, body);
@@ -1603,14 +1603,14 @@ TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
     World world{};
     
     BodyConf def;
-    def.location = Length2{31.9_m, -19.24_m};
+    def.UseLocation(Length2{31.9_m, -19.24_m});
     def.linearVelocity = LinearVelocity2{0, -9.8_mps};
     def.type = BodyType::Dynamic;
     def.linearAcceleration = EarthlyGravity;
     
     const auto body = CreateBody(world, def);
     ASSERT_NE(body, InvalidBodyID);
-    EXPECT_EQ(GetLocation(world, body), def.location);
+    EXPECT_EQ(GetLocation(world, body), def.sweep.pos0.linear);
     EXPECT_EQ(GetX(GetLinearVelocity(world, body)), 0_mps);
     EXPECT_EQ(GetY(GetLinearVelocity(world, body)), -9.8_mps);
     EXPECT_EQ(GetX(GetLinearAcceleration(world, body)), Real{0.0f} * MeterPerSquareSecond);
@@ -1633,7 +1633,7 @@ TEST(World, BodyAccelRevPerSpecWithNegativeTimeAndNoVelOrPosIterations)
         
         EXPECT_EQ(GetY(GetLinearAcceleration(world, body)), GetY(EarthlyGravity));
         
-        EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.location));
+        EXPECT_EQ(GetX(GetLocation(world, body)), GetX(def.sweep.pos0.linear));
         EXPECT_GT(GetY(GetLocation(world, body)), GetY(pos));
         EXPECT_FLOAT_EQ(static_cast<float>(Real(GetY(GetLocation(world, body)) / 1_m)),
                         static_cast<float>(Real((GetY(pos) + ((GetY(vel) + GetY(EarthlyGravity) * time_inc) * time_inc)) / 1_m)));
@@ -1765,7 +1765,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
 
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(1_m).UseRestitution(Real(1)).UseDensity(1_kgpm2));
     
-    body_def.location = Length2{-x * Meter, 0_m};
+    body_def.UseLocation(Length2{-x * Meter, 0_m});
     body_def.linearVelocity = LinearVelocity2{+x * 1_mps, 0_mps};
     const auto body_a = CreateBody(world, body_def);
     ASSERT_NE(body_a, InvalidBodyID);
@@ -1774,7 +1774,7 @@ TEST(World, NoCorrectionsWithNoVelOrPosIterations)
     EXPECT_TRUE(IsAccelerable(world, body_a));
     Attach(world, body_a, shapeId);
     
-    body_def.location = Length2{+x * Meter, 0_m};
+    body_def.UseLocation(Length2{+x * Meter, 0_m});
     body_def.linearVelocity = LinearVelocity2{-x * 1_mps, 0_mps};
     const auto body_b = CreateBody(world, body_def);
     ASSERT_NE(body_b, InvalidBodyID);
@@ -2054,21 +2054,21 @@ TEST(World, PerfectlyOverlappedSameCirclesStayPut)
     auto body_def = BodyConf{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.location = Length2{0_m, 0_m};
+    body_def.UseLocation(Length2{0_m, 0_m});
     const auto body1 = CreateBody(world, body_def);
     Attach(world, body1, shapeId);
-    ASSERT_EQ(GetLocation(world, body1), body_def.location);
+    ASSERT_EQ(GetLocation(world, body1), body_def.sweep.pos0.linear);
     
     const auto body2 = CreateBody(world, body_def);
     Attach(world, body2, shapeId);
-    ASSERT_EQ(GetLocation(world, body2), body_def.location);
+    ASSERT_EQ(GetLocation(world, body2), body_def.sweep.pos0.linear);
     
     const auto time_inc = Real(.01);
     for (auto i = 0; i < 100; ++i)
     {
         Step(world, 1_s * time_inc);
-        EXPECT_EQ(GetLocation(world, body1), body_def.location);
-        EXPECT_EQ(GetLocation(world, body2), body_def.location);
+        EXPECT_EQ(GetLocation(world, body1), body_def.sweep.pos0.linear);
+        EXPECT_EQ(GetLocation(world, body2), body_def.sweep.pos0.linear);
     }
 }
 
@@ -2084,22 +2084,22 @@ TEST(World, PerfectlyOverlappedConcentricCirclesStayPut)
     auto body_def = BodyConf{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.location = Length2{};
+    body_def.UseLocation(Length2{});
     
     const auto body1 = CreateBody(world, body_def);
     Attach(world, body1, shapeId1);
-    ASSERT_EQ(GetLocation(world, body1), body_def.location);
+    ASSERT_EQ(GetLocation(world, body1), body_def.sweep.pos0.linear);
     
     const auto body2 = CreateBody(world, body_def);
     Attach(world, body2, shapeId2);
-    ASSERT_EQ(GetLocation(world, body2), body_def.location);
+    ASSERT_EQ(GetLocation(world, body2), body_def.sweep.pos0.linear);
 
     const auto time_inc = Real(.01);
     for (auto i = 0; i < 100; ++i)
     {
         Step(world, 1_s * time_inc);
-        EXPECT_EQ(GetLocation(world, body1), body_def.location);
-        EXPECT_EQ(GetLocation(world, body2), body_def.location);
+        EXPECT_EQ(GetLocation(world, body1), body_def.sweep.pos0.linear);
+        EXPECT_EQ(GetLocation(world, body2), body_def.sweep.pos0.linear);
     }
 }
 
@@ -2129,7 +2129,7 @@ TEST(World, ListenerCalledForCircleBodyWithinCircleBody)
 
     auto body_def = BodyConf{};
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2{};
+    body_def.UseLocation(Length2{});
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRestitution(Real(1)).UseRadius(1_m));
     for (auto i = 0; i < 2; ++i)
     {
@@ -2177,7 +2177,7 @@ TEST(World, ListenerCalledForSquareBodyWithinSquareBody)
 
     auto body_def = BodyConf{};
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2{};
+    body_def.UseLocation(Length2{});
     auto conf = PolygonShapeConf{};
     conf.UseVertexRadius(1_m);
     conf.SetAsBox(2_m, 2_m);
@@ -2289,16 +2289,16 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
     body_def.bullet = false; // separation is faster if true.
     const auto shape = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRestitution(Real(1)).UseRadius(radius * Meter));
     const auto body1pos = Length2{(-radius/4) * Meter, 0_m};
-    body_def.location = body1pos;
+    body_def.UseLocation(body1pos);
     const auto body1 = CreateBody(world, body_def);
     Attach(world, body1, shape);
-    ASSERT_EQ(GetLocation(world, body1), body_def.location);
+    ASSERT_EQ(GetLocation(world, body1), body_def.sweep.pos0.linear);
     
     const auto body2pos = Length2{(+radius/4) * Meter, 0_m};
-    body_def.location = body2pos;
+    body_def.UseLocation(body2pos);
     const auto body2 = CreateBody(world, body_def);
     Attach(world, body2, shape);
-    ASSERT_EQ(GetLocation(world, body2), body_def.location);
+    ASSERT_EQ(GetLocation(world, body2), body_def.sweep.pos0.linear);
     
     auto position_diff = body2pos - body1pos;
     auto distance = GetMagnitude(position_diff);
@@ -2322,7 +2322,8 @@ TEST(World, PartiallyOverlappedSameCirclesSeparate)
         const auto new_pos_diff = GetLocation(world, body2) - GetLocation(world, body1);
         const auto new_distance = GetMagnitude(new_pos_diff);
         
-        if (AlmostEqual(Real{new_distance / Meter}, Real{full_separation / Meter}) || new_distance > full_separation)
+        if (AlmostEqual(Real{new_distance / Meter}, Real{full_separation / Meter}) ||
+            new_distance > full_separation)
         {
             break;
         }
@@ -2375,15 +2376,15 @@ TEST(World, PerfectlyOverlappedSameSquaresSeparateHorizontally)
     auto body_def = BodyConf{};
     body_def.type = BodyType::Dynamic;
     body_def.bullet = false;
-    body_def.location = Length2{};
+    body_def.UseLocation(Length2{});
     
     const auto body1 = CreateBody(world, body_def);
     Attach(world, body1, shape);
-    ASSERT_EQ(GetLocation(world, body1), body_def.location);
+    ASSERT_EQ(GetLocation(world, body1), body_def.sweep.pos0.linear);
     
     const auto body2 = CreateBody(world, body_def);
     Attach(world, body2, shape);
-    ASSERT_EQ(GetLocation(world, body2), body_def.location);
+    ASSERT_EQ(GetLocation(world, body2), body_def.sweep.pos0.linear);
     
     auto lastpos1 = GetLocation(world, body1);
     auto lastpos2 = GetLocation(world, body2);
@@ -2433,13 +2434,13 @@ TEST(World, PartiallyOverlappedSquaresSeparateProperly)
     const auto shape = CreateShape(world, PolygonShapeConf{}.UseDensity(1_kgpm2).UseRestitution(Real(1)).SetAsBox(half_dim * Meter, half_dim * Meter));
     
     const auto body1pos = Length2{Real(half_dim/2) * Meter, 0_m}; // 0 causes additional y-axis separation
-    body_def.location = body1pos;
+    body_def.UseLocation(body1pos);
     const auto body1 = CreateBody(world, body_def);
     Attach(world, body1, shape);
     ASSERT_EQ(GetLocation(world, body1), body1pos);
     
     const auto body2pos = Length2{-Real(half_dim/2) * Meter, 0_m}; // 0 causes additional y-axis separation
-    body_def.location = body2pos;
+    body_def.UseLocation(body2pos);
     const auto body2 = CreateBody(world, body_def);
     Attach(world, body2, shape);
     ASSERT_EQ(GetLocation(world, body2), body2pos);
@@ -2586,9 +2587,10 @@ TEST(World, CollidingDynamicBodies)
         listener.PostSolve(id, impulses, count);
     });
     
-    const auto shape = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRestitution(Real(1)).UseRadius(radius));
+    const auto shape =
+        CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRestitution(Real(1)).UseRadius(radius));
 
-    body_def.location = Length2{-(x + 1) * Meter, 0_m};
+    body_def.UseLocation(Length2{-(x + 1) * Meter, 0_m});
     body_def.linearVelocity = LinearVelocity2{+x * 1_mps, 0_mps};
     const auto body_a = CreateBody(world, body_def);
     ASSERT_NE(body_a, InvalidBodyID);
@@ -2597,7 +2599,7 @@ TEST(World, CollidingDynamicBodies)
     ASSERT_TRUE(IsAccelerable(world, body_a));
     Attach(world, body_a, shape);
 
-    body_def.location = Length2{+(x + 1) * Meter, 0_m};
+    body_def.UseLocation(Length2{+(x + 1) * Meter, 0_m});
     body_def.linearVelocity = LinearVelocity2{-x * 1_mps, 0_mps};
     const auto body_b = CreateBody(world, body_def);
     ASSERT_NE(body_b, InvalidBodyID);
@@ -3111,12 +3113,12 @@ TEST(World, SpeedingBulletBallWontTunnel)
     BodyConf body_def;
     body_def.type = BodyType::Static;
 
-    body_def.location = Length2{left_edge_x, 0_m};
+    body_def.UseLocation(Length2{left_edge_x, 0_m});
     const auto left_wall_body = CreateBody(world, body_def);
     ASSERT_NE(left_wall_body, InvalidBodyID);
     Attach(world, left_wall_body, edge_shape);
 
-    body_def.location = Length2{right_edge_x, 0_m};
+    body_def.UseLocation(Length2{right_edge_x, 0_m});
     const auto right_wall_body = CreateBody(world, body_def);
     ASSERT_NE(right_wall_body, InvalidBodyID);
     Attach(world, right_wall_body, edge_shape);
@@ -3124,13 +3126,14 @@ TEST(World, SpeedingBulletBallWontTunnel)
     const auto begin_x = Real(0);
 
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2{begin_x * Meter, 0_m};
+    body_def.UseLocation(Length2{begin_x * Meter, 0_m});
     body_def.bullet = false;
     const auto ball_body = CreateBody(world, body_def);
     ASSERT_NE(ball_body, InvalidBodyID);
     
     const auto ball_radius = 0.01_m;
-    const auto circle_shape = Shape(DiskShapeConf{}.UseDensity(1_kgpm2).UseRestitution(Real(1)).UseRadius(ball_radius));
+    const auto circle_shape =
+        Shape(DiskShapeConf{}.UseDensity(1_kgpm2).UseRestitution(Real(1)).UseRadius(ball_radius));
     Attach(world, ball_body, CreateShape(world, circle_shape));
 
     const auto velocity = LinearVelocity2{+1_mps, 0_mps};
@@ -3281,7 +3284,7 @@ TEST(World_Longer, TargetJointWontCauseTunnelling)
     // Setup vertical bounderies
     edgeConf.Set(Length2{0, +half_box_height * 2_m}, Length2{0, -half_box_height * 2_m});
 
-    body_def.location = Length2{left_edge_x * Meter, 0_m};
+    body_def.UseLocation(Length2{left_edge_x * Meter, 0_m});
     {
         const auto left_wall_body = CreateBody(world, body_def);
         ASSERT_NE(left_wall_body, InvalidBodyID);
@@ -3289,7 +3292,7 @@ TEST(World_Longer, TargetJointWontCauseTunnelling)
         Include(container_aabb, ComputeAABB(world, left_wall_body));
     }
     
-    body_def.location = Length2{right_edge_x * Meter, 0_m};
+    body_def.UseLocation(Length2{right_edge_x * Meter, 0_m});
     {
         const auto right_wall_body = CreateBody(world, body_def);
         ASSERT_NE(right_wall_body, InvalidBodyID);
@@ -3300,7 +3303,7 @@ TEST(World_Longer, TargetJointWontCauseTunnelling)
     // Setup horizontal bounderies
     edgeConf.Set(Length2{-half_box_width * 2_m, 0_m}, Length2{+half_box_width * 2_m, 0_m});
     
-    body_def.location = Length2{0, btm_edge_y * Meter};
+    body_def.UseLocation(Length2{0, btm_edge_y * Meter});
     {
         const auto btm_wall_body = CreateBody(world, body_def);
         ASSERT_NE(btm_wall_body, InvalidBodyID);
@@ -3308,7 +3311,7 @@ TEST(World_Longer, TargetJointWontCauseTunnelling)
         Include(container_aabb, ComputeAABB(world, btm_wall_body));
     }
     
-    body_def.location = Length2{0, top_edge_y * Meter};
+    body_def.UseLocation(Length2{0, top_edge_y * Meter});
     {
         const auto top_wall_body = CreateBody(world, body_def);
         ASSERT_NE(top_wall_body, InvalidBodyID);
@@ -3317,7 +3320,7 @@ TEST(World_Longer, TargetJointWontCauseTunnelling)
     }
 
     body_def.type = BodyType::Dynamic;
-    body_def.location = Length2{};
+    body_def.UseLocation(Length2{});
     body_def.bullet = true;
     
     const auto ball_body = CreateBody(world, body_def);
@@ -3337,7 +3340,7 @@ TEST(World_Longer, TargetJointWontCauseTunnelling)
         const auto angle = i * 2 * Pi / numBodies;
         const auto x = ball_radius * Real(2.1) * cos(angle);
         const auto y = ball_radius * Real(2.1) * sin(angle);
-        body_def.location = Length2{x, y};
+        body_def.UseLocation(Length2{x, y});
         bodies[i] = CreateBody(world, body_def);
         ASSERT_NE(bodies[i], InvalidBodyID);
         ASSERT_EQ(GetX(GetLocation(world, bodies[i])), x);


### PR DESCRIPTION
#### Description - What's this PR do?
Makes some clang-tidy suggested changes and addresses issue #549 .

#### Impacts/Risks of These Changes?
Code written to directly use `BodyConf` member variables like `location` and `angle` will need to be updated to set these via `BodyConf::UseLocation` and `BodyConf::UseAngle` or to get these using `GetLocation(const BodyConf&)` and `GetAngle(const BodyConf&)`.

#### Related Issues
Issue #549.
