### PR TITLE
Updates 20231222

### DIFF
--- a/Benchmark/BenchmarkMain.cpp
+++ b/Benchmark/BenchmarkMain.cpp
@@ -2144,7 +2144,7 @@ static void WorldStepWithStatsStaticPlayRho(benchmark::State& state)
     const auto numBodies = state.range();
     auto world = playrho::d2::World{playrho::d2::WorldConf{/* zero G */}};
     for (auto i = decltype(numBodies){0}; i < numBodies; ++i) {
-        CreateBody(world, playrho::d2::BodyConf{}.UseType(playrho::BodyType::Static));
+        CreateBody(world, playrho::d2::BodyConf{}.Use(playrho::BodyType::Static));
     }
     for (auto _ : state) {
         benchmark::DoNotOptimize(stepStats = Step(world, stepConf));
@@ -2180,7 +2180,7 @@ static void DropDisksPlayRho(benchmark::State& state)
         const auto x = i * diskRadius * 4;
         const auto location = playrho::Length2{x, 0 * playrho::Meter};
         auto body = playrho::d2::Body{playrho::d2::BodyConf{}
-                                          .UseType(playrho::BodyType::Dynamic)
+                                          .Use(playrho::BodyType::Dynamic)
                                           .UseLocation(location)
                                           .UseLinearAcceleration(playrho::d2::EarthlyGravity)};
         body.Attach(shapeId);
@@ -2206,7 +2206,7 @@ static void DropDisksSixtyStepsPlayRho(benchmark::State& state)
             const auto x = i * diskRadius * 4;
             const auto location = playrho::Length2{x, 0 * playrho::Meter};
             auto body = playrho::d2::Body{playrho::d2::BodyConf{}
-                                              .UseType(playrho::BodyType::Dynamic)
+                                              .Use(playrho::BodyType::Dynamic)
                                               .UseLocation(location)
                                               .UseLinearAcceleration(playrho::d2::EarthlyGravity)};
             body.Attach(shapeId);
@@ -2285,7 +2285,7 @@ static void AddPairStressTestPlayRho(benchmark::State& state, int count)
 
     const auto rectBodyConf =
         playrho::d2::BodyConf{}
-            .UseType(playrho::BodyType::Dynamic)
+            .Use(playrho::BodyType::Dynamic)
             .UseBullet(true)
             .UseLocation(playrho::Length2{-40.0f * playrho::Meter, 5.0f * playrho::Meter})
             .UseLinearVelocity(
@@ -2314,7 +2314,7 @@ static void AddPairStressTestPlayRho(benchmark::State& state, int count)
     const auto maxX = 0.0f;
     const auto minY = 4.0f;
     const auto maxY = 6.0f;
-    const auto bd = playrho::d2::BodyConf{}.UseType(playrho::BodyType::Dynamic);
+    const auto bd = playrho::d2::BodyConf{}.Use(playrho::BodyType::Dynamic);
     for (auto _ : state) {
         state.PauseTiming();
         auto world = playrho::d2::World{worldConf};
@@ -2467,7 +2467,7 @@ static void DropTilesPlayRho(int count, bool groundIsComboShape = true)
             y = x;
             for (auto j = i; j < count; ++j) {
                 auto body = playrho::d2::Body{playrho::d2::BodyConf{}
-                                                  .UseType(playrho::BodyType::Dynamic)
+                                                  .Use(playrho::BodyType::Dynamic)
                                                   .UseLocation(y)
                                                   .UseLinearAcceleration(gravity)};
                 body.Attach(shapeId);
@@ -2633,7 +2633,7 @@ private:
 
 TumblerPlayRho::TumblerPlayRho()
 {
-    const auto g = CreateBody(m_world, playrho::d2::BodyConf{}.UseType(playrho::BodyType::Static));
+    const auto g = CreateBody(m_world, playrho::d2::BodyConf{}.Use(playrho::BodyType::Static));
     const auto b = CreateEnclosure(m_world);
     CreateRevoluteJoint(m_world, g, b);
 
@@ -2664,7 +2664,7 @@ TumblerPlayRho::TumblerPlayRho()
 playrho::BodyID TumblerPlayRho::CreateEnclosure(playrho::d2::World& world)
 {
     auto b = playrho::d2::Body{playrho::d2::BodyConf{}
-                                   .UseType(playrho::BodyType::Dynamic)
+                                   .Use(playrho::BodyType::Dynamic)
                                    .UseLocation(playrho::Vec2(0, 10) * playrho::Meter)
                                    .UseAllowSleep(false)};
     auto conf =
@@ -2718,7 +2718,7 @@ void TumblerPlayRho::Step()
 void TumblerPlayRho::AddSquare()
 {
     auto b = playrho::d2::Body{playrho::d2::BodyConf{}
-                                   .UseType(playrho::BodyType::Dynamic)
+                                   .Use(playrho::BodyType::Dynamic)
                                    .UseLocation(playrho::Vec2(0, 10) * playrho::Meter)
                                    .UseLinearAcceleration(playrho::d2::EarthlyGravity)};
     b.Attach(m_squareId);

--- a/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
+++ b/Build/xcode5/PlayRho.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		998A7C062A80404600F29B01 /* StatsResource.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 998A7C042A80404600F29B01 /* StatsResource.hpp */; };
 		998A7C082A814F9300F29B01 /* StatsResource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 998A7C072A814F9300F29B01 /* StatsResource.cpp */; };
 		998A7C0C2A82D55100F29B01 /* Contactable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 998A7C0A2A82D55100F29B01 /* Contactable.hpp */; };
+		99A7B2792B3790610056228D /* OutOfRange.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 99A7B2782B3790610056228D /* OutOfRange.hpp */; };
 		99CF862F29B9087700D9D112 /* BaseShapeConf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99CF862E29B9087700D9D112 /* BaseShapeConf.cpp */; };
 		99CF863129C251CB00D9D112 /* ConstraintSolverConf.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 99CF863029C251CB00D9D112 /* ConstraintSolverConf.cpp */; };
 		99D1BE202AEF18F8001BA497 /* BodyShapeFunction.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 99D1BE1C2AEF18F8001BA497 /* BodyShapeFunction.hpp */; };
@@ -929,6 +930,7 @@
 		998A7C042A80404600F29B01 /* StatsResource.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = StatsResource.hpp; sourceTree = "<group>"; };
 		998A7C072A814F9300F29B01 /* StatsResource.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StatsResource.cpp; sourceTree = "<group>"; };
 		998A7C0A2A82D55100F29B01 /* Contactable.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Contactable.hpp; sourceTree = "<group>"; };
+		99A7B2782B3790610056228D /* OutOfRange.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = OutOfRange.hpp; sourceTree = "<group>"; };
 		99CF862E29B9087700D9D112 /* BaseShapeConf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BaseShapeConf.cpp; sourceTree = "<group>"; };
 		99CF863029C251CB00D9D112 /* ConstraintSolverConf.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ConstraintSolverConf.cpp; sourceTree = "<group>"; };
 		99D1BE1C2AEF18F8001BA497 /* BodyShapeFunction.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = BodyShapeFunction.hpp; sourceTree = "<group>"; };
@@ -1532,6 +1534,7 @@
 				4764085825047FA10090F711 /* NonPositive.hpp */,
 				47640854250475860090F711 /* NonZero.hpp */,
 				4764086E250EA5DE0090F711 /* ObjectPool.hpp */,
+				99A7B2782B3790610056228D /* OutOfRange.hpp */,
 				479132DD26A52AAF0011707B /* PointState.hpp */,
 				4764085A2504822F0090F711 /* Positive.hpp */,
 				9901AEF32A9BCEB90075122D /* pmr */,
@@ -1687,6 +1690,7 @@
 				4734B22D1DC2B11D00F15E29 /* Simplex.hpp in Headers */,
 				80BB899F141C3E5900F1753A /* BlockAllocator.hpp in Headers */,
 				99D1BE302AF01435001BA497 /* JointModel.hpp in Headers */,
+				99A7B2792B3790610056228D /* OutOfRange.hpp in Headers */,
 				4791330026A5344B0011707B /* ToiConf.hpp in Headers */,
 				476408942522698E0090F711 /* WorldJoint.hpp in Headers */,
 				4726DD381D387D630012A882 /* Manifold.hpp in Headers */,

--- a/Library/CMakeLists.txt
+++ b/Library/CMakeLists.txt
@@ -107,6 +107,7 @@ set(PLAYRHO_General_HDRS
     include/playrho/NonPositive.hpp
     include/playrho/NonZero.hpp
     include/playrho/ObjectPool.hpp
+    include/playrho/OutOfRange.hpp
     include/playrho/PointState.hpp
     include/playrho/Positive.hpp
     include/playrho/RayCastOpcode.hpp

--- a/Library/include/playrho/Contact.hpp
+++ b/Library/include/playrho/Contact.hpp
@@ -244,7 +244,7 @@ public:
     /// @brief Unsets the sensor state of this contact.
     /// @post <code>IsSensor()</code> returns false.
     /// @see IsSensor().
-    constexpr void UnsetIsSensor() noexcept;
+    constexpr void UnsetSensor() noexcept;
 
     /// @brief Whether or not this contact is "impenetrable".
     /// @note This should be true whenever body A or body B are impenetrable.
@@ -470,7 +470,7 @@ constexpr void Contact::SetSensor() noexcept
     m_flags |= e_sensorFlag;
 }
 
-constexpr void Contact::UnsetIsSensor() noexcept
+constexpr void Contact::UnsetSensor() noexcept
 {
     m_flags &= ~e_sensorFlag;
 }
@@ -647,9 +647,9 @@ constexpr void SetSensor(Contact& contact) noexcept
 /// @post <code>IsSensor(contact)</code> returns false.
 /// @see IsSensor(const Contact &).
 /// @relatedalso Contact
-constexpr void UnsetIsSensor(Contact& contact) noexcept
+constexpr void UnsetSensor(Contact& contact) noexcept
 {
-    contact.UnsetIsSensor();
+    contact.UnsetSensor();
 }
 
 /// @brief Gets the time of impact count.

