### PR TITLE
Updates 20240101

### DIFF
--- a/Library/include/playrho/Contact.hpp
+++ b/Library/include/playrho/Contact.hpp
@@ -287,25 +287,25 @@ private:
         // Set when the shapes are touching.
         e_touchingFlag = 0x01,
 
-        // This contact can be disabled (by user)
+        // This entity can be disabled (by user)
         e_enabledFlag = 0x02,
 
-        // This contact needs filtering because a shape filter was changed.
+        // This entity needs filtering because a shape filter was changed.
         e_filterFlag = 0x04,
 
-        // This contact has a valid TOI in m_toi
+        // This entity has a valid TOI in m_toi
         e_toiFlag = 0x08,
 
-        // This contacts needs its touching state updated.
+        // This entity needs its touching state updated.
         e_dirtyFlag = 0x10,
 
-        /// Indicates whether the contact is to be treated as a sensor or not.
+        /// Indicates whether this entity is to be treated as a sensor or not.
         e_sensorFlag = 0x20,
 
-        /// Whether contact was destroyed or not.
+        /// Whether this entity was destroyed or not.
         e_destroyed = 0x40,
 
-        /// Whether contact is to be treated as between impenetrable bodies.
+        /// Whether this entity is to be treated as between impenetrable bodies.
         e_impenetrableFlag = 0x80,
     };
 

--- a/Library/include/playrho/Contact.hpp
+++ b/Library/include/playrho/Contact.hpp
@@ -871,6 +871,30 @@ constexpr auto GetOtherBody(const Contact& c, BodyID bodyID) noexcept
         ? c.GetContactableA().bodyId: c.GetContactableB().bodyId;
 }
 
+/// @brief Whether or not the given contact was destroyed.
+/// @see SetDestroyed, UnsetDestroyed.
+/// @relatedalso Contact
+constexpr auto IsDestroyed(const Contact& c) noexcept -> bool
+{
+    return c.IsDestroyed();
+}
+
+/// @brief Sets the destroyed property of the given contact.
+/// @note This is only meaningfully used by the world implementation.
+/// @relatedalso Contact
+constexpr void SetDestroyed(Contact& c) noexcept
+{
+    c.SetDestroyed();
+}
+
+/// @brief Unsets the destroyed property of the given contact.
+/// @note This is only meaningfully used by the world implementation.
+/// @relatedalso Contact
+constexpr void UnsetDestroyed(Contact& c) noexcept
+{
+    c.UnsetDestroyed();
+}
+
 } // namespace playrho
 
 #endif // PLAYRHO_CONTACT_HPP

--- a/Library/include/playrho/InvalidArgument.hpp
+++ b/Library/include/playrho/InvalidArgument.hpp
@@ -25,6 +25,7 @@
 /// @brief Definition of the @c InvalidArgument class.
 
 #include <stdexcept>
+#include <string>
 
 namespace playrho {
 
@@ -35,6 +36,25 @@ class InvalidArgument: public std::invalid_argument
 {
 public:
     using std::invalid_argument::invalid_argument;
+};
+
+/// @brief Was destroyed invalid argument logic error.
+/// @details Indicates that an argument was invalid because it's destroyed or associated
+///   with something that has been destroyed and is not currently valid for the requested
+///   functionality.
+/// @ingroup ExceptionsGroup
+template <class T>
+struct WasDestroyed: public InvalidArgument
+{
+    using type = T; ///< Type of the argument that was destroyed.
+
+    /// @brief Initializing constructor.
+    WasDestroyed(type v, const std::string& msg): InvalidArgument{msg}, value{v} {}
+
+    /// @brief Initializing constructor.
+    WasDestroyed(type v, const char* msg): InvalidArgument{msg}, value{v} {}
+
+    type value{}; ///< Value of the type that was destroyed.
 };
 
 } // namespace playrho

--- a/Library/include/playrho/InvalidArgument.hpp
+++ b/Library/include/playrho/InvalidArgument.hpp
@@ -26,6 +26,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <utility> // for std::move
 
 namespace playrho {
 
@@ -49,10 +50,10 @@ struct WasDestroyed: public InvalidArgument
     using type = T; ///< Type of the argument that was destroyed.
 
     /// @brief Initializing constructor.
-    WasDestroyed(type v, const std::string& msg): InvalidArgument{msg}, value{v} {}
+    WasDestroyed(type v, const std::string& msg): InvalidArgument{msg}, value{std::move(v)} {}
 
     /// @brief Initializing constructor.
-    WasDestroyed(type v, const char* msg): InvalidArgument{msg}, value{v} {}
+    WasDestroyed(type v, const char* msg): InvalidArgument{msg}, value{std::move(v)} {}
 
     type value{}; ///< Value of the type that was destroyed.
 };

