### PR TITLE
Updates 20231223

### DIFF
--- a/Library/include/playrho/StepStats.hpp
+++ b/Library/include/playrho/StepStats.hpp
@@ -42,6 +42,7 @@ struct PreStepStats {
     /// @brief Counter type.
     using counter_type = std::uint32_t;
 
+    counter_type proxiesCreated = 0; ///< Proxies created count.
     counter_type proxiesMoved = 0; ///< Proxies moved count.
     counter_type destroyed = 0; ///< Count of contacts destroyed.
     counter_type added = 0; ///< Count of contacts added.
@@ -49,6 +50,24 @@ struct PreStepStats {
     counter_type updated = 0; ///< Count of contacts updated (during update processing).
     counter_type skipped = 0; ///< Count of contacts Skipped (during update processing).
 };
+
+/// @brief Operator equal support.
+constexpr auto operator==(const PreStepStats &lhs, const PreStepStats &rhs) -> bool
+{
+    return (lhs.proxiesCreated == rhs.proxiesCreated) && //
+           (lhs.proxiesMoved == rhs.proxiesMoved) && //
+           (lhs.destroyed == rhs.destroyed) && //
+           (lhs.added == rhs.added) && //
+           (lhs.ignored == rhs.ignored) && //
+           (lhs.updated == rhs.updated) && //
+           (lhs.skipped == rhs.skipped);
+}
+
+/// @brief Operator not-equal support.
+constexpr auto operator!=(const PreStepStats &lhs, const PreStepStats &rhs) -> bool
+{
+    return !(lhs == rhs);
+}
 
 /// @brief Regular-phase per-step statistics.
 struct RegStepStats {
@@ -70,6 +89,27 @@ struct RegStepStats {
     counter_type sumPosIters = 0; ///< Sum of the position iterations.
     counter_type sumVelIters = 0; ///< Sum of the velocity iterations.
 };
+
+/// @brief Operator equal support.
+constexpr auto operator==(const RegStepStats &lhs, const RegStepStats &rhs) -> bool
+{
+    return (lhs.minSeparation == rhs.minSeparation) && //
+           (lhs.maxIncImpulse == rhs.maxIncImpulse) && //
+           (lhs.islandsFound == rhs.islandsFound) && //
+           (lhs.islandsSolved == rhs.islandsSolved) && //
+           (lhs.bodiesSlept == rhs.bodiesSlept) && //
+           (lhs.maxIslandBodies == rhs.maxIslandBodies) && //
+           (lhs.contactsAdded == rhs.contactsAdded) && //
+           (lhs.proxiesMoved == rhs.proxiesMoved) && //
+           (lhs.sumPosIters == rhs.sumPosIters) && //
+           (lhs.sumVelIters == rhs.sumVelIters);
+}
+
+/// @brief Operator not-equal support.
+constexpr auto operator!=(const RegStepStats &lhs, const RegStepStats &rhs) -> bool
+{
+    return !(lhs == rhs);
+}
 
 /// @brief TOI-phase per-step statistics.
 struct ToiStepStats {
@@ -107,6 +147,33 @@ struct ToiStepStats {
     toi_iter_type maxToiIters = 0; ///< Max TOI iterations.
     root_iter_type maxRootIters = 0; ///< Max root iterations.
 };
+
+/// @brief Operator equal support.
+constexpr auto operator==(const ToiStepStats &lhs, const ToiStepStats &rhs) -> bool
+{
+    return (lhs.minSeparation == rhs.minSeparation) && //
+           (lhs.maxIncImpulse == rhs.maxIncImpulse) && //
+           (lhs.islandsFound == rhs.islandsFound) && //
+           (lhs.islandsSolved == rhs.islandsSolved) && //
+           (lhs.contactsFound == rhs.contactsFound) && //
+           (lhs.contactsAtMaxSubSteps == rhs.contactsAtMaxSubSteps) && //
+           (lhs.contactsUpdatedToi == rhs.contactsUpdatedToi) && //
+           (lhs.contactsUpdatedTouching == rhs.contactsUpdatedTouching) && //
+           (lhs.contactsSkippedTouching == rhs.contactsSkippedTouching) && //
+           (lhs.contactsAdded == rhs.contactsAdded) && //
+           (lhs.proxiesMoved == rhs.proxiesMoved) && //
+           (lhs.sumPosIters == rhs.sumPosIters) && //
+           (lhs.sumVelIters == rhs.sumVelIters) && //
+           (lhs.maxDistIters == rhs.maxDistIters) && //
+           (lhs.maxToiIters == rhs.maxToiIters) && //
+           (lhs.maxRootIters == rhs.maxRootIters);
+}
+
+/// @brief Operator not-equal support.
+constexpr auto operator!=(const ToiStepStats &lhs, const ToiStepStats &rhs) -> bool
+{
+    return !(lhs == rhs);
+}
 
 /// @brief Per-step statistics.
 /// @details These are statistics output from the <code>d2::World::Step</code> function.

--- a/Library/source/playrho/d2/Body.cpp
+++ b/Library/source/playrho/d2/Body.cpp
@@ -19,8 +19,10 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#include <algorithm> // for std::find
 #include <cassert> // for assert
 
+#include <playrho/Math.hpp> // for Cross, etc
 #include <playrho/Templates.hpp>
 
 #include <playrho/d2/Body.hpp>

--- a/UnitTests/StepStats.cpp
+++ b/UnitTests/StepStats.cpp
@@ -18,9 +18,9 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "UnitTests.hpp"
-
 #include <playrho/StepStats.hpp>
+
+#include "gtest/gtest.h"
 
 using namespace playrho;
 
@@ -76,4 +76,430 @@ TEST(RegStepStats, DefaultConstructor)
     EXPECT_EQ(object.proxiesMoved, static_cast<decltype(object.proxiesMoved)>(0));
     EXPECT_EQ(object.sumPosIters, static_cast<decltype(object.sumPosIters)>(0));
     EXPECT_EQ(object.sumVelIters, static_cast<decltype(object.sumVelIters)>(0));
+}
+
+TEST(PreStepStats, Equality)
+{
+    EXPECT_TRUE(PreStepStats() == PreStepStats());
+    {
+        auto stats = PreStepStats{};
+        ++stats.proxiesCreated;
+        EXPECT_FALSE(PreStepStats() == stats);
+        EXPECT_FALSE(stats == PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.proxiesMoved;
+        EXPECT_FALSE(PreStepStats() == stats);
+        EXPECT_FALSE(stats == PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.destroyed;
+        EXPECT_FALSE(PreStepStats() == stats);
+        EXPECT_FALSE(stats == PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.added;
+        EXPECT_FALSE(PreStepStats() == stats);
+        EXPECT_FALSE(stats == PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.ignored;
+        EXPECT_FALSE(PreStepStats() == stats);
+        EXPECT_FALSE(stats == PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.updated;
+        EXPECT_FALSE(PreStepStats() == stats);
+        EXPECT_FALSE(stats == PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.skipped;
+        EXPECT_FALSE(PreStepStats() == stats);
+        EXPECT_FALSE(stats == PreStepStats());
+    }
+}
+
+TEST(PreStepStats, Inequality)
+{
+    EXPECT_FALSE(PreStepStats() != PreStepStats());
+    {
+        auto stats = PreStepStats{};
+        ++stats.proxiesCreated;
+        EXPECT_TRUE(PreStepStats() != stats);
+        EXPECT_TRUE(stats != PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.proxiesMoved;
+        EXPECT_TRUE(PreStepStats() != stats);
+        EXPECT_TRUE(stats != PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.destroyed;
+        EXPECT_TRUE(PreStepStats() != stats);
+        EXPECT_TRUE(stats != PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.added;
+        EXPECT_TRUE(PreStepStats() != stats);
+        EXPECT_TRUE(stats != PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.ignored;
+        EXPECT_TRUE(PreStepStats() != stats);
+        EXPECT_TRUE(stats != PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.updated;
+        EXPECT_TRUE(PreStepStats() != stats);
+        EXPECT_TRUE(stats != PreStepStats());
+    }
+    {
+        auto stats = PreStepStats{};
+        ++stats.skipped;
+        EXPECT_TRUE(PreStepStats() != stats);
+        EXPECT_TRUE(stats != PreStepStats());
+    }
+}
+
+TEST(RegStepStats, Equality)
+{
+    EXPECT_TRUE(RegStepStats() == RegStepStats());
+    {
+        auto stats = RegStepStats{};
+        stats.minSeparation = 1_m;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        stats.maxIncImpulse = 1_Ns;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.islandsFound;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.islandsSolved;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.bodiesSlept;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.maxIslandBodies;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.contactsAdded;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.proxiesMoved;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.sumPosIters;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.sumVelIters;
+        EXPECT_FALSE(RegStepStats() == stats);
+        EXPECT_FALSE(stats == RegStepStats());
+    }
+}
+
+TEST(RegStepStats, Inequality)
+{
+    EXPECT_FALSE(RegStepStats() != RegStepStats());
+    {
+        auto stats = RegStepStats{};
+        stats.minSeparation = 1_m;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        stats.maxIncImpulse = 1_Ns;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.islandsFound;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.islandsSolved;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.bodiesSlept;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.maxIslandBodies;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.contactsAdded;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.proxiesMoved;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.sumPosIters;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+    {
+        auto stats = RegStepStats{};
+        ++stats.sumVelIters;
+        EXPECT_TRUE(RegStepStats() != stats);
+        EXPECT_TRUE(stats != RegStepStats());
+    }
+}
+
+TEST(ToiStepStats, Equality)
+{
+    EXPECT_TRUE(ToiStepStats() == ToiStepStats());
+    {
+        auto stats = ToiStepStats{};
+        stats.minSeparation = 1_m;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        stats.maxIncImpulse = 1_Ns;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.islandsFound;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.islandsSolved;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsFound;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsAtMaxSubSteps;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsUpdatedToi;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsUpdatedTouching;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsSkippedTouching;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsAdded;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.proxiesMoved;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.sumPosIters;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.sumVelIters;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.maxDistIters;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.maxToiIters;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.maxRootIters;
+        EXPECT_FALSE(ToiStepStats() == stats);
+        EXPECT_FALSE(stats == ToiStepStats());
+    }
+}
+
+TEST(ToiStepStats, Inequality)
+{
+    EXPECT_FALSE(ToiStepStats() != ToiStepStats());
+    {
+        auto stats = ToiStepStats{};
+        stats.minSeparation = 1_m;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        stats.maxIncImpulse = 1_Ns;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.islandsFound;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.islandsSolved;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsFound;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsAtMaxSubSteps;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsUpdatedToi;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsUpdatedTouching;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsSkippedTouching;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.contactsAdded;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.proxiesMoved;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.sumPosIters;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.sumVelIters;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.maxDistIters;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.maxToiIters;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
+    {
+        auto stats = ToiStepStats{};
+        ++stats.maxRootIters;
+        EXPECT_TRUE(ToiStepStats() != stats);
+        EXPECT_TRUE(stats != ToiStepStats());
+    }
 }


### PR DESCRIPTION
#### Description - What's this PR do?
Basically moves contact updating out from being only done when the time delta is not zero so that both contacts and manifolds can be made available with a zero delta time call of the world `Step` function. Also adds more `==` & `!=` support - adding these for the `PreStepStats`, `RegStepStats`, and `ToiStepStats` types.