--- a/Library/include/playrho/OutOfRange.hpp
+++ b/Library/include/playrho/OutOfRange.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023 Louis Langholtz https://github.com/louis-langholtz/PlayRho
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef PLAYRHO_OUTOFRANGE_HPP
+#define PLAYRHO_OUTOFRANGE_HPP
+
+#include <stdexcept> // for std::out_of_range
+#include <string>
+
+namespace playrho {
+
+/// @brief Out-of-range exception with a range type & value.
+/// @see std::out_of_range.
+template <class T>
+class OutOfRange: public std::out_of_range {
+public:
+    using type = T; ///< Type of the index whose value was out-of-range.
+
+    using std::out_of_range::out_of_range;
+
+    /// @brief Initializing constructor.
+    OutOfRange(type v, const std::string& msg): out_of_range{msg}, value{v} {}
+
+    /// @brief Initializing constructor.
+    OutOfRange(type v, const char* msg): out_of_range{msg}, value{v} {}
+
+    type value{}; ///< Value of the index that was out-of-range.
+};
+
+} // namespace playrho
+
+#endif // PLAYRHO_OUTOFRANGE_HPP

--- a/Library/include/playrho/d2/AabbTreeWorld.hpp
+++ b/Library/include/playrho/d2/AabbTreeWorld.hpp
@@ -77,7 +77,9 @@ struct StepConf;
 enum class BodyType;
 class Contact;
 
-namespace d2 {
+} // namespace playrho
+
+namespace playrho::d2 {
 
 class Body;
 class Joint;
@@ -485,15 +487,16 @@ KeyedContactIDs GetContacts(const AabbTreeWorld& world);
 const Contact& GetContact(const AabbTreeWorld& world, ContactID id);
 
 /// @brief Sets the identified contact's state.
+/// @note The new state:
+///   - Is not allowed to change the bodies, shapes, or children identified.
+///   - Is not allowed to change whether the contact is awake.
+///   - Is not allowed to change whether the contact is impenetrable.
+///   - Is not allowed to change whether the contact is for a sensor.
+///   - Is not allowed to change the TOI of the contact.
+///   - Is not allowed to change the TOI count of the contact.
 /// @param world The world of the contact whose state is to be set.
 /// @param id Identifier of the contact whose state is to be set.
-/// @param value Value the contact is to be set to. The new state:
-///   is not allowed to change whether the contact is awake,
-///   is not allowed to change whether the contact is impenetrable,
-///   is not allowed to change whether the contact is for a sensor,
-///   is not allowed to change the TOI of the contact,
-///   is not allowed to change the TOI count of the contact. Otherwise, this function
-///   will throw an <code>InvalidArgument</code> exception and not change anything.
+/// @param value Value the contact is to be set to.
 /// @throws std::out_of_range If given an invalid contact identifier or an invalid identifier
 ///   in the new contact value.
 /// @throws InvalidArgument if the identifier is to a freed contact or if the new state is
@@ -1135,7 +1138,6 @@ inline void SetPostSolveContactListener(AabbTreeWorld& world, ContactImpulsesFun
 ContactID GetSoonestContact(const Span<const KeyedContactID>& ids,
                             const Span<const Contact>& contacts) noexcept;
 
-} // namespace d2
-} // namespace playrho
+} // namespace playrho::d2
 
 #endif // PLAYRHO_D2_AABBTREEWORLD_HPP

--- a/Library/include/playrho/d2/BodyConf.hpp
+++ b/Library/include/playrho/d2/BodyConf.hpp
@@ -113,9 +113,6 @@ struct BodyConf {
     // Builder-styled methods...
 
     /// @brief Use the given type.
-    constexpr BodyConf& UseType(BodyType t) noexcept;
-
-    /// @brief Use the given type.
     constexpr BodyConf& Use(BodyType t) noexcept;
 
     /// @brief Use the given sweep.
@@ -263,11 +260,6 @@ struct BodyConf {
     /// @brief Whether mass data is "dirty".
     bool massDataDirty = DefaultMassDataDirty;
 };
-
-constexpr BodyConf& BodyConf::UseType(BodyType t) noexcept
-{
-    return Use(t);
-}
 
 constexpr BodyConf& BodyConf::Use(BodyType t) noexcept
 {

--- a/Library/source/playrho/d2/AabbTreeWorld.cpp
+++ b/Library/source/playrho/d2/AabbTreeWorld.cpp
@@ -2741,20 +2741,15 @@ void SetBody(AabbTreeWorld& world, BodyID id, Body value)
 
 void SetContact(AabbTreeWorld& world, ContactID id, Contact value)
 {
-    const auto& contact = world.m_contactBuffer.at(to_underlying(id));
-
     // Make sure body identifiers and shape identifiers are valid...
-    [[maybe_unused]] const auto& bodyA = world.m_bodyBuffer.at(to_underlying(GetBodyA(value)));
-    [[maybe_unused]] const auto& bodyB = world.m_bodyBuffer.at(to_underlying(GetBodyB(value)));
-    [[maybe_unused]] const auto& shapeA = world.m_shapeBuffer.at(to_underlying(GetShapeA(value)));
-    [[maybe_unused]] const auto& shapeB = world.m_shapeBuffer.at(to_underlying(GetShapeB(value)));
-
-    assert(IsImpenetrable(contact) == (IsImpenetrable(bodyA) || IsImpenetrable(bodyB)));
-    assert(IsSensor(contact) == (IsSensor(shapeA) || IsSensor(shapeB)));
-
+    GetBody(world, GetBodyA(value));
+    GetBody(world, GetBodyB(value));
+    GetChild(GetShape(world, GetShapeA(value)), GetChildIndexA(value));
+    GetChild(GetShape(world, GetShapeB(value)), GetChildIndexB(value));
     if (world.m_contactBuffer.FindFree(to_underlying(id))) {
         throw InvalidArgument(idIsDestroyedMsg);
     }
+    auto& contact = world.m_contactBuffer.at(to_underlying(id));
     if (IsImpenetrable(contact) != IsImpenetrable(value)) {
         throw InvalidArgument("change body A or B being impenetrable to change impenetrable state");
     }
@@ -2767,8 +2762,7 @@ void SetContact(AabbTreeWorld& world, ContactID id, Contact value)
     if (GetToiCount(contact) != GetToiCount(value)) {
         throw InvalidArgument("user may not change the TOI count");
     }
-
-    world.m_contactBuffer[to_underlying(id)] = value;
+    contact = value;
 }
 
 const Body& GetBody(const AabbTreeWorld& world, BodyID id)

--- a/Library/source/playrho/d2/DynamicTree.cpp
+++ b/Library/source/playrho/d2/DynamicTree.cpp
@@ -23,6 +23,7 @@
 #include <cassert> // for assert
 #include <limits> // for std::numeric_limits
 #include <utility>
+#include <type_traits> // for std::is_nothrow_default_constructible_v, etc
 
 #include <playrho/GrowableStack.hpp>
 #include <playrho/DynamicMemory.hpp>
@@ -32,8 +33,7 @@
 #include <playrho/d2/DynamicTree.hpp>
 #include <playrho/d2/Math.hpp> // for NextPowerOfTwo and others
 
-namespace playrho {
-namespace d2 {
+namespace playrho::d2 {
 
 static_assert(std::is_nothrow_default_constructible_v<DynamicTree>,
               "DynamicTree must be nothrow default constructible!");
@@ -823,5 +823,4 @@ bool ValidateMetrics(const DynamicTree& tree, DynamicTree::Size index) noexcept
     return ValidateMetrics(tree, child1) && ValidateMetrics(tree, child2);
 }
 
-} // namespace d2
-} // namespace playrho
+} // namespace playrho::d2

--- a/Testbed/Framework/Main.cpp
+++ b/Testbed/Framework/Main.cpp
@@ -3151,7 +3151,7 @@ static void EntityUI(Contact& contact)
                 SetSensor(contact);
             }
             else {
-                UnsetIsSensor(contact);
+                UnsetSensor(contact);
             }
         }
     }

--- a/Testbed/Framework/Test.cpp
+++ b/Testbed/Framework/Test.cpp
@@ -1096,7 +1096,7 @@ void Test::LaunchBomb(const Length2& at, const LinearVelocity2 v)
         }
     }
 
-    m_bomb = CreateBody(m_world, BodyConf{}.UseType(BodyType::Dynamic).UseBullet(true)
+    m_bomb = CreateBody(m_world, BodyConf{}.Use(BodyType::Dynamic).UseBullet(true)
                                 .UseLocation(at).UseLinearVelocity(v)
                                 .UseLinearAcceleration(m_gravity));
 

--- a/Testbed/Tests/AddPair.cpp
+++ b/Testbed/Tests/AddPair.cpp
@@ -44,7 +44,7 @@ public:
             const auto maxX = 0.0f;
             const auto minY = 4.0f;
             const auto maxY = 6.0f;
-            const auto bd = BodyConf{}.UseType(BodyType::Dynamic);
+            const auto bd = BodyConf{}.Use(BodyType::Dynamic);
             const auto shape =
                 CreateShape(GetWorld(), DiskShapeConf{}.UseRadius(0.1_m).UseDensity(0.01_kgpm2));
             for (auto i = 0; i < 400; ++i) {
@@ -56,7 +56,7 @@ public:
             }
         }
         const auto bd = BodyConf{}
-                            .UseType(BodyType::Dynamic)
+                            .Use(BodyType::Dynamic)
                             .UseBullet(true)
                             .UseLocation(Length2{-40_m, 5_m})
                             .UseLinearVelocity(LinearVelocity2{150_mps, 0_mps});

--- a/Testbed/Tests/ApplyForce.cpp
+++ b/Testbed/Tests/ApplyForce.cpp
@@ -120,7 +120,7 @@ public:
             for (auto i = 0; i < 10; ++i) {
                 const auto location = Length2{0_m, (5.0f + 1.54f * i) * 1_m};
                 const auto body = CreateBody(
-                    GetWorld(), BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location));
+                    GetWorld(), BodyConf{}.Use(BodyType::Dynamic).UseLocation(location));
                 Attach(GetWorld(), body, shape);
 
                 const auto I = GetLocalRotInertia(GetWorld(), body); // RotInertia: M * L^2 QP^-2