--- a/Library/include/playrho/d2/AabbTreeWorld.hpp
+++ b/Library/include/playrho/d2/AabbTreeWorld.hpp
@@ -64,10 +64,13 @@
 #include <playrho/pmr/PoolMemoryResource.hpp>
 #include <playrho/pmr/StatsResource.hpp>
 
+#include <playrho/d2/Body.hpp>
 #include <playrho/d2/BodyConstraint.hpp>
 #include <playrho/d2/ContactImpulsesFunction.hpp>
 #include <playrho/d2/ContactManifoldFunction.hpp>
 #include <playrho/d2/DynamicTree.hpp>
+#include <playrho/d2/Joint.hpp>
+#include <playrho/d2/Shape.hpp>
 #include <playrho/d2/Transformation.hpp>
 #include <playrho/d2/WorldConf.hpp>
 
@@ -82,9 +85,6 @@ enum class BodyType;
 
 namespace playrho::d2 {
 
-class Body;
-class Joint;
-class Shape;
 class Manifold;
 class ContactImpulsesList;
 class AabbTreeWorld;
@@ -416,9 +416,12 @@ void SetJoint(AabbTreeWorld& world, JointID id, Joint def);
 void Destroy(AabbTreeWorld& world, JointID id);
 
 /// @brief Gets whether the given identifier is to a joint that's been destroyed.
-/// @note Complexity is at most O(n) where n is the number of elements free.
+/// @note Complexity is O(1).
 /// @see Destroy(AabbTreeWorld& world, JointID).
-bool IsDestroyed(const AabbTreeWorld& world, JointID id) noexcept;
+inline auto IsDestroyed(const AabbTreeWorld& world, JointID id) -> bool
+{
+    return IsDestroyed(GetJoint(world, id));
+}
 
 /// @}
 
@@ -466,9 +469,12 @@ void SetShape(AabbTreeWorld& world, ShapeID id, Shape def);
 void Destroy(AabbTreeWorld& world, ShapeID id);
 
 /// @brief Gets whether the given identifier is to a shape that's been destroyed.
-/// @note Complexity is at most O(n) where n is the number of elements free.
+/// @note Complexity is O(1).
 /// @see Destroy(AabbTreeWorld& world, ShapeID).
-bool IsDestroyed(const AabbTreeWorld& world, ShapeID id) noexcept;
+inline auto IsDestroyed(const AabbTreeWorld& world, ShapeID id) -> bool
+{
+    return IsDestroyed(GetShape(world, id));
+}
 
 /// @}
 
@@ -627,7 +633,6 @@ public:
     friend const Joint& GetJoint(const AabbTreeWorld& world, JointID id);
     friend void SetJoint(AabbTreeWorld& world, JointID id, Joint def);
     friend void Destroy(AabbTreeWorld& world, JointID id);
-    friend bool IsDestroyed(const AabbTreeWorld& world, JointID id) noexcept;
 
     // Shape friend functions...
     friend ShapeCounter GetShapeRange(const AabbTreeWorld& world) noexcept;
@@ -635,7 +640,6 @@ public:
     friend const Shape& GetShape(const AabbTreeWorld& world, ShapeID id);
     friend void SetShape(AabbTreeWorld& world, ShapeID id, Shape def);
     friend void Destroy(AabbTreeWorld& world, ShapeID id);
-    friend bool IsDestroyed(const AabbTreeWorld& world, ShapeID id) noexcept;
 
     // Contact friend functions...
     friend ContactCounter GetContactRange(const AabbTreeWorld& world) noexcept;

--- a/Library/include/playrho/d2/AabbTreeWorld.hpp
+++ b/Library/include/playrho/d2/AabbTreeWorld.hpp
@@ -336,9 +336,12 @@ void SetBody(AabbTreeWorld& world, BodyID id, Body value);
 void Destroy(AabbTreeWorld& world, BodyID id);
 
 /// @brief Gets whether the given identifier is to a body that's been destroyed.
-/// @note Complexity is at most O(n) where n is the number of elements free.
+/// @note Complexity of this function is O(1).
 /// @see Destroy(AabbTreeWorld& world, BodyID).
-bool IsDestroyed(const AabbTreeWorld& world, BodyID id) noexcept;
+inline auto IsDestroyed(const AabbTreeWorld& world, BodyID id) -> bool
+{
+    return IsDestroyed(GetBody(world, id));
+}
 
 /// @brief Gets the proxies for the identified body.
 /// @throws std::out_of_range If given an invalid identifier.
@@ -518,8 +521,11 @@ const Manifold& GetManifold(const AabbTreeWorld& world, ContactID id);
 void SetManifold(AabbTreeWorld& world, ContactID id, const Manifold& value);
 
 /// @brief Gets whether the given identifier is to a contact that's been destroyed.
-/// @note Complexity is at most O(n) where n is the number of elements free.
-bool IsDestroyed(const AabbTreeWorld& world, ContactID id) noexcept;
+/// @note Complexity of this function is O(1).
+inline auto IsDestroyed(const AabbTreeWorld& world, ContactID id) -> bool
+{
+    return IsDestroyed(GetContact(world, id));
+}
 
 /// @}
 
@@ -610,7 +616,6 @@ public:
     friend const Body& GetBody(const AabbTreeWorld& world, BodyID id);
     friend void SetBody(AabbTreeWorld& world, BodyID id, Body value);
     friend void Destroy(AabbTreeWorld& world, BodyID id);
-    friend bool IsDestroyed(const AabbTreeWorld& world, BodyID id) noexcept;
     friend const ProxyIDs& GetProxies(const AabbTreeWorld& world, BodyID id);
     friend const BodyContactIDs& GetContacts(const AabbTreeWorld& world, BodyID id);
     friend const BodyJointIDs& GetJoints(const AabbTreeWorld& world, BodyID id);
@@ -639,7 +644,6 @@ public:
     friend void SetContact(AabbTreeWorld& world, ContactID id, Contact value);
     friend const Manifold& GetManifold(const AabbTreeWorld& world, ContactID id);
     friend void SetManifold(AabbTreeWorld& world, ContactID id, const Manifold& value);
-    friend bool IsDestroyed(const AabbTreeWorld& world, ContactID id) noexcept;
 
 private:
     /// @brief Flags type data type.

--- a/Library/include/playrho/d2/AabbTreeWorld.hpp
+++ b/Library/include/playrho/d2/AabbTreeWorld.hpp
@@ -37,6 +37,7 @@
 
 #include <playrho/BodyID.hpp>
 #include <playrho/BodyShapeFunction.hpp>
+#include <playrho/Contact.hpp>
 #include <playrho/Contactable.hpp>
 #include <playrho/ContactFunction.hpp>
 #include <playrho/ContactID.hpp>
@@ -76,7 +77,6 @@ namespace playrho {
 
 struct StepConf;
 enum class BodyType;
-class Contact;
 
 } // namespace playrho
 

--- a/Library/include/playrho/d2/Body.hpp
+++ b/Library/include/playrho/d2/Body.hpp
@@ -223,6 +223,18 @@ public:
     /// @see GetType.
     void SetType(BodyType value) noexcept;
 
+    /// @brief Whether or not this was destroyed.
+    /// @see SetDestroyed, UnsetDestroyed.
+    constexpr bool IsDestroyed() const noexcept;
+
+    /// @brief Sets the destroyed property.
+    /// @note This is only meaningfully used by the world implementation.
+    constexpr void SetDestroyed() noexcept;
+
+    /// @brief Unsets the destroyed property.
+    /// @note This is only meaningfully used by the world implementation.
+    constexpr void UnsetDestroyed() noexcept;
+
     /// @brief Is "speedable".
     /// @details Is this body able to have a non-zero speed associated with it.
     ///   Kinematic and Dynamic bodies are speedable. Static bodies are not.
@@ -395,6 +407,10 @@ private:
     /// @brief Flag enumeration.
     /// @note For internal use. Made public to facilitate unit testing.
     enum Flag : FlagsType {
+
+        /// Whether this entity was destroyed or not.
+        e_destroyed = FlagsType(0x0001u),
+
         /// @brief Awake flag.
         e_awakeFlag = FlagsType(0x0002u),
 
@@ -538,6 +554,21 @@ inline NonNegative<Frequency> Body::GetAngularDamping() const noexcept
 inline void Body::SetAngularDamping(NonNegative<Frequency> angularDamping) noexcept
 {
     m_angularDamping = angularDamping;
+}
+
+constexpr bool Body::IsDestroyed() const noexcept
+{
+    return (m_flags & e_destroyed) != 0u;
+}
+
+constexpr void Body::SetDestroyed() noexcept
+{
+    m_flags |= e_destroyed;
+}
+
+constexpr void Body::UnsetDestroyed() noexcept
+{
+    m_flags &= ~e_destroyed;
 }
 
 inline bool Body::IsImpenetrable() const noexcept
@@ -698,6 +729,27 @@ inline BodyType GetType(const Body& body) noexcept
 inline void SetType(Body& body, BodyType value) noexcept
 {
     body.SetType(value);
+}
+
+/// @brief Whether or not the given body was destroyed.
+/// @see SetDestroyed, UnsetDestroyed.
+constexpr auto IsDestroyed(const Body& body) noexcept -> bool
+{
+    return body.IsDestroyed();
+}
+
+/// @brief Sets the destroyed property of the given body.
+/// @note This is only meaningfully used by the world implementation.
+constexpr void SetDestroyed(Body& body) noexcept
+{
+    body.SetDestroyed();
+}
+
+/// @brief Unsets the destroyed property of the given body.
+/// @note This is only meaningfully used by the world implementation.
+constexpr void UnsetDestroyed(Body& body) noexcept
+{
+    body.UnsetDestroyed();
 }
 
 /// @brief Is "speedable".

--- a/Library/include/playrho/d2/Joint.hpp
+++ b/Library/include/playrho/d2/Joint.hpp
@@ -457,6 +457,13 @@ inline std::add_pointer_t<T> TypeCast(Joint* value) noexcept
     return nullptr;
 }
 
+/// @brief Gets whether the given entity is in the is-destroyed state.
+/// @relatedalso Joint
+inline auto IsDestroyed(const Joint &object) noexcept -> bool
+{
+    return !object.has_value();
+}
+
 /// Get the anchor point on body-A in local coordinates.
 /// @relatedalso Joint
 Length2 GetLocalAnchorA(const Joint& object);

--- a/Library/include/playrho/d2/Shape.hpp
+++ b/Library/include/playrho/d2/Shape.hpp
@@ -497,6 +497,13 @@ inline T TypeCast(const Shape& value)
     return static_cast<T>(*tmp);
 }
 