--- a/Testbed/Tests/BagOfDisks.cpp
+++ b/Testbed/Tests/BagOfDisks.cpp
@@ -40,7 +40,7 @@ public:
 
     BagOfDisks() : Test(GetTestConf())
     {
-        m_ground = CreateBody(GetWorld(), BodyConf{}.UseType(BodyType::Kinematic));
+        m_ground = CreateBody(GetWorld(), BodyConf{}.Use(BodyType::Kinematic));
 
         RegisterForKey(GLFW_KEY_A, GLFW_PRESS, 0, "Increase counter-clockwise angular velocity",
                        [&](KeyActionMods) {
@@ -79,7 +79,7 @@ public:
                 const auto midPoint = (vertex + *prevVertex) / 2;
                 const auto angle = GetAngle(vertex - *prevVertex);
                 const auto body = CreateBody(GetWorld(), BodyConf{}
-                                                             .UseType(BodyType::Dynamic)
+                                                             .Use(BodyType::Dynamic)
                                                              .UseBullet(true)
                                                              .UseLocation(midPoint + vertexOffset)
                                                              .UseAngle(angle)
@@ -111,7 +111,7 @@ public:
             const auto unitVector = UnitVec::Get(angle);
             const auto location = radius * unitVector;
             const auto body = CreateBody(GetWorld(), BodyConf{}
-                                                         .UseType(BodyType::Dynamic)
+                                                         .Use(BodyType::Dynamic)
                                                          .UseLocation(location + vertexOffset)
                                                          .UseLinearAcceleration(GetGravity()));
             Attach(GetWorld(), body, diskShape);

--- a/Testbed/Tests/BodyTypes.cpp
+++ b/Testbed/Tests/BodyTypes.cpp
@@ -46,7 +46,7 @@ public:
         // Define attachment
         {
             const auto bd = BodyConf{}
-                                .UseType(BodyType::Dynamic)
+                                .Use(BodyType::Dynamic)
                                 .UseLocation(Vec2(0, 3) * 1_m)
                                 .UseLinearAcceleration(GetGravity());
             m_attachment = CreateBody(GetWorld(), bd);
@@ -57,7 +57,7 @@ public:
         // Define platform
         {
             const auto bd = BodyConf{}
-                                .UseType(BodyType::Dynamic)
+                                .Use(BodyType::Dynamic)
                                 .UseLocation(Vec2(-4, 5) * 1_m)
                                 .UseLinearAcceleration(GetGravity());
             m_platform = CreateBody(GetWorld(), bd);
@@ -87,7 +87,7 @@ public:
         // Create a payload
         {
             const auto bd = BodyConf{}
-                                .UseType(BodyType::Dynamic)
+                                .Use(BodyType::Dynamic)
                                 .UseLocation(Vec2(0, 8) * 1_m)
                                 .UseLinearAcceleration(GetGravity());
             const auto body = CreateBody(GetWorld(), bd);

--- a/Testbed/Tests/BreakableTwo.cpp
+++ b/Testbed/Tests/BreakableTwo.cpp
@@ -49,7 +49,7 @@ public:
 
         BodyID bodies[20 * 20];
         const auto startLoc = Length2{-10_m, 10_m};
-        const auto bd = BodyConf{}.UseType(BodyType::Dynamic);
+        const auto bd = BodyConf{}.Use(BodyType::Dynamic);
         for (auto y = 0; y < 20; ++y) {
             for (auto x = 0; x < 20; ++x) {
                 const auto location = startLoc + Length2{x * 1_m, y * 1_m};

--- a/Testbed/Tests/Bridge.cpp
+++ b/Testbed/Tests/Bridge.cpp
@@ -43,7 +43,7 @@ public:
             for (auto i = 0; i < Count; ++i) {
                 const auto body =
                     CreateBody(GetWorld(), BodyConf{}
-                                               .UseType(BodyType::Dynamic)
+                                               .Use(BodyType::Dynamic)
                                                .UseLinearAcceleration(GetGravity())
                                                .UseLocation(Vec2(-14.5f + i, 5.0f) * 1_m));
                 Attach(GetWorld(), body, shape);
@@ -65,7 +65,7 @@ public:
         for (auto i = 0; i < 2; ++i) {
             const auto body =
                 CreateBody(GetWorld(), BodyConf{}
-                                           .UseType(BodyType::Dynamic)
+                                           .Use(BodyType::Dynamic)
                                            .UseLinearAcceleration(GetGravity())
                                            .UseLocation(Vec2(-8.0f + 8.0f * i, 12.0f) * 1_m));
             Attach(GetWorld(), body, polyshape);
@@ -76,7 +76,7 @@ public:
         for (auto i = 0; i < 3; ++i) {
             const auto body =
                 CreateBody(GetWorld(), BodyConf{}
-                                           .UseType(BodyType::Dynamic)
+                                           .Use(BodyType::Dynamic)
                                            .UseLinearAcceleration(GetGravity())
                                            .UseLocation(Vec2(-6.0f + 6.0f * i, 10.0f) * 1_m));
             Attach(GetWorld(), body, diskShape);

--- a/Testbed/Tests/Car.cpp
+++ b/Testbed/Tests/Car.cpp
@@ -129,7 +129,7 @@ public:
             for (auto i = 0; i < N; ++i) {
                 const auto body = CreateBody(GetWorld(),
                                              BodyConf{}
-                                                 .UseType(BodyType::Dynamic)
+                                                 .Use(BodyType::Dynamic)
                                                  .UseLocation(Vec2(161 + 2 * i, -0.125f) * 1_m));
                 Attach(GetWorld(), body, shape);
                 CreateJoint(GetWorld(), GetRevoluteJointConf(GetWorld(), prevBody, body,
@@ -144,7 +144,7 @@ public:
         {
             const auto box = CreateShape(
                 GetWorld(), PolygonShapeConf{}.UseDensity(0.5_kgpm2).SetAsBox(0.5_m, 0.5_m));
-            auto bd = BodyConf{}.UseType(BodyType::Dynamic);
+            auto bd = BodyConf{}.Use(BodyType::Dynamic);
             Attach(GetWorld(), CreateBody(GetWorld(), bd.UseLocation(Vec2(230, 0.5f) * 1_m)), box);
             Attach(GetWorld(), CreateBody(GetWorld(), bd.UseLocation(Vec2(230, 1.5f) * 1_m)), box);
             Attach(GetWorld(), CreateBody(GetWorld(), bd.UseLocation(Vec2(230, 2.5f) * 1_m)), box);
@@ -184,7 +184,7 @@ public:
                 })
                 .Transform(transmat);
 
-        auto bd = BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
+        auto bd = BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
         m_car = CreateBody(GetWorld(), bd.Use(carPosition).Use(carVelocity));
         Attach(GetWorld(), m_car, CreateShape(GetWorld(), carShapeConf));
 

--- a/Testbed/Tests/DistanceTest.cpp
+++ b/Testbed/Tests/DistanceTest.cpp
@@ -50,7 +50,7 @@ public:
         SetGravity(LinearAcceleration2{});
 
         const auto def = BodyConf{}
-                             .UseType(BodyType::Dynamic)
+                             .Use(BodyType::Dynamic)
                              .UseLinearDamping(0.9_Hz)
                              .UseAngularDamping(0.9_Hz);
         m_bodyA = CreateBody(GetWorld(), def);

--- a/Testbed/Tests/Dominos.cpp
+++ b/Testbed/Tests/Dominos.cpp
@@ -49,7 +49,7 @@ public:
             for (auto i = 0; i < 10; ++i) {
                 const auto body =
                     CreateBody(GetWorld(), BodyConf{}
-                                               .UseType(BodyType::Dynamic)
+                                               .Use(BodyType::Dynamic)
                                                .UseLocation(Vec2(-6.0f + 1.0f * i, 11.25f) * 1_m));
                 Attach(GetWorld(), body, shape);
             }

--- a/Testbed/Tests/HalfPipe.cpp
+++ b/Testbed/Tests/HalfPipe.cpp
@@ -37,7 +37,7 @@ public:
             Attach(GetWorld(), pipeBody, CreateShape(GetWorld(), conf));
         }
         const auto ballBody = CreateBody(GetWorld(), BodyConf{}
-                                                         .UseType(BodyType::Dynamic)
+                                                         .Use(BodyType::Dynamic)
                                                          .UseLocation(Vec2(-19, 28) * 1_m)
                                                          .UseLinearAcceleration(GetGravity()));
         Attach(GetWorld(), ballBody,

--- a/Testbed/Tests/HeavyOnLight.cpp
+++ b/Testbed/Tests/HeavyOnLight.cpp
@@ -33,7 +33,7 @@ public:
 
     HeavyOnLight()
     {
-        const auto bd = BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
+        const auto bd = BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
         const auto upperBodyConf = BodyConf(bd).UseLocation(Vec2(0.0f, 6.0f) * 1_m);
         const auto lowerBodyConf = BodyConf(bd).UseLocation(Vec2(0.0f, 0.5f) * 1_m);
 

--- a/Testbed/Tests/HeavyOnLightTwo.cpp
+++ b/Testbed/Tests/HeavyOnLightTwo.cpp
@@ -59,7 +59,7 @@ public:
     }
 
     const BodyConf DynBD =
-        BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
+        BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
     ShapeID lilDisk = InvalidShapeID;
     ShapeID bigDisk = InvalidShapeID;
     BodyID m_heavy = InvalidBodyID;

--- a/Testbed/Tests/JointsTest.cpp
+++ b/Testbed/Tests/JointsTest.cpp
@@ -429,9 +429,9 @@ private:
 
     const Length RowSize = +10_m;
     const Length ColumnSize = +10_m;
-    const BodyConf StaticBD = BodyConf{}.UseType(BodyType::Static);
+    const BodyConf StaticBD = BodyConf{}.Use(BodyType::Static);
     const BodyConf DynamicBD =
-        BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
+        BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
     const Length RectHHeight = 0.25_m;
     const Length RectHWidth = 2_m;
     ShapeID m_diskShape = InvalidShapeID;

--- a/Testbed/Tests/MotorJoint.cpp
+++ b/Testbed/Tests/MotorJoint.cpp
@@ -49,7 +49,7 @@ public:
 
         // Define motorized body
         const auto body = CreateBody(GetWorld(), BodyConf{}
-                                                     .UseType(BodyType::Dynamic)
+                                                     .Use(BodyType::Dynamic)
                                                      .UseLocation(Vec2(0.0f, 8.0f) * 1_m)
                                                      .UseLinearAcceleration(GetGravity()));
         Attach(GetWorld(), body,

--- a/Testbed/Tests/MotorJoint2.cpp
+++ b/Testbed/Tests/MotorJoint2.cpp
@@ -68,7 +68,7 @@ public:
         if (IsValid(m_bodyB))
             Destroy(GetWorld(), m_bodyB);
 
-        const auto bd = BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
+        const auto bd = BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(GetGravity());
         const auto locations = m_reversedBody ? std::make_pair(m_locationB, m_locationA)
                                               : std::make_pair(m_locationA, m_locationB);
         m_bodyA = CreateBody(GetWorld(), BodyConf(bd).UseLocation(std::get<0>(locations)));

--- a/Testbed/Tests/Revolute.cpp
+++ b/Testbed/Tests/Revolute.cpp
@@ -93,7 +93,7 @@ public:
                                              Vec2(17.19f, 36.36f) * 1_m})
                                        .UseDensity(1_kgpm2);
 
-            const auto body = CreateBody(GetWorld(), BodyConf{}.UseType(BodyType::Dynamic));
+            const auto body = CreateBody(GetWorld(), BodyConf{}.Use(BodyType::Dynamic));
             Attach(GetWorld(), body, CreateShape(GetWorld(), polyShape));
         }
 

--- a/Testbed/Tests/SolarSystem.cpp
+++ b/Testbed/Tests/SolarSystem.cpp
@@ -111,7 +111,7 @@ public:
     {
         SetBombRadius(100_km);
         SetBombDensity(2e12_kgpm2);
-        const auto DynamicBD = BodyConf{}.UseType(BodyType::Dynamic).UseBullet(true);
+        const auto DynamicBD = BodyConf{}.Use(BodyType::Dynamic).UseBullet(true);
         for (auto& sso : SolarSystemBodies) {
             const auto p = sso.orbitalPeriod;
             const auto c = sso.aveDist * Pi * 2;

--- a/Testbed/Tests/Tumbler.cpp
+++ b/Testbed/Tests/Tumbler.cpp
@@ -107,7 +107,7 @@ public:
     BodyID CreateEnclosure(Length2 at)
     {
         const auto b = CreateBody(GetWorld(), BodyConf{}
-                                                  .UseType(BodyType::Dynamic)
+                                                  .Use(BodyType::Dynamic)
                                                   .UseLocation(at)
                                                   .UseAllowSleep(false)
                                                   .UseLinearAcceleration(GetGravity()));
@@ -160,7 +160,7 @@ public:
     void CreateTumblee(Length2 at)
     {
         CreateBody(GetWorld(), BodyConf{}
-                                   .UseType(BodyType::Dynamic)
+                                   .Use(BodyType::Dynamic)
                                    .UseLocation(at)
                                    .Use(GetTumbleeShapeID())
                                    .UseLinearAcceleration(GetGravity()));

--- a/Testbed/Tests/iforce2d_TopdownCar.cpp
+++ b/Testbed/Tests/iforce2d_TopdownCar.cpp
@@ -299,7 +299,7 @@ public:
 
 inline TDTire::TDTire(iforce2d_TopdownCar& parent, ShapeID tireShape) : m_parent{parent}
 {
-    m_body = CreateBody(m_parent.GetWorld(), BodyConf{}.UseType(BodyType::Dynamic));
+    m_body = CreateBody(m_parent.GetWorld(), BodyConf{}.Use(BodyType::Dynamic));
     m_parent.m_bodyData.resize(m_body.get() + 1u);
     m_parent.m_bodyData[m_body.get()] = this;
     Attach(m_parent.GetWorld(), m_body, tireShape);

--- a/UnitTests/AabbTreeWorld.cpp
+++ b/UnitTests/AabbTreeWorld.cpp
@@ -598,6 +598,8 @@ TEST(AabbTreeWorld, SetContact)
     EXPECT_THROW(SetContact(world, ContactID(0), contact0), InvalidArgument);
     contact0.UnsetSensor();
     EXPECT_NO_THROW(SetContact(world, ContactID(0), contact0));
+    EXPECT_THROW(SetContact(world, ContactID(0), Contact{cA, Contactable{bodyId0, ShapeID(0), 0u}}), InvalidArgument);
+    EXPECT_THROW(SetContact(world, ContactID(0), Contact{Contactable{bodyId1, ShapeID(0), 0u}, cB}), InvalidArgument);
     SetLocation(body1, Length2{10_m, 10_m});
     SetBody(world, bodyId1, body1);
     Step(world, step);

--- a/UnitTests/AabbTreeWorld.cpp
+++ b/UnitTests/AabbTreeWorld.cpp
@@ -316,7 +316,7 @@ TEST(AabbTreeWorld, CreateDestroyEmptyStaticBody)
 {
     auto world = AabbTreeWorld{};
     ASSERT_EQ(GetBodies(world).size(), BodyCounter(0));
-    const auto bodyID = CreateBody(world, BodyConf{}.UseType(BodyType::Static));
+    const auto bodyID = CreateBody(world, BodyConf{}.Use(BodyType::Static));
     ASSERT_NE(bodyID, InvalidBodyID);
 
     const auto& body = GetBody(world, bodyID);
@@ -351,7 +351,7 @@ TEST(AabbTreeWorld, CreateDestroyEmptyDynamicBody)
 {
     auto world = AabbTreeWorld{};
     ASSERT_EQ(GetBodies(world).size(), BodyCounter(0));
-    const auto bodyID = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bodyID = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(bodyID, InvalidBodyID);
 
     const auto& body = GetBody(world, bodyID);
@@ -389,7 +389,7 @@ TEST(AabbTreeWorld, CreateDestroyDynamicBodyAndFixture)
     
     auto world = AabbTreeWorld{};
     ASSERT_EQ(GetBodies(world).size(), BodyCounter(0));
-    const auto bodyID = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bodyID = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(bodyID, InvalidBodyID);
 
     const auto& body = GetBody(world, bodyID);
@@ -448,8 +448,8 @@ TEST(AabbTreeWorld, CreateDestroyContactingBodies)
     const auto l1 = Length2{};
     const auto l2 = Length2{};
 
-    const auto body1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l1));
-    const auto body2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l2));
+    const auto body1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(l1));
+    const auto body2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(l2));
     EXPECT_EQ(GetBodies(world).size(), BodyCounter(2));
     EXPECT_EQ(GetBodiesForProxies(world).size(), static_cast<decltype(GetBodiesForProxies(world).size())>(0));
     EXPECT_EQ(GetFixturesForProxies(world).size(), static_cast<decltype(GetFixturesForProxies(world).size())>(0));
@@ -550,7 +550,7 @@ TEST(AabbTreeWorld, CreateDestroyContactingBodies)
 TEST(AabbTreeWorld, SetTypeOfBody)
 {
     auto world = AabbTreeWorld{};
-    const auto bodyID = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bodyID = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     const auto& body = GetBody(world, bodyID);
     ASSERT_EQ(GetType(body), BodyType::Dynamic);
     auto other = AabbTreeWorld{};
@@ -793,7 +793,7 @@ TEST(AabbTreeWorld, SetTypeBody)
 {
     auto world = AabbTreeWorld{};
 
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_EQ(GetBodiesForProxies(world).size(), 0u);
     ASSERT_EQ(GetType(GetBody(world, body)), BodyType::Dynamic);
 
@@ -825,13 +825,13 @@ TEST(AabbTreeWorld, GetBodyRange)
     auto world = AabbTreeWorld{};
     EXPECT_EQ(GetBodyRange(world), BodyCounter{0u});
     EXPECT_EQ(GetBodies(world).size(), 0u);
-    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic)));
+    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     EXPECT_EQ(GetBodyRange(world), BodyCounter{1u});
     EXPECT_EQ(GetBodies(world).size(), 1u);
-    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic)));
+    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     EXPECT_EQ(GetBodyRange(world), BodyCounter{2u});
     EXPECT_EQ(GetBodies(world).size(), 2u);
-    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic)));
+    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     EXPECT_EQ(GetBodyRange(world), BodyCounter{3u});
     EXPECT_EQ(GetBodies(world).size(), 3u);
     EXPECT_NO_THROW(Destroy(world, BodyID{0u}));
@@ -849,7 +849,7 @@ TEST(AabbTreeWorld, GetShapeRange)
     EXPECT_EQ(GetShapeRange(world), ShapeCounter{0u});
     const auto shapeId = CreateShape(world, shape);
     EXPECT_EQ(GetShapeRange(world), ShapeCounter{1u});
-    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic)));
+    EXPECT_NO_THROW(CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     EXPECT_EQ(GetShapes(world, BodyID{0u}).size(), 0u);
     EXPECT_NO_THROW(Attach(world, BodyID{0u}, shapeId));
     EXPECT_EQ(GetShapeRange(world), ShapeCounter{1u});
@@ -887,12 +887,12 @@ TEST(AabbTreeWorld, IsDestroyedBody)
     EXPECT_FALSE(IsDestroyed(world, BodyID{0u}));
 
     auto id = InvalidBodyID;
-    ASSERT_NO_THROW(id = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic)));
+    ASSERT_NO_THROW(id = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     ASSERT_EQ(to_underlying(id), 0u);
     ASSERT_EQ(GetBodies(world).size(), 1u);
     EXPECT_FALSE(IsDestroyed(world, id));
 
-    ASSERT_NO_THROW(id = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic)));
+    ASSERT_NO_THROW(id = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     ASSERT_EQ(to_underlying(id), 1u);
     ASSERT_EQ(GetBodies(world).size(), 2u);
     EXPECT_FALSE(IsDestroyed(world, id));
@@ -910,7 +910,7 @@ TEST(AabbTreeWorld, AttachDetach)
     const auto shape = Shape{DiskShapeConf{}};
     auto world = AabbTreeWorld{};
     const auto shapeId = CreateShape(world, shape);
-    ASSERT_NO_THROW(CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic)));
+    ASSERT_NO_THROW(CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     ASSERT_NO_THROW(Attach(world, BodyID{0u}, shapeId));
     ASSERT_EQ(GetShapes(world, BodyID{0}).size(), 1u);
     ASSERT_EQ(GetShapes(world, BodyID{0})[0], shapeId);

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -125,9 +125,9 @@ TEST(Body, AngularDampingOnConstruction)
 
 TEST(Body, InvMassOnConstruction)
 {
-    EXPECT_EQ(Body(BodyConf{}.UseType(BodyType::Dynamic)).GetInvMass(), Real(1) / 1_kg);
-    EXPECT_EQ(Body(BodyConf{}.UseType(BodyType::Kinematic)).GetInvMass(), Real(0) / 1_kg);
-    EXPECT_EQ(Body(BodyConf{}.UseType(BodyType::Static)).GetInvMass(), Real(0) / 1_kg);
+    EXPECT_EQ(Body(BodyConf{}.Use(BodyType::Dynamic)).GetInvMass(), Real(1) / 1_kg);
+    EXPECT_EQ(Body(BodyConf{}.Use(BodyType::Kinematic)).GetInvMass(), Real(0) / 1_kg);
+    EXPECT_EQ(Body(BodyConf{}.Use(BodyType::Static)).GetInvMass(), Real(0) / 1_kg);
 }
 
 TEST(Body, TransformationOnConstruction)

--- a/UnitTests/BodyConf.cpp
+++ b/UnitTests/BodyConf.cpp
@@ -72,11 +72,11 @@ TEST(BodyConf, DefaultConstruction)
     EXPECT_EQ(BodyConf().massDataDirty, BodyConf::DefaultMassDataDirty);
 }
 
-TEST(BodyConf, UseType)
+TEST(BodyConf, Use)
 {
-    EXPECT_EQ(BodyConf{}.UseType(BodyType::Static).type, BodyType::Static);
-    EXPECT_EQ(BodyConf{}.UseType(BodyType::Dynamic).type, BodyType::Dynamic);
-    EXPECT_EQ(BodyConf{}.UseType(BodyType::Kinematic).type, BodyType::Kinematic);
+    EXPECT_EQ(BodyConf{}.Use(BodyType::Static).type, BodyType::Static);
+    EXPECT_EQ(BodyConf{}.Use(BodyType::Dynamic).type, BodyType::Dynamic);
+    EXPECT_EQ(BodyConf{}.Use(BodyType::Kinematic).type, BodyType::Kinematic);
 }
 
 TEST(BodyConf, UseInvMass)
@@ -161,7 +161,7 @@ TEST(BodyConf, GetBodyConf2)
 TEST(BodyConf, EqualsOperator)
 {
     EXPECT_TRUE(BodyConf() == BodyConf());
-    EXPECT_FALSE(BodyConf().UseType(BodyType::Dynamic) == BodyConf());
+    EXPECT_FALSE(BodyConf().Use(BodyType::Dynamic) == BodyConf());
     EXPECT_FALSE(BodyConf().UseLocation(Length2(2_m, 3_m)) == BodyConf());
     EXPECT_FALSE(BodyConf().UseAngle(15_deg) == BodyConf());
     EXPECT_FALSE(BodyConf().UseLinearVelocity(LinearVelocity2{2_mps, 3_mps}) == BodyConf());
@@ -184,7 +184,7 @@ TEST(BodyConf, EqualsOperator)
 TEST(BodyConf, NotEqualsOperator)
 {
     EXPECT_FALSE(BodyConf() != BodyConf());
-    EXPECT_TRUE(BodyConf().UseType(BodyType::Dynamic) != BodyConf());
+    EXPECT_TRUE(BodyConf().Use(BodyType::Dynamic) != BodyConf());
     EXPECT_TRUE(BodyConf().UseLocation(Length2(2_m, 3_m)) != BodyConf());
     EXPECT_TRUE(BodyConf().UseAngle(15_deg) != BodyConf());
     EXPECT_TRUE(BodyConf().UseLinearVelocity(LinearVelocity2{2_mps, 3_mps}) != BodyConf());

--- a/UnitTests/DistanceJoint.cpp
+++ b/UnitTests/DistanceJoint.cpp
@@ -115,8 +115,8 @@ TEST(DistanceJoint, TypeCast)
 TEST(DistanceJoint, Construction)
 {
     auto world = World{};
-    const auto body0 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto body1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body0 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto body1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     auto def = DistanceJointConf{body0, body1};
     const auto joint = CreateJoint(world, Joint{def});
 
@@ -138,8 +138,8 @@ TEST(DistanceJoint, Construction)
 TEST(DistanceJoint, ShiftOrigin)
 {
     auto world = World{};
-    const auto body0 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto body1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body0 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto body1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     auto def = DistanceJointConf{body0, body1};
     const auto joint = CreateJoint(world, def);
     const auto newOrigin = Length2{1_m, 1_m};
@@ -154,13 +154,13 @@ TEST(DistanceJoint, InZeroGravBodiesMoveOutToLength)
 
     const auto location1 = Length2{-1_m, 0_m};
     const auto body1 =
-        CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location1));
+        CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(location1));
     ASSERT_EQ(GetLocation(world, body1), location1);
     ASSERT_NO_THROW(Attach(world, body1, shape));
 
     const auto location2 = Length2{+1_m, 0_m};
     const auto body2 =
-        CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location2));
+        CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(location2));
     ASSERT_EQ(GetLocation(world, body2), location2);
     ASSERT_NO_THROW(Attach(world, body2, shape));
 