+/// @brief Gets whether the given entity is in the is-destroyed state.
+/// @relatedalso Shape
+inline auto IsDestroyed(const Shape &value) noexcept -> bool
+{
+    return !value.has_value();
+}
+
 /// @brief Whether contact calculations should be performed between the two instances.
 /// @return <code>true</code> if contact calculations should be performed between these
 ///   two instances; <code>false</code> otherwise.

--- a/Library/include/playrho/d2/World.hpp
+++ b/Library/include/playrho/d2/World.hpp
@@ -372,6 +372,14 @@ void SetBody(World& world, BodyID id, const Body& body);
 /// @see PhysicalEntities.
 void Destroy(World& world, BodyID id);
 
+/// @brief Gets whether the given identifier is to a body that's been destroyed.
+/// @note Complexity of this function is O(1).
+/// @see Destroy(World& world, BodyID).
+inline auto IsDestroyed(const World& world, BodyID id) -> bool
+{
+    return IsDestroyed(GetBody(world, id));
+}
+
 /// @brief Gets the container of valid joints attached to the identified body.
 /// @throws std::out_of_range If given an out of range body identifier.
 /// @see CreateJoint, GetBodyRange.
@@ -592,6 +600,13 @@ inline ContactCounter GetContactCount(const World& world) noexcept
 {
     using std::size;
     return static_cast<ContactCounter>(size(GetContacts(world)));
+}
+
+/// @brief Gets whether the given identifier is to a contact that's been destroyed.
+/// @note Complexity of this function is O(1).
+inline auto IsDestroyed(const World& world, ContactID id) -> bool
+{
+    return IsDestroyed(GetContact(world, id));
 }
 
 /// @defgroup PhysicalEntities Physical Entities