@@ -205,13 +205,13 @@ TEST(DistanceJoint, InZeroGravBodiesMoveInToLength)
     const auto shape = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m).UseDensity(1_kgpm2));
     const auto location1 = Length2{-10_m, 10_m};
     const auto body1 =
-        CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location1));
+        CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(location1));
     ASSERT_EQ(GetLocation(world, body1), location1);
     ASSERT_NO_THROW(Attach(world, body1, shape));
 
     const auto location2 = Length2{+10_m, -10_m};
     const auto body2 =
-        CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location2));
+        CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(location2));
     ASSERT_EQ(GetLocation(world, body2), location2);
     ASSERT_NO_THROW(Attach(world, body2, shape));
 

--- a/UnitTests/FrictionJoint.cpp
+++ b/UnitTests/FrictionJoint.cpp
@@ -77,8 +77,8 @@ TEST(FrictionJointConf, GetFrictionJointConf)
     World world{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     const auto anchor = Length2{0_m, 0_m};
     const auto def = GetFrictionJointConf(world, b1, b2, anchor);
     EXPECT_EQ(def.bodyA, b1);
@@ -150,8 +150,8 @@ TEST(FrictionJoint, WithDynamicCircles)
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
     const auto s0 = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     Attach(world, b1, s0);
     Attach(world, b2, s0);
     auto jd = FrictionJointConf{};

--- a/UnitTests/GearJoint.cpp
+++ b/UnitTests/GearJoint.cpp
@@ -200,10 +200,10 @@ TEST(GearJoint, WithDynamicCirclesAndRevoluteJoints)
     const auto p3 = Length2{+2_m, 0_m};
     const auto p4 = Length2{+3_m, 0_m};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
-    const auto b3 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p3));
-    const auto b4 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p4));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
+    const auto b3 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p3));
+    const auto b4 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p4));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);
     const auto def =
@@ -228,10 +228,10 @@ TEST(GearJoint, WithDynamicCirclesAndPrismaticJoints)
     const auto p3 = Length2{+2_m, 0_m};
     const auto p4 = Length2{+3_m, 0_m};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
-    const auto b3 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p3));
-    const auto b4 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p4));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
+    const auto b3 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p3));
+    const auto b4 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p4));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);
     const auto def = GetGearJointConf(
@@ -261,10 +261,10 @@ TEST(GearJoint, GetAnchorAandB)
     const auto p3 = Length2{+2_m, 0_m};
     const auto p4 = Length2{+3_m, 0_m};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
-    const auto b3 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p3));
-    const auto b4 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p4));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
+    const auto b3 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p3));
+    const auto b4 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p4));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);
     const auto def =

--- a/UnitTests/MotorJoint.cpp
+++ b/UnitTests/MotorJoint.cpp
@@ -183,8 +183,8 @@ TEST(MotorJoint, WithDynamicCircles)
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     const auto circle = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m).UseDensity(2_kgpm2));
     ASSERT_NO_THROW(Attach(world, b1, circle));
     ASSERT_NO_THROW(Attach(world, b2, circle));
@@ -224,8 +224,8 @@ TEST(MotorJoint, SetLinearOffset)
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     const auto circle = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
     Attach(world, b1, circle);
     Attach(world, b2, circle);
@@ -248,8 +248,8 @@ TEST(MotorJoint, SetAngularOffset)
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     const auto circle = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
     Attach(world, b1, circle);
     Attach(world, b2, circle);

--- a/UnitTests/PrismaticJoint.cpp
+++ b/UnitTests/PrismaticJoint.cpp
@@ -269,8 +269,8 @@ TEST(PrismaticJointConf, WithDynamicCirclesAndLimitEnabled)
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);

--- a/UnitTests/RevoluteJoint.cpp
+++ b/UnitTests/RevoluteJoint.cpp
@@ -118,9 +118,9 @@ TEST(RevoluteJoint, EnableMotor)
 {
     World world;
     const auto b0 = CreateBody(world,
-        BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
+        BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
     const auto b1 = CreateBody(world,
-        BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
+        BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
     ASSERT_EQ(GetVelocity(world, b0), Velocity{});
     ASSERT_EQ(GetVelocity(world, b1), Velocity{});
 
@@ -144,9 +144,9 @@ TEST(RevoluteJoint, EnableMotorInWorld)
 {
     World world;
     const auto b0 = CreateBody(world,
-        BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
+        BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
     const auto b1 = CreateBody(world,
-        BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
+        BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
     ASSERT_EQ(GetVelocity(world, b0), Velocity{});
     ASSERT_EQ(GetVelocity(world, b1), Velocity{});
 
@@ -236,8 +236,8 @@ TEST(RevoluteJoint, MotorSpeed)
 TEST(RevoluteJoint, EnableLimit)
 {
     auto world = World{};
-    const auto b0 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b0 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_EQ(GetInvRotInertia(world, b0), InvRotInertia(0));
     ASSERT_EQ(GetInvRotInertia(world, b1), InvRotInertia(0));
 
@@ -311,8 +311,8 @@ TEST(RevoluteJoint, SetAngularLimits)
 TEST(RevoluteJoint, MaxMotorTorque)
 {
     World world;
-    const auto b0 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b0 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
 
     auto jd = RevoluteJointConf{};
     jd.bodyA = b0;
@@ -350,11 +350,11 @@ TEST(RevoluteJoint, MovesDynamicCircles)
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = CreateBody(world, BodyConf{}
-                                         .UseType(BodyType::Dynamic)
+                                         .Use(BodyType::Dynamic)
                                          .UseLocation(p1)
                                          .UseLinearAcceleration(EarthlyGravity));
     const auto b2 = CreateBody(world, BodyConf{}
-                                         .UseType(BodyType::Dynamic)
+                                         .Use(BodyType::Dynamic)
                                          .UseLocation(p2)
                                          .UseLinearAcceleration(EarthlyGravity));
     const auto circle = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
@@ -384,11 +384,11 @@ TEST(RevoluteJoint, LimitEnabledDynamicCircles)
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
     const auto b1 = CreateBody(world, BodyConf{}
-                                         .UseType(BodyType::Dynamic)
+                                         .Use(BodyType::Dynamic)
                                          .UseLocation(p1)
                                          .UseLinearAcceleration(EarthlyGravity));
     const auto b2 = CreateBody(world, BodyConf{}
-                                         .UseType(BodyType::Dynamic)
+                                         .Use(BodyType::Dynamic)
                                          .UseLocation(p2)
                                          .UseLinearAcceleration(EarthlyGravity));
     const auto circle = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m).UseDensity(1_kgpm2));
@@ -463,8 +463,8 @@ TEST(RevoluteJoint, DynamicJoinedToStaticStaysPut)
 
     const auto p1 = Length2{0_m, 4_m}; // Vec2{-1, 0};
     const auto p2 = Length2{0_m, -2_m}; // Vec2{+1, 0};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Static).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Static).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
 
     const auto shape1 = CreateShape(world, PolygonShapeConf{}.SetAsBox(1_m, 1_m));
     Attach(world, b1, shape1);

--- a/UnitTests/RopeJoint.cpp
+++ b/UnitTests/RopeJoint.cpp
@@ -120,8 +120,8 @@ TEST(RopeJointConf, WithDynamicCircles)
     auto world = World{};
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);

--- a/UnitTests/WeldJoint.cpp
+++ b/UnitTests/WeldJoint.cpp
@@ -141,8 +141,8 @@ TEST(WeldJoint, WithDynamicCircles)
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);
     const auto anchor = Length2(2_m, 1_m);
@@ -163,8 +163,8 @@ TEST(WeldJoint, WithDynamicCircles2)
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(0.2_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);
     const auto anchor = Length2(2_m, 1_m);

--- a/UnitTests/WheelJoint.cpp
+++ b/UnitTests/WheelJoint.cpp
@@ -238,8 +238,8 @@ TEST(WheelJointConf, WithDynamicCircles)
     const auto p1 = Length2{-1_m, 0_m};
     const auto p2 = Length2{+1_m, 0_m};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(2_m).UseDensity(10_kgpm2));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p2));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p2));
     Attach(world, b1, shapeId);
     Attach(world, b2, shapeId);
     const auto anchor = Length2(2_m, 1_m);

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -240,7 +240,7 @@ TEST(World, IsStepComplete)
     EXPECT_TRUE(IsStepComplete(world));
 
     const auto b0 = CreateBody(world, BodyConf{}
-                                     .UseType(BodyType::Dynamic)
+                                     .Use(BodyType::Dynamic)
                                      .UseLocation(Length2{-2_m, 2_m})
                                      .UseLinearAcceleration(EarthlyGravity));
     ASSERT_NE(b0, InvalidBodyID);
@@ -249,14 +249,14 @@ TEST(World, IsStepComplete)
     Attach(world, b0, shapeId0);
 
     const auto b1 = CreateBody(world, BodyConf{}
-                                     .UseType(BodyType::Dynamic)
+                                     .Use(BodyType::Dynamic)
                                      .UseLocation(Length2{+2_m, 2_m})
                                      .UseLinearAcceleration(EarthlyGravity));
     ASSERT_NE(b1, InvalidBodyID);
     const auto shapeId1 = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRadius(1_m));
     Attach(world, b1, shapeId1);
 
-    const auto stabody = CreateBody(world, BodyConf{}.UseType(BodyType::Static));
+    const auto stabody = CreateBody(world, BodyConf{}.Use(BodyType::Static));
     const auto shapeId2 = CreateShape(world, EdgeShapeConf{Length2{-10_m, 0_m}, Length2{+10_m, 0_m}});
     Attach(world, stabody, shapeId2);
 
@@ -288,18 +288,18 @@ TEST(World, CopyConstruction)
     }
     
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRadius(1_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b1, shapeId);
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b2, shapeId);
 
     // Add another body on top of previous and that's not part of any joints to ensure at 1 contact
-    const auto b3 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b3 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b3, shapeId);
 
-    const auto b4 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b4 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b4, shapeId);
-    const auto b5 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b5 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b5, shapeId);
 
     const auto rj1 = CreateJoint(world, Joint{RevoluteJointConf{b1, b2}});
@@ -360,9 +360,9 @@ TEST(World, CopyAssignment)
     }
 
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRadius(1_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b1, shapeId);
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b2, shapeId);
 
     CreateJoint(world, Joint{RevoluteJointConf{b1, b2, Length2{}}});
@@ -401,9 +401,9 @@ TEST(World, MoveConstruction)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRadius(1_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b1, shapeId);
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b2, shapeId);
     CreateJoint(world, Joint{RevoluteJointConf{b1, b2, Length2{}}});
     CreateJoint(world, Joint{GetPrismaticJointConf(world, b1, b2, Length2{}, UnitVec::GetRight())});
@@ -422,9 +422,9 @@ TEST(World, MoveAssignment)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseDensity(1_kgpm2).UseRadius(1_m));
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b1, shapeId);
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, b2, shapeId);
     CreateJoint(world, Joint{RevoluteJointConf{b1, b2, Length2{}}});
     CreateJoint(world, Joint{GetPrismaticJointConf(world, b1, b2, Length2{}, UnitVec::GetRight())});
@@ -472,7 +472,7 @@ TEST(World, CreateDestroyEmptyDynamicBody)
 {
     auto world = World{};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(body, InvalidBodyID);
     
     EXPECT_EQ(GetType(world, body), BodyType::Dynamic);
@@ -506,7 +506,7 @@ TEST(World, CreateDestroyDynamicBodyAndFixture)
     
     auto world = World{};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
-    const auto bodyId = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bodyId = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(bodyId, InvalidBodyID);
     
     EXPECT_EQ(GetType(world, bodyId), BodyType::Dynamic);
@@ -554,7 +554,7 @@ TEST(World, CreateDestroyJoinedBodies)
     SetShapeDestructionListener(world, std::ref(shapeListener));
     SetDetachListener(world, std::ref(associationListener));
 
-    const auto body1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     EXPECT_EQ(GetBodyCount(world), BodyCounter(1));
     const auto bodies1 = GetBodies(world);
     EXPECT_FALSE(bodies1.empty());
@@ -563,7 +563,7 @@ TEST(World, CreateDestroyJoinedBodies)
     ASSERT_NE(body1, InvalidBodyID);
     EXPECT_EQ(body1, *bodies1.begin());
 
-    const auto body2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     EXPECT_EQ(GetBodyCount(world), BodyCounter(2));
 
     const auto shapeId1 = CreateShape(world, DiskShapeConf{1_m});
@@ -636,8 +636,8 @@ TEST(World, CreateDestroyContactingBodies)
     const auto l1 = Length2{};
     const auto l2 = Length2{};
 
-    const auto body1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l1));
-    const auto body2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l2));
+    const auto body1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(l1));
+    const auto body2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(l2));
     EXPECT_EQ(GetBodyCount(world), BodyCounter(2));
     EXPECT_EQ(GetBodiesForProxies(world).size(), static_cast<decltype(GetBodiesForProxies(world).size())>(0));
     EXPECT_EQ(GetTree(world).GetNodeCount(), static_cast<decltype(GetTree(world).GetNodeCount())>(0));
@@ -764,7 +764,7 @@ TEST(World, SetSleepingAllowed)
 TEST(World, GetSetAngle)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Kinematic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Kinematic));
     ASSERT_EQ(GetAngle(world, body), 0_deg);
     ASSERT_EQ(GetAngularVelocity(world, body), 0_rpm);
     EXPECT_NO_THROW(SetAngle(world, body, Pi * 0.5_rad));
@@ -825,7 +825,7 @@ TEST(World, SynchronizeProxies)
 TEST(World, SetTypeOfBody)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_EQ(GetType(world, body), BodyType::Dynamic);
     auto other = World{};
     EXPECT_THROW(SetType(other, body, BodyType::Static), std::out_of_range);
@@ -839,7 +839,7 @@ TEST(World, Query)
     auto world = World{};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(body, InvalidBodyID);
     ASSERT_EQ(GetType(world, body), BodyType::Dynamic);
     ASSERT_TRUE(IsSpeedable(world, body));
@@ -886,17 +886,17 @@ TEST(World, RayCast)
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
 
     const auto p0 = Length2{-10_m, +3_m};
-    const auto b0 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p0));
+    const auto b0 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p0));
     Attach(world, b0, CreateShape(world, DiskShapeConf{1_m}));
 
     const auto p1 = Length2{+1_m, 0_m};
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(p1));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(p1));
     Attach(world, b1, CreateShape(world, DiskShapeConf{0.1_m}));
 
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Static).UseLocation(Length2{-100_m, -100_m}));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Static).UseLocation(Length2{-100_m, -100_m}));
     Attach(world, b2, CreateShape(world, EdgeShapeConf{Length2{}, Length2{-20_m, -20_m}}));
 
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(body, InvalidBodyID);
     ASSERT_EQ(GetType(world, body), BodyType::Dynamic);
     ASSERT_TRUE(IsSpeedable(world, body));
@@ -1074,7 +1074,7 @@ TEST(World, ClearForcesFreeFunction)
     World world;
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity));
     ASSERT_NE(body, InvalidBodyID);
     ASSERT_EQ(GetType(world, body), BodyType::Dynamic);
     ASSERT_TRUE(IsSpeedable(world, body));