--- a/Library/source/playrho/d2/AabbTreeWorld.cpp
+++ b/Library/source/playrho/d2/AabbTreeWorld.cpp
@@ -1105,11 +1105,6 @@ void Destroy(AabbTreeWorld& world, BodyID id)
     world.Remove(id);
 }
 
-bool IsDestroyed(const AabbTreeWorld& world, BodyID id) noexcept
-{
-    return world.m_bodyBuffer.FindFree(to_underlying(id));
-}
-
 void SetJoint(AabbTreeWorld& world, JointID id, Joint def)
 {
     if (IsLocked(world)) {
@@ -2288,11 +2283,6 @@ void AabbTreeWorld::Destroy(ContactID contactID, const Body* from)
         m_contacts.erase(*found);
     }
     InternalDestroy(contactID, from);
-}
-
-bool IsDestroyed(const AabbTreeWorld& world, ContactID id) noexcept
-{
-    return world.m_contactBuffer.FindFree(to_underlying(id));
 }
 
 AabbTreeWorld::DestroyContactsStats AabbTreeWorld::DestroyContacts(KeyedContactIDs& contacts)

--- a/Library/source/playrho/d2/Body.cpp
+++ b/Library/source/playrho/d2/Body.cpp
@@ -327,6 +327,7 @@ bool operator==(const Body& lhs, const Body& rhs)
 {
     return GetTransformation(lhs) == GetTransformation(rhs) && //
            GetSweep(lhs) == GetSweep(rhs) && //
+           IsDestroyed(lhs) == IsDestroyed(rhs) && //
            IsAwake(lhs) == IsAwake(rhs) && //
            IsSleepingAllowed(lhs) == IsSleepingAllowed(rhs) && //
            IsImpenetrable(lhs) == IsImpenetrable(rhs) && //

--- a/UnitTests/AabbTreeWorld.cpp
+++ b/UnitTests/AabbTreeWorld.cpp
@@ -641,7 +641,7 @@ TEST(AabbTreeWorld, SetManifold)
     ASSERT_EQ(imp1[1], 0_Ns);
     auto newValue = Manifold();
     EXPECT_THROW(SetManifold(world, ContactID(0), newValue), InvalidArgument); // can't change type
-    newValue = Manifold::GetForFaceA(UnitVec{}, Length2{});
+    newValue = Manifold::GetForFaceA(UnitVec::GetLeft(), Length2{});
     ASSERT_EQ(unsigned(newValue.GetType()), unsigned(original.GetType()));
     ASSERT_NE(unsigned(newValue.GetPointCount()), unsigned(original.GetPointCount()));
     EXPECT_THROW(SetManifold(world, ContactID(0), newValue), InvalidArgument); // can't change point count

--- a/UnitTests/AabbTreeWorld.cpp
+++ b/UnitTests/AabbTreeWorld.cpp
@@ -969,19 +969,20 @@ TEST(AabbTreeWorld, IsDestroyedBody)
 {
     auto world = AabbTreeWorld{};
     ASSERT_EQ(GetBodies(world).size(), 0u);
-    EXPECT_FALSE(IsDestroyed(world, BodyID{0u}));
+    EXPECT_THROW(IsDestroyed(world, BodyID{0u}), OutOfRange<BodyID>);
 
     auto id = InvalidBodyID;
     ASSERT_NO_THROW(id = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     ASSERT_EQ(to_underlying(id), 0u);
     ASSERT_EQ(GetBodies(world).size(), 1u);
-    EXPECT_FALSE(IsDestroyed(world, id));
+    auto is_destroyed = true;
+    EXPECT_NO_THROW(is_destroyed = IsDestroyed(world, id));
+    EXPECT_FALSE(is_destroyed);
 
     ASSERT_NO_THROW(id = CreateBody(world, BodyConf{}.Use(BodyType::Dynamic)));
     ASSERT_EQ(to_underlying(id), 1u);
     ASSERT_EQ(GetBodies(world).size(), 2u);
     EXPECT_FALSE(IsDestroyed(world, id));
-    EXPECT_FALSE(IsDestroyed(GetBody(world, id)));
 
     ASSERT_NO_THROW(Destroy(world, BodyID{0u}));
     EXPECT_TRUE(IsDestroyed(world, BodyID{0u}));

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -185,6 +185,12 @@ TEST(Body, SetUnsetDestroyed)
     EXPECT_TRUE(body.IsDestroyed());
     body.UnsetDestroyed();
     EXPECT_FALSE(body.IsDestroyed());
+}
+
+TEST(Body, SetUnsetDestroyedFreeFuncs)
+{
+    auto body = Body();
+    ASSERT_FALSE(IsDestroyed(body));
     SetDestroyed(body);
     EXPECT_TRUE(IsDestroyed(body));
     UnsetDestroyed(body);

--- a/UnitTests/Body.cpp
+++ b/UnitTests/Body.cpp
@@ -28,6 +28,10 @@ using namespace playrho::d2;
 TEST(Body, DefaultConstruction)
 {
     EXPECT_EQ(Body().GetType(), BodyType::Static);
+    EXPECT_TRUE(Body().IsEnabled());
+    EXPECT_FALSE(Body().IsAwake());
+    EXPECT_FALSE(Body().IsSpeedable());
+    EXPECT_FALSE(Body().IsDestroyed());
     EXPECT_TRUE(IsEnabled(Body()));
     EXPECT_FALSE(IsAwake(Body()));
     EXPECT_FALSE(IsSpeedable(Body()));
@@ -38,6 +42,7 @@ TEST(Body, DefaultConstruction)
 TEST(Body, StaticTypeConstruction)
 {
     const auto body = Body(BodyConf().Use(BodyType::Static));
+    EXPECT_FALSE(body.IsDestroyed());
     EXPECT_TRUE(body.IsImpenetrable());
     EXPECT_FALSE(body.IsSpeedable());
     EXPECT_FALSE(body.IsAccelerable());
@@ -51,6 +56,7 @@ TEST(Body, StaticTypeConstruction)
 TEST(Body, KinematicTypeConstruction)
 {
     const auto body = Body(BodyConf().Use(BodyType::Kinematic));
+    EXPECT_FALSE(body.IsDestroyed());
     EXPECT_TRUE(body.IsImpenetrable());
     EXPECT_TRUE(body.IsSpeedable());
     EXPECT_FALSE(body.IsAccelerable());
@@ -64,6 +70,7 @@ TEST(Body, KinematicTypeConstruction)
 TEST(Body, DynamicTypeConstruction)
 {
     const auto body = Body(BodyConf().Use(BodyType::Dynamic));
+    EXPECT_FALSE(body.IsDestroyed());
     EXPECT_FALSE(body.IsImpenetrable());
     EXPECT_TRUE(body.IsSpeedable());
     EXPECT_TRUE(body.IsAccelerable());
@@ -170,12 +177,38 @@ TEST(Body, AccelerationOnConstruction)
               body.GetAngularAcceleration());
 }
 
+TEST(Body, SetUnsetDestroyed)
+{
+    auto body = Body();
+    ASSERT_FALSE(body.IsDestroyed());
+    body.SetDestroyed();
+    EXPECT_TRUE(body.IsDestroyed());
+    body.UnsetDestroyed();
+    EXPECT_FALSE(body.IsDestroyed());
+    SetDestroyed(body);
+    EXPECT_TRUE(IsDestroyed(body));
+    UnsetDestroyed(body);
+    EXPECT_FALSE(IsDestroyed(body));
+}
+
 TEST(Body, EqualsOperator)
 {
     EXPECT_TRUE(Body() == Body());
     {
         auto body = Body{};
         EXPECT_TRUE(body == Body());
+    }
+    {
+        auto bodyA = Body();
+        auto bodyB = Body();
+        bodyB.SetDestroyed();
+        EXPECT_FALSE(bodyA == bodyB);
+        bodyA.SetDestroyed();
+        EXPECT_TRUE(bodyA == bodyB);
+        bodyB.UnsetDestroyed();
+        EXPECT_FALSE(bodyA == bodyB);
+        bodyA.UnsetDestroyed();
+        EXPECT_TRUE(bodyA == bodyB);
     }
     {
         auto body1 = Body{};

--- a/UnitTests/Contact.cpp
+++ b/UnitTests/Contact.cpp
@@ -209,6 +209,26 @@ TEST(Contact, GetOtherBody)
     EXPECT_EQ(GetOtherBody(contact, bodyIdB), bodyIdA);
 }
 
+TEST(Contact, SetUnsetDestroyed)
+{
+    auto c = Contact{};
+    ASSERT_FALSE(c.IsDestroyed());
+    c.SetDestroyed();
+    EXPECT_TRUE(c.IsDestroyed());
+    c.UnsetDestroyed();
+    EXPECT_FALSE(c.IsDestroyed());
+}
+
+TEST(Contact, SetUnsetDestroyedFreeFuncs)
+{
+    auto c = Contact{};
+    ASSERT_FALSE(IsDestroyed(c));
+    SetDestroyed(c);
+    EXPECT_TRUE(IsDestroyed(c));
+    UnsetDestroyed(c);
+    EXPECT_FALSE(IsDestroyed(c));
+}
+
 TEST(Contact, Equality)
 {
     EXPECT_TRUE(Contact() == Contact());


### PR DESCRIPTION
#### Description - What's this PR do?

- Addresses issue #561.
- Avoids further enlarging the `World` interface.

#### Impacts/Risks of These Changes?
- Changes semantics of empty `Joint` and empty `Shape` objects to mean _is-destroyed_.

#### Related Issues

- Issue #561.