@@ -1107,13 +1107,13 @@ TEST(World, SetAccelerationsFunctionalFF)
     ASSERT_EQ(a1.linear * 2, a2.linear);
     ASSERT_EQ(a1.angular * 2, a2.angular);
 
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(b1, InvalidBodyID);
     ASSERT_TRUE(IsAccelerable(world, b1));
     SetAcceleration(world, b1, a1);
     ASSERT_EQ(GetAcceleration(world, b1), a1);
 
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(b2, InvalidBodyID);
     ASSERT_TRUE(IsAccelerable(world, b2));
     SetAcceleration(world, b2, a2);
@@ -1136,13 +1136,13 @@ TEST(World, SetLinearAccelerationsFF)
     ASSERT_EQ(a1.linear * 2, a2.linear);
     ASSERT_EQ(a1.angular * 2, a2.angular);
     
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(b1, InvalidBodyID);
     ASSERT_TRUE(IsAccelerable(world, b1));
     SetAcceleration(world, b1, a1);
     ASSERT_EQ(GetAcceleration(world, b1), a1);
     
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(b2, InvalidBodyID);
     ASSERT_TRUE(IsAccelerable(world, b2));
     SetAcceleration(world, b2, a2);
@@ -1185,7 +1185,7 @@ TEST(World, GetAssociationCountFreeFunction)
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     ASSERT_EQ(GetAssociationCount(world), std::size_t(0));
 
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(body, InvalidBodyID);
 
     const auto v1 = Length2{-1_m, 0_m};
@@ -1214,7 +1214,7 @@ TEST(World, GetUsedShapesCountFreeFunction)
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     ASSERT_EQ(GetUsedShapesCount(world), std::size_t(0));
 
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(body, InvalidBodyID);
 
     const auto v1 = Length2{-1_m, 0_m};
@@ -1240,7 +1240,7 @@ TEST(World, GetAssociationCount)
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     ASSERT_EQ(GetAssociationCount(world), std::size_t(0));
 
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(body, InvalidBodyID);
 
     const auto v1 = Length2{-1_m, 0_m};
@@ -1263,7 +1263,7 @@ TEST(World, AwakenFreeFunction)
     World world{};
     ASSERT_EQ(GetBodyCount(world), BodyCounter(0));
     
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_NE(body, InvalidBodyID);
     ASSERT_EQ(GetType(world, body), BodyType::Dynamic);
     ASSERT_TRUE(IsSpeedable(world, body));
@@ -1303,7 +1303,7 @@ TEST(World, GetTouchingCountFreeFunction)
     const auto ground = CreateBody(world);
     Attach(world, ground, CreateShape(world, groundConf));
 
-    const auto lowerBodyConf = BodyConf{}.UseType(BodyType::Dynamic).UseLocation(Vec2(0.0f, 0.5f) * Meter);
+    const auto lowerBodyConf = BodyConf{}.Use(BodyType::Dynamic).UseLocation(Vec2(0.0f, 0.5f) * Meter);
     const auto diskConf = DiskShapeConf{}.UseDensity(10_kgpm2);
     const auto smallerDiskConf = DiskShapeConf(diskConf).UseRadius(0.5_m);
     const auto lowerBody = CreateBody(world, lowerBodyConf);
@@ -1540,7 +1540,7 @@ TEST(World, BodyAngleDoesntGrowUnbounded)
 {
     auto world = World{};
     const auto body = CreateBody(world, BodyConf{}
-                                       .UseType(BodyType::Dynamic)
+                                       .Use(BodyType::Dynamic)
                                        .UseAngularVelocity(10_rad / Second));
     ASSERT_EQ(GetAngle(world, body), 0_rad);
     auto stepConf = StepConf{};
@@ -1841,7 +1841,7 @@ TEST(World, HeavyOnLight)
     constexpr auto MaxVertexRadius = ::playrho::DefaultMaxVertexRadius;
     const auto VertexRadius = Interval<Positive<Length>>{SmallerLinearSlop, MaxVertexRadius};
 
-    const auto bd = BodyConf{}.UseType(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity);
+    const auto bd = BodyConf{}.Use(BodyType::Dynamic).UseLinearAcceleration(EarthlyGravity);
     const auto upperBodyConf = BodyConf(bd).UseLocation(Vec2(0.0f, 6.0f) * Meter);
     const auto lowerBodyConf = BodyConf(bd).UseLocation(Vec2(0.0f, 0.5f) * Meter);
 
@@ -2215,7 +2215,7 @@ TEST(World, DropDisks)
         const auto x = i * diskRadius * 4;
         const auto location = Length2{x, 0_m};
         const auto body = CreateBody(world, playrho::d2::BodyConf{}
-                                           .UseType(playrho::BodyType::Dynamic)
+                                           .Use(playrho::BodyType::Dynamic)
                                            .UseLocation(location)
                                            .UseLinearAcceleration(playrho::d2::EarthlyGravity));
         ASSERT_NO_THROW(Attach(world, body, shapeId));
@@ -2755,7 +2755,7 @@ TEST(World_Longer, TilesComesToRest)
         for (auto i = 0; i < e_count; ++i) {
             y = x;
             for (auto j = i; j < e_count; ++j) {
-                auto body = Body{BodyConf{}.UseType(BodyType::Dynamic).UseLocation(y).UseLinearAcceleration(EarthlyGravity)};
+                auto body = Body{BodyConf{}.Use(BodyType::Dynamic).UseLocation(y).UseLinearAcceleration(EarthlyGravity)};
                 ASSERT_NO_THROW(body.Attach(shapeId));
                 ASSERT_NO_THROW(CreateBody(*world, body));
                 ++createdBodyCount;
@@ -3351,7 +3351,7 @@ TEST(World_Longer, TargetJointWontCauseTunnelling)
 
     const auto spare_body = [&](){
         BodyConf bodyConf;
-        bodyConf.UseType(BodyType::Static);
+        bodyConf.Use(BodyType::Static);
         bodyConf.UseEnabled(false);
         bodyConf.UseLocation(Length2{-ball_radius / Real{2}, +ball_radius / Real{2}});
         return CreateBody(world, bodyConf);
@@ -3665,7 +3665,7 @@ public:
         {
             // (hdim + 0.05f) + (hdim * 2 + 0.1f) * i
             const auto location = Length2{original_x * Meter, (i + Real{1}) * hdim * Real{4}};
-            const auto box = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(location));
+            const auto box = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(location));
             Attach(world, box, boxShape);
             boxes[i] = box;
         }

--- a/UnitTests/World.cpp
+++ b/UnitTests/World.cpp
@@ -18,11 +18,6 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "UnitTests.hpp"
-
-#include <chrono>
-#include <type_traits>
-
 #include <playrho/Contact.hpp>
 #include <playrho/LengthError.hpp>
 #include <playrho/StepConf.hpp>
@@ -60,6 +55,8 @@
 #include <playrho/d2/WorldMisc.hpp>
 #include <playrho/d2/WorldJoint.hpp>
 #include <playrho/d2/WorldContact.hpp>
+
+#include "gtest/gtest.h"
 
 using namespace playrho;
 using namespace playrho::d2;

--- a/UnitTests/WorldBody.cpp
+++ b/UnitTests/WorldBody.cpp
@@ -228,7 +228,7 @@ TEST(WorldBody, SetType)
 {
     auto world = World{};
 
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     ASSERT_EQ(GetBodiesForProxies(world).size(), 0u);
     ASSERT_EQ(GetType(world, body), BodyType::Dynamic);
 
@@ -248,7 +248,7 @@ TEST(WorldBody, SetType)
 TEST(WorldBody, StaticIsExpected)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Static));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Static));
     EXPECT_FALSE(IsAccelerable(world, body));
     EXPECT_FALSE(IsSpeedable(world, body));
     EXPECT_TRUE(IsImpenetrable(world, body));
@@ -257,7 +257,7 @@ TEST(WorldBody, StaticIsExpected)
 TEST(WorldBody, KinematicIsExpected)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Kinematic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Kinematic));
     EXPECT_FALSE(IsAccelerable(world, body));
     EXPECT_TRUE( IsSpeedable(world, body));
     EXPECT_TRUE( IsImpenetrable(world, body));
@@ -266,7 +266,7 @@ TEST(WorldBody, KinematicIsExpected)
 TEST(WorldBody, DynamicIsExpected)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     EXPECT_TRUE(IsAccelerable(world, body));
     EXPECT_TRUE(IsSpeedable(world, body));
     EXPECT_FALSE(IsImpenetrable(world, body));
@@ -283,7 +283,7 @@ TEST(WorldBody, SetMassData)
     // has effect on dynamic bodies...
     {
         auto world = World{};
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
         EXPECT_EQ(GetMass(world, body), 1_kg);
         EXPECT_EQ(GetRotInertia(world, body), std::numeric_limits<Real>::infinity() * rotInertiaUnits);
         SetMassData(world, body, massData);
@@ -294,7 +294,7 @@ TEST(WorldBody, SetMassData)
     // has no rotational effect on fixed rotation dynamic bodies...
     {
         auto world = World{};
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseFixedRotation(true));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseFixedRotation(true));
         EXPECT_EQ(GetMass(world, body), 1_kg);
         EXPECT_EQ(GetRotInertia(world, body), std::numeric_limits<Real>::infinity() * rotInertiaUnits);
         SetMassData(world, body, massData);
@@ -305,7 +305,7 @@ TEST(WorldBody, SetMassData)
     // has no effect on static bodies...
     {
         auto world = World{};
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Static));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Static));
         EXPECT_EQ(GetMass(world, body), 0_kg);
         EXPECT_EQ(GetRotInertia(world, body), std::numeric_limits<Real>::infinity() * rotInertiaUnits);
         SetMassData(world, body, massData);
@@ -346,7 +346,7 @@ TEST(WorldBody, SetAcceleration)
 
     {
         auto world = World{};
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Static));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Static));
         ASSERT_EQ(GetLinearAcceleration(world, body), LinearAcceleration2{});
         ASSERT_EQ(GetAngularAcceleration(world, body), 0 * RadianPerSquareSecond);
         ASSERT_FALSE(IsAwake(world, body));
@@ -372,7 +372,7 @@ TEST(WorldBody, SetAcceleration)
     // Kinematic and dynamic bodies awake at creation...
     {
         auto world = World{};
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Kinematic));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Kinematic));
         ASSERT_EQ(GetLinearAcceleration(world, body), LinearAcceleration2{});
         ASSERT_TRUE(IsAwake(world, body));
         UnsetAwake(world, body);
@@ -397,7 +397,7 @@ TEST(WorldBody, SetAcceleration)
     // Dynamic bodies take a non-zero linear or angular acceleration.
     {
         auto world = World{};
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
         ASSERT_EQ(GetLinearAcceleration(world, body), LinearAcceleration2{});
         ASSERT_EQ(GetAngularAcceleration(world, body), 0 * RadianPerSquareSecond);
         ASSERT_TRUE(IsAwake(world, body));
@@ -470,7 +470,7 @@ TEST(WorldBody, SetAcceleration)
 TEST(WorldBody, SetAngularAcceleration)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     auto acceleration = AngularAcceleration{};
     acceleration = Real(2) * RadianPerSquareSecond;
     EXPECT_NO_THROW(SetAcceleration(world, body, acceleration));
@@ -483,7 +483,7 @@ TEST(WorldBody, SetAngularAcceleration)
 TEST(WorldBody, SetAngularVelocity)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     auto value = AngularVelocity{};
     value = Real(4) * RadianPerSecond;
     EXPECT_NO_THROW(SetVelocity(world, body, value));
@@ -497,7 +497,7 @@ TEST(WorldBody, ApplyForce)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, PolygonShapeConf(1_m, 1_m).UseDensity(1_kgpm2));
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, body, shapeId);
     ASSERT_EQ(GetMass(world, body), 4_kg);
     auto value = Force2{};
@@ -512,7 +512,7 @@ TEST(WorldBody, ApplyTorque)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, PolygonShapeConf(1_m, 1_m).UseDensity(1_kgpm2));
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, body, shapeId);
     ASSERT_EQ(GetMass(world, body), 4_kg);
     auto value = Torque{};
@@ -528,7 +528,7 @@ TEST(WorldBody, ApplyLinearImpulse)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, PolygonShapeConf(1_m, 1_m).UseDensity(1_kgpm2));
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, body, shapeId);
     ASSERT_EQ(GetMass(world, body), 4_kg);
     auto value = Momentum2{40_Ns, 0_Ns};
@@ -542,7 +542,7 @@ TEST(WorldBody, ApplyAngularImpulse)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, PolygonShapeConf(1_m, 1_m).UseDensity(1_kgpm2));
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, body, shapeId);
     ASSERT_EQ(GetMass(world, body), 4_kg);
     auto value = AngularMomentum{Real(8) * NewtonMeterSecond};
@@ -662,7 +662,7 @@ TEST(WorldBody, ApplyLinearAccelDoesNothingToStatic)
 TEST(WorldBody, GetAccelerationFF)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     SetAcceleration(world, body, LinearAcceleration2{}, AngularAcceleration{});
     
     ASSERT_EQ(GetLinearAcceleration(world, body), LinearAcceleration2{});
@@ -673,7 +673,7 @@ TEST(WorldBody, GetAccelerationFF)
 TEST(WorldBody, SetAccelerationFF)
 {
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     SetAcceleration(world, body, LinearAcceleration2{}, AngularAcceleration{});
     
     ASSERT_EQ(GetLinearAcceleration(world, body), LinearAcceleration2{});
@@ -695,12 +695,12 @@ TEST(WorldBody, CalcGravitationalAcceleration)
     const auto l3 = Length2{+16_m, 0_m};
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(2_m).UseDensity(1e10_kgpm2));
     
-    const auto b1 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l1));
+    const auto b1 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(l1));
     Attach(world, b1, shapeId);
     EXPECT_EQ(CalcGravitationalAcceleration(world, b1).linear, LinearAcceleration2());
     EXPECT_EQ(CalcGravitationalAcceleration(world, b1).angular, AngularAcceleration());
 
-    const auto b2 = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l2));
+    const auto b2 = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(l2));
     Attach(world, b2, shapeId);
     {
         const auto accel = CalcGravitationalAcceleration(world, b1);
@@ -709,7 +709,7 @@ TEST(WorldBody, CalcGravitationalAcceleration)
         EXPECT_EQ(GetY(accel.linear), 0 * MeterPerSquareSecond);
         EXPECT_EQ(accel.angular, 0 * RadianPerSquareSecond);
     }
-    const auto b3 = CreateBody(world, BodyConf{}.UseType(BodyType::Static).UseLocation(l3));
+    const auto b3 = CreateBody(world, BodyConf{}.Use(BodyType::Static).UseLocation(l3));
     EXPECT_EQ(CalcGravitationalAcceleration(world, b3), Acceleration{});
     {
         // Confirm b3 doesn't impact b1's acceleration...
@@ -749,7 +749,7 @@ TEST(WorldBody, GetCentripetalForce)
 {
     const auto l1 = Length2{-8_m, 0_m};
     auto world = World{};
-    const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).UseLocation(l1));
+    const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).UseLocation(l1));
     const auto shapeId = CreateShape(world, DiskShapeConf{}.UseRadius(2_m).UseDensity(1_kgpm2));
     Attach(world, body, shapeId);
     SetVelocity(world, body, LinearVelocity2{2_mps, 3_mps});
@@ -791,7 +791,7 @@ TEST(WorldBody, SetAwake)
 {
     {
         World world;
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
         EXPECT_NO_THROW(UnsetAwake(world, body));
         EXPECT_FALSE(IsAwake(world, body));
         EXPECT_NO_THROW(SetAwake(world, body));
@@ -799,7 +799,7 @@ TEST(WorldBody, SetAwake)
     }
     {
         World world;
-        const auto body = CreateBody(world, BodyConf{}.UseType(BodyType::Static));
+        const auto body = CreateBody(world, BodyConf{}.Use(BodyType::Static));
         EXPECT_NO_THROW(UnsetAwake(world, body));
         EXPECT_FALSE(IsAwake(world, body));
         EXPECT_NO_THROW(SetAwake(world, body));

--- a/UnitTests/WorldContact.cpp
+++ b/UnitTests/WorldContact.cpp
@@ -41,8 +41,8 @@ TEST(WorldContact, SetAwake)
     auto world = World{};
     const auto s1 = CreateShape(world, DiskShapeConf{});
     const auto s2 = CreateShape(world, DiskShapeConf{});
-    const auto bA = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto bB = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bA = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto bB = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, bA, s1);
     Attach(world, bB, s2);
 
@@ -73,8 +73,8 @@ TEST(WorldContact, ResetFriction)
     auto world = World{};
     const auto sA = CreateShape(world, Shape{shape});
     const auto sB = CreateShape(world, Shape{shape});
-    const auto bA = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto bB = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bA = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto bB = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, bA, sA);
     Attach(world, bB, sB);
 
@@ -104,8 +104,8 @@ TEST(WorldContact, ResetRestitution)
     auto world = World{};
     const auto sA = CreateShape(world, Shape{shape});
     const auto sB = CreateShape(world, Shape{shape});
-    const auto bA = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto bB = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bA = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto bB = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, bA, sA);
     Attach(world, bB, sB);
 
@@ -129,8 +129,8 @@ TEST(WorldContact, SetUnsetEnabled)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, DiskShapeConf{});
-    const auto bA = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto bB = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bA = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto bB = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, bA, shapeId);
     Attach(world, bB, shapeId);
     ASSERT_NO_THROW(Step(world, StepConf{}));
@@ -149,8 +149,8 @@ TEST(WorldContact, SetImpenetrable)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, DiskShapeConf{});
-    CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).Use(shapeId));
-    CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).Use(shapeId));
+    CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).Use(shapeId));
+    CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).Use(shapeId));
     ASSERT_NO_THROW(Step(world, StepConf{}));
     const auto contacts = GetContacts(world);
     ASSERT_EQ(contacts.size(), ContactCounter(1));
@@ -167,8 +167,8 @@ TEST(WorldContact, SetSensor)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, DiskShapeConf{});
-    CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).Use(shapeId));
-    CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic).Use(shapeId));
+    CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).Use(shapeId));
+    CreateBody(world, BodyConf{}.Use(BodyType::Dynamic).Use(shapeId));
     ASSERT_NO_THROW(Step(world, StepConf{}));
     const auto contacts = GetContacts(world);
     ASSERT_EQ(contacts.size(), ContactCounter(1));
@@ -185,8 +185,8 @@ TEST(WorldContact, SetTangentSpeed)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, DiskShapeConf{});
-    const auto bA = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto bB = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bA = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto bB = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, bA, shapeId);
     Attach(world, bB, shapeId);
     ASSERT_NO_THROW(Step(world, StepConf{}));
@@ -209,8 +209,8 @@ TEST(WorldContact, WorldManifoldAndMore)
 {
     auto world = World{};
     const auto shapeId = CreateShape(world, DiskShapeConf{});
-    const auto bA = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
-    const auto bB = CreateBody(world, BodyConf{}.UseType(BodyType::Dynamic));
+    const auto bA = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
+    const auto bB = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic));
     Attach(world, bA, shapeId);
     Attach(world, bB, shapeId);
     ASSERT_NO_THROW(Step(world, StepConf{}));

--- a/UnitTests/WorldContact.cpp
+++ b/UnitTests/WorldContact.cpp
@@ -175,7 +175,7 @@ TEST(WorldContact, SetSensor)
     const auto c = contacts.begin()->second;
     auto contact = GetContact(world, c);
     ASSERT_FALSE(IsSensor(contact));
-    EXPECT_NO_THROW(UnsetIsSensor(contact));
+    EXPECT_NO_THROW(UnsetSensor(contact));
     EXPECT_NO_THROW(SetContact(world, c, contact));
     EXPECT_NO_THROW(SetSensor(contact));
     EXPECT_THROW(SetContact(world, c, contact), InvalidArgument);


### PR DESCRIPTION
#### Description - What's this PR do?
- Removes `BodyConf::UseType` & replaces uses with `BodyConf::Use`.
- Renames some `Contact` interfaces.
- Updates `SetContact(AabbTreeWorld&,...)` to be more restrictive about what it allows.
- Adds `OutOfRange` derived class of `std::out_of_range` to help with diagnostics.
- Adds more unit test code.

This work was in part motivated for my getting a better handle on how to properly/fully support serialization/deserialization per #544 .